### PR TITLE
[v5.0] reproduction: Bedrock adapter crashes if model hallucinates tool call

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "issueId": 10202,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/bedrock-invalid-tool-name.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/bedrock-invalid-tool-name.ts",
+    "examples/ai-functions/package.json",
+    "pnpm-lock.yaml"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_-]+; repairCalled=false"
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/amazon-bedrock": "workspace:*",
+    "ai": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "4.19.2"
+  }
+}

--- a/examples/ai-functions/src/reproduction/bedrock-invalid-tool-name.ts
+++ b/examples/ai-functions/src/reproduction/bedrock-invalid-tool-name.ts
@@ -1,0 +1,88 @@
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { APICallError, generateText, jsonSchema, tool } from 'ai';
+
+const VALIDATION_SIGNAL =
+  'failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_-]+';
+
+async function main() {
+  const bedrock = createAmazonBedrock({ region: 'us-west-2' });
+  let repairCalled = false;
+
+  try {
+    await generateText({
+      model: bedrock('global.anthropic.claude-sonnet-4-5-20250929-v1:0'),
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Read /tmp/data.txt' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call_123',
+              toolName: '$READFILE',
+              input: {},
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_123',
+              toolName: '$READFILE',
+              output: { type: 'text', value: 'Tool not found' },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Try something else.' }],
+        },
+      ],
+      tools: {
+        answer: tool({
+          description: 'Provide an answer',
+          inputSchema: jsonSchema<{ text: string }>({
+            type: 'object',
+            properties: { text: { type: 'string' } },
+            required: ['text'],
+            additionalProperties: false,
+          }),
+          execute: async ({ text }) => text,
+        }),
+      },
+      experimental_repairToolCall: async () => {
+        repairCalled = true;
+        return null;
+      },
+    });
+
+    console.log(
+      'Request completed without a Bedrock tool-name validation crash.',
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (message.includes(VALIDATION_SIGNAL) && !repairCalled) {
+      if (APICallError.isInstance(error)) {
+        console.error(`LIVE_RESPONSE_BODY: ${error.responseBody}`);
+      }
+      console.error(
+        `BEDROCK_INVALID_TOOL_NAME_CRASH: ${message}; repairCalled=${repairCalled}`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    throw error;
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 2;
+});

--- a/packages/amazon-bedrock/src/__fixtures__/bedrock-invalid-tool-name-validation-error.json
+++ b/packages/amazon-bedrock/src/__fixtures__/bedrock-invalid-tool-name-validation-error.json
@@ -1,0 +1,3 @@
+{
+  "message": "1 validation error detected: Value at 'messages.2.member.content.1.member.toolUse.name' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_-]+"
+}

--- a/packages/amazon-bedrock/src/bedrock-invalid-tool-name.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-invalid-tool-name.test.ts
@@ -1,0 +1,126 @@
+import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { BedrockChatLanguageModel } from './bedrock-chat-language-model';
+
+const validationError = JSON.parse(
+  fs.readFileSync(
+    'src/__fixtures__/bedrock-invalid-tool-name-validation-error.json',
+    'utf8',
+  ),
+);
+
+const validResponse = {
+  output: {
+    message: {
+      role: 'assistant',
+      content: [{ text: 'Request accepted.' }],
+    },
+  },
+  usage: {
+    inputTokens: 1,
+    outputTokens: 1,
+    totalTokens: 2,
+  },
+  stopReason: 'end_turn',
+};
+
+function createModel() {
+  return new BedrockChatLanguageModel(
+    'global.anthropic.claude-sonnet-4-5-20250929-v1:0',
+    {
+      baseUrl: () => 'https://bedrock-runtime.us-west-2.amazonaws.com',
+      headers: {},
+      generateId: () => 'test-id',
+      fetch: async (_url, init) => {
+        const body = JSON.parse(String(init?.body));
+        const toolNames: string[] = body.messages.flatMap(
+          (message: { content: Array<{ toolUse?: { name: string } }> }) =>
+            message.content.flatMap(part =>
+              part.toolUse == null ? [] : [part.toolUse.name],
+            ),
+        );
+
+        if (toolNames.some(name => !/^[a-zA-Z0-9_-]+$/.test(name))) {
+          return new Response(JSON.stringify(validationError), {
+            status: 400,
+            headers: {
+              'content-type': 'application/json',
+              'x-amzn-errortype': 'ValidationException',
+            },
+          });
+        }
+
+        return new Response(JSON.stringify(validResponse), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+    },
+  );
+}
+
+function promptWithReplayedToolName(toolName: string): LanguageModelV2Prompt {
+  return [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'Read /tmp/data.txt' }],
+    },
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call_123',
+          toolName,
+          input: {},
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'call_123',
+          toolName,
+          output: { type: 'text', value: 'Tool not found' },
+        },
+      ],
+    },
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'Try something else.' }],
+    },
+  ];
+}
+
+describe('replayed invalid tool names', () => {
+  for (const toolName of [
+    '$READFILE',
+    'exchange_delivered_order_items<|channel|>',
+  ]) {
+    it(`does not cause a provider-level validation crash for ${toolName}`, async () => {
+      await expect(
+        createModel().doGenerate({
+          prompt: promptWithReplayedToolName(toolName),
+          tools: [
+            {
+              type: 'function',
+              name: 'answer',
+              description: 'Provide an answer',
+              inputSchema: {
+                type: 'object',
+                properties: { text: { type: 'string' } },
+                required: ['text'],
+                additionalProperties: false,
+              },
+            },
+          ],
+        }),
+      ).resolves.toMatchObject({
+        content: [{ type: 'text', text: 'Request accepted.' }],
+      });
+    });
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,19 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/amazon-bedrock':
+        specifier: workspace:*
+        version: link:../../packages/amazon-bedrock
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+    devDependencies:
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':
@@ -19609,7 +19622,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))
+      '@angular-devkit/build-webpack': 0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)
       '@angular-devkit/core': 20.3.18(chokidar@4.0.3)
       '@angular/build': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(@angular/compiler@20.3.17)(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)))(@types/node@20.17.24)(chokidar@4.0.3)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(postcss@8.5.6)(tailwindcss@4.2.1)(terser@5.43.1)(tslib@2.8.1)(tsx@4.19.2)(typescript@5.8.3)(vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@20.17.24)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.17.24)(typescript@5.8.3))(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))(yaml@2.7.0)
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
@@ -19623,13 +19636,13 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      '@ngtools/webpack': 20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.21(postcss@8.5.6)
-      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9))
+      babel-loader: 10.0.0(@babel/core@7.28.3)(webpack@5.105.0)
       browserslist: 4.25.1
