### PR TITLE
fix(ai): add keepAliveMs option to UI message stream responses

### DIFF
--- a/.changeset/light-lions-shake.md
+++ b/.changeset/light-lions-shake.md
@@ -1,0 +1,16 @@
+---
+'ai': patch
+---
+
+fix (ai): add `keepAliveMs` option to UI message stream responses
+
+`createUIMessageStreamResponse`, `pipeUIMessageStreamToResponse`,
+`result.toUIMessageStreamResponse`, `createAgentUIStreamResponse`, and
+`pipeAgentUIStreamToResponse` accept a `keepAliveMs` option. When it is set, an
+SSE keep-alive comment is sent immediately (so the response headers are flushed
+before the first chunk is available) and whenever the stream has been idle for
+that long.
+
+Without it, the response body stays empty until the stream produces its first
+chunk, so slow or idle streams look like hanging requests to reverse proxies and
+CDNs, which then time them out (e.g. a Cloudflare 524 after 100s).

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -4014,6 +4014,13 @@ To see `streamText` in action, check out [these examples](#examples).
               description:
                 'Function to consume the SSE stream. Required for proper abort handling in UI message streams. Use the `consumeStream` function from the AI SDK.',
             },
+            {
+              name: 'keepAliveMs',
+              type: 'number',
+              isOptional: true,
+              description:
+                'Interval in milliseconds at which SSE keep-alive comments are sent while the stream is idle. A keep-alive comment is also sent immediately, so the response headers are flushed before the first chunk is available. Useful behind reverse proxies that time out idle connections. Disabled by default.',
+            },
           ],
         },
       ],

--- a/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/18-create-agent-ui-stream-response.mdx
@@ -141,6 +141,13 @@ export async function POST(request: Request) {
       description:
         'Optional function to consume the SSE stream. When provided, this function will be called with the SSE stream to handle consumption.',
     },
+    {
+      name: 'keepAliveMs',
+      type: 'number',
+      isRequired: false,
+      description:
+        'Interval in milliseconds at which SSE keep-alive comments are sent while the stream is idle. A keep-alive comment is also sent immediately, so the response headers are flushed before the first chunk is available. Useful behind reverse proxies that time out idle connections. Disabled by default.',
+    },
   ]}
 />
 

--- a/content/docs/07-reference/02-ai-sdk-ui/41-create-ui-message-stream-response.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/41-create-ui-message-stream-response.mdx
@@ -110,6 +110,13 @@ const response = createUIMessageStreamResponse({
       description:
         'Optional callback to consume the Server-Sent Events stream.',
     },
+    {
+      name: 'keepAliveMs',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Interval in milliseconds at which SSE keep-alive comments are sent while the stream is idle. A keep-alive comment is also sent immediately, so the response headers are flushed before the first chunk is available. Disabled by default. See Streaming not working when deployed.',
+    },
   ]}
 />
 

--- a/content/docs/07-reference/02-ai-sdk-ui/42-pipe-ui-message-stream-to-response.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/42-pipe-ui-message-stream-to-response.mdx
@@ -73,6 +73,13 @@ await pipeUIMessageStreamToResponse({
       description:
         'Optional function to consume the SSE stream independently. The stream is teed and this function receives a copy.',
     },
+    {
+      name: 'keepAliveMs',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Interval in milliseconds at which SSE keep-alive comments are sent while the stream is idle. A keep-alive comment is also sent immediately, so the response headers are flushed before the first chunk is available. Disabled by default. See Streaming not working when deployed.',
+    },
   ]}
 />
 

