### PR TITLE
[v5.0] reproduction: could not reproduce LLM passing escaped double quotes in tool arguments

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/anthropic": "workspace:*",
+    "ai": "workspace:*",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  },
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11719-anthropic-quoted-tool-input.ts
+++ b/examples/ai-functions/src/reproduction/issue-11719-anthropic-quoted-tool-input.ts
@@ -1,0 +1,171 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText, streamText, tool } from 'ai';
+import { z } from 'zod';
+
+const quotedDescription =
+  "Create 'Why Pace exists' section with calm video background (clip_6). Headline 'Why Pace exists' with body text explaining the problem: 'Today you post every run to Strava to keep a history and check how friends train, but Strava doesn't answer the question: \"What should I do next after this run?\". It's a great log, but it isn't adaptive. Your races are saved from random websites, your plan sits in a spreadsheet, and your coach gets screenshots in chat. Pace is an early product that wants to fix this by putting adaptive plans, races and coaches into one app, so your running doesn't feel scattered across five tools.' Keep layout clean with text over the calming abstract background.";
+
+const Task = z.object({
+  id: z.number().optional(),
+  description: z.string(),
+  type: z.enum(['feature', 'bug']),
+  passes: z.boolean(),
+});
+
+const WebsiteUpdateInput = z.object({
+  tasks: z.array(Task),
+  assets: z.array(z.string()).optional(),
+  website_path: z.string(),
+});
+
+const expectedInput: z.infer<typeof WebsiteUpdateInput> = {
+  website_path: '/home/user/pace-landing',
+  tasks: [
+    {
+      description:
+        "Create a premium Nike-style landing page for Pace running app. Video clips are provided and must be integrated: clip_1 (hero brand intro), clip_2 (problem/chaos), clip_3 (adaptive plans), clip_4 (races), clip_5 (coaches), clip_6 (calm liquid-glass background). Build a fullscreen hero section with video background (clip_1 transitioning to clip_2) featuring headline 'Improve your Pace', subheadline 'We know this chaos: Strava screenshots, Excel plans, race sites everywhere.', body text 'Everything for running in one app.', and prominent CTA 'Join waitlist' linking to form section. Use primary color #007AFF, secondary #4B6FFF, bg #F6F8FF. Fonts: Montserrat Semibold for headlines, Inter for body. Design should feel cinematic, premium, minimal, Nike-inspired with high contrast and cool tones.",
+      type: 'feature',
+      passes: false,
+    },
+    {
+      description: quotedDescription,
+      type: 'feature',
+      passes: false,
+    },
+    {
+      description:
+        "Create solution section with 2-column layout featuring three features with corresponding video backgrounds. Headline 'Improve your Pace. And your pace.' Feature 1: 'Adaptive Plans' with video clip_3, text 'Missed a week? Classic plans ignore it. Pace rebuilds your week around real life.' Feature 2: 'Race Calendar' with video clip_4, text 'One place for all races. No more searching on random websites.' Feature 3: 'Coach Platform' with video clip_5, text 'Coach sees everything in Pace. No screenshots needed. Coach sets training week directly in app.' Include CTA 'See how it works' linking to form.",
+      type: 'feature',
+      passes: false,
+    },
+    {
+      description:
+        "Create MVP section with centered card layout and video background (clip_3). Headline 'We start simple' with body text 'Pace is early in development. The vision is one home for plans, races and coaches in a single app. The first step: adaptive plans that understand when life happens.' Add note 'Early testers shape the full running home.' Design as a premium card overlay on the video.",
+      type: 'feature',
+      passes: false,
+    },
+    {
+      description:
+        "Create final CTA section with fullscreen card and waitlist form, video background (clip_5). Headline 'Start your Pace journey', body text 'Join waitlist to test adaptive plans v0.1. Help build the running app you want. Team builders welcome.' Form fields: Email (required), WhatsApp (optional), consent checkbox 'Early access updates about Pace.' CTA button 'Join waitlist' that submits the form. Make form feel premium and minimal.",
+      type: 'feature',
+      passes: false,
+    },
+  ],
+  assets: [
+    '/home/user/Videos/4m8wxuq0li.mp4',
+    '/home/user/Videos/h46y3g4zo3.mp4',
+    '/home/user/Videos/2nqkbf2npz.mp4',
+    '/home/user/Videos/5ek2ofn3m5.mp4',
+    '/home/user/Videos/nolgvg0yag.mp4',
+    '/home/user/Videos/qs44lu51b6.mp4',
+  ],
+};
+
+const prompt = [
+  'Call website_update exactly once.',
+  'Copy every value from this JSON object verbatim into the tool input; do not summarize or rewrite strings:',
+  JSON.stringify(expectedInput, null, 2),
+].join('\n');
+
+function assertExecutedInput(
+  mode: 'generateText' | 'streamText',
+  executedInputs: Array<z.infer<typeof WebsiteUpdateInput>>,
+) {
+  if (executedInputs.length !== 1) {
+    throw new Error(
+      `${mode}: expected one successful tool execution, received ${executedInputs.length}`,
+    );
+  }
+
+  const actualDescription = executedInputs[0].tasks[1]?.description;
+
+  if (actualDescription !== quotedDescription) {
+    throw new Error(
+      `${mode}: quoted description was not preserved: ${JSON.stringify(actualDescription)}`,
+    );
+  }
+}
+
+async function runGenerateText() {
+  const executedInputs: Array<z.infer<typeof WebsiteUpdateInput>> = [];
+
+  const result = await generateText({
+    model: anthropic('claude-sonnet-4-5'),
+    temperature: 0,
+    maxOutputTokens: 5000,
+    toolChoice: { type: 'tool', toolName: 'website_update' },
+    tools: {
+      website_update: tool({
+        description: 'Update a website by completing the supplied tasks.',
+        inputSchema: WebsiteUpdateInput,
+        execute: async input => {
+          executedInputs.push(input);
+          return { ok: true };
+        },
+      }),
+    },
+    prompt,
+  });
+
+  assertExecutedInput('generateText', executedInputs);
+
+  return result.response.modelId;
+}
+
+async function runStreamText() {
+  const executedInputs: Array<z.infer<typeof WebsiteUpdateInput>> = [];
+
+  const result = streamText({
+    model: anthropic('claude-sonnet-4-5'),
+    temperature: 0,
+    maxOutputTokens: 5000,
+    toolChoice: { type: 'tool', toolName: 'website_update' },
+    tools: {
+      website_update: tool({
+        description: 'Update a website by completing the supplied tasks.',
+        inputSchema: WebsiteUpdateInput,
+        execute: async input => {
+          executedInputs.push(input);
+          return { ok: true };
+        },
+      }),
+    },
+    prompt,
+  });
+
+  await Promise.all([result.toolCalls, result.toolResults]);
+
+  assertExecutedInput('streamText', executedInputs);
+}
+
+async function main() {
+  const issueSnippet = `{"name": "hi \"hello world\""}`;
+  let issueSnippetError: unknown;
+
+  try {
+    JSON.parse(issueSnippet);
+  } catch (error) {
+    issueSnippetError = error;
+  }
+
+  if (!(issueSnippetError instanceof SyntaxError)) {
+    throw new Error(
+      'Expected the issue template-literal control to be invalid JSON',
+    );
+  }
+
+  const modelId = await runGenerateText();
+  await runStreamText();
+
+  console.log(
+    `CONTROL: the issue template-literal example is invalid at runtime: ${issueSnippetError.message}`,
+  );
+  console.log(
+    `PASS: generateText and streamText executed website_update with the quoted question using ${modelId}`,
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2022",
+    "lib": ["es2022", "dom"],
+    "module": "esnext",
+    "types": ["node"],
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/anthropic/src/__fixtures__/issue-11719-quoted-tool-input.json
+++ b/packages/anthropic/src/__fixtures__/issue-11719-quoted-tool-input.json
@@ -1,0 +1,42 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_011CdFW374nxbTHc7HAtfnNv",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "tool_use",
+      "id": "toolu_01Y3U31BsvgT4AknPd3RBQpM",
+      "name": "website_update",
+      "input": {
+        "website_path": "/home/user/pace-landing",
+        "tasks": [
+          {
+            "description": "Today you post every run to Strava, but Strava does not answer the question: \"What should I do next after this run?\". It is a great log, but it is not adaptive.",
+            "type": "feature",
+            "passes": false
+          }
+        ],
+        "assets": ["/home/user/Videos/clip.mp4"]
+      },
+      "caller": {
+        "type": "direct"
+      }
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 954,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 147,
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -949,6 +949,48 @@ describe('AnthropicMessagesLanguageModel', () => {
       expect(finishReason).toStrictEqual('tool-calls');
     });
 
+    it('should preserve quoted strings in tool input from a live fixture', async () => {
+      prepareJsonFixtureResponse('issue-11719-quoted-tool-input');
+
+      const { content, finishReason } = await provider(
+        'claude-sonnet-4-5',
+      ).doGenerate({
+        tools: [
+          {
+            type: 'function',
+            name: 'website_update',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                tasks: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      description: { type: 'string' },
+                      type: { enum: ['feature', 'bug'] },
+                      passes: { type: 'boolean' },
+                    },
+                    required: ['description', 'type', 'passes'],
+                  },
+                },
+              },
+              required: ['tasks'],
+            },
+          },
+        ],
+        prompt: TEST_PROMPT,
+      });
+
+      const toolCall = content.find(part => part.type === 'tool-call');
+
+      expect(toolCall).toBeDefined();
+      expect(JSON.parse(toolCall!.input).tasks[0].description).toContain(
+        '"What should I do next after this run?"',
+      );
+      expect(finishReason).toStrictEqual('tool-calls');
+    });
+
     it('should extract usage', async () => {
       prepareJsonResponse({
         usage: { input_tokens: 20, output_tokens: 5 },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,28 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: workspace:*
+        version: link:../../packages/anthropic
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -19609,7 +19631,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -19623,13 +19645,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
-      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
+      css-loader: 7.1.2(webpack@5.105.0)
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19637,22 +19659,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
-      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
+      license-webpack-plugin: 4.0.2(webpack@5.105.0)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
+      source-map-loader: 5.0.0(webpack@5.105.0)
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -19662,7 +19684,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -19692,7 +19714,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -24942,7 +24964,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -29418,7 +29440,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30185,7 +30207,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -30282,7 +30304,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
+  css-loader@7.1.2(webpack@5.105.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -33762,7 +33784,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -33790,7 +33812,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
+  license-webpack-plugin@4.0.2(webpack@5.105.0):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -34869,7 +34891,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36400,7 +36422,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -37357,7 +37379,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -37794,7 +37816,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
+  source-map-loader@5.0.0(webpack@5.105.0):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -39984,7 +40006,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)


### PR DESCRIPTION
## Bug

LLM passing escaped double quotes in tool arguments result in error

## Reproduction

- On target branch `release-v5.0`, `packages/ai/package.json` is version 5.0.218 and `packages/anthropic/package.json` is version 2.0.88.
- `examples/ai-functions/src/reproduction/issue-11719-anthropic-quoted-tool-input.ts` used the reported five-task input shape and quoted question; live `generateText` and `streamText` calls both parsed the input and executed `website_update`, whereas the reported bug would produce invalid input and prevent execution.
- Anthropic resolved `claude-sonnet-4-5` to `claude-sonnet-4-5-20250929` during the successful live checks.
- The live provider response is recorded in `packages/anthropic/src/__fixtures__/issue-11719-quoted-tool-input.json`, and `packages/anthropic/src/anthropic-messages-language-model.test.ts` confirms that its quoted question remains valid tool-call JSON.
- The issue's standalone template-literal control is invalid JSON because JavaScript consumes `\"` while constructing the string, leaving unescaped quotation marks.
- The report does not identify the production model, AI SDK version, runtime, or fine-grained tool-streaming configuration, so that exact production scenario could not be matched.

## Relevant Documentation

- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming

## Related Issues

Could not reproduce #11719