### PR TITLE
[v6.0] reproduction: could not reproduce SyntaxError: Export named 'simulateReadableStream' not found on GitHub

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11300-simulate-readable-stream-bun.ts
+++ b/examples/ai-functions/src/reproduction/issue-11300-simulate-readable-stream-bun.ts
@@ -1,0 +1,31 @@
+import { simulateReadableStream } from 'ai';
+
+async function main() {
+  if (typeof simulateReadableStream !== 'function') {
+    throw new Error('simulateReadableStream was not imported as a function');
+  }
+
+  const reader = simulateReadableStream({
+    chunks: ['workspace-ok'],
+    initialDelayInMs: null,
+    chunkDelayInMs: null,
+  }).getReader();
+  const chunks = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+
+  if (chunks.length !== 1 || chunks[0] !== 'workspace-ok') {
+    throw new Error(`Unexpected stream chunks: ${JSON.stringify(chunks)}`);
+  }
+
+  console.log('simulateReadableStream main-package import: workspace-ok');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

SyntaxError: Export named 'simulateReadableStream' not found` on GitHub Actions but works locally

## Reproduction

- The reported failure would prevent GitHub Actions from loading the module, but the primary `SyntaxError: Export named 'simulateReadableStream' not found` did not occur.
- Added `examples/ai-functions/src/reproduction/issue-11300-simulate-readable-stream-bun.ts`; importing `simulateReadableStream` from the release-v6.0 workspace `ai@6.0.233` succeeded under Bun 1.3.3 and produced the expected `workspace-ok` chunk.
- `packages/ai/src/util/index.ts`, `packages/ai/src/index.ts`, and `packages/ai/dist/index.mjs` expose `simulateReadableStream` through the main package entry point.
- A clean Bun 1.3.3 installation of the reported `ai@5.0.108` with compatible `zod@3.25.76`, followed by `bun install --frozen-lockfile`, also imported the function and produced `published-ok`; its installed `dist/index.mjs` contained the export.
- The sandbox was Debian 12 arm64 rather than the GitHub-hosted `ubuntu-latest` x64 environment, and the reporter's lockfile and CI cache state were unavailable, so those environment-specific factors could not be evaluated exactly.

## Relevant Documentation

- https://bun.sh/docs/runtime/module-resolution
- https://bun.sh/docs/pm/cli/install
- https://bun.sh/docs/installation

## Related Issues

Could not reproduce #11300