### PR TITLE
[v5.0] fix(provider-utils): bound media-type sniffing decode for ID3-prefixed input

### DIFF
--- a/.changeset/bound-id3-media-type-decode.md
+++ b/.changeset/bound-id3-media-type-decode.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+fix(provider-utils): bound media-type sniffing decode for ID3-prefixed input
+
+Media-type detection stripped ID3 tags before the ~18-byte prefix cap, decoding the entire base64 attachment (plus a full-size copy) whenever the data began with `ID3`/`SUQz`. This turned the intended O(1) sniff into an O(N) decode of the whole attachment. Detection now decodes at most a bounded prefix and skips the ID3 tag within that bound, keeping cost O(1) in input size on all paths (image, audio, and combined).

--- a/.changeset/bound-id3-media-type-decode.md
+++ b/.changeset/bound-id3-media-type-decode.md
@@ -1,7 +1,7 @@
 ---
-'@ai-sdk/provider-utils': patch
+'ai': patch
 ---
 
-fix(provider-utils): bound media-type sniffing decode for ID3-prefixed input
+fix(ai): bound media-type sniffing decode for ID3-prefixed input
 
-Media-type detection stripped ID3 tags before the ~18-byte prefix cap, decoding the entire base64 attachment (plus a full-size copy) whenever the data began with `ID3`/`SUQz`. This turned the intended O(1) sniff into an O(N) decode of the whole attachment. Detection now decodes at most a bounded prefix and skips the ID3 tag within that bound, keeping cost O(1) in input size on all paths (image, audio, and combined).
+Media-type detection stripped ID3 tags before the ~18-byte prefix cap, decoding the entire base64 attachment (plus a full-size copy) whenever the data began with `ID3`/`SUQz`. This turned the intended O(1) sniff into an O(N) decode of the whole attachment. Detection now decodes at most a bounded prefix and skips the ID3 tag within that bound, keeping cost O(1) in input size on both image and audio paths.

--- a/packages/ai/src/util/detect-media-type.test.ts
+++ b/packages/ai/src/util/detect-media-type.test.ts
@@ -2,13 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   audioMediaTypeSignatures,
   detectMediaType,
-<<<<<<< HEAD:packages/ai/src/util/detect-media-type.test.ts
   imageMediaTypeSignatures,
-=======
-  getTopLevelMediaType,
-  isFullMediaType,
   MAX_ID3_TAG_BYTES,
