### PR TITLE
Backport: fix(provider/amazon-bedrock): omit tool `strict` and `output_config.format` for Claude models Bedrock rejects them on (#17919)

### DIFF
--- a/.changeset/bedrock-strict-tools-newest-claude.md
+++ b/.changeset/bedrock-strict-tools-newest-claude.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(provider/amazon-bedrock): omit tool `strict` and `output_config.format` for Claude models Bedrock rejects them on

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -72,6 +72,7 @@ describe('bedrock-anthropic-provider', () => {
         transformRequestBody: expect.any(Function),
         supportedUrls: expect.any(Function),
         supportsNativeStructuredOutput: true,
+        supportsStrictTools: true,
       }),
     );
   });
@@ -83,6 +84,9 @@ describe('bedrock-anthropic-provider', () => {
     'anthropic.claude-opus-4-8',
     'us.anthropic.claude-opus-4-8',
     'eu.anthropic.claude-opus-4-8',
+    'anthropic.claude-opus-5',
+    'us.anthropic.claude-opus-5',
+    'eu.anthropic.claude-opus-5',
     'anthropic.claude-fable-5',
     'us.anthropic.claude-fable-5',
     'eu.anthropic.claude-fable-5',
@@ -107,6 +111,60 @@ describe('bedrock-anthropic-provider', () => {
       );
     },
   );
+
+  it.each([
+    'anthropic.claude-opus-4-7',
+    'us.anthropic.claude-opus-4-7',
+    'eu.anthropic.claude-opus-4-7',
+    'anthropic.claude-opus-4-8',
+    'us.anthropic.claude-opus-4-8',
+    'eu.anthropic.claude-opus-4-8',
+    'anthropic.claude-opus-5',
+    'us.anthropic.claude-opus-5',
+    'eu.anthropic.claude-opus-5',
+    'anthropic.claude-fable-5',
+    'us.anthropic.claude-fable-5',
+    'eu.anthropic.claude-fable-5',
+    'anthropic.claude-sonnet-5',
+    'us.anthropic.claude-sonnet-5',
+    'eu.anthropic.claude-sonnet-5',
+  ])(
+    'should disable strict tools for %s (Bedrock rejects tools[].strict)',
+    modelId => {
+      const provider = createBedrockAnthropic({
+        region: 'us-east-1',
+        accessKeyId: 'test-key',
+        secretAccessKey: 'test-secret',
+      });
+      provider(modelId as Parameters<typeof provider>[0]);
+
+      expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+        modelId,
+        expect.objectContaining({
+          supportsStrictTools: false,
+        }),
+      );
+    },
+  );
+
+  it.each([
+    'anthropic.claude-sonnet-4-6',
+    'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+  ])('should keep strict tools enabled for %s', modelId => {
+    const provider = createBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider(modelId as Parameters<typeof provider>[0]);
+
+    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+      modelId,
+      expect.objectContaining({
+        supportsStrictTools: true,
+      }),
+    );
+  });
 
   it('should throw an error when using new keyword', () => {
     const provider = createBedrockAnthropic({

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.ts
@@ -21,6 +21,10 @@ import {
   createSigV4FetchFunction,
   type BedrockCredentials,
 } from '../bedrock-sigv4-fetch';
+import {
+  supportsNativeStructuredOutput,
+  supportsStrictTools,
+} from '../bedrock-anthropic-model-support';
 import { createBedrockAnthropicFetch } from './bedrock-anthropic-fetch';
 import type { BedrockAnthropicModelId } from './bedrock-anthropic-options';
 import { VERSION } from '../version';
@@ -334,13 +338,8 @@ export function createBedrockAnthropic(
 
       // Bedrock Anthropic doesn't support URL sources, force download and base64 conversion
       supportedUrls: () => ({}),
-      // native structured output via output_config.format is supported on Bedrock
-      // Bedrock rejects `output_config.format` for `claude-opus-4-7`, `claude-opus-4-8`, `claude-fable-5`, and `claude-sonnet-5`
-      supportsNativeStructuredOutput:
-        !modelId.includes('claude-opus-4-7') &&
-        !modelId.includes('claude-opus-4-8') &&
-        !modelId.includes('claude-fable-5') &&
-        !modelId.includes('claude-sonnet-5'),
+      supportsNativeStructuredOutput: supportsNativeStructuredOutput(modelId),
+      supportsStrictTools: supportsStrictTools(modelId),
     });
 
   const provider = function (modelId: BedrockAnthropicModelId) {

--- a/packages/amazon-bedrock/src/bedrock-anthropic-model-support.ts
+++ b/packages/amazon-bedrock/src/bedrock-anthropic-model-support.ts
@@ -1,0 +1,23 @@
+export function supportsStrictTools(modelId: string): boolean {
+  return !rejectsNewerSchemaFields(modelId);
+}
+
+export function supportsNativeStructuredOutput(modelId: string): boolean {
+  return !rejectsNewerSchemaFields(modelId);
+}
+
+// Bedrock validates against its own copy of the Messages schema, which rejects
+// `output_config.format` and tool `strict` for the newest Claude models
+const MODELS_REJECTING_NEWER_SCHEMA_FIELDS = [
+  'claude-opus-4-7',
+  'claude-opus-4-8',
+  'claude-opus-5',
+  'claude-fable-5',
+  'claude-sonnet-5',
+];
+
+function rejectsNewerSchemaFields(modelId: string): boolean {
+  return MODELS_REJECTING_NEWER_SCHEMA_FIELDS.some(model =>
+    modelId.includes(model),
+  );
+}

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -111,6 +111,11 @@ const opusAnthropicGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
   opusAnthropicModelId,
 )}/converse`;
 
+const opus5AnthropicModelId = 'us.anthropic.claude-opus-5';
+const opus5AnthropicGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
+  opus5AnthropicModelId,
+)}/converse`;
+
 const server = createTestServer({
   [generateUrl]: {},
   [streamUrl]: {
@@ -127,6 +132,7 @@ const server = createTestServer({
   [openaiGenerateUrl]: {},
   [newerAnthropicGenerateUrl]: {},
   [opusAnthropicGenerateUrl]: {},
+  [opus5AnthropicGenerateUrl]: {},
 });
 
 describe('supportedUrls', () => {
@@ -260,6 +266,16 @@ const opusAnthropicModel = new BedrockChatLanguageModel(opusAnthropicModelId, {
   fetch: fakeFetchWithAuth,
   generateId: () => 'test-id',
 });
+
+const opus5AnthropicModel = new BedrockChatLanguageModel(
+  opus5AnthropicModelId,
+  {
+    baseUrl: () => baseUrl,
+    headers: {},
+    fetch: fakeFetchWithAuth,
+    generateId: () => 'test-id',
+  },
+);
 
 let mockOptions: { success: boolean; errorValue?: any } = { success: true };
 
@@ -4919,6 +4935,56 @@ describe('doGenerate', () => {
       ]
     `);
     expect(result.providerMetadata?.bedrock?.isJsonResponseFromTool).toBe(true);
+  });
+
+  it('should use the json tool fallback for claude-opus-5 (Bedrock rejects output_config.format)', async () => {
+    server.urls[opus5AnthropicGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                toolUse: {
+                  toolUseId: 'json-tool-id',
+                  name: 'json',
+                  input: { name: 'Test' },
+                },
+              },
+            ],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+        stopReason: 'tool_use',
+      },
+    };
+
+    await opus5AnthropicModel.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Generate a name' }],
+        },
+      ],
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+          required: ['name'],
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.toolConfig.tools[0].toolSpec.name).toBe('json');
+    expect(
+      requestBody.additionalModelRequestFields?.output_config,
+    ).toBeUndefined();
   });
 
   it('should use native output_config.format for models with structured output support even without thinking enabled', async () => {

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -38,6 +38,7 @@ import {
   amazonBedrockLanguageModelOptions,
   type BedrockChatModelId,
 } from './bedrock-chat-options';
+import { supportsNativeStructuredOutput } from './bedrock-anthropic-model-support';
 import { BedrockErrorSchema } from './bedrock-error';
 import { createBedrockEventStreamResponseHandler } from './bedrock-event-stream-response-handler';
 import { prepareTools } from './bedrock-prepare-tools';
@@ -151,18 +152,12 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       bedrockOptions.reasoningConfig?.type === 'enabled' ||
       bedrockOptions.reasoningConfig?.type === 'adaptive';
 
-    const modelRejectsNativeStructuredOutput =
-      this.modelId.includes('claude-opus-4-7') ||
-      this.modelId.includes('claude-opus-4-8') ||
-      this.modelId.includes('claude-fable-5') ||
-      this.modelId.includes('claude-sonnet-5');
-
     const { supportsStructuredOutput: modelSupportsStructuredOutput } =
       getModelCapabilities(this.modelId);
 
     const useNativeStructuredOutput =
       isAnthropicModel &&
-      !modelRejectsNativeStructuredOutput &&
+      supportsNativeStructuredOutput(this.modelId) &&
       (modelSupportsStructuredOutput || isThinkingEnabled) &&
       responseFormat?.type === 'json' &&
       responseFormat.schema != null;

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.test.ts
@@ -396,6 +396,28 @@ describe('prepareTools', () => {
       expect((tools[2] as any).toolSpec).not.toHaveProperty('strict');
     });
 
+    it.each([
+      'us.anthropic.claude-opus-5',
+      'anthropic.claude-sonnet-5',
+      'eu.anthropic.claude-fable-5',
+    ])('should omit strict for %s', async modelId => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+        ],
+        modelId,
+      });
+
+      const toolSpec = (result.toolConfig.tools![0] as any).toolSpec;
+      expect(toolSpec).not.toHaveProperty('strict');
+    });
+
     it('should omit strict for claude-opus-4-7', async () => {
       const result = await prepareTools({
         tools: [

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.ts
@@ -9,6 +9,7 @@ import {
   anthropicTools,
   prepareTools as prepareAnthropicTools,
 } from '@ai-sdk/anthropic/internal';
+import { supportsStrictTools } from './bedrock-anthropic-model-support';
 import type {
   BedrockTool,
   BedrockToolConfiguration,
@@ -133,11 +134,7 @@ export async function prepareTools({
       ? functionTools.filter(t => t.name === toolChoice.toolName)
       : functionTools;
 
-  // Bedrock's Messages API rejects `strict` on tools for these models.
-  // https://docs.aws.amazon.com/bedrock/latest/userguide/count-tokens.html
-  const supportsStrictOnTools =
-    !modelId.includes('claude-opus-4-7') &&
-    !modelId.includes('claude-opus-4-8');
+  const supportsStrictOnTools = supportsStrictTools(modelId);
 
   for (const tool of filteredFunctionTools) {
     bedrockTools.push({


### PR DESCRIPTION
Backport of #17919 to `release-v6.0` (`@ai-sdk/amazon-bedrock` 4.x), which is the line the AI Gateway serves v3-protocol traffic from.

## Background

Bedrock rejects per-tool `strict` and `output_config.format` for the newest Claude generation:

```
tools.0.custom.strict: Extra inputs are not permitted
```

#16237 covered the Converse path for `claude-opus-4-7` / `claude-opus-4-8`. The `/anthropic` sub-provider (InvokeModel) never set `supportsStrictTools` at all, and `claude-opus-5` was missing from both denylists.

## Summary

Same change as #17919, with this branch's file and symbol names (`bedrock-*`, `AnthropicMessagesLanguageModel`):

- Added `bedrock-anthropic-model-support.ts` holding the single list of affected models (`claude-opus-4-7`, `claude-opus-4-8`, `claude-opus-5`, `claude-fable-5`, `claude-sonnet-5`).
- `/anthropic` sub-provider: set `supportsStrictTools`, and source `supportsNativeStructuredOutput` from the shared list (adds opus-5).
- Converse `prepareTools`: source the `strict` denylist from the shared list (adds opus-5, sonnet-5, fable-5).
- Converse chat model: source its own `output_config.format` denylist from the shared list (also missing opus-5).

## Manual Verification

Live Bedrock verification (`us-east-1`) is shared with #17919 — every affected model, both fields, both API paths, published vs patched, HTTP status before → after:

| model | InvokeModel `strict` | InvokeModel structured | Converse `strict` | Converse structured |
| --- | --- | --- | --- | --- |
| claude-opus-4-7 | 400 → 200 | 200 → 200 | 200 → 200 | 200 → 200 |
| claude-opus-4-8 | 400 → 200 | 200 → 200 | 200 → 200 | 200 → 200 |
| claude-opus-5 | 400 → 200 | 400 → 200 | 400 → 200 | 400 → 200 |
| claude-fable-5 | 400 → 200 | 200 → 200 | 400 → 200 | 200 → 200 |
| claude-sonnet-5 | 400 → 200 | 200 → 200 | 400 → 200 | 200 → 200 |
| claude-sonnet-4-6 | 200 → 200 | 200 → 200 | 200 → 200 | 200 → 200 |
| claude-haiku-4-5 | 200 → 200 | 200 → 200 | 200 → 200 | 200 → 200 |

`claude-sonnet-4-6` and `claude-haiku-4-5` are the controls: they still send `strict` and still use `output_config.format` on the patched build.

`pnpm test:node` in `packages/amazon-bedrock`: 17 files, 415 tests passed.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
