### PR TITLE
chore: split konsistent convention for model class export and model options file into separate conventions

### DIFF
--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -99,6 +99,18 @@
         },
         {
           "use": "aisdk/provider-model-file-must-export-model-class",
+          "excludeFiles": ["${providerId}-video-model.ts"]
+        },
+        {
+          "use": "aisdk/provider-model-file-with-subtype-must-export-model-class",
+          "excludeFiles": [
+            "packages/deepinfra/src/deepinfra-chat-language-model.ts",
+            "packages/moonshotai/src/moonshotai-chat-language-model.ts"
+          ]
+        },
+        "aisdk/provider-video-model-file-must-export-model-class",
+        {
+          "use": "aisdk/provider-model-file-must-have-matching-model-options-file",
           "excludeFiles": [
             "${providerId}-video-model.ts",
             "packages/gateway/src/gateway-embedding-model.ts",
@@ -111,14 +123,14 @@
           ]
         },
         {
-          "use": "aisdk/provider-model-file-with-subtype-must-export-model-class",
+          "use": "aisdk/provider-model-file-with-subtype-must-have-matching-model-options-file",
           "excludeFiles": [
             "packages/deepinfra/src/deepinfra-chat-language-model.ts",
             "packages/moonshotai/src/moonshotai-chat-language-model.ts"
           ]
         },
         {
-          "use": "aisdk/provider-video-model-file-must-export-model-class",
+          "use": "aisdk/provider-video-model-file-must-have-matching-model-options-file",
           "excludeFiles": ["packages/gateway/src/gateway-video-model.ts"]
         },
         "aisdk/provider-language-model-file-must-import-workflow-serialization",

--- a/tools/konsistent-provider/konsistent.json
+++ b/tools/konsistent-provider/konsistent.json
@@ -30,6 +30,12 @@
         },
         "aisdk/provider-model-file-with-subtype-must-export-model-class",
         "aisdk/provider-video-model-file-must-export-model-class",
+        {
+          "use": "aisdk/provider-model-file-must-have-matching-model-options-file",
+          "excludeFiles": ["${providerId}-video-model.ts"]
+        },
+        "aisdk/provider-model-file-with-subtype-must-have-matching-model-options-file",
+        "aisdk/provider-video-model-file-must-have-matching-model-options-file",
         "aisdk/provider-language-model-file-must-import-workflow-serialization",
         "aisdk/provider-model-options-file-must-export-model-options-type",
         "aisdk/provider-model-options-file-with-subtype-must-export-model-options-type"

--- a/tools/konsistent-provider/src/index.ts
+++ b/tools/konsistent-provider/src/index.ts
@@ -139,8 +139,7 @@ export const conventions = defineConventions([
   },
   {
     name: 'provider-model-file-must-export-model-class',
-    description:
-      "Every provider's model file must export a model class and a model options type.",
+    description: "Every provider's model file must export a model class.",
     for: {
       files: [
         '${providerId}-{modelKind:segments(1)}-model.ts',
@@ -160,13 +159,26 @@ export const conventions = defineConventions([
           implement: ['${modelKind.toPascalCase()}ModelV4'],
         },
       ],
+    },
+  },
+  {
+    name: 'provider-model-file-must-have-matching-model-options-file',
+    description:
+      "Every provider's model file must have a matching model options file.",
+    for: {
+      files: [
+        '${providerId}-{modelKind:segments(1)}-model.ts',
+        '*/${providerId}-{modelKind:segments(1)}-model.ts',
+      ],
+    },
+    must: {
       haveFiles: ['${providerId}-${modelKind}-model-options.ts'],
     },
   },
   {
     name: 'provider-model-file-with-subtype-must-export-model-class',
     description:
-      "Every provider's model file with a specific subtype (e.g. chat, responses) must export a model class and a model options type.",
+      "Every provider's model file with a specific subtype (e.g. chat, responses) must export a model class.",
     for: {
       files: [
         '${providerId}-{modelKind:segments(2)}-model.ts',
@@ -186,13 +198,26 @@ export const conventions = defineConventions([
           implement: ['${modelKind.toNthSegmentPascalCase(1)}ModelV4'],
         },
       ],
+    },
+  },
+  {
+    name: 'provider-model-file-with-subtype-must-have-matching-model-options-file',
+    description:
+      "Every provider's model file with a specific subtype (e.g. chat, responses) must have a matching model options file.",
+    for: {
+      files: [
+        '${providerId}-{modelKind:segments(2)}-model.ts',
+        '*/${providerId}-{modelKind:segments(2)}-model.ts',
+      ],
+    },
+    must: {
       haveFiles: ['${providerId}-${modelKind}-model-options.ts'],
     },
   },
   {
     name: 'provider-video-model-file-must-export-model-class',
     description:
-      "Every provider's video model file must export a model class and a model options type (separated only because VideoModelV4 type is experimental).",
+      "Every provider's video model file must export a model class (separated only because VideoModelV4 type is experimental).",
     for: {
       files: ['${providerId}-video-model.ts', '*/${providerId}-video-model.ts'],
     },
@@ -209,6 +234,16 @@ export const conventions = defineConventions([
           implement: ['Experimental_VideoModelV4'],
         },
       ],
+    },
+  },
+  {
+    name: 'provider-video-model-file-must-have-matching-model-options-file',
+    description:
+      "Every provider's video model file must have a matching model options file (separated only because VideoModelV4 type is experimental).",
+    for: {
+      files: ['${providerId}-video-model.ts', '*/${providerId}-video-model.ts'],
+    },
+    must: {
       haveFiles: ['${providerId}-video-model-options.ts'],
     },
   },


### PR DESCRIPTION
## Background

See #14859: the remaining item was the lack of `providerOptions` type definitions and schemas for AI Gateway. However, since AI Gateway's API actually accepts that shape directly, has its own extraction layer, and can pass through to any other API provider, introducing those types and schemas and validate against them would likely do more harm than good, or at least make the code unnecessarily complicated.

Leaving an exception for those files therefore is reasonable.

However, this also meant the convention for exporting the correct model class from the model class file was ignored - unnecessarily because for those AI Gateway is certainly correct. In other words, two different rules were conflated in a single convention.

## Summary

This PR splits the `provider-model-file-must-export-model-class` convention (which was rather `provider-model-file-must-export-model-class-and-have-matching-model-options-file`) into two conventions:
- `provider-model-file-must-export-model-class` (now being true to its name)
- `provider-model-file-must-have-matching-model-options-file` (handling only the separate file requirement)

This way, the Gateway exclusions can be applied only to the latter, while having the former apply to Gateway too.

## End-to-End Verification

```bash
pnpm konsistent
```

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14859
