### PR TITLE
[v5.0] reproduction: Media-type sniffing performs unbounded work for ID3-prefixed attachments

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "issueId": 17709,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17709-id3-media-sniffing.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17709-id3-media-sniffing.ts",
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/tsconfig.json",
+    "pnpm-lock.yaml"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_17709_REPRODUCED: ID3 media sniffing exceeded the fixed 128 KiB scan bound and performed attachment-sized work"
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17709-id3-media-sniffing.ts
+++ b/examples/ai-functions/src/reproduction/issue-17709-id3-media-sniffing.ts
@@ -1,0 +1,345 @@
+import assert from 'node:assert/strict';
+
+const MAX_ID3_TAG_SIZE = 128 * 1024;
+const ONE_MIB = 1024 * 1024;
+const REPRODUCTION_SIGNAL =
+  'ISSUE_17709_REPRODUCED: ID3 media sniffing exceeded the fixed 128 KiB scan bound and performed attachment-sized work';
+
+function encodeSyncSafeSize(size: number): [number, number, number, number] {
+  return [
+    (size >> 21) & 0x7f,
+    (size >> 14) & 0x7f,
+    (size >> 7) & 0x7f,
+    size & 0x7f,
+  ];
+}
+
+function createId3Attachment({
+  totalSize,
+  tagSize,
+  signature,
+}: {
+  totalSize: number;
+  tagSize: number;
+  signature: readonly number[];
+}): Uint8Array {
+  const bytes = new Uint8Array(
+    Math.max(totalSize, 10 + tagSize + signature.length),
+  );
+  bytes.set([0x49, 0x44, 0x33, 0x03, 0x00, 0x00], 0);
+  bytes.set(encodeSyncSafeSize(tagSize), 6);
+  bytes.set(signature, 10 + tagSize);
+  return bytes;
+}
+
+class SliceObservedUint8Array extends Uint8Array {
+  readonly sliceLengths: number[] = [];
+
+  override slice(start?: number, end?: number): Uint8Array {
+    const result = super.slice(start, end);
+    this.sliceLengths.push(result.length);
+    return result;
+  }
+}
+
+function toObservedBytes(bytes: Uint8Array): SliceObservedUint8Array {
+  const observed = new SliceObservedUint8Array(bytes.length);
+  observed.set(bytes);
+  return observed;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64');
+}
+
+async function main() {
+  const originalAtob = globalThis.atob;
+  const decodedBase64Lengths: number[] = [];
+
+  globalThis.atob = (input: string) => {
+    decodedBase64Lengths.push(input.length);
+    return originalAtob(input);
+  };
+
+  try {
+    const {
+      audioMediaTypeSignatures,
+      detectMediaType,
+      imageMediaTypeSignatures,
+    } = await import('../../../../packages/ai/src/util/detect-media-type');
+    const { convertToLanguageModelV2DataContent } =
+      await import('../../../../packages/ai/src/prompt/data-content');
+
+    type Signatures = Parameters<typeof detectMediaType>[0]['signatures'];
+    const combinedMediaTypeSignatures = [
+      ...imageMediaTypeSignatures,
+      ...audioMediaTypeSignatures,
+    ] as unknown as Signatures;
+
+    const nonId3Controls = [
+      {
+        name: 'PNG',
+        bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+        signatures: imageMediaTypeSignatures,
+        expected: 'image/png',
+      },
+      {
+        name: 'JPEG',
+        bytes: new Uint8Array([0xff, 0xd8]),
+        signatures: imageMediaTypeSignatures,
+        expected: 'image/jpeg',
+      },
+      {
+        name: 'WEBP',
+        bytes: new Uint8Array([
+          0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42,
+          0x50,
+        ]),
+        signatures: imageMediaTypeSignatures,
+        expected: 'image/webp',
+      },
+      {
+        name: 'WAV',
+        bytes: new Uint8Array([
+          0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56,
+          0x45,
+        ]),
+        signatures: audioMediaTypeSignatures,
+        expected: 'audio/wav',
+      },
+    ] as const;
+
+    for (const control of nonId3Controls) {
+      assert.equal(
+        detectMediaType({
+          data: control.bytes,
+          signatures: control.signatures,
+        }),
+        control.expected,
+        `${control.name} raw-byte control changed`,
+      );
+      assert.equal(
+        detectMediaType({
+          data: toBase64(control.bytes),
+          signatures: control.signatures,
+        }),
+        control.expected,
+        `${control.name} base64 control changed`,
+      );
+    }
+
+    const pngBase64Url = toBase64(nonId3Controls[0].bytes)
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    assert.equal(
+      detectMediaType({
+        data: pngBase64Url,
+        signatures: imageMediaTypeSignatures,
+      }),
+      'image/png',
+      'base64url normalization changed',
+    );
+
+    const normalizedDataUrl = convertToLanguageModelV2DataContent(
+      `data:image/png;base64,${toBase64(nonId3Controls[0].bytes)}`,
+    );
+    assert.equal(normalizedDataUrl.mediaType, 'image/png');
+    assert.equal(typeof normalizedDataUrl.data, 'string');
+
+    const arrayBuffer = nonId3Controls[0].bytes.buffer.slice(0);
+    const normalizedArrayBuffer =
+      convertToLanguageModelV2DataContent(arrayBuffer);
+    assert.ok(normalizedArrayBuffer.data instanceof Uint8Array);
+    assert.equal(normalizedArrayBuffer.data.buffer, arrayBuffer);
+
+    const buffer = Buffer.from(nonId3Controls[0].bytes);
+    assert.equal(convertToLanguageModelV2DataContent(buffer).data, buffer);
+    assert.equal(
+      convertToLanguageModelV2DataContent('plain text').data,
+      'plain text',
+    );
+
+    decodedBase64Lengths.length = 0;
+    const ordinaryLargePng = new Uint8Array(ONE_MIB);
+    ordinaryLargePng.set(nonId3Controls[0].bytes);
+    const ordinaryLargePngBase64 = toBase64(ordinaryLargePng);
+    assert.equal(
+      detectMediaType({
+        data: ordinaryLargePngBase64,
+        signatures: imageMediaTypeSignatures,
+      }),
+      'image/png',
+    );
+    assert.equal(
+      decodedBase64Lengths.at(-1),
+      24,
+      'non-ID3 sniffing should decode only the normal 24-character prefix',
+    );
+
+    const pathResults: Array<{
+      path: string;
+      decodedCharacters: number;
+      attachmentCharacters: number;
+    }> = [];
+    for (const path of [
+      {
+        name: 'image',
+        signatures: imageMediaTypeSignatures,
+        signature: [0x89, 0x50, 0x4e, 0x47],
+        expected: 'image/png',
+      },
+      {
+        name: 'audio',
+        signatures: audioMediaTypeSignatures,
+        signature: [0xff, 0xfb],
+        expected: 'audio/mpeg',
+      },
+      {
+        name: 'combined',
+        signatures: combinedMediaTypeSignatures,
+        signature: [0xff, 0xfb],
+        expected: 'audio/mpeg',
+      },
+    ] as const) {
+      const attachment = createId3Attachment({
+        totalSize: ONE_MIB,
+        tagSize: 0,
+        signature: path.signature,
+      });
+      const base64 = toBase64(attachment);
+      decodedBase64Lengths.length = 0;
+      assert.equal(
+        detectMediaType({
+          data: base64,
+          signatures: path.signatures,
+        }),
+        path.expected,
+      );
+      pathResults.push({
+        path: path.name,
+        decodedCharacters: decodedBase64Lengths.at(-1) ?? 0,
+        attachmentCharacters: base64.length,
+      });
+    }
+
+    const observedRaw = toObservedBytes(
+      createId3Attachment({
+        totalSize: ONE_MIB,
+        tagSize: 0,
+        signature: [0xff, 0xfb],
+      }),
+    );
+    assert.equal(
+      detectMediaType({
+        data: observedRaw,
+        signatures: audioMediaTypeSignatures,
+      }),
+      'audio/mpeg',
+    );
+    const copiedRawBytes = observedRaw.sliceLengths.at(-1) ?? 0;
+
+    const boundaryResults = [MAX_ID3_TAG_SIZE, MAX_ID3_TAG_SIZE + 1].map(
+      tagSize => {
+        const bytes = createId3Attachment({
+          totalSize: 10 + tagSize + 2,
+          tagSize,
+          signature: [0xff, 0xfb],
+        });
+        const rawResult = detectMediaType({
+          data: bytes,
+          signatures: audioMediaTypeSignatures,
+        });
+        const base64Result = detectMediaType({
+          data: toBase64(bytes),
+          signatures: audioMediaTypeSignatures,
+        });
+        assert.equal(
+          rawResult,
+          base64Result,
+          `raw/base64 parity changed at ID3 tag size ${tagSize}`,
+        );
+        return { tagSize, rawResult, base64Result };
+      },
+    );
+
+    const malformed = createId3Attachment({
+      totalSize: ONE_MIB,
+      tagSize: 0,
+      signature: [0xff, 0xfb],
+    });
+    malformed.set([0xff, 0xff, 0xff, 0xff], 6);
+    const malformedBase64 = toBase64(malformed);
+    decodedBase64Lengths.length = 0;
+    assert.doesNotThrow(() =>
+      detectMediaType({
+        data: malformedBase64,
+        signatures: audioMediaTypeSignatures,
+      }),
+    );
+    const malformedDecodedCharacters = decodedBase64Lengths.at(-1) ?? 0;
+
+    const pdfResult = detectMediaType({
+      data: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+      signatures: combinedMediaTypeSignatures,
+    });
+
+    console.log(
+      JSON.stringify(
+        {
+          normalPrefixDecodedCharacters: 24,
+          id3Paths: pathResults,
+          rawAttachmentBytes: observedRaw.length,
+          rawCopiedBytes: copiedRawBytes,
+          boundaryResults,
+          malformed: {
+            attachmentCharacters: malformedBase64.length,
+            decodedCharacters: malformedDecodedCharacters,
+          },
+          controls: {
+            nonId3: nonId3Controls.map(control => control.name),
+            base64url: 'image/png',
+            dataUrl: normalizedDataUrl.mediaType,
+            arrayBuffer: normalizedArrayBuffer.data instanceof Uint8Array,
+            buffer: true,
+            text: true,
+            pdfOnReleaseV5: pdfResult,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const allId3PathsDecodedCompleteAttachments = pathResults.every(
+      result => result.decodedCharacters === result.attachmentCharacters,
+    );
+    const rawCopiedCompleteRemainder =
+      copiedRawBytes === observedRaw.length - 10;
+    const scannedPastBound =
+      boundaryResults[1].rawResult === 'audio/mpeg' &&
+      boundaryResults[1].base64Result === 'audio/mpeg';
+    const malformedDecodedCompleteAttachment =
+      malformedDecodedCharacters === malformedBase64.length;
+
+    if (
+      allId3PathsDecodedCompleteAttachments &&
+      rawCopiedCompleteRemainder &&
+      scannedPastBound &&
+      malformedDecodedCompleteAttachment
+    ) {
+      throw new Error(REPRODUCTION_SIGNAL);
+    }
+
+    assert.fail(
+      'Issue #17709 was not reproduced: media sniffing remained within the expected fixed bound',
+    );
+  } finally {
+    globalThis.atob = originalAtob;
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2022",
+    "lib": ["es2022", "dom"],
+    "module": "esnext",
+    "types": ["node"],
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,18 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -19609,7 +19621,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -19623,13 +19635,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
-      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
+      css-loader: 7.1.2(webpack@5.105.0)
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19637,22 +19649,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
-      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
+      license-webpack-plugin: 4.0.2(webpack@5.105.0)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
+      source-map-loader: 5.0.0(webpack@5.105.0)
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -19662,7 +19674,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -19692,7 +19704,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -24942,7 +24954,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -29418,7 +29430,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30185,7 +30197,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -30282,7 +30294,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
+  css-loader@7.1.2(webpack@5.105.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -33762,7 +33774,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -33790,7 +33802,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
+  license-webpack-plugin@4.0.2(webpack@5.105.0):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -34869,7 +34881,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36400,7 +36412,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -37357,7 +37369,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -37794,7 +37806,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
+  source-map-loader@5.0.0(webpack@5.105.0):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -39984,7 +39996,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)


### PR DESCRIPTION
## Bug

Media-type sniffing performs unbounded work for ID3-prefixed attachments

## Reproduction

- On `release-v5.0`, the affected implementation is in `packages/ai/src/util/detect-media-type.ts`: ID3-prefixed base64 is decoded before the 24-character prefix limit, and raw input is copied with `Uint8Array.slice`.
- Each image, audio, and combined-signature check decoded all 1,398,104 characters of a 1 MiB ID3-prefixed attachment; equivalent non-ID3 sniffing decoded only 24 characters.
- Raw-byte sniffing copied 1,048,566 bytes from a 1,048,576-byte attachment, confirming attachment-sized memory work.
- MP3 data behind a 128 KiB ID3 tag was correctly detected, but raw and base64 inputs with a 128 KiB-plus-one-byte tag were also detected as `audio/mpeg` instead of returning `undefined` at the fixed scan boundary.
- A malformed maximum syncsafe size field decoded the complete 1,398,104-character attachment without an out-of-bounds exception.
- PNG, JPEG, WEBP, WAV, base64url, data URL, `ArrayBuffer`, `Buffer`, text, and `raw/base64` boundary parity controls retained existing behavior; PDF auto-detection is absent from the target branch and returned `undefined`.
- `examples/ai-functions/src/reproduction/issue-17709-id3-media-sniffing.ts` is the runnable reproduction and intentionally fails because sniffing performs unbounded work rather than remaining independent of attachment size.

## Relevant Documentation

- https://id3.org/id3v2-00

## Related Issues

Reproduces #17709