### PR TITLE
reproduction: budgetTokens ignored when using an ARN as Bedrock

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "issueId": 11035,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11035-bedrock-arn-budget-tokens.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-11035-bedrock-arn-budget-tokens.ts",
+    "packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-issue-11035-without-thinking.json",
+    "packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-issue-11035-with-thinking.json"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_11035_REPRODUCED: budgetTokens was ignored for an Anthropic application inference profile ARN, so no reasoning output was returned."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11035-bedrock-arn-budget-tokens.ts
+++ b/examples/ai-functions/src/reproduction/issue-11035-bedrock-arn-budget-tokens.ts
@@ -1,0 +1,95 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText } from 'ai';
+import fs from 'node:fs';
+
+const applicationProfileArn =
+  'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/issue11035';
+const reproducedSignal =
+  'ISSUE_11035_REPRODUCED: budgetTokens was ignored for an Anthropic application inference profile ARN, so no reasoning output was returned.';
+
+function readFixture(filename: string) {
+  return JSON.parse(
+    fs.readFileSync(
+      new URL(
+        `../../../../packages/amazon-bedrock/src/__fixtures__/${filename}`,
+        import.meta.url,
+      ),
+      'utf8',
+    ),
+  );
+}
+
+async function main() {
+  (
+    globalThis as typeof globalThis & {
+      AI_SDK_LOG_WARNINGS?: false;
+    }
+  ).AI_SDK_LOG_WARNINGS = false;
+
+  let requestBody:
+    | {
+        additionalModelRequestFields?: {
+          thinking?: unknown;
+        };
+      }
+    | undefined;
+
+  const bedrock = createAmazonBedrock({
+    apiKey: 'replay-key',
+    region: 'us-east-1',
+    fetch: async (_input, init) => {
+      requestBody = JSON.parse(String(init?.body));
+      const responseFixture =
+        requestBody?.additionalModelRequestFields?.thinking == null
+          ? 'amazon-bedrock-issue-11035-without-thinking.json'
+          : 'amazon-bedrock-issue-11035-with-thinking.json';
+
+      return new Response(JSON.stringify(readFixture(responseFixture)), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+
+  const result = await generateText({
+    model: bedrock(applicationProfileArn),
+    prompt: 'Return only the word OK.',
+    maxOutputTokens: 1100,
+    providerOptions: {
+      bedrock: {
+        reasoningConfig: {
+          type: 'enabled',
+          budgetTokens: 1024,
+        },
+      },
+    },
+  });
+
+  const budgetWarning = (result.warnings ?? []).find(
+    warning =>
+      warning.type === 'unsupported' && warning.feature === 'budgetTokens',
+  );
+
+  if (
+    result.reasoningText == null &&
+    requestBody?.additionalModelRequestFields?.thinking == null &&
+    budgetWarning != null
+  ) {
+    console.error(reproducedSignal);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (result.reasoningText == null) {
+    throw new Error(
+      'Unexpected replay result: reasoning output was absent without the complete reported failure.',
+    );
+  }
+
+  console.log('Issue 11035 did not reproduce.');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-issue-11035-with-thinking.json
+++ b/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-issue-11035-with-thinking.json
@@ -1,0 +1,34 @@
+{
+  "metrics": {
+    "latencyMs": 2459
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "reasoningContent": {
+            "reasoningText": {
+              "signature": "EuMCCnAIEBABGAIqQFi8VTAlgKknv1sUQVNU9i083dhiFwXIXr9CfvxB3sVVnkvvt917z468gXqlJm/P6OA9ZQ17Vpg2LSrImOvjB10yGmNsYXVkZS1zb25uZXQtNC01LTIwMjUwOTI5OABCCHRoaW5raW5nEgzPaznqz7TECOIwi6oaDN43oO7aa2xuqdkrEyIwhgicXoIPLq8nmGgZt6E36uBds/RMCzQN9jEFgBH5JhJxrvHdv+XidNHp79qV27oVKqAB74dfzk9Sv9EwGNCLu7PEZuqIs4xOVPRMMxpIlSpQAajlREAAj2JDE8QaPXrV5ABcRaCRLmZjqa4GmPE5XnbgK33dkYHpHERG/ZAGULQGPm9Zptm9+o6oC6WnrA1X92Sp+diW6/6BPQqvjtc6MxmC0H3g+adkr/gVKu1uEaXJ1Y4HDq0wytPbuuvUNO7M9ayl0VIoBLwD1leROvBrYHACFxgB",
+              "text": "The user is asking me to return only the word \"OK\". This is a simple, straightforward request. I should just respond with \"OK\" and nothing else."
+            }
+          }
+        },
+        {
+          "text": "OK"
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "cacheReadInputTokenCount": 0,
+    "cacheReadInputTokens": 0,
+    "cacheWriteInputTokenCount": 0,
+    "cacheWriteInputTokens": 0,
+    "inputTokens": 42,
+    "outputTokens": 46,
+    "serverToolUsage": {},
+    "totalTokens": 88
+  }
+}

--- a/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-issue-11035-without-thinking.json
+++ b/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-issue-11035-without-thinking.json
@@ -1,0 +1,26 @@
+{
+  "metrics": {
+    "latencyMs": 1402
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "text": "OK"
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "cacheReadInputTokenCount": 0,
+    "cacheReadInputTokens": 0,
+    "cacheWriteInputTokenCount": 0,
+    "cacheWriteInputTokens": 0,
+    "inputTokens": 13,
+    "outputTokens": 4,
+    "serverToolUsage": {},
+    "totalTokens": 17
+  }
+}

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -213,6 +213,65 @@ const opusAnthropicModel = new AmazonBedrockChatLanguageModel(
   },
 );
 
+describe('issue 11035 reproduction', () => {
+  it('returns reasoning for an Anthropic application inference profile ARN when budgetTokens is configured', async () => {
+    const applicationProfileArn =
+      'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/issue11035';
+    let requestBody:
+      | {
+          additionalModelRequestFields?: {
+            thinking?: unknown;
+          };
+        }
+      | undefined;
+    const issueModel = new AmazonBedrockChatLanguageModel(
+      applicationProfileArn,
+      {
+        baseUrl: () => baseUrl,
+        headers: {},
+        generateId: () => 'test-id',
+        fetch: async (_input, init) => {
+          requestBody = JSON.parse(String(init?.body));
+          const fixture =
+            requestBody?.additionalModelRequestFields?.thinking == null
+              ? 'amazon-bedrock-issue-11035-without-thinking.json'
+              : 'amazon-bedrock-issue-11035-with-thinking.json';
+
+          return new Response(
+            fs.readFileSync(`src/__fixtures__/${fixture}`, 'utf8'),
+            {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            },
+          );
+        },
+      },
+    );
+
+    const result = await issueModel.doGenerate({
+      prompt: TEST_PROMPT,
+      maxOutputTokens: 1100,
+      providerOptions: {
+        bedrock: {
+          reasoningConfig: {
+            type: 'enabled',
+            budgetTokens: 1024,
+          },
+        },
+      },
+    });
+
+    expect(
+      result.content.some(part => part.type === 'reasoning'),
+      'Expected Anthropic reasoning output for the application inference profile ARN.',
+    ).toBe(true);
+    expect(requestBody?.additionalModelRequestFields?.thinking).toEqual({
+      type: 'enabled',
+      budget_tokens: 1024,
+    });
+  });
+});
+
 let mockOptions: { success: boolean; errorValue?: any } = { success: true };
 
 describe('doGenerate request metadata', () => {


### PR DESCRIPTION
## Bug

budgetTokens ignored when using an ARN as Bedrock model ID

## Reproduction

- On `main` with `@ai-sdk/amazon-bedrock` 5.0.27, a live temporary application inference profile backed by Anthropic Claude Sonnet 4.5 returned text but no reasoning, omitted the `thinking` request field, and warned that `budgetTokens` was ignored; the direct Anthropic profile ID returned reasoning with the same configuration.
- `packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts` identifies Anthropic models using `this.modelId.includes('anthropic')`, which cannot identify an opaque application inference profile ARN.
- `examples/ai-functions/src/reproduction/issue-11035-bedrock-arn-budget-tokens.ts` reproduces the expected reasoning-output failure and exits non-zero.
- `packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts` contains a failing provider test using live-recorded responses from `packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-issue-11035-without-thinking.json` and `packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-issue-11035-with-thinking.json`.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/cost-mgmt-application-inference-profiles.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-use.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_CreateInferenceProfile.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-extended-thinking.html

## Related Issues

Reproduces #11035