### PR TITLE
[v5.0] reproduction: AIInvalidPromptError "messages must be a ModelMessage" caused by

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "issueId": 10893,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-10893-undefined-tool-result-array.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/tsconfig.json",
+    "examples/ai-functions/src/reproduction/issue-10893-undefined-tool-result-array.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_10893_REPRODUCED: follow-up streamText and generateText calls rejected direct response messages with AI_InvalidPromptError"
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/examples/ai-functions/src/reproduction/issue-10893-undefined-tool-result-array.ts
+++ b/examples/ai-functions/src/reproduction/issue-10893-undefined-tool-result-array.ts
@@ -1,0 +1,222 @@
+import assert from 'node:assert/strict';
+import {
+  generateText,
+  jsonSchema,
+  stepCountIs,
+  streamText,
+  tool,
+} from '../../../../packages/ai/dist/index.mjs';
+import {
+  convertArrayToReadableStream,
+  MockLanguageModelV2,
+} from '../../../../packages/ai/dist/test/index.mjs';
+
+const usage = {
+  inputTokens: 1,
+  outputTokens: 1,
+  totalTokens: 2,
+};
+
+const listTasks = tool({
+  description: 'List tasks',
+  inputSchema: jsonSchema<{ limit?: number }>({
+    type: 'object',
+    properties: {
+      limit: { type: 'number' },
+    },
+    additionalProperties: false,
+  }),
+  execute: async () => [
+    {
+      id: '1',
+      state: 'completed',
+      startedAt: '2025-10-26T17:59:40.065Z',
+      completedAt: '2025-10-26T18:00:31.713Z',
+    },
+    {
+      id: '2',
+      state: 'archived',
+      startedAt: undefined,
+      completedAt: undefined,
+    },
+  ],
+});
+
+function toolCallStream() {
+  return convertArrayToReadableStream([
+    {
+      type: 'tool-call' as const,
+      toolCallId: 'call-1',
+      toolName: 'listTasks',
+      input: '{}',
+    },
+    {
+      type: 'finish' as const,
+      finishReason: 'tool-calls' as const,
+      usage,
+    },
+  ]);
+}
+
+function textStream(text = 'follow-up accepted') {
+  return convertArrayToReadableStream([
+    { type: 'text-start' as const, id: 'text-1' },
+    { type: 'text-delta' as const, id: 'text-1', delta: text },
+    { type: 'text-end' as const, id: 'text-1' },
+    {
+      type: 'finish' as const,
+      finishReason: 'stop' as const,
+      usage,
+    },
+  ]);
+}
+
+async function consumeText(result: {
+  textStream: AsyncIterable<string>;
+}): Promise<string> {
+  let text = '';
+  for await (const chunk of result.textStream) {
+    text += chunk;
+  }
+  return text;
+}
+
+async function captureError(run: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await run();
+    return undefined;
+  } catch (error) {
+    return error;
+  }
+}
+
+function assertInvalidPrompt(error: unknown, api: string): void {
+  assert.ok(
+    error instanceof Error,
+    `${api} unexpectedly accepted the messages`,
+  );
+  assert.equal(error.name, 'AI_InvalidPromptError');
+  assert.match(error.message, /The messages must be a ModelMessage\[\]/);
+
+  const cause = (error as Error & { cause?: unknown }).cause;
+  assert.ok(cause instanceof Error);
+  assert.equal(cause.name, 'AI_TypeValidationError');
+}
+
+async function main() {
+  const firstResult = streamText({
+    model: new MockLanguageModelV2({
+      doStream: async () => ({ stream: toolCallStream() }),
+    }),
+    messages: [{ role: 'user', content: 'List all the tasks' }],
+    tools: { listTasks },
+  });
+
+  await firstResult.consumeStream();
+  const responseMessages = (await firstResult.response).messages;
+  const toolMessage = responseMessages.find(message => message.role === 'tool');
+  assert.ok(toolMessage);
+  const output = toolMessage.content[0].output;
+  assert.equal(output.type, 'json');
+
+  const tasks = output.value as unknown as Array<{
+    startedAt?: string;
+    completedAt?: string;
+  }>;
+  assert.equal(Object.hasOwn(tasks[1], 'startedAt'), true);
+  assert.equal(tasks[1].startedAt, undefined);
+
+  const followUpModel = new MockLanguageModelV2({
+    doStream: async () => ({ stream: textStream() }),
+    doGenerate: async () => ({
+      content: [{ type: 'text', text: 'follow-up accepted' }],
+      finishReason: 'stop',
+      usage,
+      warnings: [],
+    }),
+  });
+  const directMessages = [
+    { role: 'user' as const, content: 'List all the tasks' },
+    ...responseMessages,
+  ];
+
+  let streamError: unknown;
+  const directText = await consumeText(
+    streamText({
+      model: followUpModel,
+      messages: directMessages,
+      tools: { listTasks },
+      onError: event => {
+        streamError = event.error;
+      },
+    }),
+  );
+  assert.equal(directText, '');
+  assertInvalidPrompt(streamError, 'streamText');
+
+  const generateError = await captureError(() =>
+    generateText({
+      model: followUpModel,
+      messages: directMessages,
+      tools: { listTasks },
+    }),
+  );
+  assertInvalidPrompt(generateError, 'generateText');
+
+  const serializedMessages = JSON.parse(
+    JSON.stringify(directMessages),
+  ) as typeof directMessages;
+  const serializedText = await consumeText(
+    streamText({
+      model: followUpModel,
+      messages: serializedMessages,
+      tools: { listTasks },
+    }),
+  );
+  assert.equal(serializedText, 'follow-up accepted');
+
+  const nullMessages = structuredClone(directMessages);
+  const nullToolMessage = nullMessages.find(message => message.role === 'tool');
+  assert.ok(nullToolMessage);
+  const nullOutput = nullToolMessage.content[0].output;
+  assert.equal(nullOutput.type, 'json');
+  const nullTasks = nullOutput.value as unknown as Array<{
+    startedAt: string | null;
+    completedAt: string | null;
+  }>;
+  nullTasks[1].startedAt = null;
+  nullTasks[1].completedAt = null;
+  const nullText = await consumeText(
+    streamText({
+      model: followUpModel,
+      messages: nullMessages,
+      tools: { listTasks },
+    }),
+  );
+  assert.equal(nullText, 'follow-up accepted');
+
+  let multiStepCall = 0;
+  const multiStepText = await consumeText(
+    streamText({
+      model: new MockLanguageModelV2({
+        doStream: async () => ({
+          stream: multiStepCall++ === 0 ? toolCallStream() : textStream(),
+        }),
+      }),
+      prompt: 'List all the tasks',
+      tools: { listTasks },
+      stopWhen: stepCountIs(2),
+    }),
+  );
+  assert.equal(multiStepText, 'follow-up accepted');
+
+  console.error(
+    'ISSUE_10893_REPRODUCED: follow-up streamText and generateText calls rejected direct response messages with AI_InvalidPromptError',
+  );
+  process.exitCode = 1;
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2022",
+    "lib": ["es2022", "dom"],
+    "module": "esnext",
+    "moduleResolution": "Bundler",
+    "types": ["node"],
+    "typeRoots": ["../../packages/ai/node_modules/@types"],
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Bug

AI_InvalidPromptError ("messages must be a ModelMessage[]") caused by undefined properties in tool-result arrays

## Reproduction

- On `release-v5.0` with `ai` 5.0.218, manually reusing tool-response messages containing nested `undefined` properties caused both `streamText` and `generateText` to reject the follow-up with `AI_InvalidPromptError` caused by `AI_TypeValidationError`, preventing the expected continuation.
- JSON serialization removed the `undefined` keys and made the follow-up succeed, so retained `undefined` values—not heterogeneous arrays with missing keys—are the actual failure condition.
- Replacing the values with `null` succeeded, and automatic multi-step execution with `stopWhen: stepCountIs(2)` also succeeded, matching the issue comments.
- The runnable reproduction is `examples/ai-functions/src/reproduction/issue-10893-undefined-tool-result-array.ts`, supported by `examples/ai-functions/package.json` and `examples/ai-functions/tsconfig.json`.

## Related Issues

Reproduces #10893