### PR TITLE
[v6.0] reproduction: BUG: Mistral provider flattens ThinkChunk when replaying reasoning

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17930,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/mistral-reasoning-history.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/mistral-reasoning-history.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "MISTRAL_REASONING_HISTORY_FLATTENED: expected the second request to preserve the thinking and text chunks"
+  }
+}

--- a/examples/ai-functions/src/reproduction/mistral-reasoning-history.ts
+++ b/examples/ai-functions/src/reproduction/mistral-reasoning-history.ts
@@ -1,0 +1,141 @@
+import { createMistral } from '@ai-sdk/mistral';
+import { generateText, type ModelMessage } from 'ai';
+
+async function main() {
+  const requests: Array<Record<string, unknown>> = [];
+  const responses: Array<Record<string, any>> = [];
+
+  const recordingFetch: typeof fetch = async (input, init) => {
+    if (typeof init?.body === 'string') {
+      requests.push(JSON.parse(init.body));
+    }
+
+    const response = await fetch(input, init);
+    responses.push(await response.clone().json());
+    return response;
+  };
+
+  const mistral = createMistral({
+    apiKey: process.env.MISTRAL_API_KEY!,
+    fetch: recordingFetch,
+  });
+
+  const model = mistral('mistral-small-latest');
+  const providerOptions = {
+    mistral: { reasoningEffort: 'high' as const },
+  };
+  const firstUserMessage: ModelMessage = {
+    role: 'user',
+    content: 'What is 17 * 23? Reply with only the result.',
+  };
+
+  const first = await generateText({
+    model,
+    messages: [firstUserMessage],
+    providerOptions,
+  });
+
+  const directReplayResponse = await fetch(
+    'https://api.mistral.ai/v1/chat/completions',
+    {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${process.env.MISTRAL_API_KEY!}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'mistral-small-latest',
+        reasoning_effort: 'high',
+        messages: [
+          (requests[0].messages as Array<any>)[0],
+          responses[0].choices[0].message,
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'Now multiply that result by 3. Reply with only the result.',
+              },
+            ],
+          },
+        ],
+      }),
+    },
+  );
+  const directReplayBody = await directReplayResponse.json();
+
+  if (!directReplayResponse.ok) {
+    throw new Error(
+      `DIRECT_MISTRAL_REPLAY_FAILED: ${directReplayResponse.status} ${JSON.stringify(directReplayBody)}`,
+    );
+  }
+
+  await generateText({
+    model,
+    messages: [
+      firstUserMessage,
+      ...first.response.messages,
+      {
+        role: 'user',
+        content: 'Now multiply that result by 3. Reply with only the result.',
+      },
+    ],
+    providerOptions,
+  });
+
+  const firstContent = responses[0]?.choices?.[0]?.message?.content;
+  const replayedAssistant = (requests[1]?.messages as Array<any>)?.find(
+    message => message.role === 'assistant',
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        firstResponse: responses[0],
+        directReplayStatus: directReplayResponse.status,
+        directReplayContent: directReplayBody.choices?.[0]?.message?.content,
+        replayedAssistant,
+      },
+      null,
+      2,
+    ),
+  );
+
+  const firstThinking = Array.isArray(firstContent)
+    ? firstContent.find(part => part.type === 'thinking')
+    : undefined;
+  const firstText = Array.isArray(firstContent)
+    ? firstContent.find(part => part.type === 'text')
+    : undefined;
+
+  if (firstThinking == null || firstText == null) {
+    throw new Error(
+      'LIVE_RESPONSE_DID_NOT_CONTAIN_SEPARATE_THINKING_AND_TEXT_CHUNKS',
+    );
+  }
+
+  const replayedContent = replayedAssistant?.content;
+  const preserved =
+    Array.isArray(replayedContent) &&
+    replayedContent.some(
+      part =>
+        part.type === 'thinking' &&
+        part.closed === firstThinking.closed &&
+        JSON.stringify(part.thinking) ===
+          JSON.stringify(firstThinking.thinking),
+    ) &&
+    replayedContent.some(
+      part => part.type === 'text' && part.text === firstText.text,
+    );
+
+  if (!preserved) {
+    throw new Error(
+      'MISTRAL_REASONING_HISTORY_FLATTENED: expected the second request to preserve the thinking and text chunks',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/mistral/src/__fixtures__/mistral-reasoning-history-live.json
+++ b/packages/mistral/src/__fixtures__/mistral-reasoning-history-live.json
@@ -1,0 +1,40 @@
+{
+  "id": "3fc89f3a1a2644a68bdeb50b83843cb2",
+  "created": 1785154603,
+  "model": "mistral-small-latest",
+  "usage": {
+    "prompt_tokens": 31,
+    "total_tokens": 271,
+    "completion_tokens": 240,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    }
+  },
+  "object": "chat.completion",
+  "choices": [
+    {
+      "index": 0,
+      "finish_reason": "stop",
+      "message": {
+        "role": "assistant",
+        "tool_calls": null,
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": [
+              {
+                "type": "text",
+                "text": "Okay, I need to calculate 17 multiplied by 23. Let me break it down to make sure I get it right.\n\nFirst, I can use the distributive property of multiplication over addition to simplify the calculation. That means I can break down one of the numbers into more manageable parts.\n\nLet's break down 23 into 20 and 3. So, 17 * 23 can be written as 17 * (20 + 3).\n\nNow, I can multiply 17 by each part separately and then add the results together.\n\nFirst, multiply 17 by 20:\n17 * 20 = (10 + 7) * 20 = 10*20 + 7*20 = 200 + 140 = 340\n\nNext, multiply 17 by 3:\n17 * 3 = 51\n\nNow, add the two results together:\n340 + 51 = 391\n\nSo, 17 * 23 equals 391."
+              }
+            ],
+            "closed": true
+          },
+          {
+            "type": "text",
+            "text": "391"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/mistral/src/mistral-chat-language-model.test.ts
+++ b/packages/mistral/src/mistral-chat-language-model.test.ts
@@ -105,6 +105,65 @@ describe('doGenerate', () => {
 
       expect(result).toMatchSnapshot();
     });
+
+    it('should preserve thinking chunks when replaying reasoning history', async () => {
+      prepareJsonFixtureResponse('mistral-reasoning-history-live');
+
+      const first = await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'What is 17 * 23? Reply with only the result.',
+              },
+            ],
+          },
+        ],
+      });
+
+      await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'What is 17 * 23? Reply with only the result.',
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: first.content.filter(
+              part => part.type === 'reasoning' || part.type === 'text',
+            ),
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'Now multiply that result by 3. Reply with only the result.',
+              },
+            ],
+          },
+        ],
+      });
+
+      expect((await server.calls[1].requestBodyJson).messages[1]).toEqual({
+        role: 'assistant',
+        content: (
+          JSON.parse(
+            fs.readFileSync(
+              'src/__fixtures__/mistral-reasoning-history-live.json',
+              'utf8',
+            ),
+          ) as any
+        ).choices[0].message.content,
+      });
+    });
   });
 
   it('should pass tools and toolChoice', async () => {


### PR DESCRIPTION
## Bug

BUG: Mistral provider flattens ThinkChunk when replaying reasoning history

## Reproduction

- On the `release-v6.0` target (`ai@6.0.235`, `@ai-sdk/mistral@3.0.51`), the live provider returned separate `thinking` and `text` chunks with `closed: true`.
- `examples/ai-functions/src/reproduction/mistral-reasoning-history.ts` observed the AI SDK replay them as one plain string ending in duplicated visible text (`391.391`), instead of preserving the structured chunks.
- Replaying the same raw structured assistant message directly to Mistral succeeded with HTTP 200 and produced `1173`, locating the defect in AI SDK request conversion rather than the Mistral service.
- `packages/mistral/src/__fixtures__/mistral-reasoning-history-live.json` records the live structured Mistral response.
- The regression test in `packages/mistral/src/mistral-chat-language-model.test.ts` fails because the second request contains a flattened string rather than the expected `thinking` and `text` array.

## Relevant Documentation

- https://docs.mistral.ai/studio-api/conversations/reasoning#multi-turn-conversations

## Related Issues

Reproduces #17930

Co-Authored-By: Lars Grammel <205036+lgrammel@users.noreply.github.com>