### PR TITLE
fix(harness-deepagents): fix overly limiting override of Deep Agents recursion limit default

### DIFF
--- a/.changeset/weak-rings-crash.md
+++ b/.changeset/weak-rings-crash.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-deepagents": patch
+---
+
+fix(harness-deepagents): fix overly limiting override of Deep Agents recursion limit default

--- a/content/providers/02-ai-sdk-harnesses/05-deepagents.mdx
+++ b/content/providers/02-ai-sdk-harnesses/05-deepagents.mdx
@@ -91,6 +91,8 @@ Settings:
   Gateway, use the `creator/model` slug (e.g. `anthropic/claude-sonnet-4-6`,
   `google/gemini-2.5-flash`, `openai/gpt-4.1-mini`).
 - `port`: bridge port override.
+- `recursionLimit`: maximum LangGraph super-steps per turn. When omitted, the
+  Deep Agents default applies.
 - `startupTimeoutMs`: maximum time to wait for the bridge to start.
 
 ## Authentication

--- a/examples/harness-e2e-next/agent/harness/deepagents/ai-sdk-coding-agent.ts
+++ b/examples/harness-e2e-next/agent/harness/deepagents/ai-sdk-coding-agent.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createDeepAgents } from '@ai-sdk/harness-deepagents';
+import { deepAgents } from '@ai-sdk/harness-deepagents';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import type { InferUITools, UIMessage } from 'ai';
 import {
@@ -18,7 +18,7 @@ will exceed sandbox memory. When asked to do this, use the corresponding
 `;
 
 export const aiSdkCodingDeepAgentsHarnessAgent = new HarnessAgent({
-  harness: createDeepAgents({ recursionLimit: 200 }),
+  harness: deepAgents,
   instructions,
   sandbox: createVercelSandbox({
     runtime: 'node24',

--- a/packages/harness-deepagents/src/bridge/index.ts
+++ b/packages/harness-deepagents/src/bridge/index.ts
@@ -241,7 +241,9 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   const config = {
     version: 'v2' as const,
     configurable: { thread_id: 'bridge-session' },
-    recursionLimit: start.recursionLimit ?? 100,
+    ...(start.recursionLimit != null
+      ? { recursionLimit: start.recursionLimit }
+      : {}),
     signal: turn.abortSignal,
   };
 

--- a/packages/harness-deepagents/src/deepagents-harness.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.ts
@@ -91,7 +91,10 @@ export type DeepAgentsHarnessSettings = {
   readonly port?: number;
   /** Maximum milliseconds to wait for the bridge to advertise its port. Defaults to 120000. */
   readonly startupTimeoutMs?: number;
-  /** Max LangGraph super-steps per turn before it errors. Defaults to 100; raise for long multi-step tasks. */
+  /**
+   * Maximum LangGraph super-steps per turn before it errors.
+   * When omitted, the Deep Agents default applies.
+   */
   readonly recursionLimit?: number;
 };
 


### PR DESCRIPTION
## Background

The Deep Agents bridge always passed a recursion limit of 100, overriding Deep Agents' much higher default (currently 10,000). This could prematurely terminate complex agentic tasks.

## Summary

- Preserve the Deep Agents recursion limit default when no override is configured.
- Continue forwarding explicit `recursionLimit` values.
- Remove the E2E coding agent workaround and document the delegated default.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
