### PR TITLE
[v6.0] fix: prevent warnings and skip-validator injection for valid Gemini 3 parallel function calls

### DIFF
--- a/.changeset/green-gemini-tools.md
+++ b/.changeset/green-gemini-tools.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Avoid missing thought-signature warnings and skip-validator injection for valid unsigned Gemini 3 parallel function calls in the same model response.

--- a/packages/google/src/convert-to-google-generative-ai-messages.test.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.test.ts
@@ -1346,7 +1346,7 @@ describe('Gemini 3 missing thoughtSignature mitigation', () => {
 
   it('does NOT inject the sentinel or warn for unsigned parallel calls after a signed call', () => {
     const onWarning = vi.fn();
-    const result = convertToGoogleMessages(
+    const result = convertToGoogleGenerativeAIMessages(
       [
         {
           role: 'assistant',
@@ -1377,7 +1377,7 @@ describe('Gemini 3 missing thoughtSignature mitigation', () => {
       ],
       {
         isGemini3Model: true,
-        providerOptionsNames: ['googleVertex', 'vertex'],
+        providerOptionsName: 'googleVertex',
         onWarning,
       },
     );
@@ -1413,7 +1413,7 @@ describe('Gemini 3 missing thoughtSignature mitigation', () => {
 
   it('does NOT inject the sentinel when other response parts separate parallel function calls', () => {
     const onWarning = vi.fn();
-    const result = convertToGoogleMessages(
+    const result = convertToGoogleGenerativeAIMessages(
       [
         {
           role: 'assistant',
@@ -1456,7 +1456,7 @@ describe('Gemini 3 missing thoughtSignature mitigation', () => {
 
   it('does NOT inject the sentinel when server tool parts separate parallel function calls', () => {
     const onWarning = vi.fn();
-    const result = convertToGoogleMessages(
+    const result = convertToGoogleGenerativeAIMessages(
       [
         {
           role: 'assistant',
@@ -1521,7 +1521,7 @@ describe('Gemini 3 missing thoughtSignature mitigation', () => {
 
   it('injects the sentinel when a signed server tool call precedes an unsigned function call', () => {
     const onWarning = vi.fn();
-    const result = convertToGoogleMessages(
+    const result = convertToGoogleGenerativeAIMessages(
       [
         {
           role: 'assistant',

--- a/packages/google/src/convert-to-google-generative-ai-messages.test.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.test.ts
@@ -1344,6 +1344,235 @@ describe('Gemini 3 missing thoughtSignature mitigation', () => {
     expect(onWarning.mock.calls[0][0].message).toContain('`weather`');
   });
 
+  it('does NOT inject the sentinel or warn for unsigned parallel calls after a signed call', () => {
+    const onWarning = vi.fn();
+    const result = convertToGoogleMessages(
+      [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_paris',
+              toolName: 'get_weather',
+              input: { city: 'Paris' },
+              providerOptions: {
+                vertex: { thoughtSignature: 'parallel_batch_signature' },
+              },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_tokyo',
+              toolName: 'get_weather',
+              input: { city: 'Tokyo' },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_new_york',
+              toolName: 'get_weather',
+              input: { city: 'New York' },
+            },
+          ],
+        },
+      ],
+      {
+        isGemini3Model: true,
+        providerOptionsNames: ['googleVertex', 'vertex'],
+        onWarning,
+      },
+    );
+
+    expect(result.contents[0].parts).toStrictEqual([
+      {
+        functionCall: {
+          id: 'tc_paris',
+          name: 'get_weather',
+          args: { city: 'Paris' },
+        },
+        thoughtSignature: 'parallel_batch_signature',
+      },
+      {
+        functionCall: {
+          id: 'tc_tokyo',
+          name: 'get_weather',
+          args: { city: 'Tokyo' },
+        },
+        thoughtSignature: undefined,
+      },
+      {
+        functionCall: {
+          id: 'tc_new_york',
+          name: 'get_weather',
+          args: { city: 'New York' },
+        },
+        thoughtSignature: undefined,
+      },
+    ]);
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  it('does NOT inject the sentinel when other response parts separate parallel function calls', () => {
+    const onWarning = vi.fn();
+    const result = convertToGoogleMessages(
+      [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_signed',
+              toolName: 'weather',
+              input: { location: 'SF' },
+              providerOptions: {
+                google: { thoughtSignature: 'signed_batch' },
+              },
+            },
+            {
+              type: 'text',
+              text: 'Checking another city in the same response.',
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'tc_unsigned',
+              toolName: 'weather',
+              input: { location: 'NYC' },
+            },
+          ],
+        },
+      ],
+      { isGemini3Model: true, onWarning },
+    );
+
+    expect(result.contents[0].parts[2]).toStrictEqual({
+      functionCall: {
+        id: 'tc_unsigned',
+        name: 'weather',
+        args: { location: 'NYC' },
+      },
+      thoughtSignature: undefined,
+    });
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  it('does NOT inject the sentinel when server tool parts separate parallel function calls', () => {
+    const onWarning = vi.fn();
+    const result = convertToGoogleMessages(
+      [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'signed_function_call',
+              toolName: 'weather',
+              input: { location: 'SF' },
+              providerOptions: {
+                google: { thoughtSignature: 'function_signature' },
+              },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'server_call',
+              toolName: 'server:GOOGLE_SEARCH_WEB',
+              input: { query: 'weather' },
+              providerOptions: {
+                google: {
+                  serverToolCallId: 'server_call',
+                  serverToolType: 'GOOGLE_SEARCH_WEB',
+                  thoughtSignature: 'server_call_signature',
+                },
+              },
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'server_call',
+              toolName: 'server:GOOGLE_SEARCH_WEB',
+              output: { type: 'json', value: { results: [] } },
+              providerOptions: {
+                google: {
+                  serverToolCallId: 'server_call',
+                  serverToolType: 'GOOGLE_SEARCH_WEB',
+                  thoughtSignature: 'server_response_signature',
+                },
+              },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'unsigned_function_call',
+              toolName: 'weather',
+              input: { location: 'NYC' },
+            },
+          ],
+        },
+      ],
+      { isGemini3Model: true, onWarning },
+    );
+
+    expect(result.contents[0].parts[3]).toStrictEqual({
+      functionCall: {
+        id: 'unsigned_function_call',
+        name: 'weather',
+        args: { location: 'NYC' },
+      },
+      thoughtSignature: undefined,
+    });
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  it('injects the sentinel when a signed server tool call precedes an unsigned function call', () => {
+    const onWarning = vi.fn();
+    const result = convertToGoogleMessages(
+      [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'server_call',
+              toolName: 'server:GOOGLE_SEARCH_WEB',
+              input: { query: 'weather' },
+              providerOptions: {
+                google: {
+                  serverToolCallId: 'server_call',
+                  serverToolType: 'GOOGLE_SEARCH_WEB',
+                  thoughtSignature: 'server_signature',
+                },
+              },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'function_call',
+              toolName: 'weather',
+              input: { location: 'NYC' },
+            },
+          ],
+        },
+      ],
+      { isGemini3Model: true, onWarning },
+    );
+
+    expect(result.contents[0].parts).toStrictEqual([
+      {
+        toolCall: {
+          toolType: 'GOOGLE_SEARCH_WEB',
+          args: { query: 'weather' },
+          id: 'server_call',
+        },
+        thoughtSignature: 'server_signature',
+      },
+      {
+        functionCall: {
+          id: 'function_call',
+          name: 'weather',
+          args: { location: 'NYC' },
+        },
+        thoughtSignature: SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+      },
+    ]);
+    expect(onWarning).toHaveBeenCalledTimes(1);
+    expect(onWarning.mock.calls[0][0].message).toContain('`weather`');
+  });
+
   it('does NOT inject the sentinel for non-Gemini-3 models', () => {
     const onWarning = vi.fn();
     const result = convertToGoogleGenerativeAIMessages(

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -313,6 +313,8 @@ export function convertToGoogleGenerativeAIMessages(
       case 'assistant': {
         systemMessagesAllowed = false;
 
+        let modelResponseHasSignedFunctionCall = false;
+
         contents.push({
           role: 'model',
           parts: content
@@ -375,18 +377,35 @@ export function convertToGoogleGenerativeAIMessages(
                     providerOpts?.serverToolType != null
                       ? String(providerOpts.serverToolType)
                       : undefined;
+<<<<<<< HEAD:packages/google/src/convert-to-google-generative-ai-messages.ts
 
                   // For Gemini 3, every replayed functionCall part must carry a
                   // thoughtSignature or the API returns HTTP 400. If the upstream
                   // serialization layer dropped the signature, inject the
                   // documented sentinel so the request still succeeds.
+=======
+                  const isServerToolCall =
+                    serverToolCallId != null && serverToolType != null;
+                  const shouldSkipMissingSignatureMitigation =
+                    // Gemini 3 returns a single signature for a parallel
+                    // function-call response on the first standard function
+                    // call. Subsequent standard function calls in the same
+                    // model response legitimately have no signature.
+                    !isServerToolCall &&
+                    thoughtSignature == null &&
+                    modelResponseHasSignedFunctionCall;
+>>>>>>> 5e5453ccf9 (fix: prevent warnings and skip-validator injection for valid Gemini 3 parallel function calls (#17649)):packages/google/src/convert-to-google-messages.ts
                   const effectiveThoughtSignature =
                     thoughtSignature ??
-                    (isGemini3Model
+                    (isGemini3Model && !shouldSkipMissingSignatureMitigation
                       ? injectSkipSignature(part.toolName)
                       : undefined);
 
-                  if (serverToolCallId && serverToolType) {
+                  if (!isServerToolCall && thoughtSignature != null) {
+                    modelResponseHasSignedFunctionCall = true;
+                  }
+
+                  if (isServerToolCall) {
                     return {
                       toolCall: {
                         toolType: serverToolType,

--- a/packages/google/src/convert-to-google-generative-ai-messages.ts
+++ b/packages/google/src/convert-to-google-generative-ai-messages.ts
@@ -377,13 +377,6 @@ export function convertToGoogleGenerativeAIMessages(
                     providerOpts?.serverToolType != null
                       ? String(providerOpts.serverToolType)
                       : undefined;
-<<<<<<< HEAD:packages/google/src/convert-to-google-generative-ai-messages.ts
-
-                  // For Gemini 3, every replayed functionCall part must carry a
-                  // thoughtSignature or the API returns HTTP 400. If the upstream
-                  // serialization layer dropped the signature, inject the
-                  // documented sentinel so the request still succeeds.
-=======
                   const isServerToolCall =
                     serverToolCallId != null && serverToolType != null;
                   const shouldSkipMissingSignatureMitigation =
@@ -394,7 +387,6 @@ export function convertToGoogleGenerativeAIMessages(
                     !isServerToolCall &&
                     thoughtSignature == null &&
                     modelResponseHasSignedFunctionCall;
->>>>>>> 5e5453ccf9 (fix: prevent warnings and skip-validator injection for valid Gemini 3 parallel function calls (#17649)):packages/google/src/convert-to-google-messages.ts
                   const effectiveThoughtSignature =
                     thoughtSignature ??
                     (isGemini3Model && !shouldSkipMissingSignatureMitigation


### PR DESCRIPTION
## Background

Gemini 3 legitimately signs only the first standard function call in a parallel model response, but replaying later unsigned calls caused misleading warnings and unnecessary skip-validator injection.

## Root Cause

The Google converter evaluated missing signatures per normalized tool-call part rather than recognizing that one assistant message represents a model response whose first standard parallel function call carries the shared signature. 

## Summary

The converter now tracks signed standard function calls across the entire assistant response, preserves state across mixed parts, excludes built-in server calls from seeding that state, retains fallback mitigation for genuinely missing signatures, and includes a patch changeset.

## Testing

Regression coverage verifies three-call parallel responses, intervening text and server parts, signed-server/unsigned-function behavior, genuine missing-signature fallback, and provider namespace handling. Google Node and Edge suites, full workspace type checking, and focused formatting/lint checks pass.

## End-to-end Validation

- `pnpm -C packages/google build && pnpm -C examples/ai-functions exec tsx src/stream-text/google/function-call-id.ts` — live Gemini calls produced three parallel tool calls and completed replay with final text.
- `pnpm -C examples/ai-functions exec tsx -e '<inline Gemini 3.5 Flash parallel-call probe>'` — observed `[signed,unsigned,unsigned]`, an empty warnings array, and successful final text generation.

## Related Issues

Fixes #16298

Closes #17620

Backport of #17649

Co-authored-by: mttzzz <16290052+mttzzz@users.noreply.github.com>
Co-authored-by: lgrammel <205036+lgrammel@users.noreply.github.com>