### PR TITLE
fix (provider/google): handle non-string enum and const values in schemas

### DIFF
--- a/.changeset/hip-games-tan.md
+++ b/.changeset/hip-games-tan.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix (provider/google): handle non-string enum and const values in schemas. The Gemini API only allows enum on string types, so string enums without an explicit type now get `type: 'string'`, non-string enum/const values are moved into the description while preserving the declared type, and null enum/const values are expressed via `nullable`.

--- a/examples/ai-functions/src/generate-text/google/output-object-number-enum.ts
+++ b/examples/ai-functions/src/generate-text/google/output-object-number-enum.ts
@@ -1,0 +1,26 @@
+import { google } from '@ai-sdk/google';
+import { generateText, Output } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+// Reproduction for number enums in schemas: the Gemini API only allows
+// enum on string types (https://github.com/vercel/ai/issues/6872), so
+// numeric enum/literal values are moved into the schema description
+// while keeping the declared number type.
+run(async () => {
+  const { output } = await generateText({
+    model: google('gemini-2.5-flash'),
+    output: Output.object({
+      schema: z.object({
+        name: z.string(),
+        rating: z
+          .union([z.literal(1), z.literal(2), z.literal(3)])
+          .describe('Rating from 1 to 3.'),
+        priority: z.literal(5),
+      }),
+    }),
+    prompt: 'Generate an example review for testing.',
+  });
+
+  console.log(output);
+});

--- a/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
@@ -100,7 +100,7 @@ it('should convert "const" to "enum" with a single value', () => {
   const expected = {
     type: 'object',
     properties: {
-      status: { enum: ['active'] },
+      status: { type: 'string', enum: ['active'] },
     },
   };
 
@@ -214,6 +214,7 @@ it('should convert deeply nested "const" to "enum"', () => {
                 type: 'object',
                 properties: {
                   value: {
+                    type: 'string',
                     enum: ['specific value'],
                   },
                 },
@@ -681,4 +682,179 @@ it('should convert type arrays without null to anyOf', () => {
   };
 
   expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
+});
+
+it('should move number enum values into the description (Gemini only allows enum on string type)', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      rating: {
+        type: 'number',
+        enum: [1, 2, 3],
+      },
+      count: {
+        type: 'integer',
+        enum: [10, 20],
+      },
+    },
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual({
+    type: 'object',
+    properties: {
+      rating: {
+        type: 'number',
+        description: 'Possible values: 1, 2, 3',
+      },
+      count: {
+        type: 'integer',
+        description: 'Possible values: 10, 20',
+      },
+    },
+  });
+});
+
+it('should append number enum values to an existing description', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      rating: {
+        type: 'number',
+        description: 'Rating of the review.',
+        enum: [1, 2, 3],
+      },
+    },
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual({
+    type: 'object',
+    properties: {
+      rating: {
+        type: 'number',
+        description: 'Rating of the review. (Possible values: 1, 2, 3)',
+      },
+    },
+  });
+});
+
+it('should move boolean enum values into the description', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      flag: {
+        type: 'boolean',
+        enum: [true, false],
+      },
+    },
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual({
+    type: 'object',
+    properties: {
+      flag: {
+        type: 'boolean',
+        description: 'Possible values: true, false',
+      },
+    },
+  });
+});
+
+it('should move non-string "const" into the description', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      version: { type: 'number', const: 42 },
+    },
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual({
+    type: 'object',
+    properties: {
+      version: { type: 'number', description: 'Possible values: 42' },
+    },
+  });
+});
+
+it('should infer string type for enums without an explicit type', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      value: {
+        enum: ['foo', 'bar'],
+      },
+    },
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual({
+    type: 'object',
+    properties: {
+      value: {
+        type: 'string',
+        enum: ['foo', 'bar'],
+      },
+    },
+  });
+});
+
+it('should infer number type for number enums without an explicit type', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      rating: {
+        enum: [1, 2, 3],
+      },
+    },
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual({
+    type: 'object',
+    properties: {
+      rating: {
+        type: 'number',
+        description: 'Possible values: 1, 2, 3',
+      },
+    },
+  });
+});
+
+it('should convert "const: null" to nullable', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      empty: { type: ['number', 'null'], const: null },
+    },
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual({
+    type: 'object',
+    properties: {
+      empty: {
+        anyOf: [{ type: 'number' }],
+        nullable: true,
+      },
+    },
+  });
+});
+
+it('should remove null from enum values and mark the schema as nullable', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      status: {
+        type: ['string', 'null'],
+        enum: ['active', 'inactive', null],
+      },
+    },
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual({
+    type: 'object',
+    properties: {
+      status: {
+        anyOf: [{ type: 'string' }],
+        nullable: true,
+        enum: ['active', 'inactive'],
+      },
+    },
+  });
 });

