### PR TITLE
docs: add TrustedRouter OpenAI compatible provider page

### DIFF
--- a/content/providers/04-openai-compatible-providers/55-trustedrouter.mdx
+++ b/content/providers/04-openai-compatible-providers/55-trustedrouter.mdx
@@ -1,0 +1,73 @@
+---
+title: TrustedRouter
+description: Use the TrustedRouter OpenAI compatible API with the AI SDK.
+---
+
+# TrustedRouter Provider
+
+[TrustedRouter](https://trustedrouter.com/) is an OpenAI-compatible LLM router
+that serves many models behind one endpoint through an open-source, verifiable
+attested gateway. It does not log prompts or outputs by default, which makes it
+a fit for privacy-sensitive workloads.
+
+## Setup
+
+The TrustedRouter provider is available via the `@ai-sdk/openai-compatible`
+module as it is compatible with the OpenAI API. You can install it with:
+
+<InstallPackages packages="@ai-sdk/openai-compatible" />
+
+## Provider Instance
+
+To use TrustedRouter, you can create a custom provider instance with the
+`createOpenAICompatible` function from `@ai-sdk/openai-compatible`:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+
+const trustedRouter = createOpenAICompatible({
+  name: 'trustedrouter',
+  apiKey: process.env.TRUSTEDROUTER_API_KEY,
+  baseURL: 'https://api.trustedrouter.com/v1',
+});
+```
+
+You can obtain an API key from the [TrustedRouter site](https://trustedrouter.com/).
+
+## Language Models
+
+You can create models using a provider instance. The first argument is the
+model id, e.g. `trustedrouter/zdr`:
+
+```ts
+const model = trustedRouter('trustedrouter/zdr');
+```
+
+Routing model ids include `trustedrouter/auto`, `trustedrouter/zdr` (zero data
+retention), and `trustedrouter/confidential`, plus individually addressable
+models. The live catalog is served at `https://trustedrouter.com/v1/models`.
+
+### Example
+
+You can use TrustedRouter language models to generate text with the
+`generateText` function:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { generateText } from 'ai';
+
+const trustedRouter = createOpenAICompatible({
+  name: 'trustedrouter',
+  apiKey: process.env.TRUSTEDROUTER_API_KEY,
+  baseURL: 'https://api.trustedrouter.com/v1',
+});
+
+const { text } = await generateText({
+  model: trustedRouter('trustedrouter/zdr'),
+  prompt: 'Write a vegetarian lasagna recipe for 4 people.',
+});
+
+console.log(text);
+```
+
+TrustedRouter language models can also be used in the `streamText` function.

--- a/content/providers/04-openai-compatible-providers/index.mdx
+++ b/content/providers/04-openai-compatible-providers/index.mdx
@@ -16,6 +16,7 @@ We provide detailed documentation for the following OpenAI compatible providers:
 - [Heroku](/providers/openai-compatible-providers/heroku)
 - [Clarifai](/providers/openai-compatible-providers/clarifai)
 - [NEAR AI Cloud](/providers/openai-compatible-providers/nearai)
+- [TrustedRouter](/providers/openai-compatible-providers/trustedrouter)
 
 The general setup and provider instance creation is the same for all of these providers.
 


### PR DESCRIPTION
## Background

TrustedRouter is an OpenAI-compatible LLM router. Users can already reach it through `@ai-sdk/openai-compatible`, but there is no provider page documenting the setup.

## Summary

Adds `content/providers/04-openai-compatible-providers/55-trustedrouter.mdx` following the structure of the existing Heroku/Clarifai/NEAR AI pages (provider instance via `createOpenAICompatible`, model creation, a `generateText` example), and lists it in the section index.

Docs-only change; no package code touched.

## Checklist

- [x] Documentation added/updated
- [ ] Tests added (docs-only)