### PR TITLE
fix: make rerankingModel optional in Provider type

### DIFF
--- a/.changeset/cs-reranking-model-optional.md
+++ b/.changeset/cs-reranking-model-optional.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+make rerankingModel optional in Provider type to match ProviderV3/ProviderV4

--- a/packages/ai/src/types/provider.ts
+++ b/packages/ai/src/types/provider.ts
@@ -51,5 +51,5 @@ export type Provider = {
    *
    * @throws {NoSuchModelError} If no such model exists.
    */
-  rerankingModel(modelId: string): RerankingModel;
+  rerankingModel?(modelId: string): RerankingModel;
 };


### PR DESCRIPTION
## Summary

The \Provider\ type exported from \i\ had \erankingModel\ as **required**, but \ProviderV3\ and \ProviderV4\ from \@ai-sdk/provider\ have it as **optional** (\?\). This caused type errors when assigning a \ProviderV3\ implementation (e.g. from \@ai-sdk/open-responses\) to a \Provider\ typed variable.

## Changes

- Made \erankingModel\ optional in \packages/ai/src/types/provider.ts\, matching the ProviderV3/V4 spec

## Reproduction

\\\	ypescript
import { createOpenResponses } from '@ai-sdk/open-responses'
import type { Provider } from 'ai'

// TS2322: Type 'OpenResponsesProvider' is not assignable to type 'Provider'.
const provider: Provider = createOpenResponses({ name: 'test', url: '...' })
\\\

## Closes

#13438