### PR TITLE
[v5.0] reproduction: Bedrock client doesn't support alternate URLs for non-standard

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 11197,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11197-bedrock-nonstandard-region.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/issue-11197-bedrock-nonstandard-region.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Issue #11197 reproduced: Bedrock Runtime selected incorrect endpoints."
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/examples/ai-functions/src/reproduction/issue-11197-bedrock-nonstandard-region.ts
+++ b/examples/ai-functions/src/reproduction/issue-11197-bedrock-nonstandard-region.ts
@@ -1,0 +1,110 @@
+import { createAmazonBedrock } from '../../../../packages/amazon-bedrock/src';
+
+const ISO_REGION = 'us-iso-east-1';
+const EXPECTED_ISO_ORIGIN = 'https://bedrock-runtime.us-iso-east-1.c2s.ic.gov';
+const SERVICE_OVERRIDE = 'https://bedrock-runtime.override.example';
+
+async function captureRequestUrl(options: {
+  region: string;
+  endpointOverride?: string;
+}): Promise<string> {
+  const previousOverride = process.env.AWS_ENDPOINT_URL_BEDROCK_RUNTIME;
+
+  if (options.endpointOverride == null) {
+    delete process.env.AWS_ENDPOINT_URL_BEDROCK_RUNTIME;
+  } else {
+    process.env.AWS_ENDPOINT_URL_BEDROCK_RUNTIME = options.endpointOverride;
+  }
+
+  let requestUrl: string | undefined;
+
+  try {
+    const provider = createAmazonBedrock({
+      apiKey: 'reproduction-api-key',
+      region: options.region,
+      fetch: async input => {
+        requestUrl =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+
+        return new Response(
+          JSON.stringify({
+            metrics: { latencyMs: 1 },
+            output: {
+              message: {
+                content: [{ text: 'ok' }],
+                role: 'assistant',
+              },
+            },
+            stopReason: 'end_turn',
+            usage: {
+              inputTokens: 1,
+              outputTokens: 1,
+              totalTokens: 2,
+            },
+          }),
+          {
+            headers: { 'content-type': 'application/json' },
+            status: 200,
+          },
+        );
+      },
+    });
+
+    await provider('anthropic.claude-3-haiku-20240307-v1:0').doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Reply with ok.' }],
+        },
+      ],
+    });
+  } finally {
+    if (previousOverride == null) {
+      delete process.env.AWS_ENDPOINT_URL_BEDROCK_RUNTIME;
+    } else {
+      process.env.AWS_ENDPOINT_URL_BEDROCK_RUNTIME = previousOverride;
+    }
+  }
+
+  if (requestUrl == null) {
+    throw new Error('The reproduction did not observe an outgoing request.');
+  }
+
+  return requestUrl;
+}
+
+async function main() {
+  const automaticUrl = await captureRequestUrl({ region: ISO_REGION });
+  const overrideUrl = await captureRequestUrl({
+    endpointOverride: SERVICE_OVERRIDE,
+    region: ISO_REGION,
+  });
+
+  const automaticOrigin = new URL(automaticUrl).origin;
+  const overrideOrigin = new URL(overrideUrl).origin;
+
+  if (
+    automaticOrigin !== EXPECTED_ISO_ORIGIN ||
+    overrideOrigin !== SERVICE_OVERRIDE
+  ) {
+    console.error(
+      [
+        'Issue #11197 reproduced: Bedrock Runtime selected incorrect endpoints.',
+        `Automatic ISO endpoint: ${automaticOrigin}`,
+        `Expected ISO endpoint: ${EXPECTED_ISO_ORIGIN}`,
+        `AWS_ENDPOINT_URL_BEDROCK_RUNTIME endpoint: ${overrideOrigin}`,
+        `Expected service override: ${SERVICE_OVERRIDE}`,
+      ].join('\n'),
+    );
+    process.exitCode = 1;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/issue-11197-live-attempt.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-11197-live-attempt.json
@@ -1,0 +1,8 @@
+{
+  "region": "us-iso-east-1",
+  "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+  "selectedRequestUrl": "https://bedrock-runtime.us-iso-east-1.amazonaws.com/model/anthropic.claude-3-haiku-20240307-v1%3A0/converse",
+  "expectedOrigin": "https://bedrock-runtime.us-iso-east-1.c2s.ic.gov",
+  "outcome": "AI_APICallError: Cannot connect to API: Request was cancelled.",
+  "networkBlocker": "The sandbox proxy cancelled the request after the provider selected the request URL."
+}

--- a/packages/amazon-bedrock/src/bedrock-provider.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-provider.test.ts
@@ -122,6 +122,19 @@ describe('AmazonBedrockProvider', () => {
       expect(constructorCall[1].baseUrl()).toBe('https://custom.url');
     });
 
+    it('should resolve the Bedrock Runtime endpoint for an ISO region', () => {
+      const provider = createAmazonBedrock({
+        region: 'us-iso-east-1',
+      });
+
+      provider('anthropic.claude-v2');
+
+      const constructorCall = BedrockChatLanguageModelMock.mock.calls[0];
+      expect(constructorCall[1].baseUrl()).toBe(
+        'https://bedrock-runtime.us-iso-east-1.c2s.ic.gov',
+      );
+    });
+
     it('should accept a credentialProvider in options', () => {
       const mockCredentialProvider = vi.fn().mockResolvedValue({
         accessKeyId: 'dynamic-access-key',


### PR DESCRIPTION
## Bug

Bedrock client doesn't support alternate URLs for non-standard AWS Regions.

## Reproduction

- On target `@ai-sdk/amazon-bedrock` 3.0.108, `examples/ai-functions/src/reproduction/issue-11197-bedrock-nonstandard-region.ts` observed `us-iso-east-1` resolving to `bedrock-runtime.us-iso-east-1.amazonaws.com` instead of the documented `bedrock-runtime.us-iso-east-1.c2s.ic.gov` host.
- The reproduction also observed that `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` was ignored, preventing the documented service-specific override from correcting the request destination.
- `packages/amazon-bedrock/src/bedrock-provider.test.ts` contains a focused regression test that expected the ISO endpoint but received the hard-coded `amazonaws.com` endpoint.
- `packages/amazon-bedrock/src/__fixtures__/issue-11197-live-attempt.json` records the live attempt's incorrect selected URL; the sandbox proxy cancelled the request before an AWS service response was returned.
- `packages/amazon-bedrock/src/bedrock-provider.ts` hard-codes `amazonaws.com` and does not read AWS endpoint override variables; manually supplying `baseURL` is the only available endpoint override on this branch.
- The exact Bedrock control-plane versus Runtime conflict from the comment cannot be exercised because `packages/amazon-bedrock/src/index.ts` exposes model Runtime operations but no Bedrock control-plane client.
- `examples/ai-functions/package.json` provides the workspace package required to run the reproduction replay command.

## Relevant Documentation

- https://github.com/aws/aws-sdk-js-v3/blob/a0bd362cca53a59918a8b55ed12dcda421edc9b5/codegen/sdk-codegen/aws-models/bedrock-runtime.json
- https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html
- https://docs.aws.amazon.com/sdkref/latest/guide/ss-endpoints-table.html
- https://docs.aws.amazon.com/general/latest/gr/bedrock.html

## Related Issues

Reproduces #11197