### PR TITLE
[v6.0] fix: preserve tool_search output item IDs after provider metadata round trips

### DIFF
--- a/.changeset/soft-tools-search.md
+++ b/.changeset/soft-tools-search.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Preserve stored tool search output item IDs from provider metadata.

--- a/packages/openai/src/responses/convert-to-openai-responses-input-tool-search.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input-tool-search.test.ts
@@ -1,0 +1,64 @@
+import type { ToolNameMapping } from '@ai-sdk/provider-utils';
+import { expect, it } from 'vitest';
+import { convertToOpenAIResponsesInput } from './convert-to-openai-responses-input';
+
+const testToolNameMapping: ToolNameMapping = {
+  toProviderToolName: (customToolName: string) => customToolName,
+  toCustomToolName: (providerToolName: string) => providerToolName,
+};
+
+it('preserves distinct hosted tool search item references from provider metadata', async () => {
+  const result = await convertToOpenAIResponsesInput({
+    toolNameMapping: testToolNameMapping,
+    prompt: [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'tsc_hosted_123',
+            toolName: 'tool_search',
+            input: {
+              arguments: { paths: ['get_weather'] },
+              call_id: null,
+            },
+            providerExecuted: true,
+            ...({
+              providerMetadata: {
+                openai: {
+                  itemId: 'tsc_hosted_123',
+                },
+              },
+            } as object),
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'tsc_hosted_123',
+            toolName: 'tool_search',
+            output: {
+              type: 'json',
+              value: {
+                tools: [{ name: 'get_weather', type: 'function' }],
+              },
+            },
+            ...({
+              providerMetadata: {
+                openai: {
+                  itemId: 'tso_hosted_456',
+                },
+              },
+            } as object),
+          },
+        ],
+      },
+    ],
+    systemMessageMode: 'system',
+    providerOptionsName: 'openai',
+    store: true,
+  });
+
+  expect(result.input).toEqual([
+    { type: 'item_reference', id: 'tsc_hosted_123' },
+    { type: 'item_reference', id: 'tso_hosted_456' },
+  ]);
+});

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -482,12 +482,16 @@ export async function convertToOpenAIResponsesInput({
               );
 
               if (resolvedResultToolName === 'tool_search') {
-                const itemId =
+                const itemId = (part.providerOptions?.[providerOptionsName]
+                  ?.itemId ??
                   (
-                    part.providerOptions?.[providerOptionsName] as
-                      | { itemId?: string }
-                      | undefined
-                  )?.itemId ?? part.toolCallId;
+                    part as {
+                      providerMetadata?: {
+                        [providerOptionsName]?: { itemId?: string };
+                      };
+                    }
+                  ).providerMetadata?.[providerOptionsName]?.itemId ??
+                  part.toolCallId) as string;
 
                 if (store) {
                   input.push({ type: 'item_reference', id: itemId });


### PR DESCRIPTION
## Background

Stored OpenAI Responses continuations could duplicate a hosted tool_search call item ID, causing OpenAI to reject the request.

## Root Cause

The response parser stores the tool-search output item ID in providerMetadata, but the result serializer previously read only providerOptions and therefore fell back to toolCallId. The reproduction showed this emitted the call ID twice instead of preserving distinct call and output IDs.

## Summary

Updated tool-search result serialization to prefer providerOptions, then providerMetadata, then toolCallId; added focused regression coverage using the package-level provider-utils type import; and added a patch changeset.

## Testing

Regression coverage asserts distinct stored call and output references after a providerMetadata round trip. The OpenAI Node and Edge suites each passed 791 tests, and workspace type checking plus lint and formatting checks passed.

## End-to-end Validation

- `pnpm -C examples/ai-functions exec tsx src/generate-text/openai/responses-tool-search.ts` — live OpenAI run completed successfully with distinct `tsc_...` and `tso_...` IDs and no duplicate-item rejection.

## Related Issues

Fixes #17666

Closes #17674

Backport of #17678

Co-authored-by: seandearnaley <5084762+seandearnaley@users.noreply.github.com>
Co-authored-by: lgrammel <205036+lgrammel@users.noreply.github.com>