### PR TITLE
[v6.0] reproduction: could not reproduce additionalModelResponseFieldPaths/stopsequence should be nullable

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11363.ts
+++ b/examples/ai-functions/src/reproduction/issue-11363.ts
@@ -1,0 +1,83 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText, tool } from 'ai';
+import fs from 'node:fs';
+import { z } from 'zod';
+
+const fixtureDirectory = '../../packages/amazon-bedrock/src/__fixtures__';
+
+function readFixture(name: string) {
+  const fixture = JSON.parse(
+    fs.readFileSync(`${fixtureDirectory}/${name}.json`, 'utf8'),
+  );
+
+  if (fixture.additionalModelResponseFields?.stop_sequence !== null) {
+    throw new Error('Fixture does not contain stop_sequence: null');
+  }
+
+  return fixture;
+}
+
+function createFixtureProvider(fixture: unknown) {
+  return createAmazonBedrock({
+    apiKey: 'reproduction-api-key',
+    baseURL: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+    fetch: async () =>
+      new Response(JSON.stringify(fixture), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+  });
+}
+
+async function main() {
+  const modelId = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+  const textResult = await generateText({
+    model: createFixtureProvider(
+      readFixture('issue-11363-stop-sequence-null-end-turn'),
+    )(modelId),
+    prompt: 'Say hello.',
+  });
+
+  if (
+    textResult.finishReason !== 'stop' ||
+    textResult.text !== 'Hello! How can I help you today?'
+  ) {
+    throw new Error('Expected the regular text response to complete');
+  }
+
+  const toolResult = await generateText({
+    model: createFixtureProvider(readFixture('issue-11363-stop-sequence-null'))(
+      modelId,
+    ),
+    prompt: 'Use the querySalesforce tool to list account IDs.',
+    tools: {
+      querySalesforce: tool({
+        description: 'Query Salesforce',
+        inputSchema: z.object({ query: z.string() }),
+      }),
+    },
+    toolChoice: { type: 'tool', toolName: 'querySalesforce' },
+  });
+
+  if (toolResult.finishReason !== 'tool-calls') {
+    throw new Error(
+      `Expected tool-calls finish reason, received ${toolResult.finishReason}`,
+    );
+  }
+
+  if (
+    toolResult.toolCalls.length !== 1 ||
+    toolResult.toolCalls[0].toolName !== 'querySalesforce'
+  ) {
+    throw new Error('Expected the querySalesforce tool call to be preserved');
+  }
+
+  console.log(
+    'Issue #11363 did not reproduce: null stop_sequence was accepted and the tool call completed.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null-end-turn.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null-end-turn.json
@@ -1,0 +1,29 @@
+{
+  "additionalModelResponseFields": {
+    "stop_sequence": null
+  },
+  "metrics": {
+    "latencyMs": 1278
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "text": "Hello! How can I help you today?"
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "cacheReadInputTokenCount": 0,
+    "cacheReadInputTokens": 0,
+    "cacheWriteInputTokenCount": 0,
+    "cacheWriteInputTokens": 0,
+    "inputTokens": 10,
+    "outputTokens": 12,
+    "serverToolUsage": {},
+    "totalTokens": 22
+  }
+}

--- a/packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null.json
@@ -1,0 +1,36 @@
+{
+  "additionalModelResponseFields": {
+    "stop_sequence": null
+  },
+  "metrics": {
+    "latencyMs": 2025
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "toolUse": {
+            "input": {
+              "query": "SELECT Id FROM Account"
+            },
+            "name": "querySalesforce",
+            "toolUseId": "tooluse_j6gIgqF8PljNKBylAe15oP",
+            "type": "tool_use"
+          }
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "tool_use",
+  "usage": {
+    "cacheReadInputTokenCount": 0,
+    "cacheReadInputTokens": 0,
+    "cacheWriteInputTokenCount": 0,
+    "cacheWriteInputTokens": 0,
+    "inputTokens": 674,
+    "outputTokens": 36,
+    "serverToolUsage": {},
+    "totalTokens": 710
+  }
+}

--- a/packages/amazon-bedrock/src/issue-11363.test.ts
+++ b/packages/amazon-bedrock/src/issue-11363.test.ts
@@ -1,0 +1,96 @@
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { expect, it } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+import { injectFetchHeaders } from './inject-fetch-headers';
+
+const modelId = 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+const baseUrl = 'https://bedrock-runtime.us-east-1.amazonaws.com';
+const generateUrl = `${baseUrl}/model/${encodeURIComponent(modelId)}/converse`;
+
+function readFixture(name: string) {
+  return JSON.parse(fs.readFileSync(`src/__fixtures__/${name}.json`, 'utf8'));
+}
+
+const server = createTestServer({
+  [generateUrl]: {
+    response: {
+      type: 'json-value',
+      body: readFixture('issue-11363-stop-sequence-null'),
+    },
+  },
+});
+
+const model = new BedrockChatLanguageModel(modelId, {
+  baseUrl: () => baseUrl,
+  headers: {},
+  fetch: injectFetchHeaders({ 'x-amz-auth': 'test-auth' }),
+  generateId: () => 'test-id',
+});
+
+const prompt: LanguageModelV3Prompt = [
+  {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: 'Use the querySalesforce tool to list account IDs.',
+      },
+    ],
+  },
+];
+
+it('accepts a live response with stop_sequence: null', async () => {
+  server.urls[generateUrl].response = {
+    type: 'json-value',
+    body: readFixture('issue-11363-stop-sequence-null'),
+  };
+
+  const result = await model.doGenerate({
+    prompt,
+    tools: [
+      {
+        type: 'function',
+        name: 'querySalesforce',
+        description: 'Query Salesforce',
+        inputSchema: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+          additionalProperties: false,
+        },
+      },
+    ],
+    toolChoice: { type: 'tool', toolName: 'querySalesforce' },
+  });
+
+  expect(result.finishReason).toEqual({
+    unified: 'tool-calls',
+    raw: 'tool_use',
+  });
+  expect(result.content).toContainEqual({
+    type: 'tool-call',
+    toolCallId: 'tooluse_j6gIgqF8PljNKBylAe15oP',
+    toolName: 'querySalesforce',
+    input: '{"query":"SELECT Id FROM Account"}',
+  });
+});
+
+it('accepts stop_sequence: null for a regular text response', async () => {
+  server.urls[generateUrl].response = {
+    type: 'json-value',
+    body: readFixture('issue-11363-stop-sequence-null-end-turn'),
+  };
+
+  const result = await model.doGenerate({ prompt });
+
+  expect(result.finishReason).toEqual({
+    unified: 'stop',
+    raw: 'end_turn',
+  });
+  expect(result.content).toContainEqual({
+    type: 'text',
+    text: 'Hello! How can I help you today?',
+  });
+});


### PR DESCRIPTION
## Bug

additionalModelResponseFieldPaths/stop_sequence should be nullable

## Reproduction

- The reported impact is that valid Bedrock text and tool-use responses are discarded with a validation error when `additionalModelResponseFields.stop_sequence` is `null`; this did not occur on `release-v6`.
- Live Amazon Bedrock Converse calls using the documented `/stop_sequence` path returned HTTP 200 with `stop_sequence: null` for both `end_turn` and `tool_use` responses.
- Live responses were recorded in `packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null-end-turn.json` and `packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null.json`.
- `packages/amazon-bedrock/src/issue-11363.test.ts` replayed both live responses: regular text completed and the tool call produced a `tool-calls` finish reason instead of the expected validation error.
- `examples/ai-functions/src/reproduction/issue-11363.ts` accepted both null fields and preserved the text and tool-call outcomes; the expected `Invalid input: expected string, received null` failure was not observed.
- The checked-out package is `@ai-sdk/amazon-bedrock` 4.0.138, and `packages/amazon-bedrock/CHANGELOG.md` records the null-handling fix in 4.0.1; users on the affected beta or 3.0.71 should upgrade to 4.0.1 or later.
- `packages/amazon-bedrock/src/bedrock-chat-language-model.ts` currently requests `/delta/stop_sequence`, unlike the reported `/stop_sequence`; the exact documented top-level response was nevertheless accepted, so this intermediate difference did not reproduce the reported user-visible failure.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html

## Related Issues

Could not reproduce #11363