### PR TITLE
[v6.0] reproduction: could not reproduce AWS Bedrock Kimi K2 Thinking ends abruptly due

### DIFF
--- a/examples/ai-functions/src/reproduction/amazon-bedrock-kimi-k2-thinking-tool-call.ts
+++ b/examples/ai-functions/src/reproduction/amazon-bedrock-kimi-k2-thinking-tool-call.ts
@@ -1,0 +1,117 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { stepCountIs, streamText, tool } from 'ai';
+import { z } from 'zod';
+
+const MODEL_ID = 'moonshot.kimi-k2-thinking';
+const ATTEMPTS = 3;
+const expectedAnswer = 'FOUND ISSUE_11409_CONTENT';
+
+type AttemptResult = {
+  attempt: number;
+  finishReason: string;
+  text: string;
+  toolCalls: string[];
+  rawChunks: unknown[];
+  leakedToolMarkers: boolean;
+  toolLikeJsonText: boolean;
+  leakedToolSyntax: boolean;
+  completedTask: boolean;
+};
+
+async function runAttempt(attempt: number): Promise<AttemptResult> {
+  const amazonBedrock = createAmazonBedrock({ region: 'us-east-1' });
+  const toolCalls: string[] = [];
+  const rawChunks: unknown[] = [];
+  let text = '';
+
+  const result = streamText({
+    model: amazonBedrock(MODEL_ID),
+    includeRawChunks: true,
+    maxOutputTokens: 2048,
+    stopWhen: stepCountIs(5),
+    tools: {
+      glob_search: tool({
+        description: 'Find repository files whose paths match a glob pattern.',
+        inputSchema: z.object({ pattern: z.string() }),
+        execute: async ({ pattern }) => {
+          toolCalls.push(`glob_search:${pattern}`);
+          return { files: ['src/cursor-config.ts', '.cursor/rules.md'] };
+        },
+      }),
+      read_file: tool({
+        description: 'Read the complete contents of a repository file.',
+        inputSchema: z.object({ target_file: z.string() }),
+        execute: async ({ target_file }) => {
+          toolCalls.push(`read_file:${target_file}`);
+          return { content: 'ISSUE_11409_CONTENT' };
+        },
+      }),
+    },
+    prompt: `Check whether this repository has cursor files.
+You must first call glob_search with {"pattern":"**/*cursor*"}.
+After glob_search returns files, you must call read_file for src/cursor-config.ts.
+After read_file returns, answer with exactly: ${expectedAnswer}`,
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'raw') {
+      rawChunks.push(part.rawValue);
+    } else if (part.type === 'text-delta') {
+      text += part.text;
+    }
+  }
+
+  const finishReason = await result.finishReason;
+  const leakedToolMarkers =
+    /<\|tool_call_(?:begin|argument_begin|end)\|>|<\|tool_calls_section_end\|>/.test(
+      text,
+    );
+  const toolLikeJsonText = /\{\s*"(?:target_file|pattern)"\s*:/.test(text);
+  const leakedToolSyntax = leakedToolMarkers || toolLikeJsonText;
+  const completedTask =
+    toolCalls.some(call => call.startsWith('glob_search:')) &&
+    toolCalls.some(call => call === 'read_file:src/cursor-config.ts') &&
+    text.includes(expectedAnswer);
+
+  return {
+    attempt,
+    finishReason,
+    text,
+    toolCalls,
+    rawChunks,
+    leakedToolMarkers,
+    toolLikeJsonText,
+    leakedToolSyntax,
+    completedTask,
+  };
+}
+
+async function main() {
+  const attempts: AttemptResult[] = [];
+
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    const result = await runAttempt(attempt);
+    attempts.push(result);
+    console.log(JSON.stringify(result));
+
+    if (!result.completedTask) {
+      console.error(
+        `ISSUE_11409_REPRODUCED: intended read_file tool call was not completed and the task ended before the expected answer; leakedToolSyntax=${result.leakedToolSyntax}`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  const leaked = attempts.filter(attempt => attempt.leakedToolSyntax);
+  const markerLeaks = attempts.filter(attempt => attempt.leakedToolMarkers);
+  const jsonLeaks = attempts.filter(attempt => attempt.toolLikeJsonText);
+  console.log(
+    `Could not reproduce the abrupt termination from issue #11409 in ${ATTEMPTS} attempts: every attempt called both tools and returned the expected final answer. ${markerLeaks.length} attempt(s) contained the reported tool markers; ${jsonLeaks.length} attempt(s) contained tool-like JSON in provider text; ${leaked.length} attempt(s) contained either form.`,
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 2;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-final.chunks.txt
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-final.chunks.txt
@@ -1,0 +1,13 @@
+{"messageStart":{"role":"assistant"}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":""}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" <think> The user wants me to check if this repository has cursor files. The instructions are very specific:\n1"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":". First call glob_search with {\"pattern\":\"**/*cursor*\"}\n2. After glob_search returns"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" files, call read_file for src/cursor-config.ts\n3. After read_file returns, answer"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" with exactly: FOUND ISSUE_11409_CONTENT\n\nI've completed steps 1 and 2:\n"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"- glob_search found two files: src/cursor-config.ts and .cursor/rules.md\n- read"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"_file for src/cursor-config.ts returned content"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":": \"ISSUE_11409_CONTENT\"\n\nNow I need to answer with exactly: FOUND ISSUE"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"_11409_CONTENT </think> FOUND ISSUE_11409_CONTENT"}}}
+{"contentBlockStop":{"contentBlockIndex":0}}
+{"messageStop":{"stopReason":"end_turn"}}
+{"metadata":{"metrics":{"latencyMs":1887},"usage":{"inputTokens":406,"outputTokens":143,"serverToolUsage":{},"totalTokens":549}}}

--- a/packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-glob-search.chunks.txt
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-glob-search.chunks.txt
@@ -1,0 +1,18 @@
+{"messageStart":{"role":"assistant"}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":""}}}
+{"contentBlockStop":{"contentBlockIndex":0}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"reasoningContent":{"text":" The user wants me to:\n1. First call `glob_search` with pattern \"**/*cursor*"}}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"reasoningContent":{"text":"\"\n2. Then (after getting results) call `read_file` for \"src/cursor-config"}}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"reasoningContent":{"text":".ts\"\n3. After read_file returns, answer with exactly: \"FOUND ISSUE_11409"}}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"reasoningContent":{"text":"_CONTENT\"\n\nLet me start with step 1."}}}}
+{"contentBlockStop":{"contentBlockIndex":1}}
+{"contentBlockDelta":{"contentBlockIndex":2,"delta":{"text":""}}}
+{"contentBlockStop":{"contentBlockIndex":2}}
+{"contentBlockStart":{"contentBlockIndex":3,"start":{"toolUse":{"name":"glob_search","toolUseId":"functions.glob_search:0"}}}}
+{"contentBlockDelta":{"contentBlockIndex":3,"delta":{"toolUse":{"input":"{\"pattern"}}}}
+{"contentBlockDelta":{"contentBlockIndex":3,"delta":{"toolUse":{"input":"\": \"**/*cursor*\"}"}}}}
+{"contentBlockStop":{"contentBlockIndex":3}}
+{"contentBlockDelta":{"contentBlockIndex":4,"delta":{"text":""}}}
+{"contentBlockStop":{"contentBlockIndex":4}}
+{"messageStop":{"stopReason":"tool_use"}}
+{"metadata":{"metrics":{"latencyMs":1151},"usage":{"inputTokens":208,"outputTokens":91,"serverToolUsage":{},"totalTokens":299}}}

