### PR TITLE
fix(anthropic): report thinking tokens as reasoning token usage

### DIFF
--- a/.changeset/fuzzy-ducks-think.md
+++ b/.changeset/fuzzy-ducks-think.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): report thinking tokens as reasoning token usage

--- a/packages/anthropic/src/__fixtures__/anthropic-claude-opus-5-reasoning-high.1.json
+++ b/packages/anthropic/src/__fixtures__/anthropic-claude-opus-5-reasoning-high.1.json
@@ -1,0 +1,35 @@
+{
+  "model": "claude-opus-5",
+  "id": "msg_011CdMNhurHSJCxCC2NB7WYc",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "thinking",
+      "thinking": "I need to find all roots of this cubic polynomial and verify them. The Rational Root Theorem suggests checking factors of 6, and I can confirm that 1, 2, and 3 are indeed roots. I'll use synthetic division to factor it as (x-1)(x-2)(x-3), then verify by expanding and confirm this accounts for all roots since a degree 3 polynomial has exactly 3 roots.",
+      "signature": "CAISqwQKhwEIEBgCKkAciZInI2gcLrwOU5o9XFlIxHw9HaLIY6V9wHoK2E0w9TFrU5619C4CclxQW/p2HnHQuZNnVQyUxEfWomyE2b1cMg1jbGF1ZGUtb3B1cy01OAFCCHRoaW5raW5nWiQzYjkzYTVkZC03MzAyLTQ4M2YtYWVhZS0zNjIwNzU1NDhhZTESDH+yRc1q0TFaGxqP8RoMhbsE0elIcjL7Oz64IjBZvnLReNK1l69zsogxJrmWBDJnxYY8g1kBtEVbEzOmiaiMV20Hfw/wJyWGuZGlxZoq0AKuTLuUCqYUdsLcwLq8xMstlN1cJ1QCQX0nKWJMr7lAJZfm0B5koVxMGq/lv1gcueRYChwtOB6sArPZUCOGQ5MRdrbeGTCElku9thIfrgJQLcJO7UDobkcVilvXgxpZz/qlZLXJMxkV06BZwfhunTr6LqAmN6Mk3kyjpSd6qejVWiAVnivWverxxiyhZboZjOXdh+QdwyoSR3Oex7tWBaQDEurXSaYFLAjHbeXSs7ieKZfeHv5gKOez1PLKeBVoNBqxCvxbVXK+2/YhQJBZv610Uq7tq/ePGOTB3NH3dM+DrLpCJh/ZypKdGfFkgBoU8pMelL1ItIQ526dsd8G5RMo+KMCTYlGwYih85CrX4VKyS08G77B/v/9bhoGh+/fGjgBYX/M2CopxDG59RuG5bHvgcJX8QJ17THLT+tQgH+UNyStauLcPlIdLrLIq9yWz7dcYAQ=="
+    },
+    {
+      "type": "text",
+      "text": "## Step 1: Set up the problem\n\nWe want all values of $x$ satisfying\n\n$$f(x) = x^3 - 6x^2 + 11x - 6 = 0.$$\n\n## Step 2: Use the Rational Root Theorem to find candidates\n\nFor a polynomial with integer coefficients $a_nx^n + \\cdots + a_0$, any rational root $p/q$ (in lowest terms) must have $p \\mid a_0$ and $q \\mid a_n$.\n\nHere $a_0 = -6$ and $a_n = 1$, so:\n- $p \\in \\{\\pm1, \\pm2, \\pm3, \\pm6\\}$\n- $q \\in \\{\\pm 1\\}$\n\n**Candidate roots:** $\\pm1, \\pm2, \\pm3, \\pm6$.\n\n## Step 3: Test candidates\n\n$$f(1) = 1 - 6 + 11 - 6 = 0 \\quad \\checkmark$$\n\nSo $x = 1$ is a root, and by the Factor Theorem $(x-1)$ divides $f(x)$.\n\n## Step 4: Divide out the known factor\n\nSynthetic division by $x = 1$:\n\n$$\\begin{array}{c|cccc}\n1 & 1 & -6 & 11 & -6\\\\\n  &   & 1 & -5 & 6\\\\ \\hline\n  & 1 & -5 & 6 & \\boxed{0}\n\\end{array}$$\n\nThe remainder is $0$ (confirming $x=1$ is a root), and the quotient is $x^2 - 5x + 6$. Thus\n\n$$f(x) = (x-1)(x^2 - 5x + 6).$$\n\n## Step 5: Solve the quadratic\n\nFactor directly: we need two numbers with product $6$ and sum $-5$, namely $-2$ and $-3$:\n\n$$x^2 - 5x + 6 = (x-2)(x-3).$$\n\n*(Check with the quadratic formula: $x = \\dfrac{5 \\pm \\sqrt{25-24}}{2} = \\dfrac{5 \\pm 1}{2} = 3, 2.$)*\n\n## Step 6: Complete factorization\n\n$$\\boxed{f(x) = (x-1)(x-2)(x-3)}, \\qquad \\text{roots } x = 1,\\, 2,\\, 3.$$\n\n---\n\n## Proof of correctness\n\n**(a) The factorization is an identity.** Expand:\n\n$$(x-2)(x-3) = x^2 - 5x + 6$$\n\n$$(x-1)(x^2 - 5x + 6) = x^3 - 5x^2 + 6x - x^2 + 5x - 6 = x^3 - 6x^2 + 11x - 6 = f(x). \\;\\checkmark$$\n\nSo the factored form equals the original polynomial for **all** $x$.\n\n**(b) Each value is a root.** Direct substitution:\n\n| $x$ | $x^3$ | $-6x^2$ | $+11x$ | $-6$ | $f(x)$ |\n|---|---|---|---|---|---|\n| $1$ | $1$ | $-6$ | $11$ | $-6$ | $0$ |\n| $2$ | $8$ | $-24$ | $22$ | $-6$ | $0$ |\n| $3$ | $27$ | $-54$ | $33$ | $-6$ | $0$ |\n\n**(c) There are no other roots.** Since $f(x) = (x-1)(x-2)(x-3)$ identically, suppose $f(r) = 0$ for some $r$. Then\n\n$$(r-1)(r-2)(r-3) = 0.$$\n\nBecause $\\mathbb{R}$ (and $\\mathbb{C}$) is an integral domain — a product is zero only if some factor is zero — we must have $r-1=0$, $r-2=0$, or $r-3=0$, i.e. $r \\in \\{1,2,3\\}$.\n\nHence $\\{1,2,3\\}$ is exactly the root set, each root is simple (multiplicity 1), and the count matches the Fundamental Theorem of Algebra's guarantee of 3 roots for a cubic. $\\blacksquare$\n\n---\n\n## Sanity check with Vieta's formulas\n\nFor $x^3 + bx^2 + cx + d$ with roots $r_1,r_2,r_3$:\n\n- Sum: $1+2+3 = 6 = -b = 6$ ✓\n- Pairwise sum: $1\\cdot2 + 1\\cdot3 + 2\\cdot3 = 2+3+6 = 11 = c$ ✓\n- Product: $1\\cdot2\\cdot3 = 6 = -d = 6$ ✓\n\nAll three relations hold, independently confirming the answer."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 51,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "cache_creation": {
+      "ephemeral_5m_input_tokens": 0,
+      "ephemeral_1h_input_tokens": 0
+    },
+    "output_tokens": 1699,
+    "output_tokens_details": {
+      "thinking_tokens": 139
+    },
+    "service_tier": "standard",
+    "inference_geo": "global"
+  }
+}

