### PR TITLE
fix(ai): allow nullish metadata schemas for branded message ids

### DIFF
--- a/.changeset/wild-rabbits-knock.md
+++ b/.changeset/wild-rabbits-knock.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Allow nullish metadata schemas for UI messages with branded IDs.

--- a/packages/ai/src/ui/chat.test-d.ts
+++ b/packages/ai/src/ui/chat.test-d.ts
@@ -235,3 +235,20 @@ describe('onToolCall', () => {
     });
   });
 });
+
+describe('messageMetadataSchema', () => {
+  it('accepts nullish metadata for messages with branded ids', () => {
+    const metadataSchema = z.object({ source: z.string() }).nullish();
+
+    type BrandedMessageId = string & {
+      readonly __brand: 'message-id';
+    };
+    type BrandedMessage = UIMessage<z.infer<typeof metadataSchema>> & {
+      id: BrandedMessageId;
+    };
+
+    expectTypeOf(metadataSchema).toMatchTypeOf<
+      NonNullable<ChatInit<BrandedMessage>['messageMetadataSchema']>
+    >();
+  });
+});

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -186,7 +186,9 @@ export interface ChatInit<UI_MESSAGE extends UIMessage> {
    */
   id?: string;
 
-  messageMetadataSchema?: FlexibleSchema<InferUIMessageMetadata<UI_MESSAGE>>;
+  messageMetadataSchema?: FlexibleSchema<
+    InferUIMessageMetadata<UI_MESSAGE> | undefined
+  >;
   dataPartSchemas?: UIDataTypesToSchemas<InferUIMessageData<UI_MESSAGE>>;
 
   messages?: UI_MESSAGE[];
@@ -241,7 +243,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
   protected state: ChatState<UI_MESSAGE>;
 
   private messageMetadataSchema:
-    | FlexibleSchema<InferUIMessageMetadata<UI_MESSAGE>>
+    | FlexibleSchema<InferUIMessageMetadata<UI_MESSAGE> | undefined>
     | undefined;
   private dataPartSchemas:
     | UIDataTypesToSchemas<InferUIMessageData<UI_MESSAGE>>

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -86,7 +86,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
 }: {
   // input stream is not fully typed yet:
   stream: ReadableStream<UIMessageChunk>;
-  messageMetadataSchema?: FlexibleSchema<InferUIMessageMetadata<UI_MESSAGE>>;
+  messageMetadataSchema?: FlexibleSchema<
+    InferUIMessageMetadata<UI_MESSAGE> | undefined
+  >;
   dataPartSchemas?: UIDataTypesToSchemas<InferUIMessageData<UI_MESSAGE>>;
   onToolCall?: (options: {
     toolCall: InferUIMessageToolCall<UI_MESSAGE>;


### PR DESCRIPTION
## Background

`messageMetadataSchema` rejects a Zod `.nullish()` schema when a custom `UIMessage` narrows `id` to a branded string. In that intersection, TypeScript's conditional metadata inference drops `undefined`, even though message metadata remains optional at runtime.

## Summary

Allow message metadata schemas to include `undefined` across chat initialization and UI message stream processing. Add a type regression test for branded message IDs and a patch changeset. This is a type-only fix with no runtime behavior change.

## Contributor Credit

Thanks @lensbart for reporting the issue and @lgrammel for confirming it with a reproduction.

## End-to-End Verification

Built `ai` and `@ai-sdk/react`, then compiled the issue's public `useChat` example with a branded message ID and a `.nullish()` Zod metadata schema under strict TypeScript settings. It completed with no diagnostics.

## Validation

- `pnpm -C packages/ai test`
- `pnpm check`
- `pnpm type-check:full`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #14143
