### PR TITLE
reproduction: v6: streamText onFinish callback no longer has object

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 11418,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11418-stream-text-onfinish-object.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-11418-stream-text-onfinish-object.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "BUG: streamText onFinish did not expose the complete structured output"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11418-stream-text-onfinish-object.ts
+++ b/examples/ai-functions/src/reproduction/issue-11418-stream-text-onfinish-object.ts
@@ -1,0 +1,69 @@
+import { Output, simulateReadableStream, streamText } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import { z } from 'zod';
+
+async function main() {
+  let onFinishEvent: Record<string, unknown> | undefined;
+
+  const result = streamText({
+    model: new MockLanguageModelV3({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: 'text-start', id: 'text-1' },
+            {
+              type: 'text-delta',
+              id: 'text-1',
+              delta: '{"content":"Hello, world!"}',
+            },
+            { type: 'text-end', id: 'text-1' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: {
+                inputTokens: {
+                  total: 1,
+                  noCache: 1,
+                  cacheRead: undefined,
+                  cacheWrite: undefined,
+                },
+                outputTokens: {
+                  total: 1,
+                  text: 1,
+                  reasoning: undefined,
+                },
+              },
+            },
+          ],
+          initialDelayInMs: null,
+          chunkDelayInMs: null,
+        }),
+      }),
+    }),
+    output: Output.object({
+      schema: z.object({ content: z.string() }),
+    }),
+    prompt: 'Return a greeting.',
+    onFinish(event) {
+      onFinishEvent = event as unknown as Record<string, unknown>;
+    },
+  });
+
+  const parsedOutput = await result.output;
+  const callbackOutput = onFinishEvent?.object ?? onFinishEvent?.output;
+
+  console.log('result.output:', parsedOutput);
+  console.log('onFinish keys:', Object.keys(onFinishEvent ?? {}).sort());
+  console.log('onFinish structured output:', callbackOutput);
+
+  if (callbackOutput === undefined) {
+    throw new Error(
+      'BUG: streamText onFinish did not expose the complete structured output',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

v6: streamText onFinish callback no longer has object prop for structured data

## Reproduction

- The current `main` packages contain the reported API at `ai@7.0.34` and `@ai-sdk/google@4.0.21`, so the v6 report remains applicable to the target branch.
- `result.output` successfully parsed `{ content: 'Hello, world!' }`, confirming that generation and structured-output parsing completed.
- The `onFinish` callback was invoked but exposed neither `object` nor `output`; the expected complete parsed object was therefore unavailable for callback-based persistence.
- The provider-independent reproduction is runnable from `examples/ai-functions/src/reproduction/issue-11418-stream-text-onfinish-object.ts`, ruling out Google credentials or configuration as the cause.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text
- https://ai-sdk.dev/docs/reference/ai-sdk-core/output
- https://ai-sdk.dev/docs/migration-guides/migration-guide-6-0

## Related Issues

Reproduces #11418