### PR TITLE
fix(ai/core): generate structured output when stop condition fires mid-tool-call (#13075)

### DIFF
--- a/.changeset/cs-output-stop-condition.md
+++ b/.changeset/cs-output-stop-condition.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+generate structured output when stop condition fires mid-tool-call

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -794,6 +794,11 @@ export async function generateText<
       // These tools may not return their results in the same turn as their call.
       const pendingDeferredToolCalls = new Map<string, { toolName: string }>();
 
+      // When the stop condition fires while the model is still calling tools
+      // and output is configured, allow one more output-only step with
+      // toolChoice: 'none' to let the model generate the structured output.
+      let needsOutputStep = false;
+
       do {
         if (steps.length > 0) {
           mergedAbortSignal?.throwIfAborted();
@@ -858,27 +863,39 @@ export async function generateText<
                 prepareStepResult?.runtimeContext ?? runtimeContext;
               toolsContext = prepareStepResult?.toolsContext ?? toolsContext;
 
-              const stepActiveTools = filterActiveTools({
-                tools,
-                activeTools: prepareStepResult?.activeTools ?? activeTools,
-              });
+              const stepActiveTools = needsOutputStep
+                ? ({} as ActiveToolSubset<TOOLS, ActiveTools<NoInfer<TOOLS>>>)
+                : filterActiveTools({
+                    tools,
+                    activeTools: prepareStepResult?.activeTools ?? activeTools,
+                  });
               const stepToolOrder = prepareStepResult?.toolOrder ?? toolOrder;
 
-              const stepTools = await prepareTools({
-                tools: stepActiveTools,
-                toolOrder: stepToolOrder as ToolOrder<
-                  ActiveToolSubset<TOOLS, ActiveTools<NoInfer<TOOLS>>>
-                >,
-                // active tools context is a subset of the tools context, so we can cast to the unknown type
-                toolsContext: toolsContext as unknown as InferToolSetContext<
-                  ActiveToolSubset<TOOLS, ActiveTools<NoInfer<TOOLS>>>
-                >,
-                experimental_sandbox: stepSandbox,
-              });
+              const stepTools = needsOutputStep
+                ? []
+                : await prepareTools({
+                    tools: stepActiveTools,
+                    toolOrder: stepToolOrder as ToolOrder<
+                      ActiveToolSubset<TOOLS, ActiveTools<NoInfer<TOOLS>>>
+                    >,
+                    toolsContext:
+                      toolsContext as unknown as InferToolSetContext<
+                        ActiveToolSubset<
+                          TOOLS,
+                          ActiveTools<NoInfer<TOOLS>>
+                        >
+                      >,
+                    experimental_sandbox: stepSandbox,
+                  });
 
-              const stepToolChoice = prepareToolChoice({
-                toolChoice: prepareStepResult?.toolChoice ?? toolChoice,
-              });
+              const stepToolChoice = needsOutputStep
+                ? { type: 'none' as const }
+                : prepareToolChoice({
+                    toolChoice: prepareStepResult?.toolChoice ?? toolChoice,
+                  });
+
+              // Clear flag now that the next iteration has been configured:
+              needsOutputStep = false;
 
               const stepMessages =
                 prepareStepResult?.messages ?? stepInputMessages;
@@ -1362,16 +1379,26 @@ export async function generateText<
             clearTimeout(stepTimeoutId);
           }
         }
+        const outputStepNeeded =
+          output != null &&
+          currentModelResponse.finishReason.unified === 'tool-calls' &&
+          (await isStopConditionMet({ stopConditions, steps }));
+
+        if (outputStepNeeded) {
+          needsOutputStep = true;
+        }
       } while (
         // Continue if:
-        // 1. There are client tool calls that have all been executed or denied, OR
-        // 2. There are pending deferred results from provider-executed tools
+        // 1. There are client tool calls that have all been executed or denied, AND
+        //    no stop condition is met, OR
+        // 2. An output-only step is needed to generate structured output
+        //    (overrides the stop condition for one final step with toolChoice none)
         ((clientToolCalls.length > 0 &&
           clientToolOutputs.length + deniedToolApprovalResponses.length ===
-            clientToolCalls.length) ||
-          pendingDeferredToolCalls.size > 0) &&
-        // continue until a stop condition is met:
-        !(await isStopConditionMet({ stopConditions, steps }))
+            clientToolCalls.length &&
+          !(await isStopConditionMet({ stopConditions, steps }))) ||
+          pendingDeferredToolCalls.size > 0 ||
+          needsOutputStep)
       );
 
       const lastStep = steps[steps.length - 1];


### PR DESCRIPTION
## Problem

Issue #13075: When using \generateText\ with \output\ (e.g. \Output.object({...})\) and a \stopWhen\ condition (e.g. \isStepCount(6)\), the tool-calling loop may exit while the model is still returning \	ool-calls\ as its finish reason. Since output parsing only runs when \lastStep.finishReason === 'stop'\, accessing \.output\ throws \AI_NoOutputGeneratedError\.

## Root Cause

The do-while loop at \generateText.ts:1365\ checks \isStopConditionMet\ after each step. When the condition fires (e.g., after 6 steps), the loop exits immediately. If the model's last response had finish reason \	ool-calls\, the output parsing at line 1450 is skipped, leaving \esolvedOutput\ undefined.

## Fix

Detect when:
1. Output is configured, AND
2. The current step's finish reason is \	ool-calls\, AND
3. The stop condition is met

In this case, set \
eedsOutputStep = true\ to allow one more loop iteration with \	oolChoice: 'none'\ and empty tools. The model then produces a text response with the structured output, the loop exits normally with \inishReason === 'stop'\, and the output is parsed correctly.

Closes #13075