### PR TITLE
fix: include output-denied in sendAutomaticallyWhen predicate

### DIFF
--- a/.changeset/cs-output-denied-send-automatically.md
+++ b/.changeset/cs-output-denied-send-automatically.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+include output-denied as terminal state in sendAutomaticallyWhen approval predicate

--- a/packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.test.ts
+++ b/packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.test.ts
@@ -228,6 +228,88 @@ describe('lastAssistantMessageIsCompleteWithApprovalResponses', () => {
     ).toBe(false);
   });
 
+  it('should return true when tool approval is denied (output-denied state)', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_1',
+                state: 'output-denied',
+                input: { city: 'Tokyo' },
+                approval: { id: 'approval_1', approved: false },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('should return true mixing denied and approved tools', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_1',
+                state: 'output-denied',
+                input: { city: 'Tokyo' },
+                approval: { id: 'approval_1', approved: false },
+              },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_2',
+                state: 'output-available',
+                input: { city: 'Paris' },
+                output: { temperature: 20, weather: 'cloudy' },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('should return true mixing output-denied with approval-responded', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_1',
+                state: 'approval-responded',
+                input: { city: 'Tokyo' },
+                approval: { id: 'approval_1', approved: true },
+              },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_2',
+                state: 'output-denied',
+                input: { city: 'Paris' },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
   it('should only consider the last step in a multi-step message', () => {
     expect(
       lastAssistantMessageIsCompleteWithApprovalResponses({

--- a/packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.ts
+++ b/packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.ts
@@ -36,6 +36,7 @@ export function lastAssistantMessageIsCompleteWithApprovalResponses({
       part =>
         part.state === 'output-available' ||
         part.state === 'output-error' ||
+        part.state === 'output-denied' ||
         part.state === 'approval-responded',
     )
   );


### PR DESCRIPTION
## Summary

The \lastAssistantMessageIsCompleteWithApprovalResponses\ predicate was missing the \output-denied\ terminal state. When a user denied a tool approval via \ddToolApprovalResponse({ approved: false })\, the predicate permanently returned \alse\ and the chat stalled — never resuming automatically.

## Changes

- Added \output-denied\ to the list of terminal states in the \.every()\ check
- Added 2 regression tests covering denied-only and mixed denied/approved scenarios

## Closes

#13670