### PR TITLE
reproduction: @ai-sdk/google: google.interactions silently drops topK / presencePenalty /

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 17937,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17937-google-interactions-generation-config.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17937-google-interactions-generation-config.ts",
+    "packages/google/src/interactions/__fixtures__/issue-17937-top-k.json"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Reproduced issue #17937: google.interactions() silently dropped topK, presencePenalty, and frequencyPenalty."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17937-google-interactions-generation-config.ts
+++ b/examples/ai-functions/src/reproduction/issue-17937-google-interactions-generation-config.ts
@@ -1,0 +1,172 @@
+import { createGoogle } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import fs from 'node:fs';
+
+const settings = {
+  prompt: 'Hello, how are you?',
+  temperature: 0.5,
+  topK: 10,
+  presencePenalty: 0.5,
+  frequencyPenalty: 0.5,
+} as const;
+
+const interactionFixture = JSON.parse(
+  fs.readFileSync(
+    new URL(
+      '../../../../packages/google/src/interactions/__fixtures__/issue-17937-top-k.json',
+      import.meta.url,
+    ),
+    'utf8',
+  ),
+);
+
+const generateContentFixture = {
+  candidates: [
+    {
+      content: {
+        parts: [{ text: 'OK' }],
+        role: 'model',
+      },
+      finishReason: 'STOP',
+      index: 0,
+    },
+  ],
+  usageMetadata: {
+    promptTokenCount: 6,
+    candidatesTokenCount: 1,
+    totalTokenCount: 7,
+  },
+  modelVersion: 'gemini-2.5-flash',
+};
+
+type CapturedCall = {
+  url: string;
+  body: Record<string, any>;
+};
+
+function warningMentions(warnings: unknown, option: string) {
+  return JSON.stringify(warnings).includes(option);
+}
+
+async function main() {
+  const calls: CapturedCall[] = [];
+  const google = createGoogle({
+    apiKey: 'test-api-key',
+    baseURL: 'https://issue-17937.test/v1beta',
+    fetch: async (input, init) => {
+      const url = String(input);
+      const body =
+        typeof init?.body === 'string' ? JSON.parse(init.body) : undefined;
+      calls.push({ url, body });
+
+      const responseBody = url.endsWith('/interactions')
+        ? interactionFixture
+        : generateContentFixture;
+
+      return new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+
+  await generateText({
+    model: google('gemini-2.5-flash'),
+    ...settings,
+  });
+
+  const modelResult = await generateText({
+    model: google.interactions('gemini-2.5-flash'),
+    ...settings,
+  });
+
+  const agentResult = await generateText({
+    model: google.interactions({
+      agent: 'antigravity-preview-05-2026',
+    }),
+    prompt: settings.prompt,
+    topK: settings.topK,
+    presencePenalty: settings.presencePenalty,
+    frequencyPenalty: settings.frequencyPenalty,
+  });
+
+  const standardBody = calls.find(call =>
+    call.url.includes(':generateContent'),
+  )?.body;
+  const interactionCalls = calls.filter(call =>
+    call.url.endsWith('/interactions'),
+  );
+  const modelBody = interactionCalls[0]?.body;
+  const agentBody = interactionCalls[1]?.body;
+
+  const expectedStandardConfig = {
+    topK: settings.topK,
+    presencePenalty: settings.presencePenalty,
+    frequencyPenalty: settings.frequencyPenalty,
+  };
+
+  for (const [field, expected] of Object.entries(expectedStandardConfig)) {
+    if (standardBody?.generationConfig?.[field] !== expected) {
+      throw new Error(
+        `Reproduction setup failed: google() did not forward ${field}.`,
+      );
+    }
+  }
+
+  const options = [
+    {
+      option: 'topK',
+      wireField: 'top_k',
+      value: settings.topK,
+    },
+    {
+      option: 'presencePenalty',
+      wireField: 'presence_penalty',
+      value: settings.presencePenalty,
+    },
+    {
+      option: 'frequencyPenalty',
+      wireField: 'frequency_penalty',
+      value: settings.frequencyPenalty,
+    },
+  ] as const;
+
+  const modelSilentDrops = options
+    .filter(
+      ({ option, wireField, value }) =>
+        modelBody?.generation_config?.[wireField] !== value &&
+        !warningMentions(modelResult.warnings, option),
+    )
+    .map(({ option }) => option);
+
+  const agentSilentDrops = options
+    .filter(({ option }) => !warningMentions(agentResult.warnings, option))
+    .map(({ option }) => option);
+
+  console.log(
+    JSON.stringify(
+      {
+        standardGenerationConfig: standardBody?.generationConfig,
+        interactionsGenerationConfig: modelBody?.generation_config,
+        interactionsWarnings: modelResult.warnings,
+        agentGenerationConfig: agentBody?.generation_config,
+        agentWarnings: agentResult.warnings,
+        modelSilentDrops,
+        agentSilentDrops,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (modelSilentDrops.length > 0 || agentSilentDrops.length > 0) {
+    throw new Error(
+      'Reproduced issue #17937: google.interactions() silently dropped topK, presencePenalty, and frequencyPenalty.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/google/src/interactions/__fixtures__/issue-17937-top-k.json
+++ b/packages/google/src/interactions/__fixtures__/issue-17937-top-k.json
@@ -1,0 +1,37 @@
+{
+  "status": "completed",
+  "usage": {
+    "total_tokens": 17,
+    "total_input_tokens": 6,
+    "input_tokens_by_modality": [
+      {
+        "modality": "text",
+        "tokens": 6
+      }
+    ],
+    "total_cached_tokens": 0,
+    "total_output_tokens": 1,
+    "total_tool_use_tokens": 0,
+    "total_thought_tokens": 10
+  },
+  "created": "2026-07-27T12:22:26Z",
+  "updated": "2026-07-27T12:22:26Z",
+  "service_tier": "standard",
+  "steps": [
+    {
+      "signature": "CkUBEU0yD6+X0ZJASL6Kah/IXOE4gNPp0i0RSejzNFMhMiPrTSEqfvltu8mj/UTR6YcCyxKv1pLeItHTHcs4WHQCKa7dBkM=",
+      "type": "thought"
+    },
+    {
+      "content": [
+        {
+          "text": "OK",
+          "type": "text"
+        }
+      ],
+      "type": "model_output"
+    }
+  ],
+  "object": "interaction",
+  "model": "gemini-2.5-flash"
+}

--- a/packages/google/src/interactions/google-interactions-generation-config.issue-17937.test.ts
+++ b/packages/google/src/interactions/google-interactions-generation-config.issue-17937.test.ts
@@ -1,0 +1,99 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createGoogle } from '../google-provider';
+
+vi.mock('../version', () => ({ VERSION: '0.0.0-test' }));
+
+const TEST_URL =
+  'https://generativelanguage.googleapis.com/v1beta/interactions';
+
+const TEST_PROMPT: LanguageModelV4Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello, how are you?' }] },
+];
+
+const provider = createGoogle({
+  apiKey: 'test-api-key',
+  generateId: () => 'test-id',
+});
+
+const options = [
+  { option: 'topK', wireField: 'top_k', value: 10 },
+  {
+    option: 'presencePenalty',
+    wireField: 'presence_penalty',
+    value: 0.5,
+  },
+  {
+    option: 'frequencyPenalty',
+    wireField: 'frequency_penalty',
+    value: 0.5,
+  },
+] as const;
+
+function warningMentions(warnings: unknown, option: string) {
+  return JSON.stringify(warnings).includes(option);
+}
+
+describe('issue #17937: interactions generation config', () => {
+  const server = createTestServer({ [TEST_URL]: {} });
+
+  beforeEach(() => {
+    server.urls[TEST_URL].response = {
+      type: 'json-value',
+      body: JSON.parse(
+        fs.readFileSync(
+          'src/interactions/__fixtures__/issue-17937-top-k.json',
+          'utf8',
+        ),
+      ),
+    };
+  });
+
+  it('does not silently drop model generation options', async () => {
+    const result = await provider.interactions('gemini-2.5-flash').doGenerate({
+      prompt: TEST_PROMPT,
+      temperature: 0.5,
+      topK: 10,
+      presencePenalty: 0.5,
+      frequencyPenalty: 0.5,
+    });
+
+    const body = (await server.calls[0].requestBodyJson) as {
+      generation_config?: Record<string, unknown>;
+    };
+
+    const silentlyDropped = options
+      .filter(
+        ({ option, wireField, value }) =>
+          body.generation_config?.[wireField] !== value &&
+          !warningMentions(result.warnings, option),
+      )
+      .map(({ option }) => option);
+
+    expect(silentlyDropped).toEqual([]);
+  });
+
+  it('includes every dropped option in the agent warning', async () => {
+    const result = await provider
+      .interactions({ agent: 'antigravity-preview-05-2026' })
+      .doGenerate({
+        prompt: TEST_PROMPT,
+        topK: 10,
+        presencePenalty: 0.5,
+        frequencyPenalty: 0.5,
+      });
+
+    const body = (await server.calls[0].requestBodyJson) as {
+      generation_config?: Record<string, unknown>;
+    };
+    expect(body.generation_config).toBeUndefined();
+
+    const silentlyDropped = options
+      .filter(({ option }) => !warningMentions(result.warnings, option))
+      .map(({ option }) => option);
+
+    expect(silentlyDropped).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Bug

@ai-sdk/google: google.interactions() silently drops topK / presencePenalty / frequencyPenalty that google() forwards

## Reproduction

- On `@ai-sdk/google` 4.0.24 with `ai` 7.0.37, switching from `google()` to `google.interactions()` silently removes sampling controls, changing generation behavior without notifying the user.
- Live `gemini-2.5-flash` evidence showed Google accepts `top_k`, while `presence_penalty` and `frequency_penalty` are rejected as unknown parameters; AI SDK should therefore forward `topK` and warn about both unsupported penalties.
- `examples/ai-functions/src/reproduction/issue-17937-google-interactions-generation-config.ts` observed standard `google()` forwarding all three options, while the Interactions model and agent branches silently dropped all three; each option was expected to be forwarded or identified in warnings.
- `packages/google/src/interactions/__fixtures__/issue-17937-top-k.json` records the successful live Interactions response for a request containing `top_k`.
- Both cases in `packages/google/src/interactions/google-interactions-generation-config.issue-17937.test.ts` failed because `topK`, `presencePenalty`, and `frequencyPenalty` were absent from both the request or applicable warnings.

## Relevant Documentation

- https://ai.google.dev/api/interactions-api
- https://ai.google.dev/api/generate-content
- https://ai.google.dev/gemini-api/docs/latest-model

## Related Issues

Reproduces #17937

Co-Authored-By: Lars Grammel <205036+lgrammel@users.noreply.github.com>