### PR TITLE
fix(perplexity): wrap inline PDF data in proper data URI

### DIFF
--- a/packages/perplexity/src/convert-to-perplexity-messages.test.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.test.ts
@@ -191,7 +191,7 @@ describe('convertToPerplexityMessages', () => {
 
       expect((result[0].content as unknown[])[0]).toEqual({
         type: 'file_url',
-        file_url: { url: pdfBase64 },
+        file_url: { url: `data:application/pdf;base64,${pdfBase64}` },
         file_name: 'doc.pdf',
       });
     });

--- a/packages/perplexity/src/convert-to-perplexity-messages.ts
+++ b/packages/perplexity/src/convert-to-perplexity-messages.ts
@@ -81,10 +81,11 @@ export function convertToPerplexityMessages(
                         : {
                             type: 'file_url',
                             file_url: {
-                              url:
+                              url: `data:${resolveFullMediaType({ part })};base64,${
                                 typeof part.data.data === 'string'
                                   ? part.data.data
-                                  : convertUint8ArrayToBase64(part.data.data),
+                                  : convertUint8ArrayToBase64(part.data.data)
+                              }`,
                             },
                             file_name: part.filename || `document-${index}.pdf`,
                           };

--- a/packages/perplexity/src/perplexity-language-model.test.ts
+++ b/packages/perplexity/src/perplexity-language-model.test.ts
@@ -305,7 +305,7 @@ describe('doGenerate', () => {
         {
           "file_name": "test.pdf",
           "file_url": {
-            "url": "mock-pdf-data",
+            "url": "data:application/pdf;base64,mock-pdf-data",
           },
           "type": "file_url",
         },


### PR DESCRIPTION
@
Fix: Wrapped inline PDF file part data in a proper data URI (`data:application/pdf;base64,...`) instead of passing raw base64 string.

**Bug:** In `convertToPerplexityMessages`, when an inline PDF file part is converted for the Perplexity API, the raw base64 data was passed directly as the `url` value without a data URI prefix. This was inconsistent with how image data is already handled (lines 72-80 construct `data:image/png;base64,...` data URIs). Perplexity's API expects valid URLs or data URIs for `file_url` content, so the raw base64 string would fail.

**Fix:** Wrap the internal PDF data in `data:application/pdf;base64,...` using the same `resolveFullMediaType` helper already used for image parts.

**Changes:**
- `packages/perplexity/src/convert-to-perplexity-messages.ts` — wrap inline PDF data in a proper data URI
- `packages/perplexity/src/convert-to-perplexity-messages.test.ts` — update test expectation to match corrected URI format  
- `packages/perplexity/src/perplexity-language-model.test.ts` — update inline snapshot to match corrected URI format

**Testing:**
- All 35 existing tests pass (2 test suites)
- Existing `top-level-only media type resolution > accepts top-level-only "application" mediaType for PDF via detection` test now validates the correct data URI format
- Existing `doGenerate > should handle PDF files with base64 encoding` test now validates the corrected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@