### PR TITLE
[v6.0] fix: LangChain user image conversion returning provider-specific image_url blocks

### DIFF
--- a/.changeset/bright-images-smile.md
+++ b/.changeset/bright-images-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/langchain': patch
+---
+
+Emit canonical LangChain image content blocks when converting user messages.

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -1005,8 +1005,8 @@ describe('convertModelMessages', () => {
     expect(result[0].content).toEqual([
       { type: 'text', text: 'What is in this image?' },
       {
-        type: 'image_url',
-        image_url: { url: 'https://example.com/image.jpg' },
+        type: 'image',
+        url: 'https://example.com/image.jpg',
       },
     ]);
   });
@@ -1033,8 +1033,9 @@ describe('convertModelMessages', () => {
     expect(result[0].content).toEqual([
       { type: 'text', text: 'What is in this image?' },
       {
-        type: 'image_url',
-        image_url: { url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE' },
+        type: 'image',
+        data: 'iVBORw0KGgoAAAANSUhEUgAAAAE',
+        mimeType: 'image/png',
       },
     ]);
   });
@@ -1060,8 +1061,9 @@ describe('convertModelMessages', () => {
     expect(result[0].content).toEqual([
       { type: 'text', text: 'Describe this.' },
       {
-        type: 'image_url',
-        image_url: { url: 'data:image/png;base64,abc123' },
+        type: 'image',
+        data: 'abc123',
+        mimeType: 'image/png',
       },
     ]);
   });
@@ -1153,8 +1155,8 @@ describe('convertModelMessages', () => {
     expect(result[0].content).toEqual([
       { type: 'text', text: 'Compare these:' },
       {
-        type: 'image_url',
-        image_url: { url: 'https://example.com/image1.jpg' },
+        type: 'image',
+        url: 'https://example.com/image1.jpg',
       },
       { type: 'text', text: 'And this document:' },
       {
@@ -1187,13 +1189,13 @@ describe('convertModelMessages', () => {
     expect(result[0].content).toEqual([
       { type: 'text', text: 'What is this?' },
       {
-        type: 'image_url',
-        image_url: { url: 'https://example.com/image.png' },
+        type: 'image',
+        url: 'https://example.com/image.png',
       },
     ]);
   });
 
-  it('should convert image files (file type with image mediaType) using image_url format', () => {
+  it('should convert image files to canonical image blocks', () => {
     const modelMessages: ModelMessage[] = [
       {
         role: 'user',
@@ -1215,8 +1217,8 @@ describe('convertModelMessages', () => {
     expect(result[0].content).toEqual([
       { type: 'text', text: 'Describe this photo.' },
       {
-        type: 'image_url',
-        image_url: { url: 'https://example.com/photo.jpg' },
+        type: 'image',
+        url: 'https://example.com/photo.jpg',
       },
     ]);
   });
@@ -1382,12 +1384,12 @@ describe('toBaseMessages', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]).toBeInstanceOf(HumanMessage);
-    // Image files are converted to OpenAI's image_url format
     expect(result[0].content).toEqual([
       { type: 'text', text: 'What is in this image?' },
       {
-        type: 'image_url',
-        image_url: { url: 'data:image/png;base64,abc123' },
+        type: 'image',
+        data: 'abc123',
+        mimeType: 'image/png',
       },
     ]);
   });

--- a/packages/langchain/src/utils.test.ts
+++ b/packages/langchain/src/utils.test.ts
@@ -244,7 +244,7 @@ describe('convertUserContent', () => {
     expect(result.content).toBe('Part 1 Part 2');
   });
 
-  it('should include image parts with binary data using OpenAI image_url format', () => {
+  it('should convert binary image parts to canonical image blocks', () => {
     const content: UserContent = [
       { type: 'text', text: 'Describe this image' },
       {
@@ -259,13 +259,15 @@ describe('convertUserContent', () => {
     expect(result.content).toEqual([
       { type: 'text', text: 'Describe this image' },
       {
-        type: 'image_url',
-        image_url: { url: 'data:image/png;base64,AQID' }, // base64 of [1, 2, 3]
+        type: 'image',
+        data: 'AQID', // base64 of [1, 2, 3]
+        mimeType: 'image/png',
       },
     ]);
+    expect(result.response_metadata).toEqual({ output_version: 'v1' });
   });
 
-  it('should include image parts with URL using OpenAI image_url format', () => {
+  it('should convert image URL strings to canonical image blocks', () => {
     const content: UserContent = [
       { type: 'text', text: 'What is in this image?' },
       {
@@ -279,8 +281,8 @@ describe('convertUserContent', () => {
     expect(result.content).toEqual([
       { type: 'text', text: 'What is in this image?' },
       {
-        type: 'image_url',
-        image_url: { url: 'https://example.com/image.jpg' },
+        type: 'image',
+        url: 'https://example.com/image.jpg',
       },
     ]);
   });
@@ -308,7 +310,7 @@ describe('convertUserContent', () => {
     ]);
   });
 
-  it('should handle URL objects for images using OpenAI image_url format', () => {
+  it('should convert image URL objects to canonical image blocks', () => {
     const content: UserContent = [
       { type: 'text', text: 'Describe' },
       {
@@ -322,13 +324,13 @@ describe('convertUserContent', () => {
     expect(result.content).toEqual([
       { type: 'text', text: 'Describe' },
       {
-        type: 'image_url',
-        image_url: { url: 'https://example.com/photo.png' },
+        type: 'image',
+        url: 'https://example.com/photo.png',
       },
     ]);
   });
 
-  it('should handle data URLs for images using OpenAI image_url format', () => {
+  it('should convert image data URLs to canonical image blocks', () => {
     const content: UserContent = [
       { type: 'text', text: 'Analyze' },
       {
@@ -342,13 +344,14 @@ describe('convertUserContent', () => {
     expect(result.content).toEqual([
       { type: 'text', text: 'Analyze' },
       {
-        type: 'image_url',
-        image_url: { url: 'data:image/png;base64,abc123' },
+        type: 'image',
+        data: 'abc123',
+        mimeType: 'image/png',
       },
     ]);
   });
 
-  it('should handle image files (file type with image mediaType) using OpenAI image_url format', () => {
+  it('should convert image file parts to canonical image blocks', () => {
     const content: UserContent = [
       { type: 'text', text: 'What is this?' },
       {
@@ -363,8 +366,8 @@ describe('convertUserContent', () => {
     expect(result.content).toEqual([
       { type: 'text', text: 'What is this?' },
       {
-        type: 'image_url',
-        image_url: { url: 'https://example.com/photo.jpg' },
+        type: 'image',
+        url: 'https://example.com/photo.jpg',
       },
     ]);
   });

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -203,44 +203,6 @@ export function convertUserContent(content: UserContent): HumanMessage {
         filename?: string;
       };
 
-<<<<<<< HEAD
-      /**
-       * Check if this is an image file - if so, use OpenAI's image_url format
-       */
-=======
-      // Normalize tagged data shape into the legacy bare value this code expects.
-      const normalizedData: string | Uint8Array | URL | ArrayBuffer = (() => {
-        const data = rawFilePart.data;
-        if (
-          typeof data === 'object' &&
-          data !== null &&
-          !(data instanceof URL) &&
-          !(data instanceof Uint8Array) &&
-          !(data instanceof ArrayBuffer) &&
-          'type' in data
-        ) {
-          switch (data.type) {
-            case 'data':
-              return data.data;
-            case 'url':
-              return data.url;
-            case 'text':
-              return data.text;
-            default:
-              return '';
-          }
-        }
-        return data as string | Uint8Array | URL | ArrayBuffer;
-      })();
-
-      const filePart = {
-        type: 'file' as const,
-        data: normalizedData,
-        mediaType: rawFilePart.mediaType,
-        filename: rawFilePart.filename,
-      };
-
->>>>>>> 48ec036d31 (fix: LangChain user image conversion returning provider-specific image_url blocks (#17629))
       const isImage = filePart.mediaType?.startsWith('image/');
 
       if (isImage) {

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -122,25 +122,46 @@ function getDefaultFilename(
   return `${prefix}.${ext}`;
 }
 
-/**
- * OpenAI-native content block type for images.
- * This format is passed through directly by ChatOpenAI to OpenAI's API.
- */
-type OpenAIImageBlock = {
-  type: 'image_url';
-  image_url: {
-    url: string;
-    detail?: 'auto' | 'low' | 'high';
-  };
-};
+function convertImageToContentBlock(
+  data: string | Uint8Array | URL | ArrayBuffer,
+  mediaType: string = 'image/png',
+): ContentBlock.Multimodal.Image {
+  if (data instanceof URL) {
+    if (data.protocol !== 'data:') {
+      return { type: 'image', url: data.toString() };
+    }
 
-/**
- * Content block type for HumanMessage that supports both text and OpenAI images.
- */
-type HumanMessageContentBlock =
-  | { type: 'text'; text: string }
-  | OpenAIImageBlock
-  | ContentBlock;
+    data = data.toString();
+  }
+
+  if (typeof data === 'string') {
+    if (data.startsWith('http://') || data.startsWith('https://')) {
+      return { type: 'image', url: data };
+    }
+
+    if (data.startsWith('data:')) {
+      const matches = data.match(/^data:([^;]+);base64,(.+)$/);
+      if (matches) {
+        return {
+          type: 'image',
+          data: matches[2],
+          mimeType: matches[1],
+        };
+      }
+
+      return { type: 'image', url: data };
+    }
+
+    return { type: 'image', data, mimeType: mediaType };
+  }
+
+  const bytes = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
+  return {
+    type: 'image',
+    data: btoa(String.fromCharCode(...bytes)),
+    mimeType: mediaType,
+  };
+}
 
 /**
  * Converts UserContent to LangChain HumanMessage
@@ -152,7 +173,7 @@ export function convertUserContent(content: UserContent): HumanMessage {
     return new HumanMessage({ content });
   }
 
-  const contentBlocks: HumanMessageContentBlock[] = [];
+  const contentBlocks: ContentBlock.Standard[] = [];
 
   for (const part of content) {
     if (part.type === 'text') {
@@ -164,64 +185,15 @@ export function convertUserContent(content: UserContent): HumanMessage {
         mediaType?: string;
       };
 
-      /**
-       * Use OpenAI's native image_url format which is passed through directly
-       * handle URL objects
-       */
-      if (imagePart.image instanceof URL) {
-        contentBlocks.push({
-          type: 'image_url',
-          image_url: { url: imagePart.image.toString() },
-        });
-      } else if (typeof imagePart.image === 'string') {
-        /**
-         * Handle string (could be URL or base64)
-         */
-        /**
-         * Check if it's a URL (including data: URLs)
-         */
-        if (
-          imagePart.image.startsWith('http://') ||
-          imagePart.image.startsWith('https://') ||
-          imagePart.image.startsWith('data:')
-        ) {
-          /**
-           * OpenAI accepts both http URLs and data URLs directly
-           */
-          contentBlocks.push({
-            type: 'image_url',
-            image_url: { url: imagePart.image },
-          });
-        } else {
-          /**
-           * Assume base64 encoded data - wrap in data URL
-           */
-          const mimeType = imagePart.mediaType || 'image/png';
-          contentBlocks.push({
-            type: 'image_url',
-            image_url: { url: `data:${mimeType};base64,${imagePart.image}` },
-          });
-        }
-      } else if (
-        /**
-         * Handle Uint8Array or ArrayBuffer (binary data)
-         */
+      if (
+        imagePart.image instanceof URL ||
+        typeof imagePart.image === 'string' ||
         imagePart.image instanceof Uint8Array ||
         imagePart.image instanceof ArrayBuffer
       ) {
-        const bytes =
-          imagePart.image instanceof ArrayBuffer
-            ? new Uint8Array(imagePart.image)
-            : imagePart.image;
-        /**
-         * Convert to base64 data URL
-         */
-        const base64 = btoa(String.fromCharCode(...bytes));
-        const mimeType = imagePart.mediaType || 'image/png';
-        contentBlocks.push({
-          type: 'image_url',
-          image_url: { url: `data:${mimeType};base64,${base64}` },
-        });
+        contentBlocks.push(
+          convertImageToContentBlock(imagePart.image, imagePart.mediaType),
+        );
       }
     } else if (part.type === 'file') {
       const filePart = part as {
@@ -231,58 +203,50 @@ export function convertUserContent(content: UserContent): HumanMessage {
         filename?: string;
       };
 
+<<<<<<< HEAD
       /**
        * Check if this is an image file - if so, use OpenAI's image_url format
        */
+=======
+      // Normalize tagged data shape into the legacy bare value this code expects.
+      const normalizedData: string | Uint8Array | URL | ArrayBuffer = (() => {
+        const data = rawFilePart.data;
+        if (
+          typeof data === 'object' &&
+          data !== null &&
+          !(data instanceof URL) &&
+          !(data instanceof Uint8Array) &&
+          !(data instanceof ArrayBuffer) &&
+          'type' in data
+        ) {
+          switch (data.type) {
+            case 'data':
+              return data.data;
+            case 'url':
+              return data.url;
+            case 'text':
+              return data.text;
+            default:
+              return '';
+          }
+        }
+        return data as string | Uint8Array | URL | ArrayBuffer;
+      })();
+
+      const filePart = {
+        type: 'file' as const,
+        data: normalizedData,
+        mediaType: rawFilePart.mediaType,
+        filename: rawFilePart.filename,
+      };
+
+>>>>>>> 48ec036d31 (fix: LangChain user image conversion returning provider-specific image_url blocks (#17629))
       const isImage = filePart.mediaType?.startsWith('image/');
 
       if (isImage) {
-        /**
-         * Handle image files using OpenAI's native image_url format
-         */
-        if (filePart.data instanceof URL) {
-          contentBlocks.push({
-            type: 'image_url',
-            image_url: { url: filePart.data.toString() },
-          });
-        } else if (typeof filePart.data === 'string') {
-          /**
-           * URLs (including data URLs) can be passed directly
-           */
-          if (
-            filePart.data.startsWith('http://') ||
-            filePart.data.startsWith('https://') ||
-            filePart.data.startsWith('data:')
-          ) {
-            contentBlocks.push({
-              type: 'image_url',
-              image_url: { url: filePart.data },
-            });
-          } else {
-            /**
-             * Assume base64 - wrap in data URL
-             */
-            contentBlocks.push({
-              type: 'image_url',
-              image_url: {
-                url: `data:${filePart.mediaType};base64,${filePart.data}`,
-              },
-            });
-          }
-        } else if (
-          filePart.data instanceof Uint8Array ||
-          filePart.data instanceof ArrayBuffer
-        ) {
-          const bytes =
-            filePart.data instanceof ArrayBuffer
-              ? new Uint8Array(filePart.data)
-              : filePart.data;
-          const base64 = btoa(String.fromCharCode(...bytes));
-          contentBlocks.push({
-            type: 'image_url',
-            image_url: { url: `data:${filePart.mediaType};base64,${base64}` },
-          });
-        }
+        contentBlocks.push(
+          convertImageToContentBlock(filePart.data, filePart.mediaType),
+        );
       } else {
         // Handle non-image files using LangChain's ContentBlock format
         const filename =
@@ -362,7 +326,7 @@ export function convertUserContent(content: UserContent): HumanMessage {
     });
   }
 
-  return new HumanMessage({ content: contentBlocks });
+  return new HumanMessage({ contentBlocks });
 }
 
 /**


### PR DESCRIPTION
## Background

The published @ai-sdk/langchain adapter returned OpenAI-specific image_url blocks for URL and binary images instead of LangChain's canonical image blocks.

## Root Cause

convertUserContent hard-coded OpenAI image serialization and constructed multimodal HumanMessages through content rather than contentBlocks. The reproduction confirmed inconsistent image output, and live ChatOpenAI validation showed canonical blocks require LangChain's v1 content marker for downstream translation.

## Summary

Converted image inputs and image files to canonical LangChain image blocks and constructed multimodal messages through contentBlocks so LangChain marks and translates them as v1 content. Added a patch changeset.

## Testing

Updated convertUserContent and convertModelMessages coverage for URL, binary, data-URL, and file-based images, including the v1 content marker.

## End-to-end Validation

- `pnpm -C packages/langchain build && pnpm -C examples/ai-functions exec tsx -e <assertions>` — built the package and confirmed canonical URL/binary image blocks while preserving canonical non-image files.
- `pnpm -C examples/next-langchain exec tsx -e <live ChatOpenAI validation>` — GPT-4o accepted the converted JPEG and identified it as a blue-and-yellow macaw.

## Related Issues

Fixes #11943

Closes #17619

Backport of #17629

Co-authored-by: jessieibarra <58125016+jessieibarra@users.noreply.github.com>