### PR TITLE
reproduction: @ai-sdk/openai: preserve toolsearch output item id after metadata

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17666,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17666-openai-tool-search-item-id.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17666-openai-tool-search-item-id.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE #17666 REPRODUCED: expected distinct tool_search item references"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17666-openai-tool-search-item-id.ts
+++ b/examples/ai-functions/src/reproduction/issue-17666-openai-tool-search-item-id.ts
@@ -1,0 +1,96 @@
+import { createOpenAI } from '@ai-sdk/openai';
+
+async function main() {
+  let capturedInput: unknown;
+
+  const openai = createOpenAI({
+    apiKey: 'test-api-key',
+    fetch: async (_url, init) => {
+      if (typeof init?.body !== 'string') {
+        throw new Error('Expected a JSON request body');
+      }
+
+      capturedInput = (
+        JSON.parse(init.body) as {
+          input: unknown;
+        }
+      ).input;
+
+      return new Response(
+        JSON.stringify({
+          id: 'resp_test',
+          model: 'gpt-5.6',
+          output: [],
+          usage: {
+            input_tokens: 0,
+            input_tokens_details: { cached_tokens: 0 },
+            output_tokens: 0,
+            output_tokens_details: { reasoning_tokens: 0 },
+          },
+        }),
+        {
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        },
+      );
+    },
+  });
+
+  await openai('gpt-5.6').doGenerate({
+    prompt: [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'tsc_hosted_123',
+            toolName: 'tool_search',
+            input: {
+              arguments: { paths: ['get_weather'] },
+              call_id: null,
+            },
+            providerExecuted: true,
+            providerMetadata: {
+              openai: { itemId: 'tsc_hosted_123' },
+            },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'tsc_hosted_123',
+            toolName: 'tool_search',
+            output: {
+              type: 'json',
+              value: {
+                tools: [{ name: 'get_weather', type: 'function' }],
+              },
+            },
+            providerMetadata: {
+              openai: { itemId: 'tso_hosted_456' },
+            },
+          },
+        ],
+      },
+    ] as any,
+    providerOptions: {
+      openai: { store: true },
+    },
+  });
+
+  const expectedInput = [
+    { type: 'item_reference', id: 'tsc_hosted_123' },
+    { type: 'item_reference', id: 'tso_hosted_456' },
+  ];
+
+  if (JSON.stringify(capturedInput) !== JSON.stringify(expectedInput)) {
+    throw new Error(
+      `ISSUE #17666 REPRODUCED: expected distinct tool_search item references ${JSON.stringify(
+        expectedInput,
+      )}, but captured ${JSON.stringify(capturedInput)}`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/openai/src/responses/__fixtures__/openai-tool-search-duplicate-item-error.1.json
+++ b/packages/openai/src/responses/__fixtures__/openai-tool-search-duplicate-item-error.1.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "message": "Duplicate item found with id tsc_077457e674332594006a606a565ac081a090a3f60cd0d63c21. Remove duplicate items from your input and try again.",
+    "type": "invalid_request_error",
+    "param": "input",
+    "code": null
+  }
+}

--- a/packages/openai/src/responses/issue-17666-reproduction.test.ts
+++ b/packages/openai/src/responses/issue-17666-reproduction.test.ts
@@ -1,0 +1,77 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import fs from 'node:fs';
+import { expect, it } from 'vitest';
+import { createOpenAI } from '../openai-provider';
+
+it('preserves the tool_search output item id after a provider metadata round trip', async () => {
+  const errorFixture = fs.readFileSync(
+    'src/responses/__fixtures__/openai-tool-search-duplicate-item-error.1.json',
+    'utf8',
+  );
+  let capturedBody: unknown;
+
+  const model = createOpenAI({
+    apiKey: 'test-api-key',
+    fetch: async (_url, init) => {
+      capturedBody =
+        typeof init?.body === 'string' ? JSON.parse(init.body) : undefined;
+      return new Response(errorFixture, {
+        status: 400,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+
+  const prompt = [
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'tsc_hosted_123',
+          toolName: 'tool_search',
+          input: {
+            arguments: { paths: ['get_weather'] },
+            call_id: null,
+          },
+          providerExecuted: true,
+          providerMetadata: {
+            openai: { itemId: 'tsc_hosted_123' },
+          },
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'tsc_hosted_123',
+          toolName: 'tool_search',
+          output: {
+            type: 'json',
+            value: {
+              tools: [{ name: 'get_weather', type: 'function' }],
+            },
+          },
+          providerMetadata: {
+            openai: { itemId: 'tso_hosted_456' },
+          },
+        },
+      ],
+    },
+  ] as unknown as LanguageModelV4Prompt;
+
+  try {
+    await model('gpt-5.6').doGenerate({
+      prompt,
+      providerOptions: {
+        openai: { store: true },
+      },
+    });
+  } catch {
+    // The recorded live response is the duplicate-item rejection.
+  }
+
+  expect(capturedBody).toMatchObject({
+    input: [
+      { type: 'item_reference', id: 'tsc_hosted_123' },
+      { type: 'item_reference', id: 'tso_hosted_456' },
+    ],
+  });
+});


### PR DESCRIPTION
## Bug

@ai-sdk/openai: preserve tool_search output item id after metadata round trip

## Reproduction

- `examples/ai-functions/src/reproduction/issue-17666-openai-tool-search-item-id.ts` observed two `tsc_hosted_123` references; the expected stored request references `tsc_hosted_123` and `tso_hosted_456` distinctly.
- `packages/openai/src/responses/__fixtures__/openai-tool-search-duplicate-item-error.1.json` records the live OpenAI HTTP 400 duplicate-item rejection caused by the malformed continuation request.
- `packages/openai/src/responses/issue-17666-reproduction.test.ts` fails because the tool-search output metadata ID is replaced with the call ID during request serialization.
- The checked-out `@ai-sdk/openai` 4.0.17 public adapter supports the reported APIs, and no configuration or package-version mismatch caused the failure.

## Relevant Documentation

- https://platform.openai.com/docs/api-reference/responses-streaming/response/refusal/delta?lang=curl
- https://developers.openai.com/api/docs/models/gpt-5.4-pro
- https://developers.openai.com/api/docs/guides/latest-model

## Related Issues

Reproduces #17666