### PR TITLE
fix (provider/gateway): enforce order/only on gateway.models fallback list

### DIFF
--- a/.changeset/fix-gateway-order-models-filter.md
+++ b/.changeset/fix-gateway-order-models-filter.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix (provider/gateway): enforce gateway.order and gateway.only constraints on gateway.models fallback list

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -1657,5 +1657,165 @@ describe('GatewayLanguageModel', () => {
         gateway: { quotaEntityId: 'entity-123', user: 'user-456' },
       });
     });
+
+    it('should filter gateway.models to only providers in gateway.order', async () => {
+      prepareJsonResponse({
+        content: { type: 'text', text: 'Test response' },
+      });
+
+      const { warnings } = await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          gateway: {
+            order: ['openai', 'google', 'azure'],
+            models: [
+              'google/gemini-2.5-flash',
+              'openai/gpt-5-mini',
+              'xai/grok-4.1-fast-non-reasoning',
+            ],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.providerOptions).toEqual({
+        gateway: {
+          order: ['openai', 'google', 'azure'],
+          models: ['google/gemini-2.5-flash', 'openai/gpt-5-mini'],
+        },
+      });
+      expect(warnings).toEqual([
+        {
+          type: 'other',
+          message:
+            'Model "xai/grok-4.1-fast-non-reasoning" was removed from gateway.models because its provider is not in the allowed provider list (openai, google, azure).',
+        },
+      ]);
+    });
+
+    it('should filter gateway.models to only providers in gateway.only', async () => {
+      prepareJsonResponse({
+        content: { type: 'text', text: 'Test response' },
+      });
+
+      const { warnings } = await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          gateway: {
+            only: ['anthropic'],
+            models: [
+              'anthropic/claude-sonnet-4',
+              'openai/gpt-5-mini',
+              'meta/llama-4-scout',
+            ],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.providerOptions).toEqual({
+        gateway: {
+          only: ['anthropic'],
+          models: ['anthropic/claude-sonnet-4'],
+        },
+      });
+      expect(warnings).toHaveLength(2);
+      expect(warnings[0]).toEqual({
+        type: 'other',
+        message:
+          'Model "openai/gpt-5-mini" was removed from gateway.models because its provider is not in the allowed provider list (anthropic).',
+      });
+    });
+
+    it('should not filter gateway.models when no order or only constraint is set', async () => {
+      prepareJsonResponse({
+        content: { type: 'text', text: 'Test response' },
+      });
+
+      const { warnings } = await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          gateway: {
+            models: [
+              'google/gemini-2.5-flash',
+              'xai/grok-4.1-fast-non-reasoning',
+            ],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.providerOptions).toEqual({
+        gateway: {
+          models: [
+            'google/gemini-2.5-flash',
+            'xai/grok-4.1-fast-non-reasoning',
+          ],
+        },
+      });
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('should keep all gateway.models when all providers are in gateway.order', async () => {
+      prepareJsonResponse({
+        content: { type: 'text', text: 'Test response' },
+      });
+
+      const { warnings } = await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          gateway: {
+            order: ['openai', 'google'],
+            models: ['google/gemini-2.5-flash', 'openai/gpt-5-mini'],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.providerOptions).toEqual({
+        gateway: {
+          order: ['openai', 'google'],
+          models: ['google/gemini-2.5-flash', 'openai/gpt-5-mini'],
+        },
+      });
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('should filter gateway.models for doStream when order is set', async () => {
+      prepareStreamResponse({
+        content: ['Hello', ' world'],
+      });
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          gateway: {
+            order: ['openai', 'google'],
+            models: ['openai/gpt-5-mini', 'deepseek/deepseek-v3'],
+          },
+        },
+      });
+
+      const streamParts = await convertReadableStreamToArray(stream);
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.providerOptions).toEqual({
+        gateway: {
+          order: ['openai', 'google'],
+          models: ['openai/gpt-5-mini'],
+        },
+      });
+
+      const streamStartPart = streamParts.find(
+        part => part.type === 'stream-start',
+      );
+      expect(streamStartPart?.warnings).toEqual([
+        {
+          type: 'other',
+          message:
+            'Model "deepseek/deepseek-v3" was removed from gateway.models because its provider is not in the allowed provider list (openai, google).',
+        },
+      ]);
+    });
   });
 });

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -43,10 +43,61 @@ export class GatewayLanguageModel implements LanguageModelV4 {
 
   private async getArgs(options: LanguageModelV4CallOptions) {
     const { abortSignal: _abortSignal, ...optionsWithoutSignal } = options;
+    const warnings: SharedV4Warning[] = [];
+
+    // When gateway.order or gateway.only restrict which providers may be used,
+    // also enforce that restriction on gateway.models so that fallback models
+    // whose provider prefix is not in the allowed set are silently dropped and
+    // surfaced as warnings instead of routing to unexpected providers.
+    const gatewayOptions = optionsWithoutSignal.providerOptions?.['gateway'];
+    if (gatewayOptions) {
+      const order = Array.isArray(gatewayOptions['order'])
+        ? (gatewayOptions['order'] as string[])
+        : undefined;
+      const only = Array.isArray(gatewayOptions['only'])
+        ? (gatewayOptions['only'] as string[])
+        : undefined;
+      const models = Array.isArray(gatewayOptions['models'])
+        ? (gatewayOptions['models'] as string[])
+        : undefined;
+
+      if (models && (order || only)) {
+        const allowedProviders = new Set([...(order ?? []), ...(only ?? [])]);
+        const keptModels: string[] = [];
+        const removedModels: string[] = [];
+
+        for (const modelId of models) {
+          const providerPrefix = modelId.split('/')[0];
+          if (allowedProviders.has(providerPrefix)) {
+            keptModels.push(modelId);
+          } else {
+            removedModels.push(modelId);
+          }
+        }
+
+        if (removedModels.length > 0) {
+          const allowedList = [...allowedProviders].join(', ');
+          for (const modelId of removedModels) {
+            warnings.push({
+              type: 'other',
+              message: `Model "${modelId}" was removed from gateway.models because its provider is not in the allowed provider list (${allowedList}).`,
+            });
+          }
+
+          optionsWithoutSignal.providerOptions = {
+            ...optionsWithoutSignal.providerOptions,
+            gateway: {
+              ...gatewayOptions,
+              models: keptModels,
+            },
+          };
+        }
+      }
+    }
 
     return {
       args: this.maybeEncodeFileParts(optionsWithoutSignal),
-      warnings: [],
+      warnings,
     };
   }
 


### PR DESCRIPTION
## Summary

- When `providerOptions.gateway.order` or `providerOptions.gateway.only` restrict which providers may be used, the same restriction is now applied client-side to the `providerOptions.gateway.models` fallback list before the request is sent.
- Models whose provider prefix (the part before the first `/`) is not in the allowed provider set are removed from `models` and surfaced as `type: 'other'` warnings.
- This prevents silent routing to unexpected providers (e.g. `deepinfra` for `xai/*` models) when the caller has explicitly declared a provider allowlist via `order` or `only`.

## Test plan

- [x] `should filter gateway.models to only providers in gateway.order` -- verifies `xai/grok-4.1-fast-non-reasoning` is stripped when `order` excludes `xai`, and a warning is emitted
- [x] `should filter gateway.models to only providers in gateway.only` -- same logic for `only`
- [x] `should not filter gateway.models when no order or only constraint is set` -- no filtering when neither constraint is present
- [x] `should keep all gateway.models when all providers are in gateway.order` -- no filtering when all models match
- [x] `should filter gateway.models for doStream when order is set` -- same filtering applies to the streaming path, warnings surface via the `stream-start` event
- [x] All 385 existing gateway tests still pass

Fixes #14376