### PR TITLE
fix(harness): avoid incorrectly marked invalid tool calls due to `dynamic` flag being dropped

### DIFF
--- a/.changeset/young-ducks-attack.md
+++ b/.changeset/young-ducks-attack.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness": patch
+---
+
+fix(harness): avoid incorrectly marked invalid tool calls due to `dynamic` flag being dropped

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -1080,6 +1080,7 @@ export async function validateToolCall<TOOLS extends ToolSet>(args: {
     ...(event.providerExecuted !== undefined
       ? { providerExecuted: event.providerExecuted }
       : {}),
+    ...(event.dynamic !== undefined ? { dynamic: event.dynamic } : {}),
     ...(event.providerMetadata !== undefined
       ? { providerMetadata: event.providerMetadata }
       : {}),

--- a/packages/harness/src/agent/internal/validate-tool-call.test.ts
+++ b/packages/harness/src/agent/internal/validate-tool-call.test.ts
@@ -87,11 +87,37 @@ describe('validateToolCall', () => {
     );
   });
 
-  it('omits providerExecuted when the bridge did not set it', async () => {
+  it('accepts an undeclared provider-executed dynamic tool', async () => {
     const result = await validateToolCall<typeof tools>({
       event: {
         type: 'tool-call',
         toolCallId: 'c4',
+        toolName: 'runtimeTool',
+        input: '{"value":"test"}',
+        providerExecuted: true,
+        dynamic: true,
+      },
+      tools,
+    });
+
+    expect(result).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'c4',
+      toolName: 'runtimeTool',
+      input: { value: 'test' },
+      providerExecuted: true,
+      dynamic: true,
+    });
+    expect(
+      (result as ToolCall & { invalid?: boolean }).invalid,
+    ).toBeUndefined();
+  });
+
+  it('omits providerExecuted when the bridge did not set it', async () => {
+    const result = await validateToolCall<typeof tools>({
+      event: {
+        type: 'tool-call',
+        toolCallId: 'c5',
         toolName: 'bash',
         input: '{"command":"ls"}',
       },
@@ -113,7 +139,7 @@ describe('validateToolCall', () => {
     const result = await validateToolCall<typeof noArgsTool>({
       event: {
         type: 'tool-call',
-        toolCallId: 'c5',
+        toolCallId: 'c6',
         toolName: 'empty',
         input: '',
         providerExecuted: true,
@@ -122,7 +148,7 @@ describe('validateToolCall', () => {
     });
     expect(result).toMatchObject({
       type: 'tool-call',
-      toolCallId: 'c5',
+      toolCallId: 'c6',
       toolName: 'empty',
       input: {},
     });


### PR DESCRIPTION
## Background

Provider-executed dynamic tool calls can be absent from the merged tool set. The harness dropped their `dynamic` flag before validation, causing otherwise valid calls to be marked invalid.

## Summary

- Preserve the optional `dynamic` flag when converting harness tool-call events for validation.
- Add regression coverage for undeclared provider-executed dynamic tools.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