--- a/packages/google/src/convert-json-schema-to-openapi-schema.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.ts
@@ -48,10 +48,6 @@ export function convertJSONSchemaToOpenAPISchema(
   if (required) result.required = required;
   if (format) result.format = format;
 
-  if (constValue !== undefined) {
-    result.enum = [constValue];
-  }
-
   // Handle type
   if (type) {
     if (Array.isArray(type)) {
@@ -73,9 +69,53 @@ export function convertJSONSchemaToOpenAPISchema(
     }
   }
 
-  // Handle enum
-  if (enumValues !== undefined) {
-    result.enum = enumValues;
+  // Handle enum and const (a const is a single-value enum). The Gemini API
+  // only allows enum on string types with string values, so:
+  // - a null value is expressed via `nullable` instead
+  // - string values are sent as enum (inferring `type: 'string'` when the
+  //   type is missing, since Gemini rejects enum without a type)
+  // - non-string values cannot be sent as enum without changing the type
+  //   (which would break validation of the generated output against the
+  //   original schema), so they are moved into the description instead
+  const allEnumValues =
+    enumValues !== undefined
+      ? enumValues
+      : constValue !== undefined
+        ? [constValue]
+        : undefined;
+
+  if (allEnumValues !== undefined) {
+    const nonNullEnumValues = allEnumValues.filter(value => value !== null);
+
+    if (nonNullEnumValues.length < allEnumValues.length) {
+      result.nullable = true;
+    }
+
+    if (nonNullEnumValues.length > 0) {
+      if (nonNullEnumValues.every(value => typeof value === 'string')) {
+        result.enum = nonNullEnumValues;
+        if (result.type == null && result.anyOf == null) {
+          result.type = 'string';
+        }
+      } else {
+        const valuesText = nonNullEnumValues
+          .map(value => JSON.stringify(value))
+          .join(', ');
+        result.description = result.description
+          ? `${result.description} (Possible values: ${valuesText})`
+          : `Possible values: ${valuesText}`;
+
+        if (result.type == null && result.anyOf == null) {
+          if (nonNullEnumValues.every(value => typeof value === 'number')) {
+            result.type = 'number';
+          } else if (
+            nonNullEnumValues.every(value => typeof value === 'boolean')
+          ) {
+            result.type = 'boolean';
+          }
+        }
+      }
+    }
   }
 
   if (properties != null) {


### PR DESCRIPTION
## Background

Fixes #6872.

`convertJSONSchemaToOpenAPISchema` passes `enum` values through unchanged and converts `const` into a single-value `enum`, for values of any JSON type. The Gemini API is stricter than JSON Schema here:

- `Schema.enum` is declared as `repeated string` in the API definition ([generativelanguage content.proto](https://github.com/googleapis/googleapis/blob/master/google/ai/generativelanguage/v1beta/content.proto)), so non-string values such as `enum: [1, 2, 3]` (e.g. from `z.union([z.literal(1), z.literal(2), z.literal(3)])` or `z.literal(15)`, see [this report in #6872](https://github.com/vercel/ai/issues/6872#issuecomment-3572779910)) fail request parsing with `Invalid value at '...enum[0]' (TYPE_STRING)`.
- `enum` is only accepted on `STRING`-typed schemas. This is the error from #6872 itself (`response_schema.properties[value].enum: only allowed for STRING type`), triggered when a schema contains `enum` without an accompanying `type: 'string'` (older Zod v4 versions emitted this shape for `z.enum()`). It also rules out the alternative fix of stringifying the values while keeping the declared numeric/boolean type: that shape is still rejected with the same error (see [anomalyco/opencode#28397](https://github.com/anomalyco/opencode/issues/28397), which hit exactly this after [stringifying enum values](https://github.com/anomalyco/opencode/issues/12784)).

Coercing such schemas to `type: 'string'` (the approach Google's own SDK takes for integer enums, see [`_process_enum` in python-genai](https://github.com/googleapis/python-genai/blob/main/google/genai/_transformers.py)) is not an option for the AI SDK: the model would emit string values (`"1"` instead of `1`), which then fail validation against the user's original schema in `generateObject` / tool input validation. python-genai can afford this because Pydantic coerces `"1"` back to `1` when parsing; Zod does not.

## Summary

`convertJSONSchemaToOpenAPISchema` now handles `enum` and `const` (treated as a single-value enum) as follows:

- **String values** are sent as `enum` unchanged. When no `type` is present, `type: 'string'` is inferred, since Gemini rejects `enum` without a string type (the original #6872 failure).
- **Non-string values** cannot be sent as `enum` without changing the type (which would break output validation, see above), so they are moved into the `description` as a soft constraint while the declared type is preserved, e.g. `{ type: 'number', enum: [1, 2, 3] }` becomes `{ type: 'number', description: 'Possible values: 1, 2, 3' }` (appended to an existing description if there is one). Previously these produced a request the API rejects with a 400.
- **`null` values** (`null` inside `enum`, or `const: null`) are expressed via `nullable: true`.

## Contributor Credit

- @smirea for the report and reproduction in #6872
- @DylanMerigaud for reporting the numeric-literal case in #6872

## End-to-End Verification

Added `examples/ai-functions/src/generate-text/google/output-object-number-enum.ts` reproducing the numeric enum/literal case (400 before this change). Note: I could not run it against the live API (no API key available in my environment); verification is via the unit tests plus manually inspecting the converted schema output for the reproduction cases from #6872.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- #17138 switches tool parameters to `parametersJsonSchema`, which bypasses this converter for tools; the two changes are complementary. This fix matters mainly for the response-schema path (`generateObject`/`streamObject`), which still goes through the converter.
- Migrating the response-schema path to `responseJsonSchema` (native JSON Schema, supported on newer Gemini models) would allow representing non-string enums as hard constraints again, at which point the description fallback could be retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
