### PR TITLE
feat(provider/google): forward speech language to Gemini TTS

### DIFF
--- a/.changeset/tidy-languages-speak.md
+++ b/.changeset/tidy-languages-speak.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(provider/google): forward speech language to Gemini TTS

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -2018,6 +2018,9 @@ By default the generated audio is returned as a playable WAV file (`result.audio
 `audio/wav`). Set `outputFormat: 'pcm'` to receive the raw signed 16-bit little-endian mono PCM
 bytes instead; the sample rate is reported in `result.providerMetadata.google.sampleRate`.
 
+Set `language` to a supported BCP-47 language code, such as `en-US`. The provider forwards it as
+`speechConfig.languageCode`. When omitted, Gemini detects the language from the input text.
+
 Gemini honors natural-language style direction. The `instructions` argument is prepended to the
 spoken text, so `instructions: 'Say cheerfully'` with `text: 'Hello'` speaks `Say cheerfully: Hello`.
 
@@ -2053,9 +2056,8 @@ const result = await generateSpeech({
 ```
 
 <Note>
-  Gemini TTS models do not support the `speed` or `language` options; passing
-  them adds a warning to `result.warnings`. Language is detected automatically
-  from the input text.
+  Gemini TTS models do not support the `speed` option; passing it adds a warning
+  to `result.warnings`.
 </Note>
 
 ### Model Capabilities

--- a/packages/google/src/google-speech-model.test.ts
+++ b/packages/google/src/google-speech-model.test.ts
@@ -153,7 +153,7 @@ describe('doGenerate', () => {
     );
   });
 
-  it('should warn for unsupported speed and language options', async () => {
+  it('should warn for the unsupported speed option', async () => {
     prepareJsonResponse();
 
     const result = await model.doGenerate({
@@ -165,9 +165,27 @@ describe('doGenerate', () => {
     expect(result.warnings).toContainEqual(
       expect.objectContaining({ type: 'unsupported', feature: 'speed' }),
     );
-    expect(result.warnings).toContainEqual(
+    expect(result.warnings).not.toContainEqual(
       expect.objectContaining({ type: 'unsupported', feature: 'language' }),
     );
+  });
+
+  it('should map language onto single-speaker speechConfig', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      language: 'en-US',
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      generationConfig: {
+        speechConfig: {
+          languageCode: 'en-US',
+          voiceConfig: { prebuiltVoiceConfig: { voiceName: 'Kore' } },
+        },
+      },
+    });
   });
 
   it('should prepend instructions to the prompt text', async () => {
@@ -203,6 +221,7 @@ describe('doGenerate', () => {
 
     await model.doGenerate({
       text: 'Joe: Hi. Jane: Hello.',
+      language: 'en-US',
       providerOptions: { google: { multiSpeakerVoiceConfig } },
     });
 
@@ -211,7 +230,10 @@ describe('doGenerate', () => {
       contents: [{ role: 'user', parts: [{ text: 'Joe: Hi. Jane: Hello.' }] }],
       generationConfig: {
         responseModalities: ['AUDIO'],
-        speechConfig: { multiSpeakerVoiceConfig },
+        speechConfig: {
+          languageCode: 'en-US',
+          multiSpeakerVoiceConfig,
+        },
       },
     });
   });

--- a/packages/google/src/google-speech-model.ts
+++ b/packages/google/src/google-speech-model.ts
@@ -104,8 +104,14 @@ export class GoogleSpeechModel implements SpeechModelV4 {
     // Multi-speaker (provider option) takes precedence over the single voice.
     const multiSpeakerVoiceConfig = googleOptions?.multiSpeakerVoiceConfig;
     const speechConfig = multiSpeakerVoiceConfig
-      ? { multiSpeakerVoiceConfig }
-      : { voiceConfig: { prebuiltVoiceConfig: { voiceName: voice } } };
+      ? {
+          multiSpeakerVoiceConfig,
+          ...(language != null && { languageCode: language }),
+        }
+      : {
+          voiceConfig: { prebuiltVoiceConfig: { voiceName: voice } },
+          ...(language != null && { languageCode: language }),
+        };
 
     // Gemini honors natural-language style direction expressed in the prompt
     // text, so map `instructions` onto the spoken content. With multi-speaker
@@ -132,16 +138,6 @@ export class GoogleSpeechModel implements SpeechModelV4 {
         feature: 'speed',
         details:
           'Google Gemini TTS models do not support the `speed` option. It was ignored.',
-      });
-    }
-
-    if (language != null) {
-      warnings.push({
-        type: 'unsupported',
-        feature: 'language',
-        details:
-          'Google Gemini TTS models do not support the `language` option. ' +
-          'Language is detected automatically from the input text.',
       });
     }
 


### PR DESCRIPTION
## Background

The AI SDK speech API accepts a `language` option, and Gemini GenerateContent exposes the matching `speechConfig.languageCode` field. The Google provider currently reports `language` as unsupported and drops it.

Google's current API reference documents `SpeechConfig.languageCode`; the Gemini TTS guide lists the supported language codes.

## Summary

- forward `language` as `generationConfig.speechConfig.languageCode`
- preserve it for both single-speaker and multi-speaker requests
- stop emitting the unsupported-language warning while retaining the unsupported-speed warning
- update the Google provider docs and add a patch changeset

## End-to-End Verification

The generated REST body was verified against Google's current GenerateContent `SpeechConfig` contract. A live provider call was not run because this environment does not have a Gemini API credential.

Repository verification:
- `pnpm exec turbo build --filter=@ai-sdk/google...`
- `pnpm --filter @ai-sdk/google test` — 24 files / 694 tests in Node and 24 files / 694 tests in Edge
- `pnpm --filter @ai-sdk/google type-check`
- targeted oxfmt and oxlint checks

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Gateway-side Gemini TTS metering and catalog rollout are being split into separate PRs.
