### PR TITLE
[v5.0] reproduction: could not reproduce generateObject often failing with cheaper models

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true
+}

--- a/examples/ai-functions/src/reproduction/issue-10730.ts
+++ b/examples/ai-functions/src/reproduction/issue-10730.ts
@@ -1,0 +1,108 @@
+import { createGateway } from '../../../ai-core/node_modules/@ai-sdk/gateway';
+import {
+  generateObject,
+  NoObjectGeneratedError,
+} from '../../../ai-core/node_modules/ai';
+import { z } from '../../../ai-core/node_modules/zod';
+
+const reportedModel = 'deepseek/deepseek-v3.2-exp';
+const currentModel = 'deepseek/deepseek-v3.2';
+
+const simpleSchema = z.object({
+  playerName: z
+    .string()
+    .describe('A short, creative name for your game character (1-3 words max)'),
+});
+
+const complexSchema = z.object({
+  playerName: z.string().describe('A short, creative character name'),
+  characterClass: z.enum(['warrior', 'mage', 'rogue']),
+  level: z.number().int().min(1).max(20),
+  traits: z.array(z.string()).min(3).max(5),
+  stats: z.object({
+    strength: z.number().int().min(1).max(20),
+    agility: z.number().int().min(1).max(20),
+    intelligence: z.number().int().min(1).max(20),
+  }),
+  backstory: z.string().describe('A two-sentence backstory'),
+});
+
+async function assertValidObjects({
+  attempts,
+  label,
+  prompt,
+  schema,
+}: {
+  attempts: number;
+  label: string;
+  prompt: string;
+  schema: typeof simpleSchema | typeof complexSchema;
+}) {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      await generateObject({
+        model: currentModel,
+        schema,
+        prompt,
+        maxRetries: 0,
+      });
+    } catch (error) {
+      if (NoObjectGeneratedError.isInstance(error)) {
+        throw new Error(
+          `${label} failed on attempt ${attempt} with AI_NoObjectGeneratedError: ${error.text}`,
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  console.log(`${label}: ${attempts}/${attempts} valid objects`);
+}
+
+async function main() {
+  const availableModels = await createGateway().getAvailableModels();
+  const modelIds = availableModels.models.map(model => model.id);
+
+  console.log(
+    `reported model available: ${modelIds.includes(reportedModel as never)}`,
+  );
+  console.log(
+    `current successor available: ${modelIds.includes(currentModel)}`,
+  );
+
+  await assertValidObjects({
+    attempts: 20,
+    label: 'reported simple schema',
+    schema: simpleSchema,
+    prompt: 'Generate a short, creative name for a video game character',
+  });
+
+  await assertValidObjects({
+    attempts: 40,
+    label: 'representative complex schema',
+    schema: complexSchema,
+    prompt: 'Generate a creative video game character',
+  });
+
+  await assertValidObjects({
+    attempts: 40,
+    label: 'DeepSeek-documented JSON prompt',
+    schema: complexSchema,
+    prompt: `Generate a creative video game character as JSON.
+Example JSON:
+{
+  "playerName": "Nyx Vale",
+  "characterClass": "rogue",
+  "level": 7,
+  "traits": ["resourceful", "wary", "loyal"],
+  "stats": { "strength": 9, "agility": 17, "intelligence": 14 },
+  "backstory": "Nyx grew up mapping forgotten tunnels. They now guide travelers through dangerous ruins."
+}`,
+  });
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Bug

generateObject often failing with cheaper models

## Reproduction

- The reported user-visible bug is `generateObject` throwing `AI_NoObjectGeneratedError` instead of returning a schema-valid character object.
- The runnable artifacts `examples/ai-functions/package.json` and `examples/ai-functions/src/reproduction/issue-10730.ts` observed `20/20` valid results for the reported schema and `40/40` valid results for a representative complex schema; the expected frequent failure did not occur.
- The exact reported model `deepseek/deepseek-v3.2-exp` is no longer available through AI Gateway and returned `GatewayModelNotFoundError`; the available documented successor `deepseek/deepseek-v3.2` was used, so the historical model behavior remains unevaluated.
- The DeepSeek-documented prompt mentioning JSON and providing an example also produced `40/40` valid results, matching the unconfigured complex-schema run.
- `packages/ai/src/generate-object/generate-object.ts` sends a JSON response format for every structured-object call, and `packages/ai/CHANGELOG.md` records that AI SDK 5.0.107 removed the previously unused `mode` option; therefore `mode: "json"` did not change request construction in the reported 5.0.104 implementation.

## Relevant Documentation

- https://api-docs.deepseek.com/guides/json_mode/
- https://v5.ai-sdk.dev/docs/reference/ai-sdk-core/generate-object
- https://ai-sdk.dev/docs/reference/ai-sdk-errors/ai-no-object-generated-error
- https://vercel.com/docs/ai-gateway/models-and-providers
- https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/structured-outputs
- https://vercel.com/changelog/deepseek-v3-2-now-in-vercel-ai-gateway
- https://vercel.com/ai-gateway/models/deepseek-v3.2/about

## Related Issues

Could not reproduce #10730