### PR TITLE
fix(react): throttle useChat messages snapshot to prevent maximum update depth error

### DIFF
--- a/.changeset/eleven-melons-attack.md
+++ b/.changeset/eleven-melons-attack.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/react': patch
+---
+
+fix (react): throttle the `useChat` messages snapshot to prevent "Maximum update depth exceeded" during streaming
+
+`throttle`/`experimental_throttle` only throttled the subscribe callback, while `useSyncExternalStore`'s `getSnapshot` read `messages` directly and returned a fresh array on every stream chunk. Any re-render then read that un-throttled snapshot and re-rendered per chunk, which could exceed React's nested update limit on slower devices. The React chat state now publishes a separate throttled snapshot so both the notification and the snapshot are throttled together.

--- a/packages/react/src/chat.react.ts
+++ b/packages/react/src/chat.react.ts
@@ -10,7 +10,17 @@ import { throttle } from './throttle';
 class ReactChatState<
   UI_MESSAGE extends UIMessage,
 > implements ChatState<UI_MESSAGE> {
+  // Internal, always-current message buffer. Every read/write from
+  // `AbstractChat` (slicing, finding, replacing during streaming) goes through
+  // this, so the chat logic always sees the latest messages.
   #messages: UI_MESSAGE[];
+
+  // The message array reference published to React via
+  // `useSyncExternalStore`'s `getSnapshot`. It is only swapped when
+  // `#publishMessages` runs, so between throttle windows `getSnapshot` keeps
+  // returning the same reference and React does not force a re-render.
+  #messagesSnapshot: UI_MESSAGE[];
+
   #status: ChatStatus = 'ready';
   #error: Error | undefined = undefined;
 
@@ -18,8 +28,17 @@ class ReactChatState<
   #statusCallbacks = new Set<() => void>();
   #errorCallbacks = new Set<() => void>();
 
+  // The throttle window currently configured for message updates.
+  #throttleWaitMs: number | undefined = undefined;
+
+  // Throttled version of `#publishMessages`, rebuilt whenever the throttle
+  // window changes. When no throttling is configured this is `#publishMessages`
+  // itself, so publishing happens synchronously.
+  #throttledPublishMessages: () => void = () => this.#publishMessages();
+
   constructor(initialMessages: UI_MESSAGE[] = []) {
     this.#messages = initialMessages;
+    this.#messagesSnapshot = initialMessages;
   }
 
   get status(): ChatStatus {
@@ -46,17 +65,26 @@ class ReactChatState<
 
   set messages(newMessages: UI_MESSAGE[]) {
     this.#messages = [...newMessages];
-    this.#callMessagesCallbacks();
+    this.#scheduleMessagesPublish();
+  }
+
+  /**
+   * The message array reference published to React. It stays stable between
+   * throttle windows so that `useSyncExternalStore`'s `getSnapshot` does not
+   * trip a re-render for updates that have not been flushed yet.
+   */
+  get messagesSnapshot(): UI_MESSAGE[] {
+    return this.#messagesSnapshot;
   }
 
   pushMessage = (message: UI_MESSAGE) => {
     this.#messages = this.#messages.concat(message);
-    this.#callMessagesCallbacks();
+    this.#scheduleMessagesPublish();
   };
 
   popMessage = () => {
     this.#messages = this.#messages.slice(0, -1);
-    this.#callMessagesCallbacks();
+    this.#scheduleMessagesPublish();
   };
 
   replaceMessage = (index: number, message: UI_MESSAGE) => {
@@ -66,7 +94,7 @@ class ReactChatState<
       this.snapshot(message),
       ...this.#messages.slice(index + 1),
     ];
-    this.#callMessagesCallbacks();
+    this.#scheduleMessagesPublish();
   };
 
   snapshot = <T>(value: T): T => structuredClone(value);
@@ -75,12 +103,24 @@ class ReactChatState<
     onChange: () => void,
     throttleWaitMs?: number,
   ): (() => void) => {
-    const callback = throttleWaitMs
-      ? throttle(onChange, throttleWaitMs)
-      : onChange;
-    this.#messagesCallbacks.add(callback);
+    // Configure the throttle window on the state itself, so the published
+    // snapshot and the change notification are throttled together (see
+    // `#publishMessages`). Throttling only the notification would leave
+    // `getSnapshot` returning a fresh array on every chunk, which makes
+    // `useSyncExternalStore` re-render past the throttle whenever the component
+    // re-renders for any reason, and can exceed React's nested update limit
+    // during fast streaming.
+    if (throttleWaitMs !== this.#throttleWaitMs) {
+      this.#throttleWaitMs = throttleWaitMs;
+      this.#throttledPublishMessages = throttle(
+        () => this.#publishMessages(),
+        throttleWaitMs,
+      );
+    }
+
+    this.#messagesCallbacks.add(onChange);
     return () => {
-      this.#messagesCallbacks.delete(callback);
+      this.#messagesCallbacks.delete(onChange);
     };
   };
 
