### PR TITLE
[v5.0] reproduction: could not reproduce The SDK should include output-error results as toolresult

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/anthropic": "workspace:*",
+    "ai": "workspace:*",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-10819-anthropic-web-fetch-error.ts
+++ b/examples/ai-functions/src/reproduction/issue-10819-anthropic-web-fetch-error.ts
@@ -1,0 +1,257 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { streamText, stepCountIs, tool } from 'ai';
+import { writeFile } from 'node:fs/promises';
+import { z } from 'zod';
+
+type AnthropicContentBlock = {
+  type?: string;
+  id?: string;
+  tool_use_id?: string;
+  content?: {
+    type?: string;
+    error_code?: string;
+  };
+};
+
+type AnthropicMessage = {
+  role?: string;
+  content?: AnthropicContentBlock[];
+};
+
+type AnthropicRequest = {
+  messages?: AnthropicMessage[];
+};
+
+type CapturedCall = {
+  request?: AnthropicRequest;
+  responseBody?: string;
+  responseStatus?: number;
+  responseContentType?: string | null;
+};
+
+function parseSseJson(body: string): unknown[] {
+  return body
+    .split('\n')
+    .filter(line => line.startsWith('data: '))
+    .map(line => line.slice('data: '.length))
+    .filter(data => data !== '[DONE]')
+    .map(data => JSON.parse(data));
+}
+
+function normalizeSseFixture(body: string): string {
+  return `${body
+    .split('\n')
+    .filter(line => line.startsWith('data: '))
+    .map(line => line.slice('data: '.length).trim())
+    .filter(data => data !== '[DONE]')
+    .join('\n')}\n`;
+}
+
+function findContentBlocks(value: unknown): AnthropicContentBlock[] {
+  if (value == null || typeof value !== 'object') {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap(findContentBlocks);
+  }
+
+  const record = value as Record<string, unknown>;
+  const blocks: AnthropicContentBlock[] = [];
+
+  if (
+    record.type === 'content_block_start' &&
+    record.content_block != null &&
+    typeof record.content_block === 'object'
+  ) {
+    blocks.push(record.content_block as AnthropicContentBlock);
+  }
+
+  for (const nested of Object.values(record)) {
+    blocks.push(...findContentBlocks(nested));
+  }
+
+  return blocks;
+}
+
+async function main() {
+  const calls: CapturedCall[] = [];
+
+  const anthropic = createAnthropic({
+    fetch: async (input, init) => {
+      const call: CapturedCall = {
+        request:
+          typeof init?.body === 'string'
+            ? (JSON.parse(init.body) as AnthropicRequest)
+            : undefined,
+      };
+      calls.push(call);
+
+      const response = await fetch(input, init);
+      call.responseStatus = response.status;
+      call.responseContentType = response.headers.get('content-type');
+      call.responseBody = await response.clone().text();
+
+      return response;
+    },
+  });
+
+  let finalText: string | undefined;
+  let steps: readonly unknown[] | undefined;
+  let generationError: unknown;
+
+  try {
+    const result = streamText({
+      model: anthropic('claude-sonnet-4-5-20250929'),
+      maxOutputTokens: 512,
+      temperature: 0,
+      prompt: [
+        'Follow these steps in order:',
+        '1. Use web_fetch on https://httpbin.org/status/500.',
+        '2. Wait until web_fetch has returned its result. Do not call tools in parallel.',
+        '3. Regardless of whether web_fetch succeeds, call display_products once.',
+        '4. After display_products returns, answer with exactly DONE.',
+        'Do not skip either tool call.',
+      ].join('\n'),
+      tools: {
+        web_fetch: anthropic.tools.webFetch_20250910({
+          maxUses: 1,
+        }),
+        display_products: tool({
+          description:
+            'Record that product display was attempted after the web fetch.',
+          inputSchema: z.object({}),
+          execute: async () => ({ displayed: true }),
+        }),
+      },
+      stopWhen: stepCountIs(4),
+    });
+
+    [finalText, steps] = await Promise.all([result.text, result.steps]);
+  } catch (error) {
+    generationError = error;
+  }
+
+  const fixtureBase = new URL(
+    '../../../../packages/anthropic/src/__fixtures__/',
+    import.meta.url,
+  );
+
+  await Promise.all(
+    calls.map(async (call, index) => {
+      if (call.responseBody == null) {
+        return;
+      }
+
+      const extension = call.responseContentType?.includes('text/event-stream')
+        ? 'chunks.txt'
+        : 'json';
+
+      await writeFile(
+        new URL(
+          `anthropic-issue-10819-web-fetch-error.${index + 1}.${extension}`,
+          fixtureBase,
+        ),
+        extension === 'chunks.txt'
+          ? normalizeSseFixture(call.responseBody)
+          : call.responseBody,
+      );
+    }),
+  );
+
+  const responseBlocks = calls.flatMap(call => {
+    if (call.responseBody == null) {
+      return [];
+    }
+
+    if (call.responseContentType?.includes('text/event-stream')) {
+      return findContentBlocks(parseSseJson(call.responseBody));
+    }
+
+    try {
+      return findContentBlocks(JSON.parse(call.responseBody));
+    } catch {
+      return [];
+    }
+  });
+
+  const errorResult = responseBlocks.find(
+    block =>
+      block.type === 'web_fetch_tool_result' &&
+      block.content?.type === 'web_fetch_tool_result_error',
+  );
+
+  if (errorResult?.tool_use_id == null) {
+    throw new Error(
+      'The live response did not exercise a web_fetch_tool_result_error, so issue #10819 could not be evaluated.',
+    );
+  }
+
+  const continuationRequest = calls
+    .slice(1)
+    .map(call => call.request)
+    .find(request =>
+      request?.messages?.some(
+        message =>
+          message.role === 'assistant' &&
+          message.content?.some(
+            block =>
+              block.type === 'web_fetch_tool_result' &&
+              block.tool_use_id === errorResult.tool_use_id &&
+              block.content?.type === 'web_fetch_tool_result_error',
+          ),
+      ),
+    );
+
+  const output = {
+    requestCount: calls.length,
+    responseStatuses: calls.map(call => call.responseStatus),
+    webFetchToolUseId: errorResult.tool_use_id,
+    webFetchErrorCode: errorResult.content?.error_code,
+    continuationIncludedErrorResult: continuationRequest != null,
+    stepCount: steps?.length,
+    finalText,
+    generationError:
+      generationError instanceof Error
+        ? {
+            name: generationError.name,
+            message: generationError.message,
+          }
+        : generationError,
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+
+  if (generationError != null) {
+    throw new Error(
+      'Reproduced issue #10819: multi-step generation failed after the web fetch error.',
+      { cause: generationError },
+    );
+  }
+
+  if (
+    calls.some(
+      call => call.responseStatus != null && call.responseStatus >= 400,
+    )
+  ) {
+    throw new Error(
+      'Reproduced issue #10819: Anthropic rejected a multi-step continuation request after the web fetch error.',
+    );
+  }
+
+  if (
+    steps == null ||
+    steps.length < 2 ||
+    finalText == null ||
+    !finalText.trim().endsWith('DONE')
+  ) {
+    throw new Error(
+      'Reproduced issue #10819: the multi-step continuation did not expose the expected final text after the web fetch error.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.1.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.1.chunks.txt
@@ -1,0 +1,26 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_011CdH6gYnrPKKsWxasCBMwz","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":1186,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":3,"service_tier":"standard","inference_geo":"not_available"}}  }
+{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}           }
+{"type": "ping"}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I'll follow"}          }
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" these steps in order.\n\nStep 1: Calling web_fetch on https://httpbin.org/status/500"}  }
+{"type":"content_block_stop","index":0       }
+{"type":"content_block_start","index":1,"content_block":{"type":"server_tool_use","id":"srvtoolu_01J1EKYpi3LLtWHmtZnY1gto","name":"web_fetch","input":{}}        }
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""} }
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"url"}          }
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\": \"https://"}   }
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"httpbin.org"}    }
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"/status/5"}             }
+{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"00\"}"} }
+{"type":"content_block_stop","index":1    }
+{"type":"content_block_start","index":2,"content_block":{"type":"web_fetch_tool_result","tool_use_id":"srvtoolu_01J1EKYpi3LLtWHmtZnY1gto","content":{"type":"web_fetch_tool_result_error","error_code":"url_not_accessible"},"caller":{"type":"direct"}}            }
+{"type":"content_block_stop","index":2}
+{"type":"content_block_start","index":3,"content_block":{"type":"text","text":""}  }
+{"type":"content_block_delta","index":3,"delta":{"type":"text_delta","text":"Step"}             }
+{"type":"content_block_delta","index":3,"delta":{"type":"text_delta","text":" 2: web_fetch has returned (with an error, but it"}}
+{"type":"content_block_delta","index":3,"delta":{"type":"text_delta","text":" has completed).\n\nStep 3: Now calling display_products"}        }
+{"type":"content_block_stop","index":3        }
+{"type":"content_block_start","index":4,"content_block":{"type":"tool_use","id":"toolu_01FUuDcCDweLziH8QvQFQLtV","name":"display_products","input":{},"caller":{"type":"direct"}}       }
+{"type":"content_block_delta","index":4,"delta":{"type":"input_json_delta","partial_json":""}}
+{"type":"content_block_stop","index":4           }
+{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":2509,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":158,"server_tool_use":{"web_search_requests":0,"web_fetch_requests":1}}      }
+{"type":"message_stop"   }

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.2.chunks.txt
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.2.chunks.txt
@@ -1,0 +1,9 @@
+{"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_011CdH6h1Zg2dQ1apTsav3nc","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":1436,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}               }
+{"type":"content_block_start","index":0,"content_block":{"type":"web_fetch_tool_result","tool_use_id":"srvtoolu_01J1EKYpi3LLtWHmtZnY1gto","content":{"type":"web_fetch_tool_result_error","error_code":"url_not_accessible"},"caller":{"type":"direct"}} }
+{"type":"content_block_stop","index":0      }
+{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}              }
+{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Step"}     }
+{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" 4: display_products has returned.\n\nDONE"} }
+{"type":"content_block_stop","index":1  }
+{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":1436,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":16,"server_tool_use":{"web_search_requests":0,"web_fetch_requests":1}}       }
+{"type":"message_stop"           }

