### PR TITLE
[v5.0] reproduction: On v5 I get a warning when using

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "issueId": 10372,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-10372.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/src/reproduction/issue-10372.ts",
+    "packages/anthropic/src/anthropic-messages-language-model.test.ts",
+    "packages/anthropic/src/__fixtures__/anthropic-issue-10372-tool-call.json",
+    "packages/anthropic/src/__fixtures__/anthropic-issue-10372-output.json",
+    "pnpm-lock.yaml"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_10372_REPRODUCED: getWeather was ignored when tools and experimental_output were combined."
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/anthropic": "workspace:*",
+    "ai": "workspace:*",
+    "tsx": "4.19.2",
+    "zod": "3.25.76"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-10372.ts
+++ b/examples/ai-functions/src/reproduction/issue-10372.ts
@@ -1,0 +1,231 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText, Output, stepCountIs, tool, type CallWarning } from 'ai';
+import { z } from 'zod';
+
+const modelId = 'claude-sonnet-4-5-20250929';
+const toolResult = 'TOOL_RESULT: Tokyo is sunny, 23 C';
+
+async function runAiSdk(mode: 'reported' | 'output-format') {
+  const warnings: CallWarning[] = [];
+  let executions = 0;
+
+  globalThis.AI_SDK_LOG_WARNINGS = value => {
+    warnings.push(...(value as CallWarning[]));
+  };
+
+  const result = await generateText({
+    model: anthropic(modelId),
+    tools: {
+      getWeather: tool({
+        description: 'Get the current weather for a location.',
+        inputSchema: z.object({ location: z.string() }),
+        execute: async ({ location }) => {
+          executions++;
+          return `${toolResult} in ${location}`;
+        },
+      }),
+    },
+    experimental_output: Output.object({
+      schema: z.object({ weather: z.string() }),
+    }),
+    prompt:
+      'Call getWeather for Tokyo. Then set weather to the exact string returned by the tool.',
+    stopWhen: stepCountIs(3),
+    prepareStep: ({ stepNumber }) => ({
+      toolChoice: stepNumber === 0 ? 'required' : 'none',
+    }),
+    providerOptions:
+      mode === 'output-format'
+        ? {
+            anthropic: {
+              structuredOutputMode: 'outputFormat',
+            },
+          }
+        : undefined,
+  });
+
+  const warningDetails = warnings
+    .filter(warning => warning.type === 'unsupported-setting')
+    .map(warning => `${warning.setting}: ${warning.details ?? ''}`);
+
+  console.log(
+    JSON.stringify(
+      {
+        mode,
+        executions,
+        output: result.experimental_output,
+        warningDetails,
+      },
+      null,
+      2,
+    ),
+  );
+
+  return { executions, output: result.experimental_output, warningDetails };
+}
+
+async function runDirectProvider() {
+  const headers = {
+    'anthropic-beta': 'structured-outputs-2025-11-13',
+    'anthropic-version': '2023-06-01',
+    'content-type': 'application/json',
+    'x-api-key': process.env.ANTHROPIC_API_KEY!,
+  };
+  const tools = [
+    {
+      name: 'getWeather',
+      description: 'Get the current weather for a location.',
+      input_schema: {
+        type: 'object',
+        properties: { location: { type: 'string' } },
+        required: ['location'],
+        additionalProperties: false,
+      },
+    },
+  ];
+  const outputConfig = {
+    format: {
+      type: 'json_schema',
+      schema: {
+        type: 'object',
+        properties: { weather: { type: 'string' } },
+        required: ['weather'],
+        additionalProperties: false,
+      },
+    },
+  };
+
+  const firstResponse = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      model: modelId,
+      max_tokens: 512,
+      messages: [
+        {
+          role: 'user',
+          content:
+            'Call getWeather for Tokyo. Then set weather to the exact string returned by the tool.',
+        },
+      ],
+      tools,
+      tool_choice: { type: 'tool', name: 'getWeather' },
+      output_config: outputConfig,
+    }),
+  });
+  const firstBody = (await firstResponse.json()) as {
+    content?: Array<{
+      type: string;
+      id?: string;
+      name?: string;
+      input?: { location?: string };
+    }>;
+    error?: { message?: string };
+  };
+
+  if (!firstResponse.ok) {
+    throw new Error(
+      `Direct provider request failed (${firstResponse.status}): ${firstBody.error?.message ?? 'unknown error'}`,
+    );
+  }
+
+  const call = firstBody.content?.find(
+    part => part.type === 'tool_use' && part.name === 'getWeather',
+  );
+  if (call?.id == null) {
+    throw new Error('Direct provider did not call getWeather.');
+  }
+
+  const secondResponse = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      model: modelId,
+      max_tokens: 512,
+      messages: [
+        {
+          role: 'user',
+          content:
+            'Call getWeather for Tokyo. Then set weather to the exact string returned by the tool.',
+        },
+        { role: 'assistant', content: firstBody.content },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: call.id,
+              content: `${toolResult} in ${call.input?.location ?? 'Tokyo'}`,
+            },
+          ],
+        },
+      ],
+      tools,
+      tool_choice: { type: 'none' },
+      output_config: outputConfig,
+    }),
+  });
+  const secondBody = (await secondResponse.json()) as {
+    content?: Array<{ type: string; text?: string }>;
+    error?: { message?: string };
+  };
+
+  if (!secondResponse.ok) {
+    throw new Error(
+      `Direct provider request failed (${secondResponse.status}): ${secondBody.error?.message ?? 'unknown error'}`,
+    );
+  }
+
+  const text = secondBody.content?.find(part => part.type === 'text')?.text;
+  console.log(
+    JSON.stringify(
+      {
+        mode: 'direct-provider',
+        calledTool: call.name,
+        output: text == null ? undefined : JSON.parse(text),
+        providerResponses: {
+          first: firstBody,
+          second: secondBody,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function main() {
+  const mode = process.argv[2];
+
+  if (mode === '--direct') {
+    await runDirectProvider();
+    return;
+  }
+
+  if (mode === '--output-format') {
+    await runAiSdk('output-format');
+    return;
+  }
+
+  const result = await runAiSdk('reported');
+  const reportedWarning = result.warningDetails.some(details =>
+    details.includes(
+      'JSON response format does not support tools. The provided tools are ignored.',
+    ),
+  );
+
+  if (result.executions === 0 && reportedWarning) {
+    throw new Error(
+      'ISSUE_10372_REPRODUCED: getWeather was ignored when tools and experimental_output were combined.',
+    );
+  }
+
+  throw new Error(
+    `ISSUE_10372_NOT_REPRODUCED: getWeather executions=${result.executions}, reportedWarning=${reportedWarning}.`,
+  );
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-10372-output.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-10372-output.json
@@ -1,0 +1,27 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_011CdHDFY64EhczPy9Lq3KhJ",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "{\"weather\":\"Tokyo is sunny, 23 C in Tokyo\"}"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 807,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 17,
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/packages/anthropic/src/__fixtures__/anthropic-issue-10372-tool-call.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-issue-10372-tool-call.json
@@ -1,0 +1,34 @@
+{
+  "model": "claude-sonnet-4-5-20250929",
+  "id": "msg_011CdHDFLmv4uX3LTkFoPoJA",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "tool_use",
+      "id": "toolu_01MhUGx2K4rTe9D6nZxtGURs",
+      "name": "getWeather",
+      "input": {
+        "location": "Tokyo"
+      },
+      "caller": {
+        "type": "direct"
+      }
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 822,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 33,
+    "service_tier": "standard",
+    "inference_geo": "not_available"
+  }
+}

--- a/packages/anthropic/src/anthropic-messages-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-messages-language-model.test.ts
@@ -561,6 +561,51 @@ describe('AnthropicMessagesLanguageModel', () => {
       });
     });
 
+    it('issue #10372: should preserve a Sonnet 4.5 tool call when a JSON response format is configured', async () => {
+      prepareJsonFixtureResponse('anthropic-issue-10372-tool-call');
+
+      const result = await provider('claude-sonnet-4-5-20250929').doGenerate({
+        prompt: TEST_PROMPT,
+        tools: [
+          {
+            type: 'function',
+            name: 'getWeather',
+            description: 'Get the current weather for a location.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                location: { type: 'string' },
+              },
+              required: ['location'],
+              additionalProperties: false,
+            },
+          },
+        ],
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {
+              weather: { type: 'string' },
+            },
+            required: ['weather'],
+            additionalProperties: false,
+          },
+        },
+      });
+
+      expect.soft(result.content).toEqual([
+        {
+          type: 'tool-call',
+          toolCallId: 'toolu_01MhUGx2K4rTe9D6nZxtGURs',
+          toolName: 'getWeather',
+          input: '{"location":"Tokyo"}',
+        },
+      ]);
+      expect.soft(result.finishReason).toBe('tool-calls');
+      expect(result.warnings).toEqual([]);
+    });
+
     describe('json schema response format with output format (supported model)', () => {
       let result: Awaited<ReturnType<typeof model.doGenerate>>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,21 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: workspace:*
+        version: link:../../packages/anthropic
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -19609,7 +19624,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -19623,13 +19638,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
-      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
+      css-loader: 7.1.2(webpack@5.105.0)
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19637,22 +19652,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
-      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
+      license-webpack-plugin: 4.0.2(webpack@5.105.0)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
+      source-map-loader: 5.0.0(webpack@5.105.0)
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -19662,7 +19677,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -19692,7 +19707,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -24942,7 +24957,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -29418,7 +29433,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30185,7 +30200,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -30282,7 +30297,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
+  css-loader@7.1.2(webpack@5.105.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -33762,7 +33777,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -33790,7 +33805,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
+  license-webpack-plugin@4.0.2(webpack@5.105.0):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -34869,7 +34884,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36400,7 +36415,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -37357,7 +37372,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -37794,7 +37809,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
+  source-map-loader@5.0.0(webpack@5.105.0):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -39984,7 +39999,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.25.9)):
+  webpack-subresource-integrity@5.1.0(webpack@5.105.0):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.105.0(esbuild@0.25.9)


### PR DESCRIPTION
## Bug

On v5 I get a warning when using tools and experimental_output with sonnet models

## Reproduction

- Target `release-v5.0` contains `ai@5.0.218` and `@ai-sdk/anthropic@2.0.88`, so the defect persists beyond the originally reported v5 package versions.
- The live reproduction at `examples/ai-functions/src/reproduction/issue-10372.ts` expected `getWeather` to execute and supply the structured result; instead it executed zero times and emitted the reported warning that tools were ignored.
- A direct Anthropic request using `claude-sonnet-4-5-20250929`, tools, and structured output called `getWeather` and returned schema-valid tool-derived output, locating the defect inside the AI SDK Anthropic provider.
- `packages/anthropic/src/anthropic-messages-language-model.ts` replaces configured tools with only its JSON response tool in the default `jsonTool` mode and emits the unsupported-tools warning.
- Setting `structuredOutputMode: 'outputFormat'` allowed the tool to execute, but the incorrect warning was still emitted, so configuration only partially mitigates the report.
- Live responses were recorded in `packages/anthropic/src/__fixtures__/anthropic-issue-10372-tool-call.json` and `packages/anthropic/src/__fixtures__/anthropic-issue-10372-output.json`; the added test in `packages/anthropic/src/anthropic-messages-language-model.test.ts` demonstrates that the provider converts the tool call into text, reports `stop`, and returns the warning instead of preserving the call.

## Relevant Documentation

- https://platform.claude.com/docs/en/build-with-claude/structured-outputs
- https://ai-sdk.dev/docs/troubleshooting/tool-calling-with-structured-outputs

## Related Issues

Reproduces #10372