### PR TITLE
[v5.0] reproduction: BUG: Mistral provider flattens ThinkChunk when replaying reasoning

### DIFF
--- a/.ai-sdk-factory/reproduction-replay.json
+++ b/.ai-sdk-factory/reproduction-replay.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "issueId": 17930,
+  "command": "pnpm -C examples/ai-functions exec tsx src/reproduction/mistral-reasoning-history.ts",
+  "artifactPaths": [
+    "examples/ai-functions/package.json",
+    "examples/ai-functions/tsconfig.json",
+    "examples/ai-functions/src/reproduction/mistral-reasoning-history.ts",
+    "packages/mistral/src/__fixtures__/mistral-reasoning-history-live.json",
+    "packages/mistral/src/mistral-chat-language-model.test.ts",
+    "pnpm-lock.yaml"
+  ],
+  "expectedFailure": {
+    "exitCode": 1,
+    "signal": "BUG REPRODUCED: Mistral reasoning history was flattened into one plain string and the visible answer was appended to the reasoning text."
+  }
+}

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@example/ai-functions",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@ai-sdk/mistral": "workspace:*",
+    "ai": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "tsx": "4.19.2",
+    "typescript": "5.8.3"
+  }
+}

--- a/examples/ai-functions/src/reproduction/mistral-reasoning-history.ts
+++ b/examples/ai-functions/src/reproduction/mistral-reasoning-history.ts
@@ -1,0 +1,178 @@
+import { createMistral } from '@ai-sdk/mistral';
+import { generateText, type ModelMessage } from 'ai';
+
+type MistralContentChunk =
+  | {
+      type: 'thinking';
+      thinking: Array<{ type: 'text'; text: string }>;
+      closed: boolean;
+    }
+  | { type: 'text'; text: string };
+
+type MistralResponse = {
+  choices: Array<{
+    message: {
+      content: string | Array<MistralContentChunk>;
+    };
+  }>;
+};
+
+type MistralRequest = {
+  model: string;
+  messages: Array<{
+    role: string;
+    content: unknown;
+  }>;
+  reasoning_effort?: string;
+};
+
+const failureSignal =
+  'BUG REPRODUCED: Mistral reasoning history was flattened into one plain string and the visible answer was appended to the reasoning text.';
+
+async function main() {
+  const requests: Array<MistralRequest> = [];
+  const responses: Array<MistralResponse> = [];
+
+  const recordingFetch: typeof fetch = async (input, init) => {
+    const sdkBody =
+      typeof init?.body === 'string'
+        ? (JSON.parse(init.body) as MistralRequest)
+        : undefined;
+
+    if (sdkBody != null) {
+      requests.push(structuredClone(sdkBody));
+    }
+
+    // release-v5 parses ThinkChunk responses but predates the
+    // reasoningEffort provider option. Inject the documented Mistral field so
+    // the target provider receives the response shape whose replay is under
+    // test.
+    const response = await fetch(input, {
+      ...init,
+      body:
+        sdkBody == null
+          ? init?.body
+          : JSON.stringify({ ...sdkBody, reasoning_effort: 'high' }),
+    });
+
+    responses.push((await response.clone().json()) as MistralResponse);
+    return response;
+  };
+
+  const mistral = createMistral({
+    apiKey: process.env.MISTRAL_API_KEY,
+    fetch: recordingFetch,
+  });
+  const model = mistral('mistral-small-latest');
+
+  const firstUserMessage: ModelMessage = {
+    role: 'user',
+    content: 'What is 17 * 23? Reply with only the result.',
+  };
+
+  const first = await generateText({
+    model,
+    messages: [firstUserMessage],
+  });
+
+  await generateText({
+    model,
+    messages: [
+      firstUserMessage,
+      ...first.response.messages,
+      {
+        role: 'user',
+        content: 'Now multiply that result by 3. Reply with only the result.',
+      },
+    ],
+  });
+
+  const rawFirstContent = responses[0]?.choices[0]?.message.content;
+  if (
+    !Array.isArray(rawFirstContent) ||
+    rawFirstContent[0]?.type !== 'thinking' ||
+    rawFirstContent[0].closed !== true ||
+    rawFirstContent[1]?.type !== 'text'
+  ) {
+    throw new Error(
+      'Live Mistral response did not contain a closed thinking chunk followed by a text chunk.',
+    );
+  }
+
+  const directResponse = await fetch(
+    'https://api.mistral.ai/v1/chat/completions',
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.MISTRAL_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'mistral-small-latest',
+        reasoning_effort: 'high',
+        messages: [
+          {
+            role: 'user',
+            content: 'What is 17 * 23? Reply with only the result.',
+          },
+          { role: 'assistant', content: rawFirstContent },
+          {
+            role: 'user',
+            content:
+              'Now multiply that result by 3. Reply with only the result.',
+          },
+        ],
+      }),
+    },
+  );
+  const directBody = (await directResponse.json()) as MistralResponse;
+  const directContent = directBody.choices?.[0]?.message.content;
+  const directAnswer = Array.isArray(directContent)
+    ? directContent
+        .filter(
+          (chunk): chunk is Extract<MistralContentChunk, { type: 'text' }> =>
+            chunk.type === 'text',
+        )
+        .map(chunk => chunk.text)
+        .join('')
+    : directContent;
+
+  if (!directResponse.ok || directAnswer?.trim() !== '1173') {
+    throw new Error(
+      `Direct structured replay did not succeed: HTTP ${directResponse.status}`,
+    );
+  }
+
+  const replayedAssistantContent = requests[1]?.messages[1]?.content;
+  const reasoningText = rawFirstContent[0].thinking
+    .map(chunk => chunk.text)
+    .join('');
+  const visibleAnswer = rawFirstContent[1].text;
+
+  if (
+    typeof replayedAssistantContent === 'string' &&
+    replayedAssistantContent === reasoningText + visibleAnswer
+  ) {
+    console.error(failureSignal);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (
+    !Array.isArray(replayedAssistantContent) ||
+    replayedAssistantContent[0]?.type !== 'thinking' ||
+    replayedAssistantContent[0]?.closed !== true ||
+    replayedAssistantContent[1]?.type !== 'text'
+  ) {
+    throw new Error(
+      'Second request did not preserve the complete structured assistant message.',
+    );
+  }
+
+  console.log('Mistral reasoning history was preserved.');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2022",
+    "lib": ["es2022", "dom"],
+    "module": "esnext",
+    "types": ["node"],
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/mistral/src/__fixtures__/mistral-reasoning-history-live.json
+++ b/packages/mistral/src/__fixtures__/mistral-reasoning-history-live.json
@@ -1,0 +1,40 @@
+{
+  "id": "ccb4a0d2441643bdbdeabadeb12a4bc0",
+  "created": 1785159439,
+  "model": "mistral-small-latest",
+  "usage": {
+    "prompt_tokens": 31,
+    "total_tokens": 303,
+    "completion_tokens": 272,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    }
+  },
+  "object": "chat.completion",
+  "choices": [
+    {
+      "index": 0,
+      "finish_reason": "stop",
+      "message": {
+        "role": "assistant",
+        "tool_calls": null,
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": [
+              {
+                "type": "text",
+                "text": "Okay, I need to calculate 17 multiplied by 23. Let me break it down to make sure I get it right.\n\nFirst, I recall that multiplication can be done using the distributive property of multiplication over addition. So, I can break down 23 into 20 and 3, and then multiply 17 by each part separately, and then add the results together.\n\nSo, 17 * 23 = 17 * (20 + 3) = (17 * 20) + (17 * 3)\n\nNow, let's calculate each part:\n\n1. 17 * 20:\n   - 17 * 2 = 34\n   - Then add a zero at the end because it's actually 17 * 20, so 340.\n\n2. 17 * 3:\n   - 10 * 3 = 30\n   - 7 * 3 = 21\n   - Add them together: 30 + 21 = 51\n\nNow, add the two results together:\n340 + 51 = 391\n\nSo, 17 * 23 = 391."
+              }
+            ],
+            "closed": true
+          },
+          {
+            "type": "text",
+            "text": "391"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/mistral/src/mistral-chat-language-model.test.ts
+++ b/packages/mistral/src/mistral-chat-language-model.test.ts
@@ -4,6 +4,7 @@ import {
   convertReadableStreamToArray,
   mockId,
 } from '@ai-sdk/provider-utils/test';
+import { readFileSync } from 'node:fs';
 import { createMistral } from './mistral-provider';
 import { describe, it, expect, vi } from 'vitest';
 
@@ -213,6 +214,77 @@ describe('doGenerate', () => {
         },
       ]
     `);
+  });
+
+  it('should preserve thinking chunks when replaying reasoning history', async () => {
+    const liveResponse = JSON.parse(
+      readFileSync(
+        new URL(
+          './__fixtures__/mistral-reasoning-history-live.json',
+          import.meta.url,
+        ),
+        'utf8',
+      ),
+    );
+
+    server.urls['https://api.mistral.ai/v1/chat/completions'].response = [
+      {
+        type: 'json-value',
+        body: liveResponse,
+      },
+      {
+        type: 'json-value',
+        body: {
+          ...liveResponse,
+          choices: [
+            {
+              ...liveResponse.choices[0],
+              message: {
+                role: 'assistant',
+                tool_calls: null,
+                content: [{ type: 'text', text: '1173' }],
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    const first = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+    const assistantContent = first.content.filter(
+      (
+        part,
+      ): part is Extract<
+        (typeof first.content)[number],
+        { type: 'reasoning' | 'text' }
+      > => part.type === 'reasoning' || part.type === 'text',
+    );
+
+    await model.doGenerate({
+      prompt: [
+        ...TEST_PROMPT,
+        {
+          role: 'assistant',
+          content: assistantContent,
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'Now multiply that result by 3. Reply with only the result.',
+            },
+          ],
+        },
+      ],
+    });
+
+    const secondRequest = await server.calls[1].requestBodyJson;
+    expect(secondRequest.messages[1].content).toStrictEqual(
+      liveResponse.choices[0].message.content,
+    );
   });
 
   it('should preserve ordering of mixed thinking and text content', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,25 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  examples/ai-functions:
+    dependencies:
+      '@ai-sdk/mistral':
+        specifier: workspace:*
+        version: link:../../packages/mistral
+      ai:
+        specifier: workspace:*
+        version: link:../../packages/ai
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.24
+        version: 20.17.24
+      tsx:
+        specifier: 4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   examples/angular:
     dependencies:
       '@ai-sdk/angular':


### PR DESCRIPTION
## Bug

BUG: Mistral provider flattens ThinkChunk when replaying reasoning history

## Reproduction

- On target `release-v5` (`ai@5.0.220`, `@ai-sdk/mistral@2.0.40`), live Mistral returned separate `thinking` and `text` chunks with `closed: true`.
- The follow-up AI SDK request flattened those chunks into one string ending in `391.391`; the expected request preserves the complete structured assistant content.
- Directly replaying the structured content to Mistral returned HTTP 200 with `1173`, locating the defect in AI SDK request conversion.
- `examples/ai-functions/src/reproduction/mistral-reasoning-history.ts` is the runnable live reproduction; because release-v5 predates the `reasoningEffort` provider option, its custom fetch injects the documented `reasoning_effort: "high"` field without altering replay conversion.
- `packages/mistral/src/__fixtures__/mistral-reasoning-history-live.json` records the live response, and the regression test in `packages/mistral/src/mistral-chat-language-model.test.ts` fails when structured history becomes a plain string.

## Relevant Documentation

- https://docs.mistral.ai/studio-api/conversations/reasoning#multi-turn-conversations
- https://docs.mistral.ai/api

## Related Issues

Reproduces #17930

Co-Authored-By: Lars Grammel <205036+lgrammel@users.noreply.github.com>