--- a/content/docs/09-troubleshooting/06-streaming-not-working-when-deployed.mdx
+++ b/content/docs/09-troubleshooting/06-streaming-not-working-when-deployed.mdx
@@ -30,3 +30,31 @@ You can try the following:
     },
   });
   ```
+
+- set `keepAliveMs` when you self-host behind a reverse proxy or CDN
+
+  ```tsx
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+    keepAliveMs: 25_000,
+  });
+  ```
+
+  Without `keepAliveMs`, the response body stays empty until the stream produces
+  its first chunk. Many HTTP servers only flush the status line and headers with
+  the first body byte, so a stream that is slow to start (or idle, e.g. a
+  [resumed stream](/docs/ai-sdk-ui/chatbot-resume-streams) at the live edge) can
+  look like a hanging request to a proxy in front of your app, which then times
+  the request out (for example, Cloudflare returns a 524 after 100 seconds).
+  Proxies also terminate connections that stay silent for too long once
+  streaming has started.
+
+  `keepAliveMs` sends an SSE comment immediately, which flushes the response
+  head, and another one whenever the stream has been idle for that long. SSE
+  comments are ignored by the SSE parsers of `useChat` and other clients, so
+  they do not show up in your UI. Pick a value comfortably below the timeout of
+  your proxy, e.g. `25_000` for Cloudflare's 100 second timeout.
+
+  The same option is available on `result.toUIMessageStreamResponse()`,
+  `pipeUIMessageStreamToResponse`, `createAgentUIStreamResponse`, and
+  `pipeAgentUIStreamToResponse`.

--- a/examples/node-http-server/src/server.ts
+++ b/examples/node-http-server/src/server.ts
@@ -59,5 +59,38 @@ createServer(async (req, res) => {
 
       break;
     }
+
+    // keep the connection alive while the stream is idle.
+    // try it with `curl -iN http://localhost:8080/keep-alive`: the response
+    // headers arrive immediately (instead of with the first chunk) and a
+    // `: keep-alive` comment is sent every 2 seconds until the stream produces
+    // its first chunk. this prevents reverse proxies from timing out slow or
+    // idle streams.
+    case '/keep-alive': {
+      const stream = createUIMessageStream({
+        execute: async ({ writer }) => {
+          writer.write({ type: 'start' });
+
+          // simulate a slow start, e.g. a long-running tool call:
+          await new Promise(resolve => setTimeout(resolve, 10_000));
+
+          writer.write({ type: 'text-start', id: 'text-1' });
+          writer.write({
+            type: 'text-delta',
+            id: 'text-1',
+            delta: 'Sorry for the wait!',
+          });
+          writer.write({ type: 'text-end', id: 'text-1' });
+        },
+      });
+
+      pipeUIMessageStreamToResponse({
+        stream,
+        response: res,
+        keepAliveMs: 2_000,
+      });
+
+      break;
+    }
   }
 }).listen(8080);

--- a/packages/ai/src/agent/agent-ui-stream-keep-alive.test.ts
+++ b/packages/ai/src/agent/agent-ui-stream-keep-alive.test.ts
@@ -1,0 +1,73 @@
+import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
+import { describe, expect, it } from 'vitest';
+import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
+import { createMockServerResponse } from '../test/mock-server-response';
+import { createAgentUIStreamResponse } from './create-agent-ui-stream-response';
+import { pipeAgentUIStreamToResponse } from './pipe-agent-ui-stream-to-response';
+import { ToolLoopAgent } from './tool-loop-agent';
+
+function createAgent() {
+  return new ToolLoopAgent({
+    model: new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'text-start', id: '1' },
+          { type: 'text-delta', id: '1', delta: 'Hello' },
+          { type: 'text-end', id: '1' },
+          {
+            type: 'finish',
+            finishReason: { unified: 'stop', raw: 'stop' },
+            usage: {
+              inputTokens: {
+                total: 10,
+                noCache: 10,
+                cacheRead: undefined,
+                cacheWrite: undefined,
+              },
+              outputTokens: { total: 10, text: 10, reasoning: undefined },
+            },
+          },
+        ]),
+      }),
+    }),
+  });
+}
+
+const uiMessages = [
+  { role: 'user', id: 'msg-1', parts: [{ type: 'text' as const, text: 'Hi' }] },
+];
+
+describe('agent UI stream responses', () => {
+  it('should forward keepAliveMs in createAgentUIStreamResponse', async () => {
+    const response = await createAgentUIStreamResponse({
+      agent: createAgent(),
+      uiMessages,
+      keepAliveMs: 25_000,
+    });
+
+    const reader = response
+      .body!.pipeThrough(new TextDecoderStream())
+      .getReader();
+
+    expect(await reader.read()).toEqual({
+      done: false,
+      value: ': keep-alive\n\n',
+    });
+
+    await reader.cancel();
+  });
+
+  it('should forward keepAliveMs in pipeAgentUIStreamToResponse', async () => {
+    const mockResponse = createMockServerResponse();
+
+    await pipeAgentUIStreamToResponse({
+      response: mockResponse,
+      agent: createAgent(),
+      uiMessages,
+      keepAliveMs: 25_000,
+    });
+
+    expect(mockResponse.getDecodedChunks()[0]).toBe(': keep-alive\n\n');
+  });
+});

--- a/packages/ai/src/agent/create-agent-ui-stream-response.ts
+++ b/packages/ai/src/agent/create-agent-ui-stream-response.ts
@@ -34,6 +34,7 @@ import { createAgentUIStream } from './create-agent-ui-stream';
  * @param status - The status code for the response. Optional.
  * @param statusText - The status text for the response. Optional.
  * @param consumeSseStream - Whether to consume the SSE stream. Optional.
+ * @param keepAliveMs - Interval in milliseconds at which SSE keep-alive comments are sent while the stream is idle. Optional.
  *
  * @returns The response object.
  */
@@ -48,6 +49,7 @@ export async function createAgentUIStreamResponse<
   status,
   statusText,
   consumeSseStream,
+  keepAliveMs,
   ...options
 }: {
   agent: Agent<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT, OUTPUT>;
@@ -69,6 +71,7 @@ export async function createAgentUIStreamResponse<
     status,
     statusText,
     consumeSseStream,
+    keepAliveMs,
     stream: await createAgentUIStream(options),
   });
 }

