### PR TITLE
[v5.0] reproduction: could not reproduce @ai-sdk/deepseek default export resolves to any under @typescript-eslint

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/deepseek-typescript-eslint-any.ts
+++ b/examples/ai-functions/src/reproduction/deepseek-typescript-eslint-any.ts
@@ -1,0 +1,224 @@
+import { spawn } from 'node:child_process';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+type CommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+const run = async (
+  command: string,
+  args: string[],
+  cwd: string,
+): Promise<CommandResult> =>
+  new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', chunk => {
+      stdout += String(chunk);
+    });
+    child.stderr.on('data', chunk => {
+      stderr += String(chunk);
+    });
+    child.on('error', reject);
+    child.on('close', exitCode => {
+      resolvePromise({ exitCode: exitCode ?? 1, stdout, stderr });
+    });
+  });
+
+const assertSuccess = (label: string, result: CommandResult) => {
+  if (result.exitCode === 0) {
+    return;
+  }
+
+  throw new Error(
+    [
+      `${label} failed with exit code ${result.exitCode}.`,
+      result.stdout,
+      result.stderr,
+    ]
+      .filter(Boolean)
+      .join('\n'),
+  );
+};
+
+const writeProject = async (directory: string) => {
+  await mkdir(join(directory, 'src'), { recursive: true });
+
+  await writeFile(
+    join(directory, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'issue-10218-reproduction',
+        private: true,
+        dependencies: {
+          '@ai-sdk/deepseek': '1.0.28',
+          '@typescript-eslint/eslint-plugin': '8.43.0',
+          '@typescript-eslint/parser': '8.43.0',
+          eslint: '8.57.1',
+          typescript: '5.9.2',
+          zod: '3.25.76',
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  await writeFile(
+    join(directory, 'tsconfig.json'),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          noEmit: true,
+          skipLibCheck: true,
+          strict: true,
+          target: 'ES2022',
+        },
+        include: ['src/**/*.ts'],
+      },
+      null,
+      2,
+    ),
+  );
+
+  await writeFile(
+    join(directory, '.eslintrc.cjs'),
+    `module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: './tsconfig.json',
+    tsconfigRootDir: __dirname,
+  },
+  plugins: ['@typescript-eslint'],
+  rules: {
+    '@typescript-eslint/no-unsafe-call': 'error',
+    '@typescript-eslint/no-unsafe-return': 'error',
+  },
+};
+`,
+  );
+
+  await writeFile(
+    join(directory, 'src/index.ts'),
+    `import { deepseek } from '@ai-sdk/deepseek';
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type AssertFalse<T extends false> = T;
+type DeepSeekProviderIsTyped = AssertFalse<IsAny<typeof deepseek>>;
+type DeepSeekReturnIsTyped = AssertFalse<IsAny<ReturnType<typeof deepseek>>>;
+
+export function model() {
+  return deepseek('deepseek-chat');
+}
+
+void (undefined as unknown as DeepSeekProviderIsTyped);
+void (undefined as unknown as DeepSeekReturnIsTyped);
+`,
+  );
+};
+
+const lintAndTypeCheck = async (directory: string, label: string) => {
+  const eslintResult = await run(
+    join(directory, 'node_modules/.bin/eslint'),
+    ['src/index.ts', '--format', 'unix'],
+    directory,
+  );
+  assertSuccess(`${label} typed ESLint`, eslintResult);
+
+  const typeScriptResult = await run(
+    join(directory, 'node_modules/.bin/tsc'),
+    ['--project', 'tsconfig.json'],
+    directory,
+  );
+  assertSuccess(`${label} TypeScript`, typeScriptResult);
+
+  process.stdout.write(
+    `PASS ${label}: deepseek and its return type are not any; typed ESLint reported no unsafe call or return.\n`,
+  );
+};
+
+async function main() {
+  const repositoryRoot = resolve(import.meta.dirname, '../../../..');
+  const temporaryDirectory = await mkdtemp(
+    join(repositoryRoot, '.issue-10218-'),
+  );
+
+  try {
+    await writeProject(temporaryDirectory);
+
+    const installResult = await run(
+      'npm',
+      [
+        'install',
+        '--ignore-scripts',
+        '--no-audit',
+        '--no-fund',
+        '--package-lock=false',
+      ],
+      temporaryDirectory,
+    );
+    assertSuccess('dependency installation', installResult);
+
+    const publishedManifest = JSON.parse(
+      await readFile(
+        join(temporaryDirectory, 'node_modules/@ai-sdk/deepseek/package.json'),
+        'utf8',
+      ),
+    ) as { version: string };
+
+    await lintAndTypeCheck(
+      temporaryDirectory,
+      `published @ai-sdk/deepseek ${publishedManifest.version}`,
+    );
+
+    const installedDeepSeek = join(
+      temporaryDirectory,
+      'node_modules/@ai-sdk/deepseek',
+    );
+    await rm(installedDeepSeek, { recursive: true });
+    await symlink(
+      join(repositoryRoot, 'packages/deepseek'),
+      installedDeepSeek,
+      'dir',
+    );
+
+    const workspaceManifest = JSON.parse(
+      await readFile(
+        join(repositoryRoot, 'packages/deepseek/package.json'),
+        'utf8',
+      ),
+    ) as { version: string };
+
+    await lintAndTypeCheck(
+      temporaryDirectory,
+      `release-v5.0 workspace @ai-sdk/deepseek ${workspaceManifest.version}`,
+    );
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

`@ai-sdk/deepseek` default export resolves to `any` under `@typescript-eslint`

## Reproduction

- `examples/ai-functions/src/reproduction/deepseek-typescript-eslint-any.ts` recreates typed ESLint with `@ai-sdk/deepseek` 1.0.28, TypeScript 5.9.2, typescript-eslint 8.43.0, ESLint 8.57.1, strict NodeNext settings, and both reported unsafe rules; `examples/ai-functions/package.json` makes the required replay command runnable.
- The published 1.0.28 setup exited 0: `deepseek` and its return type were not `any`, and neither `no-unsafe-call` nor `no-unsafe-return` reported an error; the issue expected those errors and a non-zero exit.
- The release-v5.0 workspace package 1.0.48 also exited 0 under the same test; `packages/deepseek/package.json` exposes `dist/index.d.ts` through both `types` fields, and `packages/deepseek/dist/index.d.ts` declares `deepseek: DeepSeekProvider` returning `LanguageModelV2`.
- The issue omits its exact ESLint version, complete ESLint configuration, and tsconfig; the focused reproduction used the versions from the issue plus ESLint 8.57.1 and a conventional legacy typed-lint configuration.

## Relevant Documentation

- https://typescript-eslint.io/troubleshooting/typed-linting/
- https://typescript-eslint.io/rules/no-unsafe-call/
- https://typescript-eslint.io/rules/no-unsafe-return/
- https://www.typescriptlang.org/docs/handbook/modules/reference

## Related Issues

Could not reproduce #10218