### PR TITLE
feat(harness-codex): support reasoning summaries

### DIFF
--- a/.changeset/codex-reasoning-summary.md
+++ b/.changeset/codex-reasoning-summary.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-codex': patch
+---
+
+Forward Codex reasoning summary settings to the CLI bridge.

--- a/packages/harness-codex/src/bridge/index.test.ts
+++ b/packages/harness-codex/src/bridge/index.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-type CodexOptions = { config?: { mcp_servers?: unknown } };
+type CodexOptions = {
+  config?: {
+    mcp_servers?: unknown;
+    model_reasoning_summary?: unknown;
+  };
+};
 const CODEX_ENV_KEYS = [
   'AI_GATEWAY_API_KEY',
   'AI_GATEWAY_BASE_URL',
@@ -55,6 +60,7 @@ vi.mock('@ai-sdk/harness/bridge', () => ({
             inputSchema: { type: 'object' },
           },
         ],
+        reasoningSummary: 'detailed',
       },
       {
         emit: () => {},
@@ -108,5 +114,14 @@ describe('Codex bridge config', () => {
 
     expect(state.codexOptions).toHaveLength(1);
     expect(state.codexOptions[0]?.config?.mcp_servers).toBeUndefined();
+  });
+
+  test('forwards reasoning summary to Codex config', async () => {
+    await import('./index');
+
+    expect(state.codexOptions).toHaveLength(1);
+    expect(state.codexOptions[0]?.config?.model_reasoning_summary).toBe(
+      'detailed',
+    );
   });
 });

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -151,6 +151,9 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
       },
     };
   }
+  if (start.reasoningSummary) {
+    codexConfig.model_reasoning_summary = start.reasoningSummary;
+  }
   const usesConfiguredModelProvider =
     typeof codexConfig.model_provider === 'string';
 

--- a/packages/harness-codex/src/codex-bridge-protocol.test.ts
+++ b/packages/harness-codex/src/codex-bridge-protocol.test.ts
@@ -71,6 +71,7 @@ describe('inboundMessageSchema', () => {
         tools: [{ name: 'deploy' }],
         model: 'gpt-5.1',
         reasoningEffort: 'high',
+        reasoningSummary: 'detailed',
         webSearch: true,
       }),
     ).not.toThrow();

