### PR TITLE
fix: sanitize User-Agent header for RFC 9110 compliance

### DIFF
--- a/.changeset/cs-user-agent-sanitize.md
+++ b/.changeset/cs-user-agent-sanitize.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/provider-utils": patch
+---
+
+sanitize User-Agent header for RFC 9110 compliance (replace slashes with dots)

--- a/packages/provider-utils/src/get-runtime-environment-user-agent.test.ts
+++ b/packages/provider-utils/src/get-runtime-environment-user-agent.test.ts
@@ -25,6 +25,36 @@ describe('getRuntimeEnvironmentUserAgent', () => {
     ).toBe('runtime/test');
   });
 
+  it('should sanitize slashes in userAgent for RFC 9110 compliance', () => {
+    expect(
+      getRuntimeEnvironmentUserAgent({
+        navigator: {
+          userAgent: 'Bun/1.3.9',
+        },
+      }),
+    ).toBe('runtime/bun.1.3.9');
+  });
+
+  it('should sanitize Deno userAgent with multiple slashes', () => {
+    expect(
+      getRuntimeEnvironmentUserAgent({
+        navigator: {
+          userAgent: 'Deno/2.4.0',
+        },
+      }),
+    ).toBe('runtime/deno.2.4.0');
+  });
+
+  it('should handle userAgent with no slashes', () => {
+    expect(
+      getRuntimeEnvironmentUserAgent({
+        navigator: {
+          userAgent: 'node',
+        },
+      }),
+    ).toBe('runtime/node');
+  });
+
   it('should return the correct user agent for Edge Runtime', () => {
     expect(
       getRuntimeEnvironmentUserAgent({

--- a/packages/provider-utils/src/get-runtime-environment-user-agent.ts
+++ b/packages/provider-utils/src/get-runtime-environment-user-agent.ts
@@ -8,7 +8,7 @@ export function getRuntimeEnvironmentUserAgent(
 
   // Cloudflare Workers / Deno / Bun / Node.js >= 21.1
   if (globalThisAny.navigator?.userAgent) {
-    return `runtime/${globalThisAny.navigator.userAgent.toLowerCase()}`;
+    return `runtime/${globalThisAny.navigator.userAgent.toLowerCase().replace(/\//g, '.')}`;
   }
 
   // Nodes.js < 21.1


### PR DESCRIPTION
## Summary

The runtime user agent string contained unescaped slashes from \
avigator.userAgent\ (e.g. \Bun/1.3.9\), producing an invalid \User-Agent\ header per RFC 9110 Section 5.6.2. Azure OpenAI rejects these headers with a 400 error.

## Changes

- Replace \/\ with \.\ in the navigator.userAgent string to produce valid HTTP product tokens
- Added test case for Bun-style userAgent strings

## Example

Before: \i-sdk/provider-utils/4.0.15 runtime/bun/1.3.9\ (invalid)
After: \i-sdk/provider-utils/4.0.15 runtime/bun.1.3.9\ (valid)

## Closes

#12799