### PR TITLE
reproduction: @ai-sdk/amazon-bedrock S3 / Image URL support

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 15792,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/amazon-bedrock-s3-image-url.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/amazon-bedrock-s3-image-url.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_REPRODUCED: Amazon Bedrock rejected an s3:// image URL before inference: URL scheme must be http, https, or data, got s3:"
+  }
+}

--- a/examples/ai-functions/src/reproduction/amazon-bedrock-s3-image-url.ts
+++ b/examples/ai-functions/src/reproduction/amazon-bedrock-s3-image-url.ts
@@ -1,0 +1,43 @@
+import { amazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { DownloadError, generateText } from 'ai';
+
+async function main() {
+  try {
+    await generateText({
+      model: amazonBedrock('anthropic.claude-3-haiku-20240307-v1:0'),
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describe the image.' },
+            {
+              type: 'file',
+              data: new URL('s3://ai-sdk-reproduction-15792/path/to/image.png'),
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      ],
+    });
+  } catch (error) {
+    if (
+      DownloadError.isInstance(error) &&
+      error.message.includes('URL scheme must be http, https, or data, got s3:')
+    ) {
+      console.error(
+        'ISSUE_REPRODUCED: Amazon Bedrock rejected an s3:// image URL before inference: URL scheme must be http, https, or data, got s3:',
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    throw error;
+  }
+
+  console.log('Amazon Bedrock accepted the s3:// image URL.');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-s3-image-url.json
+++ b/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-s3-image-url.json
@@ -1,0 +1,18 @@
+{
+  "output": {
+    "message": {
+      "content": [
+        {
+          "text": "The image was received."
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "inputTokens": 1,
+    "outputTokens": 5,
+    "totalTokens": 6
+  }
+}

--- a/packages/amazon-bedrock/src/amazon-bedrock-s3-image-url.reproduction.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-s3-image-url.reproduction.test.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { AmazonBedrockChatLanguageModel } from './amazon-bedrock-chat-language-model';
+
+describe('vercel/ai#15792', () => {
+  it('passes an s3 image URL to Bedrock as an s3Location', async () => {
+    let requestBody: unknown;
+    const responseBody = fs.readFileSync(
+      'src/__fixtures__/amazon-bedrock-s3-image-url.json',
+      'utf8',
+    );
+
+    const model = new AmazonBedrockChatLanguageModel(
+      'anthropic.claude-3-haiku-20240307-v1:0',
+      {
+        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        generateId: () => 'test-id',
+        fetch: async (_url, init) => {
+          requestBody = JSON.parse(String(init?.body));
+          return new Response(responseBody, {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        },
+      },
+    );
+
+    await model.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describe the image.' },
+            {
+              type: 'file',
+              data: {
+                type: 'url',
+                url: new URL(
+                  's3://ai-sdk-reproduction-15792/path/to/image.png',
+                ),
+              },
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(requestBody).toMatchObject({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { text: 'Describe the image.' },
+            {
+              image: {
+                format: 'png',
+                source: {
+                  s3Location: {
+                    uri: 's3://ai-sdk-reproduction-15792/path/to/image.png',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Bug

@ai-sdk/amazon-bedrock S3 / Image URL support

## Reproduction

- On `main`, `@ai-sdk/amazon-bedrock` 5.0.27 cannot pass S3-hosted images to Amazon Bedrock, forcing users toward memory-intensive byte or base64 inputs.
- `examples/ai-functions/src/reproduction/amazon-bedrock-s3-image-url.ts` observed `AI_DownloadError` for an `s3://` image before inference; AWS documents that the URL should be forwarded as `image.source.s3Location`.
- Passing the URL through with a custom download function still produced `AI_UnsupportedFunctionalityError: 'File URL data' functionality not supported`, so download configuration does not resolve the failure.
- `packages/amazon-bedrock/src/amazon-bedrock-s3-image-url.reproduction.test.ts` and `packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-s3-image-url.json` assert the expected Bedrock request; the test failed before fetch instead of producing the documented `s3Location` request.
- The report did not provide the exact HTTPS URL or download configuration needed to independently match its contextual HTTPS `APICallError`; this does not affect the reproduced S3 failure.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ImageSource.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_S3Location.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
- https://docs.aws.amazon.com/cli/latest/reference/bedrock-runtime/converse.html

## Related Issues

Reproduces #15792