### PR TITLE
[v6.0] reproduction: could not reproduce On v5 I get a warning when using

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-10372.ts
+++ b/examples/ai-functions/src/reproduction/issue-10372.ts
@@ -1,0 +1,74 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText, Output, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+
+const reportedWarning =
+  'The "tools" setting is not supported by this model - JSON response format does not support tools. The provided tools are ignored.';
+
+async function main() {
+  let toolCallCount = 0;
+
+  const result = await generateText({
+    model: anthropic('claude-sonnet-4-5-20250929'),
+    experimental_output: Output.object({
+      schema: z.object({
+        weather: z.string().describe('The weather for the given city'),
+      }),
+    }),
+    system:
+      'You are a weather assistant. You are given a city and you need to return the weather for that city. Always call getWeather before answering and use its result verbatim.',
+    prompt: 'What is the weather in Tokyo?',
+    tools: {
+      getWeather: tool({
+        description: 'Get the weather for a given city',
+        inputSchema: z.object({
+          city: z.string().describe('The city to get the weather for'),
+        }),
+        execute: async ({ city }) => {
+          toolCallCount++;
+          return `The weather in ${city} is sunny`;
+        },
+      }),
+    },
+    stopWhen: stepCountIs(3),
+  });
+
+  const warnings = result.steps.flatMap(step => step.warnings ?? []);
+  const warningText = JSON.stringify(warnings);
+
+  if (warningText.includes(reportedWarning)) {
+    throw new Error(`ISSUE_REPRODUCED: ${reportedWarning}`);
+  }
+
+  if (toolCallCount !== 1) {
+    throw new Error(
+      `ISSUE_REPRODUCED: expected getWeather to execute once, executed ${toolCallCount} times`,
+    );
+  }
+
+  const expectedWeather = 'The weather in Tokyo is sunny';
+  if (result.output.weather !== expectedWeather) {
+    throw new Error(
+      `ISSUE_REPRODUCED: expected structured output weather ${JSON.stringify(expectedWeather)}, received ${JSON.stringify(result.output.weather)}`,
+    );
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        model: 'claude-sonnet-4-5-20250929',
+        toolCallCount,
+        output: result.output,
+        warnings,
+        requestBodies: result.steps.map(step => step.request.body),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

On v5 I get a warning when using tools and experimental_output with sonnet models

## Reproduction

- The reported user impact is that combining structured output with tools emits an unsupported-tools warning and prevents tool-derived data from reaching the structured result.
- `packages/ai/package.json` and `packages/anthropic/package.json` identify the target versions as `ai@6.0.233` and `@ai-sdk/anthropic@3.0.99`; `packages/ai/src/generate-text/generate-text.ts` still supports `experimental_output` as a deprecated alias.
- The live reproduction at `examples/ai-functions/src/reproduction/issue-10372.ts` used the exact `claude-sonnet-4-5-20250929` model; `getWeather` executed once, the output was `{"weather":"The weather in Tokyo is sunny"}`, and provider warnings were empty.
- The captured Anthropic requests contained both the `getWeather` tool and `output_config.format`, showing that the configured tool was not ignored.
- A narrowing run matching the reporter's configuration without `stopWhen` also executed `getWeather` once and emitted no warnings; adding the documented `stepCountIs(3)` condition allowed the tool result to reach the final structured output.
- The expected warning and ignored-tool behavior did not occur on `release-v6.0`.

## Relevant Documentation

- https://platform.claude.com/docs/en/build-with-claude/structured-outputs
- https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions
- https://platform.claude.com/docs/en/about-claude/model-deprecations
- https://ai-sdk.dev/docs/troubleshooting/tool-calling-with-structured-outputs
- https://ai-sdk.dev/docs/ai-sdk-core/generating-structured-data

## Related Issues

Could not reproduce #10372