### PR TITLE
fix(provider/cartesia): type missing voice errors

### DIFF
--- a/.changeset/clean-cats-speak.md
+++ b/.changeset/clean-cats-speak.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cartesia': patch
+---
+
+Throw a typed invalid argument error when a Cartesia speech voice is missing.

--- a/packages/cartesia/src/cartesia-speech-model.test.ts
+++ b/packages/cartesia/src/cartesia-speech-model.test.ts
@@ -1,3 +1,4 @@
+import { InvalidArgumentError } from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { describe, expect, it, vi } from 'vitest';
 import { createCartesia } from './cartesia-provider';
@@ -58,14 +59,23 @@ describe('CartesiaSpeechModel', () => {
       });
     });
 
-    it('should throw when no voice is provided', async () => {
+    it('should throw a typed error when no voice is provided', async () => {
       prepareAudioResponse();
 
-      await expect(
-        model.doGenerate({
+      try {
+        await model.doGenerate({
           text: 'Hello, world!',
-        }),
-      ).rejects.toThrow('Cartesia speech models require a `voice` to be set.');
+        });
+      } catch (error) {
+        expect(InvalidArgumentError.isInstance(error)).toBe(true);
+        expect(error).toMatchObject({
+          argument: 'voice',
+          message: 'Cartesia speech models require a `voice` to be set.',
+        });
+        return;
+      }
+
+      throw new Error('Expected Cartesia to reject a missing voice.');
     });
 
     it('should map wav output format', async () => {

--- a/packages/cartesia/src/cartesia-speech-model.ts
+++ b/packages/cartesia/src/cartesia-speech-model.ts
@@ -1,4 +1,8 @@
-import type { SpeechModelV4, SharedV4Warning } from '@ai-sdk/provider';
+import {
+  InvalidArgumentError,
+  type SpeechModelV4,
+  type SharedV4Warning,
+} from '@ai-sdk/provider';
 import {
   combineHeaders,
   createBinaryResponseHandler,
@@ -185,7 +189,10 @@ export class CartesiaSpeechModel implements SpeechModelV4 {
     });
 
     if (!voice) {
-      throw new Error('Cartesia speech models require a `voice` to be set.');
+      throw new InvalidArgumentError({
+        argument: 'voice',
+        message: 'Cartesia speech models require a `voice` to be set.',
+      });
     }
 
     const outputFormatObject = resolveOutputFormat({


### PR DESCRIPTION
## Summary

- throw `InvalidArgumentError` when Cartesia speech is called without a voice
- cover the typed error in the speech model tests
- add a patch changeset

This lets Gateway and other SDK consumers classify the missing voice as a client error instead of an opaque provider failure.

## Validation

- Cartesia speech model tests: Node (15 passed)
- Cartesia speech model tests: Edge (15 passed)
- Cartesia package type-check
- oxfmt / oxlint on changed files