### PR TITLE
[v6.0] fix: server-response piping errors bypass caller catches

### DIFF
--- a/.changeset/tidy-bags-report.md
+++ b/.changeset/tidy-bags-report.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Return response piping promises so callers can catch stream read and write errors.

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -3511,7 +3511,7 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'pipeUIMessageStreamToResponse',
-      type: '(response: ServerResponse, options?: ResponseInit & UIMessageStreamOptions) => void',
+      type: '(response: ServerResponse, options?: ResponseInit & UIMessageStreamOptions) => Promise<void>',
       description:
         'Writes UI message stream output to a Node.js response-like object.',
       properties: [
@@ -3542,7 +3542,7 @@ To see `streamText` in action, check out [these examples](#examples).
     },
     {
       name: 'pipeTextStreamToResponse',
-      type: '(response: ServerResponse, init?: ResponseInit) => void',
+      type: '(response: ServerResponse, init?: ResponseInit) => Promise<void>',
       description:
         'Writes text delta output to a Node.js response-like object. It sets a `Content-Type` header to `text/plain; charset=utf-8` and writes each text delta as a separate chunk.',
       properties: [

--- a/content/docs/07-reference/02-ai-sdk-ui/42-pipe-ui-message-stream-to-response.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/42-pipe-ui-message-stream-to-response.mdx
@@ -17,7 +17,7 @@ The `pipeUIMessageStreamToResponse` function pipes streaming data to a Node.js S
 ## Example
 
 ```tsx
-pipeUIMessageStreamToResponse({
+await pipeUIMessageStreamToResponse({
   response: serverResponse,
   status: 200,
   statusText: 'OK',
@@ -75,3 +75,8 @@ pipeUIMessageStreamToResponse({
     },
   ]}
 />
+
+### Returns
+
+A `Promise<void>` that resolves when the stream has been written to the response
+and rejects when reading or writing the stream fails.

--- a/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
+++ b/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
@@ -56,7 +56,7 @@ export async function pipeAgentUIStreamToResponse<
   UIMessageStreamOptions<
     UIMessage<MESSAGE_METADATA, never, InferUITools<TOOLS>>
   >): Promise<void> {
-  pipeUIMessageStreamToResponse({
+  return pipeUIMessageStreamToResponse({
     response,
     headers,
     status,

--- a/packages/ai/src/generate-object/stream-object-result.ts
+++ b/packages/ai/src/generate-object/stream-object-result.ts
@@ -85,7 +85,10 @@ export interface StreamObjectResult<PARTIAL, RESULT, ELEMENT_STREAM> {
    * @param response A Node.js response-like object (ServerResponse).
    * @param init Optional headers, status code, and status text.
    */
-  pipeTextStreamToResponse(response: ServerResponse, init?: ResponseInit): void;
+  pipeTextStreamToResponse(
+    response: ServerResponse,
+    init?: ResponseInit,
+  ): Promise<void>;
 
   /**
    * Creates a simple text stream response.

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -954,7 +954,7 @@ class DefaultStreamObjectResult<
   }
 
   pipeTextStreamToResponse(response: ServerResponse, init?: ResponseInit) {
-    pipeTextStreamToResponse({
+    return pipeTextStreamToResponse({
       response,
       textStream: this.textStream,
       ...init,

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -342,7 +342,7 @@ export interface StreamTextResult<
   pipeUIMessageStreamToResponse<UI_MESSAGE extends UIMessage>(
     response: ServerResponse,
     options?: UIMessageStreamResponseInit & UIMessageStreamOptions<UI_MESSAGE>,
-  ): void;
+  ): Promise<void>;
 
   /**
    * Writes text delta output to a Node.js response-like object.
@@ -352,7 +352,10 @@ export interface StreamTextResult<
    * @param response A Node.js response-like object (ServerResponse).
    * @param init Optional headers, status code, and status text.
    */
-  pipeTextStreamToResponse(response: ServerResponse, init?: ResponseInit): void;
+  pipeTextStreamToResponse(
+    response: ServerResponse,
+    init?: ResponseInit,
+  ): Promise<void>;
 
   /**
    * Converts the result to a streamed response object with a stream data part stream.

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2914,7 +2914,7 @@ class DefaultStreamTextResult<
       ...init
     }: UIMessageStreamResponseInit & UIMessageStreamOptions<UI_MESSAGE> = {},
   ) {
-    pipeUIMessageStreamToResponse({
+    return pipeUIMessageStreamToResponse({
       response,
       stream: this.toUIMessageStream({
         originalMessages,
@@ -2932,7 +2932,7 @@ class DefaultStreamTextResult<
   }
 
   pipeTextStreamToResponse(response: ServerResponse, init?: ResponseInit) {
-    pipeTextStreamToResponse({
+    return pipeTextStreamToResponse({
       response,
       textStream: this.textStream,
       ...init,

--- a/packages/ai/src/text-stream/pipe-text-stream-to-response.test.ts
+++ b/packages/ai/src/text-stream/pipe-text-stream-to-response.test.ts
@@ -35,31 +35,6 @@ describe('pipeTextStreamToResponse', () => {
     // Verify written data using decoded chunks
     expect(mockResponse.getDecodedChunks()).toStrictEqual(['test-data']);
   });
-<<<<<<< HEAD
-=======
-
-  it('can pipe a stream created by toTextStream', async () => {
-    const mockResponse = createMockServerResponse();
-
-    pipeTextStreamToResponse({
-      response: mockResponse,
-      stream: toTextStream({
-        stream: convertArrayToReadableStream([
-          { type: 'start' },
-          { type: 'text-delta', id: 't1', text: 'Hello' },
-          { type: 'text-delta', id: 't1', text: ', world!' },
-          { type: 'text-end', id: 't1' },
-        ] satisfies TextStreamPart<{}>[]),
-      }),
-    });
-
-    await mockResponse.waitForEnd();
-
-    expect(mockResponse.getDecodedChunks()).toStrictEqual([
-      'Hello',
-      ', world!',
-    ]);
-  });
 
   it('should reject when reading the stream fails', async () => {
     const mockResponse = createMockServerResponse();
@@ -73,9 +48,8 @@ describe('pipeTextStreamToResponse', () => {
     await expect(
       pipeTextStreamToResponse({
         response: mockResponse,
-        stream,
+        textStream: stream,
       }),
     ).rejects.toBe(error);
   });
->>>>>>> 7f6650b0ea (fix: server-response piping errors bypass caller catches (#17648))
 });

--- a/packages/ai/src/text-stream/pipe-text-stream-to-response.test.ts
+++ b/packages/ai/src/text-stream/pipe-text-stream-to-response.test.ts
@@ -35,4 +35,47 @@ describe('pipeTextStreamToResponse', () => {
     // Verify written data using decoded chunks
     expect(mockResponse.getDecodedChunks()).toStrictEqual(['test-data']);
   });
+<<<<<<< HEAD
+=======
+
+  it('can pipe a stream created by toTextStream', async () => {
+    const mockResponse = createMockServerResponse();
+
+    pipeTextStreamToResponse({
+      response: mockResponse,
+      stream: toTextStream({
+        stream: convertArrayToReadableStream([
+          { type: 'start' },
+          { type: 'text-delta', id: 't1', text: 'Hello' },
+          { type: 'text-delta', id: 't1', text: ', world!' },
+          { type: 'text-end', id: 't1' },
+        ] satisfies TextStreamPart<{}>[]),
+      }),
+    });
+
+    await mockResponse.waitForEnd();
+
+    expect(mockResponse.getDecodedChunks()).toStrictEqual([
+      'Hello',
+      ', world!',
+    ]);
+  });
+
+  it('should reject when reading the stream fails', async () => {
+    const mockResponse = createMockServerResponse();
+    const error = new Error('stream read failed');
+    const stream = new ReadableStream<string>({
+      pull() {
+        throw error;
+      },
+    });
+
+    await expect(
+      pipeTextStreamToResponse({
+        response: mockResponse,
+        stream,
+      }),
+    ).rejects.toBe(error);
+  });
+>>>>>>> 7f6650b0ea (fix: server-response piping errors bypass caller catches (#17648))
 });

--- a/packages/ai/src/text-stream/pipe-text-stream-to-response.ts
+++ b/packages/ai/src/text-stream/pipe-text-stream-to-response.ts
@@ -12,12 +12,8 @@ import { writeToServerResponse } from '../util/write-to-server-response';
  * @param options.status - Optional HTTP status code.
  * @param options.statusText - Optional HTTP status text.
  * @param options.headers - Optional response headers.
-<<<<<<< HEAD
  * @param options.textStream - The text stream to pipe.
-=======
- * @param options.stream - The text stream to pipe.
  * @returns A promise that resolves when the stream has been written.
->>>>>>> 7f6650b0ea (fix: server-response piping errors bypass caller catches (#17648))
  */
 export function pipeTextStreamToResponse({
   response,
@@ -27,15 +23,9 @@ export function pipeTextStreamToResponse({
   textStream,
 }: {
   response: ServerResponse;
-<<<<<<< HEAD
   textStream: ReadableStream<string>;
-} & ResponseInit): void {
-  writeToServerResponse({
-=======
-  stream: ReadableStream<string>;
 } & ResponseInit): Promise<void> {
   return writeToServerResponse({
->>>>>>> 7f6650b0ea (fix: server-response piping errors bypass caller catches (#17648))
     response,
     status,
     statusText,

--- a/packages/ai/src/text-stream/pipe-text-stream-to-response.ts
+++ b/packages/ai/src/text-stream/pipe-text-stream-to-response.ts
@@ -12,7 +12,12 @@ import { writeToServerResponse } from '../util/write-to-server-response';
  * @param options.status - Optional HTTP status code.
  * @param options.statusText - Optional HTTP status text.
  * @param options.headers - Optional response headers.
+<<<<<<< HEAD
  * @param options.textStream - The text stream to pipe.
+=======
+ * @param options.stream - The text stream to pipe.
+ * @returns A promise that resolves when the stream has been written.
+>>>>>>> 7f6650b0ea (fix: server-response piping errors bypass caller catches (#17648))
  */
 export function pipeTextStreamToResponse({
   response,
@@ -22,9 +27,15 @@ export function pipeTextStreamToResponse({
   textStream,
 }: {
   response: ServerResponse;
+<<<<<<< HEAD
   textStream: ReadableStream<string>;
 } & ResponseInit): void {
   writeToServerResponse({
+=======
+  stream: ReadableStream<string>;
+} & ResponseInit): Promise<void> {
+  return writeToServerResponse({
+>>>>>>> 7f6650b0ea (fix: server-response piping errors bypass caller catches (#17648))
     response,
     status,
     statusText,

--- a/packages/ai/src/ui-message-stream/pipe-ui-message-stream-to-response.ts
+++ b/packages/ai/src/ui-message-stream/pipe-ui-message-stream-to-response.ts
@@ -16,6 +16,7 @@ import type { UIMessageStreamResponseInit } from './ui-message-stream-response-i
  * @param options.headers - Additional HTTP headers to include in the response.
  * @param options.stream - The UI message chunk stream to send.
  * @param options.consumeSseStream - Optional callback to consume a copy of the SSE stream independently.
+ * @returns A promise that resolves when the stream has been written.
  */
 export function pipeUIMessageStreamToResponse({
   response,
@@ -27,7 +28,7 @@ export function pipeUIMessageStreamToResponse({
 }: {
   response: ServerResponse;
   stream: ReadableStream<UIMessageChunk>;
-} & UIMessageStreamResponseInit): void {
+} & UIMessageStreamResponseInit): Promise<void> {
   let sseStream = stream.pipeThrough(new JsonToSseTransformStream());
 
   // when the consumeSseStream is provided, we need to tee the stream
@@ -39,7 +40,7 @@ export function pipeUIMessageStreamToResponse({
     consumeSseStream({ stream: stream2 }); // no await (do not block the response)
   }
 
-  writeToServerResponse({
+  return writeToServerResponse({
     response,
     status,
     statusText,

--- a/packages/ai/src/util/write-to-server-response.test.ts
+++ b/packages/ai/src/util/write-to-server-response.test.ts
@@ -32,16 +32,6 @@ describe('writeToServerResponse', () => {
     expect(mockResponse.ended).toBe(true);
   });
 
-<<<<<<< HEAD
-  it('should respect backpressure and wait for drain event', async () => {
-    const mockResponse = createBackpressureMockResponse();
-    let drainEventCount = 0;
-    let readyToEnqueue: ((value: unknown) => void) | null = null;
-
-    // Track drain events
-    mockResponse.on('drain', () => {
-      drainEventCount++;
-=======
   it('should reject when reading the stream fails', async () => {
     const mockResponse = createMockServerResponse();
     const error = new Error('stream read failed');
@@ -61,10 +51,14 @@ describe('writeToServerResponse', () => {
     expect(mockResponse.ended).toBe(true);
   });
 
-  describe('backpressure handling', () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
->>>>>>> 7f6650b0ea (fix: server-response piping errors bypass caller catches (#17648))
+  it('should respect backpressure and wait for drain event', async () => {
+    const mockResponse = createBackpressureMockResponse();
+    let drainEventCount = 0;
+    let readyToEnqueue: ((value: unknown) => void) | null = null;
+
+    // Track drain events
+    mockResponse.on('drain', () => {
+      drainEventCount++;
     });
 
     // Create stream that provides chunks on-demand (async)

--- a/packages/ai/src/util/write-to-server-response.test.ts
+++ b/packages/ai/src/util/write-to-server-response.test.ts
@@ -32,6 +32,7 @@ describe('writeToServerResponse', () => {
     expect(mockResponse.ended).toBe(true);
   });
 
+<<<<<<< HEAD
   it('should respect backpressure and wait for drain event', async () => {
     const mockResponse = createBackpressureMockResponse();
     let drainEventCount = 0;
@@ -40,6 +41,30 @@ describe('writeToServerResponse', () => {
     // Track drain events
     mockResponse.on('drain', () => {
       drainEventCount++;
+=======
+  it('should reject when reading the stream fails', async () => {
+    const mockResponse = createMockServerResponse();
+    const error = new Error('stream read failed');
+    const stream = new ReadableStream<Uint8Array>({
+      pull() {
+        throw error;
+      },
+    });
+
+    await expect(
+      writeToServerResponse({
+        response: mockResponse,
+        stream,
+      }),
+    ).rejects.toBe(error);
+
+    expect(mockResponse.ended).toBe(true);
+  });
+
+  describe('backpressure handling', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+>>>>>>> 7f6650b0ea (fix: server-response piping errors bypass caller catches (#17648))
     });
 
     // Create stream that provides chunks on-demand (async)

--- a/packages/ai/src/util/write-to-server-response.ts
+++ b/packages/ai/src/util/write-to-server-response.ts
@@ -15,7 +15,7 @@ export function writeToServerResponse({
   statusText?: string;
   headers?: Record<string, string | number | string[]>;
   stream: ReadableStream<Uint8Array>;
-}): void {
+}): Promise<void> {
   const statusCode = status ?? 200;
   if (statusText !== undefined) {
     response.writeHead(statusCode, statusText, headers);
@@ -45,5 +45,5 @@ export function writeToServerResponse({
     }
   };
 
-  read();
+  return read();
 }


### PR DESCRIPTION
## Background

Awaited server-response piping calls could bypass caller error handling and emit stream-read failures as unhandled promise rejections.

## Root Cause

The asynchronous read loop in writeToServerResponse was invoked without returning its promise, and every public piping wrapper discarded that operation. The reproduction confirmed the awaited helper returned before an InvalidResponseDataError surfaced as an unhandled rejection.

## Summary

Returned Promise<void> through server-response writing, text/UI piping helpers, result methods, and the agent wrapper; updated reference documentation and added an ai patch changeset.

## Testing

Added regression tests confirming internal and public text piping promises reject with stream-read errors while still ending the response.

## End-to-end Validation

- `pnpm -C examples/ai-functions exec tsx --eval "<stream-error reproduction>"` — the InvalidResponseDataError was caught by the caller with no unhandled rejection.

## Related Issues

Fixes #11023

Closes #17422

Backport of #17648

Co-authored-by: intellild <8379858+intellild@users.noreply.github.com>