### PR TITLE
fix(harness): Await all telemetry hooks in harness adapter

### DIFF
--- a/.changeset/calm-tools-trace.md
+++ b/.changeset/calm-tools-trace.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness': patch
+---
+
+fix(harness): execute host tools through telemetry context wrappers

--- a/packages/harness/src/agent/internal/run-prompt.test.ts
+++ b/packages/harness/src/agent/internal/run-prompt.test.ts
@@ -3,7 +3,12 @@ import {
   type Experimental_SandboxSession,
   type ToolSet,
 } from '@ai-sdk/provider-utils';
-import { hasToolCall, isStepCount, type TextStreamPart } from 'ai';
+import {
+  hasToolCall,
+  isStepCount,
+  type Telemetry,
+  type TextStreamPart,
+} from 'ai';
 import { describe, expect, test, vi } from 'vitest';
 import { z } from 'zod/v4';
 import type {
@@ -746,6 +751,21 @@ describe('runPrompt host tool generator results', () => {
   test('executes an approved pending custom tool continuation', async () => {
     const submitted: SubmittedResult[] = [];
     const settled: string[] = [];
+    const telemetryEvents: string[] = [];
+    const integration = {
+      onToolExecutionStart() {
+        telemetryEvents.push('tool-start');
+      },
+      async executeTool({ execute }) {
+        telemetryEvents.push('wrapper-start');
+        const output = await execute();
+        telemetryEvents.push('wrapper-end');
+        return output;
+      },
+      onToolExecutionEnd() {
+        telemetryEvents.push('tool-end');
+      },
+    } satisfies Telemetry;
     const weather = tool({
       description: 'Get weather',
       inputSchema: z.object({ city: z.string() }),
@@ -793,6 +813,7 @@ describe('runPrompt host tool generator results', () => {
         },
       ],
       onToolApprovalSettled: approvalId => settled.push(approvalId),
+      telemetry: { integrations: [integration] },
     });
 
     const parts: TextStreamPart<ToolSet>[] = [];
@@ -802,6 +823,12 @@ describe('runPrompt host tool generator results', () => {
     expect(settled).toEqual(['approval-1']);
     expect(submitted).toEqual([
       { toolCallId: 'c1', output: { city: 'SF', temperature: 72 } },
+    ]);
+    expect(telemetryEvents).toEqual([
+      'tool-start',
+      'wrapper-start',
+      'wrapper-end',
+      'tool-end',
     ]);
     expect(parts).toContainEqual(
       expect.objectContaining({
@@ -1006,6 +1033,123 @@ describe('runPrompt host tool generator results', () => {
 
     expect(toolResultParts(parts)).toHaveLength(0);
     expect(submitted).toEqual([{ toolCallId: 'c1', output: { echoed: 'hi' } }]);
+  });
+
+  test('executes host tools through telemetry context wrappers', async () => {
+    const events: string[] = [];
+    const callIds: string[] = [];
+    const echo = tool({
+      description: 'Echo the input',
+      inputSchema: z.object({ text: z.string() }),
+      execute: async (args: { text: string }) => {
+        events.push('execute');
+        return { echoed: args.text };
+      },
+    });
+    const integration = {
+      async onToolExecutionStart(event) {
+        await Promise.resolve();
+        callIds.push(event.callId);
+        events.push('tool-start');
+      },
+      async executeTool({ callId, toolCallId, execute }) {
+        callIds.push(callId);
+        expect(toolCallId).toBe('c1');
+        events.push('wrapper-start');
+        const output = await execute();
+        events.push('wrapper-end');
+        return output;
+      },
+    } satisfies Telemetry;
+
+    const { result, done } = runPrompt({
+      harness,
+      session: fakeSession([
+        {
+          type: 'tool-call',
+          toolCallId: 'c1',
+          toolName: 'echo',
+          input: JSON.stringify({ text: 'hi' }),
+        },
+        ...finishEvents,
+      ]),
+      prompt: 'go',
+      instructions: undefined,
+      tools: { echo } as ToolSet,
+      toolSpecs: [],
+      sandboxSession,
+      sessionWorkDir: WORK_DIR,
+      runtimeContext: {} as never,
+      abortSignal: undefined,
+      telemetry: { integrations: [integration] },
+    });
+
+    for await (const _part of result.fullStream) {
+      // Drain the stream so the turn and host tool execution complete.
+    }
+    await done;
+
+    expect(events).toEqual([
+      'tool-start',
+      'wrapper-start',
+      'execute',
+      'wrapper-end',
+    ]);
+    expect(new Set(callIds).size).toBe(1);
+  });
+
+  test('reports telemetry wrapper failures as tool errors', async () => {
+    const submitted: SubmittedResult[] = [];
+    const execute = vi.fn();
+    const echo = tool({
+      description: 'Echo the input',
+      inputSchema: z.object({ text: z.string() }),
+      execute,
+    });
+    const integration = {
+      async executeTool() {
+        throw new Error('telemetry wrapper failed');
+      },
+    } satisfies Telemetry;
+
+    const { result, done } = runPrompt({
+      harness,
+      session: fakeSession(
+        [
+          {
+            type: 'tool-call',
+            toolCallId: 'c1',
+            toolName: 'echo',
+            input: JSON.stringify({ text: 'hi' }),
+          },
+          ...finishEvents,
+        ],
+        input => submitted.push(input),
+      ),
+      prompt: 'go',
+      instructions: undefined,
+      tools: { echo } as ToolSet,
+      toolSpecs: [],
+      sandboxSession,
+      sessionWorkDir: WORK_DIR,
+      runtimeContext: {} as never,
+      abortSignal: undefined,
+      telemetry: { integrations: [integration] },
+    });
+
+    for await (const _part of result.fullStream) {
+      // Drain the stream so host tool error handling completes.
+    }
+    await done;
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(submitted).toEqual([
+      {
+        toolCallId: 'c1',
+        output: { error: 'Error: telemetry wrapper failed' },
+        isError: true,
+      },
+    ]);
   });
 
   test('strips the workDir from preliminary results before they reach consumers', async () => {

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -42,7 +42,11 @@ import type { HarnessAgentToolApprovalConfiguration } from '../harness-agent-set
 import { HarnessStreamTextResult } from './harness-stream-text-result';
 import { translateStreamPart } from './translate-stream-part';
 import { stripWorkDir } from './strip-work-dir';
-import { createTurnTelemetry, type TurnContentPart } from './turn-telemetry';
+import {
+  createTurnTelemetry,
+  type TurnContentPart,
+  type TurnTelemetry,
+} from './turn-telemetry';
 import { resolveCustomToolApproval } from './permission-mode';
 import { logBridgeError } from '../../utils/bridge-diagnostics';
 import { pinSandboxChannelEventCheckpoint } from '../../utils/sandbox-channel';
@@ -431,9 +435,16 @@ export function runPrompt<
           input: approval.input,
         } satisfies Extract<HarnessV1StreamPart, { type: 'tool-call' }>);
 
+      telemetry.start(input.session.modelId);
+      await telemetry.toolStart({
+        toolCallId: rawToolCall.toolCallId,
+        toolName: rawToolCall.toolName,
+        input: rawToolCall.input,
+      });
       const execution = await maybeExecuteHostTool({
         event: rawToolCall,
         tools: activeTools,
+        wrappedExecuteTool: telemetry.executeTool,
         sandboxSession: input.sandboxSession,
         abortSignal: input.abortSignal,
         control,
@@ -653,7 +664,7 @@ export function runPrompt<
             toolName: value.toolName,
             input: value.input,
           });
-          telemetry.toolStart({
+          await telemetry.toolStart({
             toolCallId: value.toolCallId,
             toolName: value.toolName,
             input: value.input,
@@ -854,6 +865,7 @@ export function runPrompt<
           const execution = await maybeExecuteHostTool({
             event: toolCall,
             tools: activeTools,
+            wrappedExecuteTool: telemetry.executeTool,
             sandboxSession: input.sandboxSession,
             abortSignal: input.abortSignal,
             control,
@@ -973,6 +985,7 @@ function hasTool(input: { tools: ToolSet; toolName: string }): boolean {
 async function maybeExecuteHostTool<TOOLS extends ToolSet>(input: {
   event: { toolCallId: string; toolName: string; input: string };
   tools: TOOLS;
+  wrappedExecuteTool: TurnTelemetry['executeTool'];
   sandboxSession: SandboxSession;
   abortSignal: AbortSignal | undefined;
   control: HarnessV1PromptControl;
@@ -1001,25 +1014,31 @@ async function maybeExecuteHostTool<TOOLS extends ToolSet>(input: {
      * back to the model — preliminary values are surfaced to the consumer
      * stream alone, matching how the AI SDK treats `onPreliminaryToolResult`.
      */
-    let output: unknown;
-    const stream = executeTool({
-      tool,
-      input: args as never,
-      options: {
-        toolCallId: input.event.toolCallId,
-        messages: [],
-        abortSignal: input.abortSignal,
-        context: undefined as never,
-        experimental_sandbox: input.sandboxSession,
+    const output = await input.wrappedExecuteTool({
+      toolCallId: input.event.toolCallId,
+      execute: async () => {
+        let output: unknown;
+        const stream = executeTool({
+          tool,
+          input: args as never,
+          options: {
+            toolCallId: input.event.toolCallId,
+            messages: [],
+            abortSignal: input.abortSignal,
+            context: undefined as never,
+            experimental_sandbox: input.sandboxSession,
+          },
+        });
+        for await (const part of stream) {
+          if (part.type === 'preliminary') {
+            input.onPreliminaryResult(part.output);
+          } else {
+            output = part.output;
+          }
+        }
+        return output;
       },
     });
-    for await (const part of stream) {
-      if (part.type === 'preliminary') {
-        input.onPreliminaryResult(part.output);
-      } else {
-        output = part.output;
-      }
-    }
 
     await input.control.submitToolResult({
       toolCallId: input.event.toolCallId,

--- a/packages/harness/src/agent/internal/turn-telemetry.ts
+++ b/packages/harness/src/agent/internal/turn-telemetry.ts
@@ -58,7 +58,12 @@ export interface TurnTelemetry {
     toolCallId: string;
     toolName: string;
     input: unknown;
-  }): void;
+  }): void | Promise<void>;
+  /** Execute a host tool through each telemetry integration's context wrapper. */
+  executeTool<T>(input: {
+    toolCallId: string;
+    execute: () => PromiseLike<T>;
+  }): Promise<T>;
   /**
    * A tool execution completed (on its `tool-result` or after host execution).
    * Idempotent per `toolCallId` — the first caller wins, so provider-executed
@@ -78,7 +83,10 @@ const NOOP: TurnTelemetry = {
   start() {},
   ensureStepOpen() {},
   stepFinish() {},
-  toolStart() {},
+  async toolStart() {},
+  async executeTool({ execute }) {
+    return await execute();
+  },
   toolEnd() {},
   end() {},
   error() {},
@@ -258,10 +266,11 @@ export function createTurnTelemetry(opts: {
       stepNumber += 1;
     },
 
-    toolStart(call) {
+    async toolStart(call) {
       ensureStepOpen();
+      if (openTools.has(call.toolCallId)) return;
       openTools.set(call.toolCallId, call);
-      dispatcher.onToolExecutionStart?.(
+      await dispatcher.onToolExecutionStart?.(
         cast<'onToolExecutionStart'>({
           callId,
           messages: [],
@@ -275,6 +284,11 @@ export function createTurnTelemetry(opts: {
           toolContext: undefined,
         }),
       );
+    },
+
+    async executeTool({ toolCallId, execute }) {
+      if (dispatcher.executeTool == null) return await execute();
+      return await dispatcher.executeTool({ callId, toolCallId, execute });
     },
 
     toolEnd(toolCallId, output) {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md

AI SDK maintenance is becoming increasingly automated. High-quality issues, reproductions,
failing tests, docs fixes, and focused clarifications are especially valuable. You do not
need to send a complete bug fix for your contribution to be appreciated or credited.
-->

`HarnessAgent` creates an AI SDK telemetry dispatcher and emits tool lifecycle events, but host tools were executed directly without invoking the dispatcher’s `executeTool` hook.

Telemetry integrations use this hook to establish context around tool execution. Without it, nested work started by a host tool, such as another agent invocation or a traced operation, cannot be associated with the tool span and may appear as a separate trace.

## Summary

- Execute Harness host tools through the telemetry dispatcher’s `executeTool` wrappers.
- Await `onToolExecutionStart` before executing the tool so integrations can initialize tool telemetry state before their execution wrappers run.
- Apply the wrapper to both immediate host-tool execution and approved pending-tool continuations.
- Keep `toolStart` compatible with synchronous and asynchronous implementations by accepting `void | Promise<void>`.
- Handle telemetry wrapper failures through the existing host-tool error path.
- Make tool-start handling idempotent for resumed approval flows.
- Add coverage for:
  - Tool lifecycle and wrapper ordering.
  - Correlation through the same `callId` and `toolCallId`.
  - Approved pending-tool continuations.
  - Telemetry wrapper failures.

## End-to-End Verification

I built the modified `@ai-sdk/harness` package and used it in a LangSmith integration with the official `@ai-sdk/harness-pi` adapter.

A coordinator `HarnessAgent` invoked a host delegation tool, which created and ran a second Pi-backed `HarnessAgent`. No application-side telemetry wrapper or manual context propagation was used.

The resulting hierarchy was recorded in one trace here:

https://smith.langchain.com/public/a1161407-f31f-4c96-bad8-20cac8fce0bb/r/019f8741-627d-7000-8000-013317541c5b?start_time=2026-07-22T00%3A37%3A17.053001Z

<img width="471" height="376" alt="Screenshot 2026-07-21 at 5 39 45 PM" src="https://github.com/user-attachments/assets/0e683812-a291-493e-b9d5-4fb3eb5a58a7" />

For this (rough) code:

```ts
  const piSettings = {
    auth: { customEnv: { ANTHROPIC_API_KEY: anthropicApiKey } },
    model: "claude-haiku-4-5",
    thinkingLevel: "off" as const,
  };
  const coordinatorTelemetry = LangSmithTelemetry({});
  const coordinator = new HarnessAgent({
    id: "pi-coordinator",
    harness: createPi(piSettings),
    sandbox: createJustBashSandbox({}),
    instructions: ...,
    tools: {
      delegate_to_pi_subagent: tool({
        description:
          "Delegate a self-contained task to an isolated HarnessAgent backed by Pi.",
        inputSchema: z.object({
          task: z
            .string()
            .describe("The complete task for the isolated subagent"),
        }),
        execute: async ({ task }, { abortSignal, toolCallId }) => {
          const subagent = new HarnessAgent({
            id: "pi-subagent",
            harness: createPi(piSettings),
            sandbox: createJustBashSandbox({
              env: { WORK_DIR: `/home/user/pi-${subagentSessionId}` },
            }),
            instructions: ...,
            telemetry: {
              integrations: [
                LangSmithTelemetry({}),
              ],
            },
          });
          const subagentSession = await subagent.createSession({
            sessionId: subagentSessionId,
            abortSignal,
          });
          try {
            const result = await subagent.generate({
              session: subagentSession,
              prompt: task,
              abortSignal,
            });
            return result.text.trim();
          } finally {
            await subagentSession.destroy();
          }
        },
      }),
    },
    telemetry: { integrations: [coordinatorTelemetry] },
  });
```

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)