### PR TITLE
chore(docs): disable ai-sdk-docs deployments from release-v6.0 trees

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": { "deploymentEnabled": false }
+}


### PR DESCRIPTION
## Summary

Pushes to `release-v6.0` (and branches cut from it: `changeset-release/*`, `backport-pr-*`) currently produce a **failed Vercel deployment on every push** to the `ai-sdk-docs` project: the project's Root Directory is `apps/docs`, which doesn't exist on this branch, and root-directory validation runs before the project's ignored build step can skip the build.

This adds `apps/docs/vercel.json` as the only content of `apps/docs` on this branch:

- its presence satisfies root-directory validation
- [`git.deploymentEnabled: false`](https://vercel.com/docs/project-configuration/git-configuration#git.deploymentenabled) stops deployment creation entirely for any branch containing this tree — no deployment records, no noise

## Notes

- Inert to this branch's tooling: `apps/*` is not in this branch's workspace globs, the lockfile has no `apps/` importer (frozen install unaffected), turbo derives its graph from pnpm importers, and `verify-changesets` is path-filtered to `.changeset/*.md`
- Passes `ultracite check`
- A sibling PR does the same for `release-v5.0`; a third PR adds branch patterns to main's `apps/docs/vercel.json` so **future** release branches inherit this behavior automatically

Context: reported by @aayush in Slack — every push to the release branches created failed-deployment noise since the docs app landed on main.