### PR TITLE
[v6.0] reproduction: @ai-sdk/openai: preserve toolsearch output item id after metadata

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 17666,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17666-openai-tool-search-item-id.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17666-openai-tool-search-item-id.ts",
+    "packages/openai/src/responses/__fixtures__/openai-tool-search-duplicate-item-error.1.json"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE #17666 REPRODUCED: OpenAI rejected stored tool_search history because the SDK serialized the call item id twice."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17666-openai-tool-search-item-id.ts
+++ b/examples/ai-functions/src/reproduction/issue-17666-openai-tool-search-item-id.ts
@@ -1,0 +1,138 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import fs from 'node:fs';
+
+const toolSearchCallItemId =
+  'tsc_07dac4bac56245e1006a606d9ef06481a1afbe9ba9f5b6cff2';
+const toolSearchOutputItemId =
+  'tso_07dac4bac56245e1006a606d9f135481a1b94ca1a6e53b19df';
+
+const prompt = [
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: toolSearchCallItemId,
+        toolName: 'tool_search',
+        input: {
+          arguments: { paths: ['get_weather'] },
+          call_id: null,
+        },
+        providerExecuted: true,
+        providerMetadata: {
+          openai: { itemId: toolSearchCallItemId },
+        },
+      },
+      {
+        type: 'tool-result',
+        toolCallId: toolSearchCallItemId,
+        toolName: 'tool_search',
+        output: {
+          type: 'json',
+          value: {
+            tools: [{ name: 'get_weather', type: 'function' }],
+          },
+        },
+        providerMetadata: {
+          openai: { itemId: toolSearchOutputItemId },
+        },
+      },
+    ],
+  },
+] as unknown as LanguageModelV3Prompt;
+
+const liveDuplicateItemError = fs.readFileSync(
+  new URL(
+    '../../../../packages/openai/src/responses/__fixtures__/openai-tool-search-duplicate-item-error.1.json',
+    import.meta.url,
+  ),
+  'utf8',
+);
+
+const successfulResponse = JSON.stringify({
+  id: 'resp_issue_17666_fixed',
+  created_at: 1784704415,
+  model: 'gpt-5.4-2026-03-05',
+  output: [],
+  usage: {
+    input_tokens: 0,
+    output_tokens: 0,
+  },
+});
+
+async function main() {
+  let itemReferenceIds: string[] = [];
+
+  const model = createOpenAI({
+    apiKey: 'test-api-key',
+    fetch: async (_input, init) => {
+      if (typeof init?.body !== 'string') {
+        throw new Error('Expected a JSON request body.');
+      }
+
+      const requestBody = JSON.parse(init.body) as {
+        input: Array<{ type?: string; id?: string }>;
+      };
+
+      itemReferenceIds = requestBody.input
+        .filter(
+          (item): item is { type: 'item_reference'; id: string } =>
+            item.type === 'item_reference' && typeof item.id === 'string',
+        )
+        .map(item => item.id);
+
+      const hasDuplicateItemReference =
+        new Set(itemReferenceIds).size !== itemReferenceIds.length;
+
+      return new Response(
+        hasDuplicateItemReference ? liveDuplicateItemError : successfulResponse,
+        {
+          status: hasDuplicateItemReference ? 400 : 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    },
+  })('gpt-5.4');
+
+  try {
+    await model.doGenerate({
+      prompt,
+      providerOptions: { openai: { store: true } },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (
+      message.includes('Duplicate item found') &&
+      itemReferenceIds.length === 2 &&
+      itemReferenceIds.every(id => id === toolSearchCallItemId)
+    ) {
+      console.error(
+        'ISSUE #17666 REPRODUCED: OpenAI rejected stored tool_search history because the SDK serialized the call item id twice.',
+      );
+      console.error(
+        `Captured item references: ${JSON.stringify(itemReferenceIds)}`,
+      );
+      console.error(
+        `Expected item references: ${JSON.stringify([
+          toolSearchCallItemId,
+          toolSearchOutputItemId,
+        ])}`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    throw error;
+  }
+
+  console.log(
+    `Issue #17666 was not reproduced; item references were ${JSON.stringify(itemReferenceIds)}.`,
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/openai/src/responses/__fixtures__/openai-tool-search-duplicate-item-error.1.json
+++ b/packages/openai/src/responses/__fixtures__/openai-tool-search-duplicate-item-error.1.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "message": "Duplicate item found with id tsc_07dac4bac56245e1006a606d9ef06481a1afbe9ba9f5b6cff2. Remove duplicate items from your input and try again.",
+    "type": "invalid_request_error",
+    "param": "input",
+    "code": null
+  }
+}

--- a/packages/openai/src/responses/issue-17666-reproduction.test.ts
+++ b/packages/openai/src/responses/issue-17666-reproduction.test.ts
@@ -1,0 +1,108 @@
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import fs from 'node:fs';
+import { expect, it } from 'vitest';
+import { createOpenAI } from '../openai-provider';
+
+const toolSearchCallItemId =
+  'tsc_07dac4bac56245e1006a606d9ef06481a1afbe9ba9f5b6cff2';
+const toolSearchOutputItemId =
+  'tso_07dac4bac56245e1006a606d9f135481a1b94ca1a6e53b19df';
+
+const prompt = [
+  {
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: toolSearchCallItemId,
+        toolName: 'tool_search',
+        input: {
+          arguments: { paths: ['get_weather'] },
+          call_id: null,
+        },
+        providerExecuted: true,
+        providerMetadata: {
+          openai: { itemId: toolSearchCallItemId },
+        },
+      },
+      {
+        type: 'tool-result',
+        toolCallId: toolSearchCallItemId,
+        toolName: 'tool_search',
+        output: {
+          type: 'json',
+          value: {
+            tools: [{ name: 'get_weather', type: 'function' }],
+          },
+        },
+        providerMetadata: {
+          openai: { itemId: toolSearchOutputItemId },
+        },
+      },
+    ],
+  },
+] as unknown as LanguageModelV3Prompt;
+
+const liveDuplicateItemError = fs.readFileSync(
+  new URL(
+    './__fixtures__/openai-tool-search-duplicate-item-error.1.json',
+    import.meta.url,
+  ),
+  'utf8',
+);
+
+const successfulResponse = JSON.stringify({
+  id: 'resp_issue_17666_fixed',
+  created_at: 1784704415,
+  model: 'gpt-5.4-2026-03-05',
+  output: [],
+  usage: {
+    input_tokens: 0,
+    output_tokens: 0,
+  },
+});
+
+it('preserves the tool_search output item id after a providerMetadata round trip', async () => {
+  let itemReferenceIds: string[] = [];
+
+  const model = createOpenAI({
+    apiKey: 'test-api-key',
+    fetch: async (_input, init) => {
+      if (typeof init?.body !== 'string') {
+        throw new Error('Expected a JSON request body.');
+      }
+
+      const requestBody = JSON.parse(init.body) as {
+        input: Array<{ type?: string; id?: string }>;
+      };
+
+      itemReferenceIds = requestBody.input
+        .filter(
+          (item): item is { type: 'item_reference'; id: string } =>
+            item.type === 'item_reference' && typeof item.id === 'string',
+        )
+        .map(item => item.id);
+
+      const hasDuplicateItemReference =
+        new Set(itemReferenceIds).size !== itemReferenceIds.length;
+
+      return new Response(
+        hasDuplicateItemReference ? liveDuplicateItemError : successfulResponse,
+        {
+          status: hasDuplicateItemReference ? 400 : 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    },
+  })('gpt-5.4');
+
+  await model.doGenerate({
+    prompt,
+    providerOptions: { openai: { store: true } },
+  });
+
+  expect(itemReferenceIds).toEqual([
+    toolSearchCallItemId,
+    toolSearchOutputItemId,
+  ]);
+});


### PR DESCRIPTION
## Bug

@ai-sdk/openai: preserve tool_search output item id after metadata round trip

## Reproduction

- Stored `tool_search` history should preserve distinct call and output item IDs; the target adapter instead serializes the call ID twice, causing OpenAI to reject the continuation.
- A live `gpt-5.4` response returned distinct `tsc_...` and `tso_...` IDs, while the subsequent public-adapter request received HTTP 400: “Duplicate item found”.
- `packages/openai/src/responses/convert-to-openai-responses-input.ts` reads `providerMetadata` for tool calls but not for hosted `tool_search` results; `packages/openai/package.json` identifies the applicable target package as `@ai-sdk/openai` 3.0.86.
- `examples/ai-functions/src/reproduction/issue-17666-openai-tool-search-item-id.ts` captured two call-ID references instead of the expected distinct call and output references and exited non-zero.
- `packages/openai/src/responses/__fixtures__/openai-tool-search-duplicate-item-error.1.json` records the live OpenAI duplicate-item rejection.
- `packages/openai/src/responses/issue-17666-reproduction.test.ts` replays the metadata round trip and fails with the recorded OpenAI rejection; it is expected to complete with distinct references once fixed.

## Relevant Documentation

- https://developers.openai.com/api/docs/guides/tools-tool-search
- https://developers.openai.com/api/docs/guides/conversation-state
- https://developers.openai.com/api/docs/models/gpt-5.4

## Related Issues

Reproduces #17666