### PR TITLE
chore(docs): ignore .vercel project-link directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tsconfig.vitest-temp.json
 *.local
 *.tsbuildinfo
 packages/ai/docs
+.vercel

--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -7,3 +7,6 @@
 # Next.js
 /.next/
 next-env.d.ts
+
+# Vercel CLI project link
+.vercel


### PR DESCRIPTION
## Summary

Adds the `.vercel` project-link directory (created by `vercel link`) to the root and `apps/docs` ignore files so local links to the `ai-sdk-docs` Vercel project are never committed.

The `ai-sdk-docs` Vercel project is now connected to this repository (production branch `main`, root directory `apps/docs`). Merging this PR is also the first commit that passes the project's ignored-build-step filter, so it triggers the first Git-sourced production deployment of the Geistdocs site to the SSO-protected internal domain. `ai-sdk.dev` is unaffected.

## Testing

- No code changes; ignore-file only.
- The docs build from this repo was already validated on Vercel infrastructure (Git-sourced build from `main`@`106ea59106`, enhanced build machine, READY).