### PR TITLE
fix(ai): skip smoothStream delays while the document is hidden

### DIFF
--- a/.changeset/smooth-stream-hidden-tab.md
+++ b/.changeset/smooth-stream-hidden-tab.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): skip `smoothStream` delays while the document is hidden, so background-tab timer throttling no longer stalls the stream and any tool loop gated on its consumption

--- a/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/80-smooth-stream.mdx
@@ -38,7 +38,7 @@ const result = streamText({
       type: 'number | null',
       isOptional: true,
       description:
-        'The delay in milliseconds between outputting each chunk. Defaults to 10ms. Set to `null` to disable delays.',
+        'The delay in milliseconds between outputting each chunk. Defaults to 10ms. Set to `null` to disable delays. The delay is skipped while the document is hidden (e.g. browser background tabs), where timer throttling would otherwise stall the stream.',
     },
     {
       name: 'chunking',

--- a/packages/ai/src/generate-text/smooth-stream.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream.test.ts
@@ -2,7 +2,7 @@ import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
 import { smoothStream } from './smooth-stream';
 import type { TextStreamPart } from './stream-text-result';
 import type { ToolSet } from '@ai-sdk/provider-utils';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('smoothStream', () => {
   let events: any[] = [];
@@ -2142,6 +2142,129 @@ describe('smoothStream', () => {
           {
             "id": "1",
             "text": "。",
+            "type": "text-delta",
+          },
+          {
+            "id": "1",
+            "type": "text-end",
+          },
+        ]
+      `);
+    });
+  });
+
+  describe('hidden document', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('should skip delays while the document is hidden', async () => {
+      vi.stubGlobal('document', { visibilityState: 'hidden' });
+
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'text-start', id: '1' },
+        {
+          text: 'Hello, World! This is an example text.',
+          type: 'text-delta',
+          id: '1',
+        },
+        { type: 'text-end', id: '1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      expect(events).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "type": "text-start",
+          },
+          "delay null",
+          {
+            "id": "1",
+            "text": "Hello, ",
+            "type": "text-delta",
+          },
+          "delay null",
+          {
+            "id": "1",
+            "text": "World! ",
+            "type": "text-delta",
+          },
+          "delay null",
+          {
+            "id": "1",
+            "text": "This ",
+            "type": "text-delta",
+          },
+          "delay null",
+          {
+            "id": "1",
+            "text": "is ",
+            "type": "text-delta",
+          },
+          "delay null",
+          {
+            "id": "1",
+            "text": "an ",
+            "type": "text-delta",
+          },
+          "delay null",
+          {
+            "id": "1",
+            "text": "example ",
+            "type": "text-delta",
+          },
+          {
+            "id": "1",
+            "text": "text.",
+            "type": "text-delta",
+          },
+          {
+            "id": "1",
+            "type": "text-end",
+          },
+        ]
+      `);
+    });
+
+    it('should apply delays while the document is visible', async () => {
+      vi.stubGlobal('document', { visibilityState: 'visible' });
+
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'text-start', id: '1' },
+        { text: 'Hello, ', type: 'text-delta', id: '1' },
+        { text: 'world!', type: 'text-delta', id: '1' },
+        { type: 'text-end', id: '1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      expect(events).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "1",
+            "type": "text-start",
+          },
+          "delay 10",
+          {
+            "id": "1",
+            "text": "Hello, ",
+            "type": "text-delta",
+          },
+          {
+            "id": "1",
+            "text": "world!",
             "type": "text-delta",
           },
           {

--- a/packages/ai/src/generate-text/smooth-stream.ts
+++ b/packages/ai/src/generate-text/smooth-stream.ts
@@ -10,6 +10,15 @@ const CHUNKING_REGEXPS = {
   line: /\n+/m,
 };
 
+// Browsers heavily throttle timers in hidden documents (e.g. background tabs),
+// which would stall the smoothing delay and, through backpressure, the entire
+// stream. Smoothing has no visual purpose there, so the delay is skipped.
+function isDocumentHidden(): boolean {
+  return (
+    typeof document !== 'undefined' && document.visibilityState === 'hidden'
+  );
+}
+
 /**
  * Detects the first chunk in a buffer.
  *
@@ -22,7 +31,7 @@ export type ChunkDetector = (buffer: string) => string | undefined | null;
 /**
  * Smooths text and reasoning streaming output.
  *
- * @param delayInMs - The delay in milliseconds between each chunk. Defaults to 10ms. Can be set to `null` to skip the delay.
+ * @param delayInMs - The delay in milliseconds between each chunk. Defaults to 10ms. Can be set to `null` to skip the delay. The delay is skipped while the document is hidden (e.g. browser background tabs), where timer throttling would otherwise stall the stream.
  * @param chunking - Controls how the text is chunked for streaming. Use "word" to stream word by word (default), "line" to stream line by line, provide a custom RegExp pattern that does not match the empty string for custom chunking, provide an Intl.Segmenter for locale-aware word segmentation (recommended for CJK languages), or provide a custom ChunkDetector function.
  *
  * @returns A transform stream that smooths text streaming output.
@@ -167,7 +176,7 @@ export function smoothStream<TOOLS extends ToolSet>({
           controller.enqueue({ type, text: match, id });
           buffer = buffer.slice(match.length);
 
-          await delay(delayInMs);
+          await delay(isDocumentHidden() ? null : delayInMs);
         }
       },
     });


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md

AI SDK maintenance is becoming increasingly automated. High-quality issues, reproductions,
failing tests, docs fixes, and focused clarifications are especially valuable. You do not
need to send a complete bug fix for your contribution to be appreciated or credited.
-->

## Background

<!--
Why was this change necessary?
If this PR clarifies or reproduces an issue, please explain that context here.
-->
When `streamText` runs in the browser (e.g. a fully client-side agent/tool loop consuming the stream directly), switching to another tab effectively freezes the stream and the agent: no text advances, tool calls stop being issued, and everything resumes only when the tab regains focus. No error or timeout fires.

The root cause is an interaction between `smoothStream` and browser timer throttling:

1. `smoothStream` awaits `delay(delayInMs)` (a `setTimeout`) between each emitted chunk.
2. Browsers heavily throttle timers in hidden documents - Chrome clamps chained timers to a minimum of 1 second, and after ~5 minutes to only once per minute ("intensive throttling"). The smoothing loop is exactly such a chain, so a hidden tab drains the stream at roughly one word per second, then one word per minute.
3. Because streams are pull-based, the stall propagates upstream through backpressure: the per-step stream never finishes draining, so the step's `flush` - which triggers tool execution results being consumed and the next `streamStep` in multi-step loops - never runs. The whole agent loop is gated on the smoothing delay.

We hit this in production with a browser-embedded agent, where the tool loop runs fully client-side, with tools executing against REST APIs. Users who switched tabs during long multi-step tasks found the agent frozen mid-task - no error, no timeout - until they returned to the tab.
We've since been running the equivalent of this fix in that app by injecting a visibility-aware delay through `_internal.delay`, which fully resolves the issue, including for mid-stream tab switches.

## Summary

<!-- What did you change? -->
Skip the smoothing delay while the document is hidden: `await delay(isDocumentHidden() ? null : delayInMs)`, where `isDocumentHidden()` checks `typeof document !== 'undefined' && document.visibilityState === 'hidden'`.

Smoothing has no visual purpose when nobody can see the page, so the stream drains at full speed there and resumes smoothing when the document becomes visible again. Behavior in Node/edge runtimes is unchanged (`document` is undefined).

## End-to-End Verification

<!--
For features & bugfixes.
Remove the section if it's not needed (e.g. for docs).
Please explain how you verified that the change works end-to-end as expected.
Do not include integration/unit tests or linting
-->
Verified this branch's build of the package in a production browser-embedded agent app (client-side tool loop over `streamText` + `smoothStream`) where the bug was originally discovered - the app was pointed at the locally built package from this PR, with no other changes.

1. Before: start a long multi-step agent task, switch to another tab - the task freezes (no text progress, no further tool calls or model requests) and resumes only on returning to the tab.
2. After: the same scenario streams and executes tools to completion while the tab stays hidden, including when the tab is switched mid-stream. Word-by-word smoothing behaves normally while the tab is visible and resumes on returning to it.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
If this PR adds a failing test, reproduction, or documentation fix for an issue,
please link the issue so maintainers can preserve contributor credit.
Remove the section if it's not needed.
-->

Fixes #20217