### PR TITLE
reproduction: BUG: Mistral provider flattens ThinkChunk when replaying reasoning

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "issueId": 17930,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/mistral-reasoning-history.ts",
+  "artifactPaths": [
+    "examples/ai-functions/src/reproduction/mistral-reasoning-history.ts"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "ISSUE #17930 REPRODUCED: second request flattened Mistral thinking and text chunks into a plain string, dropped closed metadata, and appended the visible answer"
+  }
+}

--- a/examples/ai-functions/src/reproduction/mistral-reasoning-history.ts
+++ b/examples/ai-functions/src/reproduction/mistral-reasoning-history.ts
@@ -1,0 +1,159 @@
+import { createMistral } from '@ai-sdk/mistral';
+import { generateText, type ModelMessage } from 'ai';
+
+const failureSignal =
+  'ISSUE #17930 REPRODUCED: second request flattened Mistral thinking and text chunks into a plain string, dropped closed metadata, and appended the visible answer';
+
+async function main() {
+  const requests: Array<Record<string, any>> = [];
+  const responses: Array<Record<string, any>> = [];
+
+  const recordingFetch: typeof fetch = async (input, init) => {
+    if (typeof init?.body === 'string') {
+      requests.push(JSON.parse(init.body));
+    }
+
+    const response = await fetch(input, init);
+    const responseBody = await response.clone().json();
+    responses.push(responseBody);
+
+    return response;
+  };
+
+  const apiKey = process.env.MISTRAL_API_KEY!;
+  const mistral = createMistral({ apiKey, fetch: recordingFetch });
+  const model = mistral('mistral-small-latest');
+  const providerOptions = {
+    mistral: { reasoningEffort: 'high' as const },
+  };
+
+  const firstUserMessage: ModelMessage = {
+    role: 'user',
+    content: 'What is 17 * 23? Reply with only the result.',
+  };
+  const secondUserMessage: ModelMessage = {
+    role: 'user',
+    content: 'Now multiply that result by 3. Reply with only the result.',
+  };
+
+  const first = await generateText({
+    model,
+    messages: [firstUserMessage],
+    providerOptions,
+  });
+
+  await generateText({
+    model,
+    messages: [firstUserMessage, ...first.response.messages, secondUserMessage],
+    providerOptions,
+  });
+
+  const firstContent = responses[0]?.choices?.[0]?.message?.content;
+  const replayedAssistant = requests[1]?.messages?.[1];
+
+  if (!Array.isArray(firstContent)) {
+    throw new Error(
+      `Expected the live provider to return structured reasoning chunks, received ${JSON.stringify(firstContent)}`,
+    );
+  }
+
+  const thinkingChunk = firstContent.find(
+    (part: any) => part.type === 'thinking',
+  );
+  const textChunk = firstContent.find((part: any) => part.type === 'text');
+
+  if (
+    thinkingChunk?.closed !== true ||
+    !Array.isArray(thinkingChunk.thinking) ||
+    typeof textChunk?.text !== 'string'
+  ) {
+    throw new Error(
+      `Expected a closed thinking chunk and a text chunk, received ${JSON.stringify(firstContent)}`,
+    );
+  }
+
+  const reasoningText = thinkingChunk.thinking
+    .filter((part: any) => part.type === 'text')
+    .map((part: any) => part.text)
+    .join('');
+  const flattenedContent = `${reasoningText}${textChunk.text}`;
+
+  const directResponse = await fetch(
+    'https://api.mistral.ai/v1/chat/completions',
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'mistral-small-latest',
+        messages: [
+          requests[0].messages[0],
+          responses[0].choices[0].message,
+          requests[1].messages[2],
+        ],
+        reasoning_effort: 'high',
+      }),
+    },
+  );
+  const directBody: any = await directResponse.json();
+
+  if (!directResponse.ok) {
+    throw new Error(
+      `Direct structured replay failed with HTTP ${directResponse.status}: ${JSON.stringify(directBody)}`,
+    );
+  }
+
+  const directContent = directBody?.choices?.[0]?.message?.content;
+  const directAnswer = Array.isArray(directContent)
+    ? directContent
+        .filter((part: any) => part.type === 'text')
+        .map((part: any) => part.text)
+        .join('')
+    : directContent;
+
+  if (directAnswer?.trim() !== '1173') {
+    throw new Error(
+      `Expected direct structured replay to produce 1173, received ${JSON.stringify(directAnswer)}`,
+    );
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        firstContent,
+        replayedAssistant,
+        directStructuredReplay: {
+          status: directResponse.status,
+          answer: directAnswer,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (
+    typeof replayedAssistant?.content === 'string' &&
+    replayedAssistant.content === flattenedContent &&
+    reasoningText.includes(textChunk.text)
+  ) {
+    throw new Error(failureSignal);
+  }
+
+  if (
+    !Array.isArray(replayedAssistant?.content) ||
+    replayedAssistant.content[0]?.type !== 'thinking' ||
+    replayedAssistant.content[0]?.closed !== true
+  ) {
+    throw new Error(
+      `Expected the second request to preserve the closed thinking chunk, received ${JSON.stringify(replayedAssistant)}`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/packages/mistral/src/__fixtures__/mistral-reasoning-history-live.json
+++ b/packages/mistral/src/__fixtures__/mistral-reasoning-history-live.json
@@ -1,0 +1,40 @@
+{
+  "id": "c3e8bf763f8b48b2896625354b7afa0d",
+  "created": 1785156128,
+  "model": "mistral-small-latest",
+  "usage": {
+    "prompt_tokens": 31,
+    "total_tokens": 192,
+    "completion_tokens": 161,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    }
+  },
+  "object": "chat.completion",
+  "choices": [
+    {
+      "index": 0,
+      "finish_reason": "stop",
+      "message": {
+        "role": "assistant",
+        "tool_calls": null,
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": [
+              {
+                "type": "text",
+                "text": "I need to calculate 17 multiplied by 23. Let me break it down:\n\nFirst, I can use the distributive property of multiplication over addition to simplify the calculation. I know that 23 can be written as 20 + 3. So, 17 * 23 can be rewritten as 17 * (20 + 3).\n\nNow, I can multiply 17 by each term separately:\n1. 17 * 20 = 340\n2. 17 * 3 = 51\n\nNow, add the two results together:\n340 + 51 = 391\n\nSo, 17 * 23 equals 391."
+              }
+            ],
+            "closed": true
+          },
+          {
+            "type": "text",
+            "text": "391"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/mistral/src/mistral-chat-language-model.test.ts
+++ b/packages/mistral/src/mistral-chat-language-model.test.ts
@@ -105,6 +105,84 @@ describe('doGenerate', () => {
 
       expect(result).toMatchSnapshot();
     });
+
+    it('should preserve thinking chunks when replaying reasoning history', async () => {
+      prepareJsonFixtureResponse('mistral-reasoning-history-live');
+
+      const firstResult = await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'What is 17 * 23? Reply with only the result.',
+              },
+            ],
+          },
+        ],
+        providerOptions: {
+          mistral: { reasoningEffort: 'high' },
+        },
+      });
+
+      const replayContent = firstResult.content.flatMap(part => {
+        if (part.type !== 'reasoning' && part.type !== 'text') {
+          return [];
+        }
+
+        return [
+          {
+            type: part.type,
+            text: part.text,
+            providerOptions: part.providerMetadata,
+          },
+        ];
+      });
+
+      await model.doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'What is 17 * 23? Reply with only the result.',
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: replayContent,
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                text: 'Now multiply that result by 3. Reply with only the result.',
+              },
+            ],
+          },
+        ],
+        providerOptions: {
+          mistral: { reasoningEffort: 'high' },
+        },
+      });
+
+      const liveResponse = JSON.parse(
+        fs.readFileSync(
+          'src/__fixtures__/mistral-reasoning-history-live.json',
+          'utf8',
+        ),
+      );
+      const secondRequest = await server.calls[1].requestBodyJson;
+
+      expect(secondRequest.messages[1]).toEqual({
+        role: 'assistant',
+        content: liveResponse.choices[0].message.content,
+      });
+    });
   });
 
   it('should pass tools and toolChoice', async () => {


### PR DESCRIPTION
## Bug

BUG: Mistral provider flattens ThinkChunk when replaying reasoning history

## Reproduction

- The checked-out target matches the reported versions: `ai@7.0.37` and `@ai-sdk/mistral@4.0.14`.
- Mistral returned separate `thinking` and `text` chunks with `closed: true`, but the next AI SDK request flattened them into a string ending in `391.391`; the expected behavior is to replay the complete structured assistant message.
- Directly replaying the same structured assistant message to Mistral returned HTTP 200 and `1173`, locating the defect in AI SDK request conversion rather than the Mistral service.
- `examples/ai-functions/src/reproduction/mistral-reasoning-history.ts` is the runnable live reproduction and exits non-zero when the structured reasoning history is flattened.
- `packages/mistral/src/__fixtures__/mistral-reasoning-history-live.json` records the live structured response, and the regression test in `packages/mistral/src/mistral-chat-language-model.test.ts` fails because the replayed assistant content is a plain string instead of the expected chunk array.

## Relevant Documentation

- https://docs.mistral.ai/studio-api/conversations/reasoning#multi-turn-conversations
- https://docs.mistral.ai/api

## Related Issues

Reproduces #17930

Co-Authored-By: Lars Grammel <205036+lgrammel@users.noreply.github.com>