### PR TITLE
fix(provider/xai): capture video request_id on failed generations

### DIFF
--- a/.changeset/xai-video-request-id.md
+++ b/.changeset/xai-video-request-id.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix (provider/xai): surface xAI's video `request_id` on failed generations. The video model now attaches xAI's resource `request_id` as a `requestId` property on every error thrown during polling — content-moderation 400s (the `APICallError` is augmented in place, preserving its type and status), timeouts, `failed`/`expired` statuses, and the `respect_moderation` block — so callers can correlate a failed generation with xAI's own logs (it was already exposed as `providerMetadata.xai.requestId` on success).

--- a/examples/ai-functions/src/generate-video/xai/request-id.ts
+++ b/examples/ai-functions/src/generate-video/xai/request-id.ts
@@ -1,0 +1,166 @@
+import 'dotenv/config';
+import { type XaiVideoModelOptions, xai } from '@ai-sdk/xai';
+import { APICallError, experimental_generateVideo as generateVideo } from 'ai';
+
+/**
+ * Diagnostic harness for xAI video provider request-id capture.
+ *
+ * Context: for `xai/grok-imagine-video` the AI Gateway records NO
+ * providerRequestId/providerResponseId on any attempt (success or failure),
+ * so we cannot hand xAI the request id (e.g. `e8720dcc-...`) they need to
+ * reconcile a moderation rejection against their own logs.
+ *
+ * This script proves WHERE xAI's resource `request_id` is observable in each
+ * outcome, so we know exactly what the gateway must read:
+ *   - success            → result.providerMetadata.xai.requestId
+ *   - moderation 400     → thrown APICallError from the poll GET /videos/:id
+ *   - failed/timeout/etc → AISDKError thrown by the SDK poll loop
+ *
+ * `recoverRequestId()` below is the extraction strategy we intend to port into
+ * the gateway (execute-video-query). Run this before/after any @ai-sdk/xai
+ * change to confirm the id is surfaced on every path.
+ *
+ * Run:
+ *   cd examples/ai-functions
+ *   pnpm tsx src/generate-video/xai/request-id.ts
+ *
+ * Iterate on the moderation path by overriding the prompt/image with a
+ * combination you know xAI moderates (no need to edit this file):
+ *   XAI_VIDEO_PROMPT="..." XAI_VIDEO_IMAGE_URL="https://..." \
+ *     pnpm tsx src/generate-video/xai/request-id.ts
+ */
+
+const DEFAULT_IMAGE =
+  'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png';
+const DEFAULT_PROMPT = 'The cat slowly turns its head and blinks';
+
+// xAI's resource id is the `{id}` in the poll URL `/videos/{id}`, which is also
+// the id embedded in the returned video filename and in xAI's own meta.requestId.
+const VIDEOS_PATH_ID = /\/videos\/([^/?#]+)/;
+const UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+
+type Recovered =
+  | { value: string; source: string }
+  | { value: null; source: 'NOT FOUND' };
+
+/**
+ * Every place xAI's resource request_id could be recovered from, in
+ * preference order. Mirrors the logic the gateway will need.
+ */
+function recoverRequestId(error: unknown): Recovered {
+  const anyErr = error as Record<string, unknown> | null;
+
+  // 0. The contract the @ai-sdk/xai fix establishes: xAI's request_id attached
+  //    as an own property on every thrown error (success uses providerMetadata).
+  //    This is what the gateway should read.
+  if (typeof anyErr?.requestId === 'string' && anyErr.requestId) {
+    return { value: anyErr.requestId, source: 'error.requestId' };
+  }
+
+  // 1. Structured field an updated SDK may attach (cleanest — target state).
+  const data = anyErr?.data as Record<string, unknown> | undefined;
+  const fromData = data?.requestId ?? data?.request_id;
+  if (typeof fromData === 'string' && fromData) {
+    return { value: fromData, source: 'error.data.requestId' };
+  }
+  const meta = anyErr?.providerMetadata as
+    | { xai?: { requestId?: unknown } }
+    | undefined;
+  if (typeof meta?.xai?.requestId === 'string' && meta.xai.requestId) {
+    return {
+      value: meta.xai.requestId,
+      source: 'error.providerMetadata.xai.requestId',
+    };
+  }
+
+  // 2. Interim, no-SDK-change recovery: the poll GET URL carries /videos/:id.
+  if (APICallError.isInstance(error) && typeof error.url === 'string') {
+    const m = error.url.match(VIDEOS_PATH_ID);
+    if (m?.[1]) {
+      return { value: m[1], source: 'APICallError.url (/videos/:id)' };
+    }
+  }
+
+  // 3. Last resort: any uuid in the message.
+  const msg = anyErr?.message;
+  if (typeof msg === 'string') {
+    const m = msg.match(UUID);
+    if (m?.[0]) {
+      return { value: m[0], source: 'error.message (uuid scan)' };
+    }
+  }
+
+  return { value: null, source: 'NOT FOUND' };
+}
+
+function dumpError(error: unknown): void {
+  const e = error as Record<string, unknown>;
+  console.log('  name:        ', e?.name);
+  console.log('  message:     ', e?.message);
+  if (APICallError.isInstance(error)) {
+    console.log('  [APICallError]');
+    console.log('  statusCode:  ', error.statusCode);
+    console.log('  url:         ', error.url);
+    console.log('  responseBody:', error.responseBody);
+    console.log('  data:        ', JSON.stringify(error.data));
+    console.log(
+      '  x-request-id (poll HTTP call, NOT the resource id):',
+      error.responseHeaders?.['x-request-id'],
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const prompt = process.env.XAI_VIDEO_PROMPT ?? DEFAULT_PROMPT;
+  const image = process.env.XAI_VIDEO_IMAGE_URL ?? DEFAULT_IMAGE;
+  // Set a tiny value (e.g. 1) to force XAI_VIDEO_GENERATION_TIMEOUT and
+  // deterministically exercise the error path without needing moderated input.
+  const pollTimeoutMs = Number(process.env.XAI_VIDEO_POLL_TIMEOUT_MS ?? 600000);
+
+  console.log('=== xAI video request-id diagnostic ===');
+  console.log('prompt:', prompt);
+  console.log('image: ', image);
+  console.log();
+
+  try {
+    const result = await generateVideo({
+      model: xai.video('grok-imagine-video'),
+      prompt: { image, text: prompt },
+      duration: 5,
+      providerOptions: {
+        xai: { pollTimeoutMs } satisfies XaiVideoModelOptions,
+      },
+    });
+
+    const requestId = (
+      result.providerMetadata?.xai as { requestId?: unknown } | undefined
+    )?.requestId;
+
+    console.log('OUTCOME: success');
+    console.log(
+      'providerMetadata:',
+      JSON.stringify(result.providerMetadata, null, 2),
+    );
+    console.log();
+    console.log(
+      requestId
+        ? `VERDICT: request_id FOUND on success → providerMetadata.xai.requestId = ${requestId}`
+        : 'VERDICT: request_id MISSING on success (unexpected — check providerMetadata shape)',
+    );
+  } catch (error) {
+    console.log('OUTCOME: error');
+    dumpError(error);
+    console.log();
+    const recovered = recoverRequestId(error);
+    console.log(
+      recovered.value
+        ? `VERDICT: request_id RECOVERABLE → "${recovered.value}" via ${recovered.source}`
+        : 'VERDICT: request_id NOT RECOVERABLE from the thrown error (SDK must attach it)',
+    );
+  }
+}
+
+main().catch(err => {
+  console.error('harness itself threw:', err);
+  process.exitCode = 1;
+});

--- a/examples/ai-functions/src/generate-video/xai/response-headers.ts
+++ b/examples/ai-functions/src/generate-video/xai/response-headers.ts
@@ -1,0 +1,109 @@
+import 'dotenv/config';
+import { createXai } from '@ai-sdk/xai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+/**
+ * Probe: what do xAI video HTTP responses actually carry in their HEADERS?
+ *
+ * The request-id capture work assumed xAI's resource request_id lives only in
+ * the response body (surfaced via providerMetadata.xai.requestId) and that
+ * headers carry nothing useful for video. That assumption was never verified.
+ *
+ * This wraps fetch to dump the response headers of EVERY xAI video HTTP call —
+ * the create POST /videos/generations and each poll GET /videos/:id — because
+ * the SDK exposes only the poll headers (result.responses[].headers) and discards
+ * the create-POST headers entirely. Use it to decide, per provider, whether
+ * header-based extraction (extractProviderRequestId) should also apply to video
+ * or whether body/providerMetadata is the only source. Separate from
+ * request-id.ts on purpose.
+ *
+ * Run:
+ *   cd examples/ai-functions
+ *   pnpm tsx src/generate-video/xai/response-headers.ts
+ *
+ * Iterate against a moderated/failing input the same way as request-id.ts:
+ *   XAI_VIDEO_PROMPT="..." XAI_VIDEO_IMAGE_URL="https://..." pnpm tsx ...
+ */
+
+const DEFAULT_IMAGE =
+  'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png';
+const DEFAULT_PROMPT = 'The cat slowly turns its head and blinks';
+
+// Header names that might carry a provider request/response/correlation id.
+const ID_HINT = /request|response|trace|correlation|(^|[-_])id($|[-_])/i;
+
+function dumpHeaders(label: string, headers: Headers): void {
+  const all: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    all[key] = value;
+  });
+  console.log(`\n[${label}]`);
+  console.log(JSON.stringify(all, null, 2));
+  const idish = Object.keys(all).filter(key => ID_HINT.test(key));
+  console.log(
+    idish.length > 0
+      ? `  → id-like headers: ${idish.map(key => `${key}=${all[key]}`).join(', ')}`
+      : '  → id-like headers: none',
+  );
+}
+
+const loggingFetch: typeof globalThis.fetch = async (input, init) => {
+  const response = await globalThis.fetch(input, init);
+  const url =
+    typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+  dumpHeaders(`${init?.method ?? 'GET'} ${url}`, response.headers);
+  return response;
+};
+
+async function main(): Promise<void> {
+  const xai = createXai({ fetch: loggingFetch });
+  const prompt = process.env.XAI_VIDEO_PROMPT ?? DEFAULT_PROMPT;
+  const image = process.env.XAI_VIDEO_IMAGE_URL ?? DEFAULT_IMAGE;
+
+  console.log('=== xAI video response-header probe ===');
+  console.log('Dumping headers for the create POST and every poll GET.');
+
+  try {
+    const result = await generateVideo({
+      model: xai.video('grok-imagine-video'),
+      prompt: { image, text: prompt },
+      duration: 5,
+    });
+
+    // Core exposes per-call metadata as `responses[]` (one entry per HTTP call
+    // it surfaced) — for xAI video these are poll-GET headers, which carry no
+    // id header. NOT `result.response` (singular), which does not exist.
+    console.log(
+      '\n=== SDK-exposed result.responses[].headers (poll GET only) ===',
+    );
+    const exposed = (
+      result as { responses?: Array<{ headers?: Record<string, string> }> }
+    ).responses?.map(entry => entry.headers ?? {});
+    console.log(JSON.stringify(exposed ?? [], null, 2));
+
+    console.log('\n=== providerMetadata.xai ===');
+    const meta = (
+      result.providerMetadata as { xai?: Record<string, unknown> } | undefined
+    )?.xai;
+    console.log(JSON.stringify(meta ?? {}, null, 2));
+
+    console.log(
+      '\nCompare: is any id-like header equal to the providerMetadata requestId,' +
+        ' or is it a distinct per-HTTP-call id?',
+    );
+  } catch (error) {
+    console.log(
+      '\n=== errored — the headers dumped above still show what xAI returned ===',
+    );
+    console.error(error);
+  }
+}
+
+main().catch(err => {
+  console.error('probe threw:', err);
+  process.exitCode = 1;
+});

--- a/packages/xai/src/xai-video-model.test.ts
+++ b/packages/xai/src/xai-video-model.test.ts
@@ -947,6 +947,95 @@ describe('XaiVideoModel', () => {
         body: doneStatusResponse,
       };
     });
+
+    it('attaches xAI request_id to a content-moderation 400 during polling', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'error',
+        status: 400,
+        body: JSON.stringify({
+          code: 'imagine:content-moderated',
+          error: 'Generated video rejected by content moderation.',
+        }),
+      };
+
+      const model = createModel();
+
+      // The original APICallError (type + status + message) must be preserved
+      // so downstream moderation detection still works; it only gains
+      // requestId, which lets callers correlate with xAI's own logs.
+      await expect(
+        model.doGenerate({ ...defaultOptions }),
+      ).rejects.toMatchObject({
+        message:
+          'imagine:content-moderated: Generated video rejected by content moderation.',
+        statusCode: 400,
+        requestId: 'req-123',
+      });
+
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: doneStatusResponse,
+      };
+    });
+
+    it('attaches xAI request_id to failed, expired, and respect_moderation errors', async () => {
+      const model = createModel();
+
+      const bodies = [
+        { status: 'failed', progress: 0 },
+        { status: 'expired' },
+        {
+          status: 'done',
+          video: { url: '', respect_moderation: false },
+        },
+      ];
+
+      for (const body of bodies) {
+        server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+          type: 'json-value',
+          body: { model: 'grok-imagine-video', ...body },
+        };
+
+        await expect(
+          model.doGenerate({ ...defaultOptions }),
+        ).rejects.toMatchObject({ requestId: 'req-123' });
+      }
+
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: doneStatusResponse,
+      };
+    });
+
+    it('attaches xAI request_id on timeout', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: {
+          status: 'pending',
+          model: 'grok-imagine-video',
+        },
+      };
+
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          providerOptions: {
+            xai: {
+              pollIntervalMs: 10,
+              pollTimeoutMs: 50,
+            },
+          },
+        }),
+      ).rejects.toMatchObject({ requestId: 'req-123' });
+
+      // Reset
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
+        type: 'json-value',
+        body: doneStatusResponse,
+      };
+    });
   });
 
   describe('reference images (R2V)', () => {

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -150,6 +150,20 @@ function resolveVideoMode(
   return undefined;
 }
 
+// Surfaces xAI's resource request id on a thrown error so callers (and the
+// Vercel AI Gateway) can correlate a failed generation with xAI's own logs.
+// `requestId` is xAI's `request_id` from the create response — the same id
+// embedded in the returned video URL and in xAI's request logs. Attached as an
+// own property so the original error instance and type (e.g. an APICallError
+// for a content-moderation 400 during polling) are preserved for downstream
+// handling, which only gains a `requestId` field.
+function withRequestId<E>(error: E, requestId: string): E {
+  if (error != null && typeof error === 'object' && !('requestId' in error)) {
+    Object.assign(error, { requestId });
+  }
+  return error;
+}
+
 export class XaiVideoModel implements Experimental_VideoModelV4 {
   readonly specificationVersion = 'v4';
   readonly maxVideosPerCall = 1;
@@ -427,10 +441,13 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
       await delay(pollIntervalMs, { abortSignal: options.abortSignal });
 
       if (Date.now() - startTime > pollTimeoutMs) {
-        throw new AISDKError({
-          name: 'XAI_VIDEO_GENERATION_TIMEOUT',
-          message: `Video generation timed out after ${pollTimeoutMs}ms`,
-        });
+        throw withRequestId(
+          new AISDKError({
+            name: 'XAI_VIDEO_GENERATION_TIMEOUT',
+            message: `Video generation timed out after ${pollTimeoutMs}ms`,
+          }),
+          requestId,
+        );
       }
 
       const { value: statusResponse, responseHeaders: pollHeaders } =
@@ -442,6 +459,11 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
           failedResponseHandler: xaiFailedResponseHandler,
           abortSignal: options.abortSignal,
           fetch: this.config.fetch,
+        }).catch((error: unknown) => {
+          // Content-moderation rejections and other upstream failures surface
+          // here as APICallErrors from the poll GET. Attach the request id and
+          // re-throw the original error so its type/status/body are preserved.
+          throw withRequestId(error, requestId);
         });
 
       responseHeaders = pollHeaders;
@@ -451,19 +473,25 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
         (statusResponse.status == null && statusResponse.video?.url)
       ) {
         if (statusResponse.video?.respect_moderation === false) {
-          throw new AISDKError({
-            name: 'XAI_VIDEO_MODERATION_ERROR',
-            message:
-              'Video generation was blocked due to a content policy violation.',
-          });
+          throw withRequestId(
+            new AISDKError({
+              name: 'XAI_VIDEO_MODERATION_ERROR',
+              message:
+                'Video generation was blocked due to a content policy violation.',
+            }),
+            requestId,
+          );
         }
 
         if (!statusResponse.video?.url) {
-          throw new AISDKError({
-            name: 'XAI_VIDEO_GENERATION_ERROR',
-            message:
-              'Video generation completed but no video URL was returned.',
-          });
+          throw withRequestId(
+            new AISDKError({
+              name: 'XAI_VIDEO_GENERATION_ERROR',
+              message:
+                'Video generation completed but no video URL was returned.',
+            }),
+            requestId,
+          );
         }
 
         return {
@@ -499,17 +527,23 @@ export class XaiVideoModel implements Experimental_VideoModelV4 {
       }
 
       if (statusResponse.status === 'expired') {
-        throw new AISDKError({
-          name: 'XAI_VIDEO_GENERATION_EXPIRED',
-          message: 'Video generation request expired.',
-        });
+        throw withRequestId(
+          new AISDKError({
+            name: 'XAI_VIDEO_GENERATION_EXPIRED',
+            message: 'Video generation request expired.',
+          }),
+          requestId,
+        );
       }
 
       if (statusResponse.status === 'failed') {
-        throw new AISDKError({
-          name: 'XAI_VIDEO_GENERATION_FAILED',
-          message: 'Video generation failed.',
-        });
+        throw withRequestId(
+          new AISDKError({
+            name: 'XAI_VIDEO_GENERATION_FAILED',
+            message: 'Video generation failed.',
+          }),
+          requestId,
+        );
       }
 
       // 'pending' → continue polling


### PR DESCRIPTION
## Summary

xAI's video resource `request_id` — the id in the returned video URL and in xAI's own request logs — was only exposed via `providerMetadata.xai.requestId` on **success**. Every error thrown during polling discarded it, so a customer hitting content-moderation rejections couldn't be handed the `request_id` xAI support needs to reconcile against their own logs.

This attaches xAI's `request_id` as a `requestId` property on **every** error thrown from the video poll loop:

- **content-moderation 400** — the `APICallError` from the poll `GET` is augmented **in place**, so its type, status code (400), and message are preserved for downstream moderation detection (e.g. the gateway's `isModeratedGenerationError`); it only gains `requestId`.
- **timeout**, **failed**/**expired** statuses, and the **`respect_moderation`** block (all `AISDKError`s).

Success behavior is unchanged.

## Testing

- 4 new unit tests in `xai-video-model.test.ts` covering the moderation-400 (asserts `statusCode: 400` + `message` + `requestId` together, proving the error type is preserved), the failed/expired/`respect_moderation` errors, and timeout. Full package suite: **415 pass** (node + edge).

## Examples

Two runnable probes under `examples/ai-functions/src/generate-video/xai`:

- `request-id.ts` — correlation harness; reports where the id is recoverable on success vs. each failure path.
- `response-headers.ts` — logging-`fetch` dump of every video HTTP call's response headers (create POST + each poll GET). Confirmed xAI returns the id in the create-POST body/`x-request-id` header, but poll GETs carry no id header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)