### PR TITLE
fix(google): omit unsupported function call IDs

### DIFF
--- a/.changeset/proud-deers-breathe.md
+++ b/.changeset/proud-deers-breathe.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(google): omit unsupported function call IDs

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -76,6 +76,7 @@ function appendToolResultParts(
     { type: 'content' }
   >['value'],
   toolCallId?: string,
+  includeFunctionCallIds = true,
 ): void {
   const functionResponseParts: GoogleFunctionResponsePart[] = [];
   const responseTextParts: string[] = [];
@@ -118,7 +119,9 @@ function appendToolResultParts(
 
   parts.push({
     functionResponse: {
-      ...(toolCallId != null ? { id: toolCallId } : {}),
+      ...(includeFunctionCallIds && toolCallId != null
+        ? { id: toolCallId }
+        : {}),
       name: toolName,
       response: {
         name: toolName,
@@ -147,13 +150,16 @@ function appendLegacyToolResultParts(
     { type: 'content' }
   >['value'],
   toolCallId?: string,
+  includeFunctionCallIds = true,
 ): void {
   for (const contentPart of outputValue) {
     switch (contentPart.type) {
       case 'text':
         parts.push({
           functionResponse: {
-            ...(toolCallId != null ? { id: toolCallId } : {}),
+            ...(includeFunctionCallIds && toolCallId != null
+              ? { id: toolCallId }
+              : {}),
             name: toolName,
             response: {
               name: toolName,
@@ -206,6 +212,7 @@ export function convertToGoogleMessages(
      */
     providerOptionsNames?: readonly string[];
     supportsFunctionResponseParts?: boolean;
+    includeFunctionCallIds?: boolean;
   },
 ): GooglePrompt {
   const systemInstructionParts: Array<{ text: string }> = [];
@@ -218,6 +225,7 @@ export function convertToGoogleMessages(
   const isVertexLike = !providerOptionsNames.includes('google');
   const supportsFunctionResponseParts =
     options?.supportsFunctionResponseParts ?? true;
+  const includeFunctionCallIds = options?.includeFunctionCallIds ?? true;
 
   let sentinelInjected = false;
   const missingSignatureToolNames: string[] = [];
@@ -497,7 +505,7 @@ export function convertToGoogleMessages(
 
                   return {
                     functionCall: {
-                      ...(part.toolCallId != null
+                      ...(includeFunctionCallIds && part.toolCallId != null
                         ? { id: part.toolCallId }
                         : {}),
                       name: part.toolName,
@@ -591,6 +599,7 @@ export function convertToGoogleMessages(
                 part.toolName,
                 output.value,
                 part.toolCallId,
+                includeFunctionCallIds,
               );
             } else {
               appendLegacyToolResultParts(
@@ -598,12 +607,15 @@ export function convertToGoogleMessages(
                 part.toolName,
                 output.value,
                 part.toolCallId,
+                includeFunctionCallIds,
               );
             }
           } else {
             parts.push({
               functionResponse: {
-                ...(part.toolCallId != null ? { id: part.toolCallId } : {}),
+                ...(includeFunctionCallIds && part.toolCallId != null
+                  ? { id: part.toolCallId }
+                  : {}),
                 name: part.toolName,
                 response: {
                   name: part.toolName,

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -610,6 +610,64 @@ describe('doGenerate', () => {
     };
   };
 
+  it('should omit function call IDs from Vertex requests', async () => {
+    prepareJsonResponse({ content: 'done' });
+
+    const vertexModel = new GoogleLanguageModel('gemini-pro', {
+      provider: 'google.vertex.chat',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      headers: { 'x-goog-api-key': 'test-api-key' },
+      generateId: () => 'test-id',
+    });
+
+    await vertexModel.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Look up the answer.' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call_repro_1',
+              toolName: 'lookup',
+              input: { query: 'vertex function id repro' },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_repro_1',
+              toolName: 'lookup',
+              output: {
+                type: 'json',
+                value: { answer: 'known' },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody.contents[1].parts[0].functionCall).toEqual({
+      name: 'lookup',
+      args: { query: 'vertex function id repro' },
+    });
+    expect(requestBody.contents[2].parts[0].functionResponse).toEqual({
+      name: 'lookup',
+      response: {
+        name: 'lookup',
+        content: { answer: 'known' },
+      },
+    });
+  });
+
   it('should send PDF tool result data as inlineData for Gemini 2.5 legacy tool results', async () => {
     server.urls[TEST_URL_GEMINI_2_5_FLASH_LITE].response = {
       type: 'json-value',

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -266,6 +266,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
       onWarning: warning => warnings.push(warning),
       providerOptionsNames,
       supportsFunctionResponseParts: usesGemini3Features,
+      includeFunctionCallIds: !isVertexProvider,
     });
 
     const {


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/15664

`toolCallId` was serialized as both `functionCall.id` and `functionResponse.id` for every Google endpoint, causing Vertex Express Mode to return HTTP 400

## Summary

Vertex requests omit those wire fields while retaining toolCallId internally. Gemini Developer API behavior remains unchanged.

## End-to-End Verification

verified by running the reproduction in the original issue

<details>
<summary>repro:</summary>

```ts
import { createGoogleVertex } from '@ai-sdk/google-vertex';
import { generateText, tool } from 'ai';
import { z } from 'zod';
import { run } from '../../lib/run';

run(async () => {
  const apiKey = process.env.GOOGLE_VERTEX_API_KEY;

  if (!apiKey) {
    throw new Error('GOOGLE_VERTEX_API_KEY is required.');
  }

  const googleVertex = createGoogleVertex({ apiKey });

  const result = await generateText({
    model: googleVertex('gemini-3.5-flash'),
    tools: {
      lookup: tool({
        description: 'Returns a known value for a lookup query.',
        inputSchema: z.object({
          query: z.string(),
        }),
      }),
    },
    messages: [
      {
        role: 'user',
        content: 'Look up the answer.',
      },
      {
        role: 'assistant',
        content: [
          {
            type: 'tool-call',
            toolCallId: 'call_repro_1',
            toolName: 'lookup',
            input: { query: 'vertex function id repro' },
          },
        ],
      },
      {
        role: 'tool',
        content: [
          {
            type: 'tool-result',
            toolCallId: 'call_repro_1',
            toolName: 'lookup',
            output: {
              type: 'json',
              value: { answer: 'known' },
            },
          },
        ],
      },
      {
        role: 'user',
        content: 'Answer briefly.',
      },
    ],
  });

  console.log(result.text);
});
```
</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #15664 

Co-authored-by: onmax <maximogarciamtnez@gmail.com>