### PR TITLE
[v5.0] reproduction: could not reproduce Thought Signatures for Images are missing in Streaming

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/google": "workspace:*",
+    "ai": "workspace:*",
+    "dotenv": "16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-10660-google-stream-image-thought-signatures.ts
+++ b/examples/ai-functions/src/reproduction/issue-10660-google-stream-image-thought-signatures.ts
@@ -1,0 +1,245 @@
+import { strict as assert } from 'node:assert';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { type ModelMessage, streamText } from 'ai';
+import 'dotenv/config';
+
+type FetchObservation = {
+  requestBody: string | undefined;
+  responseBody: Promise<string>;
+  status: number;
+};
+
+function sanitizeFixture(raw: string): string {
+  return raw
+    .split('\n')
+    .map(line => {
+      if (!line.startsWith('data: ')) {
+        return line;
+      }
+
+      const value = JSON.parse(line.slice('data: '.length));
+
+      for (const candidate of value.candidates ?? []) {
+        for (const part of candidate.content?.parts ?? []) {
+          if (part.inlineData?.data != null) {
+            part.inlineData.data = 'AA==';
+          }
+          if (part.thoughtSignature != null) {
+            part.thoughtSignature = 'live-image-thought-signature';
+          }
+        }
+      }
+
+      if (value.responseId != null) {
+        value.responseId = 'live-response-id';
+      }
+
+      return `data: ${JSON.stringify(value)}`;
+    })
+    .join('\n');
+}
+
+function hasSignedImage(raw: string): boolean {
+  return raw.split('\n').some(line => {
+    if (!line.startsWith('data: ')) {
+      return false;
+    }
+
+    const value = JSON.parse(line.slice('data: '.length));
+    return (value.candidates ?? []).some((candidate: any) =>
+      (candidate.content?.parts ?? []).some(
+        (part: any) =>
+          part.inlineData != null &&
+          typeof part.thoughtSignature === 'string' &&
+          part.thoughtSignature.length > 0,
+      ),
+    );
+  });
+}
+
+function historyHasSignedImage(messages: ModelMessage[]): boolean {
+  return messages.some(
+    message =>
+      message.role === 'assistant' &&
+      Array.isArray(message.content) &&
+      message.content.some(
+        part =>
+          part.type === 'file' &&
+          typeof part.providerOptions?.google?.thoughtSignature === 'string',
+      ),
+  );
+}
+
+function errorDescription(error: unknown): string | undefined {
+  if (error == null) {
+    return undefined;
+  }
+  return error instanceof Error
+    ? `${error.name}: ${error.message}`
+    : JSON.stringify(error);
+}
+
+async function runRefinement({
+  messages,
+  model,
+}: {
+  messages: ModelMessage[];
+  model: ReturnType<ReturnType<typeof createGoogleGenerativeAI>>;
+}) {
+  const result = streamText({
+    model,
+    messages,
+    providerOptions: {
+      google: { responseModalities: ['TEXT', 'IMAGE'] },
+    },
+  });
+
+  let error: unknown;
+  let imageCount = 0;
+
+  try {
+    for await (const part of result.fullStream) {
+      if (part.type === 'file') {
+        imageCount++;
+      } else if (part.type === 'error') {
+        error = part.error;
+      }
+    }
+  } catch (caughtError) {
+    error = caughtError;
+  }
+
+  return { error, imageCount };
+}
+
+async function main() {
+  const observations: FetchObservation[] = [];
+  const recordingFetch: typeof fetch = async (input, init) => {
+    const response = await fetch(input, init);
+    observations.push({
+      requestBody:
+        typeof init?.body === 'string' ? init.body : init?.body?.toString(),
+      responseBody: response.clone().text(),
+      status: response.status,
+    });
+    return response;
+  };
+
+  const google = createGoogleGenerativeAI({ fetch: recordingFetch });
+  const model = google('gemini-3-pro-image-preview');
+  const firstUserMessage: ModelMessage = {
+    role: 'user',
+    content: 'Create an image of the moon.',
+  };
+
+  const firstResult = streamText({
+    model,
+    messages: [firstUserMessage],
+    providerOptions: {
+      google: { responseModalities: ['TEXT', 'IMAGE'] },
+    },
+  });
+  const firstResponse = await firstResult.response;
+  const firstRawResponse = await observations[0].responseBody;
+
+  const fixturePath = resolve(
+    process.cwd(),
+    '../../packages/google/src/__fixtures__/issue-10660-image-thought-signature.chunks.txt',
+  );
+  await mkdir(resolve(fixturePath, '..'), { recursive: true });
+  await writeFile(fixturePath, sanitizeFixture(firstRawResponse));
+
+  const firstImageCount = firstResponse.messages
+    .filter(message => message.role === 'assistant')
+    .flatMap(message => (Array.isArray(message.content) ? message.content : []))
+    .filter(part => part.type === 'file').length;
+  const providerReturnedSignedImage = hasSignedImage(firstRawResponse);
+  const sdkHistoryHasSignedImage = historyHasSignedImage(
+    firstResponse.messages,
+  );
+
+  assert.ok(
+    firstImageCount > 0,
+    'The first streaming request returned no image.',
+  );
+  assert.ok(
+    providerReturnedSignedImage,
+    'The live provider response did not sign the image part.',
+  );
+
+  const messages: ModelMessage[] = [
+    firstUserMessage,
+    ...firstResponse.messages,
+    { role: 'user', content: 'Nice, but now make it cheese.' },
+  ];
+  const directRefinement = await runRefinement({ messages, model });
+
+  // release-v5 only accepts PNG assistant images, while the live model returns
+  // JPEG. Relabel the same generated bytes so the narrowing request reaches
+  // Google and isolates the missing thought signature reported by the issue.
+  const narrowedMessages = structuredClone(messages);
+  for (const message of narrowedMessages) {
+    if (message.role !== 'assistant' || !Array.isArray(message.content)) {
+      continue;
+    }
+    for (const part of message.content) {
+      if (part.type === 'file') {
+        part.mediaType = 'image/png';
+      }
+    }
+  }
+  const narrowedRefinement = await runRefinement({
+    messages: narrowedMessages,
+    model,
+  });
+
+  const secondRequest = observations.at(-1);
+  const secondRequestHasThoughtSignature =
+    secondRequest?.requestBody?.includes('thoughtSignature') ?? false;
+
+  console.log(
+    JSON.stringify(
+      {
+        firstImageCount,
+        providerReturnedSignedImage,
+        sdkHistoryHasSignedImage,
+        directRefinement: {
+          imageCount: directRefinement.imageCount,
+          error: errorDescription(directRefinement.error),
+        },
+        narrowedRefinement: {
+          imageCount: narrowedRefinement.imageCount,
+          error: errorDescription(narrowedRefinement.error),
+        },
+        secondRequestHasThoughtSignature,
+        responseStatuses: observations.map(observation => observation.status),
+        fixturePath,
+      },
+      null,
+      2,
+    ),
+  );
+
+  assert.equal(sdkHistoryHasSignedImage, false);
+  assert.equal(secondRequestHasThoughtSignature, false);
+  assert.match(
+    errorDescription(directRefinement.error) ?? '',
+    /Only PNG images are supported in assistant messages/,
+  );
+  assert.equal(
+    narrowedRefinement.error,
+    undefined,
+    'The narrowed follow-up streaming image refinement failed.',
+  );
+  assert.ok(
+    narrowedRefinement.imageCount > 0,
+    'The narrowed follow-up streaming image refinement returned no image.',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2022",
+    "lib": ["es2022", "dom"],
+    "module": "esnext",
+    "types": ["node"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/google/src/__fixtures__/issue-10660-image-thought-signature.chunks.txt
+++ b/packages/google/src/__fixtures__/issue-10660-image-thought-signature.chunks.txt
@@ -1,0 +1,4 @@
+data: {"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/jpeg","data":"AA=="},"thoughtSignature":"live-image-thought-signature"}],"role":"model"},"index":0}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":1219,"totalTokenCount":1471,"promptTokensDetails":[{"modality":"TEXT","tokenCount":8}],"candidatesTokensDetails":[{"modality":"IMAGE","tokenCount":1120}],"thoughtsTokenCount":244,"serviceTier":"standard"},"modelVersion":"gemini-3-pro-image-preview","responseId":"live-response-id"}
+
+data: {"candidates":[{"content":{"parts":[{"text":""}],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":1219,"totalTokenCount":1394,"promptTokensDetails":[{"modality":"TEXT","tokenCount":8}],"candidatesTokensDetails":[{"modality":"IMAGE","tokenCount":1120}],"thoughtsTokenCount":167,"serviceTier":"standard"},"modelVersion":"gemini-3-pro-image-preview","responseId":"live-response-id"}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,28 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/google':
+        specifier: workspace:*
+        version: link:../../packages/google
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      dotenv:
+        specifier: 16.4.5
+        version: 16.4.5
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -19609,7 +19631,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -19623,13 +19645,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
-      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
+      css-loader: 7.1.2(webpack@5.105.0)
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19637,22 +19659,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
-      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
+      license-webpack-plugin: 4.0.2(webpack@5.105.0)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
+      source-map-loader: 5.0.0(webpack@5.105.0)
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -19662,7 +19684,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -19692,7 +19714,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -24942,7 +24964,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -29418,7 +29440,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30185,7 +30207,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -30282,7 +30304,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
+  css-loader@7.1.2(webpack@5.105.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -33762,7 +33784,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -33790,7 +33812,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
+  license-webpack-plugin@4.0.2(webpack@5.105.0):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -34869,7 +34891,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36400,7 +36422,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -37357,7 +37379,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -37794,7 +37816,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
+  source-map-loader@5.0.0(webpack@5.105.0):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -39984,7 +40006,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)


### PR DESCRIPTION
## Bug

Thought Signatures for Images are missing in Streaming

## Reproduction

- Target `release-v5.0` uses `ai@5.0.218` and `@ai-sdk/google@2.0.84`.
- The live `gemini-3-pro-image-preview` stream returned one JPEG image with a thought signature, but `streamText` omitted that signature from response history and the follow-up request.
- Replaying the unmodified history failed locally because this release only accepts PNG assistant images, which is unrelated to the reported missing-signature provider failure.
- After relabeling the same image bytes as PNG to reach Google, the unsigned follow-up request returned HTTP 200 and one refined image; the expected failure caused by the omitted signature did not occur.
- Runnable investigation files are under `examples/ai-functions/`, including `examples/ai-functions/src/reproduction/issue-10660-google-stream-image-thought-signatures.ts`; the sanitized live response is `packages/google/src/__fixtures__/issue-10660-image-thought-signature.chunks.txt`.

## Relevant Documentation

- https://ai.google.dev/gemini-api/docs/thought-signatures
- https://ai.google.dev/gemini-api/docs/image-generation
- https://ai.google.dev/gemini-api/docs/gemini-3

## Related Issues

Could not reproduce #10660