->>>>>>> 02ffdcbadf (fix(provider-utils): bound media-type sniffing decode for ID3-prefixed input (#17386)):packages/provider-utils/src/detect-media-type.test.ts
 } from './detect-media-type';
 import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
 
@@ -426,13 +421,16 @@ describe('detectMediaType', () => {
     // the base64 and raw-byte paths must agree.
     it('detects an ID3-tagged MP3 whose tag is at the scan limit', () => {
       const atLimit = buildID3Mp3(MAX_ID3_TAG_BYTES);
-      expect(detectMediaType({ data: atLimit, topLevelType: 'audio' })).toBe(
-        'audio/mpeg',
-      );
+      expect(
+        detectMediaType({
+          data: atLimit,
+          signatures: audioMediaTypeSignatures,
+        }),
+      ).toBe('audio/mpeg');
       expect(
         detectMediaType({
           data: convertUint8ArrayToBase64(atLimit),
-          topLevelType: 'audio',
+          signatures: audioMediaTypeSignatures,
         }),
       ).toBe('audio/mpeg');
     });
@@ -443,12 +441,15 @@ describe('detectMediaType', () => {
     it('does not detect an ID3-tagged MP3 whose tag exceeds the scan limit', () => {
       const overLimit = buildID3Mp3(MAX_ID3_TAG_BYTES + 1);
       expect(
-        detectMediaType({ data: overLimit, topLevelType: 'audio' }),
+        detectMediaType({
+          data: overLimit,
+          signatures: audioMediaTypeSignatures,
+        }),
       ).toBeUndefined();
       expect(
         detectMediaType({
           data: convertUint8ArrayToBase64(overLimit),
-          topLevelType: 'audio',
+          signatures: audioMediaTypeSignatures,
         }),
       ).toBeUndefined();
     });

--- a/packages/ai/src/util/detect-media-type.test.ts
+++ b/packages/ai/src/util/detect-media-type.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'vitest';
 import {
   audioMediaTypeSignatures,
   detectMediaType,
+<<<<<<< HEAD:packages/ai/src/util/detect-media-type.test.ts
   imageMediaTypeSignatures,
+=======
+  getTopLevelMediaType,
+  isFullMediaType,
+  MAX_ID3_TAG_BYTES,
+>>>>>>> 02ffdcbadf (fix(provider-utils): bound media-type sniffing decode for ID3-prefixed input (#17386)):packages/provider-utils/src/detect-media-type.test.ts
 } from './detect-media-type';
 import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
 
@@ -396,6 +402,55 @@ describe('detectMediaType', () => {
           signatures: audioMediaTypeSignatures,
         }),
       ).toBe('audio/mpeg');
+    });
+
+    // Builds an ID3v2-tagged MP3 with a `tagBody`-byte tag and the frame sync
+    // placed immediately after the tag.
+    const buildID3Mp3 = (tagBody: number): Uint8Array => {
+      const bytes = new Uint8Array(10 + tagBody + 2);
+      bytes[0] = 0x49; // 'I'
+      bytes[1] = 0x44; // 'D'
+      bytes[2] = 0x33; // '3'
+      // synchsafe size = tagBody
+      bytes[6] = (tagBody >>> 21) & 0x7f;
+      bytes[7] = (tagBody >>> 14) & 0x7f;
+      bytes[8] = (tagBody >>> 7) & 0x7f;
+      bytes[9] = tagBody & 0x7f;
+      // MP3 frame sync, placed right after the tag
+      bytes[10 + tagBody] = 0xff;
+      bytes[10 + tagBody + 1] = 0xfb;
+      return bytes;
+    };
+
+    // At the size limit the frame still falls inside the scanned prefix, and
+    // the base64 and raw-byte paths must agree.
+    it('detects an ID3-tagged MP3 whose tag is at the scan limit', () => {
+      const atLimit = buildID3Mp3(MAX_ID3_TAG_BYTES);
+      expect(detectMediaType({ data: atLimit, topLevelType: 'audio' })).toBe(
+        'audio/mpeg',
+      );
+      expect(
+        detectMediaType({
+          data: convertUint8ArrayToBase64(atLimit),
+          topLevelType: 'audio',
+        }),
+      ).toBe('audio/mpeg');
+    });
+
+    // One byte past the limit the frame is beyond the scanned prefix, so it is
+    // not detected. This also proves the decode stops at the bound rather than
+    // reading the whole input; both representations must agree.
+    it('does not detect an ID3-tagged MP3 whose tag exceeds the scan limit', () => {
+      const overLimit = buildID3Mp3(MAX_ID3_TAG_BYTES + 1);
+      expect(
+        detectMediaType({ data: overLimit, topLevelType: 'audio' }),
+      ).toBeUndefined();
+      expect(
+        detectMediaType({
+          data: convertUint8ArrayToBase64(overLimit),
+          topLevelType: 'audio',
+        }),
+      ).toBeUndefined();
     });
   });
 

--- a/packages/ai/src/util/detect-media-type.ts
+++ b/packages/ai/src/util/detect-media-type.ts
@@ -129,19 +129,55 @@ export const audioMediaTypeSignatures = [
   },
 ] as const;
 
-const stripID3 = (data: Uint8Array | string) => {
-  const bytes =
-    typeof data === 'string' ? convertBase64ToUint8Array(data) : data;
+const DEFAULT_SNIFF_BYTES = 18;
+
+// Longest signature prefix in the tables above (e.g. image/avif = 12 bytes).
+const MAX_SIGNATURE_BYTES = 12;
+
+// Largest ID3v2 tag (10-byte header + body) skipped to reach the audio frame.
+// Covers typical tags including embedded cover art while keeping the decode
+// bounded and O(1) in the attachment size. Exported for boundary tests.
+export const MAX_ID3_TAG_BYTES = 128 * 1024;
+
+// Total prefix decoded when an ID3 tag is present: the tag plus room for the
+// trailing signature, so a tag right at the size limit stays detectable.
+const ID3_SCAN_BYTES = MAX_ID3_TAG_BYTES + MAX_SIGNATURE_BYTES;
+
+// Decode/view exactly the first `maxBytes` bytes from the front of the input.
+// The base64 and raw-byte paths yield the same length, so detection does not
+// depend on the input's representation.
+function decodePrefix(data: Uint8Array | string, maxBytes: number): Uint8Array {
+  if (typeof data !== 'string') {
+    return data.length > maxBytes ? data.subarray(0, maxBytes) : data;
+  }
+  // base64: 4 chars -> 3 bytes. Decode whole 4-char groups, then trim the 0-2
+  // extra bytes so the result matches the raw-byte path exactly.
+  const maxChars = Math.ceil(maxBytes / 3) * 4;
+  const bytes = convertBase64ToUint8Array(
+    data.substring(0, Math.min(data.length, maxChars)),
+  );
+  return bytes.length > maxBytes ? bytes.subarray(0, maxBytes) : bytes;
+}
+
+function hasID3(bytes: Uint8Array): boolean {
+  return (
+    bytes.length > 10 &&
+    bytes[0] === 0x49 && // 'I'
+    bytes[1] === 0x44 && // 'D'
+    bytes[2] === 0x33 // '3'
+  );
+}
+
+const stripID3 = (bytes: Uint8Array): Uint8Array => {
   const id3Size =
     ((bytes[6] & 0x7f) << 21) |
     ((bytes[7] & 0x7f) << 14) |
     ((bytes[8] & 0x7f) << 7) |
     (bytes[9] & 0x7f);
-
-  // The raw MP3 starts here
-  return bytes.slice(id3Size + 10);
+  return bytes.subarray(id3Size + 10);
 };
 
+<<<<<<< HEAD:packages/ai/src/util/detect-media-type.ts
 function stripID3TagsIfPresent(data: Uint8Array | string): Uint8Array | string {
   const hasId3 =
     (typeof data === 'string' && data.startsWith('SUQz')) ||
@@ -162,21 +198,33 @@ function stripID3TagsIfPresent(data: Uint8Array | string): Uint8Array | string {
  * @returns The media type of the file.
  */
 export function detectMediaType({
+=======
+type MediaTypeSignatures = ReadonlyArray<{
+  readonly mediaType: string;
+  readonly bytesPrefix: ReadonlyArray<number | null>;
+}>;
+
+function detectMediaTypeBySignatures<T extends MediaTypeSignatures>({
+>>>>>>> 02ffdcbadf (fix(provider-utils): bound media-type sniffing decode for ID3-prefixed input (#17386)):packages/provider-utils/src/detect-media-type.ts
   data,
   signatures,
 }: {
   data: Uint8Array | string;
+<<<<<<< HEAD:packages/ai/src/util/detect-media-type.ts
   signatures: typeof audioMediaTypeSignatures | typeof imageMediaTypeSignatures;
 }): (typeof signatures)[number]['mediaType'] | undefined {
   const processedData = stripID3TagsIfPresent(data);
+=======
+  signatures: T;
+}): T[number]['mediaType'] | undefined {
+  let bytes = decodePrefix(data, DEFAULT_SNIFF_BYTES);
+>>>>>>> 02ffdcbadf (fix(provider-utils): bound media-type sniffing decode for ID3-prefixed input (#17386)):packages/provider-utils/src/detect-media-type.ts
 
-  // Convert the first ~18 bytes (24 base64 chars) for consistent detection logic:
-  const bytes =
-    typeof processedData === 'string'
-      ? convertBase64ToUint8Array(
-          processedData.substring(0, Math.min(processedData.length, 24)),
-        )
-      : processedData;
+  // ID3v2-tagged MP3s carry the audio frame after the tag; scan a bounded
+  // prefix past it rather than decoding the whole input.
+  if (hasID3(bytes)) {
+    bytes = stripID3(decodePrefix(data, ID3_SCAN_BYTES));
+  }
 
   for (const signature of signatures) {
     if (

--- a/packages/ai/src/util/detect-media-type.ts
+++ b/packages/ai/src/util/detect-media-type.ts
@@ -177,19 +177,6 @@ const stripID3 = (bytes: Uint8Array): Uint8Array => {
   return bytes.subarray(id3Size + 10);
 };
 
-<<<<<<< HEAD:packages/ai/src/util/detect-media-type.ts
-function stripID3TagsIfPresent(data: Uint8Array | string): Uint8Array | string {
-  const hasId3 =
-    (typeof data === 'string' && data.startsWith('SUQz')) ||
-    (typeof data !== 'string' &&
-      data.length > 10 &&
-      data[0] === 0x49 && // 'I'
-      data[1] === 0x44 && // 'D'
-      data[2] === 0x33); // '3'
-
-  return hasId3 ? stripID3(data) : data;
-}
-
 /**
  * Detect the media IANA media type of a file using a list of signatures.
  *
@@ -198,27 +185,13 @@ function stripID3TagsIfPresent(data: Uint8Array | string): Uint8Array | string {
  * @returns The media type of the file.
  */
 export function detectMediaType({
-=======
-type MediaTypeSignatures = ReadonlyArray<{
-  readonly mediaType: string;
-  readonly bytesPrefix: ReadonlyArray<number | null>;
-}>;
-
-function detectMediaTypeBySignatures<T extends MediaTypeSignatures>({
->>>>>>> 02ffdcbadf (fix(provider-utils): bound media-type sniffing decode for ID3-prefixed input (#17386)):packages/provider-utils/src/detect-media-type.ts
   data,
   signatures,
 }: {
   data: Uint8Array | string;
-<<<<<<< HEAD:packages/ai/src/util/detect-media-type.ts
   signatures: typeof audioMediaTypeSignatures | typeof imageMediaTypeSignatures;
 }): (typeof signatures)[number]['mediaType'] | undefined {
-  const processedData = stripID3TagsIfPresent(data);
-=======
-  signatures: T;
-}): T[number]['mediaType'] | undefined {
   let bytes = decodePrefix(data, DEFAULT_SNIFF_BYTES);
->>>>>>> 02ffdcbadf (fix(provider-utils): bound media-type sniffing decode for ID3-prefixed input (#17386)):packages/provider-utils/src/detect-media-type.ts
 
   // ID3v2-tagged MP3s carry the audio frame after the tag; scan a bounded
   // prefix past it rather than decoding the whole input.


### PR DESCRIPTION
## Summary

Media-type sniffing is documented as an O(1) check on the first ~18 bytes (24 base64 chars). An `ID3`/`SUQz`-prefixed attachment bypassed that bound: `stripID3TagsIfPresent` ran before the truncation and decoded the entire base64 attachment (plus a full-size `.slice()` copy), then returned a `Uint8Array` so the 24-char cap was skipped. A 4-character prefix flipped intended O(1) sniffing into an O(N) decode + copy of the whole attachment, on every path including image detection.

## Hardening

- Decode a bounded prefix first, then strip ID3 within that bound, so no input can force a full decode.
- Detection now runs on decoded bytes (`ID3`) instead of the base64 string (`startsWith('SUQz')`), so string and raw-byte inputs are checked uniformly and base64 alignment tricks cannot fool it.
- The raw-`Uint8Array` path is bounded too, and `stripID3` uses `subarray` (a view) instead of `slice` (a full copy), removing the second O(N) copy.
- ID3 skip is capped at `ID3_MAX_SCAN_BYTES` (128 KB), large enough to cover typical tags with embedded cover art while keeping cost constant in attachment size.

## Happy path

- Non-ID3 attachments (PNG, JPEG, WEBP, PDF, WAV, and so on) decode only ~18 bytes exactly as before, so common detection is unchanged.
- MP3s with an ID3v2 tag up to 128 KB, including typical embedded cover art, still auto-detect as `audio/mpeg`.
- `data:` URLs, base64url, `ArrayBuffer`, `Buffer`, and `text` inputs are normalized upstream and behave the same.

## Unhappy path

- An `ID3`/`SUQz`-prefixed attachment (benign or crafted) now decodes at most ~128 KB regardless of attachment size, so sniffing stays constant-time instead of scaling with the input.
- An ID3v2 tag larger than 128 KB is no longer scanned past, so such an MP3 is not auto-detected and falls back to the caller-supplied media type (`resolveFullMediaType` throws its existing "must specify subtype" error if none was provided). Raise `ID3_MAX_SCAN_BYTES` if larger tags must be detected; cost stays O(1) either way.
- A crafted oversized `id3Size` cannot read out of bounds: `subarray` clamps to length and returns empty, so no signature matches and detection returns `undefined`.

## Testing

- Added a regression test that an ID3 tag larger than the scan bound is not detected (locks in the O(1) behavior).
- Full `detect-media-type` suite passes (67 tests).

Fixes #17709

## Related Issues

Backport of #17386