--- a/packages/anthropic/src/anthropic-api.ts
+++ b/packages/anthropic/src/anthropic-api.ts
@@ -949,6 +949,11 @@ export const anthropicResponseSchema = lazySchema(() =>
       usage: z.looseObject({
         input_tokens: z.number(),
         output_tokens: z.number(),
+        output_tokens_details: z
+          .object({
+            thinking_tokens: z.number().nullish(),
+          })
+          .nullish(),
         cache_creation_input_tokens: z.number().nullish(),
         cache_read_input_tokens: z.number().nullish(),
         iterations: z
@@ -1427,6 +1432,11 @@ export const anthropicChunkSchema = lazySchema(() =>
         usage: z.looseObject({
           input_tokens: z.number().nullish(),
           output_tokens: z.number(),
+          output_tokens_details: z
+            .object({
+              thinking_tokens: z.number().nullish(),
+            })
+            .nullish(),
           cache_creation_input_tokens: z.number().nullish(),
           cache_read_input_tokens: z.number().nullish(),
           iterations: z

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -219,6 +219,21 @@ describe('AnthropicLanguageModel', () => {
 
         expect(result.warnings).toEqual([]);
       });
+
+      it('should report thinking tokens as reasoning usage', async () => {
+        prepareJsonFixtureResponse('anthropic-claude-opus-5-reasoning-high.1');
+
+        const result = await provider('claude-opus-5').doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'high',
+        });
+
+        expect(result.usage.outputTokens).toEqual({
+          total: 1699,
+          text: 1560,
+          reasoning: 139,
+        });
+      });
     });
 
     describe('reasoning (thinking disabled)', () => {

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -2504,6 +2504,9 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                 usage.input_tokens = value.usage.input_tokens;
               }
               usage.output_tokens = value.usage.output_tokens;
+              if (value.usage.output_tokens_details != null) {
+                usage.output_tokens_details = value.usage.output_tokens_details;
+              }
 
               if (value.usage.cache_read_input_tokens != null) {
                 usage.cache_read_input_tokens =

--- a/packages/anthropic/src/convert-anthropic-usage.ts
+++ b/packages/anthropic/src/convert-anthropic-usage.ts
@@ -28,6 +28,9 @@ export type AnthropicUsageIteration = {
 export type AnthropicUsage = {
   input_tokens: number;
   output_tokens: number;
+  output_tokens_details?: {
+    thinking_tokens?: number | null;
+  } | null;
   cache_creation_input_tokens?: number | null;
   cache_read_input_tokens?: number | null;
   /**
@@ -50,6 +53,8 @@ export function convertAnthropicUsage({
 }): LanguageModelV4Usage {
   const cacheCreationTokens = usage.cache_creation_input_tokens ?? 0;
   const cacheReadTokens = usage.cache_read_input_tokens ?? 0;
+  const reasoningTokens =
+    usage.output_tokens_details?.thinking_tokens ?? undefined;
 
   // When iterations is present (compaction or advisor), sum across executor
   // iterations to get the true executor totals. The top-level input_tokens
@@ -101,8 +106,9 @@ export function convertAnthropicUsage({
     },
     outputTokens: {
       total: outputTokens,
-      text: undefined,
-      reasoning: undefined,
+      text:
+        reasoningTokens == null ? undefined : outputTokens - reasoningTokens,
+      reasoning: reasoningTokens,
     },
     raw: rawUsage ?? usage,
   };


### PR DESCRIPTION
## Background

Before:

- Anthropic returned `output_tokens_details.thinking_tokens`
- our anthropic provider ignored it.
- `outputTokenDetails` appeared empty.
- Only aggregate `outputTokens` was reported.

## Summary

After:

- `thinking_tokens` maps to `reasoningTokens` in outputTokenDetails
- `textTokens` is calculated as total output minus reasoning tokens.

## End-to-End Verification

verified by running an example with reasoning invoked and noting the result.usage

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)