### PR TITLE
reproduction: could not reproduce URLContext Gemini flash 2.5 Empty Response

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-10321-google-url-context-empty-response.ts
+++ b/examples/ai-functions/src/reproduction/issue-10321-google-url-context-empty-response.ts
@@ -1,0 +1,106 @@
+import { createGoogle } from '@ai-sdk/google';
+import { generateText } from 'ai';
+
+const modelId = 'gemini-2.5-flash';
+const prompt = `Based on the document: https://ai.google.dev/gemini-api/docs/url-context#limitations.
+Answer this question: How many URLs can the URL context tool process in one request?`;
+const requestBody = {
+  contents: [{ role: 'user', parts: [{ text: prompt }] }],
+  tools: [{ urlContext: {} }],
+};
+
+type GeminiResponse = {
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{ text?: string }>;
+    };
+    finishReason?: string;
+  }>;
+};
+
+function responseText(response: GeminiResponse): string {
+  return (
+    response.candidates?.[0]?.content?.parts
+      ?.map(part => part.text ?? '')
+      .join('') ?? ''
+  );
+}
+
+async function readGeminiResponse(response: Response): Promise<GeminiResponse> {
+  const body = await response.text();
+
+  if (!response.ok) {
+    throw new Error(
+      `Gemini request failed with HTTP ${response.status}: ${body}`,
+    );
+  }
+
+  return JSON.parse(body) as GeminiResponse;
+}
+
+async function main() {
+  const directResponse = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${modelId}:generateContent`,
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-goog-api-key':
+          process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? 'missing-api-key',
+      },
+      body: JSON.stringify(requestBody),
+    },
+  );
+  const directBody = await readGeminiResponse(directResponse);
+  const directText = responseText(directBody);
+
+  console.log(
+    `direct: textLength=${directText.length} finishReason=${directBody.candidates?.[0]?.finishReason ?? 'missing'}`,
+  );
+
+  if (directText.trim().length === 0) {
+    throw new Error('ISSUE_10321_PROVIDER_EMPTY_RESPONSE');
+  }
+
+  let rawSdkResponse: GeminiResponse | undefined;
+  const google = createGoogle({
+    fetch: async (input, init) => {
+      const response = await fetch(input, init);
+      rawSdkResponse = await readGeminiResponse(response.clone());
+      return response;
+    },
+  });
+
+  const attempts = 10;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    rawSdkResponse = undefined;
+
+    const result = await generateText({
+      model: google(modelId),
+      prompt,
+      tools: {
+        url_context: google.tools.urlContext({}),
+      },
+    });
+
+    const rawText = responseText(rawSdkResponse ?? {});
+    console.log(
+      `sdk ${attempt}/${attempts}: textLength=${result.text.length} rawTextLength=${rawText.length} finishReason=${result.finishReason}`,
+    );
+
+    if (result.text.trim().length === 0) {
+      throw new Error(
+        rawText.trim().length === 0
+          ? 'ISSUE_10321_PROVIDER_EMPTY_RESPONSE'
+          : 'ISSUE_10321_AI_SDK_EMPTY_RESPONSE',
+      );
+    }
+  }
+
+  console.log('ISSUE_10321_NOT_REPRODUCED');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

URL_Context Gemini flash 2.5 Empty Response

## Reproduction

- The reported user impact is a silent empty answer where a URL-grounded response is expected, preventing the application from presenting any result.
- Google officially documents Gemini 2.5 Flash as supporting URL Context, so the reported `model/tool` combination is valid. citeturn1view0turn1view2
- `examples/ai-functions/src/reproduction/issue-10321-google-url-context-empty-response.ts` compares a direct Gemini request with AI SDK output and fails if either response is empty or if AI SDK drops provider text.
- Two completed executions produced non-empty direct responses and non-empty, correctly mapped responses in all 20 AI SDK attempts; the reported empty response was not observed.
- The working target-branch versions are `ai@7.0.34`, `@ai-sdk/google@4.0.21`, and `@ai-sdk/provider-utils@5.0.12`; upgrading the reported packages together is the applicable configuration comparison.
- The reported `ai@5.0.93`, `@ai-sdk/google@2.0.33`, and `@ai-sdk/provider-utils@3.0.17` versions formed a compatible release set, so no partial-upgrade mismatch was identified.
- The issue does not provide the failing URL, prompt, call mode, or frequency, so the repository's documented Gemini 2.5 Flash URL Context scenario was used as the substitute case.

## Relevant Documentation

- https://ai.google.dev/gemini-api/docs/url-context
- https://ai.google.dev/api/generate-content
- https://ai.google.dev/gemini-api/docs/changelog
- https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai

## Related Issues

Could not reproduce #10321