### PR TITLE
[v6.0] reproduction: @ai-sdk/amazon-bedrock S3 / Image URL support

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 15792,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/amazon-bedrock-s3-image-url.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/amazon-bedrock-s3-image-url.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_REPRODUCED: Amazon Bedrock rejected an s3:// image URL before inference: URL scheme must be http, https, or data, got s3:"
+  }
+}

--- a/examples/ai-functions/src/reproduction/amazon-bedrock-s3-image-url.ts
+++ b/examples/ai-functions/src/reproduction/amazon-bedrock-s3-image-url.ts
@@ -1,0 +1,74 @@
+import { bedrock } from '@ai-sdk/amazon-bedrock';
+import { DownloadError, generateText, UnsupportedFunctionalityError } from 'ai';
+
+const s3ImageUrl = new URL('s3://ai-sdk-reproduction-15792/path/to/image.png');
+
+const messages = [
+  {
+    role: 'user' as const,
+    content: [
+      { type: 'text' as const, text: 'Describe the image.' },
+      {
+        type: 'file' as const,
+        data: s3ImageUrl,
+        mediaType: 'image/png',
+      },
+    ],
+  },
+];
+
+async function main() {
+  let downloadError: unknown;
+
+  try {
+    await generateText({
+      model: bedrock('us.amazon.nova-2-lite-v1:0'),
+      messages,
+    });
+  } catch (error) {
+    downloadError = error;
+  }
+
+  if (
+    !DownloadError.isInstance(downloadError) ||
+    !downloadError.message.includes(
+      'URL scheme must be http, https, or data, got s3:',
+    )
+  ) {
+    throw downloadError;
+  }
+
+  try {
+    await generateText({
+      model: bedrock('us.amazon.nova-2-lite-v1:0'),
+      messages,
+      experimental_download: requests =>
+        Promise.resolve(requests.map(() => null)),
+    });
+  } catch (error) {
+    if (
+      UnsupportedFunctionalityError.isInstance(error) &&
+      error.message.includes("'File URL data' functionality not supported")
+    ) {
+      console.error(
+        'CUSTOM_DOWNLOAD_ALSO_FAILED: Passing through the s3:// URL produced AI_UnsupportedFunctionalityError.',
+      );
+      console.error(
+        'ISSUE_REPRODUCED: Amazon Bedrock rejected an s3:// image URL before inference: URL scheme must be http, https, or data, got s3:',
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    throw error;
+  }
+
+  throw new Error(
+    'Default downloading rejected the s3:// URL, but custom pass-through unexpectedly succeeded.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-s3-image-url.json
+++ b/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-s3-image-url.json
@@ -1,0 +1,3 @@
+{
+  "message": "The model returned the following errors: Provided S3Location not found"
+}

--- a/packages/amazon-bedrock/src/amazon-bedrock-s3-image-url.reproduction.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-s3-image-url.reproduction.test.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+
+describe('vercel/ai#15792', () => {
+  it('passes an S3 image URL to Bedrock as an s3Location', async () => {
+    let requestBody: unknown;
+    const responseBody = fs.readFileSync(
+      'src/__fixtures__/amazon-bedrock-s3-image-url.json',
+      'utf8',
+    );
+    const model = new BedrockChatLanguageModel('us.amazon.nova-2-lite-v1:0', {
+      baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      headers: {},
+      generateId: () => 'test-id',
+      fetch: async (_url, init) => {
+        requestBody = JSON.parse(String(init?.body));
+        return new Response(responseBody, {
+          status: 400,
+          headers: {
+            'content-type': 'application/json',
+            'x-amzn-errortype': 'ValidationException',
+          },
+        });
+      },
+    });
+
+    await expect(
+      model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Describe the image.' },
+              {
+                type: 'file',
+                data: new URL(
+                  's3://ai-sdk-reproduction-15792/path/to/image.png',
+                ),
+                mediaType: 'image/png',
+              },
+            ],
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      name: 'AI_APICallError',
+      message:
+        'The model returned the following errors: Provided S3Location not found',
+    });
+
+    expect(requestBody).toMatchObject({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { text: 'Describe the image.' },
+            {
+              image: {
+                format: 'png',
+                source: {
+                  s3Location: {
+                    uri: 's3://ai-sdk-reproduction-15792/path/to/image.png',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Bug

@ai-sdk/amazon-bedrock S3 / Image URL support

## Reproduction

- On `release-v6.0`, `@ai-sdk/amazon-bedrock` 4.0.138 still rejects S3 image URLs before inference, despite being newer than the reported 4.0.111.
- `examples/ai-functions/src/reproduction/amazon-bedrock-s3-image-url.ts` observed `AI_DownloadError` instead of forwarding the URL as `image.source.s3Location`, preventing memory-efficient S3 image use.
- The same script confirmed that custom download pass-through instead produces `AI_UnsupportedFunctionalityError`, so download configuration does not resolve the failure.
- `packages/amazon-bedrock/src/amazon-bedrock-s3-image-url.reproduction.test.ts` expects the documented `s3Location` request using the live-response fixture `packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-s3-image-url.json`, but fails before fetch with `AI_UnsupportedFunctionalityError`.
- The report's contextual HTTPS `APICallError` could not be matched because its exact URL and download configuration were not provided; this does not affect the reproduced S3 failure.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ImageSource.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_S3Location.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
- https://docs.aws.amazon.com/cli/latest/reference/bedrock-runtime/converse.html

## Related Issues

Reproduces #15792