### PR TITLE
fix(amazon-bedrock): forward disable parallel tool use

### DIFF
--- a/.changeset/bedrock-disable-parallel-tools.md
+++ b/.changeset/bedrock-disable-parallel-tools.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Forward Anthropic disable parallel tool use setting in Bedrock requests.

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
@@ -366,7 +366,7 @@ describe('amazon-bedrock-anthropic-provider', () => {
     expect(transformedBody).toHaveProperty('anthropic_version');
   });
 
-  it('should strip disable_parallel_tool_use from tool_choice', () => {
+  it('should preserve disable_parallel_tool_use on auto tool_choice', () => {
     const provider = createAmazonBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
@@ -392,13 +392,13 @@ describe('amazon-bedrock-anthropic-provider', () => {
       new Set(),
     );
 
-    expect(transformedBody?.tool_choice).toEqual({ type: 'auto' });
-    expect(transformedBody?.tool_choice).not.toHaveProperty(
-      'disable_parallel_tool_use',
-    );
+    expect(transformedBody?.tool_choice).toEqual({
+      type: 'auto',
+      disable_parallel_tool_use: true,
+    });
   });
 
-  it('should preserve tool_choice name when present', () => {
+  it('should preserve tool_choice name and disable_parallel_tool_use when present', () => {
     const provider = createAmazonBedrockAnthropic({
       region: 'us-east-1',
       accessKeyId: 'test-key',
@@ -428,6 +428,7 @@ describe('amazon-bedrock-anthropic-provider', () => {
     expect(transformedBody?.tool_choice).toEqual({
       type: 'tool',
       name: 'my_tool',
+      disable_parallel_tool_use: true,
     });
   });
 

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
@@ -280,6 +280,12 @@ export function createAmazonBedrockAnthropic(
             ? {
                 type: tool_choice.type,
                 ...(tool_choice.name != null ? { name: tool_choice.name } : {}),
+                ...(tool_choice.disable_parallel_tool_use != null
+                  ? {
+                      disable_parallel_tool_use:
+                        tool_choice.disable_parallel_tool_use,
+                    }
+                  : {}),
               }
             : undefined;
 


### PR DESCRIPTION
## Background

`providerOptions.anthropic.disableParallelToolUse` is documented and works for the Anthropic provider, but the Bedrock Anthropic request transform was not carrying the corresponding Anthropic wire field through to Bedrock. As a result, callers could opt out of parallel tool calls in user code while the actual Bedrock request still allowed multiple `tool_use` blocks.

Root cause: the Bedrock Anthropic provider already maps `tool_choice` into Bedrock's Anthropic shape, but it only forwarded the choice type/name and dropped `disable_parallel_tool_use` for both `auto` and named-tool choices.

## Summary

- Preserve `tool_choice.disable_parallel_tool_use` when Bedrock Anthropic transforms Anthropic request bodies.
- Cover both affected paths: `auto` tool choice and named tool choice.
- Add a patch changeset for `@ai-sdk/amazon-bedrock`.

## Contributor Credit

Thanks to @sagar448 for the detailed issue report and reproduction in #17267. @lgrammel, tagging you for review since you already classified the issue as a high-confidence provider bug.

## End-to-End Verification

The reported failure is at the provider request-shaping layer. I verified the generated Bedrock Anthropic request body now includes `disable_parallel_tool_use` in the focused regression tests for the two affected tool-choice forms.

## Test Plan

- `pnpm --filter @ai-sdk/provider --filter @ai-sdk/provider-utils --filter @ai-sdk/anthropic build`
- `pnpm --filter @ai-sdk/test-server --filter @ai-sdk/openai build`
- `pnpm vitest --config vitest.node.config.js --run src/anthropic/amazon-bedrock-anthropic-provider.test.ts --testNamePattern 'preserve disable_parallel_tool_use|preserve tool_choice name'`
- `pnpm type-check`
- `pnpm test:node`
- `pnpm test:edge`
- `pnpm exec oxfmt --check packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts .changeset/bedrock-disable-parallel-tools.md`

Current PR checks are green; this is waiting on maintainer review.

## Risk / reviewer notes

Low-risk request serialization fix. The new field is only emitted when the caller has already set `disable_parallel_tool_use`, so existing default Bedrock behavior is unchanged. The main compatibility surface is Anthropic-on-Bedrock request shape parity with the existing Anthropic provider.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17267.
