### PR TITLE
[v6.0] reproduction: could not reproduce ToolLoopAgent.generate with GPT 4.1 does not call tools

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-10788.ts
+++ b/examples/ai-functions/src/reproduction/issue-10788.ts
@@ -1,0 +1,79 @@
+import { Output, stepCountIs, tool, ToolLoopAgent } from 'ai';
+import { z } from 'zod';
+
+const evidenceToken = 'EVIDENCE-10788';
+
+async function runAgent(model: string) {
+  let toolExecutionCount = 0;
+
+  const agent = new ToolLoopAgent({
+    model,
+    instructions:
+      'You refine case descriptions. You must call getCaseFacts before producing the final structured output. Base the output only on the returned facts and copy its evidenceToken exactly.',
+    tools: {
+      getCaseFacts: tool({
+        description:
+          'Returns the private facts required to refine the case description.',
+        inputSchema: z.object({}),
+        execute: async () => {
+          toolExecutionCount += 1;
+          return {
+            evidenceToken,
+            facts:
+              'The customer could not sign in after enabling single sign-on.',
+          };
+        },
+      }),
+    },
+    output: Output.object({
+      schema: z.object({
+        refinedDescription: z.string(),
+        evidenceToken: z.string(),
+      }),
+    }),
+    stopWhen: stepCountIs(6),
+  });
+
+  const result = await agent.generate({
+    prompt:
+      'Refine case 10788 using the private case facts. Do not guess or omit the evidence token.',
+  });
+
+  return {
+    model,
+    toolExecutionCount,
+    stepCount: result.steps.length,
+    toolCallsPerStep: result.steps.map(step => step.toolCalls.length),
+    output: result.output,
+  };
+}
+
+async function main() {
+  const gpt41 = await runAgent('openai/gpt-4.1');
+  const gpt51 = await runAgent('openai/gpt-5.1-instant');
+
+  console.log(JSON.stringify({ gpt41, gpt51 }, null, 2));
+
+  if (gpt41.toolExecutionCount === 0) {
+    throw new Error(
+      'Reproduced issue #10788: GPT-4.1 produced structured output without calling the configured tool.',
+    );
+  }
+
+  if (gpt41.output.evidenceToken !== evidenceToken) {
+    throw new Error(
+      'GPT-4.1 did not produce structured output based on the tool result.',
+    );
+  }
+
+  if (gpt51.toolExecutionCount === 0) {
+    throw new Error(
+      'GPT-5.1 Instant comparison did not call the configured tool.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

ToolLoopAgent.generate() with GPT 4.1 does not call tools when output is specified

## Reproduction

- The reported impact would be ungrounded structured output because GPT-4.1 skips tools containing required case facts.
- On `release-v6.0` with `ai` 6.0.233 and `@ai-sdk/gateway` 3.0.155, live GPT-4.1 executed the configured tool once and returned valid structured output in two steps; the expected zero-tool-call failure did not occur.
- The live GPT-5.1 Instant comparison also executed the tool once and completed in two steps.
- Runnable coverage is in `examples/ai-functions/src/reproduction/issue-10788.ts` and exits successfully when both models call the tool.
- The historical setup cannot be reconstructed exactly because the report uses mutable `beta` tags and omits its concrete instructions, tools, schema, and generation prompt.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-core/tool-loop-agent
- https://ai-sdk.dev/docs/ai-sdk-core/generating-structured-data
- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://vercel.com/docs/ai-gateway/sdks-and-apis
- https://vercel.com/ai-gateway/models/gpt-4.1/providers
- https://vercel.com/ai-gateway/models/gpt-5.1-instant

## Related Issues

Could not reproduce #10788