### PR TITLE
feat(provider/cartesia): support additional streaming PCM encodings

### DIFF
--- a/.changeset/tidy-pumas-listen.md
+++ b/.changeset/tidy-pumas-listen.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cartesia': patch
+---
+
+feat(provider/cartesia): support additional Ink 2 streaming PCM encodings

--- a/content/providers/01-ai-sdk-providers/95-cartesia.mdx
+++ b/content/providers/01-ai-sdk-providers/95-cartesia.mdx
@@ -246,6 +246,26 @@ Ink 2 supports English audio and uses Cartesia's native turn detection by
 default. To finalize only when the input audio stream ends, pass
 `providerOptions.cartesia.streaming.turnDetection: false`.
 
+By default, the provider maps `audio/pcm`, `audio/pcmu`, and `audio/pcma` to
+16-bit PCM, G.711 μ-law, and G.711 A-law respectively. To stream another raw
+PCM representation, set `providerOptions.cartesia.streaming.encoding` to
+`pcm_s32le`, `pcm_f16le`, or `pcm_f32le`. For example:
+
+```ts
+const result = streamTranscribe({
+  model: cartesia.transcription('ink-2'),
+  audio,
+  inputAudioFormat: { type: 'audio/pcm', rate: 48000 },
+  providerOptions: {
+    cartesia: {
+      streaming: {
+        encoding: 'pcm_f32le',
+      },
+    },
+  },
+});
+```
+
 See [Transcription](/docs/ai-sdk-core/transcription) for more information about
 streaming transcription.
 

