### PR TITLE
reproduction: could not reproduce AWS Bedrock Kimi K2 Thinking ends abruptly due

### DIFF
--- a/examples/ai-functions/src/reproduction/amazon-bedrock-kimi-k2-thinking-tool-call.ts
+++ b/examples/ai-functions/src/reproduction/amazon-bedrock-kimi-k2-thinking-tool-call.ts
@@ -1,0 +1,120 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { isStepCount, streamText, tool } from 'ai';
+import { z } from 'zod';
+
+const MODEL_ID = 'moonshot.kimi-k2-thinking';
+const ATTEMPTS = 3;
+const expectedAnswer = 'FOUND ISSUE_11409_CONTENT';
+
+type AttemptResult = {
+  attempt: number;
+  finishReason: string;
+  text: string;
+  toolCalls: string[];
+  rawChunks: unknown[];
+  leakedToolSyntax: boolean;
+  completedTask: boolean;
+};
+
+async function runAttempt(attempt: number): Promise<AttemptResult> {
+  const amazonBedrock = createAmazonBedrock({ region: 'us-east-1' });
+  const toolCalls: string[] = [];
+  const rawChunks: unknown[] = [];
+  let text = '';
+
+  const result = streamText({
+    model: amazonBedrock(MODEL_ID),
+    includeRawChunks: true,
+    maxOutputTokens: 2048,
+    stopWhen: isStepCount(5),
+    tools: {
+      glob_search: tool({
+        description: 'Find repository files whose paths match a glob pattern.',
+        inputSchema: z.object({ pattern: z.string() }),
+        execute: async ({ pattern }) => {
+          toolCalls.push(`glob_search:${pattern}`);
+          return { files: ['src/cursor-config.ts', '.cursor/rules.md'] };
+        },
+      }),
+      read_file: tool({
+        description: 'Read the complete contents of a repository file.',
+        inputSchema: z.object({ target_file: z.string() }),
+        execute: async ({ target_file }) => {
+          toolCalls.push(`read_file:${target_file}`);
+          return { content: 'ISSUE_11409_CONTENT' };
+        },
+      }),
+    },
+    prompt: `Check whether this repository has cursor files.
+You must first call glob_search with {"pattern":"**/*cursor*"}.
+After glob_search returns files, you must call read_file for src/cursor-config.ts.
+After read_file returns, answer with exactly: ${expectedAnswer}`,
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'raw') {
+      rawChunks.push(part.rawValue);
+    } else if (part.type === 'text-delta') {
+      text += part.text;
+    }
+  }
+
+  const finishReason = await result.finishReason;
+  const leakedToolSyntax =
+    /<\|tool_call_(?:begin|argument_begin|end)\|>|<\|tool_calls_section_end\|>/.test(
+      text,
+    ) || /\{\s*"(?:target_file|pattern)"\s*:/.test(text);
+  const completedTask =
+    toolCalls.some(call => call.startsWith('glob_search:')) &&
+    toolCalls.some(call => call === 'read_file:src/cursor-config.ts') &&
+    text.includes(expectedAnswer);
+
+  return {
+    attempt,
+    finishReason,
+    text,
+    toolCalls,
+    rawChunks,
+    leakedToolSyntax,
+    completedTask,
+  };
+}
+
+async function main() {
+  const attempts: AttemptResult[] = [];
+
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    const result = await runAttempt(attempt);
+    attempts.push(result);
+    console.log(JSON.stringify(result));
+
+    if (!result.completedTask && result.leakedToolSyntax) {
+      console.error(
+        'ISSUE_11409_REPRODUCED: intended read_file tool call was emitted as text and the task ended before the expected answer',
+      );
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  const incomplete = attempts.filter(attempt => !attempt.completedTask);
+  if (incomplete.length > 0) {
+    console.error(
+      `Incomplete attempts did not contain leaked tool syntax: ${incomplete
+        .map(attempt => attempt.attempt)
+        .join(', ')}`,
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const leaked = attempts.filter(attempt => attempt.leakedToolSyntax);
+  console.log(
+    `Could not reproduce the abrupt termination from issue #11409 in ${ATTEMPTS} attempts: every attempt called both tools and returned the expected final answer. ${leaked.length} attempt(s) contained tool-like JSON in provider text.`,
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 2;
+});


### PR DESCRIPTION
## Bug

AWS Bedrock Kimi K2 Thinking ends abruptly due to incorrect tool call parsing

## Reproduction

- The expected failure was an intended `read_file` call being emitted only as text, preventing tool execution and ending the conversation before the final answer.
- Live Kimi K2 Thinking runs on the target branch executed both `glob_search` and `read_file` and returned the expected final answer in all 3 attempts, so the abrupt termination was not reproduced.
- In 2 of 3 attempts, model reasoning contained tool-like JSON in provider text, but the corresponding calls were also received as structured tool-use events and executed successfully; no reported `<|tool_call_*|>` markers appeared.
- The runnable artifact is `examples/ai-functions/src/reproduction/amazon-bedrock-kimi-k2-thinking-tool-call.ts`; it exited 0 after the successful three-attempt live check rather than failing with the expected incomplete tool sequence.
- The reported `@ai-sdk/amazon-bedrock@4.0.2` and `ai@6.0.2` setup was not executed because the target branch contains `@ai-sdk/amazon-bedrock@5.0.27` and `ai@7.0.34`; this result applies to the checked-out target branch.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-thinking.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use-client-side.html

## Related Issues

Could not reproduce #11409