### PR TITLE
feat(openai): support Secure MCP tunnels

### DIFF
--- a/.changeset/friendly-tunnels-connect.md
+++ b/.changeset/friendly-tunnels-connect.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Add Secure MCP tunnel support to the OpenAI MCP tool.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -745,7 +745,7 @@ The code interpreter tool can be configured with:
 
 #### MCP Tool
 
-The OpenAI responses API supports connecting to [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers through the `openai.tools.mcp` tool. This allows models to call tools exposed by remote MCP servers or service connectors.
+The OpenAI responses API supports connecting to [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers through the `openai.tools.mcp` tool. This allows models to call tools exposed by remote MCP servers, service connectors, or [Secure MCP tunnels](https://platform.openai.com/docs/guides/tools-connectors-mcp#secure-mcp-tunnels).
 
 ```ts
 import { openai } from '@ai-sdk/openai';
@@ -764,19 +764,40 @@ const result = await generateText({
 });
 ```
 
+For a private MCP server exposed through an OpenAI Secure MCP tunnel, provide
+its tunnel ID instead of a server URL:
+
+```ts
+const result = await generateText({
+  model: openai('gpt-5'),
+  prompt: 'Search the private knowledge base',
+  tools: {
+    mcp: openai.tools.mcp({
+      serverLabel: 'private-knowledge',
+      tunnelId: 'tunnel_0123456789abcdef0123456789abcdef',
+      serverDescription: 'A private knowledge base',
+    }),
+  },
+});
+```
+
 The MCP tool can be configured with:
 
 - **serverLabel** _string_ (required)
 
   A label to identify the MCP server. This label is used in tool calls to distinguish between multiple MCP servers.
 
-- **serverUrl** _string_ (required if `connectorId` is not provided)
+- **serverUrl** _string_ (required if `connectorId` and `tunnelId` are not provided)
 
-  The URL for the MCP server. Either `serverUrl` or `connectorId` must be provided.
+  The URL for the MCP server. Exactly one of `serverUrl`, `connectorId`, or `tunnelId` must be provided.
 
-- **connectorId** _string_ (required if `serverUrl` is not provided)
+- **connectorId** _string_ (required if `serverUrl` and `tunnelId` are not provided)
 
-  Identifier for a service connector. Either `serverUrl` or `connectorId` must be provided.
+  Identifier for a service connector. Exactly one of `serverUrl`, `connectorId`, or `tunnelId` must be provided.
+
+- **tunnelId** _string_ (required if `serverUrl` and `connectorId` are not provided)
+
+  Identifier for an OpenAI Secure MCP tunnel. Exactly one of `serverUrl`, `connectorId`, or `tunnelId` must be provided.
 
 - **serverDescription** _string_ (optional)
 

--- a/packages/openai/src/openai-tools.ts
+++ b/packages/openai/src/openai-tools.ts
@@ -133,6 +133,7 @@ export const openaiTools = {
    * // param requireApproval - Approval policy ('always'|'never'|filter object). (Removed - always 'never')
    * @param serverDescription - Optional description of the server.
    * @param serverUrl - URL for the MCP server.
+   * @param tunnelId - Identifier for an OpenAI Secure MCP tunnel.
    */
   mcp,
 

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -582,6 +582,7 @@ export type OpenAIResponsesTool =
         | undefined;
       server_description: string | undefined;
       server_url: string | undefined;
+      tunnel_id: string | undefined;
     }
   | {
       type: 'custom';

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -3,6 +3,109 @@ import { prepareResponsesTools } from './openai-responses-prepare-tools';
 import { describe, it, expect } from 'vitest';
 
 describe('prepareResponsesTools', () => {
+  describe('MCP tools', () => {
+    it('should serialize a remote MCP server URL', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'openai.mcp',
+            name: 'mcp',
+            args: {
+              serverLabel: 'remote',
+              serverUrl: 'https://example.com/mcp',
+            },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result.tools).toEqual([
+        expect.objectContaining({
+          type: 'mcp',
+          server_label: 'remote',
+          server_url: 'https://example.com/mcp',
+          tunnel_id: undefined,
+        }),
+      ]);
+    });
+
+    it('should serialize a Secure MCP tunnel and preserve MCP options', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'openai.mcp',
+            name: 'mcp',
+            args: {
+              serverLabel: 'secure-tunnel',
+              tunnelId: 'tunnel_0123456789abcdef0123456789abcdef',
+              serverDescription: 'Private MCP server',
+              authorization: 'Bearer test-token',
+              headers: { 'X-Test': 'test-value' },
+              allowedTools: {
+                readOnly: true,
+                toolNames: ['search'],
+              },
+              requireApproval: {
+                never: { toolNames: ['search'] },
+              },
+            },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'mcp',
+          server_label: 'secure-tunnel',
+          tunnel_id: 'tunnel_0123456789abcdef0123456789abcdef',
+          server_url: undefined,
+          connector_id: undefined,
+          server_description: 'Private MCP server',
+          authorization: 'Bearer test-token',
+          headers: { 'X-Test': 'test-value' },
+          allowed_tools: {
+            read_only: true,
+            tool_names: ['search'],
+          },
+          require_approval: {
+            never: { tool_names: ['search'] },
+          },
+        },
+      ]);
+    });
+
+    it('should reject missing or ambiguous MCP targets', async () => {
+      const prepare = (args: Record<string, unknown>) =>
+        prepareResponsesTools({
+          tools: [
+            {
+              type: 'provider',
+              id: 'openai.mcp',
+              name: 'mcp',
+              args,
+            },
+          ],
+          toolChoice: undefined,
+        });
+
+      await expect(prepare({ serverLabel: 'missing-target' })).rejects.toThrow(
+        'Exactly one of serverUrl, connectorId, or tunnelId must be provided.',
+      );
+      await expect(
+        prepare({
+          serverLabel: 'ambiguous-target',
+          serverUrl: 'https://example.com/mcp',
+          tunnelId: 'tunnel_0123456789abcdef0123456789abcdef',
+        }),
+      ).rejects.toThrow(
+        'Exactly one of serverUrl, connectorId, or tunnelId must be provided.',
+      );
+    });
+  });
+
   describe('function tools strict mode', () => {
     it('should pass through strict mode when strict is true', async () => {
       const result = await prepareResponsesTools({

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -298,6 +298,7 @@ export async function prepareResponsesTools({
               require_approval: requireApprovalParam ?? 'never',
               server_description: args.serverDescription,
               server_url: args.serverUrl,
+              tunnel_id: args.tunnelId,
             });
 
             break;

--- a/packages/openai/src/tool/mcp.test-d.ts
+++ b/packages/openai/src/tool/mcp.test-d.ts
@@ -1,0 +1,29 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { mcp } from './mcp';
+
+describe('mcp tool type', () => {
+  it('accepts exactly one MCP server target', () => {
+    expectTypeOf(
+      mcp({ serverLabel: 'remote', serverUrl: 'https://example.com/mcp' }),
+    ).not.toBeNever();
+    expectTypeOf(
+      mcp({ serverLabel: 'connector', connectorId: 'connector_example' }),
+    ).not.toBeNever();
+    expectTypeOf(
+      mcp({
+        serverLabel: 'secure-tunnel',
+        tunnelId: 'tunnel_0123456789abcdef0123456789abcdef',
+      }),
+    ).not.toBeNever();
+
+    // @ts-expect-error an MCP target is required
+    mcp({ serverLabel: 'missing-target' });
+
+    // @ts-expect-error MCP targets are mutually exclusive
+    mcp({
+      serverLabel: 'ambiguous-target',
+      serverUrl: 'https://example.com/mcp',
+      tunnelId: 'tunnel_0123456789abcdef0123456789abcdef',
+    });
+  });
+});

--- a/packages/openai/src/tool/mcp.ts
+++ b/packages/openai/src/tool/mcp.ts
@@ -49,10 +49,14 @@ export const mcpArgsSchema = lazySchema(() =>
           .optional(),
         serverDescription: z.string().optional(),
         serverUrl: z.string().optional(),
+        tunnelId: z.string().optional(),
       })
       .refine(
-        v => v.serverUrl != null || v.connectorId != null,
-        'One of serverUrl or connectorId must be provided.',
+        v =>
+          [v.serverUrl, v.connectorId, v.tunnelId].filter(
+            value => value != null,
+          ).length === 1,
+        'Exactly one of serverUrl, connectorId, or tunnelId must be provided.',
       ),
   ),
 );
@@ -72,7 +76,7 @@ export const mcpOutputSchema = lazySchema(() =>
   ),
 );
 
-type McpArgs = {
+type McpCommonArgs = {
   /** A label for this MCP server, used to identify it in tool calls. */
   serverLabel: string;
   /** List of allowed tool names or a filter object. */
@@ -84,8 +88,6 @@ type McpArgs = {
       };
   /** OAuth access token usable with the remote MCP server or connector. */
   authorization?: string;
-  /** Identifier for a service connector. */
-  connectorId?: string;
   /** Optional HTTP headers to send to the MCP server. */
   headers?: Record<string, string>;
   /**
@@ -101,9 +103,29 @@ type McpArgs = {
       };
   /** Optional description of the MCP server. */
   serverDescription?: string;
-  /** URL for the MCP server. One of serverUrl or connectorId must be provided. */
-  serverUrl?: string;
 };
+
+type McpArgs = McpCommonArgs &
+  (
+    | {
+        /** URL for the MCP server. */
+        serverUrl: string;
+        connectorId?: never;
+        tunnelId?: never;
+      }
+    | {
+        /** Identifier for a service connector. */
+        connectorId: string;
+        serverUrl?: never;
+        tunnelId?: never;
+      }
+    | {
+        /** Identifier for an OpenAI Secure MCP tunnel. */
+        tunnelId: string;
+        serverUrl?: never;
+        connectorId?: never;
+      }
+  );
 
 export const mcpToolFactory = createProviderExecutedToolFactory<
   {},


### PR DESCRIPTION
Adds OpenAI Secure MCP tunnel support to `openai.tools.mcp`.

## Changes

- add `tunnelId` to `openai.tools.mcp` and serialize it as `tunnel_id`
- make `serverUrl`, `connectorId`, and `tunnelId` mutually exclusive
- add tests, documentation, and an `@ai-sdk/openai` patch changeset

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
