### PR TITLE
[v6.0] reproduction: Bedrock adapter crashes if model hallucinates tool call

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 10202,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/bedrock-invalid-tool-name.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/bedrock-invalid-tool-name.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE_10202_REPRODUCED: Bedrock rejected $READFILE before repairToolCall was invoked"
+  }
+}

--- a/examples/ai-functions/src/reproduction/bedrock-invalid-tool-name.ts
+++ b/examples/ai-functions/src/reproduction/bedrock-invalid-tool-name.ts
@@ -1,0 +1,84 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { APICallError, generateText, tool } from 'ai';
+import { z } from 'zod';
+
+async function main() {
+  let repairCalled = false;
+  const amazonBedrock = createAmazonBedrock({ region: 'us-west-2' });
+
+  try {
+    await generateText({
+      model: amazonBedrock('global.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Read /tmp/data.txt' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call_123',
+              toolName: '$READFILE',
+              input: {},
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_123',
+              toolName: '$READFILE',
+              output: { type: 'text', value: 'Tool not found' },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Try something else.' }],
+        },
+      ],
+      tools: {
+        answer: tool({
+          description: 'Provide an answer.',
+          inputSchema: z.object({ text: z.string() }),
+        }),
+      },
+      maxRetries: 0,
+      experimental_repairToolCall: async () => {
+        repairCalled = true;
+        return null;
+      },
+    });
+  } catch (error) {
+    if (APICallError.isInstance(error)) {
+      console.error(`Bedrock response: ${error.responseBody}`);
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (message.includes('[a-zA-Z0-9_-]+') && !repairCalled) {
+      console.error(
+        'ISSUE_10202_REPRODUCED: Bedrock rejected $READFILE before repairToolCall was invoked',
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    throw error;
+  }
+
+  console.log(
+    repairCalled
+      ? 'ISSUE_10202_NOT_REPRODUCED: repairToolCall was invoked'
+      : 'ISSUE_10202_NOT_REPRODUCED: request completed without repairToolCall',
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 2;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/bedrock-invalid-tool-name-validation-error.json
+++ b/packages/amazon-bedrock/src/__fixtures__/bedrock-invalid-tool-name-validation-error.json
@@ -1,0 +1,3 @@
+{
+  "message": "1 validation error detected: Value at 'messages.2.member.content.1.member.toolUse.name' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_-]+"
+}

--- a/packages/amazon-bedrock/src/bedrock-invalid-tool-name.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-invalid-tool-name.test.ts
@@ -1,0 +1,100 @@
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+
+const invalidToolNameResponse = fs.readFileSync(
+  'src/__fixtures__/bedrock-invalid-tool-name-validation-error.json',
+  'utf8',
+);
+const successResponse = fs.readFileSync(
+  'src/__fixtures__/bedrock-text.json',
+  'utf8',
+);
+
+describe('invalid tool names in message history', () => {
+  it.each(['$READFILE', 'exchange_delivered_order_items<|channel|>'])(
+    'does not crash when replaying %s',
+    async toolName => {
+      let requestBody: any;
+
+      const model = new BedrockChatLanguageModel('test-model', {
+        baseUrl: () => 'https://bedrock-runtime.us-west-2.amazonaws.com',
+        headers: {},
+        generateId: () => 'test-id',
+        fetch: async (_input, init) => {
+          requestBody = JSON.parse(init?.body as string);
+          const requestToolName = requestBody.messages[1].content[0].toolUse
+            .name as string;
+
+          if (!/^[a-zA-Z0-9_-]+$/.test(requestToolName)) {
+            return new Response(invalidToolNameResponse, {
+              status: 400,
+              headers: { 'content-type': 'application/json' },
+            });
+          }
+
+          return new Response(successResponse, {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        },
+      });
+
+      const prompt: LanguageModelV3Prompt = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Read /tmp/data.txt' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call_123',
+              toolName,
+              input: {},
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_123',
+              toolName,
+              output: { type: 'text', value: 'Tool not found' },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Try something else.' }],
+        },
+      ];
+
+      await expect(
+        model.doGenerate({
+          prompt,
+          tools: [
+            {
+              type: 'function',
+              name: 'answer',
+              description: 'Provide an answer.',
+              inputSchema: {
+                type: 'object',
+                properties: { text: { type: 'string' } },
+                required: ['text'],
+                additionalProperties: false,
+              },
+            },
+          ],
+        }),
+      ).resolves.toBeDefined();
+      expect(requestBody.messages[1].content[0].toolUse.name).toMatch(
+        /^[a-zA-Z0-9_-]+$/,
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Bug

Bedrock adapter crashes if model hallucinates tool call with $ in the name

## Reproduction

- Live reproduction `examples/ai-functions/src/reproduction/bedrock-invalid-tool-name.ts` observed Bedrock reject `$READFILE` with HTTP 400 before `experimental_repairToolCall` ran; the request should proceed without a provider-level crash so invalid-tool repair can occur.
- `packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts` copies `part.toolName` unchanged to `toolUse.name`, despite Bedrock requiring `[a-zA-Z0-9_-]+`.
- Recorded the live validation response in `packages/amazon-bedrock/src/__fixtures__/bedrock-invalid-tool-name-validation-error.json`.
- Added `packages/amazon-bedrock/src/bedrock-invalid-tool-name.test.ts`; it fails because both `$READFILE` and `exchange_delivered_order_items<|channel|>` are forwarded unchanged and rejected instead of being safely replayed.
- The failure remains with target-branch versions `ai` 6.0.233 and `@ai-sdk/amazon-bedrock` 4.0.138, so aligning with the release-v6 package set does not resolve it.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolUseBlock.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolSpecification.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentBlock.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-5.html
- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling

## Related Issues

Reproduces #10202