### PR TITLE
reproduction: could not reproduce On v5 I get a warning when using

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-10372.ts
+++ b/examples/ai-functions/src/reproduction/issue-10372.ts
@@ -1,0 +1,74 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText, Output, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+
+const reportedWarning =
+  'The "tools" setting is not supported by this model - JSON response format does not support tools. The provided tools are ignored.';
+
+async function main() {
+  let toolExecutionCount = 0;
+
+  const result = await generateText({
+    model: anthropic('claude-sonnet-4-5-20250929'),
+    system:
+      'You are a weather assistant. You must call getWeather before answering, then return the tool result as structured output.',
+    prompt: 'What is the weather in Tokyo?',
+    tools: {
+      getWeather: tool({
+        description: 'Get the weather for a given city',
+        inputSchema: z.object({
+          city: z.string().describe('The city to get the weather for'),
+        }),
+        execute: async ({ city }) => {
+          toolExecutionCount++;
+          return `The weather in ${city} is sunny`;
+        },
+      }),
+    },
+    output: Output.object({
+      schema: z.object({
+        weather: z.string().describe('The weather for the given city'),
+      }),
+    }),
+    stopWhen: stepCountIs(3),
+    maxOutputTokens: 512,
+  });
+
+  const warnings = result.steps.flatMap(step => step.warnings ?? []);
+  const warningText = JSON.stringify(warnings);
+
+  if (warningText.includes(reportedWarning)) {
+    throw new Error(`ISSUE_10372_REPRODUCED: ${reportedWarning}`);
+  }
+
+  if (toolExecutionCount === 0) {
+    throw new Error(
+      'ISSUE_10372_REPRODUCED: getWeather was ignored and never executed.',
+    );
+  }
+
+  if (!result.output.weather.toLowerCase().includes('sunny')) {
+    throw new Error(
+      `ISSUE_10372_REPRODUCED: structured output did not use the tool result: ${JSON.stringify(result.output)}`,
+    );
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        status: 'issue not reproduced',
+        model: 'claude-sonnet-4-5-20250929',
+        toolExecutionCount,
+        output: result.output,
+        warnings,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

On v5 I get a warning when using tools and experimental_output with sonnet models

## Reproduction

- The reported impact is that structured-output generation ignores configured tools, preventing tool-derived data from reaching the final schema-valid object.
- `packages/ai/package.json` and `packages/anthropic/package.json` identify the target branch as `ai@7.0.34` and `@ai-sdk/anthropic@4.0.18`; the current equivalent of historical `experimental_output` is `output`.
- The live reproduction at `examples/ai-functions/src/reproduction/issue-10372.ts` used the exact `claude-sonnet-4-5-20250929` model: `getWeather` executed once, the output was `{"weather":"The weather in Tokyo is sunny"}`, and provider warnings were empty.
- The expected issue behavior—emitting the reported warning and ignoring `getWeather`—did not occur on `main`.
- The historical `ai@5.0.95` and `@ai-sdk/anthropic@2.0.45` releases were not installed because evaluation is restricted to the checked-out target branch; this result applies to the current `main` versions.

## Relevant Documentation

- https://platform.claude.com/docs/en/build-with-claude/structured-outputs
- https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions
- https://ai-sdk.dev/docs/ai-sdk-core/generating-structured-data
- https://ai-sdk.dev/docs/troubleshooting/tool-calling-with-structured-outputs

## Related Issues

Could not reproduce #10372