### PR TITLE
[v5.0] reproduction: could not reproduce MCP client doesn't default to message for SSE

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/issue-10915-mcp-sse-default-message.ts
+++ b/examples/ai-functions/src/reproduction/issue-10915-mcp-sse-default-message.ts
@@ -1,0 +1,113 @@
+import { createServer, type ServerResponse } from 'node:http';
+import { experimental_createMCPClient as createMCPClient } from '../../../../packages/mcp/src';
+
+const timeoutMs = 2_000;
+
+async function main() {
+  let sseResponse: ServerResponse | undefined;
+
+  const server = createServer((request, response) => {
+    if (request.method === 'GET' && request.url === '/sse') {
+      sseResponse = response;
+      response.writeHead(200, {
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+        'content-type': 'text/event-stream',
+      });
+      response.write('event: endpoint\ndata: /messages\n\n');
+      return;
+    }
+
+    if (request.method === 'POST' && request.url === '/messages') {
+      let body = '';
+      request.setEncoding('utf8');
+      request.on('data', chunk => {
+        body += chunk;
+      });
+      request.on('end', () => {
+        const message = JSON.parse(body) as {
+          id?: number;
+          method: string;
+          params?: { protocolVersion?: string };
+        };
+
+        response.writeHead(202).end();
+
+        if (message.method === 'initialize') {
+          sseResponse?.write(
+            `data: ${JSON.stringify({
+              jsonrpc: '2.0',
+              id: message.id,
+              result: {
+                protocolVersion: message.params?.protocolVersion,
+                capabilities: {},
+                serverInfo: {
+                  name: 'issue-10915-reproduction',
+                  version: '1.0.0',
+                },
+              },
+            })}\n\n`,
+          );
+        }
+      });
+      return;
+    }
+
+    response.writeHead(404).end();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('Failed to determine reproduction server address');
+  }
+
+  let client: Awaited<ReturnType<typeof createMCPClient>> | undefined;
+
+  try {
+    client = await Promise.race([
+      createMCPClient({
+        transport: {
+          type: 'sse',
+          url: `http://127.0.0.1:${address.port}/sse`,
+        },
+      }),
+      new Promise<never>((_, reject) => {
+        setTimeout(
+          () =>
+            reject(
+              new Error(
+                'ISSUE_REPRODUCED: createMCPClient timed out after a data-only SSE initialization response',
+              ),
+            ),
+          timeoutMs,
+        );
+      }),
+    ]);
+
+    console.log(
+      'ISSUE_NOT_REPRODUCED: createMCPClient processed the data-only SSE initialization response',
+    );
+  } finally {
+    await client?.close();
+    sseResponse?.end();
+    await new Promise<void>((resolve, reject) => {
+      server.close(error => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,8 @@ importers:
         specifier: 4.1.0
         version: 4.1.0(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.1(@types/node@22.19.19)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.7.0))
 
+  examples/ai-functions: {}
+
   examples/ai-core:
     dependencies:
       '@ai-sdk/alibaba':


### PR DESCRIPTION
## Bug

MCP client doesn't default to `message` for SSE events

## Reproduction

- SSE data without an explicit `event` field defaults to `message`; dropping an initialization response can leave `createMCPClient` waiting indefinitely.
- The `@ai-sdk/mcp@0.0.11` tag confirms `packages/mcp/src/tool/mcp-sse-transport.ts` required `event === 'message'`, matching the historical report.
- The target branch contains `@ai-sdk/mcp` 0.0.26 in `packages/mcp/package.json`; `packages/mcp/src/tool/mcp-sse-transport.ts` accepts both undefined event types and explicit `message` events, and `packages/mcp/CHANGELOG.md` records the fix in 0.0.20.
- The runnable artifact `examples/ai-functions/src/reproduction/issue-10915-mcp-sse-default-message.ts`, supported by `examples/ai-functions/package.json` and `pnpm-lock.yaml`, sent a data-only SSE initialization response and completed successfully; the reported behavior would instead trigger its two-second timeout.
- Upgrading from the reported 0.0.11 setup to 0.0.20 or newer on the v5 release line resolves the behavior without product-code changes.

## Relevant Documentation

- https://html.spec.whatwg.org/multipage/server-sent-events.html
- https://modelcontextprotocol.io/specification/2024-11-05/basic/transports

## Related Issues

Could not reproduce #10915