@@ -98,7 +138,14 @@ class ReactChatState<
     };
   };
 
-  #callMessagesCallbacks = () => {
+  #scheduleMessagesPublish = () => {
+    this.#throttledPublishMessages();
+  };
+
+  // Swap the published snapshot to the current messages and notify subscribers.
+  // Doing both together keeps `getSnapshot` consistent with the notifications.
+  #publishMessages = () => {
+    this.#messagesSnapshot = this.#messages;
     this.#messagesCallbacks.forEach(callback => callback());
   };
 
@@ -120,6 +167,15 @@ export class Chat<
     const state = new ReactChatState(messages);
     super({ ...init, state });
     this.#state = state;
+  }
+
+  /**
+   * The throttled messages reference that React subscribes to via
+   * `useSyncExternalStore`. Unlike `messages`, this reference only changes when
+   * a throttled update is published, so it must be used as the store snapshot.
+   */
+  get messagesSnapshot(): UI_MESSAGE[] {
+    return this.#state.messagesSnapshot;
   }
 
   '~registerMessagesCallback' = (

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -145,8 +145,11 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
 
   const messages = useSyncExternalStore(
     subscribeToMessages,
-    () => chatRef.current.messages,
-    () => chatRef.current.messages,
+    // Use the throttled snapshot (not `messages`) so that `getSnapshot` returns
+    // a stable reference between throttle windows. Reading `messages` directly
+    // would return a fresh array on every stream chunk and bypass throttling.
+    () => chatRef.current.messagesSnapshot,
+    () => chatRef.current.messagesSnapshot,
   );
 
   const status = useSyncExternalStore(

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -2388,6 +2388,113 @@ describe('use-chat', () => {
     });
   });
 
