### PR TITLE
reproduction: @ai-sdk/xai: Responses model silently drops topK / presencePenalty

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "issueId": 17936,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17936.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17936.ts",
+    "packages/xai/src/responses/__fixtures__/xai-web-search-tool.1.json",
+    "packages/xai/src/responses/__fixtures__/xai-text-streaming.1.chunks.txt"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Issue #17936 reproduced: xAI Responses silently dropped unsupported sampling settings"
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17936.ts
+++ b/examples/ai-functions/src/reproduction/issue-17936.ts
@@ -1,0 +1,117 @@
+import { createXai } from '@ai-sdk/xai';
+import { generateText, streamText, type CallWarning } from 'ai';
+import fs from 'node:fs';
+
+const EXPECTED_FEATURES = [
+  'topK',
+  'presencePenalty',
+  'frequencyPenalty',
+] as const;
+
+const generateFixture = JSON.parse(
+  fs.readFileSync(
+    new URL(
+      '../../../../packages/xai/src/responses/__fixtures__/xai-web-search-tool.1.json',
+      import.meta.url,
+    ),
+    'utf8',
+  ),
+) as unknown;
+
+const streamFixture = fs
+  .readFileSync(
+    new URL(
+      '../../../../packages/xai/src/responses/__fixtures__/xai-text-streaming.1.chunks.txt',
+      import.meta.url,
+    ),
+    'utf8',
+  )
+  .split('\n')
+  .map(line => `data: ${line}\n\n`)
+  .concat('data: [DONE]\n\n')
+  .join('');
+
+function getUnsupportedFeatures(warnings: CallWarning[] | undefined) {
+  return (
+    warnings
+      ?.filter(warning => warning.type === 'unsupported')
+      .map(warning => warning.feature) ?? []
+  );
+}
+
+async function main() {
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const provider = createXai({
+    apiKey: 'test-key',
+    fetch: async (_url, init) => {
+      const body = (await new Response(init?.body).json()) as Record<
+        string,
+        unknown
+      >;
+      requestBodies.push(body);
+
+      if (body.stream === true) {
+        return new Response(streamFixture, {
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      }
+
+      return Response.json(generateFixture);
+    },
+  });
+
+  const settings = {
+    prompt: 'hello',
+    topK: 10,
+    presencePenalty: 0.5,
+    frequencyPenalty: 0.5,
+  } as const;
+
+  const generated = await generateText({
+    model: provider('grok-4'),
+    ...settings,
+  });
+
+  const streamed = streamText({
+    model: provider('grok-4'),
+    ...settings,
+  });
+  await streamed.consumeStream();
+
+  const generateWarnings = getUnsupportedFeatures(generated.warnings);
+  const streamWarnings = getUnsupportedFeatures(await streamed.warnings);
+  const missingGenerateWarnings = EXPECTED_FEATURES.filter(
+    feature => !generateWarnings.includes(feature),
+  );
+  const missingStreamWarnings = EXPECTED_FEATURES.filter(
+    feature => !streamWarnings.includes(feature),
+  );
+  const requestFields = requestBodies.map(body => ({
+    top_k: body.top_k,
+    presence_penalty: body.presence_penalty,
+    frequency_penalty: body.frequency_penalty,
+  }));
+
+  console.log(
+    JSON.stringify(
+      {
+        provider: provider('grok-4').provider,
+        generateWarnings,
+        streamWarnings,
+        missingGenerateWarnings,
+        missingStreamWarnings,
+        requestFields,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (missingGenerateWarnings.length > 0 || missingStreamWarnings.length > 0) {
+    throw new Error(
+      'Issue #17936 reproduced: xAI Responses silently dropped unsupported sampling settings',
+    );
+  }
+}
+
+main();

--- a/packages/xai/src/responses/xai-responses-language-model.issue-17936.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.issue-17936.test.ts
@@ -1,0 +1,80 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import {
+  convertReadableStreamToArray,
+  mockId,
+} from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { expect, it } from 'vitest';
+import { XaiResponsesLanguageModel } from './xai-responses-language-model';
+
+const TEST_PROMPT: LanguageModelV4Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+];
+
+const EXPECTED_WARNINGS = [
+  { type: 'unsupported', feature: 'topK' },
+  { type: 'unsupported', feature: 'presencePenalty' },
+  { type: 'unsupported', feature: 'frequencyPenalty' },
+];
+
+const server = createTestServer({
+  'https://api.x.ai/v1/responses': {},
+});
+
+function createModel() {
+  return new XaiResponsesLanguageModel('grok-4', {
+    provider: 'xai.responses',
+    baseURL: 'https://api.x.ai/v1',
+    headers: () => ({ Authorization: 'Bearer test-key' }),
+    generateId: mockId(),
+  });
+}
+
+it('reproduces issue #17936 for generate and stream warnings', async () => {
+  server.urls['https://api.x.ai/v1/responses'].response = {
+    type: 'json-value',
+    body: JSON.parse(
+      fs.readFileSync(
+        'src/responses/__fixtures__/xai-web-search-tool.1.json',
+        'utf8',
+      ),
+    ),
+  };
+
+  const generateResult = await createModel().doGenerate({
+    prompt: TEST_PROMPT,
+    topK: 10,
+    presencePenalty: 0.5,
+    frequencyPenalty: 0.5,
+  });
+
+  server.urls['https://api.x.ai/v1/responses'].response = {
+    type: 'stream-chunks',
+    chunks: fs
+      .readFileSync(
+        'src/responses/__fixtures__/xai-text-streaming.1.chunks.txt',
+        'utf8',
+      )
+      .split('\n')
+      .map(line => `data: ${line}\n\n`)
+      .concat('data: [DONE]\n\n'),
+  };
+
+  const streamResult = await createModel().doStream({
+    prompt: TEST_PROMPT,
+    topK: 10,
+    presencePenalty: 0.5,
+    frequencyPenalty: 0.5,
+  });
+  const streamParts = await convertReadableStreamToArray(streamResult.stream);
+  const streamStart = streamParts.find(part => part.type === 'stream-start');
+
+  expect({
+    generate: generateResult.warnings,
+    stream: streamStart?.warnings,
+  }).toEqual({
+    generate: expect.arrayContaining(EXPECTED_WARNINGS),
+    stream: expect.arrayContaining(EXPECTED_WARNINGS),
+  });
+});


### PR DESCRIPTION
## Bug

@ai-sdk/xai: Responses model silently drops topK / presencePenalty / frequencyPenalty (chat model warns)

## Reproduction

- The checked-out branch uses `@ai-sdk/xai` 4.0.18 and `ai` 7.0.37, matching the reported versions.
- A live `xai('grok-4')` call returned `warnings: []`, while the equivalent `xai.chat('grok-4')` call returned unsupported warnings for `topK`, `frequencyPenalty`, and `presencePenalty`.
- `examples/ai-functions/src/reproduction/issue-17936.ts` reproduced the primary failure for both `generateText` and `streamText`: all three expected warnings were absent and the corresponding request fields were omitted.
- `packages/xai/src/responses/xai-responses-language-model.issue-17936.test.ts` reproduced the same result with recorded provider fixtures: both generate and stream warnings were `[]` instead of containing the three unsupported-feature warnings.
- `packages/xai/src/xai-provider.ts` makes the Responses model the default, and `packages/xai/src/responses/xai-responses-language-model.ts` does not process these three call options.

## Relevant Documentation

- https://docs.x.ai/developers/rest-api-reference/inference/chat

## Related Issues

Reproduces #17936

Co-Authored-By: Lars Grammel <205036+lgrammel@users.noreply.github.com>