### PR TITLE
reproduction: could not reproduce useChat throws "No tool output found for apply

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11267-multiple-client-tool-results.ts
+++ b/examples/ai-functions/src/reproduction/issue-11267-multiple-client-tool-results.ts
@@ -1,0 +1,217 @@
+import { Chat } from '../../../../packages/react/dist/index.js';
+import {
+  lastAssistantMessageIsCompleteWithToolCalls,
+  type ChatTransport,
+  type UIMessage,
+  type UIMessageChunk,
+} from 'ai';
+
+function createStream(chunks: UIMessageChunk[]) {
+  return new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+function getApplyPatchParts(messages: UIMessage[]) {
+  let assistantMessage: UIMessage | undefined;
+
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index].role === 'assistant') {
+      assistantMessage = messages[index];
+      break;
+    }
+  }
+
+  return (
+    assistantMessage?.parts.flatMap(part =>
+      part.type === 'tool-apply_patch' &&
+      'toolCallId' in part &&
+      typeof part.toolCallId === 'string' &&
+      'state' in part &&
+      typeof part.state === 'string'
+        ? [{ toolCallId: part.toolCallId, state: part.state }]
+        : [],
+    ) ?? []
+  );
+}
+
+async function runScenario({
+  callCount,
+  errorEvery,
+}: {
+  callCount: number;
+  errorEvery?: number;
+}) {
+  let requestCount = 0;
+  let toolHandlerCount = 0;
+  const errors: Error[] = [];
+  const toolResultPromises: Promise<void>[] = [];
+
+  const transport: ChatTransport<UIMessage> = {
+    async sendMessages({ messages }) {
+      requestCount++;
+
+      if (requestCount === 1) {
+        const chunks: UIMessageChunk[] = [
+          { type: 'start' },
+          { type: 'start-step' },
+        ];
+
+        for (let index = 0; index < callCount; index++) {
+          chunks.push({
+            type: 'tool-input-available',
+            toolCallId: `apply-patch-${index}`,
+            toolName: 'apply_patch',
+            input: {
+              patch:
+                index % 2 === 0
+                  ? `*** Add File: file-${index}.txt`
+                  : `*** Delete File: file-${index}.txt`,
+            },
+          });
+        }
+
+        chunks.push(
+          { type: 'finish-step' },
+          { type: 'finish', finishReason: 'tool-calls' },
+        );
+
+        return createStream(chunks);
+      }
+
+      const toolParts = getApplyPatchParts(messages);
+      const missingPart = toolParts.find(
+        part =>
+          !(part.state === 'output-available' || part.state === 'output-error'),
+      );
+
+      if (toolParts.length !== callCount || missingPart != null) {
+        const missingToolCallId =
+          missingPart?.toolCallId ?? `expected-${callCount}-tool-results`;
+
+        return createStream([
+          { type: 'start' },
+          {
+            type: 'error',
+            errorText: `No tool output found for apply patch call ${missingToolCallId}`,
+          },
+        ]);
+      }
+
+      return createStream([
+        { type: 'start' },
+        { type: 'start-step' },
+        { type: 'text-start', id: 'done' },
+        {
+          type: 'text-delta',
+          id: 'done',
+          delta: 'All patch results received.',
+        },
+        { type: 'text-end', id: 'done' },
+        { type: 'finish-step' },
+        { type: 'finish', finishReason: 'stop' },
+      ]);
+    },
+    async reconnectToStream() {
+      return null;
+    },
+  };
+
+  let chat: Chat<UIMessage>;
+  chat = new Chat({
+    id: `issue-11267-${callCount}`,
+    generateId: (() => {
+      let id = 0;
+      return () => `message-${id++}`;
+    })(),
+    transport,
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    onError(error) {
+      errors.push(error);
+    },
+    async onToolCall({ toolCall }) {
+      toolHandlerCount++;
+
+      // Match the reported quick, sequential client-side execution.
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      if (errorEvery != null && toolHandlerCount % errorEvery === 0) {
+        toolResultPromises.push(
+          Promise.resolve(
+            chat.addToolResult({
+              state: 'output-error',
+              tool: 'apply_patch',
+              toolCallId: toolCall.toolCallId,
+              errorText: 'Patch failed as expected for this test call.',
+            }),
+          ),
+        );
+      } else {
+        toolResultPromises.push(
+          Promise.resolve(
+            chat.addToolResult({
+              tool: 'apply_patch',
+              toolCallId: toolCall.toolCallId,
+              output: { success: true },
+            }),
+          ),
+        );
+      }
+    },
+  });
+
+  await chat.sendMessage({ text: `Run ${callCount} apply_patch calls.` });
+  await Promise.all(toolResultPromises);
+
+  const toolParts = getApplyPatchParts(chat.messages);
+  const completedCount = toolParts.filter(
+    part => part.state === 'output-available' || part.state === 'output-error',
+  ).length;
+
+  if (errors.length > 0) {
+    throw errors[0];
+  }
+
+  if (toolHandlerCount !== callCount || completedCount !== callCount) {
+    throw new Error(
+      `Only ${completedCount}/${callCount} tool outputs completed after ${toolHandlerCount} handlers.`,
+    );
+  }
+
+  if (requestCount !== 2) {
+    throw new Error(
+      `Expected one automatic follow-up request, received ${requestCount - 1}.`,
+    );
+  }
+
+  if (chat.status !== 'ready') {
+    throw new Error(`Expected ready status, received ${chat.status}.`);
+  }
+}
+
+async function main() {
+  const scenarios = [
+    ...Array.from({ length: 10 }, () => ({ callCount: 2 })),
+    ...Array.from({ length: 5 }, () => ({ callCount: 5 })),
+    { callCount: 31 },
+    { callCount: 5, errorEvery: 2 },
+  ];
+
+  for (const scenario of scenarios) {
+    await runScenario(scenario);
+  }
+
+  console.log(
+    'PASS: all apply_patch outputs were present before automatic submission.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

useChat throws "No tool output found for apply patch" error despite all tool results being present

## Reproduction

- Added `examples/ai-functions/src/reproduction/issue-11267-multiple-client-tool-results.ts`, exercising the React `Chat` implementation used by `useChat` with sequential 20 ms client-side `apply_patch` execution and `addToolResult`.
- The artifact covered ten 2-call runs, five 5-call runs, one 31-call run, `create/delete` inputs, and mixed `output-available`/`output-error` results.
- All tool-result promises completed before exactly one automatic follow-up request; every tool part was complete and the chat transitioned to `ready`.
- The expected issue behavior was a `No tool output found for apply patch call` error despite completed parts; no such error occurred on `main` with `ai` 7.0.34 and `@ai-sdk/react` 4.0.37.
- The reported beta packages were not substituted into the target branch; repository tags show no relevant `chat.ts` or `process-ui-message-stream.ts` source difference between `ai@6.0.0-beta.130` and `@ai-sdk/react@3.0.0-beta.131`.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat
- https://ai-sdk.dev/v5/docs/migration-guides/migration-guide-5-0
- https://ai-sdk.dev/docs/migration-guides/migration-guide-6-0

## Related Issues

Could not reproduce #11267