### PR TITLE
[v6.0] reproduction: @ai-sdk/google: google.interactions silently drops topK / presencePenalty /

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "issueId": 17937,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/issue-17937-google-interactions-generation-config.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/issue-17937-google-interactions-generation-config.ts",
+    "packages/google/src/interactions/__fixtures__/issue-17937-top-k.json"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "Reproduced issue #17937: google.interactions() silently dropped topK, presencePenalty, and frequencyPenalty."
+  }
+}

--- a/examples/ai-functions/src/reproduction/issue-17937-google-interactions-generation-config.ts
+++ b/examples/ai-functions/src/reproduction/issue-17937-google-interactions-generation-config.ts
@@ -1,0 +1,139 @@
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import type { LanguageModelV3Prompt, SharedV3Warning } from '@ai-sdk/provider';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const prompt: LanguageModelV3Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello, how are you?' }] },
+];
+
+const settings = {
+  prompt,
+  temperature: 0.5,
+  topK: 10,
+  presencePenalty: 0.5,
+  frequencyPenalty: 0.5,
+} as const;
+
+function warningMentions(
+  warnings: Array<SharedV3Warning>,
+  feature: string,
+): boolean {
+  return JSON.stringify(warnings).includes(feature);
+}
+
+async function main() {
+  const interactionFixture = JSON.parse(
+    fs.readFileSync(
+      path.resolve(
+        process.cwd(),
+        '../../packages/google/src/interactions/__fixtures__/issue-17937-top-k.json',
+      ),
+      'utf8',
+    ),
+  );
+  const calls: Array<{ url: string; body: Record<string, any> }> = [];
+
+  const provider = createGoogleGenerativeAI({
+    apiKey: 'test-api-key',
+    generateId: () => 'test-id',
+    fetch: async (input, init) => {
+      const url = String(input);
+      calls.push({
+        url,
+        body: JSON.parse(String(init?.body)),
+      });
+
+      const responseBody = url.endsWith('/interactions')
+        ? interactionFixture
+        : {
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: 'standard model response' }],
+                  role: 'model',
+                },
+                finishReason: 'STOP',
+                index: 0,
+              },
+            ],
+            usageMetadata: {
+              promptTokenCount: 7,
+              candidatesTokenCount: 3,
+              totalTokenCount: 10,
+            },
+            modelVersion: 'gemini-2.5-flash',
+            responseId: 'test-response-id',
+          };
+
+      return new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    },
+  });
+
+  const standardResult =
+    await provider('gemini-2.5-flash').doGenerate(settings);
+  const standardBody = calls.at(-1)?.body;
+
+  const interactionsResult = await provider
+    .interactions('gemini-2.5-flash')
+    .doGenerate(settings);
+  const interactionsBody = calls.at(-1)?.body;
+
+  const agentResult = await provider
+    .interactions({ agent: 'deep-research-pro-preview-12-2025' })
+    .doGenerate(settings);
+  const agentBody = calls.at(-1)?.body;
+
+  const observed = {
+    standard: {
+      generationConfig: standardBody?.generationConfig,
+      warnings: standardResult.warnings,
+    },
+    interactionsModel: {
+      generationConfig: interactionsBody?.generation_config,
+      warnings: interactionsResult.warnings,
+    },
+    interactionsAgent: {
+      generationConfig: agentBody?.generation_config,
+      warnings: agentResult.warnings,
+    },
+  };
+
+  console.log(JSON.stringify(observed, null, 2));
+
+  const standardForwardsAll =
+    standardBody?.generationConfig?.topK === 10 &&
+    standardBody?.generationConfig?.presencePenalty === 0.5 &&
+    standardBody?.generationConfig?.frequencyPenalty === 0.5;
+  const interactionsModelHandlesAll =
+    interactionsBody?.generation_config?.top_k === 10 &&
+    warningMentions(interactionsResult.warnings, 'presencePenalty') &&
+    warningMentions(interactionsResult.warnings, 'frequencyPenalty');
+  const interactionsAgentWarnsForAll =
+    warningMentions(agentResult.warnings, 'topK') &&
+    warningMentions(agentResult.warnings, 'presencePenalty') &&
+    warningMentions(agentResult.warnings, 'frequencyPenalty');
+
+  if (
+    standardForwardsAll &&
+    (!interactionsModelHandlesAll || !interactionsAgentWarnsForAll)
+  ) {
+    throw new Error(
+      'Reproduced issue #17937: google.interactions() silently dropped topK, presencePenalty, and frequencyPenalty.',
+    );
+  }
+
+  if (!standardForwardsAll) {
+    throw new Error(
+      'Comparison setup failed: the standard Google model did not forward all three options.',
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/google/src/interactions/__fixtures__/issue-17937-top-k.json
+++ b/packages/google/src/interactions/__fixtures__/issue-17937-top-k.json
@@ -1,0 +1,38 @@
+{
+  "id": "v1_Chd5VkZuYXFuQ001ZkYtc0FQaDZXRjhBMBIXeVZGbmFxbkNNNWZGLXNBUGg2V0Y4QTA",
+  "status": "completed",
+  "usage": {
+    "total_tokens": 34,
+    "total_input_tokens": 9,
+    "input_tokens_by_modality": [
+      {
+        "modality": "text",
+        "tokens": 9
+      }
+    ],
+    "total_cached_tokens": 0,
+    "total_output_tokens": 4,
+    "total_tool_use_tokens": 0,
+    "total_thought_tokens": 21
+  },
+  "created": "2026-07-27T12:40:41Z",
+  "updated": "2026-07-27T12:40:41Z",
+  "service_tier": "standard",
+  "steps": [
+    {
+      "signature": "CnMBEU0yD/BYATCDdN364dhFzZTkMZUQqEjf9/i84bXT/79rK6XwFUtO5PBjJJLMqcqucmxKs3vKA3YHjRz3MdAZffBraMQZ83EnVHuKUsTILzl6o40u7Tgc99JvLsCRppoxeGt7tAw1lHXgZRRUFDFSsUJ6",
+      "type": "thought"
+    },
+    {
+      "content": [
+        {
+          "text": "top-k accepted",
+          "type": "text"
+        }
+      ],
+      "type": "model_output"
+    }
+  ],
+  "object": "interaction",
+  "model": "gemini-2.5-flash"
+}

--- a/packages/google/src/interactions/google-interactions-generation-config.issue-17937.test.ts
+++ b/packages/google/src/interactions/google-interactions-generation-config.issue-17937.test.ts
@@ -1,0 +1,75 @@
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import * as fs from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createGoogleGenerativeAI } from '../google-provider';
+
+vi.mock('../version', () => ({ VERSION: '0.0.0-test' }));
+
+const TEST_URL =
+  'https://generativelanguage.googleapis.com/v1beta/interactions';
+
+const TEST_PROMPT: LanguageModelV3Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello, how are you?' }] },
+];
+
+const provider = createGoogleGenerativeAI({
+  apiKey: 'test-api-key',
+  generateId: () => 'test-id',
+});
+
+describe('issue #17937: interactions generation options', () => {
+  const server = createTestServer({ [TEST_URL]: {} });
+
+  beforeEach(() => {
+    server.urls[TEST_URL].response = {
+      type: 'json-value',
+      body: JSON.parse(
+        fs.readFileSync(
+          'src/interactions/__fixtures__/issue-17937-top-k.json',
+          'utf8',
+        ),
+      ),
+    };
+  });
+
+  it('forwards supported topK and warns for unsupported penalties on model calls', async () => {
+    const result = await provider.interactions('gemini-2.5-flash').doGenerate({
+      prompt: TEST_PROMPT,
+      temperature: 0.5,
+      topK: 10,
+      presencePenalty: 0.5,
+      frequencyPenalty: 0.5,
+    });
+
+    const body = await server.calls[0].requestBodyJson;
+
+    expect(body.generation_config).toMatchObject({
+      temperature: 0.5,
+      top_k: 10,
+    });
+    expect(result.warnings).toEqual([
+      { type: 'unsupported', feature: 'presencePenalty' },
+      { type: 'unsupported', feature: 'frequencyPenalty' },
+    ]);
+  });
+
+  it('warns when all three options are dropped from agent calls', async () => {
+    const result = await provider
+      .interactions({ agent: 'deep-research-pro-preview-12-2025' })
+      .doGenerate({
+        prompt: TEST_PROMPT,
+        topK: 10,
+        presencePenalty: 0.5,
+        frequencyPenalty: 0.5,
+      });
+
+    const body = await server.calls[0].requestBodyJson;
+    const warnings = JSON.stringify(result.warnings);
+
+    expect(body.generation_config).toBeUndefined();
+    expect(warnings).toContain('topK');
+    expect(warnings).toContain('presencePenalty');
+    expect(warnings).toContain('frequencyPenalty');
+  });
+});