--- a/packages/harness-codex/src/codex-bridge-protocol.ts
+++ b/packages/harness-codex/src/codex-bridge-protocol.ts
@@ -18,6 +18,7 @@ export type OutboundMessage = z.infer<typeof outboundMessageSchema>;
 
 export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
   reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+  reasoningSummary: z.enum(['auto', 'concise', 'detailed', 'none']).optional(),
   webSearch: z.boolean().optional(),
   // Resume signal. When supplied, the bridge calls
   // `codex.resumeThread(resumeThreadId, …)` instead of starting a fresh thread.

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -85,6 +85,11 @@ export type CodexHarnessSettings = {
    */
   readonly reasoningEffort?: 'low' | 'medium' | 'high';
   /**
+   * Reasoning summary detail emitted by Codex. Leaving this unset defers to
+   * the CLI's default.
+   */
+  readonly reasoningSummary?: 'auto' | 'concise' | 'detailed' | 'none';
+  /**
    * When `true`, allow the underlying runtime to use live web search.
    */
   readonly webSearch?: boolean;
@@ -293,6 +298,7 @@ export function createCodex(
             proc: undefined,
             model: settings.model ?? DEFAULT_CODEX_MODEL,
             reasoningEffort: settings.reasoningEffort,
+            reasoningSummary: settings.reasoningSummary,
             webSearch: settings.webSearch,
             resumeThreadId: resumeThreadIdString,
             isResume: true,
@@ -440,6 +446,7 @@ export function createCodex(
         proc,
         model: settings.model ?? DEFAULT_CODEX_MODEL,
         reasoningEffort: settings.reasoningEffort,
+        reasoningSummary: settings.reasoningSummary,
         webSearch: settings.webSearch,
         resumeThreadId: resumeThreadIdString,
         isResume: respawnStrategy !== undefined,
@@ -543,6 +550,7 @@ function createSession({
   proc,
   model,
   reasoningEffort,
+  reasoningSummary,
   webSearch,
   resumeThreadId,
   isResume,
@@ -561,6 +569,7 @@ function createSession({
   proc: Experimental_SandboxProcess | undefined;
   model: string | undefined;
   reasoningEffort: 'low' | 'medium' | 'high' | undefined;
+  reasoningSummary: 'auto' | 'concise' | 'detailed' | 'none' | undefined;
   webSearch: boolean | undefined;
   resumeThreadId: string | undefined;
   isResume: boolean;
@@ -798,6 +807,7 @@ function createSession({
         tools,
         model,
         reasoningEffort,
+        reasoningSummary,
         webSearch,
         ...(permissionMode ? { permissionMode } : {}),
         ...(pendingResumeThreadId
@@ -849,6 +859,7 @@ function createSession({
             })),
             model,
             reasoningEffort,
+            reasoningSummary,
             webSearch,
             ...(permissionMode ? { permissionMode } : {}),
             ...(threadId ? { resumeThreadId: threadId } : {}),

--- a/packages/harness-codex/src/codex-instructions.test.ts
+++ b/packages/harness-codex/src/codex-instructions.test.ts
@@ -111,8 +111,11 @@ async function startSession(options?: {
   resumeFrom?: HarnessV1ResumeSessionState;
   continueFrom?: HarnessV1ContinueTurnState;
   skills?: ReadonlyArray<HarnessV1Skill>;
+  reasoningSummary?: 'auto' | 'concise' | 'detailed' | 'none';
 }): Promise<HarnessV1Session> {
-  const harness = createCodex();
+  const harness = createCodex({
+    reasoningSummary: options?.reasoningSummary,
+  });
   return harness.doStart({
     sessionId: 's1',
     sandboxSession: fakeNetworkSandboxSession(),
@@ -255,6 +258,19 @@ describe('codex adapter — instructions gating', () => {
     expect(start.prompt).toBe('resumed turn');
     expect(start.instructions).toBeUndefined();
   });
+
+  it('forwards reasoning summary settings', async () => {
+    const freshSession = await startSession({
+      reasoningSummary: 'detailed',
+    });
+    await freshSession.doPromptTurn({
+      prompt: 'fresh turn',
+      emit: () => {},
+    });
+    expect(await waitForStart({ count: 1 })).toMatchObject({
+      reasoningSummary: 'detailed',
+    });
+  });
 });
 
 describe('codex adapter — attach replay mode', () => {
@@ -268,6 +284,7 @@ describe('codex adapter — attach replay mode', () => {
 
   it('attaches a parked session without replaying old turn events', async () => {
     const session = await startSession({
+      reasoningSummary: 'concise',
       resumeFrom: {
         type: 'resume-session',
         harnessId: 'codex',
@@ -293,6 +310,7 @@ describe('codex adapter — attach replay mode', () => {
     expect(start).toMatchObject({
       type: 'start',
       prompt: 'next user turn',
+      reasoningSummary: 'concise',
     });
     expect(start.resumeThreadId).toBeUndefined();
   });


### PR DESCRIPTION
## Background

The Codex harness exposes reasoning effort but cannot configure the CLI's reasoning summary detail, so consumers must accept the runtime default.

## Summary

- Add `reasoningSummary` to `CodexHarnessSettings` with the Codex-supported `auto`, `concise`, `detailed`, and `none` values.
- Forward the setting through fresh and resumed bridge sessions to `model_reasoning_summary`.
- Cover the public setting, bridge schema, and Codex config mapping.

## Verification

- `pnpm --dir packages/harness-codex test:node`
- `pnpm --dir packages/harness-codex type-check`
- `pnpm --dir packages/harness-codex build`
- `pnpm exec oxfmt --check <changed files>`
- `pnpm exec oxlint <changed TypeScript files>`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated
- [x] Documentation has been added / updated
- [x] A patch changeset for relevant packages has been added
- [x] I have reviewed this pull request (self-review)
