### PR TITLE
fix (provider/bytedance): surface last_frame_url as providerMetadata.bytedance.lastFrameUrl

### DIFF
--- a/.changeset/spotty-bees-shake.md
+++ b/.changeset/spotty-bees-shake.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/bytedance': patch
+---
+
+fix (provider/bytedance): surface last_frame_url as providerMetadata.bytedance.lastFrameUrl when returnLastFrame is set

--- a/content/providers/01-ai-sdk-providers/85-bytedance.mdx
+++ b/content/providers/01-ai-sdk-providers/85-bytedance.mdx
@@ -398,6 +398,7 @@ type them with `ByteDanceVideoModelOptions`.
 - **returnLastFrame** _boolean_
 
   Whether to return the last frame of the generated video. Useful for chaining consecutive videos.
+  When set, the frame URL is returned as `providerMetadata.bytedance.lastFrameUrl`.
 
 - **serviceTier** _'default' | 'flex'_
 

--- a/packages/bytedance/README.md
+++ b/packages/bytedance/README.md
@@ -170,7 +170,7 @@ object with `ByteDanceVideoModelOptions`.
 | `watermark`       | Whether to add a watermark to the generated video                              |
 | `generateAudio`   | Generate synchronized audio for supported Seedance models                      |
 | `cameraFixed`     | Whether to fix the camera during generation                                    |
-| `returnLastFrame` | Return the last frame of the generated video (useful for chaining)             |
+| `returnLastFrame` | Return the video's last frame as `providerMetadata.bytedance.lastFrameUrl`     |
 | `serviceTier`     | `'default'` for online inference, `'flex'` for offline at 50% price            |
 | `draft`           | Enable draft mode for low-cost 480p preview generation (Seedance 1.5 Pro only) |
 | `lastFrameImage`  | URL of last frame image for first-and-last frame generation                    |

--- a/packages/bytedance/src/bytedance-video-model.test.ts
+++ b/packages/bytedance/src/bytedance-video-model.test.ts
@@ -366,6 +366,40 @@ describe('ByteDanceVideoModel', () => {
         },
       });
     });
+
+    it('should include lastFrameUrl when the response contains last_frame_url', async () => {
+      server.urls[
+        'https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks/test-task-id-123'
+      ].response = {
+        type: 'json-value',
+        body: {
+          id: 'test-task-id-123',
+          model: 'seedance-1-0-pro-250528',
+          status: 'succeeded',
+          content: {
+            video_url: 'https://bytedance.cdn/files/video-output.mp4',
+            last_frame_url: 'https://bytedance.cdn/files/last-frame.jpeg',
+          },
+          usage: {
+            completion_tokens: 100,
+          },
+        },
+      };
+
+      const model = createBasicModel();
+
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      expect(result.providerMetadata).toStrictEqual({
+        bytedance: {
+          taskId: 'test-task-id-123',
+          usage: {
+            completion_tokens: 100,
+          },
+          lastFrameUrl: 'https://bytedance.cdn/files/last-frame.jpeg',
+        },
+      });
+    });
   });
 
   describe('Image-to-Video', () => {

--- a/packages/bytedance/src/bytedance-video-model.ts
+++ b/packages/bytedance/src/bytedance-video-model.ts
@@ -425,6 +425,9 @@ export class ByteDanceVideoModel implements Experimental_VideoModelV4 {
         bytedance: {
           taskId,
           usage: response.usage,
+          ...(response.content?.last_frame_url != null && {
+            lastFrameUrl: response.content.last_frame_url,
+          }),
         },
       },
     };
@@ -444,6 +447,7 @@ const byteDanceStatusResponseSchema = z.object({
   content: z
     .object({
       video_url: z.string().nullish(),
+      last_frame_url: z.string().nullish(),
     })
     .nullish(),
   usage: z


### PR DESCRIPTION
## Background

`returnLastFrame` is documented as useful for chaining consecutive videos, and the provider forwards the request param — but the task-status response schema strips `content.last_frame_url`, so the frame never reaches the caller. Fixes #17883.

## Summary

- Add `last_frame_url` to the `content` object in `byteDanceStatusResponseSchema`
- Surface it as `providerMetadata.bytedance.lastFrameUrl` when present
- Regression test (mocked succeeded status with `last_frame_url`), docs line, and changeset

## End-to-End Verification

Reproduced the missing field against the live API: with `returnLastFrame: true` the generation succeeds and nothing frame-related appears in the result. I don't have direct ModelArk credentials (I call through the AI Gateway), so the patched path is verified against ModelArk's documented response shape (`content: { video_url, last_frame_url }`, matching ByteDance's own SDK types) via a mock server: `@ai-sdk/bytedance@2.0.14` drops the field, the patched provider surfaces it as `providerMetadata.bytedance.lastFrameUrl`, with `taskId`/`usage`/video output unchanged.