### PR DESCRIPTION
## Bug

@ai-sdk/google: google.interactions() silently drops topK / presencePenalty / frequencyPenalty that google() forwards

## Reproduction

- On `release-v6.0`, `@ai-sdk/google` 3.0.101 and `ai` 6.0.235 expose `google.interactions()` and reproduce the reported behavior; no dependency or configuration mismatch caused the failure.
- A direct live `gemini-2.5-flash` Interactions request accepted `top_k` with HTTP 200, while `presence_penalty` and `frequency_penalty` each returned HTTP 400 as unknown parameters; the SDK should therefore forward `topK` and warn for both penalties.
- `examples/ai-functions/src/reproduction/issue-17937-google-interactions-generation-config.ts` observed the standard model forwarding all three options, while the Interactions model silently omitted all three and the agent branch warned only for `temperature`.
- `packages/google/src/interactions/__fixtures__/issue-17937-top-k.json` records the successful live Interactions response generated with `top_k: 10`.
- Both cases in `packages/google/src/interactions/google-interactions-generation-config.issue-17937.test.ts` failed: the model request lacked `top_k`, and the agent warnings omitted `topK`, `presencePenalty`, and `frequencyPenalty`.

## Relevant Documentation

- https://ai.google.dev/api/interactions-api
- https://ai.google.dev/api/generate-content
- https://ai.google.dev/gemini-api/docs/latest-model

## Related Issues

Reproduces #17937

Co-Authored-By: Lars Grammel <205036+lgrammel@users.noreply.github.com>