### PR TITLE
fix(harness): remove broken bridge `channel.interrupt()` layer and its usage

### DIFF
--- a/.changeset/tasty-lamps-reply.md
+++ b/.changeset/tasty-lamps-reply.md
@@ -1,0 +1,10 @@
+---
+"@ai-sdk/harness-claude-code": patch
+"@ai-sdk/harness-deepagents": patch
+"@ai-sdk/harness-opencode": patch
+"@ai-sdk/workflow-harness": patch
+"@ai-sdk/harness-codex": patch
+"@ai-sdk/harness": patch
+---
+
+fix(harness): remove broken bridge `channel.interrupt()` layer and its usage

--- a/packages/harness-claude-code/src/bridge/index.ts
+++ b/packages/harness-claude-code/src/bridge/index.ts
@@ -426,8 +426,6 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
       abortSignal: abortCtl.signal,
     },
   });
-  turn.onInterrupt(() => q.interrupt());
-
   let turnUsage: Record<string, unknown> | undefined;
   let totalCostUsd: number | undefined;
   let emittedTerminalError = false;

--- a/packages/harness-claude-code/src/claude-code-bridge-protocol.test.ts
+++ b/packages/harness-claude-code/src/claude-code-bridge-protocol.test.ts
@@ -42,7 +42,6 @@ describe('outboundMessageSchema', () => {
       finishReason: { unified: 'stop', raw: 'stop' },
       totalUsage: usage,
     },
-    { type: 'bridge-interrupted', ok: true },
     { type: 'error', error: 'boom' },
     { type: 'raw', rawValue: { hello: 'world' } },
   ];
@@ -107,11 +106,10 @@ describe('inboundMessageSchema', () => {
     ).not.toThrow();
   });
 