--- a/packages/anthropic/src/issue-10819.test.ts
+++ b/packages/anthropic/src/issue-10819.test.ts
@@ -1,0 +1,82 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import fs from 'node:fs';
+import { expect, it, vi } from 'vitest';
+import { createAnthropic } from './anthropic-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const server = createTestServer({
+  'https://api.anthropic.com/v1/messages': {},
+});
+
+it('parses the live provider-executed web fetch error before the client tool call', async () => {
+  const chunks = fs
+    .readFileSync(
+      'src/__fixtures__/anthropic-issue-10819-web-fetch-error.1.chunks.txt',
+      'utf8',
+    )
+    .trim()
+    .split('\n')
+    .map(line => `data: ${line}\n\n`);
+  chunks.push('data: [DONE]\n\n');
+
+  server.urls['https://api.anthropic.com/v1/messages'].response = {
+    type: 'stream-chunks',
+    chunks,
+  };
+
+  const provider = createAnthropic({ apiKey: 'test-api-key' });
+  const result = await provider('claude-sonnet-4-5-20250929').doStream({
+    prompt: [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Run both tools.' }],
+      },
+    ],
+    tools: [
+      {
+        type: 'provider-defined',
+        id: 'anthropic.web_fetch_20250910',
+        name: 'web_fetch',
+        args: { maxUses: 1 },
+      },
+      {
+        type: 'function',
+        name: 'display_products',
+        description: 'Record that product display was attempted.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false,
+        },
+      },
+    ],
+  });
+
+  expect(await convertReadableStreamToArray(result.stream)).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: 'tool-call',
+        toolName: 'web_fetch',
+        providerExecuted: true,
+      }),
+      expect.objectContaining({
+        type: 'tool-result',
+        toolName: 'web_fetch',
+        result: {
+          type: 'web_fetch_tool_result_error',
+          errorCode: expect.any(String),
+        },
+        isError: true,
+        providerExecuted: true,
+      }),
+      expect.objectContaining({
+        type: 'tool-call',
+        toolName: 'display_products',
+      }),
+    ]),
+  );
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,25 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: workspace:*
+        version: link:../../packages/anthropic
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+    devDependencies:
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -19609,7 +19628,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -19623,13 +19642,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
-      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
+      css-loader: 7.1.2(webpack@5.105.0)
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19637,22 +19656,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
-      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
+      license-webpack-plugin: 4.0.2(webpack@5.105.0)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
+      source-map-loader: 5.0.0(webpack@5.105.0)
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -19662,7 +19681,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -19692,7 +19711,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -24942,7 +24961,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -29418,7 +29437,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30185,7 +30204,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -30282,7 +30301,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
+  css-loader@7.1.2(webpack@5.105.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -33762,7 +33781,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -33790,7 +33809,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
+  license-webpack-plugin@4.0.2(webpack@5.105.0):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -34869,7 +34888,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36400,7 +36419,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -37357,7 +37376,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -37794,7 +37813,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
+  source-map-loader@5.0.0(webpack@5.105.0):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -39984,7 +40003,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)


