### PR TITLE
fix(harness-codex): honor executable and final response

### DIFF
--- a/.changeset/codex-bridge-runtime.md
+++ b/.changeset/codex-bridge-runtime.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-codex': patch
+---
+
+Honor a configured or ambient Codex executable and expose only the final agent message as harness text.

--- a/content/providers/02-ai-sdk-harnesses/02-codex.mdx
+++ b/content/providers/02-ai-sdk-harnesses/02-codex.mdx
@@ -89,6 +89,7 @@ const harness = createCodex({
 Settings:
 
 - `auth`: authentication mode: `auto`, `direct`, or `ai-gateway`.
+- `codexPath`: path to a Codex executable installed inside the sandbox.
 - `codexConfig`: additional native Codex configuration. Values pass through as
   provided, so use the snake_case keys from Codex's `config.toml` reference.
   The adapter's managed values take precedence over conflicting entries.

--- a/packages/harness-codex/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-codex/src/bridge/create-emit-stream-event.test.ts
@@ -3,7 +3,7 @@ import type { CodexStepTracker } from './codex-step-tracker';
 import { createEmitStreamEvent } from './create-emit-stream-event';
 
 describe('createEmitStreamEvent', () => {
-  it('emits thread, accumulated text, and usage events', () => {
+  it('emits thread, final text, and usage events', () => {
     const emitted: Record<string, unknown>[] = [];
     const observed: unknown[] = [];
     const usages: unknown[] = [];
@@ -51,21 +51,27 @@ describe('createEmitStreamEvent', () => {
             "type": "bridge-thread",
           },
           {
-            "id": "message-1",
+            "rawValue": {
+              "item": {
+                "id": "message-1",
+                "text": "hello world",
+                "type": "agent_message",
+              },
+              "type": "item.completed",
+            },
+            "type": "raw",
+          },
+          {
+            "id": "codex-final-message",
             "type": "text-start",
           },
           {
-            "delta": "hello",
-            "id": "message-1",
+            "delta": "hello world",
+            "id": "codex-final-message",
             "type": "text-delta",
           },
           {
-            "delta": " world",
-            "id": "message-1",
-            "type": "text-delta",
-          },
-          {
-            "id": "message-1",
+            "id": "codex-final-message",
             "type": "text-end",
           },
         ],
@@ -169,6 +175,73 @@ describe('createEmitStreamEvent', () => {
         },
       ]
     `);
+  });
+
+  it('emits only the last completed agent message as text', () => {
+    const emitted: Record<string, unknown>[] = [];
+    const stepTracker = {
+      observeEvent: () => {},
+      finishTurn: () => {},
+    } as CodexStepTracker;
+    const emitStreamEvent = createEmitStreamEvent({
+      send: event => emitted.push(event),
+      stepTracker,
+      setTurnUsage: () => {},
+      setThreadId: () => {},
+      emitWarning: () => {},
+      emitError: () => {},
+    });
+    const progress = {
+      type: 'item.completed' as const,
+      item: { type: 'agent_message', id: 'progress', text: 'Working on it.' },
+    };
+    const final = {
+      type: 'item.completed' as const,
+      item: { type: 'agent_message', id: 'final', text: 'Done.' },
+    };
+
+    emitStreamEvent(progress);
+    emitStreamEvent(final);
+    emitStreamEvent({ type: 'turn.completed' });
+
+    expect(emitted).toEqual([
+      { type: 'raw', rawValue: progress },
+      { type: 'raw', rawValue: final },
+      { type: 'text-start', id: 'codex-final-message' },
+      { type: 'text-delta', id: 'codex-final-message', delta: 'Done.' },
+      { type: 'text-end', id: 'codex-final-message' },
+    ]);
+  });
+
+  it('does not promote an agent message when the turn fails', () => {
+    const emitted: Record<string, unknown>[] = [];
+    const errors: unknown[] = [];
+    const stepTracker = {
+      observeEvent: () => {},
+      finishTurn: () => {},
+    } as CodexStepTracker;
+    const emitStreamEvent = createEmitStreamEvent({
+      send: event => emitted.push(event),
+      stepTracker,
+      setTurnUsage: () => {},
+      setThreadId: () => {},
+      emitWarning: () => {},
+      emitError: error => errors.push(error),
+    });
+
+    emitStreamEvent({
+      type: 'item.completed',
+      item: { type: 'agent_message', id: 'progress', text: 'Working on it.' },
+    });
+    emitStreamEvent({
+      type: 'turn.failed',
+      error: { message: 'failed' },
+    });
+
+    expect(emitted.some(event => String(event.type).startsWith('text-'))).toBe(
+      false,
+    );
+    expect(errors).toHaveLength(1);
   });
 
   it('preserves command and MCP result translation', () => {

--- a/packages/harness-codex/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-codex/src/bridge/create-emit-stream-event.ts
@@ -71,7 +71,7 @@ export function createEmitStreamEvent({
   emitWarning: BridgeTurn['emitWarning'];
   emitError: BridgeTurn['emitError'];
 }): (event: CodexEvent) => void {
-  const textByItem = new Map<string, string>();
+  let finalText: string | undefined;
   const reasoningByItem = new Map<string, string>();
 
   return event => {
@@ -85,6 +85,12 @@ export function createEmitStreamEvent({
     }
     if (event.type === 'turn.completed') {
       if (event.usage) setTurnUsage(mapUsage(event.usage));
+      if (finalText !== undefined) {
+        const id = 'codex-final-message';
+        send({ type: 'text-start', id });
+        send({ type: 'text-delta', id, delta: finalText });
+        send({ type: 'text-end', id });
+      }
       stepTracker.finishTurn();
       return;
     }
@@ -110,25 +116,10 @@ export function createEmitStreamEvent({
     };
 
     if (item.type === 'agent_message' && typeof item.text === 'string') {
-      /*
-       * The presence of `id` in `textByItem` — not the `item.started` event —
-       * marks the text part as opened. Codex does not guarantee an
-       * `item.started` event carrying text precedes the first `item.updated`
-       * with text, so keying the `text-start` off the event type can emit a
-       * `text-delta` for a part that was never opened. Opening lazily on the
-       * first event with text keeps `text-start` before any `text-delta`.
-       */
-      if (!textByItem.has(id)) {
-        send({ type: 'text-start', id });
-        textByItem.set(id, '');
+      if (event.type === 'item.completed') {
+        finalText = item.text;
+        send({ type: 'raw', rawValue: event });
       }
-      const last = textByItem.get(id) ?? '';
-      const next = item.text;
-      if (next.length > last.length) {
-        send({ type: 'text-delta', id, delta: next.slice(last.length) });
-        textByItem.set(id, next);
-      }
-      if (event.type === 'item.completed') send({ type: 'text-end', id });
       observeStep();
       return;
     }

--- a/packages/harness-codex/src/bridge/index.test.ts
+++ b/packages/harness-codex/src/bridge/index.test.ts
@@ -1,15 +1,21 @@
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 type CodexOptions = {
+  codexPathOverride?: string;
   config?: Record<string, unknown>;
 };
 type ThreadOptions = { model?: string };
 type TurnOptions = { outputSchema?: Record<string, unknown> };
-const CODEX_ENV_KEYS = [
+const ENV_KEYS = [
   'AI_GATEWAY_API_KEY',
   'AI_GATEWAY_BASE_URL',
   'OPENAI_BASE_URL',
   'CODEX_API_KEY',
+  'CODEX_PATH',
+  'PATH',
 ] as const;
 
 const state = vi.hoisted(() => ({
@@ -24,10 +30,7 @@ const state = vi.hoisted(() => ({
   startCodexConfig: undefined as Record<string, unknown> | undefined,
   startMcpServers: undefined as Record<string, unknown> | undefined,
   originalArgv: [] as string[],
-  originalEnv: {} as Record<
-    (typeof CODEX_ENV_KEYS)[number],
-    string | undefined
-  >,
+  originalEnv: {} as Record<(typeof ENV_KEYS)[number], string | undefined>,
 }));
 
 vi.mock('@openai/codex-sdk', () => ({
@@ -91,6 +94,8 @@ vi.mock('@ai-sdk/harness/bridge', () => ({
 }));
 
 describe('Codex bridge config', () => {
+  const tempDirs: string[] = [];
+
   beforeEach(() => {
     state.codexOptions = [];
     state.threadOptions = [];
@@ -102,9 +107,9 @@ describe('Codex bridge config', () => {
     state.startMcpServers = undefined;
     state.originalArgv = [...process.argv];
     state.originalEnv = Object.fromEntries(
-      CODEX_ENV_KEYS.map(key => [key, process.env[key]]),
-    ) as Record<(typeof CODEX_ENV_KEYS)[number], string | undefined>;
-    for (const key of CODEX_ENV_KEYS) {
+      ENV_KEYS.map(key => [key, process.env[key]]),
+    ) as Record<(typeof ENV_KEYS)[number], string | undefined>;
+    for (const key of ENV_KEYS) {
       delete process.env[key];
     }
     process.argv.splice(
@@ -121,9 +126,9 @@ describe('Codex bridge config', () => {
     );
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     process.argv.splice(0, process.argv.length, ...state.originalArgv);
-    for (const key of CODEX_ENV_KEYS) {
+    for (const key of ENV_KEYS) {
       const value = state.originalEnv[key];
       if (value === undefined) {
         delete process.env[key];
@@ -131,6 +136,11 @@ describe('Codex bridge config', () => {
         process.env[key] = value;
       }
     }
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map(path => rm(path, { recursive: true, force: true })),
+    );
     vi.resetModules();
   });
 
@@ -283,5 +293,37 @@ describe('Codex bridge config', () => {
     expect(state.turnOptions[0]?.outputSchema).toEqual(
       state.startResponseFormat.schema,
     );
+  });
+
+  test('passes CODEX_PATH as codexPathOverride', async () => {
+    process.env.CODEX_PATH = ' /opt/codex/custom ';
+
+    await import('./index');
+
+    expect(state.codexOptions[0]?.codexPathOverride).toBe('/opt/codex/custom');
+  });
+
+  test('uses an executable codex on PATH', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'harness-codex-'));
+    tempDirs.push(dir);
+    const executable = join(
+      dir,
+      process.platform === 'win32' ? 'codex.exe' : 'codex',
+    );
+    await writeFile(executable, '');
+    await chmod(executable, 0o755);
+    process.env.PATH = [dir, '/not-a-real-bin'].join(delimiter);
+
+    await import('./index');
+
+    expect(state.codexOptions[0]?.codexPathOverride).toBe(executable);
+  });
+
+  test('leaves the SDK bundled executable as the fallback', async () => {
+    process.env.PATH = '/not-a-real-bin';
+
+    await import('./index');
+
+    expect(state.codexOptions[0]).not.toHaveProperty('codexPathOverride');
   });
 });

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -15,7 +15,9 @@ import {
   type BridgeTurn,
 } from '@ai-sdk/harness/bridge';
 import type { StartMessage } from '../codex-bridge-protocol';
+import { accessSync, constants, statSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
+import { delimiter, join } from 'node:path';
 // Temporary workaround for upstream codex MCP-tool bug — see ./cli-relay.ts
 import {
   CLI_SHIM_FILENAME,
@@ -48,6 +50,21 @@ import { argv, env as procEnv, stdout } from 'node:process';
  *   3. the dependency entry in `src/bridge/package.json`.
  */
 import * as codexSdkModule from '@openai/codex-sdk';
+
+function resolveCodexPathOverride(): string | undefined {
+  const configuredPath = procEnv.CODEX_PATH?.trim();
+  if (configuredPath) return configuredPath;
+
+  const binaryName = process.platform === 'win32' ? 'codex.exe' : 'codex';
+  for (const dir of (procEnv.PATH ?? '').split(delimiter)) {
+    if (!dir) continue;
+    const path = join(dir, binaryName);
+    try {
+      accessSync(path, constants.X_OK);
+      if (statSync(path).isFile()) return path;
+    } catch {}
+  }
+}
 
 const args = parseArgs(argv.slice(2));
 const workdir = requireArg({ value: args.workdir, name: '--workdir' });
@@ -178,8 +195,10 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   }
   const usesConfiguredModelProvider =
     typeof codexConfig.model_provider === 'string';
+  const codexPathOverride = resolveCodexPathOverride();
 
   const codex = new codexSdk.Codex({
+    ...(codexPathOverride ? { codexPathOverride } : {}),
     ...(procEnv.CODEX_API_KEY ? { apiKey: procEnv.CODEX_API_KEY } : {}),
     ...(!usesConfiguredModelProvider && apiBaseUrl
       ? { baseUrl: apiBaseUrl }

--- a/packages/harness-codex/src/codex-harness.test.ts
+++ b/packages/harness-codex/src/codex-harness.test.ts
@@ -248,12 +248,12 @@ describe('createCodex adapter', () => {
     ).rejects.toBeInstanceOf(HarnessCapabilityUnsupportedError);
   });
 
-  it('quotes dynamic startup paths in shell commands', async () => {
+  it('quotes startup paths and forwards codexPath', async () => {
     const runs: string[] = [];
     const spawns: string[] = [];
     const spawnEnvs: Array<Record<string, string | undefined>> = [];
     const writes: Array<{ path: string; content: string }> = [];
-    const harness = createCodex();
+    const harness = createCodex({ codexPath: '/opt/codex/bin/codex' });
     const session = await harness.doStart({
       sessionId: 's1; env > /tmp/leak #',
       sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
@@ -276,6 +276,7 @@ describe('createCodex adapter', () => {
       'ai-sdk/harness-codex/0.0.0-test',
     );
     expect(spawnEnvs.at(0)?.BRIDGE_CHANNEL_TOKEN).toMatch(/^[a-f0-9]{64}$/);
+    expect(spawnEnvs.at(0)?.CODEX_PATH).toBe('/opt/codex/bin/codex');
     expect(session.modelId).toBe('gpt-5.5');
     await session.doDestroy();
   });

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -86,6 +86,8 @@ const CODEX_CLIENT_APP = `ai-sdk/harness-codex/${VERSION}`;
 
 export type CodexHarnessSettings = {
   readonly auth?: CodexAuthOptions;
+  /** Path to a Codex executable inside the sandbox. */
+  readonly codexPath?: string;
   /**
    * Additional configuration passed through to Codex as-is. Codex config keys
    * typically use snake_case and must be provided in that form. Values managed
@@ -380,6 +382,7 @@ export function createCodex(
           : undefined;
       const env = {
         ...sandboxAuthEnvironment,
+        ...(settings.codexPath ? { CODEX_PATH: settings.codexPath } : {}),
         AI_SDK_HARNESS_CLIENT_APP: CODEX_CLIENT_APP,
         BRIDGE_CHANNEL_TOKEN: token,
         BRIDGE_WS_PORT: String(port),


### PR DESCRIPTION
## Background

The Codex bridge can ignore an explicitly installed Codex executable and concatenate completed progress messages with the final response.

## Summary

- Resolve `CODEX_PATH`, `CODEX_CLI`, `CODEX_BINARY`, then an executable `codex` on `PATH`, while preserving the SDK bundled fallback.
- Preserve completed agent messages as raw provider events and emit only the latest completed message as final harness text.
- Do not emit final text for failed turns.

## End-to-End Verification

No live run is included because producing both an intermediate completed message and a final completed message is nondeterministic. The executable-selection and final-message contracts are verified at the bridge boundary.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
