### PR TITLE
fix(provider/google): preserve Gemini Live lifecycle events

### DIFF
--- a/.changeset/gentle-lifecycles-signal.md
+++ b/.changeset/gentle-lifecycles-signal.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(provider/google): preserve Gemini Live lifecycle events

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -1079,6 +1079,11 @@ Google realtime models may require provider-specific audio formats, depending
 on the model and modality. See [Realtime](/docs/ai-sdk-core/realtime) for the
 complete setup and tool calling pattern.
 
+Gemini lifecycle signals that do not have provider-neutral equivalents are
+emitted as custom events. Inspect `rawType` for `goAway`,
+`sessionResumptionUpdate`, and `generationComplete` and use the event's `raw`
+payload for provider-specific details.
+
 ### Live Translation
 
 Use `gemini-3.5-live-translate-preview` for low-latency speech-to-speech

--- a/packages/google/src/realtime/google-realtime-event-mapper.test.ts
+++ b/packages/google/src/realtime/google-realtime-event-mapper.test.ts
@@ -344,6 +344,55 @@ describe('GoogleRealtimeEventMapper', () => {
       });
     });
 
+    it('maps goAway to a stable custom lifecycle event', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+      const raw = { goAway: { timeLeft: '30s' } };
+
+      expect(mapper.parseServerEvent(raw)).toEqual({
+        type: 'custom',
+        rawType: 'goAway',
+        raw,
+      });
+    });
+
+    it('maps sessionResumptionUpdate to a stable custom lifecycle event', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+      const raw = {
+        sessionResumptionUpdate: {
+          newHandle: 'resume-handle',
+          resumable: true,
+          lastConsumedClientMessageIndex: '42',
+        },
+      };
+
+      expect(mapper.parseServerEvent(raw)).toEqual({
+        type: 'custom',
+        rawType: 'sessionResumptionUpdate',
+        raw,
+      });
+    });
+
+    it('keeps generationComplete distinct from turnComplete', () => {
+      const mapper = new GoogleRealtimeEventMapper();
+      const raw = { serverContent: { generationComplete: true } };
+
+      expect(mapper.parseServerEvent(raw)).toEqual({
+        type: 'custom',
+        rawType: 'generationComplete',
+        raw,
+      });
+
+      const next = mapper.parseServerEvent({
+        serverContent: {
+          modelTurn: { parts: [{ text: 'still turn zero' }] },
+        },
+      });
+      expect(next).toMatchObject({
+        type: 'text-delta',
+        responseId: 'google-resp-0',
+      });
+    });
+
     it('maps unrecognized top-level key to custom event', () => {
       const mapper = new GoogleRealtimeEventMapper();
       const raw = { somethingNew: { data: 123 } };

--- a/packages/google/src/realtime/google-realtime-event-mapper.ts
+++ b/packages/google/src/realtime/google-realtime-event-mapper.ts
@@ -17,6 +17,7 @@ type GoogleRealtimeFunctionCall = {
 };
 
 type GoogleRealtimeServerContent = {
+  generationComplete?: boolean;
   interrupted?: boolean;
   modelTurn?: {
     parts?: Array<{
@@ -37,6 +38,12 @@ type GoogleRealtimeWireEvent = {
   toolCallCancellation?: unknown;
   serverContent?: GoogleRealtimeServerContent;
   inputTranscription?: { text?: string };
+  goAway?: { timeLeft?: string };
+  sessionResumptionUpdate?: {
+    newHandle?: string;
+    resumable?: boolean;
+    lastConsumedClientMessageIndex?: string;
+  };
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -127,6 +134,22 @@ export class GoogleRealtimeEventMapper {
       };
     }
 
+    if (data.goAway != null) {
+      return {
+        type: 'custom',
+        rawType: 'goAway',
+        raw,
+      };
+    }
+
+    if (data.sessionResumptionUpdate != null) {
+      return {
+        type: 'custom',
+        rawType: 'sessionResumptionUpdate',
+        raw,
+      };
+    }
+
     if (data.serverContent != null) {
       return this.parseServerContent(data.serverContent, raw);
     }
@@ -199,6 +222,17 @@ export class GoogleRealtimeEventMapper {
         type: 'input-transcription-completed',
         itemId: `google-input-${this.turnCounter}`,
         transcript: serverContent.inputTranscription.text,
+        raw,
+      });
+    }
+
+    // `generationComplete` means generation has stopped, but playback and the
+    // turn can remain open. Keep it distinct from `response-done`, which is
+    // emitted only when Google sends `turnComplete`.
+    if (serverContent.generationComplete) {
+      events.push({
+        type: 'custom',
+        rawType: 'generationComplete',
         raw,
       });
     }


### PR DESCRIPTION
## Background

Gemini Live emits lifecycle messages that do not have provider-neutral AI SDK equivalents. The Google mapper currently collapses nested `serverContent.generationComplete` into a generic `serverContent` custom event, while top-level `goAway` and `sessionResumptionUpdate` only survive through the generic unknown-event fallback.

Giving each signal a stable `rawType` lets callers react to graceful reconnect/resumption and distinguish generation completion from full turn completion without inventing provider-neutral semantics.

## Summary

- map `goAway` to a stable custom event
- map `sessionResumptionUpdate` to a stable custom event
- preserve `generationComplete` separately from `turnComplete`
- keep the active turn open until `turnComplete`
- document the provider-specific lifecycle surface
- add a patch changeset

This does not create or change the app-to-Gateway realtime protocol. `RealtimeModelV4` already defines the normalized event contract, and `gateway.experimental_realtime()` already transports it for GPT Realtime and Grok. This PR only makes Google-specific lifecycle information stable inside that existing custom-event extension point.

It also does not make SDK-projected usage billing-authoritative. Gateway continues to validate Google's raw modality usage before pricing it.

## End-to-End Verification

The event shapes were checked against Google's current Live API reference. A real `google/gemini-3.1-flash-live-preview` conversation has completed through the Gateway preview using the existing `RealtimeModelV4` contract, including audio/transcript deltas and `response-done`. That conversational smoke did not force `goAway` or session resumption, so a dedicated reconnect/resumption session is still required before relying operationally on those custom events.

Repository verification:

- `pnpm exec turbo build --filter=@ai-sdk/google...`
- `pnpm --filter @ai-sdk/google test` — 24 files / 696 tests in Node and 24 files / 696 tests in Edge
- `pnpm --filter @ai-sdk/google type-check`
- targeted oxfmt and oxlint checks
- full GitHub CI matrix passed

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- A reusable server-connection helper related to #16137 would be optional SDK ergonomics. It needs a current-main rebase and is not a new wire contract or a Gateway launch dependency.
- Run a dedicated live reconnect/resumption scenario to exercise `goAway` and `sessionResumptionUpdate` before depending on them operationally.