--- a/packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-read-file.chunks.txt
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-read-file.chunks.txt
@@ -1,0 +1,15 @@
+{"messageStart":{"role":"assistant"}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":""}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" <think> The user wants me to:\n1. First call glob_search with pattern \"**/*cursor*\"\n2"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":". After that returns files, call read_file for src/cursor-config.ts\n3. After read"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":"_file returns, answer with exactly: FOUND ISSUE_11409_CONTENT\n\nI've completed the glob_search"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" and found two files:\n- src/cursor-config.ts\n- .cursor/rules.md\n\nNow I"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" need to call read_file for src/cursor-config.ts. </think>"}}}
+{"contentBlockStop":{"contentBlockIndex":0}}
+{"contentBlockStart":{"contentBlockIndex":1,"start":{"toolUse":{"name":"read_file","toolUseId":"functions.read_file:1"}}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"toolUse":{"input":"{\"target_file\": \"src/cursor-config.ts\"}"}}}}
+{"contentBlockStop":{"contentBlockIndex":1}}
+{"contentBlockDelta":{"contentBlockIndex":2,"delta":{"text":""}}}
+{"contentBlockStop":{"contentBlockIndex":2}}
+{"messageStop":{"stopReason":"tool_use"}}
+{"metadata":{"metrics":{"latencyMs":1430},"usage":{"inputTokens":260,"outputTokens":116,"serverToolUsage":{},"totalTokens":376}}}

