### PR TITLE
fix(openai): preserve tool search output item references

### DIFF
--- a/.changeset/clean-tools-search.md
+++ b/.changeset/clean-tools-search.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Preserve distinct tool search call and output item references after provider metadata round-trips.

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -3461,11 +3461,15 @@ describe('convertToOpenAIResponsesInput', () => {
                   call_id: null,
                 }),
                 providerExecuted: true,
-                providerOptions: {
-                  openai: {
-                    itemId: 'tsc_hosted_123',
+                // Cast: `providerMetadata` isn't on `LanguageModelV4ToolCallPart`,
+                // but the read side writes it onto runtime tool-call parts.
+                ...({
+                  providerMetadata: {
+                    openai: {
+                      itemId: 'tsc_hosted_123',
+                    },
                   },
-                },
+                } as object),
               },
               {
                 type: 'tool-result',
@@ -3482,11 +3486,15 @@ describe('convertToOpenAIResponsesInput', () => {
                     ],
                   },
                 },
-                providerOptions: {
-                  openai: {
-                    itemId: 'tso_hosted_456',
+                // Cast: `providerMetadata` isn't on `LanguageModelV4ToolResultPart`,
+                // but the read side writes it onto runtime tool-result parts.
+                ...({
+                  providerMetadata: {
+                    openai: {
+                      itemId: 'tso_hosted_456',
+                    },
                   },
-                },
+                } as object),
               },
             ],
           },

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -586,7 +586,17 @@ export async function convertToOpenAIResponsesInput({
                     part.providerOptions?.[providerOptionsName] as
                       | { itemId?: string }
                       | undefined
-                  )?.itemId ?? part.toolCallId;
+                  )?.itemId ??
+                  ((
+                    part as {
+                      providerMetadata?: {
+                        [providerOptionsName]?: { itemId?: string };
+                      };
+                    }
+                  ).providerMetadata?.[providerOptionsName]?.itemId as
+                    | string
+                    | undefined) ??
+                  part.toolCallId;
 
                 if (store) {
                   input.push({ type: 'item_reference', id: itemId });


### PR DESCRIPTION
## Background

OpenAI Responses history can contain a `tool_search` call whose output item has a distinct provider item id. The converter preserved `providerMetadata.openai.itemId` for the call but ignored it for the assistant tool result, falling back to the local `toolCallId`; replay then emitted an `item_reference` to the wrong item. The captured-request reproduction is in #17666.

## Summary

- Read the OpenAI item id from `providerOptions` or `providerMetadata` for `tool_search` results.
- Extend the distinct-reference regression to use the provider-metadata shape produced by response conversion.
- Add the required `@ai-sdk/openai` patch changeset.

## End-to-End Verification

The original provider-request capture reproduced the duplicate call id; with this converter change, replay serializes the search output as the distinct hosted output item reference.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17666.