### PR TITLE
feat (ui): allow sendMessage to set the replacement message's id

### DIFF
--- a/.changeset/sendmessage-replacement-id.md
+++ b/.changeset/sendmessage-replacement-id.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat (ui): allow `sendMessage` to set the replacement message's `id` when `messageId` is provided. When editing a message, pass `id` to assign the new version its own id instead of reusing `messageId`; omitting `id` keeps the current replace-in-place behavior.

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -1441,6 +1441,93 @@ describe('Chat', () => {
     `);
   });
 
+  it('should assign the provided id to the replacement message', async () => {
+    server.urls['http://localhost:3000/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        formatChunk({ type: 'start' }),
+        formatChunk({ type: 'start-step' }),
+        formatChunk({ type: 'text-start', id: 'text-1' }),
+        formatChunk({ type: 'text-delta', id: 'text-1', delta: 'ok' }),
+        formatChunk({ type: 'text-end', id: 'text-1' }),
+        formatChunk({ type: 'finish-step' }),
+        formatChunk({ type: 'finish' }),
+      ],
+    };
+
+    const finishPromise = createResolvablePromise<void>();
+
+    const chat = new TestChat({
+      id: '123',
+      generateId: mockId({ prefix: 'newid' }),
+      transport: new DefaultChatTransport({
+        api: 'http://localhost:3000/api/chat',
+      }),
+      onFinish: () => finishPromise.resolve(),
+      messages: [
+        { id: 'id-0', role: 'user', parts: [{ text: 'Hi!', type: 'text' }] },
+        {
+          id: 'id-1',
+          role: 'assistant',
+          parts: [{ text: 'How can I help you?', type: 'text', state: 'done' }],
+        },
+      ],
+    });
+
+    chat.sendMessage({
+      id: 'id-0-v2',
+      text: 'Hello, world!',
+      messageId: 'id-0',
+    });
+
+    await finishPromise.promise;
+
+    expect(chat.messages[0].id).toBe('id-0-v2');
+    expect((await server.calls[0].requestBodyJson).messages[0].id).toBe(
+      'id-0-v2',
+    );
+  });
+
+  it('should keep the messageId when no id is provided (default replacement)', async () => {
+    server.urls['http://localhost:3000/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        formatChunk({ type: 'start' }),
+        formatChunk({ type: 'start-step' }),
+        formatChunk({ type: 'text-start', id: 'text-1' }),
+        formatChunk({ type: 'text-delta', id: 'text-1', delta: 'ok' }),
+        formatChunk({ type: 'text-end', id: 'text-1' }),
+        formatChunk({ type: 'finish-step' }),
+        formatChunk({ type: 'finish' }),
+      ],
+    };
+
+    const finishPromise = createResolvablePromise<void>();
+
+    const chat = new TestChat({
+      id: '123',
+      generateId: mockId({ prefix: 'newid' }),
+      transport: new DefaultChatTransport({
+        api: 'http://localhost:3000/api/chat',
+      }),
+      onFinish: () => finishPromise.resolve(),
+      messages: [
+        { id: 'id-0', role: 'user', parts: [{ text: 'Hi!', type: 'text' }] },
+        {
+          id: 'id-1',
+          role: 'assistant',
+          parts: [{ text: 'How can I help you?', type: 'text', state: 'done' }],
+        },
+      ],
+    });
+
+    chat.sendMessage({ text: 'Hello, world!', messageId: 'id-0' });
+
+    await finishPromise.promise;
+
+    expect(chat.messages[0].id).toBe('id-0');
+  });
+
   it('should handle error parts', async () => {
     server.urls['http://localhost:3000/api/chat'].response = {
       type: 'stream-chunks',

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -329,7 +329,8 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
    * Appends or replaces a user message to the chat list. This triggers the API call to fetch
    * the assistant's response.
    *
-   * If a messageId is provided, the message will be replaced.
+   * If a messageId is provided, the message will be replaced. The replacement
+   * keeps `messageId` as its id unless the message specifies its own `id`.
    */
   sendMessage = async (
     message?:
@@ -339,6 +340,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
           messageId?: string;
         })
       | {
+          id?: string;
           text: string;
           files?: FileList | FileUIPart[];
           metadata?: InferUIMessageMetadata<UI_MESSAGE>;
@@ -346,6 +348,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
           messageId?: string;
         }
       | {
+          id?: string;
           files: FileList | FileUIPart[];
           metadata?: InferUIMessageMetadata<UI_MESSAGE>;
           parts?: never;
@@ -370,6 +373,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
         : await convertFileListToFileUIParts(message.files);
 
       uiMessage = {
+        id: message.id,
         parts: [
           ...fileParts,
           ...('text' in message && message.text != null
@@ -402,7 +406,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       // update the message with the new content
       this.state.replaceMessage(messageIndex, {
         ...uiMessage,
-        id: message.messageId,
+        id: uiMessage.id ?? message.messageId,
         role: uiMessage.role ?? 'user',
         metadata: message.metadata,
       } as UI_MESSAGE);


### PR DESCRIPTION
Closes #17661

## Background

`sendMessage({ messageId })` (from #6775) replaces a user message, but always forces the replacement to reuse `messageId` as its id. The append path already honors a caller-supplied `id`; the replace path is the only place it's overridden.

## Summary

Honor a caller-supplied `id` on the replacement message. Omitting `id` keeps the current replace-in-place behavior.

- `id?: string` added to the `text`/`files` `sendMessage` variants
- the built `uiMessage` carries `id: message.id`
- the replace branch uses `id: uiMessage.id ?? message.messageId`

## Why

Enables client-owned message versioning/branching (#2251, #2929): the edited turn gets its own id, so the client transcript and a server-persisted sibling stay in sync from the first edit — no stale-id remapping.

## Verification

Two tests added to `chat.test.ts`: replacement honors a provided `id`; default (no `id`) still replaces under `messageId`. Full `chat.test.ts` passes (30/30).

## Note

Observable edge: for the full-message variant, `{ id, messageId }` previously had `id` silently overridden to `messageId`; now `id` wins. That's the intent of the change.
