### PR TITLE
chore(docs): skip docs deployments for release-family branches

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm build:site"
+  "buildCommand": "pnpm build:site",
+  "git": {
+    "deploymentEnabled": {
+      "release-v*": false,
+      "changeset-release/release-v*": false,
+      "changesets-ghcommit-temp/**": false,
+      "backport-pr-*": false
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Future-proofing companion to #17955 / #17956.

Those PRs stop the failing `ai-sdk-docs` deployments on the **existing** release branches (whose trees predate `apps/docs`). Future release branches (`release-v7.0`+) will be cut from main and *inherit* `apps/docs` — so they'd pass root-directory validation and run pointless docs builds whenever a changeset touches the lockfile.

This adds [`git.deploymentEnabled`](https://vercel.com/docs/project-configuration/git-configuration#git.deploymentenabled) branch patterns to main's `apps/docs/vercel.json`, inherited automatically by every branch cut from main:

| Pattern | Covers | Example |
|---|---|---|
| `release-v*` | release branches | `release-v7.0` |
| `changeset-release/release-v*` | release Version Packages branches | `changeset-release/release-v7.0` |
| `changesets-ghcommit-temp/**` | changesets bot temp branches | `changesets-ghcommit-temp/changeset-release/…` |
| `backport-pr-*` | backport branches | `backport-pr-10180-to-release-v5.0` |

## Verified with minimatch (the engine Vercel documents for these patterns)

Matches all of the above; does **not** match `main`, `changeset-release/main` (Version Packages PRs on main keep their docs previews), or lookalike feature branches (`release-notes-fix`). Unlisted branches default to `true`, so PR previews are unaffected.

Passes `ultracite check`; JSON valid against the vercel.json schema.