### PR TITLE
fix(harness-claude-code): preserve subagent attribution

### DIFF
--- a/.changeset/bright-agents-nest.md
+++ b/.changeset/bright-agents-nest.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-claude-code': patch
+---
+
+Preserve Claude Code subagent attribution and isolate interleaved subagent stream state.

--- a/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
+++ b/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
@@ -80,6 +80,7 @@ Use `createClaudeCode()` to configure the runtime:
 const harness = createClaudeCode({
   model: 'claude-sonnet-4-6',
   maxTurns: 10,
+  forwardSubagentText: true,
   thinking: {
     type: 'adaptive',
     display: 'summarized',
@@ -92,12 +93,46 @@ Settings:
 - `auth`: direct Anthropic or AI Gateway authentication settings.
 - `model`: Anthropic model id passed to the underlying Claude Code runtime.
 - `maxTurns`: maximum internal turns before yielding.
+- `forwardSubagentText`: forwards subagent text and reasoning events. Defaults
+  to `false`.
 - `thinking`: extended-thinking configuration. `type` can be `enabled`,
   `disabled`, or `adaptive`. For enabled or adaptive thinking, `display` can be
   `summarized` or `omitted`. Defaults to
   `{ type: 'adaptive', display: 'summarized' }`.
 - `port`: bridge port override.
 - `startupTimeoutMs`: maximum time to wait for the bridge to start.
+
+## Subagent Attribution
+
+Set `forwardSubagentText: true` to receive the full text and reasoning stream
+from Claude Code subagents:
+
+```ts
+const harness = createClaudeCode({
+  forwardSubagentText: true,
+});
+```
+
+Every forwarded descendant event carries the tool-use id of its immediate
+parent:
+
+```ts
+{
+  'claude-code': {
+    parentToolUseId: 'toolu_...',
+  },
+}
+```
+
+Text, reasoning, and step-finish bridge events carry this value as
+`harnessMetadata`. Tool calls and tool results carry it as `providerMetadata`.
+When consuming `HarnessAgent.fullStream`, both forms are exposed as
+`providerMetadata`. Root events omit this metadata entirely.
+
+The id represents only the immediate parent. For example, a grandchild event
+points to the child agent's `Agent` tool call, while the child event points to
+the root agent's `Agent` tool call. Following those ids reconstructs the
+recursive tree.
 
 ## Authentication
 

--- a/examples/ai-functions/src/harness-agent/claude-code/subagent-attribution.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/subagent-attribution.ts
@@ -1,0 +1,176 @@
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { createClaudeCode } from '@ai-sdk/harness-claude-code';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
+import { run } from '../../lib/run';
+
+const expectedFiles = {
+  'alpha.txt': 'alpha',
+  'alpha-grandchild.txt': 'alpha-grandchild',
+  'beta.txt': 'beta',
+  'beta-grandchild.txt': 'beta-grandchild',
+  'gamma.txt': 'gamma',
+  'gamma-grandchild.txt': 'gamma-grandchild',
+};
+
+run(async () => {
+  let activeSandbox: Experimental_SandboxSession | undefined;
+  let sessionWorkDir: string | undefined;
+  const sandbox = createVercelSandbox({
+    runtime: 'node24',
+    ports: [4000],
+    timeout: 10 * 60 * 1000,
+    ...(process.env.VERCEL_TOKEN &&
+    process.env.VERCEL_TEAM_ID &&
+    process.env.VERCEL_PROJECT_ID
+      ? {
+          token: process.env.VERCEL_TOKEN,
+          teamId: process.env.VERCEL_TEAM_ID,
+          projectId: process.env.VERCEL_PROJECT_ID,
+        }
+      : {}),
+  });
+  const agent = new HarnessAgent({
+    harness: createClaudeCode({
+      model: 'claude-opus-4-6',
+      forwardSubagentText: true,
+    }),
+    sandbox,
+    permissionMode: 'allow-all',
+    sandboxConfig: {
+      onSession: async ({ session, sessionWorkDir: workDir }) => {
+        activeSandbox = session;
+        sessionWorkDir = workDir;
+      },
+    },
+  });
+
+  let exitCode = 0;
+  const session = await agent.createSession();
+  try {
+    const result = await agent.stream({
+      session,
+      prompt: [
+        'This is a recursive-agent protocol test. In one assistant response,',
+        'make exactly three Agent tool calls back-to-back with these exact tasks:',
+        '1. Alpha: write alpha.txt containing alpha, then you MUST call the Agent tool',
+        'exactly once. Tell that grandchild to write alpha-grandchild.txt containing',
+        'alpha-grandchild. Verify both files before returning.',
+        '2. Beta: write beta.txt containing beta, then you MUST call the Agent tool',
+        'exactly once. Tell that grandchild to write beta-grandchild.txt containing',
+        'beta-grandchild. Verify both files before returning.',
+        '3. Gamma: write gamma.txt containing gamma, then you MUST call the Agent tool',
+        'exactly once. Tell that grandchild to write gamma-grandchild.txt containing',
+        'gamma-grandchild. Verify both files before returning.',
+        'The root must not write files or launch any agents beyond alpha, beta, and',
+        'gamma. A child may not write its grandchild file itself.',
+      ].join(' '),
+    });
+
+    const agentToolParents = new Map<string, string | undefined>();
+    const descendantEvents: Array<{
+      type: string;
+      toolCallId?: string;
+      parentToolUseId: string;
+    }> = [];
+
+    for await (const part of result.fullStream) {
+      const providerMetadata =
+        'providerMetadata' in part ? part.providerMetadata : undefined;
+      const parentToolUseId = getParentToolUseId(providerMetadata);
+
+      if (part.type === 'tool-call' && part.toolName === 'Agent') {
+        agentToolParents.set(part.toolCallId, parentToolUseId);
+        console.log('Agent tool call:', {
+          toolCallId: part.toolCallId,
+          parentToolUseId: parentToolUseId ?? null,
+        });
+      }
+      if (parentToolUseId !== undefined) {
+        descendantEvents.push({
+          type: part.type,
+          ...('toolCallId' in part ? { toolCallId: part.toolCallId } : {}),
+          parentToolUseId,
+        });
+      }
+    }
+
+    const rootAgentIds = [...agentToolParents]
+      .filter(([, parentToolUseId]) => parentToolUseId === undefined)
+      .map(([toolCallId]) => toolCallId);
+    const nestedAgentEntries = [...agentToolParents].filter(
+      ([, parentToolUseId]) => parentToolUseId !== undefined,
+    );
+    if (agentToolParents.size !== 6) {
+      throw new Error(
+        `Expected six Agent tool ids, received ${agentToolParents.size}: ${JSON.stringify([...agentToolParents])}.`,
+      );
+    }
+    if (rootAgentIds.length !== 3 || nestedAgentEntries.length !== 3) {
+      throw new Error(
+        `Expected three root and three nested Agent calls; received ${rootAgentIds.length} root and ${nestedAgentEntries.length} nested.`,
+      );
+    }
+
+    const rootAgentIdSet = new Set(rootAgentIds);
+    for (const [toolCallId, parentToolUseId] of nestedAgentEntries) {
+      if (
+        parentToolUseId === undefined ||
+        !rootAgentIdSet.has(parentToolUseId)
+      ) {
+        throw new Error(
+          `Nested Agent ${toolCallId} has unexpected parent ${String(parentToolUseId)}.`,
+        );
+      }
+    }
+    for (const event of descendantEvents) {
+      if (!agentToolParents.has(event.parentToolUseId)) {
+        throw new Error(
+          `${event.type} references unknown parent ${event.parentToolUseId}.`,
+        );
+      }
+    }
+    if (descendantEvents.length === 0) {
+      throw new Error('Expected attributed descendant events.');
+    }
+
+    const sandboxSession = activeSandbox;
+    const workDir = sessionWorkDir;
+    if (sandboxSession === undefined || workDir === undefined) {
+      throw new Error('Sandbox session was not captured.');
+    }
+    for (const [file, expectedContent] of Object.entries(expectedFiles)) {
+      const content = await sandboxSession.readTextFile({
+        path: `${workDir}/${file}`,
+      });
+      if (content?.trim() !== expectedContent) {
+        throw new Error(
+          `Expected ${file} to contain "${expectedContent}", received ${JSON.stringify(content)}.`,
+        );
+      }
+    }
+
+    console.log('Agent tool ids:', [...agentToolParents.keys()]);
+    console.log('Root Agent tool ids:', rootAgentIds);
+    console.log('Attributed descendant events:', descendantEvents);
+    console.log('Verified files:', Object.keys(expectedFiles));
+  } catch (err) {
+    exitCode = 1;
+    console.error('[example] failed:', err);
+  } finally {
+    await session.destroy();
+    process.exit(exitCode);
+  }
+});
+
+function getParentToolUseId(metadata: unknown): string | undefined {
+  if (!isRecord(metadata)) return undefined;
+  const claudeCodeMetadata = metadata['claude-code'];
+  if (!isRecord(claudeCodeMetadata)) return undefined;
+  const parentToolUseId = claudeCodeMetadata.parentToolUseId;
+  return typeof parentToolUseId === 'string' ? parentToolUseId : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createClaudeStreamEventState,
   createEmitStreamEvent,
+  emitOpenFinishSteps,
 } from './create-emit-stream-event';
 
 describe('createEmitStreamEvent', () => {
@@ -150,5 +151,474 @@ describe('createEmitStreamEvent', () => {
         ],
       }
     `);
+  });
+
+  it('keeps interleaved sibling partial blocks and steps in separate lanes', () => {
+    const state = createClaudeStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: event => emitted.push(event),
+      emitWarning: () => {},
+      emitTerminalError: () => {},
+      onCompactionBoundary: () => {},
+      toCommonName: name => name,
+    });
+
+    emitStreamEvent({
+      type: 'stream_event',
+      parent_tool_use_id: 'agent-alpha',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text' },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      parent_tool_use_id: 'agent-beta',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text' },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      parent_tool_use_id: 'agent-alpha',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 'alpha' },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      parent_tool_use_id: 'agent-beta',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 'beta' },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      parent_tool_use_id: 'agent-alpha',
+      event: { type: 'content_block_stop', index: 0 },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      parent_tool_use_id: 'agent-beta',
+      event: { type: 'content_block_stop', index: 0 },
+    });
+
+    expect(emitted[0]).toEqual({ type: 'stream-start' });
+    expect(emitted[1]).toMatchObject({
+      type: 'text-start',
+      harnessMetadata: {
+        'claude-code': { parentToolUseId: 'agent-alpha' },
+      },
+    });
+    expect(emitted[2]).toMatchObject({
+      type: 'text-start',
+      harnessMetadata: {
+        'claude-code': { parentToolUseId: 'agent-beta' },
+      },
+    });
+    expect(emitted[3]).toMatchObject({
+      type: 'text-delta',
+      id: emitted[1].id,
+      delta: 'alpha',
+      harnessMetadata: {
+        'claude-code': { parentToolUseId: 'agent-alpha' },
+      },
+    });
+    expect(emitted[4]).toMatchObject({
+      type: 'text-delta',
+      id: emitted[2].id,
+      delta: 'beta',
+      harnessMetadata: {
+        'claude-code': { parentToolUseId: 'agent-beta' },
+      },
+    });
+    expect(emitted[5]).toMatchObject({
+      type: 'text-end',
+      id: emitted[1].id,
+    });
+    expect(emitted[6]).toMatchObject({
+      type: 'text-end',
+      id: emitted[2].id,
+    });
+
+    emitStreamEvent({
+      type: 'assistant',
+      parent_tool_use_id: 'agent-alpha',
+      message: {
+        usage: { input_tokens: 1, output_tokens: 2 },
+        content: [
+          {
+            type: 'tool_use',
+            id: 'write-alpha',
+            name: 'Write',
+            input: { file_path: '/tmp/alpha' },
+          },
+        ],
+      },
+    });
+    emitStreamEvent({
+      type: 'assistant',
+      parent_tool_use_id: 'agent-beta',
+      message: {
+        usage: { input_tokens: 3, output_tokens: 4 },
+        content: [
+          {
+            type: 'tool_use',
+            id: 'write-beta',
+            name: 'Write',
+            input: { file_path: '/tmp/beta' },
+          },
+        ],
+      },
+    });
+    emitStreamEvent({
+      type: 'user',
+      parent_tool_use_id: 'agent-alpha',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'write-alpha',
+            content: 'alpha done',
+          },
+        ],
+      },
+    });
+
+    expect(emitted.at(-2)).toMatchObject({
+      type: 'tool-result',
+      toolCallId: 'write-alpha',
+      providerMetadata: {
+        'claude-code': { parentToolUseId: 'agent-alpha' },
+      },
+    });
+    expect(emitted.at(-1)).toMatchObject({
+      type: 'finish-step',
+      harnessMetadata: {
+        'claude-code': { parentToolUseId: 'agent-alpha' },
+      },
+    });
+    expect(state.lanes.get('agent-beta')?.stepOpen).toBe(true);
+    expect(state.lanes.get('agent-beta')?.pendingStepToolUseIds).toEqual(
+      new Set(['write-beta']),
+    );
+  });
+
+  it('attributes reasoning events while leaving root text metadata unset', () => {
+    const state = createClaudeStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: event => emitted.push(event),
+      emitWarning: () => {},
+      emitTerminalError: () => {},
+      onCompactionBoundary: () => {},
+      toCommonName: name => name,
+    });
+
+    emitStreamEvent({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text' },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 'root' },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      event: { type: 'content_block_stop', index: 0 },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      parent_tool_use_id: 'agent-gamma',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'thinking' },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      parent_tool_use_id: 'agent-gamma',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'thinking_delta', thinking: 'considering' },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      parent_tool_use_id: 'agent-gamma',
+      event: { type: 'content_block_stop', index: 0 },
+    });
+
+    for (const event of emitted.slice(0, 4)) {
+      expect(event).not.toHaveProperty('harnessMetadata');
+    }
+    expect(emitted.slice(4)).toEqual([
+      expect.objectContaining({
+        type: 'reasoning-start',
+        harnessMetadata: {
+          'claude-code': { parentToolUseId: 'agent-gamma' },
+        },
+      }),
+      expect.objectContaining({
+        type: 'reasoning-delta',
+        delta: 'considering',
+        harnessMetadata: {
+          'claude-code': { parentToolUseId: 'agent-gamma' },
+        },
+      }),
+      expect.objectContaining({
+        type: 'reasoning-end',
+        harnessMetadata: {
+          'claude-code': { parentToolUseId: 'agent-gamma' },
+        },
+      }),
+    ]);
+  });
+
+  it('preserves the immediate parent for nested grandchildren', () => {
+    const state = createClaudeStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: event => emitted.push(event),
+      emitWarning: () => {},
+      emitTerminalError: () => {},
+      onCompactionBoundary: () => {},
+      toCommonName: name => name,
+    });
+
+    emitStreamEvent({
+      type: 'assistant',
+      parent_tool_use_id: 'agent-alpha',
+      message: {
+        usage: { input_tokens: 2, output_tokens: 3 },
+        content: [
+          {
+            type: 'tool_use',
+            id: 'agent-alpha-child',
+            name: 'Agent',
+            input: { prompt: 'write the grandchild file' },
+          },
+        ],
+      },
+    });
+    emitStreamEvent({
+      type: 'assistant',
+      parent_tool_use_id: 'agent-alpha-child',
+      message: {
+        usage: { input_tokens: 5, output_tokens: 7 },
+        content: [
+          {
+            type: 'tool_use',
+            id: 'write-alpha-child',
+            name: 'Write',
+            input: { file_path: '/tmp/alpha-child' },
+          },
+        ],
+      },
+    });
+    emitStreamEvent({
+      type: 'user',
+      parent_tool_use_id: 'agent-alpha-child',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'write-alpha-child',
+            content: 'grandchild done',
+          },
+        ],
+      },
+    });
+    emitStreamEvent({
+      type: 'user',
+      parent_tool_use_id: 'agent-alpha',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'agent-alpha-child',
+            content: 'child done',
+          },
+        ],
+      },
+    });
+
+    expect(emitted).toEqual([
+      { type: 'stream-start' },
+      expect.objectContaining({
+        type: 'tool-call',
+        toolCallId: 'agent-alpha-child',
+        providerMetadata: {
+          'claude-code': { parentToolUseId: 'agent-alpha' },
+        },
+      }),
+      expect.objectContaining({
+        type: 'tool-call',
+        toolCallId: 'write-alpha-child',
+        providerMetadata: {
+          'claude-code': { parentToolUseId: 'agent-alpha-child' },
+        },
+      }),
+      expect.objectContaining({
+        type: 'tool-result',
+        toolCallId: 'write-alpha-child',
+        providerMetadata: {
+          'claude-code': { parentToolUseId: 'agent-alpha-child' },
+        },
+      }),
+      expect.objectContaining({
+        type: 'finish-step',
+        harnessMetadata: {
+          'claude-code': { parentToolUseId: 'agent-alpha-child' },
+        },
+      }),
+      expect.objectContaining({
+        type: 'tool-result',
+        toolCallId: 'agent-alpha-child',
+        providerMetadata: {
+          'claude-code': { parentToolUseId: 'agent-alpha' },
+        },
+      }),
+      expect.objectContaining({
+        type: 'finish-step',
+        harnessMetadata: {
+          'claude-code': { parentToolUseId: 'agent-alpha' },
+        },
+      }),
+    ]);
+  });
+
+  it('keeps failed tool results in their lane', () => {
+    const state = createClaudeStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: event => emitted.push(event),
+      emitWarning: () => {},
+      emitTerminalError: () => {},
+      onCompactionBoundary: () => {},
+      toCommonName: name => name,
+    });
+
+    emitStreamEvent({
+      type: 'assistant',
+      parent_tool_use_id: 'agent-gamma',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'write-gamma',
+            name: 'Write',
+            input: {},
+          },
+        ],
+      },
+    });
+    emitStreamEvent({
+      type: 'user',
+      parent_tool_use_id: 'agent-gamma',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'write-gamma',
+            content: 'permission denied',
+            is_error: true,
+          },
+        ],
+      },
+    });
+
+    expect(emitted.at(-2)).toMatchObject({
+      type: 'tool-result',
+      toolCallId: 'write-gamma',
+      isError: true,
+      providerMetadata: {
+        'claude-code': { parentToolUseId: 'agent-gamma' },
+      },
+    });
+    expect(emitted.at(-1)).toMatchObject({
+      type: 'finish-step',
+      harnessMetadata: {
+        'claude-code': { parentToolUseId: 'agent-gamma' },
+      },
+    });
+  });
+
+  it('closes every open lane without adding metadata to the root lane', () => {
+    const state = createClaudeStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: event => emitted.push(event),
+      emitWarning: () => {},
+      emitTerminalError: () => {},
+      onCompactionBoundary: () => {},
+      toCommonName: name => name,
+    });
+
+    emitStreamEvent({
+      type: 'assistant',
+      message: {
+        usage: { input_tokens: 1, output_tokens: 1 },
+        content: [{ type: 'text', text: 'root' }],
+      },
+    });
+    emitStreamEvent({
+      type: 'assistant',
+      parent_tool_use_id: 'agent-beta',
+      message: {
+        usage: { input_tokens: 2, output_tokens: 3 },
+        content: [{ type: 'text', text: 'beta' }],
+      },
+    });
+    emitOpenFinishSteps({
+      state,
+      emit: event => emitted.push(event),
+      rootUsage: {
+        inputTokens: { total: 10 },
+        outputTokens: { total: 5 },
+      },
+    });
+
+    expect(emitted[1]).toMatchObject({
+      type: 'finish-step',
+      usage: {
+        inputTokens: { total: 10 },
+        outputTokens: { total: 5 },
+      },
+    });
+    expect(emitted[1]).not.toHaveProperty('harnessMetadata');
+    expect(emitted[2]).toMatchObject({
+      type: 'finish-step',
+      usage: {
+        inputTokens: { total: 2 },
+        outputTokens: { total: 3 },
+      },
+      harnessMetadata: {
+        'claude-code': { parentToolUseId: 'agent-beta' },
+      },
+    });
   });
 });

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
@@ -5,6 +5,7 @@ type Emit = (message: Record<string, unknown>) => void;
 export type ClaudeMessage = {
   type?: string;
   subtype?: string;
+  parent_tool_use_id?: string | null;
   model?: string;
   error?: string;
   error_status?: number | null;
@@ -45,6 +46,16 @@ type MessageBlock = {
   is_error?: boolean;
 };
 
+type ParentToolUseId = string | null;
+
+export type ClaudeStreamEventLaneState = {
+  partialBlocks: Map<number, { id: string; kind: 'text' | 'thinking' }>;
+  stepUsage: Record<string, unknown> | undefined;
+  pendingStepToolUseIds: Set<string>;
+  pendingStepUsage: Record<string, unknown> | undefined;
+  stepOpen: boolean;
+};
+
 export type ClaudeStreamEventState = {
   /*
    * Map of native tool-use id → tool name. Claude assistant messages emit
@@ -54,11 +65,8 @@ export type ClaudeStreamEventState = {
    */
   nativeToolCallNames: Map<string, string>;
   approvalRequestedToolUseIds: Set<string>;
-  partialBlocks: Map<number, { id: string; kind: 'text' | 'thinking' }>;
-  stepUsage: Record<string, unknown> | undefined;
-  pendingStepToolUseIds: Set<string>;
-  pendingStepUsage: Record<string, unknown> | undefined;
-  stepOpen: boolean;
+  toolCallParentToolUseIds: Map<string, ParentToolUseId>;
+  lanes: Map<ParentToolUseId, ClaudeStreamEventLaneState>;
   /*
    * Tool-use ids that originated from the MCP server hosting user-supplied
    * tools. The MCP handler emits its own `tool-call`/`tool-result` pair with
@@ -74,11 +82,8 @@ export function createClaudeStreamEventState(): ClaudeStreamEventState {
   return {
     nativeToolCallNames: new Map(),
     approvalRequestedToolUseIds: new Set(),
-    partialBlocks: new Map(),
-    stepUsage: undefined,
-    pendingStepToolUseIds: new Set(),
-    pendingStepUsage: undefined,
-    stepOpen: false,
+    toolCallParentToolUseIds: new Map(),
+    lanes: new Map([[null, createLaneState()]]),
     mcpToolUseIds: new Set(),
     observedTerminalError: undefined,
   };
@@ -182,11 +187,15 @@ export function createEmitStreamEvent({
     }
 
     if (type === 'stream_event') {
-      handleStreamEvent(msg.event, state.partialBlocks, emit);
+      const parentToolUseId = msg.parent_tool_use_id ?? null;
+      const lane = getLaneState(state, parentToolUseId);
+      handleStreamEvent(msg.event, lane.partialBlocks, parentToolUseId, emit);
       return;
     }
 
     if (type === 'assistant' && msg.message?.content) {
+      const parentToolUseId = msg.parent_tool_use_id ?? null;
+      const lane = getLaneState(state, parentToolUseId);
       const usage = mapUsage(msg.message.usage);
       const toolUseIds: string[] = [];
       let opensStep = false;
@@ -197,9 +206,10 @@ export function createEmitStreamEvent({
           typeof block.name === 'string'
         ) {
           toolUseIds.push(block.id);
+          state.toolCallParentToolUseIds.set(block.id, parentToolUseId);
           const mcpPrefix = 'mcp__harness-tools__';
           if (block.name.startsWith(mcpPrefix)) {
-            state.pendingStepToolUseIds.add(block.id);
+            lane.pendingStepToolUseIds.add(block.id);
             state.mcpToolUseIds.add(block.id);
             opensStep = true;
             continue;
@@ -208,7 +218,7 @@ export function createEmitStreamEvent({
           if (state.approvalRequestedToolUseIds.has(block.id)) {
             continue;
           }
-          state.pendingStepToolUseIds.add(block.id);
+          lane.pendingStepToolUseIds.add(block.id);
           opensStep = true;
           emit({
             type: 'tool-call',
@@ -217,25 +227,34 @@ export function createEmitStreamEvent({
             nativeName: block.name,
             input: JSON.stringify(block.input ?? {}),
             providerExecuted: true,
+            ...providerMetadataFor(parentToolUseId),
           });
         }
       }
       if (opensStep || toolUseIds.length === 0) {
-        state.stepOpen = true;
-        if (usage) state.pendingStepUsage = usage;
+        lane.stepOpen = true;
+        if (usage) lane.pendingStepUsage = usage;
       }
       return;
     }
 
     if (type === 'user' && msg.message?.content) {
+      const parentToolUseId = msg.parent_tool_use_id ?? null;
+      const touchedParentToolUseIds = new Set<ParentToolUseId>();
       for (const block of msg.message.content) {
         if (
           block.type === 'tool_result' &&
           typeof block.tool_use_id === 'string'
         ) {
+          const toolCallParentToolUseId =
+            state.toolCallParentToolUseIds.get(block.tool_use_id) ??
+            parentToolUseId;
+          const lane = getLaneState(state, toolCallParentToolUseId);
+          touchedParentToolUseIds.add(toolCallParentToolUseId);
           if (state.mcpToolUseIds.has(block.tool_use_id)) {
             state.mcpToolUseIds.delete(block.tool_use_id);
-            state.pendingStepToolUseIds.delete(block.tool_use_id);
+            lane.pendingStepToolUseIds.delete(block.tool_use_id);
+            state.toolCallParentToolUseIds.delete(block.tool_use_id);
             continue;
           }
           state.approvalRequestedToolUseIds.delete(block.tool_use_id);
@@ -265,11 +284,19 @@ export function createEmitStreamEvent({
             toolName,
             result,
             isError,
+            ...providerMetadataFor(parentToolUseId),
           });
-          state.pendingStepToolUseIds.delete(block.tool_use_id);
+          lane.pendingStepToolUseIds.delete(block.tool_use_id);
+          state.toolCallParentToolUseIds.delete(block.tool_use_id);
         }
       }
-      closeStepIfReady({ state, emit });
+      for (const touchedParentToolUseId of touchedParentToolUseIds) {
+        closeStepIfReady({
+          state,
+          emit,
+          parentToolUseId: touchedParentToolUseId,
+        });
+      }
     }
   };
 }
@@ -283,46 +310,96 @@ export function finishApprovalStep({
   emit: Emit;
   approvalId: string;
 }): void {
-  state.stepOpen = true;
-  state.pendingStepToolUseIds.delete(approvalId);
-  closeStepIfReady({ state, emit });
+  const parentToolUseId =
+    state.toolCallParentToolUseIds.get(approvalId) ?? null;
+  const lane = getLaneState(state, parentToolUseId);
+  lane.stepOpen = true;
+  lane.pendingStepToolUseIds.delete(approvalId);
+  closeStepIfReady({ state, emit, parentToolUseId });
 }
 
 export function emitFinishStep({
   state,
   emit,
   usage,
+  parentToolUseId = null,
 }: {
   state: ClaudeStreamEventState;
   emit: Emit;
   usage: Record<string, unknown> | undefined;
+  parentToolUseId?: ParentToolUseId;
 }): void {
+  const lane = getLaneState(state, parentToolUseId);
   emit({
     type: 'finish-step',
     finishReason: { unified: 'stop', raw: 'stop' },
     usage: usage ?? defaultUsage(),
+    ...harnessMetadataFor(parentToolUseId),
   });
-  state.stepUsage = usage ?? state.stepUsage;
-  state.pendingStepUsage = undefined;
-  state.pendingStepToolUseIds = new Set();
-  state.stepOpen = false;
+  lane.stepUsage = usage ?? lane.stepUsage;
+  lane.pendingStepUsage = undefined;
+  lane.pendingStepToolUseIds = new Set();
+  lane.partialBlocks.clear();
+  lane.stepOpen = false;
+}
+
+export function emitOpenFinishSteps({
+  state,
+  emit,
+  rootUsage,
+}: {
+  state: ClaudeStreamEventState;
+  emit: Emit;
+  rootUsage: Record<string, unknown> | undefined;
+}): void {
+  for (const [parentToolUseId, lane] of state.lanes) {
+    if (!lane.stepOpen) continue;
+    emitFinishStep({
+      state,
+      emit,
+      usage:
+        parentToolUseId === null
+          ? (rootUsage ?? lane.pendingStepUsage)
+          : lane.pendingStepUsage,
+      parentToolUseId,
+    });
+  }
+}
+
+export function getStepUsage(
+  state: ClaudeStreamEventState,
+): Record<string, unknown> | undefined {
+  const rootUsage = state.lanes.get(null)?.stepUsage;
+  if (rootUsage) return rootUsage;
+  for (const lane of state.lanes.values()) {
+    if (lane.stepUsage) return lane.stepUsage;
+  }
+  return undefined;
 }
 
 function closeStepIfReady({
   state,
   emit,
+  parentToolUseId,
 }: {
   state: ClaudeStreamEventState;
   emit: Emit;
+  parentToolUseId: ParentToolUseId;
 }): void {
+  const lane = getLaneState(state, parentToolUseId);
   if (
-    !state.stepOpen ||
-    state.pendingStepToolUseIds.size > 0 ||
-    state.partialBlocks.size > 0
+    !lane.stepOpen ||
+    lane.pendingStepToolUseIds.size > 0 ||
+    lane.partialBlocks.size > 0
   ) {
     return;
   }
-  emitFinishStep({ state, emit, usage: state.pendingStepUsage });
+  emitFinishStep({
+    state,
+    emit,
+    usage: lane.pendingStepUsage,
+    parentToolUseId,
+  });
 }
 
 function formatApiRetryWarning(msg: ClaudeMessage): string {
@@ -347,6 +424,7 @@ function formatApiRetryWarning(msg: ClaudeMessage): string {
 function handleStreamEvent(
   event: ClaudeMessage['event'] | undefined,
   partialBlocks: Map<number, { id: string; kind: 'text' | 'thinking' }>,
+  parentToolUseId: ParentToolUseId,
   send: Emit,
 ): void {
   if (!event || typeof event.index !== 'number') return;
@@ -357,11 +435,15 @@ function handleStreamEvent(
     if (blockType === 'text') {
       const id = randomUUID();
       partialBlocks.set(index, { id, kind: 'text' });
-      send({ type: 'text-start', id });
+      send({ type: 'text-start', id, ...harnessMetadataFor(parentToolUseId) });
     } else if (blockType === 'thinking') {
       const id = randomUUID();
       partialBlocks.set(index, { id, kind: 'thinking' });
-      send({ type: 'reasoning-start', id });
+      send({
+        type: 'reasoning-start',
+        id,
+        ...harnessMetadataFor(parentToolUseId),
+      });
     }
     return;
   }
@@ -374,7 +456,12 @@ function handleStreamEvent(
       event.delta?.type === 'text_delta' &&
       typeof event.delta.text === 'string'
     ) {
-      send({ type: 'text-delta', id: block.id, delta: event.delta.text });
+      send({
+        type: 'text-delta',
+        id: block.id,
+        delta: event.delta.text,
+        ...harnessMetadataFor(parentToolUseId),
+      });
     } else if (
       block.kind === 'thinking' &&
       event.delta?.type === 'thinking_delta' &&
@@ -384,6 +471,7 @@ function handleStreamEvent(
         type: 'reasoning-delta',
         id: block.id,
         delta: event.delta.thinking,
+        ...harnessMetadataFor(parentToolUseId),
       });
     }
     return;
@@ -394,11 +482,63 @@ function handleStreamEvent(
     if (!block) return;
     partialBlocks.delete(index);
     if (block.kind === 'text') {
-      send({ type: 'text-end', id: block.id });
+      send({
+        type: 'text-end',
+        id: block.id,
+        ...harnessMetadataFor(parentToolUseId),
+      });
     } else {
-      send({ type: 'reasoning-end', id: block.id });
+      send({
+        type: 'reasoning-end',
+        id: block.id,
+        ...harnessMetadataFor(parentToolUseId),
+      });
     }
   }
+}
+
+function createLaneState(): ClaudeStreamEventLaneState {
+  return {
+    partialBlocks: new Map(),
+    stepUsage: undefined,
+    pendingStepToolUseIds: new Set(),
+    pendingStepUsage: undefined,
+    stepOpen: false,
+  };
+}
+
+function getLaneState(
+  state: ClaudeStreamEventState,
+  parentToolUseId: ParentToolUseId,
+): ClaudeStreamEventLaneState {
+  let lane = state.lanes.get(parentToolUseId);
+  if (!lane) {
+    lane = createLaneState();
+    state.lanes.set(parentToolUseId, lane);
+  }
+  return lane;
+}
+
+function harnessMetadataFor(
+  parentToolUseId: ParentToolUseId,
+): Record<string, unknown> {
+  return parentToolUseId === null
+    ? {}
+    : { harnessMetadata: claudeCodeParentMetadata(parentToolUseId) };
+}
+
+function providerMetadataFor(
+  parentToolUseId: ParentToolUseId,
+): Record<string, unknown> {
+  return parentToolUseId === null
+    ? {}
+    : { providerMetadata: claudeCodeParentMetadata(parentToolUseId) };
+}
+
+function claudeCodeParentMetadata(
+  parentToolUseId: string,
+): Record<string, unknown> {
+  return { 'claude-code': { parentToolUseId } };
 }
 
 function stringifyContent(content: unknown): string {

--- a/packages/harness-claude-code/src/bridge/index.ts
+++ b/packages/harness-claude-code/src/bridge/index.ts
@@ -38,8 +38,9 @@ import {
   createClaudeStreamEventState,
   createEmitStreamEvent,
   defaultUsage,
-  emitFinishStep,
+  emitOpenFinishSteps,
   finishApprovalStep,
+  getStepUsage,
   mapUsage,
   type ClaudeMessage,
 } from './create-emit-stream-event';
@@ -196,6 +197,7 @@ function createPermissionOptions(input: {
   finishApprovalStep: (approvalId: string) => void;
   nativeToolCallNames: Map<string, string>;
   approvalRequestedToolUseIds: Set<string>;
+  toolCallParentToolUseIds: Map<string, string | null>;
 }): Record<string, unknown> {
   const permissionMode = input.start.permissionMode ?? 'allow-all';
   const inactiveNativeTools = new Set(input.inactiveNativeTools);
@@ -236,6 +238,8 @@ function createPermissionOptions(input: {
       const approvalId = options.toolUseID;
       input.approvalRequestedToolUseIds.add(approvalId);
       input.nativeToolCallNames.set(approvalId, toolName);
+      const parentToolUseId =
+        input.toolCallParentToolUseIds.get(approvalId) ?? null;
       input.emit({
         type: 'tool-call',
         toolCallId: approvalId,
@@ -243,6 +247,13 @@ function createPermissionOptions(input: {
         nativeName: toolName,
         input: JSON.stringify(toolInput ?? {}),
         providerExecuted: true,
+        ...(parentToolUseId === null
+          ? {}
+          : {
+              providerMetadata: {
+                'claude-code': { parentToolUseId },
+              },
+            }),
       });
       input.emit({
         type: 'tool-approval-request',
@@ -384,6 +395,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     },
     nativeToolCallNames: streamEventState.nativeToolCallNames,
     approvalRequestedToolUseIds: streamEventState.approvalRequestedToolUseIds,
+    toolCallParentToolUseIds: streamEventState.toolCallParentToolUseIds,
   });
 
   const q = claudeSdk.query({
@@ -398,6 +410,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
         : {}),
       thinking: start.thinking,
       includePartialMessages: true,
+      forwardSubagentText: start.forwardSubagentText ?? false,
       // The `PostCompact` hook carries the compaction summary, which the
       // `compact_boundary` system message does not. Latch it for the unified
       // `compaction` event; return an empty output so compaction proceeds.
@@ -476,13 +489,11 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
           if (typeof msg.total_cost_usd === 'number') {
             totalCostUsd = (totalCostUsd ?? 0) + msg.total_cost_usd;
           }
-          if (streamEventState.stepOpen) {
-            emitFinishStep({
-              state: streamEventState,
-              emit,
-              usage: harnessUsage ?? streamEventState.pendingStepUsage,
-            });
-          }
+          emitOpenFinishSteps({
+            state: streamEventState,
+            emit,
+            rootUsage: harnessUsage,
+          });
           queryInput.close();
           break;
         } else {
@@ -511,7 +522,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   emit({
     type: 'finish',
     finishReason: { unified: 'stop', raw: 'stop' },
-    totalUsage: turnUsage ?? streamEventState.stepUsage ?? defaultUsage(),
+    totalUsage: turnUsage ?? getStepUsage(streamEventState) ?? defaultUsage(),
     ...(totalCostUsd !== undefined
       ? { harnessMetadata: { 'claude-code': { costUsd: totalCostUsd } } }
       : {}),

--- a/packages/harness-claude-code/src/claude-code-bridge-protocol.test.ts
+++ b/packages/harness-claude-code/src/claude-code-bridge-protocol.test.ts
@@ -69,12 +69,24 @@ describe('inboundMessageSchema', () => {
         tools: [{ name: 'deploy' }],
         model: 'claude-sonnet-4-5',
         maxTurns: 5,
+        forwardSubagentText: true,
         thinking: { type: 'adaptive', display: 'summarized' },
         skills: ['weather-forecast', 'weather-codes'],
         permissionMode: 'allow-edits',
         builtinToolFiltering: { mode: 'deny', toolNames: ['bash'] },
       }),
     ).not.toThrow();
+  });
+
+  it('rejects non-boolean forwardSubagentText values', () => {
+    expect(() =>
+      inboundMessageSchema.parse({
+        type: 'start',
+        prompt: 'hi',
+        forwardSubagentText: 'yes',
+        thinking: { type: 'adaptive' },
+      }),
+    ).toThrow();
   });
 
   it('rejects legacy string thinking values', () => {

--- a/packages/harness-claude-code/src/claude-code-bridge-protocol.ts
+++ b/packages/harness-claude-code/src/claude-code-bridge-protocol.ts
@@ -33,6 +33,7 @@ const thinkingSchema = z.discriminatedUnion('type', [
 export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
   thinking: thinkingSchema,
   maxTurns: z.number().optional(),
+  forwardSubagentText: z.boolean().optional(),
   skills: z.array(z.string()).optional(),
   // Resume signal. When true, the bridge passes `{ continue: true }` to the
   // Claude SDK so the in-workdir thread state is rehydrated. The host sets this

--- a/packages/harness-claude-code/src/claude-code-harness.test-d.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test-d.ts
@@ -3,7 +3,11 @@ import type {
   HarnessAgentSettings,
 } from '@ai-sdk/harness/agent';
 import { assertType, describe, expectTypeOf, test } from 'vitest';
-import { claudeCode, createClaudeCode } from './index';
+import {
+  claudeCode,
+  createClaudeCode,
+  type ClaudeCodeHarnessSettings,
+} from './index';
 
 /*
  * Regression guard for the harness Zod compatibility contract: a concrete
@@ -31,5 +35,16 @@ describe('claudeCode ↔ HarnessAgent harness setting', () => {
     ): THarness => harness;
 
     assertType<typeof claudeCode>(acceptsHarness(claudeCode));
+  });
+
+  test('accepts forwardSubagentText as a public setting', () => {
+    const settings: ClaudeCodeHarnessSettings = {
+      forwardSubagentText: true,
+    };
+
+    expectTypeOf(settings.forwardSubagentText).toEqualTypeOf<
+      boolean | undefined
+    >();
+    assertType<HarnessAgentSettings['harness']>(createClaudeCode(settings));
   });
 });

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -292,6 +292,28 @@ describe('createClaudeCode adapter', () => {
     await session.doDestroy();
   });
 
+  it('forwards subagent text configuration to fresh bridge starts', async () => {
+    const harness = createClaudeCode({ forwardSubagentText: true });
+    const session = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        writes: [],
+        runs: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+    });
+    const control = await session.doPromptTurn({
+      prompt: 'delegate this',
+      emit: () => {},
+    });
+    void Promise.resolve(control.done).catch(() => {});
+
+    expect(lastStart()).toMatchObject({ forwardSubagentText: true });
+
+    await session.doDestroy();
+  });
+
   it('defaults to summarized adaptive thinking', async () => {
     const harness = createClaudeCode();
     const session = await harness.doStart({
@@ -311,6 +333,69 @@ describe('createClaudeCode adapter', () => {
 
     expect(lastStart()).toMatchObject({
       thinking: { type: 'adaptive', display: 'summarized' },
+      forwardSubagentText: false,
+    });
+
+    await session.doDestroy();
+  });
+
+  it('forwards subagent text configuration to resumed bridge starts', async () => {
+    const harness = createClaudeCode({ forwardSubagentText: true });
+    const session = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        writes: [],
+        runs: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+      resumeFrom: {
+        type: 'resume-session',
+        harnessId: 'claude-code',
+        specificationVersion: 'harness-v1',
+        data: {},
+      },
+    });
+    const control = await session.doPromptTurn({
+      prompt: 'resume',
+      emit: () => {},
+    });
+    void Promise.resolve(control.done).catch(() => {});
+
+    expect(lastStart()).toMatchObject({
+      continue: true,
+      forwardSubagentText: true,
+    });
+
+    await session.doDestroy();
+  });
+
+  it('forwards subagent text configuration to rerun continuations', async () => {
+    const harness = createClaudeCode({ forwardSubagentText: true });
+    const session = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        writes: [],
+        runs: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+      continueFrom: {
+        type: 'continue-turn',
+        harnessId: 'claude-code',
+        specificationVersion: 'harness-v1',
+        data: {},
+      },
+    });
+    const control = await session.doContinueTurn({
+      emit: () => {},
+    });
+    void Promise.resolve(control.done).catch(() => {});
+
+    expect(lastStart()).toMatchObject({
+      continue: true,
+      forwardSubagentText: true,
+      prompt: 'Continue.',
     });
 
     await session.doDestroy();

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -73,6 +73,12 @@ export type ClaudeCodeHarnessSettings = {
    */
   readonly maxTurns?: number;
   /**
+   * Forward text and reasoning emitted by subagents. Forwarded events include
+   * their immediate parent tool-use id in Claude Code metadata. Defaults to
+   * `false`.
+   */
+  readonly forwardSubagentText?: boolean;
+  /**
    * Controls extended-thinking behavior and whether reasoning is summarized or
    * omitted. Defaults to `{ type: 'adaptive', display: 'summarized' }`.
    */
@@ -436,6 +442,7 @@ export function createClaudeCode(
     type: 'adaptive',
     display: 'summarized',
   };
+  const forwardSubagentText = settings.forwardSubagentText ?? false;
 
   return {
     specificationVersion: 'harness-v1',
@@ -544,6 +551,7 @@ export function createClaudeCode(
             proc: undefined,
             model: settings.model,
             maxTurns: settings.maxTurns,
+            forwardSubagentText,
             thinking,
             isResume: true,
             continueOnFirstPrompt: false,
@@ -711,6 +719,7 @@ export function createClaudeCode(
         proc,
         model: settings.model,
         maxTurns: settings.maxTurns,
+        forwardSubagentText,
         thinking,
         isResume: respawnStrategy !== undefined,
         continueOnFirstPrompt: respawnStrategy !== undefined,
@@ -953,6 +962,7 @@ function createSession({
   proc,
   model,
   maxTurns,
+  forwardSubagentText,
   thinking,
   isResume,
   continueOnFirstPrompt,
@@ -971,6 +981,7 @@ function createSession({
   proc: Experimental_SandboxProcess | undefined;
   model: string | undefined;
   maxTurns: number | undefined;
+  forwardSubagentText: boolean;
   thinking: ClaudeCodeThinkingConfig;
   isResume: boolean;
   continueOnFirstPrompt: boolean;
@@ -1161,6 +1172,7 @@ function createSession({
         })),
         model,
         maxTurns,
+        forwardSubagentText,
         thinking,
         ...(skills.length > 0
           ? { skills: skills.map(skill => skill.name) }
@@ -1213,6 +1225,7 @@ function createSession({
           })),
           model,
           maxTurns,
+          forwardSubagentText,
           thinking,
           ...(skills.length > 0
             ? { skills: skills.map(skill => skill.name) }


### PR DESCRIPTION
## Background

Claude Code SDK messages identify subagent output with `parent_tool_use_id`, but the Claude Harness bridge currently discards that field. It also keeps partial blocks, pending tools, usage, and step closure in one global state object, so interleaved sibling subagents can collide.

Issue #17116 captured the resulting flat traces. The issue was closed by its reporter to reduce their open-issue footprint, not because the behavior was fixed.

## Summary

- Add `forwardSubagentText` to `ClaudeCodeHarnessSettings`, default it to the Claude SDK's existing `false`, and forward it through fresh, resumed, and rerun continuation starts.
- Preserve each SDK message's immediate `parent_tool_use_id` as `claude-code.parentToolUseId`: text, reasoning, and finish-step bridge events use `harnessMetadata`; tool calls and results use `providerMetadata`. Root events omit parent metadata.
- Partition partial blocks, pending tool ids, usage, and step closure by parent tool-use id while keeping globally unique tool-name and approval maps shared.
- Add deterministic coverage for root output, sibling interleaving, duplicate partial indices, grandchildren, lane-local finishes, failures, protocol/settings forwarding, resume/continuation, and the public type.
- Document the setting and metadata contract, add a runnable recursive Vercel Sandbox example, and include a patch changeset for `@ai-sdk/harness-claude-code`.

## Contributor Credit

Credit to @doneumark for reporting #17116 and providing the recursive tracing reproduction and context.

## End-to-End Verification

Ran `examples/ai-functions/src/harness-agent/claude-code/subagent-attribution.ts` against a live Node 24 Vercel Sandbox with Claude Opus 4.6.

The root launched three Agent calls:

- `toolu_019X6wem3B69opGu588wsFvG`
- `toolu_01NvPSc2JUnS7G2kR6UToE4p`
- `toolu_01Nx3zvUhq5BJS7bf6WSyKs9`

Each child launched one grandchild, and every nested Agent call carried its immediate parent:

- `toolu_01G2m57ENXZ1iDVWnuvePRp5` → `toolu_019X6wem3B69opGu588wsFvG`
- `toolu_01J2hiioW9ckPYbPzLsDKJuG` → `toolu_01NvPSc2JUnS7G2kR6UToE4p`
- `toolu_013s3chrvnhZwF6fGWgdtmF8` → `toolu_01Nx3zvUhq5BJS7bf6WSyKs9`

The example also verified that all observed descendant events referenced known Agent tool ids, the three root Agent calls had no parent metadata, and these six files existed with their expected contents:

- `alpha.txt`
- `alpha-grandchild.txt`
- `beta.txt`
- `beta-grandchild.txt`
- `gamma.txt`
- `gamma-grandchild.txt`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

This PR intentionally stops at the Claude bridge metadata contract. Generic Harness lane-aware telemetry and recursive Braintrust span parenting can follow after maintainers accept or redirect this contract.

## Related Issues

Addresses the reproduction in #17116.