--- a/packages/amazon-bedrock/src/issue-11409.test.ts
+++ b/packages/amazon-bedrock/src/issue-11409.test.ts
@@ -1,0 +1,143 @@
+import type {
+  LanguageModelV3FunctionTool,
+  LanguageModelV3Prompt,
+} from '@ai-sdk/provider';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import fs from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+
+vi.mock('./bedrock-event-stream-response-handler', () => ({
+  createBedrockEventStreamResponseHandler:
+    () =>
+    async ({ response }: { response: Response }) => {
+      const chunks = (await response.text())
+        .split('\n')
+        .filter(Boolean)
+        .map(chunk => {
+          const value = JSON.parse(chunk);
+          return { success: true, value, rawValue: value };
+        });
+
+      return {
+        responseHeaders: {},
+        value: new ReadableStream({
+          start(controller) {
+            for (const chunk of chunks) {
+              controller.enqueue(chunk);
+            }
+            controller.close();
+          },
+        }),
+      };
+    },
+}));
+
+const prompt: LanguageModelV3Prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'Check for cursor files.' }],
+  },
+];
+
+const tools: LanguageModelV3FunctionTool[] = [
+  {
+    type: 'function',
+    name: 'glob_search',
+    description: 'Find repository files whose paths match a glob pattern.',
+    inputSchema: {
+      type: 'object',
+      properties: { pattern: { type: 'string' } },
+      required: ['pattern'],
+      additionalProperties: false,
+    },
+  },
+  {
+    type: 'function',
+    name: 'read_file',
+    description: 'Read the complete contents of a repository file.',
+    inputSchema: {
+      type: 'object',
+      properties: { target_file: { type: 'string' } },
+      required: ['target_file'],
+      additionalProperties: false,
+    },
+  },
+];
+
+let fixtureName = '';
+
+const model = new BedrockChatLanguageModel('moonshot.kimi-k2-thinking', {
+  baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+  headers: {},
+  generateId: () => 'test-id',
+  fetch: async () =>
+    new Response(
+      fs.readFileSync(`src/__fixtures__/${fixtureName}.chunks.txt`, 'utf8'),
+      { status: 200 },
+    ),
+});
+
+async function streamFixture(name: string) {
+  fixtureName = name;
+  const { stream } = await model.doStream({
+    prompt,
+    tools,
+    includeRawChunks: true,
+  });
+  return convertReadableStreamToArray(stream);
+}
+
+describe('issue #11409 live Kimi K2 Thinking fixtures', () => {
+  it('preserves the glob_search call as structured tool use', async () => {
+    const parts = await streamFixture(
+      'issue-11409-kimi-k2-thinking-glob-search',
+    );
+
+    expect(parts).toContainEqual({
+      type: 'tool-call',
+      toolCallId: 'functions.glob_search:0',
+      toolName: 'glob_search',
+      input: '{"pattern": "**/*cursor*"}',
+    });
+    expect(parts).toContainEqual(
+      expect.objectContaining({
+        type: 'finish',
+        finishReason: { unified: 'tool-calls', raw: 'tool_use' },
+      }),
+    );
+  });
+
+  it('preserves the read_file call as structured tool use', async () => {
+    const parts = await streamFixture('issue-11409-kimi-k2-thinking-read-file');
+
+    expect(parts).toContainEqual({
+      type: 'tool-call',
+      toolCallId: 'functions.read_file:1',
+      toolName: 'read_file',
+      input: '{"target_file": "src/cursor-config.ts"}',
+    });
+    expect(parts).toContainEqual(
+      expect.objectContaining({
+        type: 'finish',
+        finishReason: { unified: 'tool-calls', raw: 'tool_use' },
+      }),
+    );
+  });
+
+  it('preserves the final answer and end-turn finish', async () => {
+    const parts = await streamFixture('issue-11409-kimi-k2-thinking-final');
+    const text = parts
+      .filter(part => part.type === 'text-delta')
+      .map(part => part.delta)
+      .join('');
+
+    expect(text).toContain('FOUND ISSUE_11409_CONTENT');
+    expect(parts).toContainEqual(
+      expect.objectContaining({
+        type: 'finish',
+        finishReason: { unified: 'stop', raw: 'end_turn' },
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Bug

AWS Bedrock Kimi K2 Thinking ends abruptly due to incorrect tool call parsing

## Reproduction

- The expected bug was the intended `read_file` call being emitted only as text, ending the task before the required final answer.
- Live Kimi K2 Thinking runs completed both `glob_search` and `read_file` as structured tool calls and returned `FOUND ISSUE_11409_CONTENT` in all three attempts.
- Tool-like JSON appeared in visible model text, but the corresponding structured calls still executed; the reported `<|tool_call_*|>` markers were not observed.
- The runnable artifact is `examples/ai-functions/src/reproduction/amazon-bedrock-kimi-k2-thinking-tool-call.ts`; it exited 0 instead of reproducing the abrupt termination.
- Live responses are recorded in `packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-glob-search.chunks.txt`, `packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-read-file.chunks.txt`, and `packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-final.chunks.txt`.
- `packages/amazon-bedrock/src/issue-11409.test.ts` confirms the recorded responses preserve both structured tool calls and the final answer.
- The target branch contains `ai@6.0.233` and `@ai-sdk/amazon-bedrock@4.0.138`; the reporter's exact `6.0.2` and `4.0.2` versions were not executed.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-thinking.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use-client-side.html

## Related Issues

Could not reproduce #11409