### PR TITLE
[v5.0] reproduction: Bedrock: The model returned the following errors: Thinking

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "issueId": 11227,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-11227.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-11227.ts",
+    "examples/ai-functions/package.json",
+    "pnpm-lock.yaml"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_11227_REPRODUCED: Thinking may not be enabled when tool_choice forces tool use. Output.object() did not return a structured object."
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/amazon-bedrock": "workspace:*",
+    "ai": "workspace:*",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "tsx": "4.19.2"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-11227.ts
+++ b/examples/ai-functions/src/reproduction/issue-11227.ts
@@ -1,0 +1,106 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { APICallError, generateText, Output } from 'ai';
+import { z } from 'zod';
+
+const modelId =
+  process.env.AI_SDK_ISSUE_11227_MODEL ??
+  'us.anthropic.claude-opus-4-5-20251101-v1:0';
+const thinkingEnabled = process.env.AI_SDK_ISSUE_11227_THINKING !== 'disabled';
+const reportedError =
+  'Thinking may not be enabled when tool_choice forces tool use.';
+
+async function main() {
+  let requestBody: unknown;
+  let responseBody: unknown;
+
+  const bedrock = createAmazonBedrock({
+    region: 'us-east-1',
+    fetch: async (input, init) => {
+      if (typeof init?.body === 'string') {
+        requestBody = JSON.parse(init.body);
+      }
+
+      const response = await globalThis.fetch(input, init);
+      responseBody = await response.clone().json();
+      return response;
+    },
+  });
+
+  try {
+    const result = await generateText({
+      model: bedrock(modelId),
+      experimental_output: Output.object({
+        schema: z.object({
+          answer: z.string(),
+        }),
+      }),
+      prompt: 'Return an object whose answer is exactly "ok".',
+      maxOutputTokens: 128,
+      maxRetries: 0,
+      providerOptions: thinkingEnabled
+        ? {
+            bedrock: {
+              reasoningConfig: {
+                type: 'enabled',
+                budgetTokens: 1024,
+              },
+            },
+          }
+        : undefined,
+    });
+
+    if (result.experimental_output.answer !== 'ok') {
+      throw new Error(
+        `Expected structured output answer "ok", received ${JSON.stringify(result.experimental_output)}`,
+      );
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          modelId,
+          thinkingEnabled,
+          output: result.experimental_output,
+          requestBody,
+          responseBody,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    console.error(
+      JSON.stringify(
+        {
+          modelId,
+          thinkingEnabled,
+          message: error instanceof Error ? error.message : String(error),
+          statusCode: APICallError.isInstance(error)
+            ? error.statusCode
+            : undefined,
+          requestBody,
+          responseBody,
+        },
+        null,
+        2,
+      ),
+    );
+
+    if (
+      `${error instanceof Error ? error.message : String(error)}\n${JSON.stringify(responseBody)}`.includes(
+        reportedError,
+      )
+    ) {
+      throw new Error(
+        `ISSUE_11227_REPRODUCED: ${reportedError} Output.object() did not return a structured object.`,
+      );
+    }
+
+    throw error;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-issue-11227-opus-4-5-error.json
+++ b/packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-issue-11227-opus-4-5-error.json
@@ -1,0 +1,3 @@
+{
+  "message": "The model returned the following errors: Thinking may not be enabled when tool_choice forces tool use."
+}

--- a/packages/amazon-bedrock/src/issue-11227.test.ts
+++ b/packages/amazon-bedrock/src/issue-11227.test.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import { expect, it } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+
+const liveErrorFixture = JSON.parse(
+  fs.readFileSync(
+    'src/__fixtures__/amazon-bedrock-issue-11227-opus-4-5-error.json',
+    'utf8',
+  ),
+);
+
+it('returns structured output when thinking is enabled for Claude Opus 4.5', async () => {
+  const model = new BedrockChatLanguageModel(
+    'us.anthropic.claude-opus-4-5-20251101-v1:0',
+    {
+      baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      headers: {},
+      generateId: () => 'test-id',
+      fetch: async () =>
+        new Response(JSON.stringify(liveErrorFixture), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        }),
+    },
+  );
+
+  await expect(
+    model.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Return an object whose answer is exactly "ok".',
+            },
+          ],
+        },
+      ],
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            answer: { type: 'string' },
+          },
+          required: ['answer'],
+          additionalProperties: false,
+        },
+      },
+      maxOutputTokens: 128,
+      providerOptions: {
+        bedrock: {
+          reasoningConfig: {
+            type: 'enabled',
+            budgetTokens: 1024,
+          },
+        },
+      },
+    }),
+  ).resolves.toMatchObject({
+    content: [
+      {
+        type: 'text',
+        text: '{"answer":"ok"}',
+      },
+    ],
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,22 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/amazon-bedrock':
+        specifier: workspace:*
+        version: link:../../packages/amazon-bedrock
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+    devDependencies:
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -19609,7 +19625,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -19623,13 +19639,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
-      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
+      css-loader: 7.1.2(webpack@5.105.0)
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19637,22 +19653,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
-      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
+      license-webpack-plugin: 4.0.2(webpack@5.105.0)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
+      source-map-loader: 5.0.0(webpack@5.105.0)
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -19662,7 +19678,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -19692,7 +19708,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -24942,7 +24958,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -29418,7 +29434,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30185,7 +30201,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -30282,7 +30298,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
+  css-loader@7.1.2(webpack@5.105.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -33762,7 +33778,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -33790,7 +33806,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
+  license-webpack-plugin@4.0.2(webpack@5.105.0):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -34869,7 +34885,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36400,7 +36416,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -37357,7 +37373,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -37794,7 +37810,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
+  source-map-loader@5.0.0(webpack@5.105.0):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -39984,7 +40000,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)


### PR DESCRIPTION
## Bug

Bedrock: The model returned the following errors: Thinking may not be enabled when tool_choice forces tool use.

## Reproduction

- On `release-v5.0` with `ai` 5.0.218 and `@ai-sdk/amazon-bedrock` 3.0.108, `examples/ai-functions/src/reproduction/issue-11227.ts` expected `{ "answer": "ok" }` but live Claude Opus 4.5 returned HTTP 400: “Thinking may not be enabled when tool_choice forces tool use.”
- Live checks produced the same reported error for Claude Sonnet 4.0, Haiku 4.5, Sonnet 4.5, and Opus 4.6.
- Disabling thinking while retaining the same structured-output schema returned `{ "answer": "ok" }`, isolating the failure to combining thinking with structured output.
- `packages/amazon-bedrock/src/bedrock-chat-language-model.ts` implements structured output as a synthetic `json` tool with required tool choice, which becomes Bedrock `toolChoice.any` while thinking remains enabled.
- `packages/amazon-bedrock/src/__fixtures__/amazon-bedrock-issue-11227-opus-4-5-error.json` records the live provider response, and `packages/amazon-bedrock/src/issue-11227.test.ts` expects structured output but fails with that response.
- `examples/ai-functions/package.json` and `pnpm-lock.yaml` provide the target-branch dependencies required to run the reproduction command.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-structured-outputs.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-extended-thinking.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-adaptive-thinking.html

## Related Issues

Reproduces #11227