### PR TITLE
fix(providers): surface unsupported sampling settings consistently

### DIFF
--- a/packages/google/src/interactions/google-interactions-language-model.test.ts
+++ b/packages/google/src/interactions/google-interactions-language-model.test.ts
@@ -694,6 +694,38 @@ describe('GoogleInteractionsLanguageModel.doGenerate', () => {
       expect(body.generation_config?.thinking_summaries).toBe('auto');
     });
 
+    it('forwards topK, presencePenalty and frequencyPenalty into generation_config', async () => {
+      // Matches the standard Gemini model path (google-language-model.ts) and
+      // avoids the silent drop reported in #17937.
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        temperature: 0.5,
+        topP: 0.9,
+        topK: 10,
+        presencePenalty: 0.5,
+        frequencyPenalty: 0.5,
+        seed: 7,
+      });
+      const body = (await server.calls[0].requestBodyJson) as {
+        generation_config?: {
+          temperature?: number;
+          top_p?: number;
+          top_k?: number;
+          presence_penalty?: number;
+          frequency_penalty?: number;
+          seed?: number;
+        };
+      };
+      expect(body.generation_config).toMatchObject({
+        temperature: 0.5,
+        top_p: 0.9,
+        top_k: 10,
+        presence_penalty: 0.5,
+        frequency_penalty: 0.5,
+        seed: 7,
+      });
+    });
+
     it('returns interactionId for turn 1 from a captured fixture', async () => {
       prepareJsonFixtureResponse('multi-turn-stateful-turn1');
       const result = await model.doGenerate({
@@ -1502,6 +1534,9 @@ describe('GoogleInteractionsLanguageModel.doGenerate', () => {
         prompt: TEST_PROMPT,
         temperature: 0.5,
         topP: 0.9,
+        topK: 10,
+        presencePenalty: 0.5,
+        frequencyPenalty: 0.5,
         providerOptions: {
           google: { thinkingLevel: 'high' },
         },
@@ -1516,6 +1551,9 @@ describe('GoogleInteractionsLanguageModel.doGenerate', () => {
           w.type === 'other' &&
           (w as { message?: string }).message?.includes('temperature') &&
           (w as { message?: string }).message?.includes('topP') &&
+          (w as { message?: string }).message?.includes('topK') &&
+          (w as { message?: string }).message?.includes('presencePenalty') &&
+          (w as { message?: string }).message?.includes('frequencyPenalty') &&
           (w as { message?: string }).message?.includes('thinkingLevel'),
       );
       expect(warning).toBeDefined();

--- a/packages/google/src/interactions/google-interactions-language-model.ts
+++ b/packages/google/src/interactions/google-interactions-language-model.ts
@@ -276,6 +276,11 @@ export class GoogleInteractionsLanguageModel implements LanguageModelV4 {
       const droppedFields: Array<string> = [];
       if (options.temperature != null) droppedFields.push('temperature');
       if (options.topP != null) droppedFields.push('topP');
+      if (options.topK != null) droppedFields.push('topK');
+      if (options.presencePenalty != null)
+        droppedFields.push('presencePenalty');
+      if (options.frequencyPenalty != null)
+        droppedFields.push('frequencyPenalty');
       if (options.seed != null) droppedFields.push('seed');
       if (options.stopSequences != null && options.stopSequences.length > 0) {
         droppedFields.push('stopSequences');
@@ -299,6 +304,9 @@ export class GoogleInteractionsLanguageModel implements LanguageModelV4 {
       generationConfig = pruneUndefined({
         temperature: options.temperature ?? undefined,
         top_p: options.topP ?? undefined,
+        top_k: options.topK ?? undefined,
+        presence_penalty: options.presencePenalty ?? undefined,
+        frequency_penalty: options.frequencyPenalty ?? undefined,
         seed: options.seed ?? undefined,
         stop_sequences:
           options.stopSequences != null && options.stopSequences.length > 0

--- a/packages/google/src/interactions/google-interactions-prompt.ts
+++ b/packages/google/src/interactions/google-interactions-prompt.ts
@@ -461,6 +461,9 @@ export type GoogleInteractionsResponseFormatEntry =
 export type GoogleInteractionsGenerationConfig = {
   temperature?: number;
   top_p?: number;
+  top_k?: number;
+  presence_penalty?: number;
+  frequency_penalty?: number;
   seed?: number;
   stop_sequences?: Array<string>;
   max_output_tokens?: number;

--- a/packages/prodia/src/prodia-language-model.test.ts
+++ b/packages/prodia/src/prodia-language-model.test.ts
@@ -386,6 +386,7 @@ describe('ProdiaLanguageModel', () => {
         stopSequences: ['stop'],
         presencePenalty: 0.1,
         frequencyPenalty: 0.2,
+        seed: 42,
         tools: [
           {
             type: 'function',
@@ -409,6 +410,7 @@ describe('ProdiaLanguageModel', () => {
       expect(warningFeatures).toContain('stopSequences');
       expect(warningFeatures).toContain('presencePenalty');
       expect(warningFeatures).toContain('frequencyPenalty');
+      expect(warningFeatures).toContain('seed');
       expect(warningFeatures).toContain('tools');
       expect(warningFeatures).toContain('toolChoice');
       expect(warningFeatures).toContain('responseFormat');

--- a/packages/prodia/src/prodia-language-model.ts
+++ b/packages/prodia/src/prodia-language-model.ts
@@ -86,6 +86,9 @@ export class ProdiaLanguageModel implements LanguageModelV4 {
     if (options.frequencyPenalty !== undefined) {
       warnings.push({ type: 'unsupported', feature: 'frequencyPenalty' });
     }
+    if (options.seed !== undefined) {
+      warnings.push({ type: 'unsupported', feature: 'seed' });
+    }
     if (options.tools !== undefined && options.tools.length > 0) {
       warnings.push({ type: 'unsupported', feature: 'tools' });
     }

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -1146,6 +1146,31 @@ describe('XaiResponsesLanguageModel', () => {
         `);
       });
 
+      it('should warn about unsupported topK, presencePenalty and frequencyPenalty', async () => {
+        prepareJsonResponse({
+          id: 'resp_123',
+          object: 'response',
+          status: 'completed',
+          model: 'grok-4-fast-non-reasoning',
+          output: [],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        });
+
+        const result = await createModel().doGenerate({
+          prompt: TEST_PROMPT,
+          topK: 10,
+          presencePenalty: 0.5,
+          frequencyPenalty: 0.5,
+        });
+
+        const warningFeatures = result.warnings.map(w =>
+          w.type === 'unsupported' ? w.feature : undefined,
+        );
+        expect(warningFeatures).toContain('topK');
+        expect(warningFeatures).toContain('presencePenalty');
+        expect(warningFeatures).toContain('frequencyPenalty');
+      });
+
       describe('responseFormat', () => {
         it('should send response format json schema', async () => {
           prepareJsonResponse({

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -93,6 +93,9 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
     maxOutputTokens,
     temperature,
     topP,
+    topK,
+    frequencyPenalty,
+    presencePenalty,
     stopSequences,
     seed,
     responseFormat,
@@ -109,6 +112,18 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
         providerOptions,
         schema: xaiLanguageModelResponsesOptions,
       })) ?? {};
+
+    if (topK != null) {
+      warnings.push({ type: 'unsupported', feature: 'topK' });
+    }
+
+    if (frequencyPenalty != null) {
+      warnings.push({ type: 'unsupported', feature: 'frequencyPenalty' });
+    }
+
+    if (presencePenalty != null) {
+      warnings.push({ type: 'unsupported', feature: 'presencePenalty' });
+    }
 
     if (stopSequences != null) {
       warnings.push({ type: 'unsupported', feature: 'stopSequences' });


### PR DESCRIPTION
## Summary

Three related silent-drop bugs in provider call-settings handling:

1. **@ai-sdk/prodia** — `seed` was the only standard `LanguageModelV4CallOptions` field missing from the unsupported-warning list, so it was dropped with no warning (`#17938`)
2. **@ai-sdk/google `google.interactions()`** — `topK` / `presencePenalty` / `frequencyPenalty` were never forwarded into `generation_config`, unlike the standard Gemini model path in the same package (`#17937`)
3. **@ai-sdk/xai Responses model** — those same three fields were neither forwarded nor warned about, while the sibling chat model already warns (`#17936`)

## Fix

- prodia: emit `{ type: 'unsupported', feature: 'seed' }` when `seed` is set
- google.interactions: write `top_k` / `presence_penalty` / `frequency_penalty` into `generation_config` (and include them in the agent-mode dropped-fields warning)
- xai responses: emit unsupported warnings for `topK` / `presencePenalty` / `frequencyPenalty`

## Tests

```text
pnpm --filter @ai-sdk/prodia test:node -- src/prodia-language-model.test.ts
# 17 passed

pnpm --filter @ai-sdk/google test:node -- -t 'forwards topK|drops generation-config fields'
# 3 passed

pnpm --filter @ai-sdk/xai test:node -- -t 'unsupported topK'
# 1 passed
```

Fixes #17938
Fixes #17937
Fixes #17936