### PR TITLE
[v6.0] fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference

### DIFF
--- a/.changeset/calm-pandas-smile.md
+++ b/.changeset/calm-pandas-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Pass through `s3://` image URLs to Amazon Bedrock Converse as S3 image sources instead of downloading them.

--- a/packages/amazon-bedrock/src/bedrock-api-types.ts
+++ b/packages/amazon-bedrock/src/bedrock-api-types.ts
@@ -164,13 +164,7 @@ export interface BedrockGuardrailConverseContentBlock {
 
 export interface BedrockImageBlock {
   image: {
-<<<<<<< HEAD:packages/amazon-bedrock/src/bedrock-api-types.ts
     format: BedrockImageFormat;
-    source: {
-      bytes: string;
-    };
-=======
-    format: AmazonBedrockImageFormat;
     source:
       | {
           bytes: string;
@@ -180,7 +174,6 @@ export interface BedrockImageBlock {
             uri: string;
           };
         };
->>>>>>> 1f92bdb2c3 (fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference (#17681)):packages/amazon-bedrock/src/amazon-bedrock-api-types.ts
   };
 }
 

--- a/packages/amazon-bedrock/src/bedrock-api-types.ts
+++ b/packages/amazon-bedrock/src/bedrock-api-types.ts
@@ -164,10 +164,23 @@ export interface BedrockGuardrailConverseContentBlock {
 
 export interface BedrockImageBlock {
   image: {
+<<<<<<< HEAD:packages/amazon-bedrock/src/bedrock-api-types.ts
     format: BedrockImageFormat;
     source: {
       bytes: string;
     };
+=======
+    format: AmazonBedrockImageFormat;
+    source:
+      | {
+          bytes: string;
+        }
+      | {
+          s3Location: {
+            uri: string;
+          };
+        };
+>>>>>>> 1f92bdb2c3 (fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference (#17681)):packages/amazon-bedrock/src/amazon-bedrock-api-types.ts
   };
 }
 

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -114,6 +114,20 @@ const server = createTestServer({
   [opusAnthropicGenerateUrl]: {},
 });
 
+describe('supportedUrls', () => {
+  it('should support S3 URLs for image parts', () => {
+    const model = new AmazonBedrockChatLanguageModel(modelId, {
+      baseUrl: () => baseUrl,
+      generateId: () => 'test-id',
+      fetch: fakeFetchWithAuth,
+    });
+
+    expect(model.supportedUrls).toEqual({
+      'image/*': [/^s3:\/\//],
+    });
+  });
+});
+
 function prepareJsonFixtureResponse(
   filename: string,
   { headers }: { headers?: Record<string, string> } = {},

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -116,8 +116,9 @@ const server = createTestServer({
 
 describe('supportedUrls', () => {
   it('should support S3 URLs for image parts', () => {
-    const model = new AmazonBedrockChatLanguageModel(modelId, {
+    const model = new BedrockChatLanguageModel(modelId, {
       baseUrl: () => baseUrl,
+      headers: {},
       generateId: () => 'test-id',
       fetch: fakeFetchWithAuth,
     });

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -447,7 +447,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
   }
 
   readonly supportedUrls: Record<string, RegExp[]> = {
-    // no supported urls for bedrock
+    'image/*': [/^s3:\/\//],
   };
 
   private async getHeaders({

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
@@ -111,6 +111,44 @@ describe('user messages', () => {
     ]);
   });
 
+  it('should convert image parts with S3 URLs', async () => {
+    const { messages } = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe the image' },
+          {
+            type: 'file',
+            data: {
+              type: 'url' as const,
+              url: new URL('s3://my-test-bucket/path/to/image.png'),
+            },
+            mediaType: 'image/png',
+          },
+        ],
+      },
+    ]);
+
+    expect(messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          { text: 'Describe the image' },
+          {
+            image: {
+              format: 'png',
+              source: {
+                s3Location: {
+                  uri: 's3://my-test-bucket/path/to/image.png',
+                },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('should convert messages with document parts', async () => {
     const fileData = new Uint8Array([0, 1, 2, 3]);
 
@@ -1387,6 +1425,57 @@ describe('tool messages', () => {
                 image: {
                   format: 'jpeg',
                   source: { bytes: 'base64data' },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  it('should convert tool result images with S3 URLs', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-123',
+            toolName: 'image-generator',
+            output: {
+              type: 'content',
+              value: [
+                {
+                  type: 'file',
+                  data: {
+                    type: 'url',
+                    url: new URL('s3://my-test-bucket/path/to/image.png'),
+                  },
+                  mediaType: 'image/png',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.messages[0]).toEqual({
+      role: 'user',
+      content: [
+        {
+          toolResult: {
+            toolUseId: 'call-123',
+            content: [
+              {
+                image: {
+                  format: 'png',
+                  source: {
+                    s3Location: {
+                      uri: 's3://my-test-bucket/path/to/image.png',
+                    },
+                  },
                 },
               },
             ],

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
@@ -112,17 +112,14 @@ describe('user messages', () => {
   });
 
   it('should convert image parts with S3 URLs', async () => {
-    const { messages } = await convertToAmazonBedrockChatMessages([
+    const { messages } = await convertToBedrockChatMessages([
       {
         role: 'user',
         content: [
           { type: 'text', text: 'Describe the image' },
           {
             type: 'file',
-            data: {
-              type: 'url' as const,
-              url: new URL('s3://my-test-bucket/path/to/image.png'),
-            },
+            data: new URL('s3://my-test-bucket/path/to/image.png'),
             mediaType: 'image/png',
           },
         ],
@@ -1435,7 +1432,7 @@ describe('tool messages', () => {
   });
 
   it('should convert tool result images with S3 URLs', async () => {
-    const result = await convertToAmazonBedrockChatMessages([
+    const result = await convertToBedrockChatMessages([
       {
         role: 'tool',
         content: [
@@ -1447,12 +1444,8 @@ describe('tool messages', () => {
               type: 'content',
               value: [
                 {
-                  type: 'file',
-                  data: {
-                    type: 'url',
-                    url: new URL('s3://my-test-bucket/path/to/image.png'),
-                  },
-                  mediaType: 'image/png',
+                  type: 'image-url',
+                  url: 's3://my-test-bucket/path/to/image.png',
                 },
               ],
             },

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -1,9 +1,17 @@
 import {
   UnsupportedFunctionalityError,
   type JSONObject,
+<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
   type LanguageModelV3Message,
   type LanguageModelV3Prompt,
   type SharedV3ProviderMetadata,
+=======
+  type LanguageModelV4FilePart,
+  type JSONValue,
+  type LanguageModelV4Message,
+  type LanguageModelV4Prompt,
+  type SharedV4ProviderMetadata,
+>>>>>>> 1f92bdb2c3 (fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference (#17681)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
 } from '@ai-sdk/provider';
 import {
   convertToBase64,
@@ -13,6 +21,7 @@ import {
 import {
   BEDROCK_DOCUMENT_MIME_TYPES,
   BEDROCK_IMAGE_MIME_TYPES,
+<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
   type BedrockAssistantMessage,
   type BedrockCachePoint,
   type BedrockDocumentFormat,
@@ -25,6 +34,21 @@ import {
 } from './bedrock-api-types';
 import { bedrockReasoningMetadataSchema } from './bedrock-reasoning-metadata';
 import { bedrockFilePartProviderOptions } from './bedrock-chat-options';
+=======
+  type AmazonBedrockAssistantMessage,
+  type AmazonBedrockCachePoint,
+  type AmazonBedrockDocumentFormat,
+  type AmazonBedrockDocumentMimeType,
+  type AmazonBedrockImageBlock,
+  type AmazonBedrockImageFormat,
+  type AmazonBedrockImageMimeType,
+  type AmazonBedrockMessages,
+  type AmazonBedrockSystemMessages,
+  type AmazonBedrockUserMessage,
+} from './amazon-bedrock-api-types';
+import { amazonBedrockFilePartProviderOptions } from './amazon-bedrock-chat-language-model-options';
+import { amazonBedrockReasoningMetadataSchema } from './amazon-bedrock-reasoning-metadata';
+>>>>>>> 1f92bdb2c3 (fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference (#17681)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
 import { normalizeToolCallId } from './normalize-tool-call-id';
 
 function getCachePoint(
@@ -48,6 +72,28 @@ function pushCachePoint(
   const cachePoint = getCachePoint(providerMetadata);
   if (cachePoint) {
     content.push(cachePoint);
+  }
+}
+
+function getAmazonBedrockImageSource({
+  data,
+  functionality,
+}: {
+  data: Extract<LanguageModelV4FilePart['data'], { type: 'data' | 'url' }>;
+  functionality: string;
+}): AmazonBedrockImageBlock['image']['source'] {
+  switch (data.type) {
+    case 'data':
+      return { bytes: convertToBase64(data.data) };
+    case 'url':
+      if (data.url.protocol !== 's3:') {
+        throw new UnsupportedFunctionalityError({ functionality });
+      }
+      return {
+        s3Location: {
+          uri: data.url.toString(),
+        },
+      };
   }
 }
 
@@ -144,11 +190,48 @@ export async function convertToBedrockChatMessages(
                             'File mime type is required in user message part content',
                         });
                       }
+<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+=======
+                      case 'url': {
+                        if (part.data.url.protocol !== 's3:') {
+                          throw new UnsupportedFunctionalityError({
+                            functionality: 'File URL data',
+                          });
+                        }
+
+                        const fullMediaType = resolveFullMediaType({ part });
+
+                        if (getTopLevelMediaType(fullMediaType) !== 'image') {
+                          throw new UnsupportedFunctionalityError({
+                            functionality: 'File URL data',
+                          });
+                        }
+
+                        amazonBedrockContent.push({
+                          image: {
+                            format: getAmazonBedrockImageFormat(fullMediaType),
+                            source: getAmazonBedrockImageSource({
+                              data: part.data,
+                              functionality: 'File URL data',
+                            }),
+                          },
+                        });
+                        break;
+                      }
+                      case 'text': {
+                        const textMediaType = isFullMediaType(part.mediaType)
+                          ? part.mediaType
+                          : 'text/plain';
+                        const enableCitations = await shouldEnableCitations(
+                          part.providerOptions,
+                        );
+>>>>>>> 1f92bdb2c3 (fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference (#17681)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
 
                       const enableCitations = await shouldEnableCitations(
                         part.providerOptions,
                       );
 
+<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
                       bedrockContent.push({
                         document: {
                           format: getBedrockDocumentFormat(part.mediaType),
@@ -161,6 +244,42 @@ export async function convertToBedrockChatMessages(
                           }),
                         },
                       });
+=======
+                        if (getTopLevelMediaType(fullMediaType) === 'image') {
+                          amazonBedrockContent.push({
+                            image: {
+                              format:
+                                getAmazonBedrockImageFormat(fullMediaType),
+                              source: getAmazonBedrockImageSource({
+                                data: part.data,
+                                functionality: 'File URL data',
+                              }),
+                            },
+                          });
+                        } else {
+                          const enableCitations = await shouldEnableCitations(
+                            part.providerOptions,
+                          );
+
+                          amazonBedrockContent.push({
+                            document: {
+                              format:
+                                getAmazonBedrockDocumentFormat(fullMediaType),
+                              name: part.filename
+                                ? stripFileExtension(part.filename)
+                                : generateDocumentName(),
+                              source: {
+                                bytes: convertToBase64(part.data.data),
+                              },
+                              ...(enableCitations && {
+                                citations: { enabled: true },
+                              }),
+                            },
+                          });
+                        }
+                        break;
+                      }
+>>>>>>> 1f92bdb2c3 (fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference (#17681)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
                     }
 
                     break;
@@ -187,6 +306,7 @@ export async function convertToBedrockChatMessages(
                         switch (contentPart.type) {
                           case 'text':
                             return { text: contentPart.text };
+<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
                           case 'image-data': {
                             return {
                               image: {
@@ -201,6 +321,32 @@ export async function convertToBedrockChatMessages(
                           }
                           case 'file-data': {
                             if (!contentPart.mediaType.startsWith('image/')) {
+=======
+                          case 'file': {
+                            if (
+                              contentPart.data.type !== 'data' &&
+                              (contentPart.data.type !== 'url' ||
+                                contentPart.data.url.protocol !== 's3:')
+                            ) {
+                              throw new UnsupportedFunctionalityError({
+                                functionality: `tool result file data of type "${contentPart.data.type}"`,
+                              });
+                            }
+
+                            const fullMediaType = resolveFullMediaType({
+                              part: contentPart,
+                            });
+
+                            if (
+                              getTopLevelMediaType(fullMediaType) !== 'image'
+                            ) {
+                              if (contentPart.data.type !== 'data') {
+                                throw new UnsupportedFunctionalityError({
+                                  functionality: `tool result file data of type "${contentPart.data.type}"`,
+                                });
+                              }
+
+>>>>>>> 1f92bdb2c3 (fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference (#17681)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
                               const enableCitations =
                                 await shouldEnableCitations(
                                   contentPart.providerOptions,
@@ -228,12 +374,21 @@ export async function convertToBedrockChatMessages(
 
                             return {
                               image: {
+<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
                                 format: getBedrockImageFormat(
                                   contentPart.mediaType,
                                 ),
                                 source: {
                                   bytes: convertToBase64(contentPart.data),
                                 },
+=======
+                                format:
+                                  getAmazonBedrockImageFormat(fullMediaType),
+                                source: getAmazonBedrockImageSource({
+                                  data: contentPart.data,
+                                  functionality: `tool result file data of type "${contentPart.data.type}"`,
+                                }),
+>>>>>>> 1f92bdb2c3 (fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference (#17681)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
                               },
                             };
                           }

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -1,17 +1,10 @@
 import {
   UnsupportedFunctionalityError,
   type JSONObject,
-<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+  type LanguageModelV3FilePart,
   type LanguageModelV3Message,
   type LanguageModelV3Prompt,
   type SharedV3ProviderMetadata,
-=======
-  type LanguageModelV4FilePart,
-  type JSONValue,
-  type LanguageModelV4Message,
-  type LanguageModelV4Prompt,
-  type SharedV4ProviderMetadata,
->>>>>>> 1f92bdb2c3 (fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference (#17681)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
 } from '@ai-sdk/provider';
 import {
   convertToBase64,
@@ -21,11 +14,11 @@ import {
 import {
   BEDROCK_DOCUMENT_MIME_TYPES,
   BEDROCK_IMAGE_MIME_TYPES,
-<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
   type BedrockAssistantMessage,
   type BedrockCachePoint,
   type BedrockDocumentFormat,
   type BedrockDocumentMimeType,
+  type BedrockImageBlock,
   type BedrockImageFormat,
   type BedrockImageMimeType,
   type BedrockMessages,
@@ -34,21 +27,6 @@ import {
 } from './bedrock-api-types';
 import { bedrockReasoningMetadataSchema } from './bedrock-reasoning-metadata';
 import { bedrockFilePartProviderOptions } from './bedrock-chat-options';
-=======
-  type AmazonBedrockAssistantMessage,
-  type AmazonBedrockCachePoint,
-  type AmazonBedrockDocumentFormat,
-  type AmazonBedrockDocumentMimeType,
-  type AmazonBedrockImageBlock,
-  type AmazonBedrockImageFormat,
-  type AmazonBedrockImageMimeType,
-  type AmazonBedrockMessages,
-  type AmazonBedrockSystemMessages,
-  type AmazonBedrockUserMessage,
-} from './amazon-bedrock-api-types';
-import { amazonBedrockFilePartProviderOptions } from './amazon-bedrock-chat-language-model-options';
-import { amazonBedrockReasoningMetadataSchema } from './amazon-bedrock-reasoning-metadata';
->>>>>>> 1f92bdb2c3 (fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference (#17681)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
 import { normalizeToolCallId } from './normalize-tool-call-id';
 
 function getCachePoint(
@@ -75,26 +53,32 @@ function pushCachePoint(
   }
 }
 
-function getAmazonBedrockImageSource({
+function getBedrockImageSource({
   data,
   functionality,
 }: {
-  data: Extract<LanguageModelV4FilePart['data'], { type: 'data' | 'url' }>;
+  data: LanguageModelV3FilePart['data'];
   functionality: string;
-}): AmazonBedrockImageBlock['image']['source'] {
-  switch (data.type) {
-    case 'data':
-      return { bytes: convertToBase64(data.data) };
-    case 'url':
-      if (data.url.protocol !== 's3:') {
-        throw new UnsupportedFunctionalityError({ functionality });
-      }
-      return {
-        s3Location: {
-          uri: data.url.toString(),
-        },
-      };
+}): BedrockImageBlock['image']['source'] {
+  if (data instanceof URL) {
+    if (data.protocol !== 's3:') {
+      throw new UnsupportedFunctionalityError({ functionality });
+    }
+    return {
+      s3Location: {
+        uri: data.toString(),
+      },
+    };
   }
+
+  return { bytes: convertToBase64(data) };
+}
+
+function getBedrockImageFormatFromUrl(url: URL): BedrockImageFormat {
+  const extension = url.pathname.split('.').pop()?.toLowerCase();
+  return getBedrockImageFormat(
+    `image/${extension === 'jpg' ? 'jpeg' : extension}`,
+  );
 }
 
 async function shouldEnableCitations(
@@ -168,21 +152,23 @@ export async function convertToBedrockChatMessages(
                   }
 
                   case 'file': {
-                    if (part.data instanceof URL) {
-                      // The AI SDK automatically downloads files for user file parts with URLs
-                      throw new UnsupportedFunctionalityError({
-                        functionality: 'File URL data',
-                      });
-                    }
-
                     if (part.mediaType.startsWith('image/')) {
                       bedrockContent.push({
                         image: {
                           format: getBedrockImageFormat(part.mediaType),
-                          source: { bytes: convertToBase64(part.data) },
+                          source: getBedrockImageSource({
+                            data: part.data,
+                            functionality: 'File URL data',
+                          }),
                         },
                       });
                     } else {
+                      if (part.data instanceof URL) {
+                        throw new UnsupportedFunctionalityError({
+                          functionality: 'File URL data',
+                        });
+                      }
+
                       if (!part.mediaType) {
                         throw new UnsupportedFunctionalityError({
                           functionality: 'file without mime type',
@@ -190,48 +176,11 @@ export async function convertToBedrockChatMessages(
                             'File mime type is required in user message part content',
                         });
                       }
-<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
-=======
-                      case 'url': {
-                        if (part.data.url.protocol !== 's3:') {
-                          throw new UnsupportedFunctionalityError({
-                            functionality: 'File URL data',
-                          });
-                        }
-
-                        const fullMediaType = resolveFullMediaType({ part });
-
-                        if (getTopLevelMediaType(fullMediaType) !== 'image') {
-                          throw new UnsupportedFunctionalityError({
-                            functionality: 'File URL data',
-                          });
-                        }
-
-                        amazonBedrockContent.push({
-                          image: {
-                            format: getAmazonBedrockImageFormat(fullMediaType),
-                            source: getAmazonBedrockImageSource({
-                              data: part.data,
-                              functionality: 'File URL data',
-                            }),
-                          },
-                        });
-                        break;
-                      }
-                      case 'text': {
-                        const textMediaType = isFullMediaType(part.mediaType)
-                          ? part.mediaType
-                          : 'text/plain';
-                        const enableCitations = await shouldEnableCitations(
-                          part.providerOptions,
-                        );
->>>>>>> 1f92bdb2c3 (fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference (#17681)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
 
                       const enableCitations = await shouldEnableCitations(
                         part.providerOptions,
                       );
 
-<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
                       bedrockContent.push({
                         document: {
                           format: getBedrockDocumentFormat(part.mediaType),
@@ -244,42 +193,6 @@ export async function convertToBedrockChatMessages(
                           }),
                         },
                       });
-=======
-                        if (getTopLevelMediaType(fullMediaType) === 'image') {
-                          amazonBedrockContent.push({
-                            image: {
-                              format:
-                                getAmazonBedrockImageFormat(fullMediaType),
-                              source: getAmazonBedrockImageSource({
-                                data: part.data,
-                                functionality: 'File URL data',
-                              }),
-                            },
-                          });
-                        } else {
-                          const enableCitations = await shouldEnableCitations(
-                            part.providerOptions,
-                          );
-
-                          amazonBedrockContent.push({
-                            document: {
-                              format:
-                                getAmazonBedrockDocumentFormat(fullMediaType),
-                              name: part.filename
-                                ? stripFileExtension(part.filename)
-                                : generateDocumentName(),
-                              source: {
-                                bytes: convertToBase64(part.data.data),
-                              },
-                              ...(enableCitations && {
-                                citations: { enabled: true },
-                              }),
-                            },
-                          });
-                        }
-                        break;
-                      }
->>>>>>> 1f92bdb2c3 (fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference (#17681)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
                     }
 
                     break;
@@ -306,7 +219,6 @@ export async function convertToBedrockChatMessages(
                         switch (contentPart.type) {
                           case 'text':
                             return { text: contentPart.text };
-<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
                           case 'image-data': {
                             return {
                               image: {
@@ -319,34 +231,20 @@ export async function convertToBedrockChatMessages(
                               },
                             };
                           }
+                          case 'image-url': {
+                            const url = new URL(contentPart.url);
+                            return {
+                              image: {
+                                format: getBedrockImageFormatFromUrl(url),
+                                source: getBedrockImageSource({
+                                  data: url,
+                                  functionality: `tool result image URL "${contentPart.url}"`,
+                                }),
+                              },
+                            };
+                          }
                           case 'file-data': {
                             if (!contentPart.mediaType.startsWith('image/')) {
-=======
-                          case 'file': {
-                            if (
-                              contentPart.data.type !== 'data' &&
-                              (contentPart.data.type !== 'url' ||
-                                contentPart.data.url.protocol !== 's3:')
-                            ) {
-                              throw new UnsupportedFunctionalityError({
-                                functionality: `tool result file data of type "${contentPart.data.type}"`,
-                              });
-                            }
-
-                            const fullMediaType = resolveFullMediaType({
-                              part: contentPart,
-                            });
-
-                            if (
-                              getTopLevelMediaType(fullMediaType) !== 'image'
-                            ) {
-                              if (contentPart.data.type !== 'data') {
-                                throw new UnsupportedFunctionalityError({
-                                  functionality: `tool result file data of type "${contentPart.data.type}"`,
-                                });
-                              }
-
->>>>>>> 1f92bdb2c3 (fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference (#17681)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
                               const enableCitations =
                                 await shouldEnableCitations(
                                   contentPart.providerOptions,
@@ -374,21 +272,12 @@ export async function convertToBedrockChatMessages(
 
                             return {
                               image: {
-<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
                                 format: getBedrockImageFormat(
                                   contentPart.mediaType,
                                 ),
                                 source: {
                                   bytes: convertToBase64(contentPart.data),
                                 },
-=======
-                                format:
-                                  getAmazonBedrockImageFormat(fullMediaType),
-                                source: getAmazonBedrockImageSource({
-                                  data: contentPart.data,
-                                  functionality: `tool result file data of type "${contentPart.data.type}"`,
-                                }),
->>>>>>> 1f92bdb2c3 (fix: Amazon Bedrock S3 image URLs are rejected instead of passed through to inference (#17681)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
                               },
                             };
                           }


### PR DESCRIPTION
## Background

The published Amazon Bedrock provider rejected S3-hosted images before inference, forcing users to load image bytes into memory.

## Root Cause

The model declared no native URL support, causing the core downloader to reject s3:// URLs, while Bedrock message conversion also unconditionally rejected URL-backed files. Reproduction confirmed AI_DownloadError through generateText and AI_UnsupportedFunctionalityError through direct provider use.

## Summary

The provider now recognizes s3:// image URLs and serializes user and tool-result images as Bedrock s3Location sources. Bedrock image source types and a patch changeset were updated.

## Testing

Added regression coverage for native S3 URL declaration and conversion of user and tool-result S3 images.

## End-to-end Validation

- `AWS_REGION=us-east-1 pnpm -C examples/ai-functions exec tsx src/reproduction/amazon-bedrock-s3-image-url.ts` using a temporary Nova variant reached live Bedrock and returned `Provided S3Location not found`, confirming pass-through instead of the previous pre-inference `AI_DownloadError`.

## Related Issues

Fixes #15792

Closes #17676

Backport of #17681

Co-authored-by: tommyOtsai <171396937+tommyOtsai@users.noreply.github.com>