### PR TITLE
fix(chat): make resumeStream idempotent to prevent duplicate reconnects

### DIFF
--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -458,11 +458,23 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     });
   };
 
+  private isResuming = false;
+
   /**
    * Attempt to resume an ongoing streaming response.
+   * Idempotent — concurrent calls from multiple `useChat` subscribers sharing
+   * the same `Chat` instance will not trigger duplicate stream reconnects.
    */
   resumeStream = async (options: ChatRequestOptions = {}): Promise<void> => {
-    await this.makeRequest({ trigger: 'resume-stream', ...options });
+    if (this.isResuming) {
+      return;
+    }
+    this.isResuming = true;
+    try {
+      await this.makeRequest({ trigger: 'resume-stream', ...options });
+    } finally {
+      this.isResuming = false;
+    }
   };
 
   /**


### PR DESCRIPTION
When a `Chat` instance is created outside `useChat` and passed in as `chat: chatInstance`, every component that calls `useChat({ chat: chatInstance, resume: true })` mounts and fires the `useEffect`:

```ts
useEffect(() => {
  if (resume) {
    chatRef.current.resumeStream();
  }
}, [resume, chatRef]);
```

`chatRef` holds the same shared object for all consumers, so `resumeStream()` is called once per component mount. With 10+ subscribers this means 10+ concurrent `reconnectToStream` requests fire simultaneously. The async guard in `makeRequest` only checks state *after* `await reconnectToStream(...)`, so the race is wide open before any of them complete.

**Fix:** add an `isResuming` boolean flag to the `Chat` class. `resumeStream` sets it synchronously before the first `await`, short-circuiting all concurrent callers. The flag is cleared in `finally` so a subsequent manual `resume` still works.

```ts
private isResuming = false;

resumeStream = async (options = {}): Promise<void> => {
  if (this.isResuming) return;
  this.isResuming = true;
  try {
    await this.makeRequest({ trigger: 'resume-stream', ...options });
  } finally {
    this.isResuming = false;
  }
};
```

This makes `resumeStream` safe to call from any number of concurrent subscribers without spawning duplicate server reconnects.

Fixes #13863