### PR TITLE
chore(docs): disable ai-sdk-docs deployments from release-v5.0 trees

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": { "deploymentEnabled": false }
+}


### PR DESCRIPTION
## Summary

Same fix as #17955, for `release-v5.0`: pushes to this branch family fail Vercel deployments on the `ai-sdk-docs` project because its Root Directory (`apps/docs`) doesn't exist here, and that validation precedes the ignored build step.

`apps/docs/vercel.json` (the only content of `apps/docs` on this branch) satisfies root-directory validation and sets [`git.deploymentEnabled: false`](https://vercel.com/docs/project-configuration/git-configuration#git.deploymentenabled), so no deployments are created from trees containing it.

## Notes

- This branch's workspace globs include `apps/*`, but pnpm only creates importers for directories with a `package.json` — a config-only directory is ignored; the lockfile is unchanged and `--frozen-lockfile` CI is unaffected
- Passes `ultracite check`
- Siblings: #17955 (release-v6.0) and a main-side PR adding branch patterns so future release branches inherit this automatically