### PR TITLE
[v5.0] reproduction: @ai-sdk/amazon-bedrock S3 / Image URL support

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 15792,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/amazon-bedrock-s3-image-url.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/amazon-bedrock-s3-image-url.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_15792_REPRODUCED: Amazon Bedrock rejected an s3:// image before inference: URL scheme must be http, https, or data, got s3:"
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/amazon-bedrock-s3-image-url.ts
+++ b/examples/ai-functions/src/reproduction/amazon-bedrock-s3-image-url.ts
@@ -1,0 +1,86 @@
+import { createAmazonBedrock } from '../../../../packages/amazon-bedrock/src';
+import { generateText } from '../../../../packages/ai/src';
+
+const imageUrl = new URL('s3://amzn-s3-demo-bucket/myImage.png');
+const modelId = 'amazon.nova-lite-v1:0';
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function invokeWithS3Image(options?: {
+  passUrlsThrough?: boolean;
+}): Promise<void> {
+  const bedrock = createAmazonBedrock({
+    region: process.env.AWS_REGION ?? 'us-east-1',
+  });
+
+  await generateText({
+    model: bedrock(modelId),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe this image.' },
+          {
+            type: 'image',
+            image: imageUrl,
+            mediaType: 'image/png',
+          },
+        ],
+      },
+    ],
+    maxRetries: 0,
+    experimental_download: options?.passUrlsThrough
+      ? requestedDownloads => requestedDownloads.map(() => null)
+      : undefined,
+  });
+}
+
+async function main(): Promise<void> {
+  let primaryError: unknown;
+
+  try {
+    await invokeWithS3Image();
+  } catch (error) {
+    primaryError = error;
+  }
+
+  const primaryMessage = errorMessage(primaryError);
+  const expectedPrimaryFailure =
+    'URL scheme must be http, https, or data, got s3:';
+
+  if (!primaryMessage.includes(expectedPrimaryFailure)) {
+    throw new Error(
+      `Expected the default Bedrock image flow to reject the S3 URL with ${JSON.stringify(
+        expectedPrimaryFailure,
+      )}, but received: ${primaryMessage}`,
+    );
+  }
+
+  let passThroughError: unknown;
+
+  try {
+    await invokeWithS3Image({ passUrlsThrough: true });
+  } catch (error) {
+    passThroughError = error;
+  }
+
+  const passThroughMessage = errorMessage(passThroughError);
+  if (
+    !passThroughMessage.includes("'File URL data' functionality not supported")
+  ) {
+    throw new Error(
+      `Expected the pass-through comparison to reject URL-backed Bedrock files, but received: ${passThroughMessage}`,
+    );
+  }
+
+  throw new Error(
+    `ISSUE_15792_REPRODUCED: Amazon Bedrock rejected an s3:// image before inference: ${primaryMessage}`,
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-s3-image-url.json
+++ b/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-s3-image-url.json
@@ -1,0 +1,25 @@
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "text": "Describe this image."
+        },
+        {
+          "image": {
+            "format": "png",
+            "source": {
+              "s3Location": {
+                "uri": "s3://amzn-s3-demo-bucket/myImage.png"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "additionalModelResponseFieldPaths": [
+    "/delta/stop_sequence"
+  ]
+}

--- a/packages/amazon-bedrock/src/amazon-bedrock-s3-image-url.reproduction.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-s3-image-url.reproduction.test.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+
+const expectedRequest = JSON.parse(
+  fs.readFileSync('src/__fixtures__/amazon-bedrock-s3-image-url.json', 'utf8'),
+);
+
+describe('issue #15792: Amazon Bedrock S3 image URLs', () => {
+  it('sends an S3 image as image.source.s3Location', async () => {
+    let requestBody: unknown;
+
+    const model = new BedrockChatLanguageModel(
+      'anthropic.claude-3-haiku-20240307-v1:0',
+      {
+        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        headers: {},
+        generateId: () => 'test-id',
+        fetch: async (_url, init) => {
+          requestBody = JSON.parse(String(init?.body));
+
+          return new Response(
+            JSON.stringify({
+              output: {
+                message: {
+                  role: 'assistant',
+                  content: [{ text: 'The image contains a cat.' }],
+                },
+              },
+              stopReason: 'end_turn',
+              usage: {
+                inputTokens: 10,
+                outputTokens: 6,
+                totalTokens: 16,
+              },
+            }),
+            {
+              headers: { 'content-type': 'application/json' },
+              status: 200,
+            },
+          );
+        },
+      },
+    );
+
+    await model.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describe this image.' },
+            {
+              type: 'file',
+              data: new URL('s3://amzn-s3-demo-bucket/myImage.png'),
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(requestBody).toStrictEqual(expectedRequest);
+  });
+});


### PR DESCRIPTION
## Bug

@ai-sdk/amazon-bedrock S3 / Image URL support

## Reproduction

- `examples/ai-functions/package.json` and `examples/ai-functions/src/reproduction/amazon-bedrock-s3-image-url.ts` provide the runnable reproduction; the configured Bedrock invocation rejected the `s3://` image with `AI_DownloadError` before reaching AWS, although AWS documents `image.source.s3Location` as valid.
- The comparison using a custom pass-through download function failed with `AI_UnsupportedFunctionalityError: 'File URL data' functionality not supported`, so download configuration does not resolve the user-visible failure.
- `packages/amazon-bedrock/src/amazon-bedrock-s3-image-url.reproduction.test.ts` and `packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-s3-image-url.json` expect the documented `s3Location` request, but the provider failed before fetch instead of producing it.
- Target package `@ai-sdk/amazon-bedrock` 3.0.108 declares no native URL support in `packages/amazon-bedrock/src/bedrock-chat-language-model.ts`, while `packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts` rejects URL-backed files.
- The exact contextual HTTPS `APICallError` could not be independently evaluated because the report did not provide its HTTPS URL or download configuration; this does not affect the reproduced S3 failure.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ImageSource.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_S3Location.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
- https://docs.aws.amazon.com/cli/latest/reference/bedrock-runtime/converse.html

## Related Issues

Reproduces #15792