### PR TITLE
[v6.0] reproduction: UI message stream onEnd cannot distinguish a failed

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17500,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17500-ui-stream-on-end-outcome.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17500-ui-stream-on-end-outcome.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_17500_REPRODUCED: execution and merged-stream failures are indistinguishable from successful EOF in the lifecycle callback and are persisted as completed"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17500-ui-stream-on-end-outcome.ts
+++ b/examples/ai-functions/src/reproduction/issue-17500-ui-stream-on-end-outcome.ts
@@ -1,0 +1,158 @@
+import {
+  createUIMessageStream,
+  type UIMessageChunk,
+  type UIMessageStreamOnFinishCallback,
+} from 'ai';
+
+type Scenario =
+  | 'successful-eof'
+  | 'explicit-error-chunk'
+  | 'execution-rejection'
+  | 'merged-stream-rejection';
+
+type LifecycleObservation = {
+  callbackCount: number;
+  chunkTypes: string[];
+  finishReason: string | undefined;
+  hasOutcome: boolean;
+  isAborted: boolean;
+  persistedOutcome: 'completed' | 'failed' | 'interrupted';
+};
+
+async function observeScenario(
+  scenario: Scenario,
+): Promise<LifecycleObservation> {
+  const lifecycleEvents: Parameters<UIMessageStreamOnFinishCallback<any>>[0][] =
+    [];
+  const chunkTypes: string[] = [];
+
+  const stream = createUIMessageStream({
+    async execute({ writer }) {
+      writer.write({ type: 'start' });
+      writer.write({ type: 'text-start', id: 't1' });
+      writer.write({
+        type: 'text-delta',
+        id: 't1',
+        delta: 'partial output',
+      });
+      writer.write({ type: 'text-end', id: 't1' });
+
+      switch (scenario) {
+        case 'successful-eof':
+          return;
+        case 'explicit-error-chunk':
+          writer.write({
+            type: 'error',
+            errorText: 'Internal server error',
+          });
+          return;
+        case 'execution-rejection':
+          throw new Error('execution rejected');
+        case 'merged-stream-rejection':
+          writer.merge(
+            new ReadableStream<UIMessageChunk>({
+              start(controller) {
+                controller.error(new Error('merged stream rejected'));
+              },
+            }),
+          );
+      }
+    },
+    onError: () => 'An error occurred.',
+    onFinish: event => {
+      lifecycleEvents.push(event);
+    },
+    generateId: () => `${scenario}-message`,
+  });
+
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    chunkTypes.push(value.type);
+  }
+
+  if (lifecycleEvents.length !== 1) {
+    throw new Error(
+      `${scenario}: expected onFinish exactly once, received ${lifecycleEvents.length}`,
+    );
+  }
+
+  const event = lifecycleEvents[0];
+  const finishReason = event.finishReason;
+  const persistedOutcome = event.isAborted
+    ? 'interrupted'
+    : finishReason === 'error'
+      ? 'failed'
+      : 'completed';
+
+  return {
+    callbackCount: lifecycleEvents.length,
+    chunkTypes,
+    finishReason,
+    hasOutcome: Object.hasOwn(event, 'outcome'),
+    isAborted: event.isAborted,
+    persistedOutcome,
+  };
+}
+
+async function main() {
+  const scenarios: Scenario[] = [
+    'successful-eof',
+    'explicit-error-chunk',
+    'execution-rejection',
+    'merged-stream-rejection',
+  ];
+  const observations = Object.fromEntries(
+    await Promise.all(
+      scenarios.map(async scenario => [
+        scenario,
+        await observeScenario(scenario),
+      ]),
+    ),
+  ) as Record<Scenario, LifecycleObservation>;
+
+  console.log(JSON.stringify(observations, null, 2));
+
+  const success = observations['successful-eof'];
+  const fatalFailures = [
+    observations['execution-rejection'],
+    observations['merged-stream-rejection'],
+  ];
+  const sameLifecycleDataAsSuccess = fatalFailures.every(
+    observation =>
+      observation.isAborted === success.isAborted &&
+      observation.finishReason === success.finishReason &&
+      observation.hasOutcome === success.hasOutcome,
+  );
+  const failureChunksWereEmitted = fatalFailures.every(observation =>
+    observation.chunkTypes.includes('error'),
+  );
+  const failuresWerePersistedAsCompleted = fatalFailures.every(
+    observation => observation.persistedOutcome === 'completed',
+  );
+
+  if (
+    sameLifecycleDataAsSuccess &&
+    failureChunksWereEmitted &&
+    failuresWerePersistedAsCompleted &&
+    !success.hasOutcome
+  ) {
+    console.error(
+      'ISSUE_17500_REPRODUCED: execution and merged-stream failures are indistinguishable from successful EOF in the lifecycle callback and are persisted as completed',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    'Issue not reproduced: the lifecycle callback distinguished fatal failure from successful EOF.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

UI message stream onEnd cannot distinguish a failed response from a completed one

## Reproduction

- The checked-out target is `ai@6.0.233`; release-v6.0 names the reported lifecycle callback `onFinish`, and `packages/ai/src/ui-message-stream/ui-message-stream-on-finish-callback.ts` provides no operation-level outcome.
- The reproduction at `examples/ai-functions/src/reproduction/issue-17500-ui-stream-on-end-outcome.ts` observed successful EOF, an explicit error chunk, an execution rejection, and a merged-stream rejection all invoke the callback exactly once with `isAborted: false`, `finishReason: undefined`, and no outcome field.
- Execution and merged-stream rejections emitted error chunks, but a consumer using the available lifecycle fields persisted both as completed—the reported user-visible impact.
- Expected behavior is an owner-declared terminal verdict that distinguishes completed stream boundaries from failed execution and merged-stream boundaries.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-ui/create-ui-message-stream

## Related Issues

Reproduces #17500