-      copy-webpack-plugin: 13.0.1(webpack@5.105.0(esbuild@0.25.9))
-      css-loader: 7.1.2(webpack@5.105.0(esbuild@0.25.9))
+      copy-webpack-plugin: 13.0.1(webpack@5.105.0)
+      css-loader: 7.1.2(webpack@5.105.0)
       esbuild-wasm: 0.25.9
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.5
@@ -19637,22 +19650,22 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.4.0
-      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9))
-      license-webpack-plugin: 4.0.2(webpack@5.105.0(esbuild@0.25.9))
+      less-loader: 12.3.0(less@4.4.0)(webpack@5.105.0)
+      license-webpack-plugin: 4.0.2(webpack@5.105.0)
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.4(webpack@5.105.0(esbuild@0.25.9))
+      mini-css-extract-plugin: 2.9.4(webpack@5.105.0)
       open: 10.2.0
       ora: 8.2.0
       picomatch: 4.0.3
       piscina: 5.1.3
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0)
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.90.0
-      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9))
+      sass-loader: 16.0.5(sass@1.90.0)(webpack@5.105.0)
       semver: 7.7.2
-      source-map-loader: 5.0.0(webpack@5.105.0(esbuild@0.25.9))
+      source-map-loader: 5.0.0(webpack@5.105.0)
       source-map-support: 0.5.21
       terser: 5.43.1
       tree-kill: 1.2.2
