### PR TITLE
[v5.0] reproduction: AWS Bedrock Kimi K2 Thinking ends abruptly due

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "issueId": 11409,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/amazon-bedrock-kimi-k2-thinking-tool-call.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/amazon-bedrock-kimi-k2-thinking-tool-call.ts",
+    "pnpm-lock.yaml"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "emitted the intended read_file call as text, did not execute read_file, and ended without FOUND ISSUE_11409_CONTENT"
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/amazon-bedrock": "workspace:*",
+    "ai": "workspace:*",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/amazon-bedrock-kimi-k2-thinking-tool-call.ts
+++ b/examples/ai-functions/src/reproduction/amazon-bedrock-kimi-k2-thinking-tool-call.ts
@@ -1,0 +1,189 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { stepCountIs, streamText, tool } from 'ai';
+import fs from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+
+const modelId = 'moonshot.kimi-k2-thinking';
+const expectedAnswer = 'FOUND ISSUE_11409_CONTENT';
+const fixtureNames = [
+  'issue-11409-kimi-k2-thinking-glob-search.chunks.txt',
+  'issue-11409-kimi-k2-thinking-read-file.chunks.txt',
+  'issue-11409-kimi-k2-thinking-final.chunks.txt',
+];
+
+type AttemptResult = {
+  attempt: number;
+  executedTools: string[];
+  finalText: string;
+  visibleText: string;
+  leakedToolSyntax: boolean;
+  reproducedPrimaryBug: boolean;
+  rawChunksByStep: unknown[][];
+};
+
+async function runAttempt(attempt: number): Promise<AttemptResult> {
+  const executedTools: string[] = [];
+  const rawChunksByStep: unknown[][] = [];
+  let currentStep = -1;
+  let visibleText = '';
+
+  const bedrock = createAmazonBedrock({
+    region: process.env.AWS_REGION ?? 'us-east-1',
+  });
+
+  const result = streamText({
+    model: bedrock(modelId),
+    prompt: [
+      'Inspect this repository for Cursor-related files.',
+      'You must first call glob_search with the exact pattern **/*cursor*.',
+      'The glob result will include FILE1. You must then call read_file with target_file FILE1.',
+      `Only after reading FILE1, answer exactly ${expectedAnswer}.`,
+      'Do not skip either tool and do not write tool arguments as ordinary text.',
+    ].join(' '),
+    tools: {
+      glob_search: tool({
+        description: 'Find repository files matching a glob pattern.',
+        inputSchema: z.object({
+          pattern: z.string(),
+        }),
+        execute: async ({ pattern }) => {
+          executedTools.push('glob_search');
+          return pattern === '**/*cursor*'
+            ? { files: ['FILE1', 'FILE2'] }
+            : { files: [] };
+        },
+      }),
+      read_file: tool({
+        description: 'Read a repository file.',
+        inputSchema: z.object({
+          target_file: z.string(),
+        }),
+        execute: async ({ target_file }) => {
+          executedTools.push('read_file');
+          return target_file === 'FILE1'
+            ? expectedAnswer
+            : `UNEXPECTED_FILE ${target_file}`;
+        },
+      }),
+    },
+    stopWhen: stepCountIs(5),
+    maxOutputTokens: 4096,
+    maxRetries: 0,
+    includeRawChunks: true,
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'start-step') {
+      currentStep += 1;
+      rawChunksByStep[currentStep] = [];
+    } else if (part.type === 'raw') {
+      rawChunksByStep[Math.max(currentStep, 0)] ??= [];
+      rawChunksByStep[Math.max(currentStep, 0)].push(part.rawValue);
+    } else if (part.type === 'text-delta') {
+      visibleText += part.text;
+    }
+  }
+
+  const steps = await result.steps;
+  const finalText = steps.at(-1)?.text ?? '';
+  const leakedToolSyntax =
+    /<\|tool_call_(?:begin|argument_begin|end)s?\|>/.test(visibleText) ||
+    /<\|tool_calls_section_end\|>/.test(visibleText) ||
+    /"pattern"\s*:\s*"\*\*\/\*cursor\*"/.test(visibleText) ||
+    /"target_file"\s*:\s*"FILE1"/.test(visibleText);
+  const reproducedPrimaryBug =
+    !executedTools.includes('read_file') &&
+    !finalText.trim().endsWith(expectedAnswer) &&
+    /target_file|FILE1|tool_call|function_calls/.test(visibleText);
+
+  return {
+    attempt,
+    executedTools,
+    finalText,
+    visibleText,
+    leakedToolSyntax,
+    reproducedPrimaryBug,
+    rawChunksByStep,
+  };
+}
+
+function recordFixtures(result: AttemptResult) {
+  const fixtureDirectory = path.resolve(
+    process.cwd(),
+    '../../packages/amazon-bedrock/src/__fixtures__',
+  );
+
+  fixtureNames.forEach((fixtureName, index) => {
+    const chunks = result.rawChunksByStep[index];
+    const fixturePath = path.join(fixtureDirectory, fixtureName);
+    if (chunks == null) {
+      if (fs.existsSync(fixturePath)) {
+        fs.unlinkSync(fixturePath);
+      }
+      return;
+    }
+
+    fs.writeFileSync(
+      fixturePath,
+      `${chunks.map(chunk => JSON.stringify(chunk)).join('\n')}\n`,
+    );
+  });
+}
+
+async function main() {
+  const results: AttemptResult[] = [];
+  const attemptCount = Number(process.env.ISSUE_11409_ATTEMPTS ?? '10');
+
+  for (let attempt = 1; attempt <= attemptCount; attempt += 1) {
+    const result = await runAttempt(attempt);
+    results.push(result);
+
+    console.log(
+      JSON.stringify({
+        attempt: result.attempt,
+        executedTools: result.executedTools,
+        finalText: result.finalText,
+        leakedToolSyntax: result.leakedToolSyntax,
+        reproducedPrimaryBug: result.reproducedPrimaryBug,
+      }),
+    );
+  }
+
+  const reproduced = results.find(result => result.reproducedPrimaryBug);
+  if (process.env.RECORD_ISSUE_11409_FIXTURES === '1' && reproduced != null) {
+    recordFixtures(reproduced);
+  }
+
+  if (reproduced != null) {
+    console.error(
+      `ISSUE_11409_REPRODUCED: attempt ${reproduced.attempt} emitted the intended read_file call as text, did not execute read_file, and ended without ${expectedAnswer}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const allCompleted = results.every(
+    result =>
+      result.executedTools.includes('glob_search') &&
+      result.executedTools.includes('read_file') &&
+      result.finalText.trim().endsWith(expectedAnswer),
+  );
+
+  if (!allCompleted) {
+    console.error(
+      'ISSUE_11409_INCONCLUSIVE: at least one attempt did not complete the required tool sequence, but the reported text-only read_file call was not observed',
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  console.log(
+    'ISSUE_11409_NOT_REPRODUCED: all attempts executed glob_search and read_file and returned FOUND ISSUE_11409_CONTENT',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-glob-search.chunks.txt
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-glob-search.chunks.txt
@@ -1,0 +1,16 @@
+{"messageStart":{"role":"assistant"}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":""}}}
+{"contentBlockStop":{"contentBlockIndex":0}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"reasoningContent":{"text":" The user wants me to:\n1. Call glob_search with pattern **/*cursor* \n2."}}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"reasoningContent":{"text":" Read the file that results from this search (FILE1)\n3. Then answer with \"FOUND ISS"}}}}
+{"contentBlockDelta":{"contentBlockIndex":1,"delta":{"reasoningContent":{"text":"UE_11409_CONTENT\"\n\nLet me do this step by step."}}}}
+{"contentBlockStop":{"contentBlockIndex":1}}
+{"contentBlockDelta":{"contentBlockIndex":2,"delta":{"text":""}}}
+{"contentBlockStop":{"contentBlockIndex":2}}
+{"contentBlockStart":{"contentBlockIndex":3,"start":{"toolUse":{"name":"glob_search","toolUseId":"functions.glob_search:0"}}}}
+{"contentBlockDelta":{"contentBlockIndex":3,"delta":{"toolUse":{"input":"{\"pattern\": \"**/*cursor*\"}"}}}}
+{"contentBlockStop":{"contentBlockIndex":3}}
+{"contentBlockDelta":{"contentBlockIndex":4,"delta":{"text":""}}}
+{"contentBlockStop":{"contentBlockIndex":4}}
+{"messageStop":{"stopReason":"tool_use"}}
+{"metadata":{"metrics":{"latencyMs":966},"usage":{"inputTokens":217,"outputTokens":75,"serverToolUsage":{},"totalTokens":292}}}

--- a/packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-read-file.chunks.txt
+++ b/packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-read-file.chunks.txt
@@ -1,0 +1,9 @@
+{"messageStart":{"role":"assistant"}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":""}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" <think> The glob search returned two files: FILE1 and FILE2. The user specifically said the glob result"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" will include FILE1 and I must call read_file with target_file FILE1. So I will read"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":" FILE1 now.\n\n<function=read_file>\n<parameter=target_file>FILE1</parameter"}}}
+{"contentBlockDelta":{"contentBlockIndex":0,"delta":{"text":">\n</function>"}}}
+{"contentBlockStop":{"contentBlockIndex":0}}
+{"messageStop":{"stopReason":"end_turn"}}
+{"metadata":{"metrics":{"latencyMs":922},"usage":{"inputTokens":325,"outputTokens":66,"serverToolUsage":{},"totalTokens":391}}}

--- a/packages/amazon-bedrock/src/issue-11409.test.ts
+++ b/packages/amazon-bedrock/src/issue-11409.test.ts
@@ -1,0 +1,136 @@
+import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+import { injectFetchHeaders } from './inject-fetch-headers';
+
+vi.mock('./bedrock-event-stream-response-handler', () => ({
+  createBedrockEventStreamResponseHandler:
+    () =>
+    async ({ response }: { response: Response }) => {
+      const chunks = (await response.text())
+        .split('\n')
+        .filter(Boolean)
+        .map(chunk => {
+          const parsedChunk = JSON.parse(chunk);
+          return {
+            success: true,
+            value: parsedChunk,
+            rawValue: parsedChunk,
+          };
+        });
+
+      return {
+        responseHeaders: Object.fromEntries(response.headers),
+        value: new ReadableStream({
+          start(controller) {
+            chunks.forEach(chunk => controller.enqueue(chunk));
+            controller.close();
+          },
+        }),
+      };
+    },
+}));
+
+const modelId = 'moonshot.kimi-k2-thinking';
+const baseUrl = 'https://bedrock-runtime.us-east-1.amazonaws.com';
+const streamUrl = `${baseUrl}/model/${encodeURIComponent(
+  modelId,
+)}/converse-stream`;
+const fixtureDirectory = 'src/__fixtures__';
+
+const server = createTestServer({
+  [streamUrl]: {
+    response: {
+      type: 'stream-chunks',
+      chunks: [],
+    },
+  },
+});
+
+const model = new BedrockChatLanguageModel(modelId, {
+  baseUrl: () => baseUrl,
+  headers: {},
+  fetch: injectFetchHeaders({ 'x-amz-auth': 'test-auth' }),
+  generateId: () => 'test-id',
+});
+
+const prompt: LanguageModelV2Prompt = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'Inspect the repository.' }],
+  },
+];
+
+async function streamFixture(filename: string) {
+  server.urls[streamUrl].response = {
+    type: 'stream-chunks',
+    chunks: fs
+      .readFileSync(`${fixtureDirectory}/${filename}`, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map(line => `${line}\n`),
+  };
+
+  const { stream } = await model.doStream({
+    prompt,
+    tools: [
+      {
+        type: 'function',
+        name: 'glob_search',
+        inputSchema: {
+          type: 'object',
+          properties: { pattern: { type: 'string' } },
+          required: ['pattern'],
+          additionalProperties: false,
+        },
+      },
+      {
+        type: 'function',
+        name: 'read_file',
+        inputSchema: {
+          type: 'object',
+          properties: { target_file: { type: 'string' } },
+          required: ['target_file'],
+          additionalProperties: false,
+        },
+      },
+    ],
+    includeRawChunks: false,
+  });
+
+  return convertReadableStreamToArray(stream);
+}
+
+describe('issue #11409 Kimi K2 Thinking tool calls', () => {
+  it('keeps the required read_file action structured and reaches the final answer', async () => {
+    const globSearch = await streamFixture(
+      'issue-11409-kimi-k2-thinking-glob-search.chunks.txt',
+    );
+    expect(globSearch).toContainEqual({
+      type: 'tool-call',
+      toolCallId: 'functions.glob_search:0',
+      toolName: 'glob_search',
+      input: '{"pattern": "**/*cursor*"}',
+    });
+
+    const readFile = await streamFixture(
+      'issue-11409-kimi-k2-thinking-read-file.chunks.txt',
+    );
+    const visibleText = readFile
+      .filter(part => part.type === 'text-delta')
+      .map(part => part.delta)
+      .join('');
+
+    expect.soft(readFile).toContainEqual(
+      expect.objectContaining({
+        type: 'tool-call',
+        toolName: 'read_file',
+      }),
+    );
+    expect.soft(visibleText).not.toContain('<function=read_file>');
+    expect.soft(visibleText.trim()).toBe('FOUND ISSUE_11409_CONTENT');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,28 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/amazon-bedrock':
+        specifier: workspace:*
+        version: link:../../packages/amazon-bedrock
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -19609,7 +19631,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -19623,13 +19645,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
-      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
+      css-loader: 7.1.2(webpack@5.105.0)
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19637,22 +19659,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
-      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
+      license-webpack-plugin: 4.0.2(webpack@5.105.0)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
+      source-map-loader: 5.0.0(webpack@5.105.0)
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -19662,7 +19684,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -19692,7 +19714,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -24942,7 +24964,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -29418,7 +29440,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30185,7 +30207,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -30282,7 +30304,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
+  css-loader@7.1.2(webpack@5.105.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -33762,7 +33784,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -33790,7 +33812,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
+  license-webpack-plugin@4.0.2(webpack@5.105.0):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -34869,7 +34891,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36400,7 +36422,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -37357,7 +37379,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -37794,7 +37816,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
+  source-map-loader@5.0.0(webpack@5.105.0):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -39984,7 +40006,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)


### PR DESCRIPTION
## Bug

AWS Bedrock Kimi K2 Thinking ends abruptly due to incorrect tool call parsing

## Reproduction

- Expected Kimi K2 Thinking to execute `read_file` as a structured tool call and return `FOUND ISSUE_11409_CONTENT`; the final live run instead emitted the intended call as visible text, skipped execution, and stopped early in 1 of 10 attempts.
- `examples/ai-functions/src/reproduction/amazon-bedrock-kimi-k2-thinking-tool-call.ts` reproduces the intermittent user-visible failure against live Amazon Bedrock.
- `packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-glob-search.chunks.txt` records the preceding successful structured `glob_search` call.
- `packages/amazon-bedrock/src/__fixtures__/issue-11409-kimi-k2-thinking-read-file.chunks.txt` records Bedrock returning `<function=read_file>` as text followed by `stopReason: "end_turn"` instead of a structured tool-use event.
- `packages/amazon-bedrock/src/issue-11409.test.ts` replays the live fixtures and fails because `read_file` is absent, tool syntax is visible, and the final answer is missing.
- `examples/ai-functions/package.json` and `pnpm-lock.yaml` provide the runnable reproduction workspace.
- The target branch uses `ai@5.0.218` and `@ai-sdk/amazon-bedrock@3.0.108`; the reporter's exact `ai@6.0.2` and `@ai-sdk/amazon-bedrock@4.0.2` versions were not executed.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-thinking.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use-client-side.html
- https://aws.amazon.com/blogs/aws/amazon-bedrock-adds-fully-managed-open-weight-models/

## Related Issues

Reproduces #11409