--- a/packages/cartesia/src/cartesia-transcription-model-options.ts
+++ b/packages/cartesia/src/cartesia-transcription-model-options.ts
@@ -10,6 +10,20 @@ export const cartesiaTranscriptionModelOptionsSchema = z.object({
   streaming: z
     .object({
       /**
+       * Raw audio encoding sent to Ink 2. Defaults to the encoding inferred
+       * from `inputAudioFormat.type`.
+       */
+      encoding: z
+        .enum([
+          'pcm_alaw',
+          'pcm_f16le',
+          'pcm_f32le',
+          'pcm_mulaw',
+          'pcm_s16le',
+          'pcm_s32le',
+        ])
+        .optional(),
+      /**
        * Use Cartesia's native turn detection endpoint. Defaults to true.
        * Disable this to finalize the transcript only when the audio stream ends.
        */

--- a/packages/cartesia/src/cartesia-transcription-model-options.ts
+++ b/packages/cartesia/src/cartesia-transcription-model-options.ts
@@ -1,5 +1,15 @@
 import { z } from 'zod/v4';
 
+/** Raw audio encodings accepted by Ink 2 streaming transcription. */
+export const cartesiaStreamingEncodingSchema = z.enum([
+  'pcm_alaw',
+  'pcm_f16le',
+  'pcm_f32le',
+  'pcm_mulaw',
+  'pcm_s16le',
+  'pcm_s32le',
+]);
+
 // https://docs.cartesia.ai/api-reference/stt/transcribe
 export const cartesiaTranscriptionModelOptionsSchema = z.object({
   /** The language of the audio (ISO 639-1 code). Defaults to English. */
@@ -13,16 +23,7 @@ export const cartesiaTranscriptionModelOptionsSchema = z.object({
        * Raw audio encoding sent to Ink 2. Defaults to the encoding inferred
        * from `inputAudioFormat.type`.
        */
-      encoding: z
-        .enum([
-          'pcm_alaw',
-          'pcm_f16le',
-          'pcm_f32le',
-          'pcm_mulaw',
-          'pcm_s16le',
-          'pcm_s32le',
-        ])
-        .optional(),
+      encoding: cartesiaStreamingEncodingSchema.optional(),
       /**
        * Use Cartesia's native turn detection endpoint. Defaults to true.
        * Disable this to finalize the transcript only when the audio stream ends.

--- a/packages/cartesia/src/cartesia-transcription-model.test.ts
+++ b/packages/cartesia/src/cartesia-transcription-model.test.ts
@@ -349,6 +349,30 @@ describe('doStream', () => {
     });
   });
 
+  it.each(['pcm_f16le', 'pcm_f32le', 'pcm_s32le'] as const)(
+    'supports the %s streaming PCM encoding',
+    async encoding => {
+      const provider = createCartesia({
+        apiKey: 'test-api-key',
+        webSocket: MockWebSocket,
+      });
+      const result = await provider.transcription('ink-2').doStream!({
+        audio: convertArrayToReadableStream([]),
+        inputAudioFormat: { type: 'audio/pcm', rate: 48000 },
+        providerOptions: {
+          cartesia: {
+            streaming: { encoding },
+          },
+        },
+      });
+
+      expect(
+        new URL(MockWebSocket.instances[0].url).searchParams.get('encoding'),
+      ).toBe(encoding);
+      await result.stream.cancel();
+    },
+  );
+
   it('rejects unsupported model operations and Ink 2 languages', async () => {
     const provider = createCartesia({
       apiKey: 'test-api-key',

--- a/packages/cartesia/src/cartesia-transcription-model.test.ts
+++ b/packages/cartesia/src/cartesia-transcription-model.test.ts
@@ -350,7 +350,7 @@ describe('doStream', () => {
   });
 
   it.each(['pcm_f16le', 'pcm_f32le', 'pcm_s32le'] as const)(
-    'supports the %s streaming PCM encoding',
+    'supports the %s streaming PCM encoding without a warning',
     async encoding => {
       const provider = createCartesia({
         apiKey: 'test-api-key',
@@ -366,12 +366,79 @@ describe('doStream', () => {
         },
       });
 
-      expect(
-        new URL(MockWebSocket.instances[0].url).searchParams.get('encoding'),
-      ).toBe(encoding);
-      await result.stream.cancel();
+      const ws = MockWebSocket.instances[0];
+      expect(new URL(ws.url).searchParams.get('encoding')).toBe(encoding);
+
+      // Widening generic `audio/pcm` is the intended use — no warning.
+      const reader = result.stream.getReader();
+      ws.open();
+      await flush();
+      const first = await reader.read();
+      expect(first.value).toEqual({ type: 'stream-start', warnings: [] });
+      await reader.cancel();
     },
   );
+
+  it('still validates inputAudioFormat.type when streaming.encoding is set', async () => {
+    const provider = createCartesia({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    });
+
+    // The explicit encoding must not bypass the media-type allowlist.
+    await expect(
+      provider.transcription('ink-2').doStream!({
+        audio: convertArrayToReadableStream([]),
+        inputAudioFormat: { type: 'audio/mpeg', rate: 44100 },
+        providerOptions: {
+          cartesia: {
+            streaming: { encoding: 'pcm_s16le' },
+          },
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: 'AI_InvalidArgumentError',
+      message: expect.stringContaining(
+        'Unsupported Cartesia streaming audio format: audio/mpeg',
+      ),
+    });
+  });
+
+  it('warns when streaming.encoding contradicts the declared audio format', async () => {
+    const provider = createCartesia({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    });
+    const result = await provider.transcription('ink-2').doStream!({
+      audio: convertArrayToReadableStream([]),
+      inputAudioFormat: { type: 'audio/pcmu', rate: 8000 },
+      providerOptions: {
+        cartesia: {
+          streaming: { encoding: 'pcm_f32le' },
+        },
+      },
+    });
+
+    // The override wins on the wire, but the contradiction is surfaced.
+    const ws = MockWebSocket.instances[0];
+    expect(new URL(ws.url).searchParams.get('encoding')).toBe('pcm_f32le');
+
+    const reader = result.stream.getReader();
+    ws.open();
+    await flush();
+    const first = await reader.read();
+    expect(first.value).toEqual({
+      type: 'stream-start',
+      warnings: [
+        {
+          type: 'other',
+          message:
+            "providerOptions.cartesia.streaming.encoding 'pcm_f32le' contradicts inputAudioFormat.type 'audio/pcmu' (inferred 'pcm_mulaw'); sending 'pcm_f32le'.",
+        },
+      ],
+    });
+    await reader.cancel();
+  });
 
   it('rejects unsupported model operations and Ink 2 languages', async () => {
     const provider = createCartesia({

--- a/packages/cartesia/src/cartesia-transcription-model.test.ts
+++ b/packages/cartesia/src/cartesia-transcription-model.test.ts
@@ -440,6 +440,42 @@ describe('doStream', () => {
     await reader.cancel();
   });
 
+  it('warns when generic audio/pcm is overridden to a G.711 encoding', async () => {
+    const provider = createCartesia({
+      apiKey: 'test-api-key',
+      webSocket: MockWebSocket,
+    });
+    const result = await provider.transcription('ink-2').doStream!({
+      audio: convertArrayToReadableStream([]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 8000 },
+      providerOptions: {
+        cartesia: {
+          streaming: { encoding: 'pcm_mulaw' },
+        },
+      },
+    });
+
+    // Only linear PCM widths widen `audio/pcm` silently — G.711 contradicts it.
+    const ws = MockWebSocket.instances[0];
+    expect(new URL(ws.url).searchParams.get('encoding')).toBe('pcm_mulaw');
+
+    const reader = result.stream.getReader();
+    ws.open();
+    await flush();
+    const first = await reader.read();
+    expect(first.value).toEqual({
+      type: 'stream-start',
+      warnings: [
+        {
+          type: 'other',
+          message:
+            "providerOptions.cartesia.streaming.encoding 'pcm_mulaw' contradicts inputAudioFormat.type 'audio/pcm' (inferred 'pcm_s16le'); sending 'pcm_mulaw'.",
+        },
+      ],
+    });
+    await reader.cancel();
+  });
+
   it('rejects unsupported model operations and Ink 2 languages', async () => {
     const provider = createCartesia({
       apiKey: 'test-api-key',

--- a/packages/cartesia/src/cartesia-transcription-model.ts
+++ b/packages/cartesia/src/cartesia-transcription-model.ts
@@ -491,7 +491,8 @@ function buildCartesiaStreamingTranscriptionUrl({
   url.searchParams.set('model', modelId);
   url.searchParams.set(
     'encoding',
-    cartesiaEncodingFromInputAudioFormat(inputAudioFormat.type),
+    providerOptions?.streaming?.encoding ??
+      cartesiaEncodingFromInputAudioFormat(inputAudioFormat.type),
   );
   url.searchParams.set('sample_rate', String(inputAudioFormat.rate ?? 24000));
   url.searchParams.set('cartesia_version', version);

--- a/packages/cartesia/src/cartesia-transcription-model.ts
+++ b/packages/cartesia/src/cartesia-transcription-model.ts
@@ -28,6 +28,7 @@ import { z } from 'zod/v4';
 import type { CartesiaConfig } from './cartesia-config';
 import { cartesiaFailedResponseHandler } from './cartesia-error';
 import {
+  cartesiaStreamingEncodingSchema,
   cartesiaTranscriptionModelOptionsSchema,
   type CartesiaTranscriptionModelOptions,
 } from './cartesia-transcription-model-options';
@@ -489,13 +490,23 @@ function createCartesiaStreamingTranscriptionStream({
   });
 }
 
-/** Linear PCM encodings that legitimately widen generic `audio/pcm` input. */
-const LINEAR_PCM_STREAMING_ENCODINGS: ReadonlySet<string> = new Set([
-  'pcm_s16le',
-  'pcm_s32le',
-  'pcm_f16le',
-  'pcm_f32le',
+/** G.711 companding laws — the only non-linear members of the encoding enum. */
+const G711_STREAMING_ENCODINGS: ReadonlySet<string> = new Set([
+  'pcm_mulaw',
+  'pcm_alaw',
 ]);
+
+/**
+ * Linear PCM encodings that legitimately widen generic `audio/pcm` input.
+ * Derived from the option enum so a future linear encoding added there is
+ * treated as widening-compatible by default; G.711 is a closed set (the
+ * standard defines exactly two companding laws), so it is the hardcoded half.
+ */
+const LINEAR_PCM_STREAMING_ENCODINGS: ReadonlySet<string> = new Set(
+  cartesiaStreamingEncodingSchema.options.filter(
+    encoding => !G711_STREAMING_ENCODINGS.has(encoding),
+  ),
+);
 
 function buildCartesiaStreamingTranscriptionUrl({
   baseURL,

--- a/packages/cartesia/src/cartesia-transcription-model.ts
+++ b/packages/cartesia/src/cartesia-transcription-model.ts
@@ -221,6 +221,29 @@ export class CartesiaTranscriptionModel implements TranscriptionModelV4 {
       });
     }
 
+    // Always validate the declared media type — an explicit
+    // `streaming.encoding` override must not bypass the allowlist.
+    const inferredEncoding = cartesiaEncodingFromInputAudioFormat(
+      options.inputAudioFormat.type,
+    );
+    const encoding = cartesiaOptions?.streaming?.encoding ?? inferredEncoding;
+    // `audio/pcm` is generic linear PCM, so widening its default 16-bit
+    // interpretation is the intended use of the option. Overriding a G.711
+    // media type (or turning generic PCM into G.711) contradicts the declared
+    // format; surface that instead of sending it silently.
+    if (
+      encoding !== inferredEncoding &&
+      !(
+        inferredEncoding === 'pcm_s16le' &&
+        LINEAR_PCM_STREAMING_ENCODINGS.has(encoding)
+      )
+    ) {
+      warnings.push({
+        type: 'other',
+        message: `providerOptions.cartesia.streaming.encoding '${encoding}' contradicts inputAudioFormat.type '${options.inputAudioFormat.type}' (inferred '${inferredEncoding}'); sending '${encoding}'.`,
+      });
+    }
+
     const token = await this.createStreamingAccessToken(options);
     const useTurnDetection =
       cartesiaOptions?.streaming?.turnDetection !== false;
@@ -228,6 +251,7 @@ export class CartesiaTranscriptionModel implements TranscriptionModelV4 {
       baseURL: this.config.url({ path: '/', modelId: this.modelId }),
       version: this.config.version ?? '2026-03-01',
       modelId: this.modelId,
+      encoding,
       inputAudioFormat: options.inputAudioFormat,
       providerOptions: cartesiaOptions,
       token,
@@ -465,10 +489,19 @@ function createCartesiaStreamingTranscriptionStream({
   });
 }
 
+/** Linear PCM encodings that legitimately widen generic `audio/pcm` input. */
+const LINEAR_PCM_STREAMING_ENCODINGS: ReadonlySet<string> = new Set([
+  'pcm_s16le',
+  'pcm_s32le',
+  'pcm_f16le',
+  'pcm_f32le',
+]);
+
 function buildCartesiaStreamingTranscriptionUrl({
   baseURL,
   version,
   modelId,
+  encoding,
   inputAudioFormat,
   providerOptions,
   token,
@@ -477,6 +510,7 @@ function buildCartesiaStreamingTranscriptionUrl({
   baseURL: string;
   version: string;
   modelId: string;
+  encoding: string;
   inputAudioFormat: TranscriptionModelV4StreamOptions['inputAudioFormat'];
   providerOptions: CartesiaTranscriptionModelOptions | undefined;
   token: string;
@@ -489,11 +523,7 @@ function buildCartesiaStreamingTranscriptionUrl({
     ),
   );
   url.searchParams.set('model', modelId);
-  url.searchParams.set(
-    'encoding',
-    providerOptions?.streaming?.encoding ??
-      cartesiaEncodingFromInputAudioFormat(inputAudioFormat.type),
-  );
+  url.searchParams.set('encoding', encoding);
   url.searchParams.set('sample_rate', String(inputAudioFormat.rate ?? 24000));
   url.searchParams.set('cartesia_version', version);
   url.searchParams.set('access_token', token);


### PR DESCRIPTION
## Summary

- add `providerOptions.cartesia.streaming.encoding` for Ink 2 streaming transcription
- support Cartesia's `pcm_s32le`, `pcm_f16le`, and `pcm_f32le` input encodings while preserving the existing inferred defaults
- document the option and cover the exact WebSocket query mapping

## Why

Cartesia accepts multiple raw PCM representations for realtime STT, but the provider currently always maps `audio/pcm` to `pcm_s16le`. An explicit Cartesia streaming option exposes the additional formats without changing the shared transcription specification or inventing new media-type strings.

This shape also lets AI Gateway read the same provider option and meter 16-bit versus 32-bit audio correctly before forwarding it.

## Validation

- `pnpm --filter @ai-sdk/cartesia test` (40 node + 40 edge tests)
- `pnpm --filter @ai-sdk/cartesia type-check`
- `pnpm check`
- `pnpm type-check:full`
