### PR TITLE
feat(tools-registry): add serpdive

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -584,4 +584,36 @@ console.log(result.text);`,
     websiteUrl: 'https://nitrosend.com',
     npmUrl: 'https://www.npmjs.com/package/@nitrosend/ai-sdk',
   },
+  {
+    slug: 'serpdive',
+    name: 'SERPdive',
+    description:
+      'SERPdive is a real-time web search API built for AI agents. Each result carries the extracted, answer-ready content of the page — not a link or snippet — so agents can quote and cite facts straight from the response. On a public, replayable 1,000-question benchmark it wins 60.7% of decided quality duels against the leading comparable search API while returning 20.2% fewer tokens at the same speed. Localization is automatic: a query in any language searches the web in that language.',
+    packageName: '@serpdive/ai-sdk',
+    tags: ['search', 'web', 'extraction'],
+    apiKeyEnvName: 'SERPDIVE_API_KEY',
+    installCommand: {
+      pnpm: 'pnpm add @serpdive/ai-sdk',
+      npm: 'npm install @serpdive/ai-sdk',
+      yarn: 'yarn add @serpdive/ai-sdk',
+      bun: 'bun add @serpdive/ai-sdk',
+    },
+    codeExample: `import { generateText, isStepCount } from 'ai';
+import { serpdiveSearch } from '@serpdive/ai-sdk';
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-5',
+  prompt: 'What changed in the latest Next.js release?',
+  tools: {
+    webSearch: serpdiveSearch(),
+  },
+  stopWhen: isStepCount(3),
+});
+
+console.log(text);`,
+    docsUrl: 'https://serpdive.com/docs',
+    apiKeyUrl: 'https://serpdive.com/dashboard/keys',
+    websiteUrl: 'https://serpdive.com',
+    npmUrl: 'https://www.npmjs.com/package/@serpdive/ai-sdk',
+  },
 ];

--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -588,7 +588,7 @@ console.log(result.text);`,
     slug: 'serpdive',
     name: 'SERPdive',
     description:
-      'SERPdive is a real-time web search API built for AI agents. Each result carries the extracted, answer-ready content of the page — not a link or snippet — so agents can quote and cite facts straight from the response. On a public, replayable 1,000-question benchmark it wins 60.7% of decided quality duels against the leading comparable search API while returning 20.2% fewer tokens at the same speed. Localization is automatic: a query in any language searches the web in that language.',
+      'SERPdive is a real-time web search API built for AI agents. Each result carries the extracted, answer-ready content of the page — not a link or snippet — so agents can quote and cite facts straight from the response. On a public, replayable 1,000-question benchmark it wins 60.7% of decided quality duels against the leading comparable search API while returning 20.2% fewer tokens at the same speed. A free tier is included: the `krill` model is free and unlimited under fair use, no card required. Localization is automatic: a query in any language searches the web in that language.',
     packageName: '@serpdive/ai-sdk',
     tags: ['search', 'web', 'extraction'],
     apiKeyEnvName: 'SERPDIVE_API_KEY',


### PR DESCRIPTION
## Background

The tools registry lists search providers agents can call for real-time information (Exa, Tavily, Parallel). [`contributing/add-new-tool-to-registry.md`](https://github.com/vercel/ai/blob/main/contributing/add-new-tool-to-registry.md) is the documented path for adding one; this follows it.

## Summary

Adds [SERPdive](https://serpdive.com) to the tools registry — a single entry in `registry.ts`, no code changes.

SERPdive is a real-time web search API built for AI agents: each result carries the extracted, answer-ready content of the page, not a link or a snippet, so an agent can quote and cite facts straight from the tool result.

Prerequisites from the guide:

- **Published to npm**: [`@serpdive/ai-sdk`](https://www.npmjs.com/package/@serpdive/ai-sdk)
- **Documented**: [README](https://github.com/serpdive/serpdive-ai-sdk) with usage, options and response shape
- **Tested with the AI SDK**: the package's test suite includes a full `generateText` tool-loop test (mock model → tool call → `serpdiveSearch` execution → final answer), plus request-shape tests

The entry mirrors the existing search-tool entries in structure and tags.

## End-to-End Verification

- `registry.ts` parses cleanly with the new entry.
- The code example in the registry entry is the exact pattern covered by the package's `generateText` tool-loop test, run against a mock model — so what a reader copies out of the registry is what the tests exercise.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

Two notes on the unchecked boxes. **Signed commits: not yet** — I am registering a signing key and will re-sign and force-push this branch; flagging it openly rather than leaving the box quietly unticked. **Tests, docs and changeset**: this is a registry-data addition with no package code touched, so on my reading none of the three apply here — tell me if the registry has its own expectation and I will add it.

## Related Issues

None.

---

Disclosure: I built SERPdive. Happy to adjust the description or anything else to fit registry conventions, or to close this if the registry is curated rather than open to submissions.
