### PR TITLE
[v5.0] reproduction: could not reproduce additionalModelResponseFieldPaths/stopsequence should be nullable

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/issue-11363.ts
+++ b/examples/ai-functions/src/reproduction/issue-11363.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { BedrockChatLanguageModel } from '../../../../packages/amazon-bedrock/src/bedrock-chat-language-model';
+
+function readFixture(filename: string) {
+  return fs.readFileSync(
+    path.resolve(
+      process.cwd(),
+      '../../packages/amazon-bedrock/src/__fixtures__',
+      filename,
+    ),
+    'utf8',
+  );
+}
+
+async function main() {
+  const textFixture = readFixture(
+    'issue-11363-stop-sequence-null-end-turn.json',
+  );
+  const toolFixture = readFixture(
+    'issue-11363-stop-sequence-null-tool-use.json',
+  );
+
+  const model = new BedrockChatLanguageModel(
+    'us.anthropic.claude-sonnet-4-20250514-v1:0',
+    {
+      baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      headers: {},
+      generateId: () => 'test-id',
+      fetch: async (_url, options) => {
+        const request = JSON.parse(String(options?.body));
+        return new Response(request.toolConfig ? toolFixture : textFixture, {
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        });
+      },
+    },
+  );
+
+  const prompt = [
+    {
+      role: 'user' as const,
+      content: [{ type: 'text' as const, text: 'Hello' }],
+    },
+  ];
+
+  const textResult = await model.doGenerate({
+    prompt,
+  });
+  assert.deepEqual(textResult.content, [{ type: 'text', text: 'OK' }]);
+  assert.equal(textResult.finishReason, 'stop');
+
+  const toolResult = await model.doGenerate({
+    prompt,
+    tools: [
+      {
+        type: 'function',
+        name: 'weather',
+        description: 'Get weather',
+        inputSchema: {
+          type: 'object',
+          properties: { location: { type: 'string' } },
+          required: ['location'],
+          additionalProperties: false,
+        },
+      },
+    ],
+  });
+  assert.equal(toolResult.finishReason, 'tool-calls');
+  assert.deepEqual(toolResult.content, [
+    {
+      type: 'tool-call',
+      toolCallId: 'tooluse_rTk04lpyTTTvtXcoOyVT6p',
+      toolName: 'weather',
+      input: '{"location":"Seattle"}',
+    },
+  ]);
+
+  console.log(
+    'Issue #11363 not reproduced: null stop_sequence preserved text and tool-call outcomes.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null-end-turn.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null-end-turn.json
@@ -1,0 +1,29 @@
+{
+  "additionalModelResponseFields": {
+    "stop_sequence": null
+  },
+  "metrics": {
+    "latencyMs": 765
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "text": "OK"
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "cacheReadInputTokenCount": 0,
+    "cacheReadInputTokens": 0,
+    "cacheWriteInputTokenCount": 0,
+    "cacheWriteInputTokens": 0,
+    "inputTokens": 12,
+    "outputTokens": 4,
+    "serverToolUsage": {},
+    "totalTokens": 16
+  }
+}

--- a/packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null-tool-use.json
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null-tool-use.json
@@ -1,0 +1,36 @@
+{
+  "additionalModelResponseFields": {
+    "stop_sequence": null
+  },
+  "metrics": {
+    "latencyMs": 900
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "toolUse": {
+            "input": {
+              "location": "Seattle"
+            },
+            "name": "weather",
+            "toolUseId": "tooluse_rTk04lpyTTTvtXcoOyVT6p",
+            "type": "tool_use"
+          }
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "tool_use",
+  "usage": {
+    "cacheReadInputTokenCount": 0,
+    "cacheReadInputTokens": 0,
+    "cacheWriteInputTokenCount": 0,
+    "cacheWriteInputTokens": 0,
+    "inputTokens": 407,
+    "outputTokens": 33,
+    "serverToolUsage": {},
+    "totalTokens": 440
+  }
+}

--- a/packages/amazon-bedrock/src/issue-11363.test.ts
+++ b/packages/amazon-bedrock/src/issue-11363.test.ts
@@ -1,0 +1,78 @@
+import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+import { injectFetchHeaders } from './inject-fetch-headers';
+
+const modelId = 'anthropic.claude-3-haiku-20240307-v1:0';
+const generateUrl = `https://bedrock-runtime.us-east-1.amazonaws.com/model/${encodeURIComponent(modelId)}/converse`;
+
+const server = createTestServer({
+  [generateUrl]: {},
+});
+
+const model = new BedrockChatLanguageModel(modelId, {
+  baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+  headers: {},
+  fetch: injectFetchHeaders({ 'x-amz-auth': 'test-auth' }),
+  generateId: () => 'test-id',
+});
+
+const prompt: LanguageModelV2Prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'Hello' }],
+  },
+];
+
+function prepareFixture(filename: string) {
+  server.urls[generateUrl].response = {
+    type: 'json-value',
+    body: JSON.parse(
+      fs.readFileSync(`src/__fixtures__/${filename}.json`, 'utf8'),
+    ),
+  };
+}
+
+describe('issue #11363', () => {
+  it('accepts a text response with a null top-level stop_sequence', async () => {
+    prepareFixture('issue-11363-stop-sequence-null-end-turn');
+
+    const result = await model.doGenerate({ prompt });
+
+    expect(result.finishReason).toBe('stop');
+    expect(result.content).toEqual([{ type: 'text', text: 'OK' }]);
+  });
+
+  it('accepts a tool-use response with a null top-level stop_sequence', async () => {
+    prepareFixture('issue-11363-stop-sequence-null-tool-use');
+
+    const result = await model.doGenerate({
+      prompt,
+      tools: [
+        {
+          type: 'function',
+          name: 'weather',
+          description: 'Get weather',
+          inputSchema: {
+            type: 'object',
+            properties: { location: { type: 'string' } },
+            required: ['location'],
+            additionalProperties: false,
+          },
+        },
+      ],
+    });
+
+    expect(result.finishReason).toBe('tool-calls');
+    expect(result.content).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'tooluse_rTk04lpyTTTvtXcoOyVT6p',
+        toolName: 'weather',
+        input: '{"location":"Seattle"}',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Bug

additionalModelResponseFieldPaths/stop_sequence should be nullable

## Reproduction

- The expected bug was rejection of valid Bedrock text or tool-use responses when `additionalModelResponseFields.stop_sequence` is `null`; both outcomes completed successfully with `@ai-sdk/amazon-bedrock` 3.0.108 on `release-v5.0`.
- Live Bedrock Converse calls using the documented `/stop_sequence` path returned HTTP 200 and a top-level null `stop_sequence` for both `end_turn` and `tool_use`; responses are recorded in `packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null-end-turn.json` and `packages/amazon-bedrock/src/__fixtures__/issue-11363-stop-sequence-null-tool-use.json`.
- `packages/amazon-bedrock/src/issue-11363.test.ts` replayed both live responses without the expected `Invalid input: expected string, received null` validation error, preserving the text and tool-call outcomes.
- `examples/ai-functions/src/reproduction/issue-11363.ts` replayed both null responses and exited successfully instead of reproducing the reported validation failure.
- `packages/amazon-bedrock/src/bedrock-chat-language-model.ts` accepts a null nested stop sequence with `z.string().nullish()`; `packages/amazon-bedrock/CHANGELOG.md` places that change in 3.0.72, so users affected on 3.0.71 should upgrade to 3.0.72 or later.
- The provider currently requests `/delta/stop_sequence` rather than the documented `/stop_sequence`, but the exact documented top-level null response was accepted, so this intermediate difference did not cause the reported user-visible failure.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html

## Related Issues

Could not reproduce #11363