-  it('accepts user-message, abort, interrupt, shutdown', () => {
+  it('accepts user-message, abort, and shutdown', () => {
     for (const sample of [
       { type: 'user-message', text: 'hi' },
       { type: 'abort' },
-      { type: 'interrupt' },
       { type: 'shutdown' },
     ]) {
       expect(() => inboundMessageSchema.parse(sample)).not.toThrow();

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -1190,7 +1190,7 @@ function createSession({
        *
        * rerun: the bridge was respawned with no in-flight turn to attach to, so
        * re-drive the runtime's own thread from the workdir snapshot via
-       * `continue: true`. Lossy — work in flight at the interruption is
+       * `continue: true`. Lossy — work in flight at the suspension is
        * recomputed. This is the rare bridge-died fallback; the common slice path
        * is `attach`.
        */
@@ -1378,16 +1378,13 @@ function createSession({
       }
       stopped = true;
       /*
-       * First ask the runtime to interrupt the active model turn, then freeze
-       * the host at a precise cursor. `channel.suspend` stops processing
-       * inbound frames (the cursor stops advancing exactly at the last
-       * delivered event), drains what was already dispatched, then closes the
-       * host socket with reason `'suspended'` — which `wireTurn`'s `onClose`
-       * treats as a clean turn end. The bridge keeps the turn running and
-       * accumulates events past the cursor for the next slice to replay. The
-       * sandbox process is deliberately left alive (no `shutdown`/`detach`).
+       * Freeze the host at a precise cursor without stopping the active model
+       * turn. `channel.suspend` stops processing inbound frames, drains what
+       * was already dispatched, then closes the host socket with reason
+       * `'suspended'`. The bridge keeps the turn running and accumulates events
+       * past the cursor for the next slice to replay. The sandbox process is
+       * deliberately left alive.
        */
-      await channel.interrupt();
       const lastSeenEventId = await channel.suspend();
       const payload: HarnessV1ContinueTurnState = {
         type: 'continue-turn',

--- a/packages/harness-codex/src/codex-bridge-protocol.test.ts
+++ b/packages/harness-codex/src/codex-bridge-protocol.test.ts
@@ -45,7 +45,6 @@ describe('outboundMessageSchema', () => {
     { type: 'file-change', event: 'create', path: 'notes.md' },
     { type: 'file-change', event: 'modify', path: 'src/lib.ts' },
     { type: 'file-change', event: 'delete', path: 'old.txt' },
-    { type: 'bridge-interrupted', ok: true },
     { type: 'error', error: 'boom' },
     { type: 'raw', rawValue: { hello: 'world' } },
   ];
@@ -98,11 +97,10 @@ describe('inboundMessageSchema', () => {
     ).not.toThrow();
   });
 
-  it('accepts user-message, abort, interrupt, shutdown', () => {
+  it('accepts user-message, abort, and shutdown', () => {
     for (const sample of [
       { type: 'user-message', text: 'hi' },
       { type: 'abort' },
-      { type: 'interrupt' },
       { type: 'shutdown' },
     ]) {
       expect(() => inboundMessageSchema.parse(sample)).not.toThrow();

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -825,7 +825,7 @@ function createSession({
        *
        * rerun: the bridge was respawned with no in-flight turn to attach to, so
        * re-drive codex's own thread via `resumeThreadId`. Lossy — work in flight
-       * at the interruption is recomputed. This is the rare bridge-died
+       * at the suspension is recomputed. This is the rare bridge-died
        * fallback; the common slice path is `attach`.
        */
       if (rerunContinue) {
@@ -1011,16 +1011,13 @@ function createSession({
       }
       stopped = true;
       /*
-       * First ask the runtime to interrupt the active model turn, then freeze
-       * the host at a precise cursor. `channel.suspend` stops processing
-       * inbound frames (the cursor stops advancing exactly at the last
-       * delivered event), drains what was already dispatched, then closes the
-       * host socket with reason `'suspended'` — which `wireTurn`'s `onClose`
-       * treats as a clean turn end. The bridge keeps the turn running and
-       * accumulates events past the cursor for the next slice to replay. The
-       * sandbox process is deliberately left alive (no `shutdown`/`detach`).
+       * Freeze the host at a precise cursor without stopping the active model
+       * turn. `channel.suspend` stops processing inbound frames, drains what
+       * was already dispatched, then closes the host socket with reason
+       * `'suspended'`. The bridge keeps the turn running and accumulates events
+       * past the cursor for the next slice to replay. The sandbox process is
+       * deliberately left alive.
        */
-      await channel.interrupt();
       const lastSeenEventId = await channel.suspend();
       const payload: HarnessV1ContinueTurnState = {
         type: 'continue-turn',

--- a/packages/harness-codex/src/codex-instructions.test.ts
+++ b/packages/harness-codex/src/codex-instructions.test.ts
@@ -21,7 +21,6 @@ const openCalls: Array<{ resume?: boolean } | undefined> = [];
 const runCommands: Array<string> = [];
 const spawnEnvs: Array<Record<string, string | undefined>> = [];
 const writes: Array<{ path: string; content: string }> = [];
-const interrupts: Array<'interrupt'> = [];
 
 vi.mock('@ai-sdk/harness/utils', async importOriginal => {
   const actual = await importOriginal<typeof HarnessUtils>();
@@ -42,9 +41,6 @@ vi.mock('@ai-sdk/harness/utils', async importOriginal => {
     }
     async suspend(): Promise<number> {
       return 7;
-    }
-    async interrupt(): Promise<void> {
-      interrupts.push('interrupt');
     }
     close(): void {}
   }
@@ -151,7 +147,6 @@ describe('codex adapter — instructions gating', () => {
     runCommands.length = 0;
     spawnEnvs.length = 0;
     writes.length = 0;
-    interrupts.length = 0;
   });
 
   it('defers the start frame until after prompt control is returned', async () => {
@@ -269,7 +264,6 @@ describe('codex adapter — attach replay mode', () => {
     runCommands.length = 0;
     spawnEnvs.length = 0;
     writes.length = 0;
-    interrupts.length = 0;
   });
 
   it('attaches a parked session without replaying old turn events', async () => {
@@ -338,7 +332,6 @@ describe('codex adapter — attach replay mode', () => {
 
     const suspended = await (await startSession()).doSuspendTurn();
     expect(suspended.type).toBe('continue-turn');
-    expect(interrupts).toHaveLength(1);
     expect(
       (
         suspended.data as {
@@ -358,7 +351,6 @@ describe('codex adapter — skills', () => {
     runCommands.length = 0;
     spawnEnvs.length = 0;
     writes.length = 0;
-    interrupts.length = 0;
   });
 
   it('writes skills to sandbox HOME without sending skill metadata', async () => {

--- a/packages/harness-deepagents/src/deepagents-bridge-protocol.test.ts
+++ b/packages/harness-deepagents/src/deepagents-bridge-protocol.test.ts
@@ -22,7 +22,6 @@ describe('deepagents bridge protocol', () => {
       { type: 'tool-result', toolCallId: 't1', output: { ok: true } },
       { type: 'user-message', text: 'more' },
       { type: 'abort' },
-      { type: 'interrupt' },
       { type: 'shutdown' },
       { type: 'resume', lastSeenEventId: 3 },
       { type: 'detach' },
@@ -78,7 +77,6 @@ describe('deepagents bridge protocol', () => {
           totalUsage: { inputTokens: { total: 1 }, outputTokens: { total: 2 } },
         },
       ],
-      ['bridge-interrupted', { type: 'bridge-interrupted', ok: true }],
       ['error', { type: 'error', error: { message: 'boom' } }],
     ];
 

--- a/packages/harness-deepagents/src/deepagents-harness.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.ts
@@ -676,7 +676,6 @@ function createSession({
       }
       stopped = true;
       // Freeze the active turn at the cursor, leaving the bridge running so the next slice replays the tail.
-      await channel.interrupt();
       const lastSeenEventId = await channel.suspend();
       const payload: HarnessV1ContinueTurnState = {
         type: 'continue-turn',

--- a/packages/harness-opencode/src/opencode-bridge-protocol.test.ts
+++ b/packages/harness-opencode/src/opencode-bridge-protocol.test.ts
@@ -45,9 +45,6 @@ describe('OpenCode bridge protocol', () => {
     expect(inboundMessageSchema.parse({ type: 'abort' })).toEqual({
       type: 'abort',
     });
-    expect(inboundMessageSchema.parse({ type: 'interrupt' })).toEqual({
-      type: 'interrupt',
-    });
     expect(
       inboundMessageSchema.parse({
         type: 'tool-result',
@@ -58,15 +55,6 @@ describe('OpenCode bridge protocol', () => {
       type: 'tool-result',
       toolCallId: 'tool-1',
       output: { ok: true },
-    });
-  });
-
-  it('accepts interrupt acknowledgements', () => {
-    expect(
-      outboundMessageSchema.parse({ type: 'bridge-interrupted', ok: true }),
-    ).toEqual({
-      type: 'bridge-interrupted',
-      ok: true,
     });
   });
 });

--- a/packages/harness-opencode/src/opencode-harness.ts
+++ b/packages/harness-opencode/src/opencode-harness.ts
@@ -932,7 +932,6 @@ function createSession({
         );
       }
       stopped = true;
-      await channel.interrupt();
       const lastSeenEventId = await channel.suspend();
       const payload: HarnessV1ContinueTurnState = {
         type: 'continue-turn',

--- a/packages/harness/src/agent/harness-agent-session.ts
+++ b/packages/harness/src/agent/harness-agent-session.ts
@@ -212,6 +212,8 @@ export class HarnessAgentSession {
         onTurnFailed: () => {
           this.finishTrackedTurn({ turnId });
         },
+        isTurnSuspending: () =>
+          this.activeTurnSequence === turnId && this.suspendedTurnState != null,
         onStopConditionMet: () =>
           this.captureStopConditionBoundary({ session, turnId }),
       });
@@ -287,6 +289,8 @@ export class HarnessAgentSession {
         onTurnFailed: () => {
           this.finishTrackedTurn({ turnId });
         },
+        isTurnSuspending: () =>
+          this.activeTurnSequence === turnId && this.suspendedTurnState != null,
         onStopConditionMet: () =>
           this.captureStopConditionBoundary({ session, turnId }),
       });

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -42,6 +42,7 @@ function mockHarness(options: {
   onDoStart?: (options: Parameters<HarnessV1['doStart']>[0]) => void;
   onPromptTurn?: (options: HarnessV1PromptTurnOptions) => void;
   promptDone?: (options: HarnessV1PromptTurnOptions) => Promise<void>;
+  onSuspendTurn?: () => void | Promise<void>;
   continueScript?: (
     submitToolResult: (input: {
       toolCallId: string;
@@ -88,7 +89,10 @@ function mockHarness(options: {
   const doDestroy = vi.fn(async () => {});
   const doCompact = vi.fn(async (_customInstructions?: string) => {});
   const doDetach = vi.fn(async () => resumeState);
-  const doSuspendTurn = vi.fn(async () => continueState);
+  const doSuspendTurn = vi.fn(async () => {
+    await options.onSuspendTurn?.();
+    return continueState;
+  });
   const doContinueTurn = vi.fn(async (opts: HarnessV1ContinueTurnOptions) => {
     const control: HarnessV1PromptControl = {
       submitToolResult: async input => {
@@ -700,6 +704,38 @@ describe('HarnessAgent', () => {
     ).resolves.toBeDefined();
 
     await session.destroy();
+  });
+
+  test('keeps a turn unfinished when suspension closes its stream mid-step', async () => {
+    let resolvePromptDone!: () => void;
+    const promptDone = new Promise<void>(resolve => {
+      resolvePromptDone = resolve;
+    });
+    const { harness } = mockHarness({
+      script: () => [
+        { type: 'text-start', id: 't1' },
+        { type: 'text-delta', id: 't1', delta: 'partial' },
+      ],
+      promptDone: () => promptDone,
+      onSuspendTurn: () => {
+        resolvePromptDone();
+      },
+    });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession();
+    const result = await agent.stream({ session, prompt: 'work' });
+
+    const continueFrom = await session.suspendTurn();
+    await result.consumeStream();
+
+    expect(continueFrom).toEqual({
+      type: 'continue-turn',
+      harnessId: 'mock',
+      specificationVersion: 'harness-v1',
+      data: {},
+    });
+    expect(session.hasUnfinishedTurn()).toBe(true);
+    await expect(result.steps).resolves.toEqual([]);
   });
 
   test('settles an aborted turn with an abort part and releases the session for the next turn', async () => {

--- a/packages/harness/src/agent/internal/run-prompt.test.ts
+++ b/packages/harness/src/agent/internal/run-prompt.test.ts
@@ -467,6 +467,71 @@ describe('runPrompt step accounting', () => {
     await expect(result.steps).resolves.toHaveLength(1);
   });
 
+  test('closes a deliberately suspended mid-step stream without failing the turn', async () => {
+    const onTurnFailed = vi.fn();
+    const { result, done } = runPrompt({
+      harness,
+      session: fakeSession([
+        { type: 'text-start', id: 't1' },
+        { type: 'text-delta', id: 't1', delta: 'partial' },
+      ]),
+      prompt: 'go',
+      instructions: undefined,
+      tools: {},
+      toolSpecs: [],
+      sandboxSession,
+      sessionWorkDir: WORK_DIR,
+      runtimeContext: {} as never,
+      abortSignal: undefined,
+      isTurnSuspending: () => true,
+      onTurnFailed,
+    });
+
+    const parts: TextStreamPart<ToolSet>[] = [];
+    for await (const part of result.fullStream) parts.push(part);
+    await done;
+
+    expect(parts.some(part => part.type === 'error')).toBe(false);
+    expect(parts).toContainEqual(
+      expect.objectContaining({ type: 'text-delta', text: 'partial' }),
+    );
+    expect(onTurnFailed).not.toHaveBeenCalled();
+    await expect(result.steps).resolves.toEqual([]);
+  });
+
+  test('fails a mid-step stream that closes without an intentional suspension', async () => {
+    const onTurnFailed = vi.fn();
+    const { result, done } = runPrompt({
+      harness,
+      session: fakeSession([
+        { type: 'text-start', id: 't1' },
+        { type: 'text-delta', id: 't1', delta: 'partial' },
+      ]),
+      prompt: 'go',
+      instructions: undefined,
+      tools: {},
+      toolSpecs: [],
+      sandboxSession,
+      sessionWorkDir: WORK_DIR,
+      runtimeContext: {} as never,
+      abortSignal: undefined,
+      onTurnFailed,
+    });
+
+    const parts: TextStreamPart<ToolSet>[] = [];
+    for await (const part of result.fullStream) parts.push(part);
+    await done;
+
+    expect(parts).toContainEqual({
+      type: 'error',
+      error: expect.objectContaining({
+        message: expect.stringContaining('unclosed step content'),
+      }),
+    });
+    expect(onTurnFailed).toHaveBeenCalledTimes(1);
+    await expect(result.steps).rejects.toThrow(/unclosed step content/);
+  });
+
   test('fails when terminal finish receives unclosed step content', async () => {
     const { result, done } = runPrompt({
       harness,

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -103,6 +103,11 @@ export function runPrompt<
   onToolResultSettled?: (toolCallId: string) => void;
   onTurnFinished?: () => void;
   onTurnFailed?: () => void;
+  /**
+   * Reports that the adapter stream closed because the host intentionally
+   * suspended the still-running turn at a workflow slice boundary.
+   */
+  isTurnSuspending?: () => boolean;
   onStopConditionMet?: () => Promise<void>;
 }): {
   result: HarnessStreamTextResult<TOOLS, RUNTIME_CONTEXT>;
@@ -910,6 +915,14 @@ export function runPrompt<
       }
       if (finalFinish != null) {
         input.onTurnFinished?.();
+      } else if (input.isTurnSuspending?.()) {
+        /*
+         * A timed slice may stop in the middle of a model step. Its partial
+         * content remains in the bridge replay log for the next slice, but it
+         * cannot form a valid StepResult in this slice because no finish-step
+         * has arrived yet.
+         */
+        result.discardCurrentStepContent();
       } else {
         input.onTurnFailed?.();
       }

--- a/packages/harness/src/bridge/index.test.ts
+++ b/packages/harness/src/bridge/index.test.ts
@@ -146,8 +146,7 @@ describe('runBridge', () => {
     await turnFinished;
 
     b.send({ type: 'resume', lastSeenEventId: 2 });
-    b.send({ type: 'interrupt' });
-    await b.waitFor(f => f.type === 'bridge-interrupted');
+    await b.waitFor(f => f.seq === 4);
 
     const events = b.frames.filter(f => typeof f.seq === 'number');
     expect(events).toEqual([
@@ -257,103 +256,6 @@ describe('runBridge', () => {
     } finally {
       writeSpy.mockRestore();
     }
-  });
-
-  it('runs the active turn interrupt handler before acknowledging interrupt', async () => {
-    let interrupted = false;
-    let release!: () => void;
-    const gate = new Promise<void>(resolve => {
-      release = resolve;
-    });
-    const handle = await startBridge(async (_start, turn) => {
-      turn.onInterrupt(async () => {
-        await gate;
-        interrupted = true;
-      });
-      await new Promise<void>(() => {});
-    });
-    const client = await connect(handle.port);
-    await client.waitFor(f => f.type === 'bridge-hello');
-    client.send({ type: 'start' });
-
-    client.send({ type: 'interrupt' });
-    await new Promise(resolve => setTimeout(resolve, 20));
-    expect(client.frames.some(f => f.type === 'bridge-interrupted')).toBe(
-      false,
-    );
-
-    release();
-    const ack = await client.waitFor(f => f.type === 'bridge-interrupted');
-    expect(interrupted).toBe(true);
-    expect(ack).toMatchObject({ type: 'bridge-interrupted', ok: true });
-  });
-
-  it('preserves a turn waiting for a host tool result when interrupted', async () => {
-    let interrupted = false;
-    const handle = await startBridge(async (_start, turn) => {
-      turn.onInterrupt(() => {
-        interrupted = true;
-      });
-      turn.emit({ type: 'tool-call', toolCallId: 'tool-1' });
-      const result = await turn.requestToolResult('tool-1');
-      turn.emit({ type: 'text-delta', delta: String(result.output) });
-      turn.emit({ type: 'finish' });
-    });
-    const client = await connect(handle.port);
-    await client.waitFor(f => f.type === 'bridge-hello');
-    client.send({ type: 'start' });
-    await client.waitFor(f => f.type === 'tool-call');
-
-    client.send({ type: 'interrupt' });
-    const ack = await client.waitFor(f => f.type === 'bridge-interrupted');
-    expect(interrupted).toBe(false);
-    expect(ack).toMatchObject({ type: 'bridge-interrupted', ok: true });
-
-    client.send({
-      type: 'tool-result',
-      toolCallId: 'tool-1',
-      output: 'sunny',
-    });
-    await client.waitFor(f => f.type === 'finish');
-    expect(client.frames).toContainEqual(
-      expect.objectContaining({ type: 'text-delta', delta: 'sunny' }),
-    );
-  });
-
-  it('preserves a turn waiting for host approval when interrupted', async () => {
-    let interrupted = false;
-    const handle = await startBridge(async (_start, turn) => {
-      turn.onInterrupt(() => {
-        interrupted = true;
-      });
-      turn.emit({
-        type: 'tool-approval-request',
-        approvalId: 'approval-1',
-        toolCallId: 'tool-1',
-      });
-      const response = await turn.requestToolApproval('approval-1');
-      turn.emit({ type: 'text-delta', delta: String(response.approved) });
-      turn.emit({ type: 'finish' });
-    });
-    const client = await connect(handle.port);
-    await client.waitFor(f => f.type === 'bridge-hello');
-    client.send({ type: 'start' });
-    await client.waitFor(f => f.type === 'tool-approval-request');
-
-    client.send({ type: 'interrupt' });
-    const ack = await client.waitFor(f => f.type === 'bridge-interrupted');
-    expect(interrupted).toBe(false);
-    expect(ack).toMatchObject({ type: 'bridge-interrupted', ok: true });
-
-    client.send({
-      type: 'tool-approval-response',
-      approvalId: 'approval-1',
-      approved: true,
-    });
-    await client.waitFor(f => f.type === 'finish');
-    expect(client.frames).toContainEqual(
-      expect.objectContaining({ type: 'text-delta', delta: 'true' }),
-    );
   });
 
   it('clears the log per turn but keeps seq monotonic across turns', async () => {

--- a/packages/harness/src/bridge/index.ts
+++ b/packages/harness/src/bridge/index.ts
@@ -120,13 +120,6 @@ export interface BridgeTurn {
   /** Aborts when the host sends `abort`. */
   readonly abortSignal: AbortSignal;
 
-  /**
-   * Register the runtime-specific interrupt hook for this active turn. The
-   * shared bridge invokes it when the host sends `interrupt`, then acknowledges
-   * only after the hook settles.
-   */
-  onInterrupt(handler: () => void | Promise<void>): void;
-
   /** True for the first turn since this bridge process started. */
   readonly firstTurn: boolean;
 
@@ -191,7 +184,6 @@ type InboundControl =
     }
   | { type: 'user-message'; text: string }
   | { type: 'abort' }
-  | { type: 'interrupt' }
   | { type: 'shutdown' }
   | { type: 'detach' }
   | { type: 'resume'; lastSeenEventId: number };
@@ -238,7 +230,6 @@ export async function runBridge<TStart extends { type: 'start' }>(
   let isFirstTurn = true;
   let turnAbort: AbortController | undefined;
   let currentUserMessages: string[] | undefined;
-  let currentInterruptHandler: (() => void | Promise<void>) | undefined;
 
   // Diagnostics. Resolved per turn from `start.debug` with a sandbox-side
   // env fallback; gates console capture + structured `debug-event`s.
@@ -259,7 +250,7 @@ export async function runBridge<TStart extends { type: 'start' }>(
    * Disk mirror of the in-memory replay log. The in-memory log is lost when the
    * bridge process dies; the on-disk `event-log.ndjson` survives in the sandbox
    * filesystem so a respawned bridge (started with `BRIDGE_REPLAY_FROM_DISK=1`)
-   * can reload the just-interrupted turn and serve a host's resume cursor —
+   * can reload the in-flight turn and serve a host's resume cursor —
    * `replay` recovery. Writes are batched on `setImmediate` (single-flight via
    * `flushPromise`) to keep `emit` off the disk hot path.
    */
@@ -537,7 +528,6 @@ export async function runBridge<TStart extends { type: 'start' }>(
         void writeFile(eventLogPath, '').catch(() => {});
         turnAbort = new AbortController();
         currentTurnState = 'running';
-        currentInterruptHandler = undefined;
         void writeStartConfig(msg);
         void writeBridgeMeta('running');
         const startDebug = (msg as { debug?: BridgeDebugConfig }).debug;
@@ -565,9 +555,6 @@ export async function runBridge<TStart extends { type: 'start' }>(
             }),
           pendingUserMessages: [],
           abortSignal: turnAbort.signal,
-          onInterrupt: handler => {
-            currentInterruptHandler = handler;
-          },
           firstTurn,
           bridgeLog: input => {
             const level = input.level ?? 'debug';
@@ -592,7 +579,6 @@ export async function runBridge<TStart extends { type: 'start' }>(
         } catch (err) {
           emitError({ error: err, message: 'bridge turn failed' });
         } finally {
-          currentInterruptHandler = undefined;
           currentTurnState = 'waiting';
           void writeBridgeMeta('waiting');
         }
@@ -619,34 +605,6 @@ export async function runBridge<TStart extends { type: 'start' }>(
         return;
       case 'abort':
         turnAbort?.abort();
-        return;
-      case 'interrupt':
-        try {
-          /*
-           * A bridge waiting for a host tool result or approval is already
-           * paused at a resumable boundary. Interrupting the native runtime at
-           * that point terminates the operation that owns the pending request,
-           * so a later host process cannot satisfy it. Active turns without
-           * pending host input are interrupted before suspension as usual.
-           */
-          if (
-            pendingToolResults.size === 0 &&
-            pendingToolApprovals.size === 0
-          ) {
-            if (currentInterruptHandler) {
-              await currentInterruptHandler();
-            } else {
-              turnAbort?.abort();
-            }
-          }
-          sendControl({ type: 'bridge-interrupted', ok: true });
-        } catch (err) {
-          sendControl({
-            type: 'bridge-interrupted',
-            ok: false,
-            error: serialiseError(err),
-          });
-        }
         return;
       case 'resume':
         if (activeSocket !== ws) return;

--- a/packages/harness/src/utils/sandbox-channel.test.ts
+++ b/packages/harness/src/utils/sandbox-channel.test.ts
@@ -14,18 +14,12 @@ const outboundSchema = z.discriminatedUnion('type', [
   }),
   z.object({ type: z.literal('finish') }),
   z.object({ type: z.literal('finish-step') }),
-  z.object({
-    type: z.literal('bridge-interrupted'),
-    ok: z.boolean(),
-    error: z.unknown().optional(),
-  }),
   z.object({ type: z.literal('error'), error: z.unknown() }),
 ]);
 type Outbound = z.infer<typeof outboundSchema>;
 type Inbound =
   | { type: 'start' }
   | { type: 'abort' }
-  | { type: 'interrupt' }
   | { type: 'resume'; lastSeenEventId: number };
 
 type FakeSocket = {
@@ -168,20 +162,6 @@ describe('SandboxChannel', () => {
     ]);
   });
 
-  it('sends interrupt and resolves after the bridge acknowledges it', async () => {
-    const connector = makeConnector();
-    const channel = makeChannel(connector);
-    await channel.open();
-
-    const interrupted = channel.interrupt();
-    expect(connector.current().sent).toEqual([
-      JSON.stringify({ type: 'interrupt' }),
-    ]);
-
-    connector.current().deliver({ type: 'bridge-interrupted', ok: true });
-    await expect(interrupted).resolves.toBeUndefined();
-  });
-
   it('suspends from a pinned event even after later events were dispatched', async () => {
     const connector = makeConnector();
     const channel = makeChannel(connector);
@@ -205,12 +185,11 @@ describe('SandboxChannel', () => {
     expect(pinSandboxChannelEventCheckpoint(finishStep)).toEqual(
       expect.any(Function),
     );
-    await expect(channel.interrupt()).resolves.toBeUndefined();
     expect(connector.current().sent).toEqual([]);
     await expect(channel.suspend()).resolves.toBe(1);
   });
 
-  it('returns to the latest cursor and normal interruption after releasing a checkpoint', async () => {
+  it('returns to the latest cursor after releasing a checkpoint', async () => {
     const connector = makeConnector();
     const channel = makeChannel(connector);
     await channel.open();
@@ -230,28 +209,7 @@ describe('SandboxChannel', () => {
     expect(releaseCheckpoint).toEqual(expect.any(Function));
     releaseCheckpoint?.();
 
-    const interrupted = channel.interrupt();
-    expect(connector.current().sent).toEqual([
-      JSON.stringify({ type: 'interrupt' }),
-    ]);
-    connector.current().deliver({ type: 'bridge-interrupted', ok: true });
-    await expect(interrupted).resolves.toBeUndefined();
     await expect(channel.suspend()).resolves.toBe(2);
-  });
-
-  it('rejects interrupt when the bridge reports a failure', async () => {
-    const connector = makeConnector();
-    const channel = makeChannel(connector);
-    await channel.open();
-
-    const interrupted = channel.interrupt();
-    connector.current().deliver({
-      type: 'bridge-interrupted',
-      ok: false,
-      error: { message: 'native interrupt failed' },
-    });
-
-    await expect(interrupted).rejects.toThrow(/native interrupt failed/);
   });
 
   it('refuses to send once terminally closed', async () => {

--- a/packages/harness/src/utils/sandbox-channel.ts
+++ b/packages/harness/src/utils/sandbox-channel.ts
@@ -277,62 +277,6 @@ export class SandboxChannel<
     this.enqueue(() => this.finalizeClose(1000, 'closed'));
   }
 
-  interrupt(options?: { timeoutMs?: number }): Promise<void> {
-    if (this.pinnedSuspensionCursor != null) {
-      return Promise.resolve();
-    }
-    const timeoutMs = options?.timeoutMs ?? 5000;
-    return new Promise<void>((resolve, reject) => {
-      let settled = false;
-      let unsub = (): void => {};
-      const timer = setTimeout(() => {
-        complete(
-          new Error(
-            `SandboxChannel: interrupt was not acknowledged within ${timeoutMs}ms.`,
-          ),
-        );
-      }, timeoutMs);
-      timer.unref?.();
-
-      const complete = (error?: unknown): void => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        unsub();
-        if (error) {
-          reject(error);
-        } else {
-          resolve();
-        }
-      };
-
-      unsub = this.on('bridge-interrupted' as EventTypeOf<TOut>, event => {
-        const response = event as unknown as {
-          type: 'bridge-interrupted';
-          ok: boolean;
-          error?: unknown;
-        };
-        if (response.ok) {
-          complete();
-          return;
-        }
-        complete(
-          new Error(
-            `SandboxChannel: interrupt failed: ${formatControlError(
-              response.error,
-            )}`,
-          ),
-        );
-      });
-
-      try {
-        this.send({ type: 'interrupt' } as TIn);
-      } catch (err) {
-        complete(err);
-      }
-    });
-  }
-
   /**
    * Gracefully suspend at a slice boundary: stop processing inbound frames
    * (so the cursor freezes at the last delivered event), drain any frames
@@ -570,14 +514,4 @@ export class SandboxChannel<
     this.connected = false;
     for (const h of this.onCloseHandlers) h(code, reason);
   }
-}
-
-function formatControlError(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (error && typeof error === 'object') {
-    const message = (error as { message?: unknown }).message;
-    if (typeof message === 'string' && message.length > 0) return message;
-  }
-  if (typeof error === 'string' && error.length > 0) return error;
-  return 'unknown error';
 }

--- a/packages/harness/src/v1/harness-v1-bridge-protocol.ts
+++ b/packages/harness/src/v1/harness-v1-bridge-protocol.ts
@@ -140,17 +140,6 @@ export const harnessV1BridgeThreadSchema = z.object({
   threadId: z.string(),
 });
 
-/**
- * Acknowledgement for an inbound `interrupt` command. The host waits for this
- * before freezing its replay cursor so the adapter-specific interrupt has
- * actually reached the underlying runtime.
- */
-export const harnessV1BridgeInterruptedSchema = z.object({
-  type: z.literal('bridge-interrupted'),
-  ok: z.boolean(),
-  error: z.unknown().optional(),
-});
-
 // --- Diagnostics frames (outbound, not consumer events) ---
 
 /**
@@ -211,7 +200,6 @@ export const harnessV1BridgeOutboundMessageSchema = z.discriminatedUnion(
     harnessV1BridgeHelloSchema,
     harnessV1BridgeDetachSchema,
     harnessV1BridgeThreadSchema,
-    harnessV1BridgeInterruptedSchema,
     harnessV1BridgeSandboxLogSchema,
     harnessV1BridgeDebugEventSchema,
   ],
@@ -289,10 +277,6 @@ export const harnessV1BridgeAbortInboundSchema = z.object({
   type: z.literal('abort'),
 });
 
-export const harnessV1BridgeInterruptInboundSchema = z.object({
-  type: z.literal('interrupt'),
-});
-
 export const harnessV1BridgeShutdownInboundSchema = z.object({
   type: z.literal('shutdown'),
 });
@@ -324,7 +308,6 @@ export const harnessV1BridgeInboundCommandSchemas = [
   harnessV1BridgeToolApprovalResponseInboundSchema,
   harnessV1BridgeUserMessageInboundSchema,
   harnessV1BridgeAbortInboundSchema,
-  harnessV1BridgeInterruptInboundSchema,
   harnessV1BridgeShutdownInboundSchema,
   harnessV1BridgeResumeInboundSchema,
   harnessV1BridgeDetachInboundSchema,

--- a/packages/harness/src/v1/harness-v1-lifecycle-state.ts
+++ b/packages/harness/src/v1/harness-v1-lifecycle-state.ts
@@ -53,7 +53,7 @@ export type HarnessV1ResumeSessionState = HarnessV1LifecycleStateBase & {
 /**
  * Opaque payload returned by `doSuspendTurn` and accepted by a future
  * `HarnessV1.doStart({ continueFrom })` to reconnect to the same session before
- * continuing the interrupted turn.
+ * continuing the suspended turn.
  */
 export type HarnessV1ContinueTurnState = HarnessV1LifecycleStateBase & {
   readonly type: 'continue-turn';

--- a/packages/harness/src/v1/harness-v1-session.ts
+++ b/packages/harness/src/v1/harness-v1-session.ts
@@ -216,7 +216,7 @@ export type HarnessV1Session = {
   /**
    * Continue the in-flight turn **without a new user prompt**, returning the
    * same control surface as `doPromptTurn`. Used to keep consuming a turn that
-   * was interrupted at a process boundary (the workflow slice loop), after the
+   * was suspended at a process boundary (the workflow slice loop), after the
    * session itself has been resumed via `doStart({ continueFrom })`:
    *
    *  - When the runtime's turn is still live and reachable (bridge `attach` /
@@ -225,7 +225,7 @@ export type HarnessV1Session = {
    *  - When the live turn is gone (bridge respawned `rerun`, or a host-resident
    *    runtime like Pi whose turn cannot survive its process), the adapter
    *    re-drives the runtime's own thread from its persisted state. Lossy: work
-   *    in flight at the interruption is recomputed.
+   *    in flight at the suspension is recomputed.
    *
    * Required on every adapter. The behaviour an adapter can guarantee follows
    * from its architecture; the contract is uniform.

--- a/packages/harness/src/v1/harness-v1.ts
+++ b/packages/harness/src/v1/harness-v1.ts
@@ -87,7 +87,7 @@ export type HarnessV1<TBuiltinTools extends ToolSet = ToolSet> = {
 
   /**
    * Start a fresh session, resume a parked session via `resumeFrom`, or resume
-   * an interrupted turn via `continueFrom`. The host then issues prompts against
+   * a suspended turn via `continueFrom`. The host then issues prompts against
    * the returned session, ending with `doDetach`, `doStop`, or `doDestroy`.
    */
   doStart(options: HarnessV1StartOptions): PromiseLike<HarnessV1Session>;

--- a/packages/workflow-harness/src/harness-workflow-state.ts
+++ b/packages/workflow-harness/src/harness-workflow-state.ts
@@ -63,7 +63,7 @@ export interface HarnessWorkflowStreamContext {
  *
  *  - `resumeFrom` reattaches to a warm session before starting this run's new
  *    user turn.
- *  - `continueFrom` reattaches to an interrupted turn from this same run and
+ *  - `continueFrom` reattaches to a suspended turn from this same run and
  *    continues it without sending `prompt` again.
  */
 export interface HarnessWorkflowState {
@@ -83,7 +83,7 @@ export interface HarnessWorkflowState {
   /**
    * Full AI SDK model messages for continuing a suspended approval turn. When
    * present, the next slice sends these to `HarnessAgent.stream()` so approval
-   * responses can resume the interrupted turn.
+   * responses can resume the suspended turn.
    */
   readonly messages?: HarnessWorkflowModelMessage[];
   readonly status: HarnessWorkflowStatus;


### PR DESCRIPTION
## Background

PR #17026 introduced the shared `channel.interrupt()` layer as part of related `finish-step` work. The interruption layer was not directly needed for that change, and that specific behavior was not verified.

This led to a regression with timed workflows: suspending a workflow slice could interrupt the active CLI command, causing a rejected tool result and a failed harness turn instead of leaving the turn running for the next slice. Testing the merge commit and its parent confirmed the regression boundary.

## Summary

- Remove the shared interrupt command, acknowledgement, channel method, and bridge hook.
- Remove interrupt calls from all bridge-backed harness adapters.
- Keep timed suspension non-interrupting so the bridge can buffer and replay the running turn's remaining events.
- Close deliberately suspended mid-step results cleanly while preserving errors for unexpected mid-step stream closures.
- Add regression coverage for suspended mid-step turns.

## End-to-End Verification

Verified via per-commit end-to-end testing that the `channel.interrupt()` addition from #17026 was indeed the problem.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
