### PR TITLE
fix(harness): Ensure all harness agent telemetry hooks are awaited

### DIFF
--- a/.changeset/quiet-hooks-wait.md
+++ b/.changeset/quiet-hooks-wait.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness': patch
+---
+
+Ensure harness telemetry hooks are awaited before stream processing continues.

--- a/.changeset/quiet-hooks-wait.md
+++ b/.changeset/quiet-hooks-wait.md
@@ -2,4 +2,4 @@
 '@ai-sdk/harness': patch
 ---
 
-Ensure harness telemetry hooks are awaited before stream processing continues.
+fix(harness): ensure harness telemetry hooks are awaited before stream processing continues

--- a/packages/harness/src/agent/internal/run-prompt.test.ts
+++ b/packages/harness/src/agent/internal/run-prompt.test.ts
@@ -250,6 +250,108 @@ describe('runPrompt usage', () => {
   });
 });
 
+describe('runPrompt telemetry lifecycle', () => {
+  test('does not settle until async end callbacks complete in order', async () => {
+    const events: string[] = [];
+    let resolveLanguageModelEnd!: () => void;
+    let resolveStepEnd!: () => void;
+    let resolveEnd!: () => void;
+    const languageModelEnd = new Promise<void>(resolve => {
+      resolveLanguageModelEnd = resolve;
+    });
+    const stepEnd = new Promise<void>(resolve => {
+      resolveStepEnd = resolve;
+    });
+    const end = new Promise<void>(resolve => {
+      resolveEnd = resolve;
+    });
+    const integration = {
+      async onLanguageModelCallEnd() {
+        events.push('language-model-end:start');
+        await languageModelEnd;
+        events.push('language-model-end:done');
+      },
+      async onStepEnd() {
+        events.push('step-end:start');
+        await stepEnd;
+        events.push('step-end:done');
+      },
+      async onEnd() {
+        events.push('end:start');
+        await end;
+        events.push('end:done');
+      },
+    } satisfies Telemetry;
+
+    const { result, done } = runPrompt({
+      harness,
+      session: fakeSession([
+        { type: 'stream-start' },
+        { type: 'text-delta', id: 'text-1', delta: 'done' },
+        ...finishEvents,
+      ]),
+      prompt: 'go',
+      instructions: undefined,
+      tools: {} as ToolSet,
+      toolSpecs: [],
+      sandboxSession,
+      sessionWorkDir: WORK_DIR,
+      runtimeContext: {} as never,
+      abortSignal: undefined,
+      telemetry: { integrations: [integration] },
+    });
+
+    let settled = false;
+    void done.finally(() => {
+      settled = true;
+    });
+    const consumeStream = (async () => {
+      for await (const _part of result.fullStream) {
+        // Drain the stream while lifecycle callbacks are gated.
+      }
+    })();
+
+    await vi.waitFor(() => {
+      expect(events).toEqual(['language-model-end:start']);
+    });
+    expect(settled).toBe(false);
+
+    resolveLanguageModelEnd();
+    await vi.waitFor(() => {
+      expect(events).toEqual([
+        'language-model-end:start',
+        'language-model-end:done',
+        'step-end:start',
+      ]);
+    });
+    expect(settled).toBe(false);
+
+    resolveStepEnd();
+    await vi.waitFor(() => {
+      expect(events).toEqual([
+        'language-model-end:start',
+        'language-model-end:done',
+        'step-end:start',
+        'step-end:done',
+        'end:start',
+      ]);
+    });
+    expect(settled).toBe(false);
+
+    resolveEnd();
+    await Promise.all([done, consumeStream]);
+    expect(settled).toBe(true);
+    expect(events).toEqual([
+      'language-model-end:start',
+      'language-model-end:done',
+      'step-end:start',
+      'step-end:done',
+      'end:start',
+      'end:done',
+    ]);
+  });
+});
+
 describe('runPrompt step accounting', () => {
   test('records one step per finish-step without counting terminal finish', async () => {
     const { result, done } = runPrompt({

--- a/packages/harness/src/agent/internal/run-prompt.test.ts
+++ b/packages/harness/src/agent/internal/run-prompt.test.ts
@@ -288,7 +288,8 @@ describe('runPrompt telemetry lifecycle', () => {
       session: fakeSession([
         { type: 'stream-start' },
         { type: 'text-delta', id: 'text-1', delta: 'done' },
-        ...finishEvents,
+        finishEvents[0]!,
+        { type: 'text-delta', id: 'text-2', delta: 'ignored' },
       ]),
       prompt: 'go',
       instructions: undefined,
@@ -298,6 +299,7 @@ describe('runPrompt telemetry lifecycle', () => {
       sessionWorkDir: WORK_DIR,
       runtimeContext: {} as never,
       abortSignal: undefined,
+      stopConditions: [({ steps }) => steps.length === 1],
       telemetry: { integrations: [integration] },
     });
 

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -184,7 +184,7 @@ export function runPrompt<
               },
       });
     } catch (err) {
-      telemetry.error(err);
+      await telemetry.error(err);
       logBridgeError({
         harnessId: input.harness.harnessId,
         sessionId: input.session.sessionId,
@@ -278,12 +278,12 @@ export function runPrompt<
       unified: 'tool-calls',
       raw: undefined,
     };
-    const completeStep = (input: {
+    const completeStep = async (input: {
       finishReason: LanguageModelV4FinishReason;
       usage: LanguageModelV4Usage;
       providerMetadata: ProviderMetadata | undefined;
-    }): StepResult<TOOLS, RUNTIME_CONTEXT> => {
-      telemetry.stepFinish({
+    }): Promise<StepResult<TOOLS, RUNTIME_CONTEXT>> => {
+      await telemetry.stepFinish({
         finishReason: input.finishReason,
         usage: input.usage,
         providerMetadata: input.providerMetadata,
@@ -303,13 +303,13 @@ export function runPrompt<
       completeCurrentStep: boolean;
     }): Promise<void> => {
       if (options.completeCurrentStep) {
-        completeStep({
+        await completeStep({
           finishReason: toolCallsFinishReason,
           usage: zeroUsage,
           providerMetadata: undefined,
         });
       }
-      telemetry.end({
+      await telemetry.end({
         finishReason: toolCallsFinishReason,
         usage: zeroUsage,
       });
@@ -435,7 +435,7 @@ export function runPrompt<
           input: approval.input,
         } satisfies Extract<HarnessV1StreamPart, { type: 'tool-call' }>);
 
-      telemetry.start(input.session.modelId);
+      await telemetry.start(input.session.modelId);
       await telemetry.toolStart({
         toolCallId: rawToolCall.toolCallId,
         toolName: rawToolCall.toolName,
@@ -476,7 +476,7 @@ export function runPrompt<
         await finishForHostInputPause({ completeCurrentStep: false });
         return 'awaiting-tool-result';
       }
-      telemetry.toolEnd(rawToolCall.toolCallId, execution.outcome);
+      await telemetry.toolEnd(rawToolCall.toolCallId, execution.outcome);
       return 'continued';
     };
 
@@ -539,7 +539,7 @@ export function runPrompt<
         // Begin the operation span on stream-start, using the runtime-resolved
         // model the adapter reports (falling back to the session's model).
         if (value.type === 'stream-start') {
-          telemetry.start(value.modelId ?? input.session.modelId);
+          await telemetry.start(value.modelId ?? input.session.modelId);
         }
 
         // Open a step span lazily before the first content of each step.
@@ -549,7 +549,7 @@ export function runPrompt<
           value.type !== 'finish' &&
           value.type !== 'error'
         ) {
-          telemetry.ensureStepOpen();
+          await telemetry.ensureStepOpen();
         }
 
         /*
@@ -620,7 +620,7 @@ export function runPrompt<
           // Telemetry and stderr diagnostics keep the raw error (absolute
           // paths help debugging); the consumer-facing settle uses the
           // workDir-stripped one, like every other forwarded part.
-          telemetry.error(value.error);
+          await telemetry.error(value.error);
           logBridgeError({
             harnessId: input.harness.harnessId,
             sessionId: input.session.sessionId,
@@ -673,7 +673,7 @@ export function runPrompt<
 
         // Telemetry: close a tool span when its provider-executed result lands.
         if (value.type === 'tool-result') {
-          telemetry.toolEnd(
+          await telemetry.toolEnd(
             value.toolCallId,
             value.isError
               ? { ok: false, error: value.result }
@@ -736,7 +736,7 @@ export function runPrompt<
 
         // Drive step boundaries.
         if (value.type === 'finish-step') {
-          completeStep({
+          await completeStep({
             finishReason: value.finishReason,
             usage: value.usage,
             providerMetadata: value.harnessMetadata,
@@ -752,7 +752,7 @@ export function runPrompt<
 
         if (value.type === 'finish') {
           finalFinish = value;
-          telemetry.end({
+          await telemetry.end({
             finishReason: value.finishReason,
             usage: value.totalUsage,
           });
@@ -778,7 +778,7 @@ export function runPrompt<
               toolCallId: toolCall.toolCallId,
               output,
             });
-            telemetry.toolEnd(toolCall.toolCallId, { ok: true, output });
+            await telemetry.toolEnd(toolCall.toolCallId, { ok: true, output });
             continue;
           }
           const customToolApprovalDecision = resolveCustomToolApproval({
@@ -807,7 +807,7 @@ export function runPrompt<
               toolCallId: toolCall.toolCallId,
               output,
             });
-            telemetry.toolEnd(toolCall.toolCallId, { ok: true, output });
+            await telemetry.toolEnd(toolCall.toolCallId, { ok: true, output });
             continue;
           }
           const pendingApproval =
@@ -905,7 +905,7 @@ export function runPrompt<
             await finishForHostInputPause({ completeCurrentStep: true });
             return;
           }
-          telemetry.toolEnd(toolCall.toolCallId, execution.outcome);
+          await telemetry.toolEnd(toolCall.toolCallId, execution.outcome);
         }
       }
       if (finalFinish != null) {
@@ -923,7 +923,7 @@ export function runPrompt<
           : undefined,
       );
     } catch (err) {
-      telemetry.error(err);
+      await telemetry.error(err);
       logBridgeError({
         harnessId: input.harness.harnessId,
         sessionId: input.session.sessionId,

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -528,7 +528,7 @@ export function runPrompt<
             await input.onStopConditionMet?.();
             const { finishReason, usage } = pendingStopBoundary;
             releasePendingStopBoundary();
-            telemetry.end({ finishReason, usage });
+            await telemetry.end({ finishReason, usage });
             await result.finish();
             return;
           } else {

--- a/packages/harness/src/agent/internal/turn-telemetry.test.ts
+++ b/packages/harness/src/agent/internal/turn-telemetry.test.ts
@@ -13,7 +13,7 @@ const usage = {
 };
 
 describe('createTurnTelemetry', () => {
-  test('includes the current stepNumber on onStepEnd events', () => {
+  test('includes the current stepNumber on onStepEnd events', async () => {
     const stepStartNumbers: number[] = [];
     const stepEndNumbers: number[] = [];
     const integration = {
@@ -34,16 +34,16 @@ describe('createTurnTelemetry', () => {
       runtimeContext: undefined,
     });
 
-    telemetry.start();
-    telemetry.ensureStepOpen();
-    telemetry.stepFinish({
+    await telemetry.start();
+    await telemetry.ensureStepOpen();
+    await telemetry.stepFinish({
       finishReason: { unified: 'stop', raw: 'stop' },
       usage,
       content: [{ type: 'text', text: 'done' }],
     });
 
-    telemetry.ensureStepOpen();
-    telemetry.end({
+    await telemetry.ensureStepOpen();
+    await telemetry.end({
       finishReason: { unified: 'stop', raw: 'stop' },
       usage,
     });

--- a/packages/harness/src/agent/internal/turn-telemetry.ts
+++ b/packages/harness/src/agent/internal/turn-telemetry.ts
@@ -42,9 +42,9 @@ export interface TurnTelemetry {
    * model the runtime resolved to (overriding the session's configured id).
    * Idempotent — the first call wins.
    */
-  start(modelId?: string): void;
+  start(modelId?: string): Promise<void>;
   /** Open a step span lazily, before the first content of a step. */
-  ensureStepOpen(): void;
+  ensureStepOpen(): Promise<void>;
   /** Close the current step (on a harness `finish-step`). */
   stepFinish(info: {
     finishReason: unknown;
@@ -52,13 +52,13 @@ export interface TurnTelemetry {
     providerMetadata?: unknown;
     /** The model's output content for this step (text/reasoning/tool-calls). */
     content?: TurnContentPart[];
-  }): void;
+  }): Promise<void>;
   /** A tool execution began (on a `tool-call`). */
   toolStart(call: {
     toolCallId: string;
     toolName: string;
     input: unknown;
-  }): void | Promise<void>;
+  }): Promise<void>;
   /** Execute a host tool through each telemetry integration's context wrapper. */
   executeTool<T>(input: {
     toolCallId: string;
@@ -72,24 +72,24 @@ export interface TurnTelemetry {
   toolEnd(
     toolCallId: string,
     output: { ok: true; output: unknown } | { ok: false; error: unknown },
-  ): void;
+  ): Promise<void>;
   /** The turn ended (on a harness `finish`). */
-  end(info: { finishReason: unknown; usage: unknown }): void;
+  end(info: { finishReason: unknown; usage: unknown }): Promise<void>;
   /** The turn failed. */
-  error(err: unknown): void;
+  error(err: unknown): Promise<void>;
 }
 
 const NOOP: TurnTelemetry = {
-  start() {},
-  ensureStepOpen() {},
-  stepFinish() {},
+  async start() {},
+  async ensureStepOpen() {},
+  async stepFinish() {},
   async toolStart() {},
   async executeTool({ execute }) {
     return await execute();
   },
-  toolEnd() {},
-  end() {},
-  error() {},
+  async toolEnd() {},
+  async end() {},
+  async error() {},
 };
 
 export function createTurnTelemetry(opts: {
@@ -130,10 +130,10 @@ export function createTurnTelemetry(opts: {
 
   // onStart — open the operation (root) span. Deferred until `start()` so the
   // runtime-resolved model can be attached to the operation span + trace label.
-  const fireStart = (): void => {
+  const fireStart = async (): Promise<void> => {
     if (started) return;
     started = true;
-    dispatcher.onStart?.(
+    await dispatcher.onStart?.(
       cast<'onStart'>({
         callId,
         operationId: 'ai.harness',
@@ -155,17 +155,17 @@ export function createTurnTelemetry(opts: {
     );
   };
 
-  const start = (overrideModelId?: string): void => {
+  const start = async (overrideModelId?: string): Promise<void> => {
     if (started) return;
     if (overrideModelId) modelId = overrideModelId;
-    fireStart();
+    await fireStart();
   };
 
-  const ensureStepOpen = (): void => {
-    if (!started) fireStart();
+  const ensureStepOpen = async (): Promise<void> => {
+    if (!started) await fireStart();
     if (stepOpen || ended) return;
     stepOpen = true;
-    dispatcher.onStepStart?.(
+    await dispatcher.onStepStart?.(
       cast<'onStepStart'>({
         callId,
         provider,
@@ -183,7 +183,7 @@ export function createTurnTelemetry(opts: {
     );
     // Open the inference (language-model call) span — the gen_ai home for the
     // step's input and (on end) output messages.
-    dispatcher.onLanguageModelCallStart?.(
+    await dispatcher.onLanguageModelCallStart?.(
       cast<'onLanguageModelCallStart'>({
         callId,
         provider,
@@ -195,12 +195,12 @@ export function createTurnTelemetry(opts: {
   };
 
   /** Close the inference span with the step's output content. */
-  const inferenceEnd = (info: {
+  const inferenceEnd = async (info: {
     finishReason: unknown;
     usage: unknown;
     content: TurnContentPart[];
-  }): void => {
-    dispatcher.onLanguageModelCallEnd?.(
+  }): Promise<void> => {
+    await dispatcher.onLanguageModelCallEnd?.(
       cast<'onLanguageModelCallEnd'>({
         callId,
         finishReason: info.finishReason,
@@ -211,9 +211,9 @@ export function createTurnTelemetry(opts: {
     );
   };
 
-  const closeOpenTools = (): void => {
+  const closeOpenTools = async (): Promise<void> => {
     for (const call of openTools.values()) {
-      dispatcher.onToolExecutionEnd?.(
+      await dispatcher.onToolExecutionEnd?.(
         cast<'onToolExecutionEnd'>({
           callId,
           toolExecutionMs: 0,
@@ -237,16 +237,16 @@ export function createTurnTelemetry(opts: {
     start,
     ensureStepOpen,
 
-    stepFinish(info) {
+    async stepFinish(info) {
       if (!stepOpen) return;
       const content = info.content ?? [];
-      closeOpenTools();
-      inferenceEnd({
+      await closeOpenTools();
+      await inferenceEnd({
         finishReason: info.finishReason,
         usage: info.usage,
         content,
       });
-      dispatcher.onStepEnd?.(
+      await dispatcher.onStepEnd?.(
         cast<'onStepEnd'>({
           callId,
           stepNumber,
@@ -267,7 +267,7 @@ export function createTurnTelemetry(opts: {
     },
 
     async toolStart(call) {
-      ensureStepOpen();
+      await ensureStepOpen();
       if (openTools.has(call.toolCallId)) return;
       openTools.set(call.toolCallId, call);
       await dispatcher.onToolExecutionStart?.(
@@ -291,11 +291,11 @@ export function createTurnTelemetry(opts: {
       return await dispatcher.executeTool({ callId, toolCallId, execute });
     },
 
-    toolEnd(toolCallId, output) {
+    async toolEnd(toolCallId, output) {
       const call = openTools.get(toolCallId);
       if (call == null) return;
       openTools.delete(toolCallId);
-      dispatcher.onToolExecutionEnd?.(
+      await dispatcher.onToolExecutionEnd?.(
         cast<'onToolExecutionEnd'>({
           callId,
           toolExecutionMs: 0,
@@ -315,17 +315,17 @@ export function createTurnTelemetry(opts: {
       );
     },
 
-    end(info) {
+    async end(info) {
       if (ended) return;
-      if (!started) fireStart();
+      if (!started) await fireStart();
       if (stepOpen) {
-        closeOpenTools();
-        inferenceEnd({
+        await closeOpenTools();
+        await inferenceEnd({
           finishReason: info.finishReason,
           usage: info.usage,
           content: [],
         });
-        dispatcher.onStepEnd?.(
+        await dispatcher.onStepEnd?.(
           cast<'onStepEnd'>({
             callId,
             stepNumber,
@@ -344,7 +344,7 @@ export function createTurnTelemetry(opts: {
         stepOpen = false;
       }
       ended = true;
-      dispatcher.onEnd?.(
+      await dispatcher.onEnd?.(
         cast<'onEnd'>({
           callId,
           operationId: 'ai.harness',
@@ -364,12 +364,12 @@ export function createTurnTelemetry(opts: {
       );
     },
 
-    error(err) {
+    async error(err) {
       if (ended) return;
-      if (!started) fireStart();
-      closeOpenTools();
+      if (!started) await fireStart();
+      await closeOpenTools();
       ended = true;
-      dispatcher.onError?.(err);
+      await dispatcher.onError?.(err);
     },
   };
 }


### PR DESCRIPTION
## Background

Telemetry integrations may perform asynchronous work, such as exporting spans or persisting traces. AI SDK’s `Telemetry` contract therefore allows lifecycle callbacks to return `PromiseLike<void>`.

The `HarnessAgent` was invoking these callbacks without awaiting their returned promises. Consequently, `generate()` could resolve while final telemetry work was still in flight. In short-lived environments—such as serverless functions and test processes—the runtime or session could then be torn down before the final language-model, step, and operation events were persisted, resulting in incomplete traces.

Awaiting these callbacks also preserves lifecycle ordering: language-model completion finishes before step completion, and step completion finishes before operation completion.

## Summary

- Make the internal Harness telemetry lifecycle methods return `Promise<void>`.
- Await telemetry callbacks throughout `runPrompt`, including operation, step, model-call, tool, end, and error events.
- Ensure a Harness turn does not settle until its terminal telemetry callbacks have completed.
- Add a regression test using delayed `onLanguageModelCallEnd`, `onStepEnd`, and `onEnd` callbacks to verify that:
  - the turn remains pending while telemetry is in flight;
  - callbacks complete in lifecycle order.

The affected telemetry driver and prompt runner are internal. Public Harness APIs and return types are unchanged. The observable behavior change is that turn completion now waits for asynchronous telemetry finalization, as required by the telemetry callback contract.

## End-to-End Verification

Verified with real HarnessAgent + Pi turns.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

- Originally stacked on https://github.com/vercel/ai/pull/17783 (PR name was bad there, sorry)!