### PR TITLE
chore(harness): refactor bridge code to break out stream event emission from launcher to make it testable

### DIFF
--- a/.changeset/few-melons-burn.md
+++ b/.changeset/few-melons-burn.md
@@ -1,0 +1,8 @@
+---
+"@ai-sdk/harness-claude-code": patch
+"@ai-sdk/harness-deepagents": patch
+"@ai-sdk/harness-opencode": patch
+"@ai-sdk/harness-codex": patch
+---
+
+chore(harness): refactor bridge code to break out stream event emission from launcher to make it testable

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -298,10 +298,15 @@
           "description": "Every harness bridge index file must declare and use the relevant symbols.",
           "for": { "files": ["bridge/index.ts"] },
           "must": {
+            "haveFiles": ["create-emit-stream-event.ts"],
             "import": [
               {
                 "name": "runBridge",
                 "from": "@ai-sdk/harness/bridge"
+              },
+              {
+                "name": "createEmitStreamEvent",
+                "from": "./create-emit-stream-event"
               }
             ],
             "importTypes": [
@@ -325,6 +330,14 @@
                 "returnValueOfType": "Promise<void>"
               }
             ]
+          }
+        },
+        {
+          "name": "harness-stream-event-emitter-must-export-factory",
+          "description": "Every harness stream event emitter file must export its factory function.",
+          "for": { "files": ["bridge/create-emit-stream-event.ts"] },
+          "must": {
+            "exportFunctions": ["createEmitStreamEvent"]
           }
         },
         {

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createClaudeStreamEventState,
+  createEmitStreamEvent,
+} from './create-emit-stream-event';
+
+describe('createEmitStreamEvent', () => {
+  it('emits the resolved model and a native tool step', () => {
+    const state = createClaudeStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: event => emitted.push(event),
+      emitWarning: () => {},
+      emitTerminalError: () => {},
+      onCompactionBoundary: () => {},
+      toCommonName: name => (name === 'Bash' ? 'bash' : name),
+    });
+
+    emitStreamEvent({ type: 'system', subtype: 'init', model: 'claude-opus' });
+    emitStreamEvent({
+      type: 'assistant',
+      message: {
+        usage: { input_tokens: 3, output_tokens: 2 },
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-1',
+            name: 'Bash',
+            input: { command: 'pwd' },
+          },
+        ],
+      },
+    });
+    emitStreamEvent({
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-1',
+            content: '/tmp',
+          },
+        ],
+      },
+    });
+
+    expect(emitted).toMatchInlineSnapshot(`
+      [
+        {
+          "modelId": "claude-opus",
+          "type": "stream-start",
+        },
+        {
+          "input": "{\"command\":\"pwd\"}",
+          "nativeName": "Bash",
+          "providerExecuted": true,
+          "toolCallId": "tool-1",
+          "toolName": "bash",
+          "type": "tool-call",
+        },
+        {
+          "isError": false,
+          "result": {
+            "exitCode": 0,
+            "stdout": "/tmp",
+          },
+          "toolCallId": "tool-1",
+          "toolName": "bash",
+          "type": "tool-result",
+        },
+        {
+          "finishReason": {
+            "raw": "stop",
+            "unified": "stop",
+          },
+          "type": "finish-step",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": 0,
+              "noCache": 3,
+              "total": 3,
+            },
+            "outputTokens": {
+              "text": 2,
+              "total": 2,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('preserves retry and compaction handling', () => {
+    const state = createClaudeStreamEventState();
+    const warnings: unknown[] = [];
+    const terminalErrors: unknown[] = [];
+    const boundaries: unknown[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: () => {},
+      emitWarning: warning => warnings.push(warning),
+      emitTerminalError: error => terminalErrors.push(error),
+      onCompactionBoundary: boundary => boundaries.push(boundary),
+      toCommonName: name => name,
+    });
+
+    emitStreamEvent({
+      type: 'system',
+      subtype: 'api_retry',
+      attempt: 2,
+      max_retries: 4,
+      error_status: 500,
+      retry_delay_ms: 100,
+      error: 'temporary',
+    });
+    emitStreamEvent({
+      type: 'system',
+      subtype: 'compact_boundary',
+      compact_metadata: {
+        trigger: 'auto',
+        pre_tokens: 20,
+        post_tokens: 5,
+      },
+    });
+    emitStreamEvent({
+      type: 'system',
+      subtype: 'api_retry',
+      error_status: 401,
+      error: 'unauthorized',
+    });
+
+    expect({ warnings, terminalErrors, boundaries }).toMatchInlineSnapshot(`
+      {
+        "boundaries": [
+          {
+            "tokensAfter": 5,
+            "tokensBefore": 20,
+            "trigger": "auto",
+          },
+        ],
+        "terminalErrors": [
+          "HTTP 401: unauthorized",
+        ],
+        "warnings": [
+          {
+            "message": "Claude Code API retry: attempt 2/4; HTTP 500; retrying in 100ms; temporary",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
@@ -1,0 +1,448 @@
+import { randomUUID } from 'node:crypto';
+
+type Emit = (message: Record<string, unknown>) => void;
+
+export type ClaudeMessage = {
+  type?: string;
+  subtype?: string;
+  model?: string;
+  error?: string;
+  error_status?: number | null;
+  attempt?: number;
+  max_retries?: number;
+  retry_delay_ms?: number;
+  patch?: { status?: string; error?: string };
+  compact_metadata?: {
+    trigger: 'manual' | 'auto';
+    pre_tokens?: number;
+    post_tokens?: number;
+  };
+  event?: {
+    type?: string;
+    index?: number;
+    content_block?: { type?: string };
+    delta?: { type?: string; text?: string; thinking?: string };
+  };
+  message?: {
+    content?: ReadonlyArray<MessageBlock>;
+    usage?: Record<string, unknown>;
+  };
+  result?: string;
+  errors?: ReadonlyArray<string>;
+  usage?: Record<string, unknown>;
+  total_cost_usd?: number;
+};
+
+type MessageBlock = {
+  type: string;
+  text?: string;
+  thinking?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  content?: unknown;
+  is_error?: boolean;
+};
+
+export type ClaudeStreamEventState = {
+  /*
+   * Map of native tool-use id → tool name. Claude assistant messages emit
+   * `tool_use` blocks with both `id` and `name`; the matching `tool_result`
+   * block on a later user message carries only `tool_use_id`, so without this
+   * map the tool-result event would have to emit `toolName: 'unknown'`.
+   */
+  nativeToolCallNames: Map<string, string>;
+  approvalRequestedToolUseIds: Set<string>;
+  partialBlocks: Map<number, { id: string; kind: 'text' | 'thinking' }>;
+  stepUsage: Record<string, unknown> | undefined;
+  pendingStepToolUseIds: Set<string>;
+  pendingStepUsage: Record<string, unknown> | undefined;
+  stepOpen: boolean;
+  /*
+   * Tool-use ids that originated from the MCP server hosting user-supplied
+   * tools. The MCP handler emits its own `tool-call`/`tool-result` pair with
+   * the user-facing tool name and a synthetic id, so the duplicate
+   * `tool_result` block Claude reports for the underlying native id must be
+   * suppressed.
+   */
+  mcpToolUseIds: Set<string>;
+  observedTerminalError: string | undefined;
+};
+
+export function createClaudeStreamEventState(): ClaudeStreamEventState {
+  return {
+    nativeToolCallNames: new Map(),
+    approvalRequestedToolUseIds: new Set(),
+    partialBlocks: new Map(),
+    stepUsage: undefined,
+    pendingStepToolUseIds: new Set(),
+    pendingStepUsage: undefined,
+    stepOpen: false,
+    mcpToolUseIds: new Set(),
+    observedTerminalError: undefined,
+  };
+}
+
+const UNRECOVERABLE_API_RETRY_STATUSES = new Set([401, 403, 404]);
+
+export function createEmitStreamEvent({
+  state,
+  emit,
+  emitWarning,
+  emitTerminalError,
+  onCompactionBoundary,
+  toCommonName,
+}: {
+  state: ClaudeStreamEventState;
+  emit: Emit;
+  emitWarning: (warning: { message: string }) => void;
+  emitTerminalError: (message: string | undefined) => void;
+  onCompactionBoundary: (boundary: {
+    trigger: 'manual' | 'auto';
+    tokensBefore?: number;
+    tokensAfter?: number;
+  }) => void;
+  toCommonName: (nativeName: string) => string;
+}): (event: ClaudeMessage) => void {
+  let streamStarted = false;
+
+  return msg => {
+    const type = msg.type;
+
+    // Emit `stream-start` once, on the first message, carrying the model the
+    // CLI resolved to (the `system`/`init` message reports it — this is the
+    // default model when none was configured).
+    if (!streamStarted) {
+      const initModel =
+        type === 'system' &&
+        msg.subtype === 'init' &&
+        typeof (msg as { model?: unknown }).model === 'string'
+          ? (msg as { model: string }).model
+          : undefined;
+      emit({
+        type: 'stream-start',
+        ...(initModel ? { modelId: initModel } : {}),
+      });
+      streamStarted = true;
+    }
+
+    if (type === 'system' && msg.subtype === 'api_retry') {
+      if (
+        typeof msg.error_status === 'number' &&
+        UNRECOVERABLE_API_RETRY_STATUSES.has(msg.error_status)
+      ) {
+        emitTerminalError(
+          `HTTP ${msg.error_status}: ${msg.error ?? 'provider request failed'}`,
+        );
+        return;
+      }
+
+      emitWarning({ message: formatApiRetryWarning(msg) });
+      return;
+    }
+
+    if (typeof msg.error === 'string' && msg.error.trim()) {
+      state.observedTerminalError = msg.error.trim();
+    }
+
+    if (
+      type === 'auth_status' &&
+      typeof msg.error === 'string' &&
+      msg.error.trim()
+    ) {
+      emitTerminalError(msg.error);
+      return;
+    }
+
+    if (
+      type === 'system' &&
+      msg.subtype === 'task_updated' &&
+      msg.patch?.status === 'failed' &&
+      typeof msg.patch.error === 'string'
+    ) {
+      emitTerminalError(msg.patch.error);
+      return;
+    }
+
+    if (type === 'system' && msg.subtype === 'compact_boundary') {
+      const meta = msg.compact_metadata;
+      if (meta) {
+        onCompactionBoundary({
+          trigger: meta.trigger,
+          ...(typeof meta.pre_tokens === 'number'
+            ? { tokensBefore: meta.pre_tokens }
+            : {}),
+          ...(typeof meta.post_tokens === 'number'
+            ? { tokensAfter: meta.post_tokens }
+            : {}),
+        });
+      }
+      return;
+    }
+
+    if (type === 'stream_event') {
+      handleStreamEvent(msg.event, state.partialBlocks, emit);
+      return;
+    }
+
+    if (type === 'assistant' && msg.message?.content) {
+      const usage = mapUsage(msg.message.usage);
+      const toolUseIds: string[] = [];
+      let opensStep = false;
+      for (const block of msg.message.content) {
+        if (
+          block.type === 'tool_use' &&
+          typeof block.id === 'string' &&
+          typeof block.name === 'string'
+        ) {
+          toolUseIds.push(block.id);
+          const mcpPrefix = 'mcp__harness-tools__';
+          if (block.name.startsWith(mcpPrefix)) {
+            state.pendingStepToolUseIds.add(block.id);
+            state.mcpToolUseIds.add(block.id);
+            opensStep = true;
+            continue;
+          }
+          state.nativeToolCallNames.set(block.id, block.name);
+          if (state.approvalRequestedToolUseIds.has(block.id)) {
+            continue;
+          }
+          state.pendingStepToolUseIds.add(block.id);
+          opensStep = true;
+          emit({
+            type: 'tool-call',
+            toolCallId: block.id,
+            toolName: toCommonName(block.name),
+            nativeName: block.name,
+            input: JSON.stringify(block.input ?? {}),
+            providerExecuted: true,
+          });
+        }
+      }
+      if (opensStep || toolUseIds.length === 0) {
+        state.stepOpen = true;
+        if (usage) state.pendingStepUsage = usage;
+      }
+      return;
+    }
+
+    if (type === 'user' && msg.message?.content) {
+      for (const block of msg.message.content) {
+        if (
+          block.type === 'tool_result' &&
+          typeof block.tool_use_id === 'string'
+        ) {
+          if (state.mcpToolUseIds.has(block.tool_use_id)) {
+            state.mcpToolUseIds.delete(block.tool_use_id);
+            state.pendingStepToolUseIds.delete(block.tool_use_id);
+            continue;
+          }
+          state.approvalRequestedToolUseIds.delete(block.tool_use_id);
+          const nativeName =
+            state.nativeToolCallNames.get(block.tool_use_id) ?? 'unknown';
+          state.nativeToolCallNames.delete(block.tool_use_id);
+          const toolName = toCommonName(nativeName);
+          const isError = !!block.is_error;
+          const content = stringifyContent(block.content);
+          /*
+           * Claude Code's Bash tool does not report the command's real
+           * numeric exit code — the SDK exposes only stdout/stderr text and
+           * an is_error flag. Consumers (and the example UI) render bash
+           * failures from an `exitCode` field on a structured result, the
+           * shape Codex's shell tool provides natively. To match it, derive
+           * a binary code from is_error: 1 on failure, 0 on success. This is
+           * a stand-in for failed/succeeded, not the process's true exit
+           * status.
+           */
+          const result =
+            toolName === 'bash'
+              ? { exitCode: isError ? 1 : 0, stdout: content }
+              : content;
+          emit({
+            type: 'tool-result',
+            toolCallId: block.tool_use_id,
+            toolName,
+            result,
+            isError,
+          });
+          state.pendingStepToolUseIds.delete(block.tool_use_id);
+        }
+      }
+      closeStepIfReady({ state, emit });
+    }
+  };
+}
+
+export function finishApprovalStep({
+  state,
+  emit,
+  approvalId,
+}: {
+  state: ClaudeStreamEventState;
+  emit: Emit;
+  approvalId: string;
+}): void {
+  state.stepOpen = true;
+  state.pendingStepToolUseIds.delete(approvalId);
+  closeStepIfReady({ state, emit });
+}
+
+export function emitFinishStep({
+  state,
+  emit,
+  usage,
+}: {
+  state: ClaudeStreamEventState;
+  emit: Emit;
+  usage: Record<string, unknown> | undefined;
+}): void {
+  emit({
+    type: 'finish-step',
+    finishReason: { unified: 'stop', raw: 'stop' },
+    usage: usage ?? defaultUsage(),
+  });
+  state.stepUsage = usage ?? state.stepUsage;
+  state.pendingStepUsage = undefined;
+  state.pendingStepToolUseIds = new Set();
+  state.stepOpen = false;
+}
+
+function closeStepIfReady({
+  state,
+  emit,
+}: {
+  state: ClaudeStreamEventState;
+  emit: Emit;
+}): void {
+  if (
+    !state.stepOpen ||
+    state.pendingStepToolUseIds.size > 0 ||
+    state.partialBlocks.size > 0
+  ) {
+    return;
+  }
+  emitFinishStep({ state, emit, usage: state.pendingStepUsage });
+}
+
+function formatApiRetryWarning(msg: ClaudeMessage): string {
+  const details: string[] = [];
+  if (typeof msg.attempt === 'number') {
+    const maxRetries =
+      typeof msg.max_retries === 'number' ? `/${msg.max_retries}` : '';
+    details.push(`attempt ${msg.attempt}${maxRetries}`);
+  }
+  if (typeof msg.error_status === 'number') {
+    details.push(`HTTP ${msg.error_status}`);
+  }
+  if (typeof msg.retry_delay_ms === 'number') {
+    details.push(`retrying in ${msg.retry_delay_ms}ms`);
+  }
+  if (msg.error) details.push(msg.error);
+  return details.length > 0
+    ? `Claude Code API retry: ${details.join('; ')}`
+    : 'Claude Code API retry';
+}
+
+function handleStreamEvent(
+  event: ClaudeMessage['event'] | undefined,
+  partialBlocks: Map<number, { id: string; kind: 'text' | 'thinking' }>,
+  send: Emit,
+): void {
+  if (!event || typeof event.index !== 'number') return;
+  const index = event.index;
+
+  if (event.type === 'content_block_start') {
+    const blockType = event.content_block?.type;
+    if (blockType === 'text') {
+      const id = randomUUID();
+      partialBlocks.set(index, { id, kind: 'text' });
+      send({ type: 'text-start', id });
+    } else if (blockType === 'thinking') {
+      const id = randomUUID();
+      partialBlocks.set(index, { id, kind: 'thinking' });
+      send({ type: 'reasoning-start', id });
+    }
+    return;
+  }
+
+  if (event.type === 'content_block_delta') {
+    const block = partialBlocks.get(index);
+    if (!block) return;
+    if (
+      block.kind === 'text' &&
+      event.delta?.type === 'text_delta' &&
+      typeof event.delta.text === 'string'
+    ) {
+      send({ type: 'text-delta', id: block.id, delta: event.delta.text });
+    } else if (
+      block.kind === 'thinking' &&
+      event.delta?.type === 'thinking_delta' &&
+      typeof event.delta.thinking === 'string'
+    ) {
+      send({
+        type: 'reasoning-delta',
+        id: block.id,
+        delta: event.delta.thinking,
+      });
+    }
+    return;
+  }
+
+  if (event.type === 'content_block_stop') {
+    const block = partialBlocks.get(index);
+    if (!block) return;
+    partialBlocks.delete(index);
+    if (block.kind === 'text') {
+      send({ type: 'text-end', id: block.id });
+    } else {
+      send({ type: 'reasoning-end', id: block.id });
+    }
+  }
+}
+
+function stringifyContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map(entry =>
+        entry && typeof entry === 'object' && 'text' in entry
+          ? String((entry as { text?: unknown }).text ?? '')
+          : JSON.stringify(entry),
+      )
+      .join('');
+  }
+  return JSON.stringify(content);
+}
+
+export function mapUsage(usage: unknown): Record<string, unknown> | undefined {
+  if (!usage || typeof usage !== 'object') return undefined;
+  const u = usage as {
+    input_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+    output_tokens?: number;
+  };
+  return {
+    inputTokens: {
+      total:
+        (u.input_tokens ?? 0) +
+        (u.cache_creation_input_tokens ?? 0) +
+        (u.cache_read_input_tokens ?? 0),
+      noCache: u.input_tokens ?? 0,
+      cacheRead: u.cache_read_input_tokens ?? 0,
+      cacheWrite: u.cache_creation_input_tokens ?? 0,
+    },
+    outputTokens: {
+      total: u.output_tokens ?? 0,
+      text: u.output_tokens ?? 0,
+    },
+  };
+}
+
+export function defaultUsage(): Record<string, unknown> {
+  return {
+    inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+    outputTokens: { total: 0, text: 0 },
+  };
+}

--- a/packages/harness-claude-code/src/bridge/index.ts
+++ b/packages/harness-claude-code/src/bridge/index.ts
@@ -34,6 +34,15 @@ import { argv, stdout } from 'node:process';
 import * as claudeAgentSdk from '@anthropic-ai/claude-agent-sdk';
 import * as mcpServerModule from '@modelcontextprotocol/sdk/server/mcp.js';
 import { toClaudeSkillsOption } from './claude-skills-option';
+import {
+  createClaudeStreamEventState,
+  createEmitStreamEvent,
+  defaultUsage,
+  emitFinishStep,
+  finishApprovalStep,
+  mapUsage,
+  type ClaudeMessage,
+} from './create-emit-stream-event';
 import { jsonSchemaToZodShape } from './json-schema-to-zod';
 
 /*
@@ -90,7 +99,6 @@ const PUBLIC_TO_NATIVE: Readonly<Record<string, string>> = {
 };
 
 const PUBLIC_TOOL_NAMES = Object.keys(PUBLIC_TO_NATIVE);
-const UNRECOVERABLE_API_RETRY_STATUSES = new Set([401, 403, 404]);
 
 const NATIVE_TOOL_KINDS: Readonly<
   Record<string, 'readonly' | 'edit' | 'bash'>
@@ -305,50 +313,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     });
   }
 
-  /*
-   * Map of native tool-use id → tool name. Claude assistant messages emit
-   * `tool_use` blocks with both `id` and `name`; the matching `tool_result`
-   * block on a later user message carries only `tool_use_id`, so without this
-   * map the tool-result event would have to emit `toolName: 'unknown'`.
-   */
-  const nativeToolCallNames = new Map<string, string>();
-  const approvalRequestedToolUseIds = new Set<string>();
-  const partialBlocks = new Map<
-    number,
-    { id: string; kind: 'text' | 'thinking' }
-  >();
-  let stepUsage: Record<string, unknown> | undefined;
-  let pendingStepToolUseIds = new Set<string>();
-  let pendingStepUsage: Record<string, unknown> | undefined;
-  let stepOpen = false;
-
-  const emitFinishStep = (usage: Record<string, unknown> | undefined): void => {
-    emit({
-      type: 'finish-step',
-      finishReason: { unified: 'stop', raw: 'stop' },
-      usage: usage ?? defaultUsage(),
-    });
-    stepUsage = usage ?? stepUsage;
-    pendingStepUsage = undefined;
-    pendingStepToolUseIds = new Set();
-    stepOpen = false;
-  };
-
-  const closeStepIfReady = (): void => {
-    if (!stepOpen || pendingStepToolUseIds.size > 0 || partialBlocks.size > 0) {
-      return;
-    }
-    emitFinishStep(pendingStepUsage);
-  };
-
-  /*
-   * Tool-use ids that originated from the MCP server hosting user-supplied
-   * tools. The MCP handler emits its own `tool-call`/`tool-result` pair with
-   * the user-facing tool name and a synthetic id, so the duplicate
-   * `tool_result` block Claude reports for the underlying native id must be
-   * suppressed.
-   */
-  const mcpToolUseIds = new Set<string>();
+  const streamEventState = createClaudeStreamEventState();
 
   const mcpServers: Record<string, unknown> = {};
   if (start.tools && start.tools.length > 0) {
@@ -415,12 +380,10 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     turn,
     emit,
     finishApprovalStep: approvalId => {
-      stepOpen = true;
-      pendingStepToolUseIds.delete(approvalId);
-      closeStepIfReady();
+      finishApprovalStep({ state: streamEventState, emit, approvalId });
     },
-    nativeToolCallNames,
-    approvalRequestedToolUseIds,
+    nativeToolCallNames: streamEventState.nativeToolCallNames,
+    approvalRequestedToolUseIds: streamEventState.approvalRequestedToolUseIds,
   });
 
   const q = claudeSdk.query({
@@ -467,15 +430,13 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
 
   let turnUsage: Record<string, unknown> | undefined;
   let totalCostUsd: number | undefined;
-  let observedTerminalError: string | undefined;
   let emittedTerminalError = false;
   let emittedTerminalFinish = false;
-  let streamStarted = false;
 
   const emitTerminalError = (message: string | undefined): void => {
     const normalized = message?.trim();
     if (!normalized || emittedTerminalError || emittedTerminalFinish) return;
-    observedTerminalError = normalized;
+    streamEventState.observedTerminalError = normalized;
     emittedTerminalError = true;
     turn.emitError({
       error: normalized,
@@ -485,182 +446,28 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     abortCtl.abort();
   };
 
+  const emitStreamEvent = createEmitStreamEvent({
+    state: streamEventState,
+    emit,
+    emitWarning: turn.emitWarning,
+    emitTerminalError,
+    onCompactionBoundary: boundary => compaction.onBoundary(boundary),
+    toCommonName,
+  });
+
   try {
     for await (const msg of q as AsyncIterable<ClaudeMessage>) {
       if (abortCtl.signal.aborted) break;
 
       const type = msg.type;
 
-      // Emit `stream-start` once, on the first message, carrying the model the
-      // CLI resolved to (the `system`/`init` message reports it — this is the
-      // default model when none was configured).
-      if (!streamStarted) {
-        const initModel =
-          type === 'system' &&
-          msg.subtype === 'init' &&
-          typeof (msg as { model?: unknown }).model === 'string'
-            ? (msg as { model: string }).model
-            : undefined;
-        emit({
-          type: 'stream-start',
-          ...(initModel ? { modelId: initModel } : {}),
-        });
-        streamStarted = true;
-      }
-
-      if (type === 'system' && msg.subtype === 'api_retry') {
-        if (
-          typeof msg.error_status === 'number' &&
-          UNRECOVERABLE_API_RETRY_STATUSES.has(msg.error_status)
-        ) {
-          emitTerminalError(
-            `HTTP ${msg.error_status}: ${
-              msg.error ?? 'provider request failed'
-            }`,
-          );
-          continue;
-        }
-
-        turn.emitWarning({ message: formatApiRetryWarning(msg) });
-        continue;
-      }
-
-      if (typeof msg.error === 'string' && msg.error.trim()) {
-        observedTerminalError = msg.error.trim();
-      }
-
-      if (
-        type === 'auth_status' &&
-        typeof msg.error === 'string' &&
-        msg.error.trim()
-      ) {
-        emitTerminalError(msg.error);
-        continue;
-      }
-
-      if (
-        type === 'system' &&
-        msg.subtype === 'task_updated' &&
-        msg.patch?.status === 'failed' &&
-        typeof msg.patch.error === 'string'
-      ) {
-        emitTerminalError(msg.patch.error);
-        continue;
-      }
-
-      if (type === 'system' && msg.subtype === 'compact_boundary') {
-        const meta = msg.compact_metadata;
-        if (meta) {
-          compaction.onBoundary({
-            trigger: meta.trigger,
-            ...(typeof meta.pre_tokens === 'number'
-              ? { tokensBefore: meta.pre_tokens }
-              : {}),
-            ...(typeof meta.post_tokens === 'number'
-              ? { tokensAfter: meta.post_tokens }
-              : {}),
-          });
-        }
-        continue;
-      }
-
-      if (type === 'stream_event') {
-        handleStreamEvent(msg.event, partialBlocks, emit);
-        continue;
-      }
-
-      if (type === 'assistant' && msg.message?.content) {
-        const usage = mapUsage(msg.message.usage);
-        const toolUseIds: string[] = [];
-        let opensStep = false;
-        for (const block of msg.message.content) {
-          if (
-            block.type === 'tool_use' &&
-            typeof block.id === 'string' &&
-            typeof block.name === 'string'
-          ) {
-            toolUseIds.push(block.id);
-            const mcpPrefix = 'mcp__harness-tools__';
-            if (block.name.startsWith(mcpPrefix)) {
-              pendingStepToolUseIds.add(block.id);
-              mcpToolUseIds.add(block.id);
-              opensStep = true;
-              continue;
-            }
-            nativeToolCallNames.set(block.id, block.name);
-            if (approvalRequestedToolUseIds.has(block.id)) {
-              continue;
-            }
-            pendingStepToolUseIds.add(block.id);
-            opensStep = true;
-            emit({
-              type: 'tool-call',
-              toolCallId: block.id,
-              toolName: toCommonName(block.name),
-              nativeName: block.name,
-              input: JSON.stringify(block.input ?? {}),
-              providerExecuted: true,
-            });
-          }
-        }
-        if (opensStep || toolUseIds.length === 0) {
-          stepOpen = true;
-          if (usage) pendingStepUsage = usage;
-        }
-        continue;
-      }
-
-      if (type === 'user' && msg.message?.content) {
-        for (const block of msg.message.content) {
-          if (
-            block.type === 'tool_result' &&
-            typeof block.tool_use_id === 'string'
-          ) {
-            if (mcpToolUseIds.has(block.tool_use_id)) {
-              mcpToolUseIds.delete(block.tool_use_id);
-              pendingStepToolUseIds.delete(block.tool_use_id);
-              continue;
-            }
-            approvalRequestedToolUseIds.delete(block.tool_use_id);
-            const nativeName =
-              nativeToolCallNames.get(block.tool_use_id) ?? 'unknown';
-            nativeToolCallNames.delete(block.tool_use_id);
-            const toolName = toCommonName(nativeName);
-            const isError = !!block.is_error;
-            const content = stringifyContent(block.content);
-            /*
-             * Claude Code's Bash tool does not report the command's real
-             * numeric exit code — the SDK exposes only stdout/stderr text and
-             * an is_error flag. Consumers (and the example UI) render bash
-             * failures from an `exitCode` field on a structured result, the
-             * shape Codex's shell tool provides natively. To match it, derive
-             * a binary code from is_error: 1 on failure, 0 on success. This is
-             * a stand-in for failed/succeeded, not the process's true exit
-             * status.
-             */
-            const result =
-              toolName === 'bash'
-                ? { exitCode: isError ? 1 : 0, stdout: content }
-                : content;
-            emit({
-              type: 'tool-result',
-              toolCallId: block.tool_use_id,
-              toolName,
-              result,
-              isError,
-            });
-            pendingStepToolUseIds.delete(block.tool_use_id);
-          }
-        }
-        closeStepIfReady();
-        continue;
-      }
+      emitStreamEvent(msg);
 
       if (type === 'result') {
         if (msg.subtype === 'success') {
           const emptyResult = !msg.result?.trim?.();
-          if (emptyResult && observedTerminalError) {
-            emitTerminalError(observedTerminalError);
+          if (emptyResult && streamEventState.observedTerminalError) {
+            emitTerminalError(streamEventState.observedTerminalError);
             continue;
           }
           const usage = msg.usage ?? msg.message?.usage;
@@ -669,13 +476,19 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
           if (typeof msg.total_cost_usd === 'number') {
             totalCostUsd = (totalCostUsd ?? 0) + msg.total_cost_usd;
           }
-          if (stepOpen) emitFinishStep(harnessUsage ?? pendingStepUsage);
+          if (streamEventState.stepOpen) {
+            emitFinishStep({
+              state: streamEventState,
+              emit,
+              usage: harnessUsage ?? streamEventState.pendingStepUsage,
+            });
+          }
           queryInput.close();
           break;
         } else {
           emitTerminalError(
             (Array.isArray(msg.errors) ? msg.errors.join('\n') : undefined) ||
-              observedTerminalError ||
+              streamEventState.observedTerminalError ||
               msg.result ||
               'Unknown error',
           );
@@ -698,117 +511,11 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   emit({
     type: 'finish',
     finishReason: { unified: 'stop', raw: 'stop' },
-    totalUsage: turnUsage ?? stepUsage ?? defaultUsage(),
+    totalUsage: turnUsage ?? streamEventState.stepUsage ?? defaultUsage(),
     ...(totalCostUsd !== undefined
       ? { harnessMetadata: { 'claude-code': { costUsd: totalCostUsd } } }
       : {}),
   });
-}
-
-type ClaudeMessage = {
-  type?: string;
-  subtype?: string;
-  error?: string;
-  error_status?: number | null;
-  attempt?: number;
-  max_retries?: number;
-  retry_delay_ms?: number;
-  patch?: { status?: string; error?: string };
-  compact_metadata?: {
-    trigger: 'manual' | 'auto';
-    pre_tokens?: number;
-    post_tokens?: number;
-  };
-  event?: {
-    type?: string;
-    index?: number;
-    content_block?: { type?: string };
-    delta?: { type?: string; text?: string; thinking?: string };
-  };
-  message?: {
-    content?: ReadonlyArray<MessageBlock>;
-    usage?: Record<string, unknown>;
-  };
-  result?: string;
-  errors?: ReadonlyArray<string>;
-  usage?: Record<string, unknown>;
-  total_cost_usd?: number;
-};
-
-function formatApiRetryWarning(msg: ClaudeMessage): string {
-  const details: string[] = [];
-  if (typeof msg.attempt === 'number') {
-    const maxRetries =
-      typeof msg.max_retries === 'number' ? `/${msg.max_retries}` : '';
-    details.push(`attempt ${msg.attempt}${maxRetries}`);
-  }
-  if (typeof msg.error_status === 'number') {
-    details.push(`HTTP ${msg.error_status}`);
-  }
-  if (typeof msg.retry_delay_ms === 'number') {
-    details.push(`retrying in ${msg.retry_delay_ms}ms`);
-  }
-  if (msg.error) details.push(msg.error);
-  return details.length > 0
-    ? `Claude Code API retry: ${details.join('; ')}`
-    : 'Claude Code API retry';
-}
-
-function handleStreamEvent(
-  event: ClaudeMessage['event'] | undefined,
-  partialBlocks: Map<number, { id: string; kind: 'text' | 'thinking' }>,
-  send: Emit,
-): void {
-  if (!event || typeof event.index !== 'number') return;
-  const index = event.index;
-
-  if (event.type === 'content_block_start') {
-    const blockType = event.content_block?.type;
-    if (blockType === 'text') {
-      const id = randomUUID();
-      partialBlocks.set(index, { id, kind: 'text' });
-      send({ type: 'text-start', id });
-    } else if (blockType === 'thinking') {
-      const id = randomUUID();
-      partialBlocks.set(index, { id, kind: 'thinking' });
-      send({ type: 'reasoning-start', id });
-    }
-    return;
-  }
-
-  if (event.type === 'content_block_delta') {
-    const block = partialBlocks.get(index);
-    if (!block) return;
-    if (
-      block.kind === 'text' &&
-      event.delta?.type === 'text_delta' &&
-      typeof event.delta.text === 'string'
-    ) {
-      send({ type: 'text-delta', id: block.id, delta: event.delta.text });
-    } else if (
-      block.kind === 'thinking' &&
-      event.delta?.type === 'thinking_delta' &&
-      typeof event.delta.thinking === 'string'
-    ) {
-      send({
-        type: 'reasoning-delta',
-        id: block.id,
-        delta: event.delta.thinking,
-      });
-    }
-    return;
-  }
-
-  if (event.type === 'content_block_stop') {
-    const block = partialBlocks.get(index);
-    if (!block) return;
-    partialBlocks.delete(index);
-    if (block.kind === 'text') {
-      send({ type: 'text-end', id: block.id });
-    } else {
-      send({ type: 'reasoning-end', id: block.id });
-    }
-  }
 }
 
 function createQueryInput({
@@ -870,64 +577,6 @@ function createQueryInput({
         };
       },
     },
-  };
-}
-
-type MessageBlock = {
-  type: string;
-  text?: string;
-  thinking?: string;
-  id?: string;
-  name?: string;
-  input?: unknown;
-  tool_use_id?: string;
-  content?: unknown;
-  is_error?: boolean;
-};
-
-function stringifyContent(content: unknown): string {
-  if (typeof content === 'string') return content;
-  if (Array.isArray(content)) {
-    return content
-      .map(entry =>
-        entry && typeof entry === 'object' && 'text' in entry
-          ? String((entry as { text?: unknown }).text ?? '')
-          : JSON.stringify(entry),
-      )
-      .join('');
-  }
-  return JSON.stringify(content);
-}
-
-function mapUsage(usage: unknown): Record<string, unknown> | undefined {
-  if (!usage || typeof usage !== 'object') return undefined;
-  const u = usage as {
-    input_tokens?: number;
-    cache_creation_input_tokens?: number;
-    cache_read_input_tokens?: number;
-    output_tokens?: number;
-  };
-  return {
-    inputTokens: {
-      total:
-        (u.input_tokens ?? 0) +
-        (u.cache_creation_input_tokens ?? 0) +
-        (u.cache_read_input_tokens ?? 0),
-      noCache: u.input_tokens ?? 0,
-      cacheRead: u.cache_read_input_tokens ?? 0,
-      cacheWrite: u.cache_creation_input_tokens ?? 0,
-    },
-    outputTokens: {
-      total: u.output_tokens ?? 0,
-      text: u.output_tokens ?? 0,
-    },
-  };
-}
-
-function defaultUsage(): Record<string, unknown> {
-  return {
-    inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
-    outputTokens: { total: 0, text: 0 },
   };
 }
 

--- a/packages/harness-codex/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-codex/src/bridge/create-emit-stream-event.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+import type { CodexStepTracker } from './codex-step-tracker';
+import { createEmitStreamEvent } from './create-emit-stream-event';
+
+describe('createEmitStreamEvent', () => {
+  it('emits thread, accumulated text, and usage events', () => {
+    const emitted: Record<string, unknown>[] = [];
+    const observed: unknown[] = [];
+    const usages: unknown[] = [];
+    const threadIds: string[] = [];
+    const stepTracker = {
+      observeEvent: input => observed.push(input),
+      finishStep: () => observed.push('finish'),
+    } as CodexStepTracker;
+    const emitStreamEvent = createEmitStreamEvent({
+      send: event => emitted.push(event),
+      stepTracker,
+      setTurnUsage: usage => usages.push(usage),
+      setThreadId: threadId => threadIds.push(threadId),
+      emitWarning: () => {},
+      emitError: () => {},
+    });
+
+    emitStreamEvent({ type: 'thread.started', thread_id: 'thread-1' });
+    emitStreamEvent({
+      type: 'item.updated',
+      item: { type: 'agent_message', id: 'message-1', text: 'hello' },
+    });
+    emitStreamEvent({
+      type: 'item.completed',
+      item: {
+        type: 'agent_message',
+        id: 'message-1',
+        text: 'hello world',
+      },
+    });
+    emitStreamEvent({
+      type: 'turn.completed',
+      usage: {
+        input_tokens: 5,
+        cached_input_tokens: 2,
+        output_tokens: 3,
+      },
+    });
+
+    expect({ emitted, usages, threadIds, observed }).toMatchInlineSnapshot(`
+      {
+        "emitted": [
+          {
+            "threadId": "thread-1",
+            "type": "bridge-thread",
+          },
+          {
+            "id": "message-1",
+            "type": "text-start",
+          },
+          {
+            "delta": "hello",
+            "id": "message-1",
+            "type": "text-delta",
+          },
+          {
+            "delta": " world",
+            "id": "message-1",
+            "type": "text-delta",
+          },
+          {
+            "id": "message-1",
+            "type": "text-end",
+          },
+        ],
+        "observed": [
+          {
+            "event": {
+              "item": {
+                "id": "message-1",
+                "text": "hello",
+                "type": "agent_message",
+              },
+              "type": "item.updated",
+            },
+            "itemId": "message-1",
+          },
+          {
+            "event": {
+              "item": {
+                "id": "message-1",
+                "text": "hello world",
+                "type": "agent_message",
+              },
+              "type": "item.completed",
+            },
+            "itemId": "message-1",
+          },
+          "finish",
+        ],
+        "threadIds": [
+          "thread-1",
+        ],
+        "usages": [
+          {
+            "inputTokens": {
+              "cacheRead": 2,
+              "cacheWrite": 0,
+              "noCache": 3,
+              "total": 5,
+            },
+            "outputTokens": {
+              "text": 3,
+              "total": 3,
+            },
+          },
+        ],
+      }
+    `);
+  });
+
+  it('preserves command and MCP result translation', () => {
+    const emitted: Record<string, unknown>[] = [];
+    const stepTracker = {
+      observeEvent: () => {},
+      finishStep: () => {},
+    } as CodexStepTracker;
+    const emitStreamEvent = createEmitStreamEvent({
+      send: event => emitted.push(event),
+      stepTracker,
+      setTurnUsage: () => {},
+      setThreadId: () => {},
+      emitWarning: () => {},
+      emitError: () => {},
+    });
+
+    emitStreamEvent({
+      type: 'item.started',
+      item: {
+        type: 'command_execution',
+        id: 'command-1',
+        command: 'pwd',
+      },
+    });
+    emitStreamEvent({
+      type: 'item.completed',
+      item: {
+        type: 'command_execution',
+        id: 'command-1',
+        exit_code: 0,
+        aggregated_output: '/tmp',
+      },
+    });
+    emitStreamEvent({
+      type: 'item.completed',
+      item: {
+        type: 'mcp_tool_call',
+        id: 'mcp-1',
+        tool: 'weather',
+        result: { structured_content: { temperature: 72 } },
+      },
+    });
+
+    expect(emitted).toMatchInlineSnapshot(`
+      [
+        {
+          "input": "{\"command\":\"pwd\"}",
+          "nativeName": "shell",
+          "providerExecuted": true,
+          "toolCallId": "command-1",
+          "toolName": "bash",
+          "type": "tool-call",
+        },
+        {
+          "result": {
+            "exitCode": 0,
+            "output": "/tmp",
+            "status": "completed",
+          },
+          "toolCallId": "command-1",
+          "toolName": "bash",
+          "type": "tool-result",
+        },
+        {
+          "result": {
+            "temperature": 72,
+          },
+          "toolCallId": "mcp-1",
+          "toolName": "weather",
+          "type": "tool-result",
+        },
+      ]
+    `);
+  });
+});

--- a/packages/harness-codex/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-codex/src/bridge/create-emit-stream-event.ts
@@ -1,0 +1,287 @@
+import type { HarnessV1BuiltinToolName } from '@ai-sdk/harness';
+import type { BridgeTurn } from '@ai-sdk/harness/bridge';
+import { randomUUID } from 'node:crypto';
+import type { CodexStepTracker } from './codex-step-tracker';
+
+type Emit = (message: Record<string, unknown>) => void;
+
+export type CodexItem = {
+  type: string;
+  id?: string;
+  text?: string;
+  command?: string;
+  exit_code?: number;
+  aggregated_output?: string;
+  status?: 'in_progress' | 'completed' | 'failed';
+  server?: string;
+  tool?: string;
+  arguments?: unknown;
+  result?: { content?: unknown; structured_content?: unknown } | unknown;
+  error?: { message?: string };
+  query?: string;
+  message?: string;
+  changes?: ReadonlyArray<{
+    path: string;
+    kind: 'add' | 'delete' | 'update';
+  }>;
+};
+
+export type CodexEvent = {
+  type:
+    | 'thread.started'
+    | 'turn.completed'
+    | 'turn.failed'
+    | 'error'
+    | 'item.started'
+    | 'item.updated'
+    | 'item.completed';
+  item?: CodexItem;
+  usage?: Record<string, number>;
+  error?: { message: string };
+  message?: string;
+  thread_id?: string;
+};
+
+/*
+ * Native Codex tool name → cross-harness common name. Tools outside this map
+ * (e.g. MCP tools the model invokes by name) have no common equivalent; their
+ * native name is forwarded as-is on `tool-call` events.
+ */
+const NATIVE_TO_COMMON: Readonly<Record<string, HarnessV1BuiltinToolName>> = {
+  shell: 'bash',
+  web_search: 'webSearch',
+};
+
+function toCommonName(nativeName: string): HarnessV1BuiltinToolName | string {
+  return NATIVE_TO_COMMON[nativeName] ?? nativeName;
+}
+
+export function createEmitStreamEvent({
+  send,
+  stepTracker,
+  setTurnUsage,
+  setThreadId,
+  emitWarning,
+  emitError,
+}: {
+  send: Emit;
+  stepTracker: CodexStepTracker;
+  setTurnUsage: (usage: Record<string, unknown>) => void;
+  setThreadId: (threadId: string) => void;
+  emitWarning: BridgeTurn['emitWarning'];
+  emitError: BridgeTurn['emitError'];
+}): (event: CodexEvent) => void {
+  const textByItem = new Map<string, string>();
+  const reasoningByItem = new Map<string, string>();
+
+  return event => {
+    if (
+      event.type === 'thread.started' &&
+      typeof event.thread_id === 'string'
+    ) {
+      setThreadId(event.thread_id);
+      // Announce to the host so it can include the id in resume state.
+      send({ type: 'bridge-thread', threadId: event.thread_id });
+    }
+    if (event.type === 'turn.completed') {
+      if (event.usage) setTurnUsage(mapUsage(event.usage));
+      stepTracker.finishStep();
+      return;
+    }
+    if (event.type === 'turn.failed') {
+      emitError({
+        error: event.error?.message ?? 'codex turn failed',
+        message: 'codex turn failed',
+      });
+      return;
+    }
+    if (event.type === 'error') {
+      emitError({
+        error: event.message ?? 'codex error',
+        message: 'codex stream error',
+      });
+      return;
+    }
+    if (!event.item) return;
+    const item = event.item;
+    const id = item.id ?? randomUUID();
+    const observeStep = (): void => {
+      stepTracker.observeEvent({ event, itemId: id });
+    };
+
+    if (item.type === 'agent_message' && typeof item.text === 'string') {
+      /*
+       * The presence of `id` in `textByItem` — not the `item.started` event —
+       * marks the text part as opened. Codex does not guarantee an
+       * `item.started` event carrying text precedes the first `item.updated`
+       * with text, so keying the `text-start` off the event type can emit a
+       * `text-delta` for a part that was never opened. Opening lazily on the
+       * first event with text keeps `text-start` before any `text-delta`.
+       */
+      if (!textByItem.has(id)) {
+        send({ type: 'text-start', id });
+        textByItem.set(id, '');
+      }
+      const last = textByItem.get(id) ?? '';
+      const next = item.text;
+      if (next.length > last.length) {
+        send({ type: 'text-delta', id, delta: next.slice(last.length) });
+        textByItem.set(id, next);
+      }
+      if (event.type === 'item.completed') send({ type: 'text-end', id });
+      observeStep();
+      return;
+    }
+
+    if (item.type === 'reasoning' && typeof item.text === 'string') {
+      if (!reasoningByItem.has(id)) {
+        send({ type: 'reasoning-start', id });
+        reasoningByItem.set(id, '');
+      }
+      const last = reasoningByItem.get(id) ?? '';
+      const next = item.text;
+      if (next.length > last.length) {
+        send({ type: 'reasoning-delta', id, delta: next.slice(last.length) });
+        reasoningByItem.set(id, next);
+      }
+      if (event.type === 'item.completed') send({ type: 'reasoning-end', id });
+      observeStep();
+      return;
+    }
+
+    if (item.type === 'command_execution') {
+      const nativeName = 'shell';
+      if (event.type === 'item.started') {
+        send({
+          type: 'tool-call',
+          toolCallId: id,
+          toolName: toCommonName(nativeName),
+          nativeName,
+          input: JSON.stringify({ command: item.command ?? '' }),
+          providerExecuted: true,
+        });
+      } else if (event.type === 'item.completed') {
+        send({
+          type: 'tool-result',
+          toolCallId: id,
+          toolName: toCommonName(nativeName),
+          result: {
+            exitCode: item.exit_code ?? null,
+            output: item.aggregated_output ?? '',
+            status: item.status ?? 'completed',
+          },
+        });
+      }
+      observeStep();
+      return;
+    }
+
+    if (item.type === 'mcp_tool_call') {
+      if (event.type === 'item.started') {
+        send({
+          type: 'tool-call',
+          toolCallId: id,
+          toolName: item.tool ?? 'unknown',
+          nativeName: item.tool ?? 'unknown',
+          input: JSON.stringify(item.arguments ?? {}),
+          providerExecuted: true,
+        });
+      } else if (event.type === 'item.completed') {
+        send({
+          type: 'tool-result',
+          toolCallId: id,
+          toolName: item.tool ?? 'unknown',
+          result: extractMcpToolCallResult(item),
+        });
+      }
+      observeStep();
+      return;
+    }
+
+    if (item.type === 'web_search') {
+      const nativeName = 'web_search';
+      if (event.type === 'item.started') {
+        send({
+          type: 'tool-call',
+          toolCallId: id,
+          toolName: toCommonName(nativeName),
+          nativeName,
+          input: JSON.stringify({ query: item.query ?? '' }),
+          providerExecuted: true,
+        });
+      } else if (event.type === 'item.completed') {
+        send({
+          type: 'tool-result',
+          toolCallId: id,
+          toolName: toCommonName(nativeName),
+          result: item.result ?? null,
+        });
+      }
+      observeStep();
+      return;
+    }
+
+    if (item.type === 'file_change' && event.type === 'item.completed') {
+      for (const change of item.changes ?? []) {
+        send({
+          type: 'file-change',
+          event:
+            change.kind === 'add'
+              ? 'create'
+              : change.kind === 'delete'
+                ? 'delete'
+                : 'modify',
+          path: change.path,
+        });
+      }
+      observeStep();
+      return;
+    }
+
+    if (item.type === 'error' && event.type === 'item.completed') {
+      const message =
+        typeof item.message === 'string' && item.message.trim()
+          ? item.message
+          : 'codex reported a non-fatal error item';
+      emitWarning({ message });
+    }
+  };
+}
+
+function extractMcpToolCallResult(item: CodexItem): unknown {
+  if (
+    item.result === undefined ||
+    item.result === null ||
+    typeof item.result !== 'object'
+  ) {
+    return item.error?.message ? { error: item.error.message } : null;
+  }
+  const result = item.result as {
+    content?: unknown;
+    structured_content?: unknown;
+  };
+  if (
+    result.structured_content !== undefined &&
+    result.structured_content !== null
+  ) {
+    return result.structured_content;
+  }
+  return result.content ?? null;
+}
+
+function mapUsage(usage: Record<string, number>): Record<string, unknown> {
+  const input = usage.input_tokens ?? 0;
+  const cacheRead = usage.cached_input_tokens ?? 0;
+  return {
+    inputTokens: {
+      total: input,
+      noCache: Math.max(0, input - cacheRead),
+      cacheRead,
+      cacheWrite: 0,
+    },
+    outputTokens: {
+      total: usage.output_tokens ?? 0,
+      text: usage.output_tokens ?? 0,
+    },
+  };
+}

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -14,9 +14,7 @@ import {
   type BridgeEvent,
   type BridgeTurn,
 } from '@ai-sdk/harness/bridge';
-import type { HarnessV1BuiltinToolName } from '@ai-sdk/harness';
 import type { StartMessage } from '../codex-bridge-protocol';
-import { randomUUID } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 // Temporary workaround for upstream codex MCP-tool bug — see ./cli-relay.ts
 import {
@@ -24,11 +22,11 @@ import {
   buildCliShimScript,
   parseToolRelayCommands,
 } from './cli-relay';
+import { createCodexStepTracker, defaultUsage } from './codex-step-tracker';
 import {
-  createCodexStepTracker,
-  defaultUsage,
-  type CodexStepTracker,
-} from './codex-step-tracker';
+  createEmitStreamEvent,
+  type CodexEvent,
+} from './create-emit-stream-event';
 import { startAuthorizedToolRelay, type ToolRelay } from './tool-relay';
 import { argv, env as procEnv, stdout } from 'node:process';
 
@@ -50,20 +48,6 @@ import { argv, env as procEnv, stdout } from 'node:process';
  *   3. the dependency entry in `src/bridge/package.json`.
  */
 import * as codexSdkModule from '@openai/codex-sdk';
-
-/*
- * Native Codex tool name → cross-harness common name. Tools outside this map
- * (e.g. MCP tools the model invokes by name) have no common equivalent; their
- * native name is forwarded as-is on `tool-call` events.
- */
-const NATIVE_TO_COMMON: Readonly<Record<string, HarnessV1BuiltinToolName>> = {
-  shell: 'bash',
-  web_search: 'webSearch',
-};
-
-function toCommonName(nativeName: string): HarnessV1BuiltinToolName | string {
-  return NATIVE_TO_COMMON[nativeName] ?? nativeName;
-}
 
 const args = parseArgs(argv.slice(2));
 const workdir = requireArg({ value: args.workdir, name: '--workdir' });
@@ -202,9 +186,15 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
 
   const userMessage = start.prompt;
   let turnUsage: Record<string, unknown> | undefined;
-  const textByItem = new Map<string, string>();
-  const reasoningByItem = new Map<string, string>();
   const stepTracker = createCodexStepTracker({ send: emit });
+  const emitStreamEvent = createEmitStreamEvent({
+    send: emit,
+    stepTracker,
+    setTurnUsage: usage => (turnUsage = usage),
+    setThreadId: threadId => (threadState.id = threadId),
+    emitWarning: turn.emitWarning,
+    emitError: turn.emitError,
+  });
 
   try {
     const { events } = await thread.runStreamed(userMessage, {
@@ -212,14 +202,6 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     });
     for await (const event of events as AsyncIterable<CodexEvent>) {
       if (turn.abortSignal.aborted) break;
-      if (
-        event.type === 'thread.started' &&
-        typeof event.thread_id === 'string'
-      ) {
-        threadState.id = event.thread_id;
-        // Announce to the host so it can include the id in resume state.
-        emit({ type: 'bridge-thread', threadId: event.thread_id });
-      }
       // Temporary workaround for upstream codex MCP-tool bug — see ./cli-relay.ts
       if (cliShimPath && event.item?.type === 'command_execution') {
         const relayCalls =
@@ -239,15 +221,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
           continue;
         }
       }
-      translateAndEmit(event, {
-        send: emit,
-        textByItem,
-        reasoningByItem,
-        stepTracker,
-        setTurnUsage: u => (turnUsage = u),
-        emitWarning: turn.emitWarning,
-        emitError: turn.emitError,
-      });
+      emitStreamEvent(event);
     }
   } catch (err) {
     turn.emitError({ error: err, message: 'codex turn failed' });
@@ -263,259 +237,6 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   });
 
   void turn.pendingUserMessages; // accepted but only consumed when codex supports streamed user input
-}
-
-type CodexItem = {
-  type: string;
-  id?: string;
-  text?: string;
-  command?: string;
-  exit_code?: number;
-  aggregated_output?: string;
-  status?: 'in_progress' | 'completed' | 'failed';
-  server?: string;
-  tool?: string;
-  arguments?: unknown;
-  result?: { content?: unknown; structured_content?: unknown } | unknown;
-  error?: { message?: string };
-  query?: string;
-  message?: string;
-  changes?: ReadonlyArray<{
-    path: string;
-    kind: 'add' | 'delete' | 'update';
-  }>;
-};
-
-function extractMcpToolCallResult(item: CodexItem): unknown {
-  if (
-    item.result === undefined ||
-    item.result === null ||
-    typeof item.result !== 'object'
-  ) {
-    return item.error?.message ? { error: item.error.message } : null;
-  }
-  const result = item.result as {
-    content?: unknown;
-    structured_content?: unknown;
-  };
-  if (
-    result.structured_content !== undefined &&
-    result.structured_content !== null
-  ) {
-    return result.structured_content;
-  }
-  return result.content ?? null;
-}
-
-type CodexEvent = {
-  type:
-    | 'thread.started'
-    | 'turn.completed'
-    | 'turn.failed'
-    | 'error'
-    | 'item.started'
-    | 'item.updated'
-    | 'item.completed';
-  item?: CodexItem;
-  usage?: Record<string, number>;
-  error?: { message: string };
-  message?: string;
-  thread_id?: string;
-};
-
-function translateAndEmit(
-  event: CodexEvent,
-  ctx: {
-    send: Emit;
-    textByItem: Map<string, string>;
-    reasoningByItem: Map<string, string>;
-    stepTracker: CodexStepTracker;
-    setTurnUsage: (u: Record<string, unknown>) => void;
-    emitWarning: BridgeTurn['emitWarning'];
-    emitError: BridgeTurn['emitError'];
-  },
-): void {
-  if (event.type === 'turn.completed') {
-    if (event.usage) ctx.setTurnUsage(mapUsage(event.usage));
-    ctx.stepTracker.finishStep();
-    return;
-  }
-  if (event.type === 'turn.failed') {
-    ctx.emitError({
-      error: event.error?.message ?? 'codex turn failed',
-      message: 'codex turn failed',
-    });
-    return;
-  }
-  if (event.type === 'error') {
-    ctx.emitError({
-      error: event.message ?? 'codex error',
-      message: 'codex stream error',
-    });
-    return;
-  }
-  if (!event.item) return;
-  const item = event.item;
-  const id = item.id ?? randomUUID();
-  const observeStep = (): void => {
-    ctx.stepTracker.observeEvent({ event, itemId: id });
-  };
-
-  if (item.type === 'agent_message' && typeof item.text === 'string') {
-    /*
-     * The presence of `id` in `textByItem` — not the `item.started` event —
-     * marks the text part as opened. Codex does not guarantee an
-     * `item.started` event carrying text precedes the first `item.updated`
-     * with text, so keying the `text-start` off the event type can emit a
-     * `text-delta` for a part that was never opened. Opening lazily on the
-     * first event with text keeps `text-start` before any `text-delta`.
-     */
-    if (!ctx.textByItem.has(id)) {
-      ctx.send({ type: 'text-start', id });
-      ctx.textByItem.set(id, '');
-    }
-    const last = ctx.textByItem.get(id) ?? '';
-    const next = item.text;
-    if (next.length > last.length) {
-      ctx.send({ type: 'text-delta', id, delta: next.slice(last.length) });
-      ctx.textByItem.set(id, next);
-    }
-    if (event.type === 'item.completed') ctx.send({ type: 'text-end', id });
-    observeStep();
-    return;
-  }
-
-  if (item.type === 'reasoning' && typeof item.text === 'string') {
-    if (!ctx.reasoningByItem.has(id)) {
-      ctx.send({ type: 'reasoning-start', id });
-      ctx.reasoningByItem.set(id, '');
-    }
-    const last = ctx.reasoningByItem.get(id) ?? '';
-    const next = item.text;
-    if (next.length > last.length) {
-      ctx.send({ type: 'reasoning-delta', id, delta: next.slice(last.length) });
-      ctx.reasoningByItem.set(id, next);
-    }
-    if (event.type === 'item.completed')
-      ctx.send({ type: 'reasoning-end', id });
-    observeStep();
-    return;
-  }
-
-  if (item.type === 'command_execution') {
-    const nativeName = 'shell';
-    if (event.type === 'item.started') {
-      ctx.send({
-        type: 'tool-call',
-        toolCallId: id,
-        toolName: toCommonName(nativeName),
-        nativeName,
-        input: JSON.stringify({ command: item.command ?? '' }),
-        providerExecuted: true,
-      });
-    } else if (event.type === 'item.completed') {
-      ctx.send({
-        type: 'tool-result',
-        toolCallId: id,
-        toolName: toCommonName(nativeName),
-        result: {
-          exitCode: item.exit_code ?? null,
-          output: item.aggregated_output ?? '',
-          status: item.status ?? 'completed',
-        },
-      });
-    }
-    observeStep();
-    return;
-  }
-
-  if (item.type === 'mcp_tool_call') {
-    if (event.type === 'item.started') {
-      ctx.send({
-        type: 'tool-call',
-        toolCallId: id,
-        toolName: item.tool ?? 'unknown',
-        nativeName: item.tool ?? 'unknown',
-        input: JSON.stringify(item.arguments ?? {}),
-        providerExecuted: true,
-      });
-    } else if (event.type === 'item.completed') {
-      ctx.send({
-        type: 'tool-result',
-        toolCallId: id,
-        toolName: item.tool ?? 'unknown',
-        result: extractMcpToolCallResult(item),
-      });
-    }
-    observeStep();
-    return;
-  }
-
-  if (item.type === 'web_search') {
-    const nativeName = 'web_search';
-    if (event.type === 'item.started') {
-      ctx.send({
-        type: 'tool-call',
-        toolCallId: id,
-        toolName: toCommonName(nativeName),
-        nativeName,
-        input: JSON.stringify({ query: item.query ?? '' }),
-        providerExecuted: true,
-      });
-    } else if (event.type === 'item.completed') {
-      ctx.send({
-        type: 'tool-result',
-        toolCallId: id,
-        toolName: toCommonName(nativeName),
-        result: item.result ?? null,
-      });
-    }
-    observeStep();
-    return;
-  }
-
-  if (item.type === 'file_change' && event.type === 'item.completed') {
-    for (const change of item.changes ?? []) {
-      ctx.send({
-        type: 'file-change',
-        event:
-          change.kind === 'add'
-            ? 'create'
-            : change.kind === 'delete'
-              ? 'delete'
-              : 'modify',
-        path: change.path,
-      });
-    }
-    observeStep();
-    return;
-  }
-
-  if (item.type === 'error' && event.type === 'item.completed') {
-    const message =
-      typeof item.message === 'string' && item.message.trim()
-        ? item.message
-        : 'codex reported a non-fatal error item';
-    ctx.emitWarning({ message });
-    return;
-  }
-}
-
-function mapUsage(usage: Record<string, number>): Record<string, unknown> {
-  const input = usage.input_tokens ?? 0;
-  const cacheRead = usage.cached_input_tokens ?? 0;
-  return {
-    inputTokens: {
-      total: input,
-      noCache: Math.max(0, input - cacheRead),
-      cacheRead,
-      cacheWrite: 0,
-    },
-    outputTokens: {
-      total: usage.output_tokens ?? 0,
-      text: usage.output_tokens ?? 0,
-    },
-  };
 }
 
 /**

--- a/packages/harness-deepagents/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-deepagents/src/bridge/create-emit-stream-event.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createDeepAgentsStreamEventState,
+  createEmitStreamEvent,
+} from './create-emit-stream-event';
+
+vi.mock('node:crypto', () => ({ randomUUID: () => 'uuid' }));
+
+describe('createEmitStreamEvent', () => {
+  it('emits model, content, and step events while counting nested usage', () => {
+    const state = createDeepAgentsStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      configuredModel: 'configured-model',
+      hostToolNames: new Set(),
+      emit: event => emitted.push(event),
+    });
+
+    emitStreamEvent({
+      event: 'on_chat_model_start',
+      metadata: { ls_model_name: 'resolved-model' },
+    });
+    emitStreamEvent({
+      event: 'on_chat_model_stream',
+      data: {
+        chunk: {
+          content: 'hello',
+          usage_metadata: { input_tokens: 3, output_tokens: 1 },
+        },
+      },
+    });
+    emitStreamEvent({
+      event: 'on_chat_model_end',
+      data: {
+        output: { usage_metadata: { input_tokens: 3, output_tokens: 2 } },
+      },
+    });
+    emitStreamEvent({
+      event: 'on_chat_model_end',
+      metadata: { langgraph_checkpoint_ns: 'root|subagent' },
+      data: {
+        output: { usage_metadata: { input_tokens: 5, output_tokens: 4 } },
+      },
+    });
+    emitStreamEvent({ event: 'on_chat_model_start' });
+
+    expect({ emitted, input: state.inputTokens, output: state.outputTokens })
+      .toMatchInlineSnapshot(`
+        {
+          "emitted": [
+            {
+              "modelId": "resolved-model",
+              "type": "stream-start",
+            },
+            {
+              "id": "text-uuid",
+              "type": "text-start",
+            },
+            {
+              "delta": "hello",
+              "id": "text-uuid",
+              "type": "text-delta",
+            },
+            {
+              "id": "text-uuid",
+              "type": "text-end",
+            },
+            {
+              "finishReason": {
+                "unified": "stop",
+              },
+              "type": "finish-step",
+              "usage": {
+                "inputTokens": {
+                  "total": 3,
+                },
+                "outputTokens": {
+                  "total": 2,
+                },
+              },
+            },
+          ],
+          "input": 8,
+          "output": 6,
+        }
+      `);
+  });
+
+  it('preserves tool input unwrapping and approved call ids', () => {
+    const state = createDeepAgentsStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      configuredModel: undefined,
+      hostToolNames: new Set(),
+      emit: event => emitted.push(event),
+    });
+
+    emitStreamEvent({
+      event: 'on_tool_start',
+      name: 'execute',
+      run_id: 'run-1',
+      data: { input: { input: '{"command":"pwd"}' } },
+    });
+    state.approvedToolQueue.set('read_file', ['approval-1']);
+    emitStreamEvent({
+      event: 'on_tool_start',
+      name: 'read_file',
+      run_id: 'run-2',
+      data: { input: { path: 'README.md' } },
+    });
+    emitStreamEvent({
+      event: 'on_tool_end',
+      name: 'read_file',
+      run_id: 'run-2',
+      data: { output: { content: 'contents' } },
+    });
+
+    expect(emitted).toMatchInlineSnapshot(`
+      [
+        {
+          "input": "{\"command\":\"pwd\"}",
+          "nativeName": "execute",
+          "providerExecuted": true,
+          "toolCallId": "run-1",
+          "toolName": "bash",
+          "type": "tool-call",
+        },
+        {
+          "result": "contents",
+          "toolCallId": "approval-1",
+          "toolName": "read",
+          "type": "tool-result",
+        },
+      ]
+    `);
+  });
+});

--- a/packages/harness-deepagents/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-deepagents/src/bridge/create-emit-stream-event.ts
@@ -1,0 +1,322 @@
+import { randomUUID } from 'node:crypto';
+
+type Emit = (event: Record<string, unknown>) => void;
+
+export type DeepAgentsStreamEvent = {
+  event?: string;
+  name?: string;
+  run_id?: string;
+  data?: unknown;
+  metadata?: {
+    langgraph_checkpoint_ns?: string;
+    ls_model_name?: unknown;
+  };
+};
+
+export type DeepAgentsStreamEventState = {
+  streamStarted: boolean;
+  textBlockId: string | undefined;
+  reasoningBlockId: string | undefined;
+  inputTokens: number;
+  outputTokens: number;
+  // Per-call streamed-usage fallback (max over chunks), used only when model-end carries no usage.
+  streamedStepInput: number;
+  streamedStepOutput: number;
+  // Top-level step usage is buffered at model-end and flushed as finish-step only after the step's tools run.
+  pendingStep: { input: number; output: number } | undefined;
+  // Approval-gated tools are announced before execution; these tie the later run back to the approval id and dedup the call.
+  approvedToolQueue: Map<string, string[]>;
+  approvedRunIds: Map<string, string>;
+};
+
+export function createDeepAgentsStreamEventState(): DeepAgentsStreamEventState {
+  return {
+    streamStarted: false,
+    textBlockId: undefined,
+    reasoningBlockId: undefined,
+    inputTokens: 0,
+    outputTokens: 0,
+    streamedStepInput: 0,
+    streamedStepOutput: 0,
+    pendingStep: undefined,
+    approvedToolQueue: new Map(),
+    approvedRunIds: new Map(),
+  };
+}
+
+// Native Deep Agents tool name -> harness-v1 common name (renames only; grep/glob/ls/task/write_todos forward unchanged).
+const NATIVE_TO_COMMON: Readonly<Record<string, string>> = {
+  read_file: 'read',
+  write_file: 'write',
+  edit_file: 'edit',
+  execute: 'bash',
+};
+
+export function toCommonName(nativeName: string): string {
+  return NATIVE_TO_COMMON[nativeName] ?? nativeName;
+}
+
+export function createEmitStreamEvent({
+  state,
+  configuredModel,
+  hostToolNames,
+  emit,
+}: {
+  state: DeepAgentsStreamEventState;
+  configuredModel: string | undefined;
+  hostToolNames: ReadonlySet<string>;
+  emit: Emit;
+}): (event: DeepAgentsStreamEvent) => void {
+  return event => {
+    const kind = event.event;
+    const data = (event.data ?? {}) as Record<string, unknown>;
+    // Subagent (e.g. `task`) events carry a `|`-delimited checkpoint namespace; keep their internals out of the top-level stream.
+    const ns = event.metadata?.langgraph_checkpoint_ns ?? '';
+    const nested = ns.includes('|');
+
+    if (kind === 'on_chat_model_start') {
+      if (!nested) {
+        if (!state.streamStarted) {
+          state.streamStarted = true;
+          const modelId = resolveDeepAgentsModelId({
+            configuredModel,
+            metadata: event.metadata,
+          });
+          emit({
+            type: 'stream-start',
+            ...(modelId ? { modelId } : {}),
+          });
+        }
+        // A new top-level model call means the previous step's tools have run; close it now.
+        flushStep({ state, emit });
+      }
+    } else if (kind === 'on_chat_model_stream') {
+      if (nested) return;
+      const chunk = data.chunk as
+        | {
+            content?: unknown;
+            usage_metadata?: {
+              input_tokens?: number;
+              output_tokens?: number;
+            };
+          }
+        | undefined;
+      if (!chunk) return;
+      const content = chunk.content;
+      if (typeof content === 'string' && content) {
+        emitText({ state, emit, delta: content });
+      } else if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block && typeof block === 'object') {
+            const value = block as {
+              type?: string;
+              text?: string;
+              thinking?: string;
+            };
+            if (value.type === 'text' && value.text) {
+              emitText({ state, emit, delta: value.text });
+            } else if (value.type === 'thinking' && value.thinking) {
+              emitReasoning({ state, emit, delta: value.thinking });
+            }
+          }
+        }
+      }
+      const usage = chunk.usage_metadata;
+      if (usage) {
+        state.streamedStepInput = Math.max(
+          state.streamedStepInput,
+          usage.input_tokens ?? 0,
+        );
+        state.streamedStepOutput = Math.max(
+          state.streamedStepOutput,
+          usage.output_tokens ?? 0,
+        );
+      }
+    } else if (kind === 'on_chat_model_end') {
+      // Final usage lands on model-end, not the chunks; each model call is one step.
+      const output = data.output as
+        | {
+            usage_metadata?: {
+              input_tokens?: number;
+              output_tokens?: number;
+            };
+          }
+        | undefined;
+      const usage = output?.usage_metadata;
+      // One model call = one step; count its usage exactly once (model-end usage, else the streamed max).
+      const stepInput = usage?.input_tokens ?? state.streamedStepInput;
+      const stepOutput = usage?.output_tokens ?? state.streamedStepOutput;
+      state.inputTokens += stepInput;
+      state.outputTokens += stepOutput;
+      state.streamedStepInput = 0;
+      state.streamedStepOutput = 0;
+      // Nested (subagent) calls still count toward total usage, but only top-level calls bound a visible step.
+      if (!nested) {
+        endTextBlock({ state, emit });
+        endReasoningBlock({ state, emit });
+        // Buffer the step; flushStep emits finish-step after this step's tools run (next start / turn end).
+        state.pendingStep = { input: stepInput, output: stepOutput };
+      }
+    } else if (kind === 'on_tool_start') {
+      const toolName = event.name ?? 'unknown';
+      const runId = event.run_id ?? '';
+      // Host tools emit their own tool-call; surface only top-level builtin (providerExecuted) tools.
+      if (!nested && !hostToolNames.has(toolName)) {
+        const queued = state.approvedToolQueue.get(toolName);
+        if (queued && queued.length > 0) {
+          // Already announced at approval time; tie this run to that id and don't re-emit the call.
+          const approvalId = queued.shift()!;
+          if (runId) state.approvedRunIds.set(runId, approvalId);
+        } else {
+          endTextBlock({ state, emit });
+          endReasoningBlock({ state, emit });
+          emit({
+            type: 'tool-call',
+            toolCallId: runId,
+            toolName: toCommonName(toolName),
+            input: toToolCallInput(data.input),
+            providerExecuted: true,
+            nativeName: toolName,
+          });
+        }
+      }
+    } else if (kind === 'on_tool_end') {
+      const toolName = event.name ?? 'unknown';
+      const runId = event.run_id ?? '';
+      if (!nested && !hostToolNames.has(toolName)) {
+        let output: unknown = data.output ?? '';
+        if (output && typeof output === 'object' && 'content' in output) {
+          output = (output as { content: unknown }).content;
+        }
+        emit({
+          type: 'tool-result',
+          toolCallId: state.approvedRunIds.get(runId) ?? runId,
+          toolName: toCommonName(toolName),
+          result: output ?? null,
+        });
+        state.approvedRunIds.delete(runId);
+      }
+    }
+  };
+}
+
+export function endTextBlock({
+  state,
+  emit,
+}: {
+  state: DeepAgentsStreamEventState;
+  emit: Emit;
+}): void {
+  if (state.textBlockId) {
+    emit({ type: 'text-end', id: state.textBlockId });
+    state.textBlockId = undefined;
+  }
+}
+
+export function endReasoningBlock({
+  state,
+  emit,
+}: {
+  state: DeepAgentsStreamEventState;
+  emit: Emit;
+}): void {
+  if (state.reasoningBlockId) {
+    emit({ type: 'reasoning-end', id: state.reasoningBlockId });
+    state.reasoningBlockId = undefined;
+  }
+}
+
+// Close the buffered top-level step; called when the next step starts and at turn end so finish-step lands after the step's tools.
+export function flushStep({
+  state,
+  emit,
+}: {
+  state: DeepAgentsStreamEventState;
+  emit: Emit;
+}): void {
+  if (!state.pendingStep) return;
+  emit({
+    type: 'finish-step',
+    finishReason: { unified: 'stop' },
+    usage: {
+      inputTokens: { total: state.pendingStep.input },
+      outputTokens: { total: state.pendingStep.output },
+    },
+  });
+  state.pendingStep = undefined;
+}
+
+function ensureTextBlock({
+  state,
+  emit,
+}: {
+  state: DeepAgentsStreamEventState;
+  emit: Emit;
+}): string {
+  if (!state.textBlockId) {
+    state.textBlockId = `text-${randomUUID()}`;
+    emit({ type: 'text-start', id: state.textBlockId });
+  }
+  return state.textBlockId;
+}
+
+// Text and reasoning are mutually exclusive open blocks: starting one closes the other.
+function emitText({
+  state,
+  emit,
+  delta,
+}: {
+  state: DeepAgentsStreamEventState;
+  emit: Emit;
+  delta: string;
+}): void {
+  endReasoningBlock({ state, emit });
+  emit({ type: 'text-delta', id: ensureTextBlock({ state, emit }), delta });
+}
+
+function emitReasoning({
+  state,
+  emit,
+  delta,
+}: {
+  state: DeepAgentsStreamEventState;
+  emit: Emit;
+  delta: string;
+}): void {
+  endTextBlock({ state, emit });
+  if (!state.reasoningBlockId) {
+    state.reasoningBlockId = `reasoning-${randomUUID()}`;
+    emit({ type: 'reasoning-start', id: state.reasoningBlockId });
+  }
+  emit({ type: 'reasoning-delta', id: state.reasoningBlockId, delta });
+}
+
+function resolveDeepAgentsModelId({
+  configuredModel,
+  metadata,
+}: {
+  configuredModel: string | undefined;
+  metadata: unknown;
+}): string | undefined {
+  if (metadata && typeof metadata === 'object' && !Array.isArray(metadata)) {
+    const modelId = (metadata as { ls_model_name?: unknown }).ls_model_name;
+    if (typeof modelId === 'string' && modelId.length > 0) return modelId;
+  }
+
+  return configuredModel;
+}
+
+// LangChain reports some built-in tool args wrapped as `{ input: "<json>" }`; unwrap to the inner JSON so AI SDK validates the real shape.
+function toToolCallInput(raw: unknown): string {
+  if (
+    raw &&
+    typeof raw === 'object' &&
+    !Array.isArray(raw) &&
+    Object.keys(raw).length === 1 &&
+    typeof (raw as { input?: unknown }).input === 'string'
+  ) {
+    const inner = (raw as { input: string }).input;
+    if (/^\s*[[{]/.test(inner)) return inner;
+  }
+  return JSON.stringify(raw ?? {});
+}

--- a/packages/harness-deepagents/src/bridge/index.ts
+++ b/packages/harness-deepagents/src/bridge/index.ts
@@ -13,22 +13,20 @@ import { Command, MemorySaver } from '@langchain/langgraph';
 import { createDeepAgent } from 'deepagents';
 import type { StartMessage } from '../deepagents-bridge-protocol';
 import { buildInterruptOn, collectActionRequests } from './approvals';
+import {
+  createDeepAgentsStreamEventState,
+  createEmitStreamEvent,
+  endReasoningBlock,
+  endTextBlock,
+  flushStep,
+  toCommonName,
+  type DeepAgentsStreamEvent,
+} from './create-emit-stream-event';
 import { jsonSchemaToZodObject } from './json-schema-to-zod';
 import { createLocalShellBackend } from './local-shell-backend';
 import { createBuiltinToolFilteringMiddleware } from './tool-filtering';
 
-// Native Deep Agents tool name -> harness-v1 common name (renames only; grep/glob/ls/task/write_todos forward unchanged).
-const NATIVE_TO_COMMON: Readonly<Record<string, string>> = {
-  read_file: 'read',
-  write_file: 'write',
-  edit_file: 'edit',
-  execute: 'bash',
-};
 const HARNESS_CLIENT_APP = procEnv.AI_SDK_HARNESS_CLIENT_APP;
-
-function toCommonName(nativeName: string): string {
-  return NATIVE_TO_COMMON[nativeName] ?? nativeName;
-}
 
 function parseArgs(rawArgs: string[]): Record<string, string> {
   const out: Record<string, string> = {};
@@ -43,21 +41,6 @@ function parseArgs(rawArgs: string[]): Record<string, string> {
     }
   }
   return out;
-}
-
-function resolveDeepAgentsModelId({
-  configuredModel,
-  metadata,
-}: {
-  configuredModel: string | undefined;
-  metadata: unknown;
-}): string | undefined {
-  if (metadata && typeof metadata === 'object' && !Array.isArray(metadata)) {
-    const modelId = (metadata as { ls_model_name?: unknown }).ls_model_name;
-    if (typeof modelId === 'string' && modelId.length > 0) return modelId;
-  }
-
-  return configuredModel;
 }
 
 // Always drive the Anthropic client. Through the gateway, models keep their
@@ -81,21 +64,6 @@ function buildModel(rawModel: string | undefined) {
         }
       : {}),
   });
-}
-
-// LangChain reports some built-in tool args wrapped as `{ input: "<json>" }`; unwrap to the inner JSON so AI SDK validates the real shape.
-function toToolCallInput(raw: unknown): string {
-  if (
-    raw &&
-    typeof raw === 'object' &&
-    !Array.isArray(raw) &&
-    Object.keys(raw).length === 1 &&
-    typeof (raw as { input?: unknown }).input === 'string'
-  ) {
-    const inner = (raw as { input: string }).input;
-    if (/^\s*[[{]/.test(inner)) return inner;
-  }
-  return JSON.stringify(raw ?? {});
 }
 
 const args = parseArgs(argv.slice(2));
@@ -178,65 +146,13 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   }
 
   const hostToolNames = new Set((start.tools ?? []).map(t => t.name));
-  let streamStarted = false;
-  let textBlockId: string | undefined;
-  let reasoningBlockId: string | undefined;
-  let inputTokens = 0;
-  let outputTokens = 0;
-  // Per-call streamed-usage fallback (max over chunks), used only when model-end carries no usage.
-  let streamedStepInput = 0;
-  let streamedStepOutput = 0;
-  // Top-level step usage is buffered at model-end and flushed as finish-step only after the step's tools run.
-  let pendingStep: { input: number; output: number } | undefined;
-  // Approval-gated tools are announced before execution; these tie the later run back to the approval id and dedup the call.
-  const approvedToolQueue = new Map<string, string[]>();
-  const approvedRunIds = new Map<string, string>();
-
-  const ensureTextBlock = (): string => {
-    if (!textBlockId) {
-      textBlockId = `text-${randomUUID()}`;
-      emit({ type: 'text-start', id: textBlockId });
-    }
-    return textBlockId;
-  };
-  const endTextBlock = () => {
-    if (textBlockId) {
-      emit({ type: 'text-end', id: textBlockId });
-      textBlockId = undefined;
-    }
-  };
-  const endReasoningBlock = () => {
-    if (reasoningBlockId) {
-      emit({ type: 'reasoning-end', id: reasoningBlockId });
-      reasoningBlockId = undefined;
-    }
-  };
-  // Text and reasoning are mutually exclusive open blocks: starting one closes the other.
-  const emitText = (delta: string) => {
-    endReasoningBlock();
-    emit({ type: 'text-delta', id: ensureTextBlock(), delta });
-  };
-  const emitReasoning = (delta: string) => {
-    endTextBlock();
-    if (!reasoningBlockId) {
-      reasoningBlockId = `reasoning-${randomUUID()}`;
-      emit({ type: 'reasoning-start', id: reasoningBlockId });
-    }
-    emit({ type: 'reasoning-delta', id: reasoningBlockId, delta });
-  };
-  // Close the buffered top-level step; called when the next step starts and at turn end so finish-step lands after the step's tools.
-  const flushStep = () => {
-    if (!pendingStep) return;
-    emit({
-      type: 'finish-step',
-      finishReason: { unified: 'stop' },
-      usage: {
-        inputTokens: { total: pendingStep.input },
-        outputTokens: { total: pendingStep.output },
-      },
-    });
-    pendingStep = undefined;
-  };
+  const streamEventState = createDeepAgentsStreamEventState();
+  const emitStreamEvent = createEmitStreamEvent({
+    state: streamEventState,
+    configuredModel: start.model,
+    hostToolNames,
+    emit,
+  });
 
   const config = {
     version: 'v2' as const,
@@ -267,135 +183,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     const stream = await agent.streamEvents(resumeInput as never, config);
 
     for await (const event of stream) {
-      const kind = event.event;
-      const data = (event.data ?? {}) as Record<string, unknown>;
-      // Subagent (e.g. `task`) events carry a `|`-delimited checkpoint namespace; keep their internals out of the top-level stream.
-      const ns =
-        (event as { metadata?: { langgraph_checkpoint_ns?: string } }).metadata
-          ?.langgraph_checkpoint_ns ?? '';
-      const nested = ns.includes('|');
-
-      if (kind === 'on_chat_model_start') {
-        if (!nested) {
-          if (!streamStarted) {
-            streamStarted = true;
-            const modelId = resolveDeepAgentsModelId({
-              configuredModel: start.model,
-              metadata: event.metadata,
-            });
-            emit({
-              type: 'stream-start',
-              ...(modelId ? { modelId } : {}),
-            });
-          }
-          // A new top-level model call means the previous step's tools have run; close it now.
-          flushStep();
-        }
-      } else if (kind === 'on_chat_model_stream') {
-        if (nested) continue;
-        const chunk = data.chunk as
-          | {
-              content?: unknown;
-              usage_metadata?: {
-                input_tokens?: number;
-                output_tokens?: number;
-              };
-            }
-          | undefined;
-        if (!chunk) continue;
-        const content = chunk.content;
-        if (typeof content === 'string' && content) {
-          emitText(content);
-        } else if (Array.isArray(content)) {
-          for (const block of content) {
-            if (block && typeof block === 'object') {
-              const b = block as {
-                type?: string;
-                text?: string;
-                thinking?: string;
-              };
-              if (b.type === 'text' && b.text) emitText(b.text);
-              else if (b.type === 'thinking' && b.thinking)
-                emitReasoning(b.thinking);
-            }
-          }
-        }
-        const usage = chunk.usage_metadata;
-        if (usage) {
-          streamedStepInput = Math.max(
-            streamedStepInput,
-            usage.input_tokens ?? 0,
-          );
-          streamedStepOutput = Math.max(
-            streamedStepOutput,
-            usage.output_tokens ?? 0,
-          );
-        }
-      } else if (kind === 'on_chat_model_end') {
-        // Final usage lands on model-end, not the chunks; each model call is one step.
-        const output = data.output as
-          | {
-              usage_metadata?: {
-                input_tokens?: number;
-                output_tokens?: number;
-              };
-            }
-          | undefined;
-        const usage = output?.usage_metadata;
-        // One model call = one step; count its usage exactly once (model-end usage, else the streamed max).
-        const stepInput = usage?.input_tokens ?? streamedStepInput;
-        const stepOutput = usage?.output_tokens ?? streamedStepOutput;
-        inputTokens += stepInput;
-        outputTokens += stepOutput;
-        streamedStepInput = 0;
-        streamedStepOutput = 0;
-        // Nested (subagent) calls still count toward total usage, but only top-level calls bound a visible step.
-        if (!nested) {
-          endTextBlock();
-          endReasoningBlock();
-          // Buffer the step; flushStep emits finish-step after this step's tools run (next start / turn end).
-          pendingStep = { input: stepInput, output: stepOutput };
-        }
-      } else if (kind === 'on_tool_start') {
-        const toolName = (event.name as string) ?? 'unknown';
-        const runId = (event.run_id as string) ?? '';
-        // Host tools emit their own tool-call; surface only top-level builtin (providerExecuted) tools.
-        if (!nested && !hostToolNames.has(toolName)) {
-          const queued = approvedToolQueue.get(toolName);
-          if (queued && queued.length > 0) {
-            // Already announced at approval time; tie this run to that id and don't re-emit the call.
-            const approvalId = queued.shift()!;
-            if (runId) approvedRunIds.set(runId, approvalId);
-          } else {
-            endTextBlock();
-            endReasoningBlock();
-            emit({
-              type: 'tool-call',
-              toolCallId: runId,
-              toolName: toCommonName(toolName),
-              input: toToolCallInput(data.input),
-              providerExecuted: true,
-              nativeName: toolName,
-            });
-          }
-        }
-      } else if (kind === 'on_tool_end') {
-        const toolName = (event.name as string) ?? 'unknown';
-        const runId = (event.run_id as string) ?? '';
-        if (!nested && !hostToolNames.has(toolName)) {
-          let output: unknown = data.output ?? '';
-          if (output && typeof output === 'object' && 'content' in output) {
-            output = (output as { content: unknown }).content;
-          }
-          emit({
-            type: 'tool-result',
-            toolCallId: approvedRunIds.get(runId) ?? runId,
-            toolName: toCommonName(toolName),
-            result: output ?? null,
-          });
-          approvedRunIds.delete(runId);
-        }
-      }
+      emitStreamEvent(event as DeepAgentsStreamEvent);
     }
 
     const actionRequests = await readPendingApprovals();
@@ -407,8 +195,8 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     > = [];
     for (const action of actionRequests) {
       const approvalId = `approval-${randomUUID()}`;
-      endTextBlock();
-      endReasoningBlock();
+      endTextBlock({ state: streamEventState, emit });
+      endReasoningBlock({ state: streamEventState, emit });
       emit({
         type: 'tool-call',
         toolCallId: approvalId,
@@ -422,12 +210,12 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
         approvalId,
         toolCallId: approvalId,
       });
-      flushStep();
+      flushStep({ state: streamEventState, emit });
       const decision = await turn.requestToolApproval(approvalId);
       if (decision.approved) {
-        const queue = approvedToolQueue.get(action.name) ?? [];
+        const queue = streamEventState.approvedToolQueue.get(action.name) ?? [];
         queue.push(approvalId);
-        approvedToolQueue.set(action.name, queue);
+        streamEventState.approvedToolQueue.set(action.name, queue);
         decisions.push({ type: 'approve' });
       } else {
         // Rejected tools never execute, so surface the outcome as the result now.
@@ -447,15 +235,15 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     resumeInput = new Command({ resume: { decisions } });
   }
 
-  endTextBlock();
-  endReasoningBlock();
-  flushStep();
+  endTextBlock({ state: streamEventState, emit });
+  endReasoningBlock({ state: streamEventState, emit });
+  flushStep({ state: streamEventState, emit });
   emit({
     type: 'finish',
     finishReason: { unified: 'stop' },
     totalUsage: {
-      inputTokens: { total: inputTokens },
-      outputTokens: { total: outputTokens },
+      inputTokens: { total: streamEventState.inputTokens },
+      outputTokens: { total: streamEventState.outputTokens },
     },
   });
 }

--- a/packages/harness-opencode/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-opencode/src/bridge/create-emit-stream-event.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+import { createEmitStreamEvent } from './create-emit-stream-event';
+import { createTranslationState } from './opencode-events';
+
+function createEmitter({
+  hostToolNames = new Set<string>(),
+}: {
+  hostToolNames?: Set<string>;
+} = {}) {
+  const state = createTranslationState();
+  const emitted: Record<string, unknown>[] = [];
+  const warnings: unknown[] = [];
+  const errors: unknown[] = [];
+  const authorized: unknown[] = [];
+  const toWireToolName = (name: string) =>
+    ({ view: 'read', task: 'agent' })[name] ?? name;
+  const getHostToolName = (toolName: string, rawToolName: unknown) => {
+    if (hostToolNames.has(toolName)) return toolName;
+    return typeof rawToolName === 'string' && hostToolNames.has(rawToolName)
+      ? rawToolName
+      : undefined;
+  };
+  const emitStreamEvent = createEmitStreamEvent({
+    state,
+    emit: event => emitted.push(event),
+    emitWarning: warning => warnings.push(warning),
+    emitError: error => errors.push(error),
+    toWireToolName,
+    nativeNameField: ({ nativeName, toolName }) =>
+      nativeName === toolName ? {} : { nativeName },
+    getHostToolName,
+    authorizeHostToolCall: input => authorized.push(input),
+    stripWorkDir: file => file.replace('/work/', ''),
+    formatError: error => String(error),
+  });
+  return { state, emitted, warnings, errors, authorized, emitStreamEvent };
+}
+
+describe('createEmitStreamEvent', () => {
+  it('emits text, final deltas, and step usage', () => {
+    const { emitted, emitStreamEvent } = createEmitter();
+
+    emitStreamEvent({
+      type: 'session.next.text.started',
+      properties: { textID: 'text-1' },
+    });
+    emitStreamEvent({
+      type: 'session.next.text.delta',
+      properties: { textID: 'text-1', delta: 'hello ' },
+    });
+    emitStreamEvent({
+      type: 'session.next.text.ended',
+      properties: { textID: 'text-1', text: 'hello world' },
+    });
+    emitStreamEvent({
+      type: 'session.next.step.ended',
+      properties: {
+        finish: 'stop',
+        tokens: {
+          input: 3,
+          output: 2,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        cost: 0.01,
+      },
+    });
+
+    expect(emitted).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "text-1",
+          "type": "text-start",
+        },
+        {
+          "delta": "hello ",
+          "id": "text-1",
+          "type": "text-delta",
+        },
+        {
+          "delta": "world",
+          "id": "text-1",
+          "type": "text-delta",
+        },
+        {
+          "id": "text-1",
+          "type": "text-end",
+        },
+        {
+          "finishReason": {
+            "raw": "stop",
+            "unified": "stop",
+          },
+          "harnessMetadata": {
+            "opencode": {
+              "cost": 0.01,
+            },
+          },
+          "type": "finish-step",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": 0,
+              "cacheWrite": 0,
+              "noCache": 3,
+              "total": 3,
+            },
+            "outputTokens": {
+              "reasoning": 0,
+              "text": 2,
+              "total": 2,
+            },
+          },
+        },
+      ]
+    `);
+  });
+
+  it('translates provider and host tool events without duplication', () => {
+    const { emitted, authorized, emitStreamEvent } = createEmitter({
+      hostToolNames: new Set(['weather']),
+    });
+
+    emitStreamEvent({
+      type: 'session.next.tool.called',
+      properties: {
+        callID: 'tool-1',
+        tool: 'view',
+        input: { file: 'README.md' },
+      },
+    });
+    emitStreamEvent({
+      type: 'session.next.tool.success',
+      properties: { callID: 'tool-1', result: 'contents' },
+    });
+    emitStreamEvent({
+      type: 'session.next.tool.called',
+      properties: {
+        callID: 'tool-2',
+        tool: 'weather',
+        input: { city: 'Berlin' },
+      },
+    });
+    emitStreamEvent({
+      type: 'session.next.tool.success',
+      properties: { callID: 'tool-2', result: 'sunny' },
+    });
+
+    expect({ emitted, authorized }).toMatchInlineSnapshot(`
+      {
+        "authorized": [
+          {
+            "callID": "tool-2",
+            "input": {
+              "city": "Berlin",
+            },
+            "toolName": "weather",
+          },
+        ],
+        "emitted": [
+          {
+            "input": "{\"file\":\"README.md\"}",
+            "nativeName": "view",
+            "providerExecuted": true,
+            "toolCallId": "tool-1",
+            "toolName": "read",
+            "type": "tool-call",
+          },
+          {
+            "result": "contents",
+            "toolCallId": "tool-1",
+            "toolName": "read",
+            "type": "tool-result",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('preserves retry, error, compaction, and file events', () => {
+    const { emitted, warnings, errors, emitStreamEvent } = createEmitter();
+
+    emitStreamEvent({
+      type: 'session.next.retried',
+      properties: {
+        attempt: 2,
+        error: { statusCode: 500, message: 'temporary' },
+      },
+    });
+    emitStreamEvent({
+      type: 'session.next.compaction.ended',
+      properties: { reason: 'auto', text: 'summary', recent: 'recent' },
+    });
+    emitStreamEvent({
+      type: 'file.edited',
+      properties: { file: '/work/src/index.ts' },
+    });
+    emitStreamEvent({
+      type: 'session.next.step.failed',
+      properties: { error: 'failed' },
+    });
+
+    expect({ emitted, warnings, errors }).toMatchInlineSnapshot(`
+      {
+        "emitted": [
+          {
+            "harnessMetadata": {
+              "opencode": {
+                "recent": "recent",
+              },
+            },
+            "summary": "summary",
+            "trigger": "auto",
+            "type": "compaction",
+          },
+          {
+            "event": "modify",
+            "path": "src/index.ts",
+            "type": "file-change",
+          },
+        ],
+        "errors": [
+          {
+            "error": "failed",
+            "message": "OpenCode step failed",
+          },
+        ],
+        "warnings": [
+          {
+            "message": "OpenCode session retry: attempt 2; HTTP 500; temporary",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/packages/harness-opencode/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-opencode/src/bridge/create-emit-stream-event.ts
@@ -1,0 +1,512 @@
+import type { BridgeTurn } from '@ai-sdk/harness/bridge';
+import {
+  emitLegacyPartDelta,
+  emitLegacyTextPartUpdate,
+  emitMissingFinalDelta,
+  type OpenCodeEvent,
+  type TranslationState,
+} from './opencode-events';
+import {
+  legacyStepFinishPartToFinishStep,
+  mapOpenCodeFinishReason,
+} from './opencode-finish-step';
+import { mapUsage } from './opencode-usage';
+
+type Emit = (message: Record<string, unknown>) => void;
+
+export function createEmitStreamEvent({
+  state,
+  emit,
+  emitWarning,
+  emitError,
+  toWireToolName,
+  nativeNameField,
+  getHostToolName,
+  authorizeHostToolCall,
+  stripWorkDir,
+  formatError,
+}: {
+  state: TranslationState;
+  emit: Emit;
+  emitWarning: BridgeTurn['emitWarning'];
+  emitError: BridgeTurn['emitError'];
+  toWireToolName: (nativeName: string) => string;
+  nativeNameField: (input: { nativeName: string; toolName: string }) => {
+    nativeName?: string;
+  };
+  getHostToolName: (
+    toolName: string,
+    rawToolName: unknown,
+  ) => string | undefined;
+  authorizeHostToolCall: (input: {
+    callID: string;
+    toolName: string;
+    input: unknown;
+  }) => void;
+  stripWorkDir: (file: string) => string;
+  formatError: (error: unknown) => string;
+}): (event: OpenCodeEvent) => void {
+  return event => {
+    const type = event.type;
+    const props = event.properties ?? {};
+
+    if (type === 'message.updated') {
+      const info = props.info;
+      if (isRecord(info)) {
+        const id = stringValue(info.id);
+        const role = stringValue(info.role);
+        if (id && role) state.messageRoles.set(id, role);
+      }
+      return;
+    }
+
+    if (type === 'message.part.delta') {
+      emitLegacyPartDelta({ props, state, emit });
+      return;
+    }
+
+    if (type === 'message.part.updated') {
+      if (emitLegacyTextPartUpdate({ part: props.part, state, emit })) return;
+      if (emitLegacyStepFinishPart({ part: props.part, state, emit })) return;
+      emitLegacyToolPart({
+        part: props.part,
+        state,
+        emit,
+        toWireToolName,
+        nativeNameField,
+        getHostToolName,
+        authorizeHostToolCall,
+      });
+      return;
+    }
+
+    if (type === 'session.next.text.started') {
+      emit({ type: 'text-start', id: String(props.textID ?? event.id) });
+      return;
+    }
+    if (type === 'session.next.text.delta') {
+      const id = String(props.textID ?? event.id);
+      state.textDeltas.set(
+        id,
+        `${state.textDeltas.get(id) ?? ''}${String(props.delta ?? '')}`,
+      );
+      emit({
+        type: 'text-delta',
+        id,
+        delta: String(props.delta ?? ''),
+      });
+      return;
+    }
+    if (type === 'session.next.text.ended') {
+      const id = String(props.textID ?? event.id);
+      emitMissingFinalDelta({
+        id,
+        fullText: typeof props.text === 'string' ? props.text : undefined,
+        emittedText: state.textDeltas.get(id) ?? '',
+        emit,
+        type: 'text-delta',
+      });
+      emit({ type: 'text-end', id });
+      return;
+    }
+    if (type === 'session.next.reasoning.started') {
+      emit({
+        type: 'reasoning-start',
+        id: String(props.reasoningID ?? event.id),
+      });
+      return;
+    }
+    if (type === 'session.next.reasoning.delta') {
+      const id = String(props.reasoningID ?? event.id);
+      state.reasoningDeltas.set(
+        id,
+        `${state.reasoningDeltas.get(id) ?? ''}${String(props.delta ?? '')}`,
+      );
+      emit({
+        type: 'reasoning-delta',
+        id,
+        delta: String(props.delta ?? ''),
+      });
+      return;
+    }
+    if (type === 'session.next.reasoning.ended') {
+      const id = String(props.reasoningID ?? event.id);
+      emitMissingFinalDelta({
+        id,
+        fullText: typeof props.text === 'string' ? props.text : undefined,
+        emittedText: state.reasoningDeltas.get(id) ?? '',
+        emit,
+        type: 'reasoning-delta',
+      });
+      emit({ type: 'reasoning-end', id });
+      return;
+    }
+    if (type === 'session.next.shell.started') {
+      const callID = String(props.callID ?? event.id);
+      const command = String(props.command ?? '');
+      state.shellCommands.set(callID, command);
+      emit({
+        type: 'tool-call',
+        toolCallId: callID,
+        toolName: 'bash',
+        nativeName: 'bash',
+        input: JSON.stringify({ command }),
+        providerExecuted: true,
+      });
+      return;
+    }
+    if (type === 'session.next.shell.ended') {
+      const callID = String(props.callID ?? event.id);
+      emit({
+        type: 'tool-result',
+        toolCallId: callID,
+        toolName: 'bash',
+        result: {
+          command: state.shellCommands.get(callID) ?? '',
+          output: String(props.output ?? ''),
+        },
+      });
+      return;
+    }
+    if (type === 'session.next.tool.input.delta') {
+      const callID = String(props.callID ?? event.id);
+      state.toolInputs.set(
+        callID,
+        `${state.toolInputs.get(callID) ?? ''}${String(props.delta ?? '')}`,
+      );
+      return;
+    }
+    if (type === 'session.next.tool.input.ended') {
+      state.toolInputs.set(
+        String(props.callID ?? event.id),
+        String(props.text ?? ''),
+      );
+      return;
+    }
+    if (type === 'session.next.tool.called') {
+      const callID = String(props.callID ?? event.id);
+      const rawToolName = String(props.tool ?? 'unknown');
+      const toolName = toWireToolName(rawToolName);
+      state.toolNames.set(callID, { rawToolName, toolName });
+      const hostToolName = getHostToolName(toolName, props.tool);
+      if (hostToolName) {
+        authorizeHostToolCall({
+          callID,
+          toolName: hostToolName,
+          input: props.input ?? parseToolInput(state, props),
+        });
+        return;
+      }
+      emit({
+        type: 'tool-call',
+        toolCallId: callID,
+        toolName,
+        ...nativeNameField({ nativeName: rawToolName, toolName }),
+        input: JSON.stringify(props.input ?? parseToolInput(state, props)),
+        providerExecuted: true,
+        ...(props.provider?.metadata
+          ? { providerMetadata: props.provider.metadata }
+          : {}),
+      });
+      return;
+    }
+    if (
+      type === 'session.next.tool.success' ||
+      type === 'session.next.tool.failed'
+    ) {
+      const callID = String(props.callID ?? event.id);
+      const cachedTool = state.toolNames.get(callID);
+      const rawToolName =
+        cachedTool?.rawToolName ??
+        String((props as { tool?: unknown }).tool ?? '');
+      const toolName =
+        cachedTool?.toolName ?? toWireToolName(rawToolName || 'unknown');
+      if (getHostToolName(toolName, rawToolName)) return;
+      emit({
+        type: 'tool-result',
+        toolCallId: callID,
+        toolName,
+        result:
+          props.result ??
+          props.structured ??
+          ('content' in props ? props.content : null) ??
+          null,
+        ...(type === 'session.next.tool.failed' ? { isError: true } : {}),
+      });
+      return;
+    }
+    if (type === 'session.next.retried') {
+      const error = props.error ?? event;
+      if (isRecord(error) && error.isRetryable === false) {
+        emitError({
+          error,
+          message: 'OpenCode session retry failed',
+        });
+      } else {
+        emitWarning({ message: nextRetryEventMessage({ event, formatError }) });
+      }
+      return;
+    }
+    if (type === 'session.next.step.ended') {
+      closeLegacyOpenParts({ state, emit });
+      state.turnUsage = mapUsage(props.tokens);
+      emit({
+        type: 'finish-step',
+        finishReason: {
+          unified: mapOpenCodeFinishReason(String(props.finish ?? 'stop')),
+          raw: String(props.finish ?? 'stop'),
+        },
+        usage: state.turnUsage,
+        ...(typeof props.cost === 'number'
+          ? { harnessMetadata: { opencode: { cost: props.cost } } }
+          : {}),
+      });
+      return;
+    }
+    if (type === 'session.next.compaction.ended') {
+      emit({
+        type: 'compaction',
+        trigger: props.reason === 'auto' ? 'auto' : 'manual',
+        summary: String(props.text ?? ''),
+        harnessMetadata: {
+          opencode: {
+            recent: String(props.recent ?? ''),
+          },
+        },
+      });
+      return;
+    }
+    if (type === 'file.edited') {
+      emit({
+        type: 'file-change',
+        event: 'modify',
+        path: stripWorkDir(String(props.file ?? '')),
+      });
+      return;
+    }
+    if (type === 'session.error' || type === 'session.next.step.failed') {
+      const error = props.error ?? event;
+      emitError({
+        error,
+        message:
+          type === 'session.error'
+            ? 'OpenCode session error'
+            : 'OpenCode step failed',
+      });
+    }
+  };
+}
+
+function closeLegacyOpenParts({
+  state,
+  emit,
+}: {
+  state: TranslationState;
+  emit: Emit;
+}): void {
+  for (const id of state.legacyReasoningPartIds) {
+    emit({ type: 'reasoning-end', id });
+    state.reasoningDeltas.delete(id);
+  }
+  state.legacyReasoningPartIds.clear();
+  for (const id of state.legacyTextPartIds) {
+    emit({ type: 'text-end', id });
+    state.textDeltas.delete(id);
+  }
+  state.legacyTextPartIds.clear();
+}
+
+function emitLegacyStepFinishPart({
+  part,
+  state,
+  emit,
+}: {
+  part: unknown;
+  state: TranslationState;
+  emit: Emit;
+}): boolean {
+  const event = legacyStepFinishPartToFinishStep(part);
+  if (!event) return false;
+  const id = isRecord(part) ? stringValue(part.id) : undefined;
+  if (id) {
+    if (state.legacyStepFinishPartIds.has(id)) return true;
+    state.legacyStepFinishPartIds.add(id);
+  }
+  closeLegacyOpenParts({ state, emit });
+  state.turnUsage = event.usage as Record<string, unknown>;
+  emit(event);
+  return true;
+}
+
+function emitLegacyToolPart({
+  part,
+  state,
+  emit,
+  toWireToolName,
+  nativeNameField,
+  getHostToolName,
+  authorizeHostToolCall,
+}: {
+  part: unknown;
+  state: TranslationState;
+  emit: Emit;
+  toWireToolName: (nativeName: string) => string;
+  nativeNameField: (input: { nativeName: string; toolName: string }) => {
+    nativeName?: string;
+  };
+  getHostToolName: (
+    toolName: string,
+    rawToolName: unknown,
+  ) => string | undefined;
+  authorizeHostToolCall: (input: {
+    callID: string;
+    toolName: string;
+    input: unknown;
+  }) => void;
+}): void {
+  if (!part || typeof part !== 'object') return;
+  const toolPart = part as Record<string, any>;
+  if (toolPart.type !== 'tool') return;
+  const status = legacyToolPartStatus(toolPart);
+  if (status !== 'running' && status !== 'completed' && status !== 'error') {
+    return;
+  }
+  if (
+    typeof toolPart.tool !== 'string' ||
+    typeof toolPart.callID !== 'string'
+  ) {
+    return;
+  }
+  const callID = toolPart.callID;
+  const rawToolName = toolPart.tool;
+  const toolName = toWireToolName(rawToolName);
+  state.toolNames.set(callID, { rawToolName, toolName });
+  const hostToolName = getHostToolName(toolName, rawToolName);
+  if (hostToolName) {
+    if (status === 'running') {
+      authorizeHostToolCall({
+        callID,
+        toolName: hostToolName,
+        input: legacyToolPartInput(toolPart),
+      });
+    }
+    return;
+  }
+  if (!state.toolCallsEmitted.has(callID)) {
+    state.toolCallsEmitted.add(callID);
+    emit({
+      type: 'tool-call',
+      toolCallId: callID,
+      toolName,
+      ...nativeNameField({ nativeName: rawToolName, toolName }),
+      input: JSON.stringify(legacyToolPartInput(toolPart)),
+      providerExecuted: true,
+      ...(toolPart.provider?.metadata
+        ? { providerMetadata: toolPart.provider.metadata }
+        : {}),
+    });
+  }
+  if (
+    (status === 'completed' || status === 'error') &&
+    !state.toolResultsEmitted.has(callID)
+  ) {
+    state.toolResultsEmitted.add(callID);
+    emit({
+      type: 'tool-result',
+      toolCallId: callID,
+      toolName,
+      result: legacyToolPartOutput(toolPart),
+      ...(status === 'error' ? { isError: true } : {}),
+    });
+  }
+}
+
+function legacyToolPartStatus(part: Record<string, any>): string | undefined {
+  return typeof part.state === 'string'
+    ? part.state
+    : typeof part.state === 'object' && part.state !== null
+      ? String(part.state.status ?? '')
+      : undefined;
+}
+
+function legacyToolPartInput(
+  part: Record<string, any>,
+): Record<string, unknown> {
+  const state =
+    typeof part.state === 'object' && part.state !== null
+      ? (part.state as Record<string, any>)
+      : undefined;
+  return {
+    ...(isRecord(part.metadata) ? part.metadata : {}),
+    ...(isRecord(state?.metadata) ? state.metadata : {}),
+    ...(isRecord(state?.input) ? state.input : {}),
+  };
+}
+
+function legacyToolPartOutput(part: Record<string, any>): unknown {
+  const state =
+    typeof part.state === 'object' && part.state !== null
+      ? (part.state as Record<string, any>)
+      : undefined;
+  if (state?.status === 'error') {
+    return state.error ?? part.error ?? state.result ?? 'tool failed';
+  }
+  return (
+    state?.output ??
+    state?.result ??
+    state?.structured ??
+    state?.content ??
+    null
+  );
+}
+
+function parseToolInput(
+  state: TranslationState,
+  props: Record<string, any>,
+): unknown {
+  const text = state.toolInputs.get(String(props.callID ?? ''));
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { input: text };
+  }
+}
+
+function nextRetryEventMessage({
+  event,
+  formatError,
+}: {
+  event: OpenCodeEvent;
+  formatError: (error: unknown) => string;
+}): string {
+  const props = event.properties ?? {};
+  const details: string[] = [];
+  if (typeof props.attempt === 'number') {
+    details.push(`attempt ${props.attempt}`);
+  }
+  const error = props.error;
+  if (isRecord(error)) {
+    const message =
+      stringValue(error.message) ??
+      (isRecord(error.data) ? stringValue(error.data.message) : undefined);
+    const statusCode = error.statusCode;
+    if (typeof statusCode === 'number') {
+      details.push(`HTTP ${statusCode}`);
+    }
+    if (message) details.push(message);
+  } else if (error != null) {
+    details.push(formatError(error));
+  }
+  return details.length > 0
+    ? `OpenCode session retry: ${details.join('; ')}`
+    : 'OpenCode session retry';
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+export function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/packages/harness-opencode/src/bridge/index.ts
+++ b/packages/harness-opencode/src/bridge/index.ts
@@ -15,9 +15,6 @@ import {
 } from '@opencode-ai/sdk/v2';
 import {
   createTranslationState,
-  emitLegacyPartDelta,
-  emitLegacyTextPartUpdate,
-  emitMissingFinalDelta,
   emitOpenCodeStreamStart,
   getOpenCodeEventSessionId,
   isStepSettlementEvent,
@@ -26,9 +23,11 @@ import {
   unwrapOpenCodeEvent,
 } from './opencode-events';
 import {
-  legacyStepFinishPartToFinishStep,
-  mapOpenCodeFinishReason,
-} from './opencode-finish-step';
+  createEmitStreamEvent,
+  isRecord,
+  stringValue,
+} from './create-emit-stream-event';
+import { mapOpenCodeFinishReason } from './opencode-finish-step';
 import { prependOpenCodeBinToPath } from './opencode-path';
 import {
   addUsage,
@@ -486,30 +485,6 @@ function legacyRetryStatusMessage(event: OpenCodeEvent): string {
     : 'OpenCode session retry';
 }
 
-function nextRetryEventMessage(event: OpenCodeEvent): string {
-  const props = event.properties ?? {};
-  const details: string[] = [];
-  if (typeof props.attempt === 'number') {
-    details.push(`attempt ${props.attempt}`);
-  }
-  const error = props.error;
-  if (isRecord(error)) {
-    const message =
-      stringValue(error.message) ??
-      (isRecord(error.data) ? stringValue(error.data.message) : undefined);
-    const statusCode = error.statusCode;
-    if (typeof statusCode === 'number') {
-      details.push(`HTTP ${statusCode}`);
-    }
-    if (message) details.push(message);
-  } else if (error != null) {
-    details.push(formatError(error));
-  }
-  return details.length > 0
-    ? `OpenCode session retry: ${details.join('; ')}`
-    : 'OpenCode session retry';
-}
-
 async function ensureSession({
   client,
   start,
@@ -792,471 +767,47 @@ async function consumeEvents({
   const stream = await subscribeLegacyEvents({ client, signal });
   onSubscribed?.();
   if (!stream) return;
+  const emitStreamEvent = createEmitStreamEvent({
+    state,
+    emit,
+    emitWarning: turn.emitWarning,
+    emitError: turn.emitError,
+    toWireToolName,
+    nativeNameField,
+    getHostToolName,
+    authorizeHostToolCall: input => authorizeHostToolCall({ ...input, state }),
+    stripWorkDir,
+    formatError,
+  });
   for await (const rawEvent of stream) {
     if (signal.aborted || turn.abortSignal.aborted) break;
     const event = unwrapOpenCodeEvent(rawEvent);
     const eventSessionId = event ? getOpenCodeEventSessionId(event) : undefined;
     if (!event || (eventSessionId && eventSessionId !== sessionId)) continue;
-    await translateAndEmit({
-      event,
-      state,
-      sessionId,
-      permissionMode,
-      builtinToolFiltering,
-      client,
-      turn,
-      emit,
-    });
-    if (onEvent?.(event)) break;
-  }
-}
-
-async function translateAndEmit({
-  event,
-  state,
-  sessionId,
-  permissionMode,
-  builtinToolFiltering,
-  client,
-  turn,
-  emit,
-}: {
-  event: OpenCodeEvent;
-  state: TranslationState;
-  sessionId: string;
-  permissionMode: StartMessage['permissionMode'];
-  builtinToolFiltering: StartMessage['builtinToolFiltering'];
-  client: OpenCodeClient;
-  turn: BridgeTurn;
-  emit: Emit;
-}): Promise<void> {
-  const type = event.type;
-  const props = event.properties ?? {};
-
-  if (type === 'message.updated') {
-    const info = props.info;
-    if (isRecord(info)) {
-      const id = stringValue(info.id);
-      const role = stringValue(info.role);
-      if (id && role) state.messageRoles.set(id, role);
-    }
-    return;
-  }
-
-  if (type === 'message.part.delta') {
-    emitLegacyPartDelta({ props, state, emit });
-    return;
-  }
-
-  if (type === 'message.part.updated') {
-    if (emitLegacyTextPartUpdate({ part: props.part, state, emit })) return;
-    if (emitLegacyStepFinishPart({ part: props.part, state, emit })) return;
-    emitLegacyToolPart({ part: props.part, state, emit });
-    return;
-  }
-
-  if (type === 'session.next.text.started') {
-    emit({ type: 'text-start', id: String(props.textID ?? event.id) });
-    return;
-  }
-  if (type === 'session.next.text.delta') {
-    const id = String(props.textID ?? event.id);
-    state.textDeltas.set(
-      id,
-      `${state.textDeltas.get(id) ?? ''}${String(props.delta ?? '')}`,
-    );
-    emit({
-      type: 'text-delta',
-      id,
-      delta: String(props.delta ?? ''),
-    });
-    return;
-  }
-  if (type === 'session.next.text.ended') {
-    const id = String(props.textID ?? event.id);
-    emitMissingFinalDelta({
-      id,
-      fullText: typeof props.text === 'string' ? props.text : undefined,
-      emittedText: state.textDeltas.get(id) ?? '',
-      emit,
-      type: 'text-delta',
-    });
-    emit({ type: 'text-end', id });
-    return;
-  }
-  if (type === 'session.next.reasoning.started') {
-    emit({
-      type: 'reasoning-start',
-      id: String(props.reasoningID ?? event.id),
-    });
-    return;
-  }
-  if (type === 'session.next.reasoning.delta') {
-    const id = String(props.reasoningID ?? event.id);
-    state.reasoningDeltas.set(
-      id,
-      `${state.reasoningDeltas.get(id) ?? ''}${String(props.delta ?? '')}`,
-    );
-    emit({
-      type: 'reasoning-delta',
-      id,
-      delta: String(props.delta ?? ''),
-    });
-    return;
-  }
-  if (type === 'session.next.reasoning.ended') {
-    const id = String(props.reasoningID ?? event.id);
-    emitMissingFinalDelta({
-      id,
-      fullText: typeof props.text === 'string' ? props.text : undefined,
-      emittedText: state.reasoningDeltas.get(id) ?? '',
-      emit,
-      type: 'reasoning-delta',
-    });
-    emit({ type: 'reasoning-end', id });
-    return;
-  }
-  if (type === 'session.next.shell.started') {
-    const callID = String(props.callID ?? event.id);
-    const command = String(props.command ?? '');
-    state.shellCommands.set(callID, command);
-    emit({
-      type: 'tool-call',
-      toolCallId: callID,
-      toolName: 'bash',
-      nativeName: 'bash',
-      input: JSON.stringify({ command }),
-      providerExecuted: true,
-    });
-    return;
-  }
-  if (type === 'session.next.shell.ended') {
-    const callID = String(props.callID ?? event.id);
-    emit({
-      type: 'tool-result',
-      toolCallId: callID,
-      toolName: 'bash',
-      result: {
-        command: state.shellCommands.get(callID) ?? '',
-        output: String(props.output ?? ''),
-      },
-    });
-    return;
-  }
-  if (type === 'session.next.tool.input.delta') {
-    const callID = String(props.callID ?? event.id);
-    state.toolInputs.set(
-      callID,
-      `${state.toolInputs.get(callID) ?? ''}${String(props.delta ?? '')}`,
-    );
-    return;
-  }
-  if (type === 'session.next.tool.input.ended') {
-    state.toolInputs.set(
-      String(props.callID ?? event.id),
-      String(props.text ?? ''),
-    );
-    return;
-  }
-  if (type === 'session.next.tool.called') {
-    const callID = String(props.callID ?? event.id);
-    const rawToolName = String(props.tool ?? 'unknown');
-    const toolName = toWireToolName(rawToolName);
-    state.toolNames.set(callID, { rawToolName, toolName });
-    const hostToolName = getHostToolName(toolName, props.tool);
-    if (hostToolName) {
-      authorizeHostToolCall({
-        callID,
-        toolName: hostToolName,
-        input: props.input ?? parseToolInput(state, props),
-        state,
+    if (event.type === 'permission.v2.asked') {
+      await handlePermissionV2({
+        client,
+        sessionId,
+        permissionMode,
+        builtinToolFiltering,
+        turn,
+        emit,
+        event,
       });
-      return;
-    }
-    emit({
-      type: 'tool-call',
-      toolCallId: callID,
-      toolName,
-      ...nativeNameField({ nativeName: rawToolName, toolName }),
-      input: JSON.stringify(props.input ?? parseToolInput(state, props)),
-      providerExecuted: true,
-      ...(props.provider?.metadata
-        ? { providerMetadata: props.provider.metadata }
-        : {}),
-    });
-    return;
-  }
-  if (
-    type === 'session.next.tool.success' ||
-    type === 'session.next.tool.failed'
-  ) {
-    const callID = String(props.callID ?? event.id);
-    const cachedTool = state.toolNames.get(callID);
-    const rawToolName =
-      cachedTool?.rawToolName ??
-      String((props as { tool?: unknown }).tool ?? '');
-    const toolName =
-      cachedTool?.toolName ?? toWireToolName(rawToolName || 'unknown');
-    if (getHostToolName(toolName, rawToolName)) return;
-    emit({
-      type: 'tool-result',
-      toolCallId: callID,
-      toolName,
-      result:
-        props.result ??
-        props.structured ??
-        ('content' in props ? props.content : null) ??
-        null,
-      ...(type === 'session.next.tool.failed' ? { isError: true } : {}),
-    });
-    return;
-  }
-  if (type === 'session.next.retried') {
-    const error = props.error ?? event;
-    if (isRecord(error) && error.isRetryable === false) {
-      turn.emitError({
-        error,
-        message: 'OpenCode session retry failed',
+    } else if (event.type === 'permission.asked') {
+      await handlePermission({
+        client,
+        sessionId,
+        permissionMode,
+        builtinToolFiltering,
+        turn,
+        emit,
+        event,
       });
     } else {
-      turn.emitWarning({ message: nextRetryEventMessage(event) });
+      emitStreamEvent(event);
     }
-    return;
-  }
-  if (type === 'session.next.step.ended') {
-    closeLegacyOpenParts({ state, emit });
-    state.turnUsage = mapUsage(props.tokens);
-    emit({
-      type: 'finish-step',
-      finishReason: {
-        unified: mapOpenCodeFinishReason(String(props.finish ?? 'stop')),
-        raw: String(props.finish ?? 'stop'),
-      },
-      usage: state.turnUsage,
-      ...(typeof props.cost === 'number'
-        ? { harnessMetadata: { opencode: { cost: props.cost } } }
-        : {}),
-    });
-    return;
-  }
-  if (type === 'session.next.compaction.ended') {
-    emit({
-      type: 'compaction',
-      trigger: props.reason === 'auto' ? 'auto' : 'manual',
-      summary: String(props.text ?? ''),
-      harnessMetadata: {
-        opencode: {
-          recent: String(props.recent ?? ''),
-        },
-      },
-    });
-    return;
-  }
-  if (type === 'file.edited') {
-    emit({
-      type: 'file-change',
-      event: 'modify',
-      path: stripWorkDir(String(props.file ?? '')),
-    });
-    return;
-  }
-  if (type === 'session.error' || type === 'session.next.step.failed') {
-    const error = props.error ?? event;
-    turn.emitError({
-      error,
-      message:
-        type === 'session.error'
-          ? 'OpenCode session error'
-          : 'OpenCode step failed',
-    });
-    return;
-  }
-  if (type === 'permission.v2.asked') {
-    await handlePermissionV2({
-      client,
-      sessionId,
-      permissionMode,
-      builtinToolFiltering,
-      turn,
-      emit,
-      event,
-    });
-    return;
-  }
-  if (type === 'permission.asked') {
-    await handlePermission({
-      client,
-      sessionId,
-      permissionMode,
-      builtinToolFiltering,
-      turn,
-      emit,
-      event,
-    });
-  }
-}
-
-function closeLegacyOpenParts({
-  state,
-  emit,
-}: {
-  state: TranslationState;
-  emit: Emit;
-}): void {
-  for (const id of state.legacyReasoningPartIds) {
-    emit({ type: 'reasoning-end', id });
-    state.reasoningDeltas.delete(id);
-  }
-  state.legacyReasoningPartIds.clear();
-  for (const id of state.legacyTextPartIds) {
-    emit({ type: 'text-end', id });
-    state.textDeltas.delete(id);
-  }
-  state.legacyTextPartIds.clear();
-}
-
-function emitLegacyStepFinishPart({
-  part,
-  state,
-  emit,
-}: {
-  part: unknown;
-  state: TranslationState;
-  emit: Emit;
-}): boolean {
-  const event = legacyStepFinishPartToFinishStep(part);
-  if (!event) return false;
-  const id = isRecord(part) ? stringValue(part.id) : undefined;
-  if (id) {
-    if (state.legacyStepFinishPartIds.has(id)) return true;
-    state.legacyStepFinishPartIds.add(id);
-  }
-  closeLegacyOpenParts({ state, emit });
-  state.turnUsage = event.usage as Record<string, unknown>;
-  emit(event);
-  return true;
-}
-
-function emitLegacyToolPart({
-  part,
-  state,
-  emit,
-}: {
-  part: unknown;
-  state: TranslationState;
-  emit: Emit;
-}): void {
-  if (!part || typeof part !== 'object') return;
-  const toolPart = part as Record<string, any>;
-  if (toolPart.type !== 'tool') return;
-  const status = legacyToolPartStatus(toolPart);
-  if (status !== 'running' && status !== 'completed' && status !== 'error') {
-    return;
-  }
-  if (
-    typeof toolPart.tool !== 'string' ||
-    typeof toolPart.callID !== 'string'
-  ) {
-    return;
-  }
-  const callID = toolPart.callID;
-  const rawToolName = toolPart.tool;
-  const toolName = toWireToolName(rawToolName);
-  state.toolNames.set(callID, { rawToolName, toolName });
-  const hostToolName = getHostToolName(toolName, rawToolName);
-  if (hostToolName) {
-    if (status === 'running') {
-      authorizeHostToolCall({
-        callID,
-        toolName: hostToolName,
-        input: legacyToolPartInput(toolPart),
-        state,
-      });
-    }
-    return;
-  }
-  if (!state.toolCallsEmitted.has(callID)) {
-    state.toolCallsEmitted.add(callID);
-    emit({
-      type: 'tool-call',
-      toolCallId: callID,
-      toolName,
-      ...nativeNameField({ nativeName: rawToolName, toolName }),
-      input: JSON.stringify(legacyToolPartInput(toolPart)),
-      providerExecuted: true,
-      ...(toolPart.provider?.metadata
-        ? { providerMetadata: toolPart.provider.metadata }
-        : {}),
-    });
-  }
-  if (
-    (status === 'completed' || status === 'error') &&
-    !state.toolResultsEmitted.has(callID)
-  ) {
-    state.toolResultsEmitted.add(callID);
-    emit({
-      type: 'tool-result',
-      toolCallId: callID,
-      toolName,
-      result: legacyToolPartOutput(toolPart),
-      ...(status === 'error' ? { isError: true } : {}),
-    });
-  }
-}
-
-function legacyToolPartStatus(part: Record<string, any>): string | undefined {
-  return typeof part.state === 'string'
-    ? part.state
-    : typeof part.state === 'object' && part.state !== null
-      ? String(part.state.status ?? '')
-      : undefined;
-}
-
-function legacyToolPartInput(
-  part: Record<string, any>,
-): Record<string, unknown> {
-  const state =
-    typeof part.state === 'object' && part.state !== null
-      ? (part.state as Record<string, any>)
-      : undefined;
-  return {
-    ...(isRecord(part.metadata) ? part.metadata : {}),
-    ...(isRecord(state?.metadata) ? state.metadata : {}),
-    ...(isRecord(state?.input) ? state.input : {}),
-  };
-}
-
-function legacyToolPartOutput(part: Record<string, any>): unknown {
-  const state =
-    typeof part.state === 'object' && part.state !== null
-      ? (part.state as Record<string, any>)
-      : undefined;
-  if (state?.status === 'error') {
-    return state.error ?? part.error ?? state.result ?? 'tool failed';
-  }
-  return (
-    state?.output ??
-    state?.result ??
-    state?.structured ??
-    state?.content ??
-    null
-  );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
-}
-
-function parseToolInput(
-  state: TranslationState,
-  props: Record<string, any>,
-): unknown {
-  const text = state.toolInputs.get(String(props.callID ?? ''));
-  if (!text) return {};
-  try {
-    return JSON.parse(text);
-  } catch {
-    return { input: text };
+    if (onEvent?.(event)) break;
   }
 }
 
@@ -1781,10 +1332,6 @@ function modelRefFromValue(value: unknown): OpenCodeModelRef | undefined {
   const modelID = stringValue(value.modelID ?? value.id);
   if (!providerID || !modelID) return undefined;
   return { providerID, modelID };
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 function stripWorkDir(file: string): string {


### PR DESCRIPTION
## Background

Harness bridge entrypoints currently combine process orchestration with substantial stream event translation logic, which prevents that logic from being imported and tested in isolation because test files by definition cannot import from that `index.ts` file due to its side effects.

## Summary

- Extract stream event translation for Claude Code, Codex, Deep Agents, and OpenCode into dedicated `createEmitStreamEvent` factories.
- Preserve existing event ordering, control flow, permission handling, and runtime behavior while keeping launcher concerns in each bridge entrypoint.
- Add focused unit coverage for content, tool, usage, model, retry, error, and compaction event translation.
- Enforce the new bridge file and factory import/export conventions via `konsistent.json`.

## End-to-End Verification

`examples/harness-e2e-next` for all bridge harnesses was used to verify no behavioral changes occurred - this is purely a code refactoring to improve test coverage.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
