### PR TITLE
[v6.0] fix: prevent invalid hallucinated tool names from crashing Bedrock conversation replay

### DIFF
--- a/.changeset/fuzzy-tools-sanitize.md
+++ b/.changeset/fuzzy-tools-sanitize.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Sanitize invalid characters in replayed tool call names before sending conversation history to Amazon Bedrock.

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
@@ -1290,45 +1290,8 @@ describe('assistant messages', () => {
     });
   });
 
-<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
-=======
-  it('should wrap non-object (invalid) tool call input in an object', async () => {
-    const result = await convertToAmazonBedrockChatMessages([
-      {
-        role: 'assistant',
-        content: [
-          {
-            type: 'tool-call',
-            toolCallId: 'call-1',
-            toolName: 'cityAttractions',
-            // malformed JSON the model produced, kept as a raw string
-            input: '{ "city": "San Francisco", }',
-          },
-        ],
-      },
-    ]);
-
-    expect(result).toEqual({
-      messages: [
-        {
-          role: 'assistant',
-          content: [
-            {
-              toolUse: {
-                toolUseId: 'call-1',
-                name: 'cityAttractions',
-                input: { rawInvalidInput: '{ "city": "San Francisco", }' },
-              },
-            },
-          ],
-        },
-      ],
-      system: [],
-    });
-  });
-
   it('should strip invalid characters from tool call names', async () => {
-    const result = await convertToAmazonBedrockChatMessages([
+    const result = await convertToBedrockChatMessages([
       {
         role: 'assistant',
         content: [
@@ -1384,7 +1347,6 @@ describe('assistant messages', () => {
     ]);
   });
 
->>>>>>> 8fcb72c347 (fix: prevent invalid hallucinated tool names from crashing Bedrock conversation replay (#17769)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
   it('should preserve empty text blocks when reasoning blocks are present', async () => {
     const result = await convertToBedrockChatMessages([
       {

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
@@ -1290,6 +1290,101 @@ describe('assistant messages', () => {
     });
   });
 
+<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+=======
+  it('should wrap non-object (invalid) tool call input in an object', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'cityAttractions',
+            // malformed JSON the model produced, kept as a raw string
+            input: '{ "city": "San Francisco", }',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              toolUse: {
+                toolUseId: 'call-1',
+                name: 'cityAttractions',
+                input: { rawInvalidInput: '{ "city": "San Francisco", }' },
+              },
+            },
+          ],
+        },
+      ],
+      system: [],
+    });
+  });
+
+  it('should strip invalid characters from tool call names', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: '$READFILE',
+            input: {},
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-2',
+            toolName: 'exchange_delivered_order_items<|channel|>',
+            input: {},
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-3',
+            toolName: '$',
+            input: {},
+          },
+        ],
+      },
+    ]);
+
+    expect(result.messages).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            toolUse: {
+              toolUseId: 'call-1',
+              name: 'READFILE',
+              input: {},
+            },
+          },
+          {
+            toolUse: {
+              toolUseId: 'call-2',
+              name: 'exchange_delivered_order_itemschannel',
+              input: {},
+            },
+          },
+          {
+            toolUse: {
+              toolUseId: 'call-3',
+              name: '_',
+              input: {},
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+>>>>>>> 8fcb72c347 (fix: prevent invalid hallucinated tool names from crashing Bedrock conversation replay (#17769)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
   it('should preserve empty text blocks when reasoning blocks are present', async () => {
     const result = await convertToBedrockChatMessages([
       {

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -53,15 +53,11 @@ function pushCachePoint(
   }
 }
 
-<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
-function getBedrockImageSource({
-=======
 function sanitizeToolName(toolName: string): string {
   return toolName.replace(/[^a-zA-Z0-9_-]/g, '') || '_';
 }
 
-function getAmazonBedrockImageSource({
->>>>>>> 8fcb72c347 (fix: prevent invalid hallucinated tool names from crashing Bedrock conversation replay (#17769)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+function getBedrockImageSource({
   data,
   functionality,
 }: {
@@ -418,13 +414,8 @@ export async function convertToBedrockChatMessages(
                 bedrockContent.push({
                   toolUse: {
                     toolUseId: normalizeToolCallId(part.toolCallId, isMistral),
-<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
-                    name: part.toolName,
-                    input: part.input as JSONObject,
-=======
                     name: sanitizeToolName(part.toolName),
-                    input: toBedrockToolInput(part.input),
->>>>>>> 8fcb72c347 (fix: prevent invalid hallucinated tool names from crashing Bedrock conversation replay (#17769)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+                    input: part.input as JSONObject,
                   },
                 });
                 break;

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -53,7 +53,15 @@ function pushCachePoint(
   }
 }
 
+<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
 function getBedrockImageSource({
+=======
+function sanitizeToolName(toolName: string): string {
+  return toolName.replace(/[^a-zA-Z0-9_-]/g, '') || '_';
+}
+
+function getAmazonBedrockImageSource({
+>>>>>>> 8fcb72c347 (fix: prevent invalid hallucinated tool names from crashing Bedrock conversation replay (#17769)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
   data,
   functionality,
 }: {
@@ -410,8 +418,13 @@ export async function convertToBedrockChatMessages(
                 bedrockContent.push({
                   toolUse: {
                     toolUseId: normalizeToolCallId(part.toolCallId, isMistral),
+<<<<<<< HEAD:packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
                     name: part.toolName,
                     input: part.input as JSONObject,
+=======
+                    name: sanitizeToolName(part.toolName),
+                    input: toBedrockToolInput(part.input),
+>>>>>>> 8fcb72c347 (fix: prevent invalid hallucinated tool names from crashing Bedrock conversation replay (#17769)):packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
                   },
                 });
                 break;


### PR DESCRIPTION
## Background

Hallucinated tool names containing unsupported characters caused Amazon Bedrock to reject replayed conversation history with a 400 validation error.

## Root Cause

The Bedrock message converter copied `part.toolName` directly into `toolUse.name`; focused and live reproductions confirmed `$READFILE` reached Bedrock unchanged and violated its `[a-zA-Z0-9_-]+` constraint.

## Summary

Sanitized replayed tool-call names to Bedrock-compatible characters, added a valid fallback for fully invalid names, removed reproduction-only artifacts, and added a patch changeset.

## Testing

Added converter regression coverage for `$READFILE`, names containing `<|channel|>`, and names containing no valid characters.

## End-to-end Validation

- `pnpm -C packages/amazon-bedrock build` followed by `pnpm -C examples/ai-functions exec tsx -e '<live reproduction>'`: Claude Sonnet 4.5 completed the request with `$READFILE` in history without Bedrock's tool-name validation error.

## Related Issues

Fixes #10202

Closes #17763

Backport of #17769

Co-authored-by: MaxAller <2164925+MaxAller@users.noreply.github.com>