### PR TITLE
[v5.0] reproduction: could not reproduce useChat .stop does not cancel streaming responses

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@ai-sdk/react": "workspace:*",
+    "ai": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-10719-use-chat-stop.ts
+++ b/examples/ai-functions/src/reproduction/issue-10719-use-chat-stop.ts
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { setTimeout as delay } from 'node:timers/promises';
+import { DefaultChatTransport, type UIMessage, type UIMessageChunk } from 'ai';
+
+type ChatInstance = {
+  messages: unknown[];
+  sendMessage: (message: { text: string }) => Promise<void>;
+  status: 'submitted' | 'streaming' | 'ready' | 'error';
+  stop: () => Promise<void>;
+};
+
+type ChatConstructor = new (options: {
+  id: string;
+  transport: DefaultChatTransport<UIMessage>;
+  onFinish: (options: { isAbort: boolean }) => void;
+}) => ChatInstance;
+
+function formatChunk(chunk: UIMessageChunk) {
+  return `data: ${JSON.stringify(chunk)}\n\n`;
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  description: string,
+  timeoutMs = 1_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${description}`);
+    }
+
+    await delay(10);
+  }
+}
+
+async function main() {
+  let generatedChunks = 0;
+  let responseClosed = false;
+  let responseFinished = false;
+
+  const server = createServer((request, response) => {
+    request.resume();
+    response.writeHead(200, {
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+      'content-type': 'text/event-stream',
+      'x-vercel-ai-ui-message-stream': 'v1',
+    });
+    response.flushHeaders();
+    response.write(formatChunk({ type: 'text-start', id: 'text-1' }));
+
+    const interval = setInterval(() => {
+      generatedChunks += 1;
+      response.write(
+        formatChunk({
+          type: 'text-delta',
+          id: 'text-1',
+          delta: `token-${generatedChunks} `,
+        }),
+      );
+
+      if (generatedChunks === 200) {
+        clearInterval(interval);
+        response.end(formatChunk({ type: 'text-end', id: 'text-1' }));
+      }
+    }, 25);
+
+    response.on('finish', () => {
+      responseFinished = true;
+    });
+    response.on('close', () => {
+      responseClosed = true;
+      clearInterval(interval);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  try {
+    const address = server.address();
+    assert.ok(address != null && typeof address === 'object');
+
+    const reactPackageUrl = new URL(
+      '../../../../packages/react/dist/index.mjs',
+      import.meta.url,
+    ).href;
+    const { Chat } = (await import(reactPackageUrl)) as {
+      Chat: ChatConstructor;
+    };
+
+    let finishWasAbort: boolean | undefined;
+    const chat = new Chat({
+      id: 'issue-10719',
+      transport: new DefaultChatTransport({
+        api: `http://127.0.0.1:${address.port}/api/chat`,
+      }),
+      onFinish: ({ isAbort }) => {
+        finishWasAbort = isAbort;
+      },
+    });
+
+    const sendPromise = chat.sendMessage({ text: 'Write a long story' });
+
+    await waitFor(
+      () => chat.status === 'streaming' && generatedChunks >= 2,
+      'the chat to start streaming',
+    );
+
+    const messagesAtStop = JSON.stringify(chat.messages);
+    const stopStartedAt = performance.now();
+    await chat.stop();
+    const stopReturnedInMs = performance.now() - stopStartedAt;
+
+    await Promise.race([
+      sendPromise,
+      delay(1_000).then(() => {
+        throw new Error('The chat request remained open after stop()');
+      }),
+    ]);
+    await waitFor(
+      () => responseClosed,
+      'the server response to receive the client disconnect',
+    );
+
+    const chunksAtAbort = generatedChunks;
+    await delay(150);
+
+    assert.equal(chat.status, 'ready', 'status should return to ready');
+    assert.equal(
+      finishWasAbort,
+      true,
+      'onFinish should identify the stopped response as aborted',
+    );
+    assert.equal(
+      responseFinished,
+      false,
+      'the server response should close before normal completion',
+    );
+    assert.equal(
+      generatedChunks,
+      chunksAtAbort,
+      'server generation should stop after the client disconnects',
+    );
+    assert.equal(
+      JSON.stringify(chat.messages),
+      messagesAtStop,
+      'messages should not receive more tokens after stop()',
+    );
+    assert.ok(
+      stopReturnedInMs < 200,
+      `stop() took ${stopReturnedInMs.toFixed(1)}ms to return`,
+    );
+
+    console.log(
+      JSON.stringify({
+        finishWasAbort,
+        generatedChunks,
+        messageUpdatesStopped: true,
+        responseClosed,
+        responseFinished,
+        status: chat.status,
+        stopReturnedInMs: Number(stopReturnedInMs.toFixed(1)),
+      }),
+    );
+  } finally {
+    const closeError = await new Promise<Error | undefined>(resolve => {
+      server.close(resolve);
+    });
+    if (closeError != null) throw closeError;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,25 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -27375,7 +27394,7 @@ snapshots:
     dependencies:
       '@sentry/bundler-plugin-core': 5.1.1(encoding@0.1.13)
       uuid: 9.0.1
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -36804,7 +36823,7 @@ snapshots:
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
 
   react@18.3.1:
     dependencies:


### PR DESCRIPTION
## Bug

useChat `.stop()` does not cancel streaming responses

## Reproduction

- The reported impact would leave the UI unusably `streaming` while consuming server resources after the user requests cancellation.
- The runnable artifact `examples/ai-functions/src/reproduction/issue-10719-use-chat-stop.ts`, supported by `examples/ai-functions/package.json` and `pnpm-lock.yaml`, exercised an actual streaming HTTP response through `DefaultChatTransport` and the React `Chat` implementation used by `useChat`.
- On `ai@5.0.218`, `@ai-sdk/react@2.0.220`, and Node.js 22.23.1, `stop()` returned in 12.4 ms, status became `ready`, `isAbort` was `true`, and the HTTP response closed before normal completion.
- Server generation and message updates stopped after cancellation; the reported open request, persistent `streaming` status, and continued tokens did not occur.
- `packages/react/src/use-chat.ts` delegates `stop` to the chat instance, `packages/ai/src/ui/chat.ts` aborts its active controller, and `packages/ai/src/ui/http-chat-transport.ts` forwards that signal to `fetch`.
- The reported route omits `abortSignal: request.signal`; official documentation requires forwarding that signal to `streamText` for provider-side generation cancellation.
- The reported AI SDK 6 beta packages, Node.js 20.16.0, and `Remix/Hono` setup were not executed because this evaluation targets the checked-out `release-v5.0` branch.

## Relevant Documentation

- https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat
- https://ai-sdk.dev/docs/advanced/stopping-streams
- https://ai-sdk.dev/docs/ai-sdk-ui/transport

## Related Issues

Could not reproduce #10719