### PR TITLE
fix(mistral): preserve thinking chunk structure when replaying reasoning history

### DIFF
--- a/.changeset/fix-mistral-thinking-chunks.md
+++ b/.changeset/fix-mistral-thinking-chunks.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mistral': patch
+---
+
+fix(mistral): preserve thinking chunk structure when replaying reasoning history

--- a/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
@@ -123,10 +123,111 @@ describe('user messages', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "Let me think about this...The answer is 42.",
+          "content": [
+            {
+              "closed": true,
+              "thinking": [
+                {
+                  "text": "Let me think about this...",
+                  "type": "text",
+                },
+              ],
+              "type": "thinking",
+            },
+            {
+              "text": "The answer is 42.",
+              "type": "text",
+            },
+          ],
           "prefix": true,
           "role": "assistant",
           "tool_calls": undefined,
+        },
+      ]
+    `);
+  });
+
+  it('should keep plain string content for text-only assistant messages', () => {
+    const result = convertToMistralChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hi there!' }],
+      },
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "text": "Hello",
+              "type": "text",
+            },
+          ],
+          "role": "user",
+        },
+        {
+          "content": "Hi there!",
+          "prefix": true,
+          "role": "assistant",
+          "tool_calls": undefined,
+        },
+      ]
+    `);
+  });
+
+  it('should convert reasoning with tool calls', () => {
+    const result = convertToMistralChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'I should look this up.' },
+          { type: 'text', text: 'Let me search.' },
+          {
+            type: 'tool-call',
+            input: { query: 'test' },
+            toolCallId: 'tc-1',
+            toolName: 'search',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "closed": true,
+              "thinking": [
+                {
+                  "text": "I should look this up.",
+                  "type": "text",
+                },
+              ],
+              "type": "thinking",
+            },
+            {
+              "text": "Let me search.",
+              "type": "text",
+            },
+          ],
+          "prefix": true,
+          "role": "assistant",
+          "tool_calls": [
+            {
+              "function": {
+                "arguments": "{\"query\":\"test\"}",
+                "name": "search",
+              },
+              "id": "tc-1",
+              "type": "function",
+            },
+          ],
         },
       ]
     `);

--- a/packages/mistral/src/convert-to-mistral-chat-messages.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.ts
@@ -3,7 +3,11 @@ import {
   type LanguageModelV4FilePart,
   type LanguageModelV4Prompt,
 } from '@ai-sdk/provider';
-import type { MistralPrompt } from './mistral-chat-prompt';
+import type {
+  MistralPrompt,
+  MistralTextContent,
+  MistralThinkingContent,
+} from './mistral-chat-prompt';
 import {
   convertToBase64,
   getTopLevelMediaType,
@@ -101,6 +105,9 @@ export function convertToMistralChatMessages(
 
       case 'assistant': {
         let text = '';
+        let hasReasoning = false;
+        const contentParts: Array<MistralThinkingContent | MistralTextContent> =
+          [];
         const toolCalls: Array<{
           id: string;
           type: 'function';
@@ -111,6 +118,7 @@ export function convertToMistralChatMessages(
           switch (part.type) {
             case 'text': {
               text += part.text;
+              contentParts.push({ type: 'text', text: part.text });
               break;
             }
             case 'tool-call': {
@@ -125,7 +133,12 @@ export function convertToMistralChatMessages(
               break;
             }
             case 'reasoning': {
-              text += part.text;
+              hasReasoning = true;
+              contentParts.push({
+                type: 'thinking',
+                thinking: [{ type: 'text', text: part.text }],
+                closed: true,
+              });
               break;
             }
             default: {
@@ -138,7 +151,7 @@ export function convertToMistralChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: hasReasoning ? contentParts : text,
           prefix: isLastMessage ? true : undefined,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/mistral/src/mistral-chat-prompt.ts
+++ b/packages/mistral/src/mistral-chat-prompt.ts
@@ -21,9 +21,20 @@ export type MistralUserMessageContent =
   | { type: 'image_url'; image_url: string }
   | { type: 'document_url'; document_url: string };
 
+export type MistralThinkingContent = {
+  type: 'thinking';
+  thinking: Array<{ type: 'text'; text: string }>;
+  closed: boolean;
+};
+
+export type MistralTextContent = {
+  type: 'text';
+  text: string;
+};
+
 export interface MistralAssistantMessage {
   role: 'assistant';
-  content: string;
+  content: string | Array<MistralThinkingContent | MistralTextContent>;
   prefix?: boolean;
   tool_calls?: Array<{
     id: string;


### PR DESCRIPTION
## Summary

Fixes #17930

When assistant messages with reasoning parts are replayed in multi-turn conversations, the Mistral provider concatenates reasoning text and visible answer into a single plain string. This drops the structured `thinking`/`text` chunk format that Mistral's API requires for multi-turn replay, causing reasoning context to be lost and the visible answer to be duplicated.

## Changes

- **`mistral-chat-prompt.ts`**: Add `MistralThinkingContent` and `MistralTextContent` types; change `MistralAssistantMessage.content` from `string` to `string | Array<MistralThinkingContent | MistralTextContent>`
- **`convert-to-mistral-chat-messages.ts`**: When `reasoning` parts exist in assistant messages, emit `content` as a structured array of `{type: "thinking", thinking: [{type: "text", text}], closed: true}` and `{type: "text", text}` chunks — matching Mistral's API response format. When no reasoning parts exist, keep plain `string` content (backward compatible).
- **`convert-to-mistral-chat-messages.test.ts`**: Update existing reasoning test to expect structured output; add tests for text-only (backward compat) and reasoning + tool calls scenarios.

## Before / After

**Before** (flattened):
```json
{ "role": "assistant", "content": "So, 17 * 23 = 391.391" }
```

**After** (structured):
```json
{
  "role": "assistant",
  "content": [
    { "type": "thinking", "thinking": [{ "type": "text", "text": "So, 17 * 23 = 391." }], "closed": true },
    { "type": "text", "text": "391" }
  ]
}
```

This mirrors the format used on the response parsing side in `mistral-chat-language-model.ts` (lines 255-270).