### PR TITLE
reproduction: could not reproduce Thought Signatures for Images are missing in Streaming

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-10660-google-stream-image-thought-signatures.ts
+++ b/examples/ai-functions/src/reproduction/issue-10660-google-stream-image-thought-signatures.ts
@@ -1,0 +1,132 @@
+import { createGoogle, type GoogleLanguageModelOptions } from '@ai-sdk/google';
+import { streamText, type ModelMessage } from 'ai';
+
+type GooglePart = {
+  inlineData?: {
+    data?: string;
+    mimeType?: string;
+  };
+  thoughtSignature?: string;
+};
+
+type GoogleRequest = {
+  contents?: Array<{
+    role?: string;
+    parts?: GooglePart[];
+  }>;
+};
+
+const providerOptions = {
+  google: {
+    responseModalities: ['TEXT', 'IMAGE'],
+  } satisfies GoogleLanguageModelOptions,
+};
+
+async function main() {
+  const requests: GoogleRequest[] = [];
+  const google = createGoogle({
+    fetch: async (input, init) => {
+      if (typeof init?.body === 'string') {
+        requests.push(JSON.parse(init.body) as GoogleRequest);
+      }
+      return fetch(input, init);
+    },
+  });
+  const model = google('gemini-3-pro-image-preview');
+  const messages: ModelMessage[] = [
+    {
+      role: 'user',
+      content: 'Create an image of the moon.',
+    },
+  ];
+
+  const turn1 = streamText({
+    model,
+    messages,
+    providerOptions,
+  });
+
+  const turn1ImageSignatures: string[] = [];
+  let turn1ImageCount = 0;
+
+  for await (const part of turn1.fullStream) {
+    if (part.type === 'file' && part.file.mediaType.startsWith('image/')) {
+      turn1ImageCount++;
+      const signature = part.providerMetadata?.google?.thoughtSignature;
+      if (typeof signature === 'string') {
+        turn1ImageSignatures.push(signature);
+      }
+    }
+  }
+
+  messages.push(...(await turn1.response).messages);
+  messages.push({
+    role: 'user',
+    content: 'Nice, but now make it cheese.',
+  });
+
+  const turn2 = streamText({
+    model,
+    messages,
+    providerOptions,
+  });
+
+  let turn2ImageCount = 0;
+  for await (const part of turn2.fullStream) {
+    if (part.type === 'file' && part.file.mediaType.startsWith('image/')) {
+      turn2ImageCount++;
+    }
+  }
+
+  const historyImageParts =
+    requests[1]?.contents
+      ?.filter(content => content.role === 'model')
+      .flatMap(content => content.parts ?? [])
+      .filter(
+        part =>
+          part.inlineData?.mimeType?.startsWith('image/') === true &&
+          typeof part.thoughtSignature === 'string',
+      ) ?? [];
+
+  console.log(
+    JSON.stringify(
+      {
+        model: 'gemini-3-pro-image-preview',
+        requestCount: requests.length,
+        turn1ImageCount,
+        turn1SignedImageCount: turn1ImageSignatures.length,
+        signedHistoryImageCount: historyImageParts.length,
+        turn2ImageCount,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (turn1ImageCount === 0) {
+    throw new Error('Turn 1 did not return an image.');
+  }
+
+  if (turn1ImageSignatures.length !== turn1ImageCount) {
+    throw new Error(
+      'Reproduced issue #10660: streamed image output is missing a thought signature.',
+    );
+  }
+
+  if (historyImageParts.length === 0) {
+    throw new Error(
+      'Reproduced issue #10660: the streamed image thought signature was not included in the follow-up request history.',
+    );
+  }
+
+  if (turn2ImageCount === 0) {
+    throw new Error(
+      'Reproduced issue #10660: the follow-up streamed image refinement did not produce an image.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

Thought Signatures for Images are missing in Streaming

## Reproduction

- On `main`, the checkout uses `ai@7.0.34` and `@ai-sdk/google@4.0.21`; `packages/google/CHANGELOG.md` and `packages/ai/CHANGELOG.md` record image thought-signature support as fixed in versions 3.0.38 and 6.0.114 respectively.
- The exact live `gemini-3-pro-image-preview` scenario returned one signed streamed image, included that signature in the second request history, and successfully generated the refined image.
- The issue expected the first streamed image to lack its thought signature and the follow-up refinement to fail; neither behavior occurred with the current packages.
- Runnable reproduction `examples/ai-functions/src/reproduction/issue-10660-google-stream-image-thought-signatures.ts` captures the two live requests and asserts the stream signature, history propagation, and successful second image.
- Upgrading from the reported beta versions to `ai@6.0.114` and `@ai-sdk/google@3.0.38` or newer incorporates the released fixes without product-code changes.

## Relevant Documentation

- https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures
- https://ai.google.dev/gemini-api/docs/generate-content/image-generation
- https://ai.google.dev/gemini-api/docs/generate-content/gemini-3

## Related Issues

Could not reproduce #10660