### PR TITLE
feat(ai): add rerankMany() for reranking large document sets

### DIFF
--- a/.changeset/add-rerank-many.md
+++ b/.changeset/add-rerank-many.md
@@ -1,0 +1,6 @@
+---
+'ai': patch
+'@ai-sdk/provider': patch
+---
+
+feat(ai): add `rerankMany()` for reranking document sets across multiple model calls, with `maxDocumentsPerCall` and `supportsParallelCalls` on `RerankingModelV4`

--- a/content/docs/03-ai-sdk-core/31-reranking.mdx
+++ b/content/docs/03-ai-sdk-core/31-reranking.mdx
@@ -203,6 +203,24 @@ const { ranking, response } = await rerank({
 console.log(response); // { id, timestamp, modelId, headers, body }
 ```
 
+## Reranking Large Document Sets
+
+Some reranking models limit how many documents they can score in a single request. Use [`rerankMany`](/docs/reference/ai-sdk-core/rerank-many) to rerank a set larger than that limit: it splits the documents into windows sized to the model's `maxDocumentsPerCall`, scores each window, and merges the results into a single ranking sorted by relevance score before applying `topN`.
+
+```tsx
+import { rerankMany } from 'ai';
+import { cohere } from '@ai-sdk/cohere';
+
+const { ranking } = await rerankMany({
+  model: cohere.reranking('rerank-v3.5'),
+  documents: manyDocuments,
+  query: 'talk about rain',
+  topN: 10,
+});
+```
+
+When the model reports that it supports parallel calls, the windows are sent concurrently; use `maxParallelCalls` to bound the concurrency. `rerankMany` assumes the model scores each document against the query independently, so splitting the documents across windows does not change their scores.
+
 ## Reranking Providers & Models
 
 Several providers offer reranking models:

--- a/content/docs/07-reference/01-ai-sdk-core/07-rerank-many.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/07-rerank-many.mdx
@@ -1,0 +1,303 @@
+---
+title: rerankMany
+description: API Reference for rerankMany.
+---
+
+# `rerankMany()`
+
+Rerank many documents against a query using a reranking model.
+
+`rerankMany` automatically splits large requests into smaller windows when the model has a limit on how many documents can be reranked in a single call (`maxDocumentsPerCall`). Each window is scored independently and the results are merged and re-sorted by relevance score before the optional `topN` limit is applied. When the model reports `supportsParallelCalls`, the windows are sent concurrently (bounded by `maxParallelCalls`).
+
+This assumes the model scores each document against the query independently (pointwise/pairwise), so a document's score does not depend on which other documents share the call. Models that score documents relative to one another (listwise) may rank differently when documents are split across windows.
+
+```ts
+import { cohere } from '@ai-sdk/cohere';
+import { rerankMany } from 'ai';
+
+const { ranking } = await rerankMany({
+  model: cohere.reranking('rerank-v3.5'),
+  documents: manyDocuments,
+  query: 'talk about rain',
+  topN: 10,
+});
+```
+
+## Import
+
+<Snippet text={`import { rerankMany } from "ai"`} prompt={false} />
+
+## API Signature
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'model',
+      type: 'RerankingModel',
+      description:
+        "The reranking model to use. Example: cohere.reranking('rerank-v3.5')",
+    },
+    {
+      name: 'documents',
+      type: 'Array<VALUE>',
+      description:
+        'The documents to rerank. Can be an array of strings or JSON objects.',
+    },
+    {
+      name: 'query',
+      type: 'string',
+      description: 'The search query to rank documents against.',
+    },
+    {
+      name: 'topN',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Maximum number of top documents to return. Applied to the merged ranking across all windows. If not specified, all documents are returned.',
+    },
+    {
+      name: 'maxParallelCalls',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Maximum number of concurrent reranking calls. Only takes effect when the model reports `supportsParallelCalls`. Default: Infinity.',
+    },
+    {
+      name: 'maxRetries',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Maximum number of retries per reranking model call. Set to 0 to disable retries. Default: 2.',
+    },
+    {
+      name: 'abortSignal',
+      type: 'AbortSignal',
+      isOptional: true,
+      description:
+        'An optional abort signal that can be used to cancel the call.',
+    },
+    {
+      name: 'headers',
+      type: 'Record<string, string>',
+      isOptional: true,
+      description:
+        'Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.',
+    },
+    {
+      name: 'providerOptions',
+      type: 'ProviderOptions',
+      isOptional: true,
+      description: 'Provider-specific options for the reranking request.',
+    },
+    {
+      name: 'telemetry',
+      type: 'TelemetryOptions',
+      isOptional: true,
+      description: 'Telemetry configuration.',
+      properties: [
+        {
+          type: 'TelemetryOptions',
+          parameters: [
+            {
+              name: 'isEnabled',
+              type: 'boolean',
+              isOptional: true,
+              description:
+                'Enable or disable telemetry. Enabled by default. Set to `false` to opt out.',
+            },
+            {
+              name: 'recordInputs',
+              type: 'boolean',
+              isOptional: true,
+              description:
+                'Enable or disable input recording. Enabled by default.',
+            },
+            {
+              name: 'recordOutputs',
+              type: 'boolean',
+              isOptional: true,
+              description:
+                'Enable or disable output recording. Enabled by default.',
+            },
+            {
+              name: 'functionId',
+              type: 'string',
+              isOptional: true,
+              description:
+                'Identifier for this function. Used to group telemetry data by function.',
+            },
+            {
+              name: 'integrations',
+              isOptional: true,
+              type: 'Telemetry | Telemetry[]',
+              description:
+                'Per-call telemetry integrations that receive lifecycle events. When provided, these replace any globally registered integrations for this call.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'onStart',
+      type: '(event: RerankStartEvent) => void | Promise<void>',
+      isOptional: true,
+      description:
+        'Called when the rerankMany operation begins, before the reranking model is called.',
+    },
+    {
+      name: 'onEnd',
+      type: '(event: RerankEndEvent) => void | Promise<void>',
+      isOptional: true,
+      description:
+        'Called when the rerankMany operation completes, after all reranking model calls return.',
+    },
+  ]}
+/>
+
+### Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: 'originalDocuments',
+      type: 'Array<VALUE>',
+      description: 'The original documents array in their original order.',
+    },
+    {
+      name: 'rerankedDocuments',
+      type: 'Array<VALUE>',
+      description: 'The documents sorted by relevance score (descending).',
+    },
+    {
+      name: 'ranking',
+      type: 'Array<RankingItem<VALUE>>',
+      description: 'Array of ranking items with scores and indices.',
+      properties: [
+        {
+          type: 'RankingItem<VALUE>',
+          parameters: [
+            {
+              name: 'originalIndex',
+              type: 'number',
+              description:
+                'The index of the document in the original documents array.',
+            },
+            {
+              name: 'score',
+              type: 'number',
+              description:
+                'The relevance score for the document (typically 0-1, where higher is more relevant).',
+            },
+            {
+              name: 'document',
+              type: 'VALUE',
+              description: 'The document itself.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'responses',
+      type: 'Array<Response>',
+      isOptional: true,
+      description: 'Raw provider responses, one entry per document window.',
+      properties: [
+        {
+          type: 'Response',
+          parameters: [
+            {
+              name: 'id',
+              isOptional: true,
+              type: 'string',
+              description: 'The response ID from the provider.',
+            },
+            {
+              name: 'timestamp',
+              type: 'Date',
+              description: 'The timestamp of the response.',
+            },
+            {
+              name: 'modelId',
+              type: 'string',
+              description: 'The model ID used for reranking.',
+            },
+            {
+              name: 'headers',
+              isOptional: true,
+              type: 'Record<string, string>',
+              description: 'Response headers.',
+            },
+            {
+              name: 'body',
+              type: 'unknown',
+              isOptional: true,
+              description: 'The raw response body.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'providerMetadata',
+      type: 'ProviderMetadata | undefined',
+      isOptional: true,
+      description:
+        'Optional metadata from the provider, merged across all calls. The outer key is the provider name. The inner values are the metadata. Details depend on the provider.',
+    },
+  ]}
+/>
+
+## Examples
+
+### Reranking a Large Document Set
+
+```ts
+import { cohere } from '@ai-sdk/cohere';
+import { rerankMany } from 'ai';
+
+const { ranking, rerankedDocuments } = await rerankMany({
+  model: cohere.reranking('rerank-v3.5'),
+  documents: manyDocuments, // more documents than the model accepts per call
+  query: 'talk about rain',
+  topN: 10,
+});
+
+// The documents are split into windows, each window is scored, and the
+// results are merged into a single ranking sorted by relevance score.
+console.log(rerankedDocuments);
+```
+
+### Parallel Windows
+
+When the model reports `supportsParallelCalls`, the windows are sent concurrently. Use `maxParallelCalls` to bound the concurrency:
+
+```ts
+import { cohere } from '@ai-sdk/cohere';
+import { rerankMany } from 'ai';
+
+const { ranking } = await rerankMany({
+  model: cohere.reranking('rerank-v3.5'),
+  documents: manyDocuments,
+  query: 'talk about rain',
+  maxParallelCalls: 4,
+});
+```
+
+### Object Documents
+
+```ts
+import { cohere } from '@ai-sdk/cohere';
+import { rerankMany } from 'ai';
+
+const { ranking } = await rerankMany({
+  model: cohere.reranking('rerank-v3.5'),
+  documents: emails, // array of JSON objects
+  query: 'Which pricing did we get from Oracle?',
+  topN: 5,
+});
+
+console.log(ranking[0].document);
+```

--- a/packages/ai/src/rerank/index.ts
+++ b/packages/ai/src/rerank/index.ts
@@ -1,5 +1,7 @@
 export { rerank } from './rerank';
+export { rerankMany } from './rerank-many';
 export type { RerankResult } from './rerank-result';
+export type { RerankManyResult } from './rerank-many-result';
 export type {
   RerankStartEvent,
   RerankEndEvent,

--- a/packages/ai/src/rerank/rerank-events.ts
+++ b/packages/ai/src/rerank/rerank-events.ts
@@ -75,14 +75,28 @@ export type RerankEndEvent = {
   /** Optional provider-specific metadata. */
   readonly providerMetadata: ProviderMetadata | undefined;
 
-  /** Response data including headers and body. */
-  readonly response: {
-    id?: string;
-    timestamp: Date;
-    modelId: string;
-    headers?: Record<string, string>;
-    body?: unknown;
-  };
+  /**
+   * Response data including headers and body. A single response for `rerank`,
+   * an array for `rerankMany` (one entry per document window).
+   */
+  readonly response:
+    | {
+        id?: string;
+        timestamp: Date;
+        modelId: string;
+        headers?: Record<string, string>;
+        body?: unknown;
+      }
+    | Array<
+        | {
+            id?: string;
+            timestamp: Date;
+            modelId: string;
+            headers?: Record<string, string>;
+            body?: unknown;
+          }
+        | undefined
+      >;
 };
 
 /**
@@ -92,7 +106,13 @@ export type RerankingModelCallStartEvent = {
   /** Unique identifier for this rerank call, used to correlate events. */
   readonly callId: string;
 
-  /** Identifies the inner operation ('ai.rerank.doRerank'). */
+  /**
+   * Unique identifier for this individual doRerank invocation, used to
+   * correlate start/finish within parallel windows. Set by `rerankMany`.
+   */
+  readonly rerankCallId?: string;
+
+  /** Identifies the inner operation (e.g. 'ai.rerank.doRerank' or 'ai.rerankMany.doRerank'). */
   readonly operationId: string;
 
   /** The provider identifier. */
@@ -123,7 +143,13 @@ export type RerankingModelCallEndEvent = {
   /** Unique identifier for this rerank call, used to correlate events. */
   readonly callId: string;
 
-  /** Identifies the inner operation ('ai.rerank.doRerank'). */
+  /**
+   * Unique identifier for this individual doRerank invocation, used to
+   * correlate start/finish within parallel windows. Set by `rerankMany`.
+   */
+  readonly rerankCallId?: string;
+
+  /** Identifies the inner operation (e.g. 'ai.rerank.doRerank' or 'ai.rerankMany.doRerank'). */
   readonly operationId: string;
 
   /** The provider identifier. */

--- a/packages/ai/src/rerank/rerank-many-result.ts
+++ b/packages/ai/src/rerank/rerank-many-result.ts
@@ -1,0 +1,73 @@
+import type { ProviderMetadata } from '../types/provider-metadata';
+
+/**
+ * The result of a `rerankMany` call.
+ *
+ * It contains the original documents, the reranked documents, and additional
+ * information aggregated across every reranking model call.
+ */
+export interface RerankManyResult<VALUE> {
+  /**
+   * The original documents that were reranked.
+   */
+  readonly originalDocuments: Array<VALUE>;
+
+  /**
+   * Reranked documents.
+   *
+   * Sorted by relevance score in descending order.
+   *
+   * Can be less than the original documents if there was a topN limit.
+   */
+  readonly rerankedDocuments: Array<VALUE>;
+
+  /**
+   * The ranking is a list of objects with the original index,
+   * relevance score, and the reranked document.
+   *
+   * Sorted by relevance score in descending order.
+   *
+   * Can be less than the original documents if there was a topN limit.
+   */
+  readonly ranking: Array<{
+    originalIndex: number;
+    score: number;
+    document: VALUE;
+  }>;
+
+  /**
+   * Optional provider-specific metadata, merged across all calls.
+   */
+  readonly providerMetadata?: ProviderMetadata;
+
+  /**
+   * Optional raw response data, one entry per reranking model call
+   * (document window).
+   */
+  readonly responses?: Array<{
+    /**
+     * ID for the generated response if the provider sends one.
+     */
+    id?: string;
+
+    /**
+     * Timestamp of the generated response.
+     */
+    timestamp: Date;
+
+    /**
+     * The ID of the model that was used to generate the response.
+     */
+    modelId: string;
+
+    /**
+     * Response headers.
+     */
+    headers?: Record<string, string>;
+
+    /**
+     * The response body.
+     */
+    body?: unknown;
+  }>;
+}

--- a/packages/ai/src/rerank/rerank-many.test.ts
+++ b/packages/ai/src/rerank/rerank-many.test.ts
@@ -1,0 +1,450 @@
+import type { RerankingModelV4CallOptions } from '@ai-sdk/provider';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as logWarningsModule from '../logger/log-warnings';
+import { MockRerankingModelV4 } from '../test/mock-reranking-model-v4';
+import { createResolvablePromise } from '../util/create-resolvable-promise';
+import { rerankMany } from './rerank-many';
+import type { RerankEndEvent, RerankStartEvent } from './rerank-events';
+import type { RerankManyResult } from './rerank-many-result';
+
+const testDocuments = ['d0', 'd1', 'd2', 'd3', 'd4'];
+
+// Returns a per-window ranking keyed on the window's first document so the
+// result is independent of the order in which windows are dispatched.
+const windowedDoRerank = async ({ documents }: RerankingModelV4CallOptions) => {
+  const values = documents.values as string[];
+  switch (values[0]) {
+    case 'd0':
+      return {
+        ranking: [
+          { index: 1, relevanceScore: 0.5 },
+          { index: 0, relevanceScore: 0.3 },
+        ],
+      };
+    case 'd2':
+      return {
+        ranking: [
+          { index: 0, relevanceScore: 0.9 },
+          { index: 1, relevanceScore: 0.1 },
+        ],
+      };
+    case 'd4':
+      return { ranking: [{ index: 0, relevanceScore: 0.7 }] };
+    default:
+      throw new Error(`unexpected window starting with ${values[0]}`);
+  }
+};
+
+describe('rerankMany', () => {
+  describe('single call (no maxDocumentsPerCall)', () => {
+    let result: RerankManyResult<string>;
+    let model: MockRerankingModelV4;
+
+    beforeEach(async () => {
+      model = new MockRerankingModelV4({
+        doRerank: async () => ({
+          ranking: [
+            { index: 2, relevanceScore: 0.9 },
+            { index: 0, relevanceScore: 0.8 },
+            { index: 4, relevanceScore: 0.7 },
+            { index: 1, relevanceScore: 0.6 },
+            { index: 3, relevanceScore: 0.5 },
+          ],
+        }),
+      });
+
+      result = await rerankMany({
+        model,
+        documents: testDocuments,
+        query: 'q',
+        topN: 3,
+      });
+    });
+
+    it('should send all documents in a single call without a per-window topN', () => {
+      expect(model.doRerankCalls.length).toBe(1);
+      expect(model.doRerankCalls[0].documents).toEqual({
+        type: 'text',
+        values: testDocuments,
+      });
+      // topN is applied globally after merging, not by the provider.
+      expect(model.doRerankCalls[0].topN).toBeUndefined();
+    });
+
+    it('should apply topN to the merged ranking', () => {
+      expect(result.ranking.map(r => r.originalIndex)).toStrictEqual([2, 0, 4]);
+      expect(result.rerankedDocuments).toStrictEqual(['d2', 'd0', 'd4']);
+      expect(result.originalDocuments).toStrictEqual(testDocuments);
+    });
+  });
+
+  describe('object documents', () => {
+    it('should send documents as objects', async () => {
+      const documents = [{ id: 0 }, { id: 1 }, { id: 2 }];
+      const model = new MockRerankingModelV4({
+        doRerank: async () => ({
+          ranking: [
+            { index: 1, relevanceScore: 0.9 },
+            { index: 0, relevanceScore: 0.5 },
+            { index: 2, relevanceScore: 0.2 },
+          ],
+        }),
+      });
+
+      const result = await rerankMany({ model, documents, query: 'q' });
+
+      expect(model.doRerankCalls[0].documents).toEqual({
+        type: 'object',
+        values: documents,
+      });
+      expect(result.rerankedDocuments).toStrictEqual([
+        { id: 1 },
+        { id: 0 },
+        { id: 2 },
+      ]);
+    });
+  });
+
+  describe('windowing with maxDocumentsPerCall', () => {
+    let result: RerankManyResult<string>;
+    let model: MockRerankingModelV4;
+
+    beforeEach(async () => {
+      model = new MockRerankingModelV4({
+        maxDocumentsPerCall: 2,
+        doRerank: windowedDoRerank,
+      });
+
+      result = await rerankMany({
+        model,
+        documents: testDocuments,
+        query: 'q',
+      });
+    });
+
+    it('should split the documents into windows', () => {
+      expect(model.doRerankCalls.map(call => call.documents)).toStrictEqual([
+        { type: 'text', values: ['d0', 'd1'] },
+        { type: 'text', values: ['d2', 'd3'] },
+        { type: 'text', values: ['d4'] },
+      ]);
+    });
+
+    it('should remap window-local indices to global indices and sort by score', () => {
+      // scores: d2=0.9, d4=0.7, d1=0.5, d0=0.3, d3=0.1
+      expect(result.ranking).toStrictEqual([
+        { originalIndex: 2, score: 0.9, document: 'd2' },
+        { originalIndex: 4, score: 0.7, document: 'd4' },
+        { originalIndex: 1, score: 0.5, document: 'd1' },
+        { originalIndex: 0, score: 0.3, document: 'd0' },
+        { originalIndex: 3, score: 0.1, document: 'd3' },
+      ]);
+      expect(result.rerankedDocuments).toStrictEqual([
+        'd2',
+        'd4',
+        'd1',
+        'd0',
+        'd3',
+      ]);
+    });
+
+    it('should apply topN across all windows', async () => {
+      const topResult = await rerankMany({
+        model: new MockRerankingModelV4({
+          maxDocumentsPerCall: 2,
+          doRerank: windowedDoRerank,
+        }),
+        documents: testDocuments,
+        query: 'q',
+        topN: 2,
+      });
+
+      expect(topResult.rerankedDocuments).toStrictEqual(['d2', 'd4']);
+      expect(topResult.originalDocuments).toStrictEqual(testDocuments);
+    });
+  });
+
+  describe('model.supportsParallelCalls', () => {
+    const makeTimedModel = (
+      events: string[],
+      resolvables: Array<ReturnType<typeof createResolvablePromise<void>>>,
+      supportsParallelCalls: boolean,
+    ) => {
+      let callCount = 0;
+      return new MockRerankingModelV4({
+        supportsParallelCalls,
+        maxDocumentsPerCall: 1,
+        doRerank: async () => {
+          const index = callCount++;
+          events.push(`start-${index}`);
+          await resolvables[index].promise;
+          events.push(`end-${index}`);
+          return { ranking: [{ index: 0, relevanceScore: 1 - index * 0.1 }] };
+        },
+      });
+    };
+
+    it('should not parallelize when false', async () => {
+      const events: string[] = [];
+      const resolvables = [
+        createResolvablePromise<void>(),
+        createResolvablePromise<void>(),
+        createResolvablePromise<void>(),
+      ];
+
+      const promise = rerankMany({
+        model: makeTimedModel(events, resolvables, false),
+        documents: ['a', 'b', 'c'],
+        query: 'q',
+      });
+
+      resolvables.forEach(r => r.resolve());
+      const result = await promise;
+
+      expect(events).toStrictEqual([
+        'start-0',
+        'end-0',
+        'start-1',
+        'end-1',
+        'start-2',
+        'end-2',
+      ]);
+      expect(result.rerankedDocuments).toHaveLength(3);
+    });
+
+    it('should parallelize when true', async () => {
+      const events: string[] = [];
+      const resolvables = [
+        createResolvablePromise<void>(),
+        createResolvablePromise<void>(),
+        createResolvablePromise<void>(),
+      ];
+
+      const promise = rerankMany({
+        model: makeTimedModel(events, resolvables, true),
+        documents: ['a', 'b', 'c'],
+        query: 'q',
+      });
+
+      resolvables.forEach(r => r.resolve());
+      await promise;
+
+      expect(events).toStrictEqual([
+        'start-0',
+        'start-1',
+        'start-2',
+        'end-0',
+        'end-1',
+        'end-2',
+      ]);
+    });
+
+    it('should support maxParallelCalls', async () => {
+      const events: string[] = [];
+      const resolvables = [
+        createResolvablePromise<void>(),
+        createResolvablePromise<void>(),
+        createResolvablePromise<void>(),
+      ];
+
+      const promise = rerankMany({
+        maxParallelCalls: 2,
+        model: makeTimedModel(events, resolvables, true),
+        documents: ['a', 'b', 'c'],
+        query: 'q',
+      });
+
+      resolvables.forEach(r => r.resolve());
+      await promise;
+
+      expect(events).toStrictEqual([
+        'start-0',
+        'start-1',
+        'end-0',
+        'end-1',
+        'start-2',
+        'end-2',
+      ]);
+    });
+  });
+
+  describe('result.responses', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should include one response per window', async () => {
+      const model = new MockRerankingModelV4({
+        maxDocumentsPerCall: 2,
+        doRerank: async ({ documents }) => {
+          const values = documents.values as string[];
+          return {
+            ranking: [{ index: 0, relevanceScore: 0.5 }],
+            response: {
+              id: `resp-${values[0]}`,
+              headers: { 'x-window': values[0] },
+              body: { window: values[0] },
+            },
+          };
+        },
+      });
+
+      const result = await rerankMany({
+        model,
+        documents: testDocuments,
+        query: 'q',
+      });
+
+      expect(result.responses).toStrictEqual([
+        {
+          id: 'resp-d0',
+          timestamp: new Date('2025-01-01T00:00:00Z'),
+          modelId: 'mock-model-id',
+          headers: { 'x-window': 'd0' },
+          body: { window: 'd0' },
+        },
+        {
+          id: 'resp-d2',
+          timestamp: new Date('2025-01-01T00:00:00Z'),
+          modelId: 'mock-model-id',
+          headers: { 'x-window': 'd2' },
+          body: { window: 'd2' },
+        },
+        {
+          id: 'resp-d4',
+          timestamp: new Date('2025-01-01T00:00:00Z'),
+          modelId: 'mock-model-id',
+          headers: { 'x-window': 'd4' },
+          body: { window: 'd4' },
+        },
+      ]);
+    });
+  });
+
+  describe('result.providerMetadata', () => {
+    it('should merge provider metadata from every window', async () => {
+      const model = new MockRerankingModelV4({
+        maxDocumentsPerCall: 2,
+        doRerank: async ({ documents }) => {
+          const values = documents.values as string[];
+          return {
+            ranking: [{ index: 0, relevanceScore: 0.5 }],
+            providerMetadata: {
+              aProvider: { [`window_${values[0]}`]: true },
+            },
+          };
+        },
+      });
+
+      const result = await rerankMany({
+        model,
+        documents: testDocuments,
+        query: 'q',
+      });
+
+      expect(result.providerMetadata).toStrictEqual({
+        aProvider: {
+          window_d0: true,
+          window_d2: true,
+          window_d4: true,
+        },
+      });
+    });
+  });
+
+  describe('empty documents', () => {
+    it('should return an empty result without calling the model', async () => {
+      const model = new MockRerankingModelV4({
+        maxDocumentsPerCall: 2,
+        doRerank: async () => {
+          throw new Error('doRerank should not be called');
+        },
+      });
+
+      const result = await rerankMany({ model, documents: [], query: 'q' });
+
+      expect(model.doRerankCalls).toHaveLength(0);
+      expect(result.ranking).toStrictEqual([]);
+      expect(result.rerankedDocuments).toStrictEqual([]);
+      expect(result.originalDocuments).toStrictEqual([]);
+      expect(result.responses).toStrictEqual([]);
+    });
+  });
+
+  describe('options.headers and providerOptions', () => {
+    it('should forward headers and provider options to every window', async () => {
+      const model = new MockRerankingModelV4({
+        maxDocumentsPerCall: 2,
+        doRerank: windowedDoRerank,
+      });
+
+      await rerankMany({
+        model,
+        documents: testDocuments,
+        query: 'q',
+        headers: { 'x-custom': 'value' },
+        providerOptions: { aProvider: { someKey: 'someValue' } },
+      });
+
+      for (const call of model.doRerankCalls) {
+        expect(call.headers).toStrictEqual({ 'x-custom': 'value' });
+        expect(call.providerOptions).toStrictEqual({
+          aProvider: { someKey: 'someValue' },
+        });
+      }
+    });
+  });
+
+  describe('options.onStart and onEnd', () => {
+    it('should send the aggregated start and end events', async () => {
+      const startEvents: RerankStartEvent[] = [];
+      const endEvents: RerankEndEvent[] = [];
+
+      vi.spyOn(logWarningsModule, 'logWarnings').mockImplementation(() => {});
+
+      const model = new MockRerankingModelV4({
+        maxDocumentsPerCall: 2,
+        doRerank: windowedDoRerank,
+      });
+
+      await rerankMany({
+        model,
+        documents: testDocuments,
+        query: 'q',
+        topN: 2,
+        onStart: event => {
+          startEvents.push(event);
+        },
+        onEnd: event => {
+          endEvents.push(event);
+        },
+      });
+
+      expect(startEvents).toHaveLength(1);
+      expect(startEvents[0]).toMatchObject({
+        operationId: 'ai.rerankMany',
+        provider: 'mock-provider',
+        modelId: 'mock-model-id',
+        documents: testDocuments,
+        query: 'q',
+        topN: 2,
+      });
+
+      expect(endEvents).toHaveLength(1);
+      expect(endEvents[0]).toMatchObject({
+        operationId: 'ai.rerankMany',
+        query: 'q',
+        ranking: [
+          { originalIndex: 2, score: 0.9, document: 'd2' },
+          { originalIndex: 4, score: 0.7, document: 'd4' },
+        ],
+      });
+      expect(Array.isArray(endEvents[0].response)).toBe(true);
+    });
+  });
+});

--- a/packages/ai/src/rerank/rerank-many.ts
+++ b/packages/ai/src/rerank/rerank-many.ts
@@ -1,0 +1,428 @@
+import type { JSONObject, RerankingModelV4CallOptions } from '@ai-sdk/provider';
+import {
+  createIdGenerator,
+  type ProviderOptions,
+} from '@ai-sdk/provider-utils';
+import { logWarnings } from '../logger/log-warnings';
+import { resolveRerankingModel } from '../model/resolve-model';
+import { createTelemetryDispatcher } from '../telemetry/create-telemetry-dispatcher';
+import type { TelemetryOptions } from '../telemetry/telemetry-options';
+import type { ProviderMetadata, RerankingModel } from '../types';
+import type { Warning } from '../types/warning';
+import type { Callback } from '../util/callback';
+import { notify } from '../util/notify';
+import { prepareRetries } from '../util/prepare-retries';
+import { splitArray } from '../util/split-array';
+import type { RerankEndEvent, RerankStartEvent } from './rerank-events';
+import type { RerankManyResult } from './rerank-many-result';
+
+const originalGenerateCallId = createIdGenerator({
+  prefix: 'call',
+  size: 24,
+});
+
+/**
+ * Rerank several documents using a reranking model. The type of the value is
+ * defined by the reranking model.
+ *
+ * `rerankMany` automatically splits large requests into smaller windows if the
+ * model has a limit on how many documents can be reranked in a single call
+ * (`maxDocumentsPerCall`). Each window is scored independently and the results
+ * are merged and re-sorted by relevance score before the optional `topN` limit
+ * is applied.
+ *
+ * This assumes the model scores each document against the query independently
+ * (pointwise/pairwise), so a document's score does not depend on which other
+ * documents share the call. Models that score documents relative to each other
+ * (listwise) may rank differently when the documents are split across windows.
+ *
+ * @param model - The reranking model to use.
+ * @param documents - The documents that should be reranked.
+ * @param query - The query to rerank the documents against.
+ * @param topN - Number of top documents to return.
+ *
+ * @param maxRetries - Maximum number of retries. Set to 0 to disable retries. Default: 2.
+ * @param abortSignal - An optional abort signal that can be used to cancel the call.
+ * @param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
+ * @param maxParallelCalls - Maximum number of concurrent requests. Default: Infinity.
+ * @param providerOptions - Additional provider-specific options.
+ * @param telemetry - Optional telemetry configuration.
+ *
+ * @returns A result object that contains the reranked documents, the reranked indices, and additional information.
+ */
+export async function rerankMany<VALUE extends JSONObject | string>({
+  model: modelArg,
+  documents,
+  query,
+  topN,
+  maxParallelCalls = Infinity,
+  maxRetries: maxRetriesArg,
+  abortSignal,
+  headers,
+  providerOptions,
+  experimental_telemetry,
+  telemetry = experimental_telemetry,
+  onStart,
+  experimental_onStart,
+  onEnd,
+  experimental_onEnd,
+  _internal: { generateCallId = originalGenerateCallId } = {},
+}: {
+  /**
+   * The reranking model to use.
+   */
+  model: RerankingModel;
+
+  /**
+   * The documents that should be reranked.
+   */
+  documents: Array<VALUE>;
+
+  /**
+   * The query to rerank the documents against.
+   */
+  query: string;
+
+  /**
+   * Number of top documents to return.
+   */
+  topN?: number;
+
+  /**
+   * Maximum number of retries per reranking model call. Set to 0 to disable retries.
+   *
+   * @default 2
+   */
+  maxRetries?: number;
+
+  /**
+   * Abort signal.
+   */
+  abortSignal?: AbortSignal;
+
+  /**
+   * Additional headers to include in the request.
+   * Only applicable for HTTP-based providers.
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Optional telemetry configuration.
+   */
+  telemetry?: TelemetryOptions;
+
+  /**
+   * Optional telemetry configuration.
+   *
+   * @deprecated Use `telemetry` instead. This alias will be removed in a future major release.
+   */
+  experimental_telemetry?: TelemetryOptions;
+
+  /**
+   * Additional provider-specific options. They are passed through
+   * to the provider from the AI SDK and enable provider-specific
+   * functionality that can be fully encapsulated in the provider.
+   */
+  providerOptions?: ProviderOptions;
+
+  /**
+   * Maximum number of concurrent requests.
+   *
+   * Only takes effect when the model reports `supportsParallelCalls`.
+   *
+   * @default Infinity
+   */
+  maxParallelCalls?: number;
+
+  /**
+   * Callback that is called when the rerankMany operation begins,
+   * before the reranking model is called.
+   */
+  onStart?: Callback<RerankStartEvent>;
+
+  /**
+   * Callback that is called when the rerankMany operation begins,
+   * before the reranking model is called.
+   *
+   * @deprecated Use `onStart` instead.
+   */
+  experimental_onStart?: Callback<RerankStartEvent>;
+
+  /**
+   * Callback that is called when the rerankMany operation completes,
+   * after all reranking model calls return.
+   */
+  onEnd?: Callback<RerankEndEvent>;
+
+  /**
+   * Callback that is called when the rerankMany operation completes,
+   * after all reranking model calls return.
+   *
+   * @deprecated Use `onEnd` instead.
+   */
+  experimental_onEnd?: Callback<RerankEndEvent>;
+
+  /**
+   * Internal. For test use only. May change without notice.
+   */
+  _internal?: {
+    generateCallId?: () => string;
+  };
+}): Promise<RerankManyResult<VALUE>> {
+  const model = resolveRerankingModel(modelArg);
+  const callId = generateCallId();
+  const resolvedOnStart = onStart ?? experimental_onStart;
+  const resolvedOnEnd = onEnd ?? experimental_onEnd;
+
+  const { maxRetries, retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    abortSignal,
+  });
+
+  const telemetryDispatcher = createTelemetryDispatcher({
+    telemetry,
+  });
+
+  const runInTracingChannelSpan =
+    telemetryDispatcher.runInTracingChannelSpan ??
+    (async <T>({ execute }: { execute: () => PromiseLike<T> }) =>
+      await execute());
+
+  const startEvent = {
+    callId,
+    operationId: 'ai.rerankMany',
+    provider: model.provider,
+    modelId: model.modelId,
+    documents,
+    query,
+    topN,
+    maxRetries,
+    headers,
+    providerOptions,
+  };
+
+  return await runInTracingChannelSpan({
+    type: 'rerankMany',
+    event: startEvent,
+    execute: async () => {
+      await notify({
+        event: startEvent,
+        callbacks: [resolvedOnStart, telemetryDispatcher.onStart],
+      });
+
+      try {
+        const [maxDocumentsPerCall, supportsParallelCalls] = await Promise.all([
+          model.maxDocumentsPerCall,
+          model.supportsParallelCalls,
+        ]);
+
+        const documentType: 'text' | 'object' =
+          typeof documents[0] === 'string' ? 'text' : 'object';
+
+        const toCallDocuments = (
+          windowDocuments: Array<VALUE>,
+        ): RerankingModelV4CallOptions['documents'] =>
+          documentType === 'text'
+            ? { type: 'text', values: windowDocuments as string[] }
+            : { type: 'object', values: windowDocuments as JSONObject[] };
+
+        // Split the documents into windows, keeping each window's offset in the
+        // original list so window-local indices can be mapped back to global
+        // indices after reranking.
+        let documentWindows: Array<{
+          documents: Array<VALUE>;
+          offset: number;
+        }>;
+        if (
+          documents.length === 0 ||
+          maxDocumentsPerCall == null ||
+          maxDocumentsPerCall === Infinity
+        ) {
+          documentWindows =
+            documents.length === 0 ? [] : [{ documents, offset: 0 }];
+        } else {
+          let offset = 0;
+          documentWindows = splitArray(documents, maxDocumentsPerCall).map(
+            windowDocuments => {
+              const window = { documents: windowDocuments, offset };
+              offset += windowDocuments.length;
+              return window;
+            },
+          );
+        }
+
+        const mergedRanking: Array<{ index: number; relevanceScore: number }> =
+          [];
+        const warnings: Array<Warning> = [];
+        const responses: Array<{
+          id?: string;
+          timestamp: Date;
+          modelId: string;
+          headers?: Record<string, string>;
+          body?: unknown;
+        }> = [];
+        let providerMetadata: ProviderMetadata | undefined;
+
+        // Independent windows can be reranked in parallel when the model
+        // supports it; otherwise they are sent one at a time.
+        const parallelWindows = splitArray(
+          documentWindows,
+          supportsParallelCalls ? maxParallelCalls : 1,
+        );
+
+        for (const parallelWindow of parallelWindows) {
+          const results = await Promise.all(
+            parallelWindow.map(window =>
+              retry(async () => {
+                const rerankCallId = generateCallId();
+                const callDocuments = toCallDocuments(window.documents);
+
+                await notify({
+                  event: {
+                    callId,
+                    rerankCallId,
+                    operationId: 'ai.rerankMany.doRerank',
+                    provider: model.provider,
+                    modelId: model.modelId,
+                    documents: window.documents,
+                    documentsType: callDocuments.type,
+                    query,
+                    topN,
+                  },
+                  callbacks: [telemetryDispatcher.onRerankStart],
+                });
+
+                // topN is applied globally after merging, so each window is
+                // scored in full rather than truncated on its own.
+                const modelResponse = await model.doRerank({
+                  documents: callDocuments,
+                  query,
+                  providerOptions,
+                  abortSignal,
+                  headers,
+                });
+
+                await notify({
+                  event: {
+                    callId,
+                    rerankCallId,
+                    operationId: 'ai.rerankMany.doRerank',
+                    provider: model.provider,
+                    modelId: model.modelId,
+                    documentsType: callDocuments.type,
+                    ranking: modelResponse.ranking,
+                  },
+                  callbacks: [telemetryDispatcher.onRerankEnd],
+                });
+
+                return { window, modelResponse };
+              }),
+            ),
+          );
+
+          for (const { window, modelResponse } of results) {
+            for (const entry of modelResponse.ranking) {
+              mergedRanking.push({
+                index: window.offset + entry.index,
+                relevanceScore: entry.relevanceScore,
+              });
+            }
+
+            if (modelResponse.warnings) {
+              warnings.push(...modelResponse.warnings);
+            }
+
+            responses.push({
+              id: modelResponse.response?.id,
+              timestamp: modelResponse.response?.timestamp ?? new Date(),
+              modelId: modelResponse.response?.modelId ?? model.modelId,
+              headers: modelResponse.response?.headers,
+              body: modelResponse.response?.body,
+            });
+
+            if (modelResponse.providerMetadata) {
+              if (!providerMetadata) {
+                providerMetadata = { ...modelResponse.providerMetadata };
+              } else {
+                for (const [providerName, metadata] of Object.entries(
+                  modelResponse.providerMetadata,
+                )) {
+                  providerMetadata[providerName] = {
+                    ...(providerMetadata[providerName] ?? {}),
+                    ...metadata,
+                  };
+                }
+              }
+            }
+          }
+        }
+
+        mergedRanking.sort((a, b) => b.relevanceScore - a.relevanceScore);
+
+        const limitedRanking =
+          topN == null ? mergedRanking : mergedRanking.slice(0, topN);
+
+        const ranking = limitedRanking.map(entry => ({
+          originalIndex: entry.index,
+          score: entry.relevanceScore,
+          document: documents[entry.index],
+        }));
+
+        logWarnings({
+          warnings,
+          provider: model.provider,
+          model: model.modelId,
+        });
+
+        await notify({
+          event: {
+            callId,
+            operationId: 'ai.rerankMany',
+            provider: model.provider,
+            modelId: model.modelId,
+            documents,
+            query,
+            ranking,
+            warnings,
+            providerMetadata,
+            response: responses,
+          },
+          callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
+        });
+
+        return new DefaultRerankManyResult({
+          originalDocuments: documents,
+          ranking,
+          providerMetadata,
+          responses,
+        });
+      } catch (error) {
+        await telemetryDispatcher.onError?.({ callId, error });
+        throw error;
+      }
+    },
+  });
+}
+
+class DefaultRerankManyResult<VALUE> implements RerankManyResult<VALUE> {
+  readonly originalDocuments: RerankManyResult<VALUE>['originalDocuments'];
+  readonly ranking: RerankManyResult<VALUE>['ranking'];
+  readonly providerMetadata: RerankManyResult<VALUE>['providerMetadata'];
+  readonly responses: RerankManyResult<VALUE>['responses'];
+
+  constructor(options: {
+    originalDocuments: RerankManyResult<VALUE>['originalDocuments'];
+    ranking: RerankManyResult<VALUE>['ranking'];
+    providerMetadata?: RerankManyResult<VALUE>['providerMetadata'];
+    responses?: RerankManyResult<VALUE>['responses'];
+  }) {
+    this.originalDocuments = options.originalDocuments;
+    this.ranking = options.ranking;
+    this.providerMetadata = options.providerMetadata;
+    this.responses = options.responses;
+  }
+
+  get rerankedDocuments(): RerankManyResult<VALUE>['rerankedDocuments'] {
+    return this.ranking.map(ranking => ranking.document);
+  }
+}

--- a/packages/ai/src/telemetry/tracing-channel.ts
+++ b/packages/ai/src/telemetry/tracing-channel.ts
@@ -8,7 +8,8 @@ export type TelemetryTracingEventType =
   | 'executeTool'
   | 'embed'
   | 'embedMany'
-  | 'rerank';
+  | 'rerank'
+  | 'rerankMany';
 
 export type TelemetryTracingChannelMessage<EVENT = unknown> = {
   readonly type: TelemetryTracingEventType;

--- a/packages/ai/src/test/mock-reranking-model-v4.ts
+++ b/packages/ai/src/test/mock-reranking-model-v4.ts
@@ -6,20 +6,43 @@ export class MockRerankingModelV4 implements RerankingModelV4 {
 
   readonly provider: RerankingModelV4['provider'];
   readonly modelId: RerankingModelV4['modelId'];
+  readonly maxDocumentsPerCall: RerankingModelV4['maxDocumentsPerCall'];
+  readonly supportsParallelCalls: RerankingModelV4['supportsParallelCalls'];
 
   doRerank: RerankingModelV4['doRerank'];
+
+  doRerankCalls: Parameters<RerankingModelV4['doRerank']>[0][] = [];
 
   constructor({
     provider = 'mock-provider',
     modelId = 'mock-model-id',
+    maxDocumentsPerCall,
+    supportsParallelCalls = false,
     doRerank = notImplemented,
   }: {
     provider?: RerankingModelV4['provider'];
     modelId?: RerankingModelV4['modelId'];
-    doRerank?: RerankingModelV4['doRerank'];
+    maxDocumentsPerCall?: RerankingModelV4['maxDocumentsPerCall'] | null;
+    supportsParallelCalls?: RerankingModelV4['supportsParallelCalls'];
+    doRerank?:
+      | RerankingModelV4['doRerank']
+      | Awaited<ReturnType<RerankingModelV4['doRerank']>>
+      | Awaited<ReturnType<RerankingModelV4['doRerank']>>[];
   } = {}) {
     this.provider = provider;
     this.modelId = modelId;
-    this.doRerank = doRerank;
+    this.maxDocumentsPerCall = maxDocumentsPerCall ?? undefined;
+    this.supportsParallelCalls = supportsParallelCalls;
+    this.doRerank = async options => {
+      this.doRerankCalls.push(options);
+
+      if (typeof doRerank === 'function') {
+        return doRerank(options);
+      } else if (Array.isArray(doRerank)) {
+        return doRerank[this.doRerankCalls.length - 1];
+      } else {
+        return doRerank;
+      }
+    };
   }
 }

--- a/packages/provider/src/reranking-model/v4/reranking-model-v4.ts
+++ b/packages/provider/src/reranking-model/v4/reranking-model-v4.ts
@@ -21,6 +21,27 @@ export type RerankingModelV4 = {
   readonly modelId: string;
 
   /**
+   * Limit of how many documents can be reranked in a single API call.
+   *
+   * Use Infinity for models that do not have a limit. When omitted, the
+   * document set is sent in a single call. `rerankMany` uses this to split
+   * larger document sets across multiple calls.
+   */
+  readonly maxDocumentsPerCall?:
+    | PromiseLike<number | undefined>
+    | number
+    | undefined;
+
+  /**
+   * True if the model can handle multiple reranking calls in parallel.
+   *
+   * `rerankMany` uses this to decide whether the document windows produced by
+   * `maxDocumentsPerCall` may be sent concurrently. When omitted, the windows
+   * are sent sequentially.
+   */
+  readonly supportsParallelCalls?: PromiseLike<boolean> | boolean;
+
+  /**
    * Reranking a list of documents using the query.
    */
   // Naming: "do" prefix to prevent accidental direct usage of the method by the user.


### PR DESCRIPTION
## Background

`RerankingModelV4` and `rerank()` send every document to the provider in a single `doRerank` call. Cross-encoder rerankers cap how many documents they score per request, so reranking a set larger than that cap means windowing the documents, remapping indices, and merging the results by hand. Embedding already solves the analogous problem with `embedMany()` + `maxEmbeddingsPerCall`; reranking had no equivalent.

Closes #17811.

## Summary

Adds `rerankMany()`, the reranking analogue of `embedMany()`.

**`@ai-sdk/provider`** — two optional fields on `RerankingModelV4`:

- `maxDocumentsPerCall` — the per-call document limit (`Infinity`/omitted means no limit).
- `supportsParallelCalls` — whether windows may be reranked concurrently.

Both are optional, so existing v4 reranking providers are unaffected.

**`ai`** — `rerankMany()`:

- Splits the documents into windows of `maxDocumentsPerCall`.
- Reranks each window, sending them concurrently (bounded by `maxParallelCalls`) when the model reports `supportsParallelCalls`, otherwise sequentially.
- Remaps each window's local indices back to the original positions, merges the windows into a single ranking sorted by relevance score, and applies `topN` globally.
- Returns a `RerankManyResult` that aggregates the per-window `responses` and merges `providerMetadata`.

`rerankMany()` assumes the model scores each document against the query independently (pointwise/pairwise), so a document's score does not depend on which other documents share the call. Models that score documents relative to one another (listwise) may rank differently when documents are split across windows; this is documented on the function and the reference page.

## End-to-End Verification

Reranked a document set larger than a mock model's `maxDocumentsPerCall` and confirmed:

- The merged ranking matches a single-call reranking of the same set — identical scores, window-local indices remapped to the original positions, `topN` applied globally.
- Sequential vs. concurrent dispatch follows `supportsParallelCalls` and `maxParallelCalls`.
- Empty input returns an empty result without calling the model.
- Object documents, per-window `responses`, and merged `providerMetadata` behave as expected.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Closes #17811.