--- a/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
+++ b/packages/ai/src/agent/pipe-agent-ui-stream-to-response.ts
@@ -36,6 +36,7 @@ import { createAgentUIStream } from './create-agent-ui-stream';
  * @param status - The status code for the response. Optional.
  * @param statusText - The status text for the response. Optional.
  * @param consumeSseStream - Whether to consume the SSE stream. Optional.
+ * @param keepAliveMs - Interval in milliseconds at which SSE keep-alive comments are sent while the stream is idle. Optional.
  */
 export async function pipeAgentUIStreamToResponse<
   CALL_OPTIONS = never,
@@ -49,6 +50,7 @@ export async function pipeAgentUIStreamToResponse<
   status,
   statusText,
   consumeSseStream,
+  keepAliveMs,
   ...options
 }: {
   response: ServerResponse;
@@ -72,6 +74,7 @@ export async function pipeAgentUIStreamToResponse<
     status,
     statusText,
     consumeSseStream,
+    keepAliveMs,
     stream: await createAgentUIStream(options),
   });
 }

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -4922,6 +4922,34 @@ describe('streamText', () => {
   });
 
   describe('result.toUIMessageStreamResponse', () => {
+    it('should send keep-alive comments when keepAliveMs is set', async () => {
+      const result = streamText({
+        model: createTestModel(),
+        prompt: 'test-input',
+        _internal: {
+          generateId: mockId({ prefix: 'id' }),
+          generateCallId: () => 'test-telemetry-call-id',
+        },
+      });
+
+      const response = result.toUIMessageStreamResponse({
+        keepAliveMs: 25_000,
+      });
+
+      const reader = response
+        .body!.pipeThrough(new TextDecoderStream())
+        .getReader();
+
+      // the keep-alive comment flushes the response head before the model
+      // produces its first chunk:
+      expect(await reader.read()).toEqual({
+        done: false,
+        value: ': keep-alive\n\n',
+      });
+
+      await reader.cancel();
+    });
+
     it('should create a Response with a data stream', async () => {
       const result = streamText({
         model: createTestModel(),

--- a/packages/ai/src/ui-message-stream/create-keep-alive-sse-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/create-keep-alive-sse-stream.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { InvalidArgumentError } from '../error/invalid-argument-error';
+import { createKeepAliveSseStream } from './create-keep-alive-sse-stream';
+
+const KEEP_ALIVE_COMMENT = ': keep-alive\n\n';
+
+/**
+ * A source stream that stays silent until the test explicitly pushes into it.
+ * This is what an idle stream (e.g. a resumed stream at the live edge) looks
+ * like on the server.
+ */
+function createGatedStream() {
+  let controller!: ReadableStreamDefaultController<string>;
+  const cancel = vi.fn();
+  const read = vi.fn();
+
+  const stream = new ReadableStream<string>({
+    start(controllerArg) {
+      controller = controllerArg;
+    },
+    cancel,
+  });
+
+  // count the reads that the keep-alive stream performs on the source:
+  const getReader = stream.getReader.bind(stream);
+  stream.getReader = (() => {
+    const reader = getReader();
+    const originalRead = reader.read.bind(reader);
+    reader.read = () => {
+      read();
+      return originalRead();
+    };
+    return reader;
+  }) as typeof stream.getReader;
+
+  return {
+    stream,
+    push: (chunk: string) => controller.enqueue(chunk),
+    close: () => controller.close(),
+    error: (error: unknown) => controller.error(error),
+    cancel,
+    read,
+  };
+}
+
+describe('createKeepAliveSseStream', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should enqueue a keep-alive comment before the source emits anything', async () => {
+    const source = createGatedStream();
+
+    const reader = createKeepAliveSseStream({
+      stream: source.stream,
+      keepAliveMs: 25_000,
+    }).getReader();
+
+    expect(await reader.read()).toEqual({
+      done: false,
+      value: KEEP_ALIVE_COMMENT,
+    });
+  });
+
+  it('should enqueue a keep-alive comment for each idle interval', async () => {
+    const source = createGatedStream();
+
+    const reader = createKeepAliveSseStream({
+      stream: source.stream,
+      keepAliveMs: 25_000,
+    }).getReader();
+
+    await reader.read(); // initial keep-alive comment
+
+    for (let i = 0; i < 3; i++) {
+      const read = reader.read();
+      await vi.advanceTimersByTimeAsync(25_000);
+      expect(await read).toEqual({ done: false, value: KEEP_ALIVE_COMMENT });
+    }
+  });
+
+  it('should forward chunks from the source', async () => {
+    const source = createGatedStream();
+
+    const reader = createKeepAliveSseStream({
+      stream: source.stream,
+      keepAliveMs: 25_000,
+    }).getReader();
+
+    await reader.read(); // initial keep-alive comment
+
+    source.push('data: 1\n\n');
+    source.push('data: 2\n\n');
+
+    expect(await reader.read()).toEqual({ done: false, value: 'data: 1\n\n' });
+    expect(await reader.read()).toEqual({ done: false, value: 'data: 2\n\n' });
+  });
+
+  it('should restart the idle interval after a source chunk', async () => {
+    const source = createGatedStream();
+
+    const reader = createKeepAliveSseStream({
+      stream: source.stream,
+      keepAliveMs: 25_000,
+    }).getReader();
+
+    await reader.read(); // initial keep-alive comment
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    source.push('data: 1\n\n');
+    expect(await reader.read()).toEqual({ done: false, value: 'data: 1\n\n' });
+
+    // the remaining 5s of the previous interval must not trigger a keep-alive:
+    const read = reader.read();
+    let resolved = false;
+    read.then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(24_999);
+    expect(resolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(await read).toEqual({ done: false, value: KEEP_ALIVE_COMMENT });
+  });
+
+  it('should close when the source closes', async () => {
+    const source = createGatedStream();
+
+    const reader = createKeepAliveSseStream({
+      stream: source.stream,
+      keepAliveMs: 25_000,
+    }).getReader();
+
+    await reader.read(); // initial keep-alive comment
+
+    source.close();
+
+    expect(await reader.read()).toEqual({ done: true, value: undefined });
+  });
+
+  it('should propagate source errors to the consumer', async () => {
+    const source = createGatedStream();
+
+    const reader = createKeepAliveSseStream({
+      stream: source.stream,
+      keepAliveMs: 25_000,
+    }).getReader();
+
+    await reader.read(); // initial keep-alive comment
+
+    const read = reader.read();
+    source.error(new Error('source failed'));
+
+    await expect(read).rejects.toThrow('source failed');
+  });
+
+  it('should cancel the source when the consumer cancels while a read is pending', async () => {
+    const source = createGatedStream();
+
+    const reader = createKeepAliveSseStream({
+      stream: source.stream,
+      keepAliveMs: 25_000,
+    }).getReader();
+
+    await reader.read(); // initial keep-alive comment
+
+    reader.read(); // pending read on the idle source
+    await vi.advanceTimersByTimeAsync(0);
+
+    await reader.cancel('client disconnected');
+
+    expect(source.cancel).toHaveBeenCalledWith('client disconnected');
+  });
+
+  it('should not queue additional source reads while the source is idle', async () => {
+    const source = createGatedStream();
+
+    const reader = createKeepAliveSseStream({
+      stream: source.stream,
+      keepAliveMs: 25_000,
+    }).getReader();
+
+    await reader.read(); // initial keep-alive comment
+
+    for (let i = 0; i < 5; i++) {
+      const read = reader.read();
+      await vi.advanceTimersByTimeAsync(25_000);
+      await read;
+    }
+
+    // a single outstanding read is reused across all keep-alive intervals:
+    expect(source.read).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    'should throw an InvalidArgumentError for keepAliveMs %s',
+    keepAliveMs => {
+      expect(() =>
+        createKeepAliveSseStream({
+          stream: createGatedStream().stream,
+          keepAliveMs,
+        }),
+      ).toThrow(InvalidArgumentError);
+    },
+  );
+
+  it('should not leave keep-alive timers behind after the source closes', async () => {
+    const source = createGatedStream();
+
+    const reader = createKeepAliveSseStream({
+      stream: source.stream,
+      keepAliveMs: 25_000,
+    }).getReader();
+
+    await reader.read(); // initial keep-alive comment
+
+    source.close();
+    await reader.read();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/ai/src/ui-message-stream/create-keep-alive-sse-stream.ts
+++ b/packages/ai/src/ui-message-stream/create-keep-alive-sse-stream.ts
@@ -1,0 +1,94 @@
+import { InvalidArgumentError } from '../error/invalid-argument-error';
+
+/**
+ * SSE comment that is used to keep the connection alive.
+ *
+ * Lines that start with a colon are comments in the SSE wire format and are
+ * ignored by conforming SSE parsers, so they never reach the client code.
+ */
+const KEEP_ALIVE_COMMENT = ': keep-alive\n\n';
+
+const KEEP_ALIVE = Symbol('keep-alive');
+
+/**
+ * Wraps an SSE stream so that it never stays silent for longer than
+ * `keepAliveMs` milliseconds:
+ *
+ * - a keep-alive comment is enqueued immediately, so the response head is
+ *   flushed even when the source stream has not produced a chunk yet
+ * - a keep-alive comment is enqueued whenever the source stream has been idle
+ *   for `keepAliveMs` milliseconds
+ *
+ * Keep-alive comments are only enqueued when the consumer is ready to receive
+ * data, so backpressure is preserved.
+ */
+export function createKeepAliveSseStream({
+  stream,
+  keepAliveMs,
+}: {
+  stream: ReadableStream<string>;
+  keepAliveMs: number;
+}): ReadableStream<string> {
+  if (!Number.isFinite(keepAliveMs) || keepAliveMs <= 0) {
+    throw new InvalidArgumentError({
+      parameter: 'keepAliveMs',
+      value: keepAliveMs,
+      message: 'keepAliveMs must be a positive number',
+    });
+  }
+
+  const reader = stream.getReader();
+
+  // a single outstanding read is reused across keep-alive intervals,
+  // otherwise reads would pile up on a long-idle source:
+  let pendingRead: Promise<ReadableStreamReadResult<string>> | undefined;
+
+  return new ReadableStream<string>({
+    start(controller) {
+      controller.enqueue(KEEP_ALIVE_COMMENT);
+    },
+
+    async pull(controller) {
+      pendingRead ??= reader.read();
+
+      let keepAliveTimeout: ReturnType<typeof setTimeout> | undefined;
+
+      try {
+        const result = await Promise.race([
+          pendingRead,
+          new Promise<typeof KEEP_ALIVE>(resolve => {
+            keepAliveTimeout = setTimeout(
+              () => resolve(KEEP_ALIVE),
+              keepAliveMs,
+            );
+          }),
+        ]);
+
+        if (result === KEEP_ALIVE) {
+          controller.enqueue(KEEP_ALIVE_COMMENT);
+          return;
+        }
+
+        pendingRead = undefined;
+
+        if (result.done) {
+          controller.close();
+        } else {
+          controller.enqueue(result.value);
+        }
+      } catch (error) {
+        pendingRead = undefined;
+        controller.error(error);
+      } finally {
+        clearTimeout(keepAliveTimeout);
+      }
+    },
+
+    cancel(reason) {
+      pendingRead = undefined;
+      // cancelling through the reader that we hold resolves a pending read
+      // and cancels the source stream through the lock:
+      return reader.cancel(reason);
+    },
+  });
+}

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream-response.test.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream-response.test.ts
@@ -1,3 +1,4 @@
+import { parseJsonEventStream } from '@ai-sdk/provider-utils';
 import {
   convertArrayToReadableStream,
   convertReadableStreamToArray,
@@ -5,6 +6,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TextStreamPart } from '../generate-text/stream-text-result';
 import { createUIMessageStreamResponse } from './create-ui-message-stream-response';
+import { type UIMessageChunk, uiMessageChunkSchema } from './ui-message-chunks';
 import { toUIMessageStream } from './to-ui-message-stream';
 
 describe('createUIMessageStreamResponse', () => {
@@ -275,6 +277,205 @@ describe('createUIMessageStreamResponse', () => {
       ",
       ]
     `);
+  });
+
+  describe('keepAliveMs', () => {
+    /**
+     * A stream that stays silent until the test pushes into it - this is what an
+     * idle stream (e.g. a resumed stream at the live edge) looks like.
+     */
+    function createGatedStream() {
+      let controller!: ReadableStreamDefaultController<UIMessageChunk>;
+      const stream = new ReadableStream<UIMessageChunk>({
+        start(controllerArg) {
+          controller = controllerArg;
+        },
+      });
+      return {
+        stream,
+        push: (chunk: UIMessageChunk) => controller.enqueue(chunk),
+        close: () => controller.close(),
+      };
+    }
+
+    it('should send a keep-alive comment before the stream produces its first chunk', async () => {
+      const source = createGatedStream();
+
+      const response = createUIMessageStreamResponse({
+        stream: source.stream,
+        keepAliveMs: 25_000,
+      });
+
+      const reader = response
+        .body!.pipeThrough(new TextDecoderStream())
+        .getReader();
+
+      // the source has not produced anything yet, but the response body
+      // already has bytes, so the response head is flushed:
+      expect(await reader.read()).toEqual({
+        done: false,
+        value: ': keep-alive\n\n',
+      });
+    });
+
+    it('should send a keep-alive comment for each idle interval', async () => {
+      const source = createGatedStream();
+
+      const response = createUIMessageStreamResponse({
+        stream: source.stream,
+        keepAliveMs: 25_000,
+      });
+
+      const reader = response
+        .body!.pipeThrough(new TextDecoderStream())
+        .getReader();
+
+      await reader.read(); // initial keep-alive comment
+
+      const read = reader.read();
+      await vi.advanceTimersByTimeAsync(25_000);
+
+      expect(await read).toEqual({ done: false, value: ': keep-alive\n\n' });
+    });
+
+    it('should send the stream chunks in between keep-alive comments', async () => {
+      const source = createGatedStream();
+
+      const response = createUIMessageStreamResponse({
+        stream: source.stream,
+        keepAliveMs: 25_000,
+      });
+
+      const reader = response
+        .body!.pipeThrough(new TextDecoderStream())
+        .getReader();
+
+      await reader.read(); // initial keep-alive comment
+
+      source.push({ type: 'text-delta', id: '1', delta: 'test-data' });
+      source.close();
+
+      expect(await reader.read()).toEqual({
+        done: false,
+        value: 'data: {"type":"text-delta","id":"1","delta":"test-data"}\n\n',
+      });
+      expect(await reader.read()).toEqual({
+        done: false,
+        value: 'data: [DONE]\n\n',
+      });
+      expect(await reader.read()).toEqual({ done: true, value: undefined });
+    });
+
+    it('should not send keep-alive comments when keepAliveMs is not set', async () => {
+      const response = createUIMessageStreamResponse({
+        stream: convertArrayToReadableStream([
+          { type: 'text-delta', id: '1', delta: 'test-data' },
+        ]),
+      });
+
+      expect(
+        await convertReadableStreamToArray(
+          response.body!.pipeThrough(new TextDecoderStream()),
+        ),
+      ).toEqual([
+        'data: {"type":"text-delta","id":"1","delta":"test-data"}\n\n',
+        'data: [DONE]\n\n',
+      ]);
+    });
+
+    it('should not send keep-alive comments to consumeSseStream', async () => {
+      const consumedData: string[] = [];
+      const source = createGatedStream();
+
+      const response = createUIMessageStreamResponse({
+        stream: source.stream,
+        keepAliveMs: 25_000,
+        consumeSseStream: async ({ stream }) => {
+          consumedData.push(...(await convertReadableStreamToArray(stream)));
+        },
+      });
+
+      const reader = response
+        .body!.pipeThrough(new TextDecoderStream())
+        .getReader();
+
+      await reader.read(); // initial keep-alive comment
+
+      const keepAlive = reader.read();
+      await vi.advanceTimersByTimeAsync(25_000);
+      await keepAlive;
+
+      source.push({ type: 'text-delta', id: '1', delta: 'test-data' });
+      source.close();
+
+      while (!(await reader.read()).done) {
+        // drain the response body
+      }
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(consumedData).toEqual([
+        'data: {"type":"text-delta","id":"1","delta":"test-data"}\n\n',
+        'data: [DONE]\n\n',
+      ]);
+    });
+
+    it('should send keep-alive comments that SSE clients ignore', async () => {
+      const source = createGatedStream();
+
+      const response = createUIMessageStreamResponse({
+        stream: source.stream,
+        keepAliveMs: 25_000,
+      });
+
+      // parse the response the same way the UI transports do:
+      const chunks = parseJsonEventStream({
+        stream: response.body!,
+        schema: uiMessageChunkSchema,
+      });
+
+      const reader = chunks.getReader();
+
+      const read = reader.read();
+      await vi.advanceTimersByTimeAsync(25_000); // one idle interval
+      source.push({ type: 'text-delta', id: '1', delta: 'test-data' });
+      source.close();
+
+      // the keep-alive comments are not visible to the client:
+      expect(await read).toEqual({
+        done: false,
+        value: {
+          success: true,
+          value: { type: 'text-delta', id: '1', delta: 'test-data' },
+          rawValue: { type: 'text-delta', id: '1', delta: 'test-data' },
+        },
+      });
+      expect(await reader.read()).toEqual({ done: true, value: undefined });
+    });
+
+    it('should cancel the stream when the client disconnects', async () => {
+      let cancelReason: unknown;
+      const stream = new ReadableStream<UIMessageChunk>({
+        cancel(reason) {
+          cancelReason = reason;
+        },
+      });
+
+      const response = createUIMessageStreamResponse({
+        stream,
+        keepAliveMs: 25_000,
+      });
+
+      const reader = response.body!.getReader();
+      await reader.read(); // initial keep-alive comment
+      reader.read(); // pending read on the idle stream
+      await vi.advanceTimersByTimeAsync(0);
+
+      await reader.cancel('client disconnected');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(cancelReason).toBe('client disconnected');
+    });
   });
 
   it('should handle consumeSseStream errors gracefully', async () => {

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream-response.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream-response.ts
@@ -1,4 +1,5 @@
 import { prepareHeaders } from '../util/prepare-headers';
+import { createKeepAliveSseStream } from './create-keep-alive-sse-stream';
 import { JsonToSseTransformStream } from './json-to-sse-transform-stream';
 import { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
 import type { UIMessageChunk } from './ui-message-chunks';
@@ -13,6 +14,7 @@ import type { UIMessageStreamResponseInit } from './ui-message-stream-response-i
  * @param options.headers - Additional HTTP headers to include in the response.
  * @param options.stream - The UI message chunk stream to send.
  * @param options.consumeSseStream - Optional callback to consume a copy of the SSE stream independently.
+ * @param options.keepAliveMs - Optional interval in milliseconds at which SSE keep-alive comments are sent while the stream is idle.
  *
  * @returns A `Response` object with the UI message stream as the body.
  */
@@ -22,6 +24,7 @@ export function createUIMessageStreamResponse({
   headers,
   stream,
   consumeSseStream,
+  keepAliveMs,
 }: UIMessageStreamResponseInit & {
   stream: ReadableStream<UIMessageChunk>;
 }): Response {
@@ -34,6 +37,12 @@ export function createUIMessageStreamResponse({
     const [stream1, stream2] = sseStream.tee();
     sseStream = stream1;
     consumeSseStream({ stream: stream2 }); // no await (do not block the response)
+  }
+
+  // keep-alive comments are transport-level and added after the tee,
+  // so they are not sent to consumeSseStream:
+  if (keepAliveMs != null) {
+    sseStream = createKeepAliveSseStream({ stream: sseStream, keepAliveMs });
   }
 
   return new Response(sseStream.pipeThrough(new TextEncoderStream()), {

--- a/packages/ai/src/ui-message-stream/pipe-ui-message-stream-to-response.test.ts
+++ b/packages/ai/src/ui-message-stream/pipe-ui-message-stream-to-response.test.ts
@@ -3,9 +3,60 @@ import { createMockServerResponse } from '../test/mock-server-response';
 import type { TextStreamPart } from '../generate-text/stream-text-result';
 import { pipeUIMessageStreamToResponse } from './pipe-ui-message-stream-to-response';
 import { toUIMessageStream } from './to-ui-message-stream';
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UIMessageChunk } from './ui-message-chunks';
 
 describe('pipeUIMessageStreamToResponse', () => {
+  describe('keepAliveMs', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should write a keep-alive comment before the stream produces its first chunk', async () => {
+      const mockResponse = createMockServerResponse();
+
+      pipeUIMessageStreamToResponse({
+        response: mockResponse,
+        // a stream that never produces anything:
+        stream: new ReadableStream<UIMessageChunk>(),
+        keepAliveMs: 25_000,
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockResponse.getDecodedChunks()).toEqual([': keep-alive\n\n']);
+
+      await vi.advanceTimersByTimeAsync(25_000);
+
+      expect(mockResponse.getDecodedChunks()).toEqual([
+        ': keep-alive\n\n',
+        ': keep-alive\n\n',
+      ]);
+    });
+
+    it('should not write keep-alive comments when keepAliveMs is not set', async () => {
+      const mockResponse = createMockServerResponse();
+
+      pipeUIMessageStreamToResponse({
+        response: mockResponse,
+        stream: convertArrayToReadableStream([
+          { type: 'text-delta', id: '1', delta: 'test-data' },
+        ]),
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockResponse.getDecodedChunks()).toEqual([
+        'data: {"type":"text-delta","id":"1","delta":"test-data"}\n\n',
+        'data: [DONE]\n\n',
+      ]);
+    });
+  });
+
   it('should write to ServerResponse with correct headers and encoded stream', async () => {
     const mockResponse = createMockServerResponse();
 

--- a/packages/ai/src/ui-message-stream/pipe-ui-message-stream-to-response.ts
+++ b/packages/ai/src/ui-message-stream/pipe-ui-message-stream-to-response.ts
@@ -1,6 +1,7 @@
 import type { ServerResponse } from 'node:http';
 import { prepareHeaders } from '../util/prepare-headers';
 import { writeToServerResponse } from '../util/write-to-server-response';
+import { createKeepAliveSseStream } from './create-keep-alive-sse-stream';
 import { JsonToSseTransformStream } from './json-to-sse-transform-stream';
 import { UI_MESSAGE_STREAM_HEADERS } from './ui-message-stream-headers';
 import type { UIMessageChunk } from './ui-message-chunks';
@@ -16,6 +17,7 @@ import type { UIMessageStreamResponseInit } from './ui-message-stream-response-i
  * @param options.headers - Additional HTTP headers to include in the response.
  * @param options.stream - The UI message chunk stream to send.
  * @param options.consumeSseStream - Optional callback to consume a copy of the SSE stream independently.
+ * @param options.keepAliveMs - Optional interval in milliseconds at which SSE keep-alive comments are sent while the stream is idle.
  * @returns A promise that resolves when the stream has been written.
  */
 export function pipeUIMessageStreamToResponse({
@@ -25,6 +27,7 @@ export function pipeUIMessageStreamToResponse({
   headers,
   stream,
   consumeSseStream,
+  keepAliveMs,
 }: {
   response: ServerResponse;
   stream: ReadableStream<UIMessageChunk>;
@@ -38,6 +41,12 @@ export function pipeUIMessageStreamToResponse({
     const [stream1, stream2] = sseStream.tee();
     sseStream = stream1;
     consumeSseStream({ stream: stream2 }); // no await (do not block the response)
+  }
+
+  // keep-alive comments are transport-level and added after the tee,
+  // so they are not sent to consumeSseStream:
+  if (keepAliveMs != null) {
+    sseStream = createKeepAliveSseStream({ stream: sseStream, keepAliveMs });
   }
 
   return writeToServerResponse({

--- a/packages/ai/src/ui-message-stream/ui-message-stream-response-init.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-stream-response-init.ts
@@ -11,4 +11,21 @@ export type UIMessageStreamResponseInit = ResponseInit & {
   consumeSseStream?: (options: {
     stream: ReadableStream<string>;
   }) => PromiseLike<void> | void;
+
+  /**
+   * Interval in milliseconds at which SSE keep-alive comments are sent while
+   * the stream is idle. A keep-alive comment is also sent immediately, so that
+   * the response headers are flushed before the first chunk is available.
+   *
+   * Keep-alive comments are ignored by SSE clients (they are comments in the
+   * SSE wire format) and are not sent to `consumeSseStream`.
+   *
+   * This is useful when the response is served through a reverse proxy or CDN
+   * that terminates connections that are idle or have not started sending a
+   * response yet. Choose a value comfortably below the proxy timeout,
+   * e.g. `25000` for the 100s Cloudflare timeout.
+   *
+   * Keep-alive comments are disabled by default.
+   */
+  keepAliveMs?: number;
 };


### PR DESCRIPTION
Fixes #17805.

## Problem

A UI message stream response writes nothing to the response body until the source stream produces its first chunk. Most HTTP servers only flush the status line and headers with the first body byte, so a stream that is slow to start — or idle, e.g. a resumed stream sitting at the live edge of an idle run — looks like a hanging request to a reverse proxy or CDN, which then times it out (Cloudflare returns a 524 after 100s, and the origin logs a 0-byte 499). Proxies also sever connections that stay silent for too long after streaming has started.

Reproduced on `main` with a Node server and two identical routes over a stream that never emits:

```
/no-keep-alive:   NO RESPONSE HEADERS after 6.01s (request hangs)
/with-keep-alive: headers after 0.01s -> 200
   first body bytes: b': keep-alive\n\n' at 0.01s
```

## Fix

A new `keepAliveMs` option on `UIMessageStreamResponseInit`. When set, an SSE keep-alive comment is sent immediately — which flushes the response head — and again whenever the stream has been idle for that long:

```ts
return createUIMessageStreamResponse({
  stream: toUIMessageStream({ stream: result.stream }),
  keepAliveMs: 25_000, // comfortably below Cloudflare's 100s timeout
});
```

Available on `createUIMessageStreamResponse`, `pipeUIMessageStreamToResponse`, `result.toUIMessageStreamResponse`, `createAgentUIStreamResponse`, and `pipeAgentUIStreamToResponse`. Disabled by default — no behavior change unless the option is set.

Implementation notes (`packages/ai/src/ui-message-stream/create-keep-alive-sse-stream.ts`):

- Comments are injected at the SSE string layer, after `JsonToSseTransformStream`, so they are raw wire bytes and never pass through the JSON chunk encoder.
- They are added **after** the `consumeSseStream` tee, so a persisted/resumable copy of the stream is byte-identical to today.
- A manual pump rather than `pipeTo`, because periodic writes can't be injected while `pipeTo` holds the lock. Comments are only enqueued from `pull`, so backpressure is preserved — a consumer that isn't reading gets no keep-alives.
- One outstanding `read()` is reused across intervals (a fresh read per interval piles up unbounded reads on a long-idle source), and each race's timer is cleared.
- Cancellation goes through the reader the wrapper holds — `reader.cancel(reason)` is what resolves a pending read and cancels the source through the lock. Source errors propagate to the client instead of leaving a silently dead stream.

## Verification

- `packages/ai`: 3297 tests pass (node + edge), `pnpm check` and `pnpm type-check:full` clean.
- New tests cover: first-byte flush against a gated (silent) source, one comment per idle interval, interval reset after a real chunk, backpressure, close, source-error propagation, client-disconnect cancellation, single-pending-read, no leaked timers, `consumeSseStream` isolation, and forwarding through the `streamText`/agent entry points.
- The keep-alive comments are invisible to clients: a test pipes the response through the SDK's own `parseJsonEventStream` (what `DefaultChatTransport` and `useChat` use) and asserts only the real chunks come out. Each of the load-bearing tests was mutation-checked — reverting the corresponding line makes it fail.
- Ran the new `examples/node-http-server` route end to end (`/keep-alive`): headers at 0.01s, a `: keep-alive` comment every 2s through a 10s idle period, then the real chunks.

Docs: the `keepAliveMs` parameter is documented on the four reference pages, and the "Streaming Not Working When Deployed" troubleshooting page explains the proxy failure mode.

## Notes for maintainers

- **API shape is the open question.** This implements the `keepAliveMs` opt-in from the issue, where one option covers both the immediate flush and the idle heartbeat. If you'd rather have the prelude always on (it costs 14 bytes and is spec-invisible) with only the heartbeat opt-in, or split the two into separate options, both are small changes on top of this — happy to adjust.
- `keepAliveMs <= 0` / non-finite throws `InvalidArgumentError` rather than spinning.
- I read CONTRIBUTING and I'm aware maintainers may prefer to prepare the final fix themselves; the issue (#17805) has the full write-up, and this PR is offered as a complete implementation with tests if that's useful.
- Context: we've been running an equivalent prelude + 25s heartbeat pump in production (Next.js standalone on Railway behind Cloudflare) since the incident that prompted the issue. The lessons above — reused pending read, timer cleanup, cancel-through-the-reader — are all things that bit us there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
