### PR TITLE
fix(harness-opencode): fix OpenCode missing model ID in telemetry

### DIFF
--- a/.changeset/sharp-lobsters-doubt.md
+++ b/.changeset/sharp-lobsters-doubt.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-opencode": patch
+---
+
+fix(harness-opencode): fix OpenCode missing model ID in telemetry

--- a/packages/harness-opencode/src/bridge/index.ts
+++ b/packages/harness-opencode/src/bridge/index.ts
@@ -18,6 +18,7 @@ import {
   emitLegacyPartDelta,
   emitLegacyTextPartUpdate,
   emitMissingFinalDelta,
+  emitOpenCodeStreamStart,
   getOpenCodeEventSessionId,
   isStepSettlementEvent,
   type OpenCodeEvent,
@@ -562,6 +563,7 @@ async function runPrompt({
   let sawFinishStep = false;
   let sawBusy = false;
   let terminalError: string | undefined;
+  const state = createTranslationState();
   const initialSessionTokens = await readSessionTokens({
     client,
     sessionId,
@@ -575,6 +577,7 @@ async function runPrompt({
     permissionMode: start.permissionMode,
     builtinToolFiltering: start.builtinToolFiltering,
     turn,
+    state,
     emit: msg => {
       if (msg.type === 'text-delta' || msg.type === 'reasoning-delta') {
         sawContent = true;
@@ -591,6 +594,13 @@ async function runPrompt({
     signal: eventsAbort.signal,
     onSubscribed: () => eventsReady.resolve(undefined),
     onEvent: event => {
+      if (event.type === 'message.updated') {
+        emitOpenCodeStreamStart({
+          info: event.properties?.info,
+          state,
+          emit,
+        });
+      }
       if (event.type === 'session.updated') {
         latestSessionTokens =
           extractSessionTokens(event.properties) ?? latestSessionTokens;
@@ -619,10 +629,6 @@ async function runPrompt({
     eventsReady.resolve(undefined);
     turnSettled.resolve();
   });
-  emit({
-    type: 'stream-start',
-    ...(start.model ? { modelId: start.model } : {}),
-  });
   await eventsReady.promise;
   const prompted = await legacySessionPrompt({
     client,
@@ -641,6 +647,7 @@ async function runPrompt({
     const emittedFallback = await emitContextFallback({
       client,
       sessionId,
+      state,
       emit,
       emitContent: !sawContent,
     }).catch(() => false);
@@ -701,6 +708,7 @@ async function runCompaction({
     permissionMode: start.permissionMode,
     builtinToolFiltering: start.builtinToolFiltering,
     turn,
+    state: createTranslationState(),
     emit: msg => {
       if (msg.type === 'compaction') sawCompaction = true;
       emit(msg);
@@ -764,6 +772,7 @@ async function consumeEvents({
   permissionMode,
   builtinToolFiltering,
   turn,
+  state,
   emit,
   signal,
   onSubscribed,
@@ -774,6 +783,7 @@ async function consumeEvents({
   permissionMode: StartMessage['permissionMode'];
   builtinToolFiltering: StartMessage['builtinToolFiltering'];
   turn: BridgeTurn;
+  state: TranslationState;
   emit: Emit;
   signal: AbortSignal;
   onSubscribed?: () => void;
@@ -782,7 +792,6 @@ async function consumeEvents({
   const stream = await subscribeLegacyEvents({ client, signal });
   onSubscribed?.();
   if (!stream) return;
-  const state = createTranslationState();
   for await (const rawEvent of stream) {
     if (signal.aborted || turn.abortSignal.aborted) break;
     const event = unwrapOpenCodeEvent(rawEvent);
@@ -1509,16 +1518,19 @@ function authorizeHostToolCall({
 async function emitContextFallback({
   client,
   sessionId,
+  state,
   emit,
   emitContent,
 }: {
   client: OpenCodeClient;
   sessionId: string;
+  state: TranslationState;
   emit: Emit;
   emitContent: boolean;
 }): Promise<boolean> {
   const assistant = await latestAssistantSnapshot({ client, sessionId });
   if (!assistant) return false;
+  emitOpenCodeStreamStart({ info: assistant, state, emit });
   if (emitContent && Array.isArray(assistant.contentParts)) {
     for (const part of assistant.contentParts) {
       emitAssistantContentPart(part, emit);

--- a/packages/harness-opencode/src/bridge/opencode-events.test.ts
+++ b/packages/harness-opencode/src/bridge/opencode-events.test.ts
@@ -4,6 +4,7 @@ import {
   emitLegacyPartDelta,
   emitLegacyTextPartUpdate,
   emitMissingFinalDelta,
+  emitOpenCodeStreamStart,
   getOpenCodeEventSessionId,
   isStepSettlementEvent,
   unwrapOpenCodeEvent,
@@ -70,6 +71,49 @@ describe('OpenCode event helpers', () => {
         },
       }),
     ).toBe('session-1');
+  });
+
+  it('emits the resolved assistant model once', () => {
+    const state = createTranslationState();
+    const emitted: Record<string, unknown>[] = [];
+    const emit = (message: Record<string, unknown>) => emitted.push(message);
+
+    emitOpenCodeStreamStart({
+      info: {
+        role: 'user',
+        providerID: 'anthropic',
+        modelID: 'claude-sonnet-4-6',
+      },
+      state,
+      emit,
+    });
+    emitOpenCodeStreamStart({
+      info: {
+        role: 'assistant',
+        providerID: 'anthropic',
+        modelID: 'claude-sonnet-4-6',
+      },
+      state,
+      emit,
+    });
+    emitOpenCodeStreamStart({
+      info: {
+        role: 'assistant',
+        providerID: 'openai',
+        modelID: 'gpt-5.3-codex',
+      },
+      state,
+      emit,
+    });
+
+    expect(emitted).toMatchInlineSnapshot(`
+      [
+        {
+          "modelId": "anthropic/claude-sonnet-4-6",
+          "type": "stream-start",
+        },
+      ]
+    `);
   });
 
   it('emits only the final text that has not already streamed', () => {

--- a/packages/harness-opencode/src/bridge/opencode-events.test.ts
+++ b/packages/harness-opencode/src/bridge/opencode-events.test.ts
@@ -116,6 +116,34 @@ describe('OpenCode event helpers', () => {
     `);
   });
 
+  it('emits stream-start without a model when assistant metadata omits it', () => {
+    const state = createTranslationState();
+    const emitted: Record<string, unknown>[] = [];
+
+    emitOpenCodeStreamStart({
+      info: { role: 'assistant' },
+      state,
+      emit: message => emitted.push(message),
+    });
+    emitOpenCodeStreamStart({
+      info: {
+        role: 'assistant',
+        providerID: 'anthropic',
+        modelID: 'claude-sonnet-4-6',
+      },
+      state,
+      emit: message => emitted.push(message),
+    });
+
+    expect(emitted).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+        },
+      ]
+    `);
+  });
+
   it('emits only the final text that has not already streamed', () => {
     const emitted: Record<string, unknown>[] = [];
 

--- a/packages/harness-opencode/src/bridge/opencode-events.ts
+++ b/packages/harness-opencode/src/bridge/opencode-events.ts
@@ -7,6 +7,7 @@ export type OpenCodeEvent = {
 type Emit = (msg: Record<string, unknown>) => void;
 
 export type TranslationState = {
+  streamStarted: boolean;
   textDeltas: Map<string, string>;
   reasoningDeltas: Map<string, string>;
   toolInputs: Map<string, string>;
@@ -24,6 +25,7 @@ export type TranslationState = {
 
 export function createTranslationState(): TranslationState {
   return {
+    streamStarted: false,
     textDeltas: new Map(),
     reasoningDeltas: new Map(),
     toolInputs: new Map(),
@@ -38,6 +40,25 @@ export function createTranslationState(): TranslationState {
     legacyReasoningPartIds: new Set(),
     legacyStepFinishPartIds: new Set(),
   };
+}
+
+export function emitOpenCodeStreamStart({
+  info,
+  state,
+  emit,
+}: {
+  info: unknown;
+  state: TranslationState;
+  emit: Emit;
+}): void {
+  if (state.streamStarted || !isRecord(info)) return;
+  if (info.role !== 'assistant' && info.type !== 'assistant') return;
+  const providerID = stringValue(info.providerID);
+  const modelID = stringValue(info.modelID);
+  if (!providerID || !modelID) return;
+
+  state.streamStarted = true;
+  emit({ type: 'stream-start', modelId: `${providerID}/${modelID}` });
 }
 
 export function unwrapOpenCodeEvent(

--- a/packages/harness-opencode/src/bridge/opencode-events.ts
+++ b/packages/harness-opencode/src/bridge/opencode-events.ts
@@ -55,10 +55,11 @@ export function emitOpenCodeStreamStart({
   if (info.role !== 'assistant' && info.type !== 'assistant') return;
   const providerID = stringValue(info.providerID);
   const modelID = stringValue(info.modelID);
-  if (!providerID || !modelID) return;
+  const modelId =
+    providerID && modelID ? `${providerID}/${modelID}` : undefined;
 
   state.streamStarted = true;
-  emit({ type: 'stream-start', modelId: `${providerID}/${modelID}` });
+  emit({ type: 'stream-start', ...(modelId ? { modelId } : {}) });
 }
 
 export function unwrapOpenCodeEvent(


### PR DESCRIPTION
## Background

The OpenCode harnesses was not yet capturing the model ID used for telemetry, unlike other harnesses.

## Summary

This PR adds capturing the model used.

## End-to-End Verification

End-to-end testing via `examples/harness-e2e-next` confirms this is now working.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
