### PR TITLE
fix(prodia): emit unsupported-setting warning for seed

### DIFF
--- a/.changeset/prodia-seed-warning.md
+++ b/.changeset/prodia-seed-warning.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/prodia': patch
+---
+
+Add missing `seed` unsupported-setting warning in `doGenerate` / `doStream`

--- a/packages/prodia/src/prodia-language-model.test.ts
+++ b/packages/prodia/src/prodia-language-model.test.ts
@@ -396,6 +396,7 @@ describe('ProdiaLanguageModel', () => {
         toolChoice: { type: 'auto' },
         responseFormat: { type: 'json' },
         reasoning: 'medium',
+        seed: 42,
         providerOptions: {},
       });
 
@@ -413,6 +414,7 @@ describe('ProdiaLanguageModel', () => {
       expect(warningFeatures).toContain('toolChoice');
       expect(warningFeatures).toContain('responseFormat');
       expect(warningFeatures).toContain('reasoning');
+      expect(warningFeatures).toContain('seed');
     });
 
     it('passes aspectRatio from provider options', async () => {

--- a/packages/prodia/src/prodia-language-model.ts
+++ b/packages/prodia/src/prodia-language-model.ts
@@ -99,6 +99,10 @@ export class ProdiaLanguageModel implements LanguageModelV4 {
       warnings.push({ type: 'unsupported', feature: 'responseFormat' });
     }
 
+    if (options.seed !== undefined) {
+      warnings.push({ type: 'unsupported', feature: 'seed' });
+    }
+
     if (isCustomReasoning(options.reasoning)) {
       warnings.push({
         type: 'unsupported',


### PR DESCRIPTION
## Summary

`ProdiaLanguageModel.doGenerate()` warns about every unsupported `LanguageModelV4CallOptions` field except `seed`. This adds the missing check so `seed` emits a warning consistent with the other 11 settings.

Closes #17938

## Changes

- **`packages/prodia/src/prodia-language-model.ts`** — add `seed` unsupported-feature warning block (3 lines, identical pattern to the adjacent checks)
- **`packages/prodia/src/prodia-language-model.test.ts`** — pass `seed: 42` in the unsupported-features test and assert the warning is emitted

## Testing

Verified by reading the existing test structure. The test now covers all 12 standard `LanguageModelV4CallOptions` fields.