### PR TITLE
fix(harness-codex): fix obsolete default Codex model ID

### DIFF
--- a/.changeset/thin-mangos-run.md
+++ b/.changeset/thin-mangos-run.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-codex": patch
+---
+
+fix(harness-codex): fix obsolete default Codex model ID

--- a/packages/harness-codex/src/codex-harness.test.ts
+++ b/packages/harness-codex/src/codex-harness.test.ts
@@ -195,6 +195,7 @@ describe('createCodex adapter', () => {
     expect(spawnEnvs.at(0)?.AI_SDK_HARNESS_CLIENT_APP).toBe(
       'ai-sdk/harness-codex/0.0.0-test',
     );
+    expect(session.modelId).toBe('gpt-5.6-sol');
     await session.doDestroy();
   });
 

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -60,12 +60,12 @@ type WriteSkillsResult = {
  * The model the adapter pins when the consumer configures none. The Codex SDK
  * does not report the model it resolves to at runtime (no model field on any
  * event), and exposes no default-model constant, so we pin the latest
- * codex-specialized model available for the bundled `@openai/codex@0.130.0`
- * (published 2026-05-08): `gpt-5.3-codex` (released 2026-02). Keep this in sync
- * when bumping the codex SDK/binary. Passing it explicitly makes the resolved
- * model deterministic and the telemetry (`gen_ai.request.model`) accurate.
+ * default model resolved by the bundled `@openai/codex@0.144.5`:
+ * `gpt-5.6-sol`. Keep this in sync when bumping the codex SDK/binary. Passing
+ * it explicitly makes the resolved model deterministic and the telemetry
+ * (`gen_ai.request.model`) accurate.
  */
-const DEFAULT_CODEX_MODEL = 'gpt-5.3-codex';
+const DEFAULT_CODEX_MODEL = 'gpt-5.6-sol';
 
 /**
  * Value to use in User-Agent and `x-client-app` headers.


### PR DESCRIPTION
## Background

The Codex harness pinned `gpt-5.3-codex`, which is absent from the latest bundled Codex model metadata and caused Codex to warn that it was using fallback metadata.

Ideally we wouldn't need to hard-code this, but there's no way to identify the model used via the Codex SDK, so it is currently being handled this way.

## Summary

- Update the harness default to Codex 0.144.5's resolved default, `gpt-5.6-sol`.
- Add regression coverage for the session model ID.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