### PR DESCRIPTION
## Bug

The SDK should include output-error results as tool_result blocks

## Reproduction

- On `release-v5`, `ai` 5.0.218 and `@ai-sdk/anthropic` 2.0.88 expose all APIs required by the report.
- The exact model `claude-sonnet-4-5-20250929` produced a provider-executed web-fetch error followed by `display_products`; both requests returned HTTP 200, generation completed two steps, and final text ended in `DONE` instead of the reported Anthropic 400 failure.
- The continuation request omitted the errored `web_fetch_tool_result` and emitted the corresponding unsupported `error-json` warning, but Anthropic returned the matching error result in its second response and completed generation, so only the secondary request-shaping mismatch was observed.
- Runnable live reproduction is stored at `examples/ai-functions/src/reproduction/issue-10819-anthropic-web-fetch-error.ts`, supported by `examples/ai-functions/package.json` and `pnpm-lock.yaml`.
- Live responses are recorded at `packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.1.chunks.txt` and `packages/anthropic/src/__fixtures__/anthropic-issue-10819-web-fetch-error.2.chunks.txt`.
- `packages/anthropic/src/issue-10819.test.ts` verifies that the live fixture parses into the provider-executed web-fetch error and subsequent client tool call.

## Relevant Documentation

- https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-fetch-tool
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/server-tools
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls

## Related Issues

Could not reproduce #10819