### PR TITLE
[v6.0] reproduction: could not reproduce Bedrock: The model returned the following errors: Thinking

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-11227.ts
+++ b/examples/ai-functions/src/reproduction/issue-11227.ts
@@ -1,0 +1,101 @@
+import {
+  createAmazonBedrock,
+  type AmazonBedrockLanguageModelOptions,
+} from '@ai-sdk/amazon-bedrock';
+import { generateText, Output } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+const models = {
+  'opus-4.5': 'us.anthropic.claude-opus-4-5-20251101-v1:0',
+  'sonnet-4.0': 'us.anthropic.claude-sonnet-4-20250514-v1:0',
+  'haiku-4.5': 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+  'sonnet-4.5': 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+  'opus-4.6': 'us.anthropic.claude-opus-4-6-v1',
+} as const;
+
+async function main() {
+  const modelName = process.env.MODEL ?? 'opus-4.5';
+
+  if (!(modelName in models)) {
+    throw new Error(`Unknown MODEL: ${modelName}`);
+  }
+
+  const modelId = models[modelName as keyof typeof models];
+  let requestBody: Record<string, unknown> | undefined;
+
+  const bedrock = createAmazonBedrock({
+    region: process.env.AWS_REGION ?? 'us-east-1',
+    fetch: async (url, options) => {
+      requestBody = JSON.parse(String(options?.body));
+      return fetch(url, options);
+    },
+  });
+
+  const result = await generateText({
+    model: bedrock(modelId),
+    prompt: 'Return an object whose answer is exactly "ok".',
+    output: Output.object({
+      schema: z.object({
+        answer: z.string(),
+      }),
+    }),
+    maxRetries: 0,
+    providerOptions: {
+      bedrock: {
+        reasoningConfig: {
+          type: 'enabled',
+          budgetTokens: 1024,
+        },
+      } satisfies AmazonBedrockLanguageModelOptions,
+    },
+  });
+
+  if (result.output.answer !== 'ok') {
+    throw new Error(
+      `Expected {"answer":"ok"}, received ${JSON.stringify(result.output)}`,
+    );
+  }
+
+  if (requestBody?.toolConfig != null) {
+    throw new Error(
+      `Expected no forced toolConfig, received ${JSON.stringify(requestBody.toolConfig)}`,
+    );
+  }
+
+  const additionalFields = requestBody?.additionalModelRequestFields as
+    | {
+        output_config?: { format?: unknown };
+        thinking?: unknown;
+      }
+    | undefined;
+
+  if (
+    additionalFields?.output_config?.format == null ||
+    additionalFields.thinking == null
+  ) {
+    throw new Error(
+      `Expected thinking with native output_config.format, received ${JSON.stringify(requestBody)}`,
+    );
+  }
+
+  console.log(
+    JSON.stringify({
+      model: modelName,
+      modelId,
+      output: result.output,
+      request: {
+        hasThinking: true,
+        hasNativeOutputFormat: true,
+        hasForcedToolConfig: false,
+      },
+    }),
+  );
+}
+
+main().catch(error => {
+  console.error(
+    `ISSUE_11227_FAILURE: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

Bedrock: The model returned the following errors: Thinking may not be enabled when tool_choice forces tool use.

## Reproduction

- Expected behavior: `Output.object()` with Bedrock Claude thinking enabled returns a schema-valid object; the reported behavior instead aborts with “Thinking may not be enabled when tool_choice forces tool use.”
- On release-v6.0 with `ai` 6.0.233 and `@ai-sdk/amazon-bedrock` 4.0.138, `examples/ai-functions/src/reproduction/issue-11227.ts` returned `{"answer":"ok"}` from live Claude Opus 4.5; its request included thinking and native `output_config.format` without forced `toolConfig`.
- Live Claude Haiku 4.5, Sonnet 4.5, and Opus 4.6 comparisons also returned `{"answer":"ok"}` without the reported error.
- Claude Sonnet 4.0 returned the different error `output_config: Extra inputs are not permitted`; AWS documentation does not list Sonnet 4.0 as supporting structured outputs.
- `packages/amazon-bedrock/src/bedrock-chat-language-model.ts` selects native structured output for the supported reported models, and `packages/amazon-bedrock/CHANGELOG.md` records that support beginning in version 4.0.68.
- The issue supplied no AI SDK version, so its exact historical package combination could not be compared with the target branch.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-structured-outputs.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-extended-thinking.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-adaptive-thinking.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_ToolChoice.html
- https://ai-sdk.dev/docs/reference/ai-sdk-core/output

## Related Issues

Could not reproduce #11227