### PR TITLE
fix(provider-utils): preserve record value schemas

### DIFF
--- a/.changeset/calm-records-remain.md
+++ b/.changeset/calm-records-remain.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Preserve schema-valued `additionalProperties` when converting Zod 4 schemas.

--- a/packages/provider-utils/src/add-additional-properties-to-json-schema.test.ts
+++ b/packages/provider-utils/src/add-additional-properties-to-json-schema.test.ts
@@ -278,6 +278,29 @@ describe('addAdditionalPropertiesToJsonSchema', () => {
     });
   });
 
+  it('preserves schema-valued additionalProperties recursively', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      additionalProperties: {
+        type: 'object',
+        properties: {
+          value: { type: 'string' },
+        },
+      },
+    };
+
+    expect(addAdditionalPropertiesToJsonSchema(schema)).toEqual({
+      type: 'object',
+      additionalProperties: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          value: { type: 'string' },
+        },
+      },
+    });
+  });
+
   it('leaves non-object schemas unchanged', () => {
     const schema: JSONSchema7 = { type: 'string' };
 

--- a/packages/provider-utils/src/add-additional-properties-to-json-schema.ts
+++ b/packages/provider-utils/src/add-additional-properties-to-json-schema.ts
@@ -1,7 +1,9 @@
 import type { JSONSchema7, JSONSchema7Definition } from '@ai-sdk/provider';
 
 /**
- * Recursively adds additionalProperties: false to the JSON schema. This is necessary because some providers (e.g. OpenAI) do not support additionalProperties: true.
+ * Recursively adds additionalProperties: false to closed object schemas while
+ * preserving schema-valued additionalProperties. This is necessary because
+ * some providers (e.g. OpenAI) do not support additionalProperties: true.
  */
 export function addAdditionalPropertiesToJsonSchema(
   jsonSchema: JSONSchema7,
@@ -10,7 +12,12 @@ export function addAdditionalPropertiesToJsonSchema(
     jsonSchema.type === 'object' ||
     (Array.isArray(jsonSchema.type) && jsonSchema.type.includes('object'))
   ) {
-    jsonSchema.additionalProperties = false;
+    const { additionalProperties } = jsonSchema;
+    jsonSchema.additionalProperties =
+      additionalProperties != null && typeof additionalProperties === 'object'
+        ? visit(additionalProperties)
+        : false;
+
     const { properties } = jsonSchema;
     if (properties != null) {
       for (const key of Object.keys(properties)) {

--- a/packages/provider-utils/src/schema.test.ts
+++ b/packages/provider-utils/src/schema.test.ts
@@ -84,6 +84,48 @@ describe('zodSchema', () => {
         expect(schema.jsonSchema).toMatchSnapshot();
       });
 
+      it('should preserve record value schemas', () => {
+        const schema = zodSchema(
+          z4.object({
+            values: z4.record(z4.string(), z4.string()),
+          }),
+        );
+
+        expect(schema.jsonSchema).toStrictEqual({
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          properties: {
+            values: {
+              type: 'object',
+              propertyNames: { type: 'string' },
+              additionalProperties: { type: 'string' },
+            },
+          },
+          required: ['values'],
+          additionalProperties: false,
+        });
+      });
+
+      it('should preserve object catchall schemas', () => {
+        const schema = zodSchema(
+          z4
+            .object({
+              fixed: z4.string(),
+            })
+            .catchall(z4.number()),
+        );
+
+        expect(schema.jsonSchema).toStrictEqual({
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          properties: {
+            fixed: { type: 'string' },
+          },
+          required: ['fixed'],
+          additionalProperties: { type: 'number' },
+        });
+      });
+
       it('should support optional arrays', () => {
         const schema = zodSchema(
           z4.object({


### PR DESCRIPTION
## Background

Zod 4 emits schema-valued `additionalProperties` for records and object
catchalls. AI SDK's recursive closed-object conversion overwrote every such
value with `false`, changing the schema sent to providers while runtime
validation still used the original Zod schema.

## Summary

- preserve schema-valued `additionalProperties` during JSON Schema conversion;
- recursively apply the existing closed-object handling inside those schemas;
- retain the existing behavior for absent or boolean `additionalProperties`;
- add regressions for the helper, `z.record()`, and object catchalls.

## Contributor Credit

Thanks to @MaratFM for the report and provider-free reproduction in #17871.

## Validation

- `pnpm --filter @ai-sdk/provider-utils test` — 785 Node + 785 Edge tests passed
- `pnpm --filter @ai-sdk/provider-utils type-check`
- `pnpm type-check:full`
- focused Ultracite formatting and lint checks for all changed source and test files

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Providers that do not accept schema-valued `additionalProperties` should handle
that compatibility at their provider boundary instead of changing the generic
Zod conversion.

## Related Issues

Fixes #17871
