### PR TITLE
fix: aggregate numeric cost in generateImage provider metadata

### DIFF
--- a/.changeset/cs-generate-image-cost.md
+++ b/.changeset/cs-generate-image-cost.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+aggregate numeric cost in generateImage provider metadata across parallel calls

--- a/packages/ai/src/generate-image/generate-image.test.ts
+++ b/packages/ai/src/generate-image/generate-image.test.ts
@@ -932,6 +932,57 @@ describe('generateImage', () => {
       expect(result.providerMetadata.gateway).not.toHaveProperty('images');
     });
 
+    it('should aggregate numeric cost across multiple gateway calls', async () => {
+      let callCount = 0;
+      const result = await generateImage({
+        model: new MockImageModelV4({
+          maxImagesPerCall: 1,
+          doGenerate: async () => {
+            callCount++;
+            return createMockResponse({
+              images: [pngBase64],
+              providerMetaData: {
+                gateway: {
+                  images: [],
+                  cost: 0.02,
+                  generationId: `gen-${callCount}`,
+                },
+              },
+            });
+          },
+        }),
+        prompt,
+        n: 4,
+      });
+
+      expect(result.providerMetadata.gateway).toStrictEqual({
+        cost: 0.08,
+        generationId: 'gen-4',
+      });
+      expect(result.providerMetadata.gateway).not.toHaveProperty('images');
+    });
+
+    it('should not aggregate non-numeric cost values', async () => {
+      const result = await generateImage({
+        model: new MockImageModelV4({
+          maxImagesPerCall: 1,
+          doGenerate: async () => ({
+            images: [pngBase64],
+            providerMetaData: {
+              gateway: {
+                images: [],
+                cost: 'flat-rate',
+              },
+            },
+          }),
+        }),
+        prompt,
+        n: 2,
+      });
+
+      expect(result.providerMetadata.gateway.cost).toBe('flat-rate');
+    });
+
     it('should handle undefined providerMetadata', async () => {
       const result = await generateImage({
         model: new MockImageModelV4({

--- a/packages/ai/src/generate-image/generate-image.ts
+++ b/packages/ai/src/generate-image/generate-image.ts
@@ -223,10 +223,20 @@ export async function generateImage({
         if (providerName === 'gateway') {
           const currentEntry = providerMetadata[providerName];
           if (currentEntry != null && typeof currentEntry === 'object') {
-            providerMetadata[providerName] = {
-              ...(currentEntry as object),
-              ...metadata,
-            } as ImageModelV4ProviderMetadata[string];
+            const merged = { ...(currentEntry as object), ...metadata };
+            const currentObj = currentEntry as Record<string, unknown>;
+            const metadataObj = metadata as Record<string, unknown>;
+            const mergedObj = merged as Record<string, unknown>;
+            if (
+              'cost' in currentObj &&
+              'cost' in metadataObj &&
+              typeof currentObj.cost === 'number' &&
+              typeof metadataObj.cost === 'number'
+            ) {
+              mergedObj.cost = currentObj.cost + metadataObj.cost;
+            }
+            providerMetadata[providerName] =
+              merged as ImageModelV4ProviderMetadata[string];
           } else {
             providerMetadata[providerName] =
               metadata as ImageModelV4ProviderMetadata[string];


### PR DESCRIPTION
## Summary

When \generateImage()\ splits into multiple parallel calls (\
 > maxImagesPerCall\), the gateway \providerMetadata\ was spread-merged, overwriting scalar values like \cost\. If 4 calls each cost \\.02\, the final result reported \\.02\ instead of \\.08\.

## Changes

- Sum numeric \cost\ values across parallel calls instead of overwriting
- Added test case verifying cost aggregation across 4 calls

## Reproduction

\\\	ypescript
const result = await generateImage({
  model: fakeImageModel, // maxImagesPerCall: 1
  prompt: 'a cat',
  n: 4, // 4 calls, each cost .02
});
// Before: result.providerMetadata.gateway.cost === '.02'
// After:  result.providerMetadata.gateway.cost === 0.08
\\\

## Closes

#12796