### PR TITLE
reproduction: Bedrock adapter crashes if model hallucinates tool call

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 10202,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/bedrock-invalid-tool-name.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/bedrock-invalid-tool-name.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_10202_REPRODUCED: Bedrock rejected $READFILE before repairToolCall was invoked"
+  }
+}

--- a/examples/ai-functions/src/reproduction/bedrock-invalid-tool-name.ts
+++ b/examples/ai-functions/src/reproduction/bedrock-invalid-tool-name.ts
@@ -1,0 +1,79 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+async function main() {
+  let repairCalled = false;
+  const amazonBedrock = createAmazonBedrock({ region: 'us-west-2' });
+
+  try {
+    await generateText({
+      model: amazonBedrock('global.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Read /tmp/data.txt' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call_123',
+              toolName: '$READFILE',
+              input: {},
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_123',
+              toolName: '$READFILE',
+              output: { type: 'text', value: 'Tool not found' },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Try something else.' }],
+        },
+      ],
+      tools: {
+        answer: tool({
+          description: 'Provide an answer.',
+          inputSchema: z.object({ text: z.string() }),
+        }),
+      },
+      experimental_repairToolCall: async () => {
+        repairCalled = true;
+        return null;
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (message.includes('[a-zA-Z0-9_-]+') && !repairCalled) {
+      console.error(
+        'ISSUE_10202_REPRODUCED: Bedrock rejected $READFILE before repairToolCall was invoked',
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    throw error;
+  }
+
+  console.log(
+    repairCalled
+      ? 'ISSUE_10202_NOT_REPRODUCED: repairToolCall was invoked'
+      : 'ISSUE_10202_NOT_REPRODUCED: request completed without repairToolCall',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 2;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/bedrock-invalid-tool-name-validation-error.json
+++ b/packages/amazon-bedrock/src/__fixtures__/bedrock-invalid-tool-name-validation-error.json
@@ -1,0 +1,3 @@
+{
+  "message": "1 validation error detected: Value at 'messages.2.member.content.1.member.toolUse.name' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_-]+"
+}

--- a/packages/amazon-bedrock/src/amazon-bedrock-invalid-tool-name.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-invalid-tool-name.test.ts
@@ -1,0 +1,96 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { AmazonBedrockChatLanguageModel } from './amazon-bedrock-chat-language-model';
+
+const invalidToolNameResponse = fs.readFileSync(
+  'src/__fixtures__/bedrock-invalid-tool-name-validation-error.json',
+  'utf8',
+);
+const successResponse = fs.readFileSync(
+  'src/__fixtures__/amazon-bedrock-text.json',
+  'utf8',
+);
+
+describe('invalid tool names in message history', () => {
+  it('does not crash when replaying a hallucinated tool name', async () => {
+    let requestBody: any;
+
+    const model = new AmazonBedrockChatLanguageModel('test-model', {
+      baseUrl: () => 'https://bedrock-runtime.us-west-2.amazonaws.com',
+      generateId: () => 'test-id',
+      fetch: async (_input, init) => {
+        requestBody = JSON.parse(init?.body as string);
+        const toolName = requestBody.messages[1].content[0].toolUse
+          .name as string;
+
+        if (!/^[a-zA-Z0-9_-]+$/.test(toolName)) {
+          return new Response(invalidToolNameResponse, {
+            status: 400,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+
+        return new Response(successResponse, {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+    });
+
+    const prompt: LanguageModelV4Prompt = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Read /tmp/data.txt' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call_123',
+            toolName: '$READFILE',
+            input: {},
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_123',
+            toolName: '$READFILE',
+            output: { type: 'text', value: 'Tool not found' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Try something else.' }],
+      },
+    ];
+
+    await expect(
+      model.doGenerate({
+        prompt,
+        tools: [
+          {
+            type: 'function',
+            name: 'answer',
+            description: 'Provide an answer.',
+            inputSchema: {
+              type: 'object',
+              properties: { text: { type: 'string' } },
+              required: ['text'],
+              additionalProperties: false,
+            },
+          },
+        ],
+      }),
+    ).resolves.toBeDefined();
+    expect(requestBody.messages[1].content[0].toolUse.name).toMatch(
+      /^[a-zA-Z0-9_-]+$/,
+    );
+  });
+});


### PR DESCRIPTION
## Bug

Bedrock adapter crashes if model hallucinates tool call with $ in the name

## Reproduction

- The live reproduction on `main` with `@ai-sdk/amazon-bedrock` 5.0.27 sent `$READFILE` in conversation history to Claude Sonnet 4.5; Bedrock rejected the request with its tool-name validation error before `experimental_repairToolCall` ran, rather than allowing repair with `NoSuchToolError`.
- `packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts` forwards `part.toolName` unchanged into Bedrock's `toolUse.name`, although AWS requires names to match `[a-zA-Z0-9_-]+`; the bug therefore remains in the current adapter rather than being resolved by upgrading from the reported versions.
- Added the runnable live reproduction at `examples/ai-functions/src/reproduction/bedrock-invalid-tool-name.ts`, the recorded live response at `packages/amazon-bedrock/src/__fixtures__/bedrock-invalid-tool-name-validation-error.json`, and a failing provider regression test at `packages/amazon-bedrock/src/amazon-bedrock-invalid-tool-name.test.ts`.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolUseBlock.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolSpecification.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-5.html
- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling

## Related Issues

Reproduces #10202