+  describe('throttle snapshot stability', () => {
+    const throttleMs = 100;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    setupTestComponent(() => {
+      const { messages, sendMessage, status } = useChat({
+        throttle: throttleMs,
+        generateId: mockId(),
+      });
+      const [, setTick] = useState(0);
+
+      return (
+        <div>
+          <div data-testid="status">{status.toString()}</div>
+          {messages.map((m, idx) => (
+            <div data-testid={`message-${idx}`} key={m.id}>
+              {m.role === 'user' ? 'User: ' : 'AI: '}
+              {m.parts
+                .map(part => (part.type === 'text' ? part.text : ''))
+                .join('')}
+            </div>
+          ))}
+          <button
+            data-testid="do-send"
+            onClick={() => {
+              sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
+            }}
+          />
+          <button
+            data-testid="force-rerender"
+            onClick={() => {
+              setTick(tick => tick + 1);
+            }}
+          />
+        </div>
+      );
+    });
+
+    // Regression test for https://github.com/vercel/ai/issues/6166:
+    // `experimental_throttle`/`throttle` only throttled the subscribe callback,
+    // while `useSyncExternalStore`'s `getSnapshot` returned a fresh `messages`
+    // array on every chunk. Any unrelated re-render then read that fresh
+    // snapshot and re-rendered past the throttle, which could exceed React's
+    // nested update limit during fast streaming.
+    it('does not bypass throttling when the component re-renders for an unrelated reason', async () => {
+      const controller = new TestResponseController();
+
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      fireEvent.click(screen.getByTestId('do-send'));
+      expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
+
+      controller.write(formatChunk({ type: 'text-start', id: '0' }));
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hel' }),
+      );
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(throttleMs + 10);
+      });
+
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hel');
+
+      // Stream another chunk and let the stream reader consume it (advancing a
+      // small amount, well under the throttle window) so the internal buffer
+      // becomes 'Hello' while the throttled publish is still pending.
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'lo' }),
+      );
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10);
+      });
+
+      // Force an unrelated re-render before the throttle window elapses. The
+      // displayed messages must stay throttled and not reflect the buffered
+      // 'lo' chunk (before the fix, `getSnapshot` returned the live `messages`
+      // array here, so this re-render showed 'Hello' immediately).
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('force-rerender'));
+      });
+
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hel');
+      expect(screen.getByTestId('message-1')).not.toHaveTextContent(
+        'AI: Hello',
+      );
+
+      // Once the throttle window elapses, the buffered update is published.
+      controller.write(formatChunk({ type: 'text-end', id: '0' }));
+      await act(async () => {
+        await controller.close();
+        await vi.advanceTimersByTimeAsync(throttleMs + 10);
+      });
+
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
+    });
+  });
+
   describe('experimental_throttle (deprecated)', () => {
     const throttleMs = 50;
 


### PR DESCRIPTION
## Background

`useChat` re-renders past `throttle` / `experimental_throttle` and can hit React's "Maximum update depth exceeded" during streaming on slower devices (Android, heavy markdown, CPU throttling). Reported in #6166.

The root cause is a mismatch between what `experimental_throttle` throttles and what actually drives re-renders. `useChat` subscribes to messages via `useSyncExternalStore`:

```ts
const messages = useSyncExternalStore(
  subscribeToMessages,
  () => chatRef.current.messages, // getSnapshot
  () => chatRef.current.messages,
);
```

The throttle was applied **only to the subscribe callback** (`~registerMessagesCallback`). But `replaceMessage` swaps `#messages` for a **new array on every chunk**, and that is exactly what `getSnapshot()` returned. `useSyncExternalStore` re-reads `getSnapshot()` on every render and, when the reference differs from the rendered one, forces a synchronous re-render (tearing prevention). That path never goes through `subscribe`, so throttling the subscribe callback did not limit it — during streaming the array reference changes on essentially every commit, so React re-renders per chunk regardless of the throttle. Once renders fall behind chunk arrival it trips the nested-update limit.

This matches the reports in the thread: it is machine/load dependent (a threshold, not a hard infinite loop), and raising the throttle / using `chunking: 'line'` / memoizing markdown only reduces how much work each forced render does, rather than capping the re-render count.

## Summary

Keep the published snapshot separate from the internal message buffer so that `getSnapshot()` returns a **stable reference between throttle windows**:

- `ReactChatState` now holds `#messages` (internal buffer, always current — used by `AbstractChat` for slicing/finding/replacing) and a separate `#messagesSnapshot` (the reference React reads).
- Throttling is moved onto the state itself: `#publishMessages` swaps `#messagesSnapshot = #messages` **and** notifies subscribers together, and that whole publish is throttled. So the notification and the snapshot are throttled in lockstep, and `experimental_throttle` behaves as documented.
- `useChat`'s `getSnapshot` now reads `chatRef.current.messagesSnapshot` instead of `messages`.

When throttling is disabled (the default) publishing is synchronous, so behavior is unchanged.

## End-to-End Verification

Reproduced with a long streamed response under Chrome DevTools 6x CPU throttling: before this change, `experimental_throttle: 100` did not prevent "Maximum update depth exceeded"; after it, streaming stays throttled and no longer trips the limit.

The added regression test (`does not bypass throttling when the component re-renders for an unrelated reason`) fails on `main` (an unrelated re-render mid-window shows the un-throttled buffered content) and passes with this change. The full `@ai-sdk/react` suite (90 tests) passes.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #6166