### PR TITLE
[v6.0] reproduction: AITypeValidationError on stream finish

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 11269,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11269-finish-version-skew.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-11269-finish-version-skew.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Type validation failed: Value: {\"type\":\"finish\",\"finishReason\":\"stop\"}."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11269-finish-version-skew.ts
+++ b/examples/ai-functions/src/reproduction/issue-11269-finish-version-skew.ts
@@ -1,0 +1,167 @@
+import {
+  parseJsonEventStream,
+  streamText,
+  uiMessageChunkSchema,
+  type UIMessageChunk,
+} from 'ai';
+import {
+  convertArrayToReadableStream,
+  convertReadableStreamToArray,
+  MockLanguageModelV3,
+} from 'ai/test';
+import { z } from 'zod/v4';
+
+const ai5053StreamChunkSchema = z.union([
+  z.strictObject({
+    type: z.literal('text-start'),
+    id: z.string(),
+    providerMetadata: z.record(z.string(), z.unknown()).optional(),
+  }),
+  z.strictObject({
+    type: z.literal('text-delta'),
+    id: z.string(),
+    delta: z.string(),
+    providerMetadata: z.record(z.string(), z.unknown()).optional(),
+  }),
+  z.strictObject({
+    type: z.literal('text-end'),
+    id: z.string(),
+    providerMetadata: z.record(z.string(), z.unknown()).optional(),
+  }),
+  z.strictObject({
+    type: z.literal('start-step'),
+  }),
+  z.strictObject({
+    type: z.literal('finish-step'),
+  }),
+  z.strictObject({
+    type: z.literal('start'),
+    messageId: z.string().optional(),
+    messageMetadata: z.unknown().optional(),
+  }),
+  z.strictObject({
+    type: z.literal('finish'),
+    messageMetadata: z.unknown().optional(),
+  }),
+]);
+
+function createSseStream(chunks: unknown[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`),
+        );
+      }
+      controller.close();
+    },
+  });
+}
+
+async function main() {
+  const result = streamText({
+    model: new MockLanguageModelV3({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'text-start' as const, id: 'text-1' },
+          {
+            type: 'text-delta' as const,
+            id: 'text-1',
+            delta: 'Hello',
+          },
+          { type: 'text-end' as const, id: 'text-1' },
+          {
+            type: 'finish' as const,
+            finishReason: { raw: 'stop', unified: 'stop' as const },
+            usage: {
+              inputTokens: {
+                total: 1,
+                noCache: 1,
+                cacheRead: undefined,
+                cacheWrite: undefined,
+              },
+              outputTokens: {
+                total: 1,
+                text: 1,
+                reasoning: undefined,
+              },
+            },
+          },
+        ]),
+      }),
+    }),
+    prompt: 'Say hello.',
+  });
+
+  const chunks = await convertReadableStreamToArray(result.toUIMessageStream());
+  const finishChunk = chunks.find(
+    (chunk): chunk is UIMessageChunk & { type: 'finish' } =>
+      chunk.type === 'finish',
+  );
+
+  if (
+    finishChunk == null ||
+    finishChunk.finishReason !== 'stop' ||
+    JSON.stringify(finishChunk) !==
+      JSON.stringify({ type: 'finish', finishReason: 'stop' })
+  ) {
+    throw new Error(
+      `Expected the backend stream to contain {"type":"finish","finishReason":"stop"}, received ${JSON.stringify(
+        finishChunk,
+      )}`,
+    );
+  }
+
+  const currentParseResults = await convertReadableStreamToArray(
+    parseJsonEventStream({
+      stream: createSseStream(chunks),
+      schema: uiMessageChunkSchema,
+    }),
+  );
+
+  if (currentParseResults.some(result => !result.success)) {
+    throw new Error(
+      'The current client schema unexpectedly rejected the stream.',
+    );
+  }
+
+  const currentClientOldBackendResults = await convertReadableStreamToArray(
+    parseJsonEventStream({
+      stream: createSseStream([{ type: 'finish' }]),
+      schema: uiMessageChunkSchema,
+    }),
+  );
+
+  if (currentClientOldBackendResults.some(result => !result.success)) {
+    throw new Error(
+      'The current client schema unexpectedly rejected the older finish chunk.',
+    );
+  }
+
+  const oldClientParseResults = parseJsonEventStream({
+    stream: createSseStream(chunks),
+    schema: ai5053StreamChunkSchema,
+  });
+  const reader = oldClientParseResults.getReader();
+
+  while (true) {
+    const { done, value: parseResult } = await reader.read();
+    if (done) {
+      break;
+    }
+    if (!parseResult.success) {
+      throw parseResult.error;
+    }
+  }
+
+  throw new Error(
+    'Expected the ai@5.0.53 frontend schema to reject the newer finish chunk.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

AI_TypeValidationError on stream finish

## Reproduction

- `examples/ai-functions/src/reproduction/issue-11269-finish-version-skew.ts` generates a UI stream ending with `{"type":"finish","finishReason":"stop"}` and reproduces the reported `AI_TypeValidationError` with the `ai@5.0.53` strict client schema; the expected behavior is for the older frontend to complete the stream during a staggered patch deployment.
- Repository history for `packages/ai/src/ui-message-stream/ui-message-chunks.ts` shows `ai@5.0.53` rejected extra finish fields and `ai@5.0.92` introduced `finishReason`, placing the reported `ai@5.0.114` backend and `ai@5.0.53` frontend across the incompatible protocol change.
- The release-v6.0 client schema accepts both the older finish chunk and the newer finish chunk, confirming that deploying the upgraded frontend before the backend avoids the validation failure.
- The current `packages/ai/src/ui-message-stream/ui-message-chunks.ts` uses loose object schemas to preserve compatibility with additional fields on known chunk types.

## Relevant Documentation

- https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol
- https://ai-sdk.dev/docs/reference/ai-sdk-ui/create-ui-message-stream
- https://ai-sdk.dev/v5/docs/migration-guides/migration-guide-5-0

## Related Issues

Reproduces #11269