### PR TITLE
[v6.0] reproduction: Bedrock client doesn't support alternate URLs for non-standard

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 11197,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11197-bedrock-nonstandard-region.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-11197-bedrock-nonstandard-region.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_11197_REPRODUCED: us-iso-east-1 resolved to https://bedrock-runtime.us-iso-east-1.amazonaws.com"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11197-bedrock-nonstandard-region.ts
+++ b/examples/ai-functions/src/reproduction/issue-11197-bedrock-nonstandard-region.ts
@@ -1,0 +1,140 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText, rerank } from 'ai';
+
+const modelId = 'anthropic.claude-3-haiku-20240307-v1:0';
+
+function createCapturingFetch(urls: string[]) {
+  return async (input: RequestInfo | URL): Promise<Response> => {
+    urls.push(
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url,
+    );
+    throw new TypeError('Request intentionally stopped after URL capture.');
+  };
+}
+
+async function captureRuntimeUrl(options: {
+  region: string;
+  baseURL?: string;
+}) {
+  const urls: string[] = [];
+  const provider = createAmazonBedrock({
+    ...options,
+    apiKey: 'reproduction-api-key',
+    fetch: createCapturingFetch(urls),
+  });
+
+  try {
+    await generateText({
+      model: provider(modelId),
+      prompt: 'Reply with OK.',
+      maxRetries: 0,
+    });
+  } catch {
+    // The request is intentionally stopped after the provider selects its URL.
+  }
+
+  if (urls.length !== 1) {
+    throw new Error(`Expected one Runtime request, observed ${urls.length}.`);
+  }
+
+  return urls[0];
+}
+
+async function captureAgentRuntimeUrl(baseURL: string) {
+  const urls: string[] = [];
+  const provider = createAmazonBedrock({
+    region: 'us-east-1',
+    baseURL,
+    apiKey: 'reproduction-api-key',
+    fetch: createCapturingFetch(urls),
+  });
+
+  try {
+    await rerank({
+      model: provider.reranking('amazon.rerank-v1:0'),
+      documents: ['first', 'second'],
+      query: 'first',
+      topN: 1,
+      maxRetries: 0,
+    });
+  } catch {
+    // The request is intentionally stopped after the provider selects its URL.
+  }
+
+  if (urls.length !== 1) {
+    throw new Error(
+      `Expected one Agent Runtime request, observed ${urls.length}.`,
+    );
+  }
+
+  return urls[0];
+}
+
+async function main() {
+  const expectedIsoUrl =
+    'https://bedrock-runtime.us-iso-east-1.c2s.ic.gov/model/anthropic.claude-3-haiku-20240307-v1%3A0/converse';
+  const observedIsoUrl = await captureRuntimeUrl({
+    region: 'us-iso-east-1',
+  });
+
+  const previousRuntimeOverride = process.env.AWS_ENDPOINT_URL_BEDROCK_RUNTIME;
+  process.env.AWS_ENDPOINT_URL_BEDROCK_RUNTIME =
+    'https://runtime-override.example.test';
+  let observedEnvironmentOverrideUrl: string;
+  try {
+    observedEnvironmentOverrideUrl = await captureRuntimeUrl({
+      region: 'us-east-1',
+    });
+  } finally {
+    if (previousRuntimeOverride == null) {
+      delete process.env.AWS_ENDPOINT_URL_BEDROCK_RUNTIME;
+    } else {
+      process.env.AWS_ENDPOINT_URL_BEDROCK_RUNTIME = previousRuntimeOverride;
+    }
+  }
+
+  const sharedBaseURL = 'https://bedrock-runtime.us-east-1.amazonaws.com';
+  const observedRuntimeBaseUrl = await captureRuntimeUrl({
+    region: 'us-east-1',
+    baseURL: sharedBaseURL,
+  });
+  const observedAgentRuntimeBaseUrl =
+    await captureAgentRuntimeUrl(sharedBaseURL);
+
+  console.log(
+    JSON.stringify(
+      {
+        nonstandardRegion: {
+          expected: expectedIsoUrl,
+          observed: observedIsoUrl,
+        },
+        serviceSpecificEnvironmentOverride: {
+          configured:
+            'https://runtime-override.example.test/model/anthropic.claude-3-haiku-20240307-v1%3A0/converse',
+          observed: observedEnvironmentOverrideUrl,
+        },
+        sharedBaseURL: {
+          runtime: observedRuntimeBaseUrl,
+          agentRuntime: observedAgentRuntimeBaseUrl,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (observedIsoUrl !== expectedIsoUrl) {
+    throw new Error(
+      `ISSUE_11197_REPRODUCED: us-iso-east-1 resolved to ${observedIsoUrl} instead of ${expectedIsoUrl}`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/amazon-bedrock/src/__fixtures__/issue-11197-live-attempt.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-11197-live-attempt.json
@@ -1,0 +1,13 @@
+{
+  "scenario": {
+    "region": "us-iso-east-1",
+    "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+    "operation": "Converse"
+  },
+  "expectedBaseURL": "https://bedrock-runtime.us-iso-east-1.c2s.ic.gov",
+  "observed": {
+    "url": "https://bedrock-runtime.us-iso-east-1.amazonaws.com/model/anthropic.claude-3-haiku-20240307-v1%3A0/converse",
+    "error": "Cannot connect to API: Request was cancelled.",
+    "statusCode": null
+  }
+}

--- a/packages/amazon-bedrock/src/bedrock-provider.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.test.ts
@@ -2,6 +2,7 @@ import type * as AnthropicModule from '@ai-sdk/anthropic';
 import { anthropicTools } from '@ai-sdk/anthropic/internal';
 import { loadOptionalSetting } from '@ai-sdk/provider-utils';
 import type * as ProviderUtilsModule from '@ai-sdk/provider-utils';
+import fs from 'node:fs';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
 import { BedrockEmbeddingModel } from './bedrock-embedding-model';
@@ -86,6 +87,23 @@ describe('AmazonBedrockProvider', () => {
   });
 
   describe('createAmazonBedrock', () => {
+    it('should resolve the AWS ISO partition endpoint', () => {
+      const liveAttempt = JSON.parse(
+        fs.readFileSync(
+          'src/__fixtures__/issue-11197-live-attempt.json',
+          'utf8',
+        ),
+      );
+      const provider = createAmazonBedrock({
+        region: liveAttempt.scenario.region,
+      });
+
+      provider(liveAttempt.scenario.modelId);
+
+      const constructorCall = BedrockChatLanguageModelMock.mock.calls[0];
+      expect(constructorCall[1].baseUrl()).toBe(liveAttempt.expectedBaseURL);
+    });
+
     it('should create a provider instance with default options', () => {
       const provider = createAmazonBedrock();
       const model = provider('anthropic.claude-v2');


### PR DESCRIPTION
## Bug

Bedrock client doesn't support alternate URLs for non-standard AWS Regions.

## Reproduction

- On `release-v6.0`, `packages/amazon-bedrock/src/bedrock-provider.ts` hard-codes `amazonaws.com`; `us-iso-east-1` therefore resolves to `bedrock-runtime.us-iso-east-1.amazonaws.com` instead of AWS's `bedrock-runtime.us-iso-east-1.c2s.ic.gov` endpoint.
- `examples/ai-functions/src/reproduction/issue-11197-bedrock-nonstandard-region.ts` reproduced the invalid ISO endpoint, showed that `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` is ignored, and showed that one `baseURL` routes both Runtime and Agent Runtime operations to the same host.
- `packages/amazon-bedrock/src/bedrock-provider.test.ts` contains a focused regression test that expects the ISO endpoint and receives the hard-coded `amazonaws.com` endpoint.
- `packages/amazon-bedrock/src/__fixtures__/issue-11197-live-attempt.json` records the live attempt's selected URL; the sandbox canceled the network request after the invalid URL had been selected, so no AWS service response was available.
- The package exposes Bedrock Runtime and Agent Runtime operations but not Bedrock control-plane operations, so the comment's exact control-plane-versus-Runtime pair could not be exercised; the analogous shared-`baseURL` conflict was observed between Runtime and Agent Runtime.

## Relevant Documentation

- https://github.com/aws/aws-sdk-js-v3/blob/a0bd362cca53a59918a8b55ed12dcda421edc9b5/codegen/sdk-codegen/aws-models/bedrock-runtime.json
- https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html
- https://docs.aws.amazon.com/sdkref/latest/guide/ss-endpoints-table.html
- https://docs.aws.amazon.com/general/latest/gr/bedrock.html

## Related Issues

Reproduces #11197