### PR TITLE
reproduction: could not reproduce Bedrock: The model returned the following errors: Thinking

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11227.ts
+++ b/examples/ai-functions/src/reproduction/issue-11227.ts
@@ -1,0 +1,71 @@
+import {
+  createAmazonBedrock,
+  type AmazonBedrockLanguageModelChatOptions,
+} from '@ai-sdk/amazon-bedrock';
+import { generateText, Output } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const modelId =
+    process.env.AI_SDK_ISSUE_11227_MODEL ?? 'us.anthropic.claude-opus-4-6-v1';
+  let requestBody: unknown;
+  let responseBody: unknown;
+
+  const bedrock = createAmazonBedrock({
+    region: 'us-east-1',
+    fetch: async (input, init) => {
+      if (typeof init?.body === 'string') {
+        requestBody = JSON.parse(init.body);
+      }
+
+      const response = await globalThis.fetch(input, init);
+      responseBody = await response.clone().json();
+      return response;
+    },
+  });
+
+  const result = await generateText({
+    model: bedrock(modelId),
+    output: Output.object({
+      schema: z.object({
+        answer: z.string(),
+      }),
+    }),
+    prompt: 'Return an object whose answer is exactly "ok".',
+    maxOutputTokens: 128,
+    maxRetries: 0,
+    providerOptions: {
+      bedrock: {
+        reasoningConfig: {
+          type: 'enabled',
+          budgetTokens: 1024,
+        },
+      } satisfies AmazonBedrockLanguageModelChatOptions,
+    },
+  });
+
+  if (result.output.answer !== 'ok') {
+    throw new Error(
+      `Expected structured output answer "ok", received ${JSON.stringify(result.output)}`,
+    );
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        modelId,
+        output: result.output,
+        requestBody,
+        responseBody,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-issue-11227-opus-4-6.json
+++ b/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-issue-11227-opus-4-6.json
@@ -1,0 +1,34 @@
+{
+  "metrics": {
+    "latencyMs": 12753
+  },
+  "output": {
+    "message": {
+      "content": [
+        {
+          "reasoningContent": {
+            "reasoningText": {
+              "signature": "EuABCmUIEBABGAIqQAVpBHRYEMT8naJAL/360s5kWHr27f/UWj5X1RkWbf3RHsFdZTOIvjxIQJhgbPzwISVtaCeINcL46fcSWuZdhYwyD2NsYXVkZS1vcHVzLTQtNjgAQgh0aGlua2luZxIMYCxrksRoEXd3zDOuGgyMim1M3IhlCQj2ZrwiMArtok6RP7DmSAGmR3YudbM6Fkqrr1JJXwWIiZs61ppxGjyJ7LmPVI2NXJ2KM6tLzCopZAnv7L1MI52HpwENtapa03Cj/0Tq07YjMwgdmCYrKkeQHPK/OtSE1GUYAQ==",
+              "text": "<thinking>\nSimple enough."
+            }
+          }
+        },
+        {
+          "text": "{\"answer\":\"ok\"}"
+        }
+      ],
+      "role": "assistant"
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "cacheReadInputTokenCount": 0,
+    "cacheReadInputTokens": 0,
+    "cacheWriteInputTokenCount": 0,
+    "cacheWriteInputTokens": 0,
+    "inputTokens": 209,
+    "outputTokens": 36,
+    "serverToolUsage": {},
+    "totalTokens": 245
+  }
+}

--- a/packages/amazon-bedrock/src/issue-11227.test.ts
+++ b/packages/amazon-bedrock/src/issue-11227.test.ts
@@ -1,0 +1,97 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { expect, it } from 'vitest';
+import { AmazonBedrockChatLanguageModel } from './amazon-bedrock-chat-language-model';
+import { injectFetchHeaders } from './inject-fetch-headers';
+
+const baseUrl = 'https://bedrock-runtime.us-east-1.amazonaws.com';
+const modelId = 'us.anthropic.claude-opus-4-6-v1';
+const generateUrl = `${baseUrl}/model/${encodeURIComponent(modelId)}/converse`;
+
+const server = createTestServer({
+  [generateUrl]: {
+    response: {
+      type: 'json-value',
+      body: JSON.parse(
+        fs.readFileSync(
+          'src/__fixtures__/amazon-bedrock-issue-11227-opus-4-6.json',
+          'utf8',
+        ),
+      ),
+    },
+  },
+});
+
+const model = new AmazonBedrockChatLanguageModel(modelId, {
+  baseUrl: () => baseUrl,
+  headers: {},
+  fetch: injectFetchHeaders({ 'x-amz-auth': 'test-auth' }),
+  generateId: () => 'test-id',
+});
+
+it('supports structured output with thinking for Claude Opus 4.6', async () => {
+  const result = await model.doGenerate({
+    prompt: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'Return an object whose answer is exactly "ok".',
+          },
+        ],
+      },
+    ],
+    responseFormat: {
+      type: 'json',
+      schema: {
+        type: 'object',
+        properties: {
+          answer: { type: 'string' },
+        },
+        required: ['answer'],
+        additionalProperties: false,
+      },
+    },
+    maxOutputTokens: 128,
+    providerOptions: {
+      bedrock: {
+        reasoningConfig: {
+          type: 'enabled',
+          budgetTokens: 1024,
+        },
+      },
+    },
+  });
+
+  const requestBody = await server.calls[0].requestBodyJson;
+
+  expect(requestBody.toolConfig).toBeUndefined();
+  expect(requestBody.additionalModelRequestFields).toMatchObject({
+    thinking: {
+      type: 'enabled',
+      budget_tokens: 1024,
+    },
+    output_config: {
+      format: {
+        type: 'json_schema',
+        schema: {
+          type: 'object',
+          properties: {
+            answer: { type: 'string' },
+          },
+          required: ['answer'],
+          additionalProperties: false,
+        },
+      },
+    },
+  });
+  expect(result.content).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: 'text',
+        text: '{"answer":"ok"}',
+      }),
+    ]),
+  );
+});


### PR DESCRIPTION
## Bug

Bedrock: The model returned the following errors: Thinking may not be enabled when tool_choice forces tool use.

## Reproduction

- The expected user-visible behavior is for `Output.object()` with Bedrock Claude thinking enabled to return a schema-valid object instead of aborting with the reported forced-tool error.
- On `main` with `ai` 7.0.34 and `@ai-sdk/amazon-bedrock` 5.0.27, `examples/ai-functions/src/reproduction/issue-11227.ts` returned `{ "answer": "ok" }` from live Claude Opus 4.6; the request used `thinking` with native `output_config.format` and did not contain forced `toolConfig`.
- Live checks also returned valid structured output for Claude Opus 4.5, Haiku 4.5, and Sonnet 4.5 without the reported error.
- Claude Sonnet 4.0 returned `output_config: Extra inputs are not permitted`, not the reported forced-tool error; current AWS documentation does not list Sonnet 4.0 as supporting structured outputs.
- `packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts` now selects native structured output instead of a forced synthetic tool for the supported reported models, and `packages/amazon-bedrock/CHANGELOG.md` records native Bedrock Anthropic structured-output support in version 4.0.68.
- The live Opus 4.6 response is recorded in `packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-issue-11227-opus-4-6.json` and covered by `packages/amazon-bedrock/src/issue-11227.test.ts`.
- The issue supplied no AI SDK version, so its exact historical dependency combination could not be compared with the current branch.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-structured-outputs.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-extended-thinking.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-adaptive-thinking.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
- https://ai-sdk.dev/docs/reference/ai-sdk-core/output

## Related Issues

Could not reproduce #11227