### PR TITLE
fix(provider/amazon-bedrock): omit tool `strict` and `output_config.format` for Claude models Bedrock rejects them on

### DIFF
--- a/.changeset/bedrock-strict-tools-newest-claude.md
+++ b/.changeset/bedrock-strict-tools-newest-claude.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(provider/amazon-bedrock): omit tool `strict` and `output_config.format` for Claude models Bedrock rejects them on

--- a/packages/amazon-bedrock/src/amazon-bedrock-anthropic-model-support.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-anthropic-model-support.ts
@@ -1,0 +1,23 @@
+export function supportsStrictTools(modelId: string): boolean {
+  return !rejectsNewerSchemaFields(modelId);
+}
+
+export function supportsNativeStructuredOutput(modelId: string): boolean {
+  return !rejectsNewerSchemaFields(modelId);
+}
+
+// Bedrock validates against its own copy of the Messages schema, which rejects
+// `output_config.format` and tool `strict` for the newest Claude models
+const MODELS_REJECTING_NEWER_SCHEMA_FIELDS = [
+  'claude-opus-4-7',
+  'claude-opus-4-8',
+  'claude-opus-5',
+  'claude-fable-5',
+  'claude-sonnet-5',
+];
+
+function rejectsNewerSchemaFields(modelId: string): boolean {
+  return MODELS_REJECTING_NEWER_SCHEMA_FIELDS.some(model =>
+    modelId.includes(model),
+  );
+}

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -98,6 +98,11 @@ const opusAnthropicGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
   opusAnthropicModelId,
 )}/converse`;
 
+const opus5AnthropicModelId = 'us.anthropic.claude-opus-5';
+const opus5AnthropicGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
+  opus5AnthropicModelId,
+)}/converse`;
+
 const server = createTestServer({
   [generateUrl]: {},
   [streamUrl]: {
@@ -112,6 +117,7 @@ const server = createTestServer({
   [openaiGenerateUrl]: {},
   [newerAnthropicGenerateUrl]: {},
   [opusAnthropicGenerateUrl]: {},
+  [opus5AnthropicGenerateUrl]: {},
 });
 
 describe('supportedUrls', () => {
@@ -205,6 +211,16 @@ const newerAnthropicModel = new AmazonBedrockChatLanguageModel(
 
 const opusAnthropicModel = new AmazonBedrockChatLanguageModel(
   opusAnthropicModelId,
+  {
+    baseUrl: () => baseUrl,
+    headers: {},
+    fetch: fakeFetchWithAuth,
+    generateId: () => 'test-id',
+  },
+);
+
+const opus5AnthropicModel = new AmazonBedrockChatLanguageModel(
+  opus5AnthropicModelId,
   {
     baseUrl: () => baseUrl,
     headers: {},
@@ -5064,6 +5080,56 @@ describe('doGenerate', () => {
       ]
     `);
     expect(result.providerMetadata?.bedrock?.isJsonResponseFromTool).toBe(true);
+  });
+
+  it('should use the json tool fallback for claude-opus-5 (Bedrock rejects output_config.format)', async () => {
+    server.urls[opus5AnthropicGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                toolUse: {
+                  toolUseId: 'json-tool-id',
+                  name: 'json',
+                  input: { name: 'Test' },
+                },
+              },
+            ],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+        stopReason: 'tool_use',
+      },
+    };
+
+    await opus5AnthropicModel.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Generate a name' }],
+        },
+      ],
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+          required: ['name'],
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.toolConfig.tools[0].toolSpec.name).toBe('json');
+    expect(
+      requestBody.additionalModelRequestFields?.output_config,
+    ).toBeUndefined();
   });
 
   it('should use native output_config.format for models with structured output support even without thinking enabled', async () => {

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -45,6 +45,7 @@ import {
   type AmazonBedrockLanguageModelChatOptions,
   type AmazonBedrockChatModelId,
 } from './amazon-bedrock-chat-language-model-options';
+import { supportsNativeStructuredOutput } from './amazon-bedrock-anthropic-model-support';
 import { AmazonBedrockErrorSchema } from './amazon-bedrock-error';
 import { createAmazonBedrockEventStreamResponseHandler } from './amazon-bedrock-event-stream-response-handler';
 import { prepareTools } from './amazon-bedrock-prepare-tools';
@@ -193,15 +194,9 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
     const { supportsStructuredOutput: modelSupportsStructuredOutput } =
       getModelCapabilities(this.modelId);
 
-    const modelRejectsNativeStructuredOutput =
-      this.modelId.includes('claude-opus-4-7') ||
-      this.modelId.includes('claude-opus-4-8') ||
-      this.modelId.includes('claude-fable-5') ||
-      this.modelId.includes('claude-sonnet-5');
-
     const useNativeStructuredOutput =
       isAnthropicModel &&
-      !modelRejectsNativeStructuredOutput &&
+      supportsNativeStructuredOutput(this.modelId) &&
       (modelSupportsStructuredOutput || isThinkingEnabled) &&
       responseFormat?.type === 'json' &&
       responseFormat.schema != null;

--- a/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.test.ts
@@ -396,6 +396,28 @@ describe('prepareTools', () => {
       expect((tools[2] as any).toolSpec).not.toHaveProperty('strict');
     });
 
+    it.each([
+      'us.anthropic.claude-opus-5',
+      'anthropic.claude-sonnet-5',
+      'eu.anthropic.claude-fable-5',
+    ])('should omit strict for %s', async modelId => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+        ],
+        modelId,
+      });
+
+      const toolSpec = (result.toolConfig.tools![0] as any).toolSpec;
+      expect(toolSpec).not.toHaveProperty('strict');
+    });
+
     it('should omit strict for claude-opus-4-7', async () => {
       const result = await prepareTools({
         tools: [

--- a/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.ts
@@ -9,6 +9,7 @@ import {
   anthropicTools,
   prepareTools as prepareAnthropicTools,
 } from '@ai-sdk/anthropic/internal';
+import { supportsStrictTools } from './amazon-bedrock-anthropic-model-support';
 import type {
   AmazonBedrockTool,
   AmazonBedrockToolConfiguration,
@@ -133,11 +134,7 @@ export async function prepareTools({
       ? functionTools.filter(t => t.name === toolChoice.toolName)
       : functionTools;
 
-  // Bedrock's Messages API rejects `strict` on tools for these models.
-  // https://docs.aws.amazon.com/bedrock/latest/userguide/count-tokens.html
-  const supportsStrictOnTools =
-    !modelId.includes('claude-opus-4-7') &&
-    !modelId.includes('claude-opus-4-8');
+  const supportsStrictOnTools = supportsStrictTools(modelId);
 
   for (const tool of filteredFunctionTools) {
     amazonBedrockTools.push({

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
@@ -79,6 +79,7 @@ describe('amazon-bedrock-anthropic-provider', () => {
         transformRequestBody: expect.any(Function),
         supportedUrls: expect.any(Function),
         supportsNativeStructuredOutput: true,
+        supportsStrictTools: true,
       }),
     );
   });
@@ -90,6 +91,9 @@ describe('amazon-bedrock-anthropic-provider', () => {
     'anthropic.claude-opus-4-8',
     'us.anthropic.claude-opus-4-8',
     'eu.anthropic.claude-opus-4-8',
+    'anthropic.claude-opus-5',
+    'us.anthropic.claude-opus-5',
+    'eu.anthropic.claude-opus-5',
     'anthropic.claude-fable-5',
     'us.anthropic.claude-fable-5',
     'eu.anthropic.claude-fable-5',
@@ -114,6 +118,60 @@ describe('amazon-bedrock-anthropic-provider', () => {
       );
     },
   );
+
+  it.each([
+    'anthropic.claude-opus-4-7',
+    'us.anthropic.claude-opus-4-7',
+    'eu.anthropic.claude-opus-4-7',
+    'anthropic.claude-opus-4-8',
+    'us.anthropic.claude-opus-4-8',
+    'eu.anthropic.claude-opus-4-8',
+    'anthropic.claude-opus-5',
+    'us.anthropic.claude-opus-5',
+    'eu.anthropic.claude-opus-5',
+    'anthropic.claude-fable-5',
+    'us.anthropic.claude-fable-5',
+    'eu.anthropic.claude-fable-5',
+    'anthropic.claude-sonnet-5',
+    'us.anthropic.claude-sonnet-5',
+    'eu.anthropic.claude-sonnet-5',
+  ])(
+    'should disable strict tools for %s (Bedrock rejects tools[].strict)',
+    modelId => {
+      const provider = createAmazonBedrockAnthropic({
+        region: 'us-east-1',
+        accessKeyId: 'test-key',
+        secretAccessKey: 'test-secret',
+      });
+      provider(modelId as Parameters<typeof provider>[0]);
+
+      expect(AnthropicLanguageModel).toHaveBeenCalledWith(
+        modelId,
+        expect.objectContaining({
+          supportsStrictTools: false,
+        }),
+      );
+    },
+  );
+
+  it.each([
+    'anthropic.claude-sonnet-4-6',
+    'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+  ])('should keep strict tools enabled for %s', modelId => {
+    const provider = createAmazonBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider(modelId as Parameters<typeof provider>[0]);
+
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
+      modelId,
+      expect.objectContaining({
+        supportsStrictTools: true,
+      }),
+    );
+  });
 
   it('should throw an error when using new keyword', () => {
     const provider = createAmazonBedrockAnthropic({

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
@@ -21,6 +21,10 @@ import {
   createSigV4FetchFunction,
   type AmazonBedrockCredentials,
 } from '../amazon-bedrock-sigv4-fetch';
+import {
+  supportsNativeStructuredOutput,
+  supportsStrictTools,
+} from '../amazon-bedrock-anthropic-model-support';
 import { createAmazonBedrockAnthropicFetch } from './amazon-bedrock-anthropic-fetch';
 import type { AmazonBedrockAnthropicModelId } from './amazon-bedrock-anthropic-options';
 import { VERSION } from '../version';
@@ -342,13 +346,8 @@ export function createAmazonBedrockAnthropic(
 
       // Bedrock Anthropic doesn't support URL sources, force download and base64 conversion
       supportedUrls: () => ({}),
-      // native structured output via output_config.format is supported on Bedrock
-      // Bedrock rejects `output_config.format` for `claude-opus-4-7`, `claude-opus-4-8`, `claude-fable-5`, and `claude-sonnet-5`
-      supportsNativeStructuredOutput:
-        !modelId.includes('claude-opus-4-7') &&
-        !modelId.includes('claude-opus-4-8') &&
-        !modelId.includes('claude-fable-5') &&
-        !modelId.includes('claude-sonnet-5'),
+      supportsNativeStructuredOutput: supportsNativeStructuredOutput(modelId),
+      supportsStrictTools: supportsStrictTools(modelId),
     });
 
   const provider = function (modelId: AmazonBedrockAnthropicModelId) {


### PR DESCRIPTION
## Background

Bedrock validates Anthropic requests against its own copy of the Messages schema, which lags the Anthropic API for the newest Claude generation. Requests carrying per-tool `strict` fail with:

```
tools.0.custom.strict: Extra inputs are not permitted
```

#16237 fixed this for `claude-opus-4-7` / `claude-opus-4-8` on the Converse path. Two gaps remained:

1. The `/anthropic` sub-provider (`bedrock.anthropic.messages`, InvokeModel) never set `supportsStrictTools`, so `strict` was forwarded for every model whose capabilities report `supportsStructuredOutput: true`, including all of the models Bedrock rejects it for.
2. `claude-opus-5` was missing from the Converse `strict` denylist and from both `output_config.format` denylists (the `/anthropic` sub-provider and the Converse chat model), so `Output.object()` against opus-5 on Bedrock fails the same way with `output_config.format: Extra inputs are not permitted`.

## Summary

- Added `amazon-bedrock-anthropic-model-support.ts` holding the one list of models whose Bedrock schema rejects these fields (`claude-opus-4-7`, `claude-opus-4-8`, `claude-opus-5`, `claude-fable-5`, `claude-sonnet-5`), so the next Claude launch is a one-line change instead of three.
- `/anthropic` sub-provider: set `supportsStrictTools`, and source `supportsNativeStructuredOutput` from the shared list (adds opus-5).
- Converse `prepareTools`: source the `strict` denylist from the shared list (adds opus-5, sonnet-5, fable-5).
- Converse chat model: source its own `output_config.format` denylist from the shared list, which was the third copy and was also missing opus-5.

Affected models now drop `strict` and emit the existing unsupported-feature warning, matching what `@ai-sdk/google-vertex/anthropic` already does. Models Bedrock accepts `strict` on are unchanged.

## Manual Verification

Live requests against Bedrock (`us-east-1`): a function tool carrying `strict: true`, and a `responseFormat: json` request that drives `output_config.format`.

Every affected model against live Bedrock, both fields, both API paths, published `5.0.31` vs this branch (HTTP status before → after):

| model | InvokeModel `strict` | InvokeModel structured | Converse `strict` | Converse structured |
| --- | --- | --- | --- | --- |
| claude-opus-4-7 | 400 → 200 | 200 → 200 | 200 → 200 | 200 → 200 |
| claude-opus-4-8 | 400 → 200 | 200 → 200 | 200 → 200 | 200 → 200 |
| claude-opus-5 | 400 → 200 | 400 → 200 | 400 → 200 | 400 → 200 |
| claude-fable-5 | 400 → 200 | 200 → 200 | 400 → 200 | 200 → 200 |
| claude-sonnet-5 | 400 → 200 | 200 → 200 | 400 → 200 | 200 → 200 |
| claude-sonnet-4-6 | 200 → 200 | 200 → 200 | 200 → 200 | 200 → 200 |
| claude-haiku-4-5 | 200 → 200 | 200 → 200 | 200 → 200 | 200 → 200 |

`claude-sonnet-4-6` and `claude-haiku-4-5` are the controls: Bedrock accepts both fields there and this branch leaves them alone. On the patched build the outbound bodies confirm the intended split, `strict` forwarded and `output_config.format` used for the two controls, `strict` dropped and the json tool fallback used for the five affected models.

The `claude-opus-5` column is what Zapier is hitting, and it also shows the two sites the earlier fixes missed: `output_config.format` on both paths, plus `strict` on Converse for opus-5, sonnet-5, and fable-5.

Through a local AI Gateway dev server (`/v4/ai`, routing pinned to Bedrock, function tool with `strict: true`), swapping only the `@ai-sdk/amazon-bedrock` build:

| model | published `5.0.31` | this branch |
| --- | --- | --- |
| anthropic/claude-opus-5 | 400 `tools.0.custom.strict: Extra inputs are not permitted` | 200, tool call returned |
| anthropic/claude-sonnet-5 | 400 `tools.0.custom.strict: Extra inputs are not permitted` | 200, tool call returned |

`pnpm test:node` in `packages/amazon-bedrock`: 17 files, 443 tests passed.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Follows #16237, which covered the Converse path for opus-4-7/4-8 only.
