### PR TITLE
reproduction: could not reproduce additionalModelResponseFieldPaths/stopsequence should be nullable

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11363.ts
+++ b/examples/ai-functions/src/reproduction/issue-11363.ts
@@ -1,0 +1,52 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+async function main() {
+  const fixture = await readFile(
+    new URL(
+      '../../../../packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null.json',
+      import.meta.url,
+    ),
+    'utf8',
+  );
+
+  const bedrock = createAmazonBedrock({
+    region: 'us-east-1',
+    accessKeyId: 'test-access-key',
+    secretAccessKey: 'test-secret-key',
+    fetch: async () =>
+      new Response(fixture, {
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      }),
+  });
+
+  const result = await generateText({
+    model: bedrock('anthropic.claude-3-haiku-20240307-v1:0'),
+    prompt: 'Use the weather tool for Seattle.',
+    tools: {
+      weather: tool({
+        description: 'Get weather',
+        inputSchema: z.object({ city: z.string() }),
+      }),
+    },
+    toolChoice: 'required',
+    maxOutputTokens: 100,
+  });
+
+  assert.equal(result.finishReason, 'tool-calls');
+  assert.equal(result.toolCalls[0]?.toolName, 'weather');
+  assert.deepEqual(result.providerMetadata?.amazonBedrock?.stopSequence, null);
+
+  console.log(
+    'Issue #11363 could not be reproduced: stop_sequence: null was accepted and the tool call completed.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null.json
@@ -1,0 +1,36 @@
+{
+  "additionalModelResponseFields": {
+    "stop_sequence": null
+  },
+  "metrics": {
+    "latencyMs": 2066
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "toolUse": {
+            "input": {
+              "city": "Seattle"
+            },
+            "name": "weather",
+            "toolUseId": "tooluse_93FMnHYRGfM9Sz0BGGvFc4",
+            "type": "tool_use"
+          }
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "tool_use",
+  "usage": {
+    "cacheReadInputTokenCount": 0,
+    "cacheReadInputTokens": 0,
+    "cacheWriteInputTokenCount": 0,
+    "cacheWriteInputTokens": 0,
+    "inputTokens": 677,
+    "outputTokens": 36,
+    "serverToolUsage": {},
+    "totalTokens": 713
+  }
+}

--- a/packages/amazon-bedrock/src/issue-11363.test.ts
+++ b/packages/amazon-bedrock/src/issue-11363.test.ts
@@ -1,0 +1,61 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import fs from 'node:fs';
+import { expect, it } from 'vitest';
+import { createAmazonBedrock } from './amazon-bedrock-provider';
+
+const prompt: LanguageModelV4Prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'Use the weather tool for Seattle.' }],
+  },
+];
+
+it('accepts a live response with top-level stop_sequence: null', async () => {
+  const fixture = fs.readFileSync(
+    'src/__fixtures__/issue-11363-stop-sequence-null.json',
+    'utf8',
+  );
+  const provider = createAmazonBedrock({
+    region: 'us-east-1',
+    accessKeyId: 'test-access-key',
+    secretAccessKey: 'test-secret-key',
+    fetch: async () =>
+      new Response(fixture, {
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      }),
+  });
+
+  const result = await provider(
+    'anthropic.claude-3-haiku-20240307-v1:0',
+  ).doGenerate({
+    prompt,
+    tools: [
+      {
+        type: 'function',
+        name: 'weather',
+        description: 'Get weather',
+        inputSchema: {
+          type: 'object',
+          properties: { city: { type: 'string' } },
+          required: ['city'],
+          additionalProperties: false,
+        },
+      },
+    ],
+    toolChoice: { type: 'required' },
+  });
+
+  expect(result.finishReason).toEqual({
+    unified: 'tool-calls',
+    raw: 'tool_use',
+  });
+  expect(result.content).toEqual([
+    {
+      type: 'tool-call',
+      toolCallId: 'tooluse_93FMnHYRGfM9Sz0BGGvFc4',
+      toolName: 'weather',
+      input: '{"city":"Seattle"}',
+    },
+  ]);
+});


### PR DESCRIPTION
## Bug

additionalModelResponseFieldPaths/stop_sequence should be nullable

## Reproduction

- The reported user-visible bug is a Bedrock response being discarded with a validation error when `additionalModelResponseFields.stop_sequence` is `null`; that failure did not occur on `main`.
- A live Amazon Bedrock narrowing call using the reported `/stop_sequence` response path returned HTTP 200 with `additionalModelResponseFields.stop_sequence: null`; the response is recorded in `packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null.json`.
- `packages/amazon-bedrock/src/issue-11363.test.ts` replayed the live response and completed with a `tool-calls` finish reason instead of the expected validation error.
- `examples/ai-functions/src/reproduction/issue-11363.ts` also accepted the null field and completed the tool call successfully with the checked-out `@ai-sdk/amazon-bedrock` 5.0.27.
- `packages/amazon-bedrock/CHANGELOG.md` records the null-handling fix in version 4.0.1, and `packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts` currently permits a null stop sequence; users on the affected beta should upgrade to 4.0.1 or later.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html

## Related Issues

Could not reproduce #11363