### PR TITLE
[v6.0] reproduction: Gemini 3 parallel function calls: converter injects skipthoughtsignaturevalidator

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 16298,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-16298-gemini3-parallel-tool-calls.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-16298-gemini3-parallel-tool-calls.ts",
+    "packages/google/src/__fixtures__/issue-16298-gemini3-parallel-tool-calls.json"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Issue #16298 reproduced: valid parallel Gemini 3 tool calls triggered the skip_thought_signature_validator warning."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-16298-gemini3-parallel-tool-calls.ts
+++ b/examples/ai-functions/src/reproduction/issue-16298-gemini3-parallel-tool-calls.ts
@@ -1,0 +1,114 @@
+import { readFile } from 'node:fs/promises';
+import type {
+  LanguageModelV3Prompt,
+  SharedV3ProviderMetadata,
+  SharedV3Warning,
+} from '@ai-sdk/provider';
+import {
+  convertToGoogleGenerativeAIMessages,
+  SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+} from '../../../../packages/google/src/convert-to-google-generative-ai-messages';
+
+const failureSignal =
+  'Issue #16298 reproduced: valid parallel Gemini 3 tool calls triggered the skip_thought_signature_validator warning.';
+
+type Fixture = {
+  prompt: string;
+  warnings: SharedV3Warning[];
+  toolCalls: Array<{
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+    providerMetadata: SharedV3ProviderMetadata | null;
+  }>;
+};
+
+function readThoughtSignature(
+  providerMetadata: SharedV3ProviderMetadata | null,
+): string | undefined {
+  for (const namespace of ['google', 'vertex', 'googleVertex']) {
+    const thoughtSignature = providerMetadata?.[namespace]?.thoughtSignature;
+    if (typeof thoughtSignature === 'string') {
+      return thoughtSignature;
+    }
+  }
+}
+
+async function main() {
+  const fixture = JSON.parse(
+    await readFile(
+      new URL(
+        '../../../../packages/google/src/__fixtures__/issue-16298-gemini3-parallel-tool-calls.json',
+        import.meta.url,
+      ),
+      'utf8',
+    ),
+  ) as Fixture;
+
+  if (
+    readThoughtSignature(fixture.toolCalls[0].providerMetadata) == null ||
+    readThoughtSignature(fixture.toolCalls[1].providerMetadata) != null
+  ) {
+    throw new Error(
+      'Recorded provider fixture does not contain the documented signed-first, unsigned-second parallel call shape.',
+    );
+  }
+
+  const prompt: LanguageModelV3Prompt = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: fixture.prompt }],
+    },
+    {
+      role: 'assistant',
+      content: fixture.toolCalls.map(call => ({
+        type: 'tool-call' as const,
+        toolCallId: call.toolCallId,
+        toolName: call.toolName,
+        input: call.input,
+        providerOptions: call.providerMetadata ?? undefined,
+      })),
+    },
+  ];
+  const warnings: SharedV3Warning[] = [];
+  const converted = convertToGoogleGenerativeAIMessages(prompt, {
+    isGemini3Model: true,
+    providerOptionsName: 'googleVertex',
+    onWarning: warning => warnings.push(warning),
+  });
+
+  const hasWarning = warnings.some(
+    warning =>
+      warning.type === 'other' &&
+      warning.message.includes(SKIP_THOUGHT_SIGNATURE_VALIDATOR) &&
+      warning.message.includes('application code that drops'),
+  );
+  const hasInjectedSentinel = converted.contents[1].parts.some(
+    part =>
+      'thoughtSignature' in part &&
+      part.thoughtSignature === SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        recordedWarnings: fixture.warnings,
+        replayWarnings: warnings,
+        convertedToolCallParts: converted.contents[1].parts,
+        hasMisleadingWarning: hasWarning,
+        hasInjectedSentinel,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (hasWarning && hasInjectedSentinel) {
+    throw new Error(failureSignal);
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/google/src/__fixtures__/issue-16298-gemini3-parallel-tool-calls.json
+++ b/packages/google/src/__fixtures__/issue-16298-gemini3-parallel-tool-calls.json
@@ -1,0 +1,39 @@
+{
+  "capturedAt": "2026-07-21",
+  "provider": "Vercel AI Gateway routed only to Vertex AI",
+  "model": "google/gemini-3.1-flash-lite",
+  "prompt": "Use get_weather for Paris and Tokyo in parallel in one assistant step, then summarize both weather results.",
+  "warnings": [
+    {
+      "type": "other",
+      "message": "Replayed 1 `functionCall` part(s) for a Gemini 3 model without a `thoughtSignature` (tools: `get_weather`). Injected the documented `skip_thought_signature_validator` sentinel to keep the request from failing with HTTP 400. The likely cause is application code that drops `providerOptions.google.thoughtSignature` when persisting or serializing assistant tool-call messages. See https://ai.google.dev/gemini-api/docs/thought-signatures."
+    }
+  ],
+  "toolCalls": [
+    {
+      "stepIndex": 0,
+      "toolCallId": "lpndqlku",
+      "toolName": "get_weather",
+      "input": {
+        "city": "Paris"
+      },
+      "providerMetadata": {
+        "googleVertex": {
+          "thoughtSignature": "AY89a19YsnFp7FOSIejJDV9XuMU996D+ZaDJiD6L9EEi+Lh+VGTEGqM3Lip3DPI7QzY="
+        },
+        "vertex": {
+          "thoughtSignature": "AY89a19YsnFp7FOSIejJDV9XuMU996D+ZaDJiD6L9EEi+Lh+VGTEGqM3Lip3DPI7QzY="
+        }
+      }
+    },
+    {
+      "stepIndex": 0,
+      "toolCallId": "m6rogicj",
+      "toolName": "get_weather",
+      "input": {
+        "city": "Tokyo"
+      },
+      "providerMetadata": null
+    }
+  ]
+}

--- a/packages/google/src/issue-16298-gemini3-parallel-tool-calls.test.ts
+++ b/packages/google/src/issue-16298-gemini3-parallel-tool-calls.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import type {
+  LanguageModelV3Prompt,
+  SharedV3ProviderMetadata,
+  SharedV3Warning,
+} from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import {
+  convertToGoogleGenerativeAIMessages,
+  SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+} from './convert-to-google-generative-ai-messages';
+
+type Fixture = {
+  prompt: string;
+  toolCalls: Array<{
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+    providerMetadata: SharedV3ProviderMetadata | null;
+  }>;
+};
+
+describe('issue #16298: Gemini 3 parallel tool-call thought signatures', () => {
+  it('does not warn or inject a sentinel when the first parallel call is signed', () => {
+    const fixture = JSON.parse(
+      readFileSync(
+        new URL(
+          './__fixtures__/issue-16298-gemini3-parallel-tool-calls.json',
+          import.meta.url,
+        ),
+        'utf8',
+      ),
+    ) as Fixture;
+    const warnings: SharedV3Warning[] = [];
+    const prompt: LanguageModelV3Prompt = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: fixture.prompt }],
+      },
+      {
+        role: 'assistant',
+        content: fixture.toolCalls.map(call => ({
+          type: 'tool-call' as const,
+          toolCallId: call.toolCallId,
+          toolName: call.toolName,
+          input: call.input,
+          providerOptions: call.providerMetadata ?? undefined,
+        })),
+      },
+    ];
+
+    const result = convertToGoogleGenerativeAIMessages(prompt, {
+      isGemini3Model: true,
+      providerOptionsName: 'googleVertex',
+      onWarning: warning => warnings.push(warning),
+    });
+
+    expect(warnings).toEqual([]);
+    expect(result.contents[1].parts).not.toContainEqual(
+      expect.objectContaining({
+        thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Bug

Gemini 3 parallel function calls: converter injects `skip_thought_signature_validator` + warns every turn (only the first parallel call is signed)

## Reproduction

- Google documents that only the first function call in a Gemini 3 parallel batch carries a thought signature; subsequent unsigned calls are valid.
- The target `release-v6.0` versions (`ai@6.0.233`, `@ai-sdk/google@3.0.98`, and `@ai-sdk/gateway@3.0.155`) still reproduce the behavior, so upgrading from the reported versions does not resolve it.
- The recorded live response in `packages/google/src/__fixtures__/issue-16298-gemini3-parallel-tool-calls.json` contains a signed first Vertex call and an unsigned second parallel call.
- `examples/ai-functions/src/reproduction/issue-16298-gemini3-parallel-tool-calls.ts` replayed that valid batch and observed both the misleading application-code warning and sentinel injection, instead of accepting the batch without false attribution.
- `packages/google/src/issue-16298-gemini3-parallel-tool-calls.test.ts` asserts the expected `no-warning/no-sentinel` behavior and fails because the converter emits the reported warning.
- A new live Vertex request was not made because Google Vertex live-service checks are skipped by policy; the July 21, 2026 recorded live fixture was used.

## Relevant Documentation

- https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures
- https://ai.google.dev/gemini-api/docs/generate-content/gemini-3
- https://vercel.com/ai-gateway/models/gemini-3.1-flash-lite/providers
- https://ai-sdk.dev/providers/ai-sdk-providers/ai-gateway

## Related Issues

Reproduces #16298