### PR TITLE
[v6.0] reproduction: could not reproduce URLContext Gemini flash 2.5 Empty Response

### DIFF
--- a/examples/ai-functions/src/reproduction/issue-10321-google-url-context-empty-response.ts
+++ b/examples/ai-functions/src/reproduction/issue-10321-google-url-context-empty-response.ts
@@ -1,0 +1,121 @@
+import {
+  createGoogleGenerativeAI,
+  type GoogleGenerativeAIProviderMetadata,
+} from '@ai-sdk/google';
+import { generateText } from 'ai';
+
+const modelId = 'gemini-2.5-flash';
+const attempts = 20;
+const prompt =
+  'Based on this context: https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai, tell me how to use Gemini with AI SDK.';
+
+type GeminiResponse = {
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{
+        text?: string;
+      }>;
+    };
+  }>;
+};
+
+function extractProviderText(response: GeminiResponse | undefined) {
+  return (
+    response?.candidates?.[0]?.content?.parts
+      ?.map(part => part.text ?? '')
+      .join('') ?? ''
+  );
+}
+
+async function requestGeminiDirectly(apiKey: string) {
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${modelId}:generateContent`,
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-goog-api-key': apiKey,
+      },
+      body: JSON.stringify({
+        contents: [{ role: 'user', parts: [{ text: prompt }] }],
+        tools: [{ urlContext: {} }],
+      }),
+    },
+  );
+
+  const body = (await response.json()) as GeminiResponse;
+
+  if (!response.ok) {
+    throw new Error(
+      `Direct Gemini request failed with HTTP ${response.status}: ${JSON.stringify(body)}`,
+    );
+  }
+
+  const text = extractProviderText(body);
+  if (text.trim().length === 0) {
+    throw new Error(
+      `DIRECT_PROVIDER_EMPTY_RESPONSE: Gemini returned no text: ${JSON.stringify(body)}`,
+    );
+  }
+
+  console.log(`Direct Gemini response: ${text.length} text characters`);
+}
+
+async function main() {
+  const apiKey = process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+  if (apiKey == null) {
+    throw new Error('GOOGLE_GENERATIVE_AI_API_KEY is required');
+  }
+
+  await requestGeminiDirectly(apiKey);
+
+  let latestProviderResponse: GeminiResponse | undefined;
+  const google = createGoogleGenerativeAI({
+    apiKey,
+    fetch: async (input, init) => {
+      const response = await fetch(input, init);
+      latestProviderResponse = (await response
+        .clone()
+        .json()) as GeminiResponse;
+      return response;
+    },
+  });
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    latestProviderResponse = undefined;
+
+    const result = await generateText({
+      model: google(modelId),
+      prompt,
+      tools: {
+        url_context: google.tools.urlContext({}),
+      },
+    });
+
+    const providerText = extractProviderText(latestProviderResponse);
+    const urlContextMetadata = (
+      result.providerMetadata?.google as
+        | GoogleGenerativeAIProviderMetadata
+        | undefined
+    )?.urlContextMetadata;
+
+    if (result.text.trim().length === 0) {
+      throw new Error(
+        `ISSUE_10321_EMPTY_AI_SDK_RESPONSE: attempt ${attempt}; providerTextLength=${providerText.length}; finishReason=${result.finishReason}; urlContextMetadata=${JSON.stringify(urlContextMetadata)}`,
+      );
+    }
+
+    console.log(
+      `AI SDK attempt ${attempt}/${attempts}: ${result.text.length} text characters; provider text preserved=${result.text === providerText}`,
+    );
+  }
+
+  console.log(
+    `ISSUE_10321_NOT_REPRODUCED: direct response and all ${attempts} AI SDK responses contained text.`,
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug

URL_Context Gemini flash 2.5 Empty Response

## Reproduction

- The reported user impact is a silent empty answer where URL-grounded text is expected, leaving the application with no result and no actionable error.
- Google documentation confirms that Gemini 2.5 Flash supports URL Context, so the reported model and tool combination is valid.
- `examples/ai-functions/src/reproduction/issue-10321-google-url-context-empty-response.ts` checks a direct Gemini request and 20 AI SDK requests per execution, failing if the expected URL-grounded text is empty.
- Across two executions, both direct Gemini responses and all 40 AI SDK responses contained text; every AI SDK result exactly preserved the text captured from its raw provider response instead of exhibiting the expected empty-output failure.
- The working target-branch versions are declared in `packages/ai/package.json`, `packages/google/package.json`, and `packages/provider-utils/package.json`: `ai@6.0.233`, `@ai-sdk/google@3.0.98`, and `@ai-sdk/provider-utils@4.0.40`.
- Published metadata shows the reported `ai@5.0.93` and `@ai-sdk/google@2.0.33` packages both depended on `@ai-sdk/provider-utils@3.0.17`, so the report does not indicate a partial-upgrade dependency mismatch.
- The issue does not provide the intermittently failing URL, prompt, call mode, or failure frequency; the repository's documented Gemini 2.5 Flash URL Context scenario was therefore used as the substitute case.

## Relevant Documentation

- https://ai.google.dev/gemini-api/docs/url-context
- https://ai.google.dev/api/generate-content
- https://ai.google.dev/gemini-api/docs/changelog
- https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai

## Related Issues

Could not reproduce #10321