@@ -19662,7 +19675,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(webpack@5.105.0)
       webpack-dev-server: 5.2.2(webpack@5.105.0)
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.25.9))
+      webpack-subresource-integrity: 5.1.0(webpack@5.105.0)
     optionalDependencies:
       '@angular/core': 20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.17(@angular/common@20.3.17(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.17(@angular/compiler@20.3.17)(rxjs@7.8.2)(zone.js@0.15.1))
@@ -19692,7 +19705,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9))':
+  '@angular-devkit/build-webpack@0.2003.18(chokidar@4.0.3)(webpack-dev-server@5.2.2(webpack@5.105.0))(webpack@5.105.0)':
     dependencies:
       '@angular-devkit/architect': 0.2003.18(chokidar@4.0.3)
       rxjs: 7.8.2
@@ -24942,7 +24955,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.7':
     optional: true
 
-  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9))':
+  '@ngtools/webpack@20.3.18(@angular/compiler-cli@20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3))(typescript@5.8.3)(webpack@5.105.0)':
     dependencies:
       '@angular/compiler-cli': 20.3.17(@angular/compiler@20.3.17)(typescript@5.8.3)
       typescript: 5.8.3
@@ -29418,7 +29431,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0(esbuild@0.25.9)):
+  babel-loader@10.0.0(@babel/core@7.28.3)(webpack@5.105.0):
     dependencies:
       '@babel/core': 7.28.3
       find-up: 5.0.0
@@ -30185,7 +30198,7 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  copy-webpack-plugin@13.0.1(webpack@5.105.0(esbuild@0.25.9)):
+  copy-webpack-plugin@13.0.1(webpack@5.105.0):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -30282,7 +30295,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  css-loader@7.1.2(webpack@5.105.0(esbuild@0.25.9)):
+  css-loader@7.1.2(webpack@5.105.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -33762,7 +33775,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0(esbuild@0.25.9)):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.105.0):
     dependencies:
       less: 4.4.0
     optionalDependencies:
@@ -33790,7 +33803,7 @@ snapshots:
       type-check: 0.4.0
     optional: true
 
-  license-webpack-plugin@4.0.2(webpack@5.105.0(esbuild@0.25.9)):
+  license-webpack-plugin@4.0.2(webpack@5.105.0):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -34869,7 +34882,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.105.0(esbuild@0.25.9)):
+  mini-css-extract-plugin@2.9.4(webpack@5.105.0):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.1
@@ -36400,7 +36413,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.7.0
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0(esbuild@0.25.9)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.105.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
@@ -37357,7 +37370,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0(esbuild@0.25.9)):
+  sass-loader@16.0.5(sass@1.90.0)(webpack@5.105.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -37794,7 +37807,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.105.0(esbuild@0.25.9)):
+  source-map-loader@5.0.0(webpack@5.105.0):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1


### PR DESCRIPTION
## Bug

Bedrock adapter crashes if model hallucinates tool call with $ in the name

## Reproduction

- Live reproduction with `ai` 5.0.218 and `@ai-sdk/amazon-bedrock` 3.0.108 replayed `$READFILE` to Claude Sonnet 4.5; Bedrock returned HTTP 400 for the `[a-zA-Z0-9_-]+` constraint before `experimental_repairToolCall` ran, instead of reaching `NoSuchToolError` repair.
- `packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts` copies `part.toolName` unchanged into Bedrock's `toolUse.name`, establishing the adapter as the source of the invalid request.
- The failure persists on the target branch's newer package set, so upgrading from the reported versions or aligning existing workspace dependencies does not resolve it.
- Added the runnable reproduction at `examples/ai-functions/src/reproduction/bedrock-invalid-tool-name.ts`, with its workspace setup in `examples/ai-functions/package.json` and `pnpm-lock.yaml`; it exits 1 on the provider crash rather than completing through tool-call repair.
- Recorded the live response in `packages/amazon-bedrock/src/__fixtures__/bedrock-invalid-tool-name-validation-error.json` and added `packages/amazon-bedrock/src/bedrock-invalid-tool-name.test.ts`; the test fails for both `$READFILE` and `exchange_delivered_order_items<|channel|>` because each causes the provider-level validation error.

## Relevant Documentation

- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolUseBlock.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolSpecification.html
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentBlock.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-5.html
- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling
- https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-text

## Related Issues

Reproduces #10202