### PR TITLE
feat(openai): add blocked domains to web search tool

### DIFF
--- a/.changeset/calm-ravens-search.md
+++ b/.changeset/calm-ravens-search.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): support blocked domain filters for web search

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -539,6 +539,7 @@ const result = await generateText({
       },
       filters: {
         allowedDomains: ['sfchronicle.com', 'sfgate.com'],
+        blockedDomains: ['example.com'],
       },
     }),
   },
@@ -566,8 +567,9 @@ The web search tool supports the following configuration options:
 - **userLocation** - Optional location information to provide geographically relevant results. Includes `type` (always `'approximate'`), `country`, `city`, `region`, and `timezone`.
 - **filters** - Optional filter configuration to restrict search results.
   - **allowedDomains** _string[]_ - Array of allowed domains for the search. Subdomains of the provided domains are automatically included.
+  - **blockedDomains** _string[]_ - Array of blocked domains for the search. Subdomains of the provided domains are automatically excluded.
 
-For detailed information on configuration options see the [OpenAI Web Search Tool documentation](https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses).
+For detailed information on configuration options see the [OpenAI Web Search Tool documentation](https://developers.openai.com/api/docs/guides/tools-web-search#domain-filtering).
 
 #### File Search Tool
 

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -497,7 +497,12 @@ export type OpenAIResponsesTool =
   | {
       type: 'web_search';
       external_web_access: boolean | undefined;
-      filters: { allowed_domains: string[] | undefined } | undefined;
+      filters:
+        | {
+            allowed_domains: string[] | undefined;
+            blocked_domains: string[] | undefined;
+          }
+        | undefined;
       search_context_size: 'low' | 'medium' | 'high' | undefined;
       user_location:
         | {

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -637,6 +637,7 @@ describe('prepareResponsesTools', () => {
               externalWebAccess: true,
               filters: {
                 allowedDomains: ['example.com', 'test.org'],
+                blockedDomains: ['blocked.example'],
               },
               searchContextSize: 'high',
               userLocation: {
@@ -663,6 +664,9 @@ describe('prepareResponsesTools', () => {
                 "allowed_domains": [
                   "example.com",
                   "test.org",
+                ],
+                "blocked_domains": [
+                  "blocked.example",
                 ],
               },
               "search_context_size": "high",
@@ -708,6 +712,7 @@ describe('prepareResponsesTools', () => {
                 "allowed_domains": [
                   "example.com",
                 ],
+                "blocked_domains": undefined,
               },
               "search_context_size": undefined,
               "type": "web_search",

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -204,7 +204,10 @@ export async function prepareResponsesTools({
               type: 'web_search',
               filters:
                 args.filters != null
-                  ? { allowed_domains: args.filters.allowedDomains }
+                  ? {
+                      allowed_domains: args.filters.allowedDomains,
+                      blocked_domains: args.filters.blockedDomains,
+                    }
                   : undefined,
               external_web_access: args.externalWebAccess,
               search_context_size: args.searchContextSize,

--- a/packages/openai/src/tool/web-search.ts
+++ b/packages/openai/src/tool/web-search.ts
@@ -10,7 +10,10 @@ export const webSearchArgsSchema = lazySchema(() =>
     z.object({
       externalWebAccess: z.boolean().optional(),
       filters: z
-        .object({ allowedDomains: z.array(z.string()).optional() })
+        .object({
+          allowedDomains: z.array(z.string()).optional(),
+          blockedDomains: z.array(z.string()).optional(),
+        })
         .optional(),
       searchContextSize: z.enum(['low', 'medium', 'high']).optional(),
       userLocation: z
@@ -142,6 +145,13 @@ export const webSearchToolFactory = createProviderExecutedToolFactory<
        * Subdomains of the provided domains are allowed as well.
        */
       allowedDomains?: string[];
+
+      /**
+       * Blocked domains for the search.
+       * Results from these domains are excluded.
+       * Subdomains of the provided domains are blocked as well.
+       */
+      blockedDomains?: string[];
     };
 
     /**


### PR DESCRIPTION
## Background

OpenAI Responses `web_search` supports `filters.blocked_domains`, but `@ai-sdk/openai` only exposes `allowedDomains`. Consumers currently need to patch the provider to apply a domain blocklist.

OpenAI documents the option in its [web search domain-filtering guide](https://developers.openai.com/api/docs/guides/tools-web-search#domain-filtering).

## Summary

- Add `filters.blockedDomains` to `openai.tools.webSearch()`.
- Forward it to the Responses API as `blocked_domains`.
- Add regression coverage, provider documentation, and a patch changeset.

## Contributor Credit

@TristanJanicki authored the downstream patch and manual verification that surfaced this provider gap.

## End-to-End Verification

Verified in a downstream application: repeated web searches that previously returned Wikipedia stopped returning it when `wikipedia.org` was configured through `blockedDomains`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17898