### PR TITLE
fix(build): replace rm -rf with del-cli in package clean scripts for Windows compatibility

### DIFF
--- a/.changeset/clean-scripts-del-cli.md
+++ b/.changeset/clean-scripts-del-cli.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/baseten': patch
+'@ai-sdk/huggingface': patch
+'@ai-sdk/mcp': patch
+'@ai-sdk/test-server': patch
+---
+
+fix: replace rm -rf with del-cli in package clean scripts for Windows compatibility

--- a/packages/baseten/package.json
+++ b/packages/baseten/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
     "build:watch": "pnpm clean && tsup --watch",
-    "clean": "rm -rf dist docs *.tsbuildinfo",
+    "clean": "del-cli dist docs *.tsbuildinfo",
     "prepack": "mkdir -p docs && cp ../../content/providers/01-ai-sdk-providers/170-baseten.mdx ./docs/",
     "postpack": "del-cli docs",
     "type-check": "tsc --build",

--- a/packages/huggingface/package.json
+++ b/packages/huggingface/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
     "build:watch": "pnpm clean && tsup --watch",
-    "clean": "rm -rf dist docs *.tsbuildinfo",
+    "clean": "del-cli dist docs *.tsbuildinfo",
     "prepack": "mkdir -p docs && cp ../../content/providers/01-ai-sdk-providers/170-huggingface.mdx ./docs/",
     "postpack": "del-cli docs",
     "type-check": "tsc --build",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
     "build:watch": "pnpm clean && tsup --watch",
-    "clean": "rm -rf dist *.tsbuildinfo",
+    "clean": "del-cli dist *.tsbuildinfo",
     "type-check": "tsc --build",
     "test": "pnpm test:node && pnpm test:edge",
     "test:update": "pnpm test:node -u",

--- a/packages/test-server/package.json
+++ b/packages/test-server/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
     "build:watch": "pnpm clean && tsup --watch",
-    "clean": "rm -rf dist *.tsbuildinfo",
+    "clean": "del-cli dist *.tsbuildinfo",
     "type-check": "tsc --build",
     "test": "pnpm test:node && pnpm test:edge",
     "test:update": "pnpm test:node -u",


### PR DESCRIPTION
## Background

Running `pnpm build` or `pnpm test` on Windows environments fails when Turborepo builds package dependencies (such as `@ai-sdk/test-server`). 

While most of the packages in the monorepo use `del-cli` for cross-platform file deletion in their `clean` script, 4 packages (`@ai-sdk/test-server`, `@ai-sdk/mcp`, `@ai-sdk/huggingface`, `@ai-sdk/baseten`) still used `rm -rf`. Standard Windows shells (PowerShell / Command Prompt) fail with `'rm' is not recognized as an internal or external command`, halting the build and test process for Windows developers.

## Summary

Replaced `"clean": "rm -rf ..."` with `"clean": "del-cli ..."` in `package.json` for the 4 affected packages:
- `packages/test-server/package.json`
- `packages/mcp/package.json`
- `packages/huggingface/package.json`
- `packages/baseten/package.json`

Added a patch changeset covering all 4 updated packages.

## Contributor Credit

- Kushal Rathod (Issue reporter & PR author)

## End-to-End Verification

Tested on a Windows machine:
1. Navigated to `packages/test-server` and executed `pnpm clean`.
2. Confirmed `del-cli dist *.tsbuildinfo` runs cleanly without `'rm' is not recognized` errors.
3. Verified `pnpm build` completes successfully.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17951 