### PR TITLE
fix(ai/core): recognize output-denied as terminal state in approval responses check (#13670)

### DIFF
--- a/packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.test.ts
+++ b/packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.test.ts
@@ -228,6 +228,57 @@ describe('lastAssistantMessageIsCompleteWithApprovalResponses', () => {
     ).toBe(false);
   });
 
+  it('should return false if all tools are output-denied (none approval-responded)', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_1',
+                state: 'output-denied',
+                input: { city: 'Tokyo' },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('should return true mixing output-denied with approval-responded', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithApprovalResponses({
+        messages: [
+          {
+            id: '1',
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_1',
+                state: 'approval-responded',
+                input: { city: 'Tokyo' },
+                approval: { id: 'approval_1', approved: true },
+              },
+              {
+                type: 'tool-getWeather',
+                toolCallId: 'call_2',
+                state: 'output-denied',
+                input: { city: 'Paris' },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
   it('should only consider the last step in a multi-step message', () => {
     expect(
       lastAssistantMessageIsCompleteWithApprovalResponses({

--- a/packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.ts
+++ b/packages/ai/src/ui/last-assistant-message-is-complete-with-approval-responses.ts
@@ -36,6 +36,7 @@ export function lastAssistantMessageIsCompleteWithApprovalResponses({
       part =>
         part.state === 'output-available' ||
         part.state === 'output-error' ||
+        part.state === 'output-denied' ||
         part.state === 'approval-responded',
     )
   );


### PR DESCRIPTION
## Problem

Issue #13670: When a user denies a tool call via approval response, the UI assistant does not recognize the message as complete. The \lastAssistantMessageIsCompleteWithApprovalResponses\ function's terminal state check was missing \output-denied\, so the conversation appears frozen after denying a tool call.

## Root Cause

In \last-assistant-message-is-complete-with-approval-responses.ts\, the \.every()\ predicate only recognized \output-available\, \output-error\, and \pproval-responded\ as terminal states. The \output-denied\ state (set when a user denies a tool via \ddToolApprovalResponse({ approved: false })\) was not included, so the function never returned \	rue\ when tools were denied.

## Fix

Added \output-denied\ to the list of recognized terminal states in the \.every()\ predicate.

## Companion PR

This is a companion fix to PR #17900 which added \output-denied\ to \sendAutomaticallyWhen\ terminal states but missed this function.

Closes #13670