### PR TITLE
fix(harness): complete telemetry event shape for otel

### DIFF
--- a/.changeset/fuzzy-snakes-share.md
+++ b/.changeset/fuzzy-snakes-share.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness": patch
+---
+
+fix(harness): fix telemetry end events to report `final-step` text and reasoning for multi-step turns

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -68,6 +68,8 @@
     }
   },
   "devDependencies": {
+    "@ai-sdk/otel": "workspace:*",
+    "@opentelemetry/sdk-trace-base": "2.7.1",
     "@types/node": "22.19.19",
     "@types/ws": "^8.5.13",
     "@vercel/ai-tsconfig": "workspace:*",

--- a/packages/harness/src/agent/internal/turn-telemetry.ts
+++ b/packages/harness/src/agent/internal/turn-telemetry.ts
@@ -1,6 +1,6 @@
 import { generateId, type ModelMessage } from '@ai-sdk/provider-utils';
 import { createTelemetryDispatcher } from 'ai/internal';
-import type { TelemetryOptions } from 'ai';
+import type { LanguageModelUsage, TelemetryOptions } from 'ai';
 
 /*
  * Drives AI SDK's pluggable `Telemetry` lifecycle from a harness turn.
@@ -92,6 +92,69 @@ const NOOP: TurnTelemetry = {
   async error() {},
 };
 
+function normalizeFinishReason(finishReason: unknown): unknown {
+  if (
+    finishReason != null &&
+    typeof finishReason === 'object' &&
+    'unified' in finishReason
+  ) {
+    return (finishReason as { unified: unknown }).unified;
+  }
+
+  return finishReason;
+}
+
+function addTokenCounts(
+  tokenCount1: number | undefined,
+  tokenCount2: number | undefined,
+): number | undefined {
+  return tokenCount1 == null && tokenCount2 == null
+    ? undefined
+    : (tokenCount1 ?? 0) + (tokenCount2 ?? 0);
+}
+
+function normalizeUsage(usage: unknown): LanguageModelUsage | unknown {
+  if (
+    usage == null ||
+    typeof usage !== 'object' ||
+    !('inputTokens' in usage) ||
+    !('outputTokens' in usage)
+  ) {
+    return usage;
+  }
+
+  const inputTokens = (usage as { inputTokens: unknown }).inputTokens;
+  const outputTokens = (usage as { outputTokens: unknown }).outputTokens;
+
+  if (
+    inputTokens == null ||
+    typeof inputTokens !== 'object' ||
+    outputTokens == null ||
+    typeof outputTokens !== 'object'
+  ) {
+    return usage;
+  }
+
+  const input = inputTokens as Record<string, number | undefined>;
+  const output = outputTokens as Record<string, number | undefined>;
+
+  return {
+    inputTokens: input.total,
+    inputTokenDetails: {
+      noCacheTokens: input.noCache,
+      cacheReadTokens: input.cacheRead,
+      cacheWriteTokens: input.cacheWrite,
+    },
+    outputTokens: output.total,
+    outputTokenDetails: {
+      textTokens: output.text,
+      reasoningTokens: output.reasoning,
+    },
+    totalTokens: addTokenCounts(input.total, output.total),
+    raw: (usage as { raw?: LanguageModelUsage['raw'] }).raw,
+  };
+}
+
 export function createTurnTelemetry(opts: {
   telemetry: TelemetryOptions | undefined;
   harnessId: string;
@@ -119,6 +182,15 @@ export function createTurnTelemetry(opts: {
   let stepOpen = false;
   let stepNumber = 0;
   let ended = false;
+  let finalStepText = '';
+  let finalStepReasoning: Array<{ text: string }> = [];
+  let finalStepProviderMetadata: unknown;
+  let outputToolCalls: Array<{
+    type: 'tool-call';
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+  }> = [];
   /** Tool calls started in the current turn and not yet ended. */
   const openTools = new Map<
     string,
@@ -200,15 +272,38 @@ export function createTurnTelemetry(opts: {
     usage: unknown;
     content: TurnContentPart[];
   }): Promise<void> => {
+    const finishReason = normalizeFinishReason(info.finishReason);
+    const usage = normalizeUsage(info.usage);
+
     await dispatcher.onLanguageModelCallEnd?.(
       cast<'onLanguageModelCallEnd'>({
         callId,
-        finishReason: info.finishReason,
+        finishReason,
         responseId: callId,
-        usage: info.usage,
+        usage,
         content: info.content,
+        performance: {
+          responseTimeMs: undefined,
+          timeToFirstOutputMs: undefined,
+          timeBetweenOutputChunksMs: undefined,
+        },
       }),
     );
+  };
+
+  const recordOutputContent = (content: TurnContentPart[]): void => {
+    finalStepText = '';
+    finalStepReasoning = [];
+
+    for (const part of content) {
+      if (part.type === 'text') {
+        finalStepText += part.text;
+      } else if (part.type === 'reasoning') {
+        finalStepReasoning.push({ text: part.text });
+      } else if (part.type === 'tool-call') {
+        outputToolCalls.push(part);
+      }
+    }
   };
 
   const closeOpenTools = async (): Promise<void> => {
@@ -240,18 +335,22 @@ export function createTurnTelemetry(opts: {
     async stepFinish(info) {
       if (!stepOpen) return;
       const content = info.content ?? [];
+      const finishReason = normalizeFinishReason(info.finishReason);
+      const usage = normalizeUsage(info.usage);
+      recordOutputContent(content);
+      finalStepProviderMetadata = info.providerMetadata;
       await closeOpenTools();
       await inferenceEnd({
-        finishReason: info.finishReason,
-        usage: info.usage,
+        finishReason,
+        usage,
         content,
       });
       await dispatcher.onStepEnd?.(
         cast<'onStepEnd'>({
           callId,
           stepNumber,
-          finishReason: info.finishReason,
-          usage: info.usage,
+          finishReason,
+          usage,
           providerMetadata: info.providerMetadata,
           content,
           response: {
@@ -293,6 +392,9 @@ export function createTurnTelemetry(opts: {
 
     async toolEnd(toolCallId, output) {
       const call = openTools.get(toolCallId);
+      const normalizedOutput = output.ok
+        ? { type: 'tool-result' as const, output: output.output }
+        : { type: 'error' as const, error: output.error };
       if (call == null) return;
       openTools.delete(toolCallId);
       await dispatcher.onToolExecutionEnd?.(
@@ -308,29 +410,29 @@ export function createTurnTelemetry(opts: {
             dynamic: true,
           },
           toolContext: undefined,
-          toolOutput: output.ok
-            ? { type: 'tool-result', output: output.output }
-            : { type: 'error', error: output.error },
+          toolOutput: normalizedOutput,
         }),
       );
     },
 
     async end(info) {
       if (ended) return;
+      const finishReason = normalizeFinishReason(info.finishReason);
+      const usage = normalizeUsage(info.usage);
       if (!started) await fireStart();
       if (stepOpen) {
         await closeOpenTools();
         await inferenceEnd({
-          finishReason: info.finishReason,
-          usage: info.usage,
+          finishReason,
+          usage,
           content: [],
         });
         await dispatcher.onStepEnd?.(
           cast<'onStepEnd'>({
             callId,
             stepNumber,
-            finishReason: info.finishReason,
-            usage: info.usage,
+            finishReason,
+            usage,
             providerMetadata: undefined,
             content: [],
             response: {
@@ -348,10 +450,17 @@ export function createTurnTelemetry(opts: {
         cast<'onEnd'>({
           callId,
           operationId: 'ai.harness',
-          finishReason: info.finishReason,
-          usage: info.usage,
-          totalUsage: info.usage,
+          finishReason,
+          usage,
+          totalUsage: usage,
           content: [],
+          text: finalStepText,
+          finalStep: {
+            reasoning: finalStepReasoning,
+            providerMetadata: finalStepProviderMetadata,
+          },
+          toolCalls: outputToolCalls,
+          files: [],
           steps: new Array(stepNumber),
           response: {
             id: callId,

--- a/packages/harness/src/agent/telemetry-integration.test.ts
+++ b/packages/harness/src/agent/telemetry-integration.test.ts
@@ -1,3 +1,9 @@
+import { OpenTelemetry } from '@ai-sdk/otel';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
 import type { Telemetry } from 'ai';
 import { describe, expect, test } from 'vitest';
 import type {
@@ -86,6 +92,24 @@ function makeSandboxProvider(): HarnessV1SandboxProvider {
   };
 }
 
+function createSdkTracer() {
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+
+  return {
+    exporter,
+    tracer: provider.getTracer('harness-test-tracer'),
+  };
+}
+
+function getExportedSpan(exporter: InMemorySpanExporter, name: string) {
+  const span = exporter.getFinishedSpans().find(span => span.name === name);
+  expect(span).toBeDefined();
+  return span!;
+}
+
 /** A telemetry integration that records the lifecycle methods it receives. */
 function recordingIntegration(): {
   integration: Telemetry;
@@ -171,7 +195,12 @@ describe('HarnessAgent telemetry integration', () => {
 
     // The model's output content reaches the inference-call end (gen_ai output
     // messages): the streamed text and the tool-call, captured non-lossily.
-    const lmEnd = events.onLanguageModelCallEnd as { content: unknown[] };
+    const lmEnd = events.onLanguageModelCallEnd as {
+      content: unknown[];
+      finishReason: unknown;
+      usage: unknown;
+      performance: unknown;
+    };
     expect(lmEnd.content).toEqual([
       { type: 'text', text: 'hi' },
       {
@@ -181,6 +210,49 @@ describe('HarnessAgent telemetry integration', () => {
         input: '{"command":"ls"}',
       },
     ]);
+    expect(lmEnd.performance).toEqual({
+      responseTimeMs: undefined,
+      timeToFirstOutputMs: undefined,
+      timeBetweenOutputChunksMs: undefined,
+    });
+    expect(lmEnd.finishReason).toBe('stop');
+    expect(lmEnd.usage).toEqual({
+      inputTokens: 5,
+      inputTokenDetails: {
+        noCacheTokens: 5,
+        cacheReadTokens: undefined,
+        cacheWriteTokens: undefined,
+      },
+      outputTokens: 2,
+      outputTokenDetails: { textTokens: 2, reasoningTokens: undefined },
+      totalTokens: 7,
+      raw: undefined,
+    });
+
+    const end = events.onEnd as {
+      text: string;
+      finishReason: unknown;
+      usage: unknown;
+      finalStep: { reasoning: unknown[]; providerMetadata: unknown };
+      toolCalls: unknown[];
+      files: unknown[];
+    };
+    expect(end.text).toBe('hi');
+    expect(end.finalStep).toEqual({
+      reasoning: [],
+      providerMetadata: undefined,
+    });
+    expect(end.toolCalls).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'c1',
+        toolName: 'bash',
+        input: '{"command":"ls"}',
+      },
+    ]);
+    expect(end.files).toEqual([]);
+    expect(end.finishReason).toBe('stop');
+    expect(end.usage).toEqual(lmEnd.usage);
     // The input prompt is on the operation start (gen_ai input messages).
     const start = events.onStart as { messages: unknown[] };
     expect(start.messages).toEqual([{ role: 'user', content: 'go' }]);
@@ -188,6 +260,163 @@ describe('HarnessAgent telemetry integration', () => {
     const callIds = new Set(calls.map(c => c.callId));
     expect(callIds.size).toBe(1);
     expect([...callIds][0]).toBeTruthy();
+  });
+
+  test('uses final-step text and reasoning on the telemetry end event', async () => {
+    const harness = scriptedHarness([
+      { type: 'stream-start' },
+      { type: 'text-start', id: 't1' },
+      { type: 'text-delta', id: 't1', delta: 'draft' },
+      { type: 'text-end', id: 't1' },
+      { type: 'reasoning-start', id: 'r1' },
+      { type: 'reasoning-delta', id: 'r1', delta: 'first thought' },
+      { type: 'reasoning-end', id: 'r1' },
+      {
+        type: 'finish-step',
+        finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+        usage,
+      },
+      { type: 'text-start', id: 't2' },
+      { type: 'text-delta', id: 't2', delta: 'final' },
+      { type: 'text-end', id: 't2' },
+      { type: 'reasoning-start', id: 'r2' },
+      { type: 'reasoning-delta', id: 'r2', delta: 'final thought' },
+      { type: 'reasoning-end', id: 'r2' },
+      {
+        type: 'finish-step',
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage,
+      },
+      {
+        type: 'finish',
+        finishReason: { unified: 'stop', raw: 'stop' },
+        totalUsage: usage,
+      },
+    ]);
+
+    const { integration, events } = recordingIntegration();
+    const agent = new HarnessAgent({
+      harness,
+      sandbox: makeSandboxProvider(),
+      telemetry: { integrations: [integration] },
+    });
+    const session = await agent.createSession();
+    await agent.generate({ session, prompt: 'go' });
+    await session.destroy();
+
+    const end = events.onEnd as {
+      text: string;
+      finalStep: { reasoning: unknown[] };
+    };
+    expect(end.text).toBe('final');
+    expect(end.finalStep.reasoning).toEqual([{ text: 'final thought' }]);
+  });
+
+  test('exports normalized OpenTelemetry spans from HarnessAgent turns', async () => {
+    const harness = scriptedHarness([
+      { type: 'stream-start', modelId: 'otel-model' },
+      { type: 'text-start', id: 't1' },
+      { type: 'text-delta', id: 't1', delta: 'draft' },
+      { type: 'text-end', id: 't1' },
+      {
+        type: 'tool-call',
+        toolCallId: 'c1',
+        toolName: 'bash',
+        input: '{"command":"ls"}',
+        providerExecuted: true,
+      },
+      {
+        type: 'tool-result',
+        toolCallId: 'c1',
+        toolName: 'bash',
+        result: { output: 'ok' },
+      },
+      {
+        type: 'finish-step',
+        finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+        usage,
+      },
+      { type: 'text-start', id: 't2' },
+      { type: 'text-delta', id: 't2', delta: 'final' },
+      { type: 'text-end', id: 't2' },
+      {
+        type: 'finish-step',
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage,
+      },
+      {
+        type: 'finish',
+        finishReason: { unified: 'stop', raw: 'stop' },
+        totalUsage: usage,
+      },
+    ]);
+    const { exporter, tracer } = createSdkTracer();
+    const agent = new HarnessAgent({
+      harness,
+      sandbox: makeSandboxProvider(),
+      telemetry: {
+        isEnabled: true,
+        recordInputs: true,
+        recordOutputs: true,
+        integrations: [new OpenTelemetry({ tracer })],
+      },
+    });
+
+    const session = await agent.createSession();
+    await agent.generate({ session, prompt: 'go' });
+    await session.destroy();
+
+    const chatSpan = exporter.getFinishedSpans().find(span => {
+      const finishReasons = span.attributes['gen_ai.response.finish_reasons'];
+      return (
+        span.name === 'chat otel-model' &&
+        Array.isArray(finishReasons) &&
+        (finishReasons as unknown[])[0] === 'stop'
+      );
+    });
+    expect(chatSpan).toBeDefined();
+    const rootSpan = getExportedSpan(exporter, 'ai.harness otel-model');
+
+    expect(chatSpan!.attributes).toMatchObject({
+      'gen_ai.input.messages': JSON.stringify([
+        { role: 'user', parts: [{ type: 'text', content: 'go' }] },
+      ]),
+      'gen_ai.response.finish_reasons': ['stop'],
+      'gen_ai.usage.input_tokens': 5,
+      'gen_ai.usage.output_tokens': 2,
+    });
+    expect(chatSpan!.attributes['gen_ai.output.messages']).toBe(
+      JSON.stringify([
+        {
+          role: 'assistant',
+          parts: [{ type: 'text', content: 'final' }],
+          finish_reason: 'stop',
+        },
+      ]),
+    );
+
+    expect(rootSpan.attributes).toMatchObject({
+      'gen_ai.response.finish_reasons': ['stop'],
+      'gen_ai.usage.input_tokens': 5,
+      'gen_ai.usage.output_tokens': 2,
+    });
+    expect(rootSpan.attributes['gen_ai.output.messages']).toBe(
+      JSON.stringify([
+        {
+          role: 'assistant',
+          parts: [
+            { type: 'text', content: 'final' },
+            {
+              type: 'tool_call',
+              id: 'c1',
+              name: 'bash',
+              arguments: '{"command":"ls"}',
+            },
+          ],
+          finish_reason: 'stop',
+        },
+      ]),
+    );
   });
 
   test('fires no telemetry when settings.telemetry is unset', async () => {

--- a/packages/harness/tsconfig.json
+++ b/packages/harness/tsconfig.json
@@ -14,6 +14,7 @@
   ],
   "references": [
     { "path": "../ai" },
+    { "path": "../otel" },
     { "path": "../provider" },
     { "path": "../provider-utils" }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2636,6 +2636,12 @@ importers:
         specifier: workspace:*
         version: link:../ai
     devDependencies:
+      '@ai-sdk/otel':
+        specifier: workspace:*
+        version: link:../otel
+      '@opentelemetry/sdk-trace-base':
+        specifier: 2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
       '@types/node':
         specifier: 22.19.19
         version: 22.19.19


### PR DESCRIPTION
## Summary
- populate the harness model-call `performance` field before `@ai-sdk/otel` ends the inference span
- include `text`, `finalStep`, `toolCalls`, and `files` on the harness root end event so otel can end/export the operation span
- normalize finish reason and token usage for OpenTelemetry export
- add regression coverage for the compatibility event shape and exported OpenTelemetry spans

Fixes #16658.

Follow-up to #16689, reopened with the reviewed changes on latest `main` and a GitHub-signed commit.

## Test Plan
Verified on #16689 before reopening:
- `pnpm --filter @ai-sdk/harness exec vitest run src/agent/telemetry-integration.test.ts --config vitest.node.config.js`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @ai-sdk/harness type-check`
- `git diff --check`
