### PR TITLE
reproduction: could not reproduce ZodError: "Message must contain at least one part"

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11444-stop-before-response.ts
+++ b/examples/ai-functions/src/reproduction/issue-11444-stop-before-response.ts
@@ -1,0 +1,206 @@
+import {
+  AbstractChat,
+  createAgentUIStreamResponse,
+  DefaultChatTransport,
+  type Agent,
+  type ChatState,
+  type ChatStatus,
+  type StreamTextResult,
+  type TextStreamPart,
+  type UIMessage,
+  validateUIMessages,
+} from 'ai';
+import type { Context } from '@ai-sdk/provider-utils';
+
+class ReproductionChatState implements ChatState<UIMessage> {
+  status: ChatStatus = 'ready';
+  error: Error | undefined;
+  messages: UIMessage[] = [];
+
+  pushMessage = (message: UIMessage) => {
+    this.messages = [...this.messages, message];
+  };
+
+  popMessage = () => {
+    this.messages = this.messages.slice(0, -1);
+  };
+
+  replaceMessage = (index: number, message: UIMessage) => {
+    this.messages = [
+      ...this.messages.slice(0, index),
+      message,
+      ...this.messages.slice(index + 1),
+    ];
+  };
+
+  snapshot = <T>(value: T): T => structuredClone(value);
+}
+
+class ReproductionChat extends AbstractChat<UIMessage> {
+  constructor({
+    transport,
+    onError,
+  }: {
+    transport: DefaultChatTransport<UIMessage>;
+    onError: (error: Error) => void;
+  }) {
+    let nextId = 0;
+    super({
+      id: 'issue-11444',
+      generateId: () => `client-message-${nextId++}`,
+      transport,
+      state: new ReproductionChatState(),
+      onError,
+    });
+  }
+}
+
+function createAgentStream({
+  requestNumber,
+  abortSignal,
+}: {
+  requestNumber: number;
+  abortSignal?: AbortSignal;
+}) {
+  return new ReadableStream<TextStreamPart<{}>>({
+    start(controller) {
+      controller.enqueue({ type: 'start' });
+
+      if (requestNumber === 1) {
+        const abort = () => {
+          controller.enqueue({
+            type: 'abort',
+            reason: 'stopped before assistant content',
+          });
+          controller.close();
+        };
+
+        if (abortSignal?.aborted) {
+          abort();
+        } else {
+          abortSignal?.addEventListener('abort', abort, { once: true });
+        }
+        return;
+      }
+
+      controller.enqueue({ type: 'text-start', id: 'response-text' });
+      controller.enqueue({
+        type: 'text-delta',
+        id: 'response-text',
+        text: 'Follow-up request succeeded.',
+      });
+      controller.enqueue({ type: 'text-end', id: 'response-text' });
+      controller.close();
+    },
+  });
+}
+
+async function waitFor(
+  condition: () => boolean,
+  description: string,
+): Promise<void> {
+  const deadline = Date.now() + 2_000;
+
+  while (!condition()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${description}`);
+    }
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+}
+
+async function main() {
+  let requestNumber = 0;
+  const observedErrors: Error[] = [];
+
+  const agent: Agent = {
+    version: 'agent-v1',
+    id: 'issue-11444-agent',
+    tools: {},
+    generate: async () => {
+      throw new Error('generate is not used by this reproduction');
+    },
+    stream: async ({ abortSignal }) => {
+      requestNumber++;
+      return {
+        stream: createAgentStream({ requestNumber, abortSignal }),
+      } as StreamTextResult<{}, Context, never>;
+    },
+  };
+
+  const fetchHandler: typeof fetch = async (_input, init) => {
+    const body = (await new Response(init?.body).json()) as {
+      messages: UIMessage[];
+    };
+
+    return createAgentUIStreamResponse({
+      agent,
+      uiMessages: body.messages,
+      abortSignal: init?.signal ?? undefined,
+      generateMessageId: () => `server-assistant-${requestNumber}`,
+    });
+  };
+
+  const chat = new ReproductionChat({
+    transport: new DefaultChatTransport({
+      api: 'https://example.test/api/chat',
+      fetch: fetchHandler,
+    }),
+    onError: error => observedErrors.push(error),
+  });
+
+  const firstRequest = chat.sendMessage({ text: 'First message' });
+
+  await waitFor(
+    () =>
+      chat.messages.length === 2 &&
+      chat.messages[1].role === 'assistant' &&
+      chat.messages[1].parts.length === 0,
+    'the empty assistant message created before content arrives',
+  );
+
+  await chat.stop();
+  await firstRequest;
+
+  const emptyAssistantMessage = chat.messages[1];
+  if (
+    emptyAssistantMessage?.role !== 'assistant' ||
+    emptyAssistantMessage.parts.length !== 0
+  ) {
+    throw new Error(
+      'Setup failed: stopping before content did not retain an empty assistant message.',
+    );
+  }
+
+  await validateUIMessages({ messages: chat.messages });
+  await chat.sendMessage({ text: 'Second message' });
+
+  const followUpText = chat.messages
+    .at(-1)
+    ?.parts.find(part => part.type === 'text');
+
+  if (observedErrors.length > 0 || chat.error != null) {
+    const error = observedErrors[0] ?? chat.error;
+    throw new Error(
+      `Unexpected validation error after stop: ${error?.message ?? 'unknown error'}`,
+    );
+  }
+
+  if (
+    followUpText?.type !== 'text' ||
+    followUpText.text !== 'Follow-up request succeeded.'
+  ) {
+    throw new Error(
+      'Follow-up request did not complete after the empty assistant message.',
+    );
+  }
+
+  console.log(
+    'PASS: stopping before assistant content retained empty parts, validation succeeded, and createAgentUIStreamResponse handled the follow-up request.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

ZodError: "Message must contain at least one part" when stopping stream before AI response

## Reproduction

- `examples/ai-functions/src/reproduction/issue-11444-stop-before-response.ts` stops before assistant content, retains an assistant message with empty `parts`, and then successfully validates the chat and completes a follow-up through `createAgentUIStreamResponse`; the reported ZodError did not occur.
- The issue expected stopping to produce `Message must contain at least one part`, preventing valid cancellation and subsequent chat requests.
- Current `main` uses `ai@7.0.34`; `packages/ai/src/ui/validate-ui-messages.ts` permits empty assistant parts while retaining non-empty validation for user and system messages.
- `packages/ai/CHANGELOG.md` records this fix in `ai@7.0.27`; the v6 backport first appears in `ai@6.0.226`, whose release snapshot pairs with `@ai-sdk/react@3.0.228`.
- Users on the reported `ai@6.0.3` and `@ai-sdk/react@3.0.3` setup should upgrade to aligned current versions, or at least the fixed v6 release line.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-core/create-agent-ui-stream-response
- https://ai-sdk.dev/docs/reference/ai-sdk-core/validate-ui-messages
- https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat

## Related Issues

Could not reproduce #11444