### PR TITLE
fix(harness-deepagents): fix Deep Agents missing model ID in telemetry

### DIFF
--- a/.changeset/lazy-frogs-divide.md
+++ b/.changeset/lazy-frogs-divide.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-deepagents": patch
+---
+
+fix(harness-deepagents): fix Deep Agents missing model ID in telemetry

--- a/packages/harness-deepagents/src/bridge/index.ts
+++ b/packages/harness-deepagents/src/bridge/index.ts
@@ -45,6 +45,21 @@ function parseArgs(rawArgs: string[]): Record<string, string> {
   return out;
 }
 
+function resolveDeepAgentsModelId({
+  configuredModel,
+  metadata,
+}: {
+  configuredModel: string | undefined;
+  metadata: unknown;
+}): string | undefined {
+  if (metadata && typeof metadata === 'object' && !Array.isArray(metadata)) {
+    const modelId = (metadata as { ls_model_name?: unknown }).ls_model_name;
+    if (typeof modelId === 'string' && modelId.length > 0) return modelId;
+  }
+
+  return configuredModel;
+}
+
 // Always drive the Anthropic client. Through the gateway, models keep their
 // `creator/model` slug (gateway translates); direct Anthropic wants the bare id.
 function buildModel(rawModel: string | undefined) {
@@ -162,12 +177,8 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     });
   }
 
-  emit({
-    type: 'stream-start',
-    ...(start.model ? { modelId: start.model } : {}),
-  });
-
   const hostToolNames = new Set((start.tools ?? []).map(t => t.name));
+  let streamStarted = false;
   let textBlockId: string | undefined;
   let reasoningBlockId: string | undefined;
   let inputTokens = 0;
@@ -265,8 +276,21 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
       const nested = ns.includes('|');
 
       if (kind === 'on_chat_model_start') {
-        // A new top-level model call means the previous step's tools have run; close it now.
-        if (!nested) flushStep();
+        if (!nested) {
+          if (!streamStarted) {
+            streamStarted = true;
+            const modelId = resolveDeepAgentsModelId({
+              configuredModel: start.model,
+              metadata: event.metadata,
+            });
+            emit({
+              type: 'stream-start',
+              ...(modelId ? { modelId } : {}),
+            });
+          }
+          // A new top-level model call means the previous step's tools have run; close it now.
+          flushStep();
+        }
       } else if (kind === 'on_chat_model_stream') {
         if (nested) continue;
         const chunk = data.chunk as


### PR DESCRIPTION
## Background

The Deep Agents harnesses was not yet capturing the model ID used for telemetry, unlike other harnesses.

## Summary

This PR adds capturing the model used.

## End-to-End Verification

End-to-end testing via `examples/harness-e2e-next` confirms this is now working.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
