### PR TITLE
feat(tools-registry): add SQAI

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -584,4 +584,36 @@ console.log(result.text);`,
     websiteUrl: 'https://nitrosend.com',
     npmUrl: 'https://www.npmjs.com/package/@nitrosend/ai-sdk',
   },
+  {
+    slug: 'sqai',
+    name: 'SQAI',
+    description:
+      'SQAI (Structured Query AI) is a governed, read-only structured-data tool for AI agents. It turns a natural-language question into a typed, policy-checked plan, runs it on an on-device runtime, and returns the answer with replayable provenance hashes. Query CSV, JSON, record arrays, and SQLite in-process, alongside 4,574 read-only compute capabilities across statistics, finance, linear algebra, time series, option pricing, and more. Policy lives in code — the model can only narrow what you allow, never widen it. Runs on your machine, no cloud; local compute uses a one-time free `sqai login`.',
+    packageName: '@thyn-ai/sqai-ai-sdk',
+    tags: ['data', 'analytics', 'structured-data', 'read-only', 'governance', 'provenance'],
+    installCommand: {
+      pnpm: 'pnpm add @thyn-ai/sqai-ai-sdk',
+      npm: 'npm install @thyn-ai/sqai-ai-sdk',
+      yarn: 'yarn add @thyn-ai/sqai-ai-sdk',
+      bun: 'bun add @thyn-ai/sqai-ai-sdk',
+    },
+    codeExample: `import { generateText, isStepCount } from 'ai';
+import { createSQAI } from '@thyn-ai/sqai-ai-sdk';
+
+const sqai = createSQAI({
+  sources: [{ data: './sales.csv', name: 'sales' }],
+});
+
+const { text } = await generateText({
+  model: 'openai/gpt-5-mini',
+  tools: sqai.tools(),
+  stopWhen: isStepCount(8),
+  prompt: 'Which region had the highest total revenue, and what explains it?',
+});
+
+console.log(text);`,
+    docsUrl: 'https://docs.sqai.com',
+    websiteUrl: 'https://sqai.com',
+    npmUrl: 'https://www.npmjs.com/package/@thyn-ai/sqai-ai-sdk',
+  },
 ];


### PR DESCRIPTION
Adds **SQAI** (Structured Query AI) to the AI SDK tools registry.

SQAI is a governed, read-only structured-data tool for AI agents: a natural-language question becomes a typed, policy-checked plan, runs on an on-device runtime, and returns the answer with replayable provenance hashes. It exposes CSV/JSON/record/SQLite querying in-process plus 4,574 read-only, deterministic compute capabilities (statistics, finance, linear algebra, time series, option pricing, and more). Policy lives in code — the model can only narrow what you allow, never widen it.

- Package: [`@thyn-ai/sqai-ai-sdk`](https://www.npmjs.com/package/@thyn-ai/sqai-ai-sdk) (published, 0.1.9)
- Docs: https://docs.sqai.com · Site: https://sqai.com
- `createSQAI({ sources }).tools()` returns three AI SDK tools (`listSources`, `queryData`, `explainQuery`), assignable to `ToolSet` with no cast; they never throw (ambiguity/rejection/failure come back as typed results).

Checklist (per contributing/add-new-tool-to-registry.md):
- [x] Package published to npm
- [x] Documented (https://docs.sqai.com)
- [x] Tested with the AI SDK; the `codeExample` is a complete, working snippet
- [x] Entry appended to `content/tools-registry/registry.ts`; file type-checks

No API key is required to start — local compute uses a one-time free `sqai login` (device-code); runs on your machine, no cloud.