### PR TITLE
Enable `includeUsage` for TogetherAI so streaming responses report token usage

### DIFF
--- a/.changeset/togetherai-include-usage.md
+++ b/.changeset/togetherai-include-usage.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/togetherai': patch
+---
+
+Enable `includeUsage` for TogetherAI so streaming responses report token usage

--- a/packages/togetherai/src/togetherai-provider.test.ts
+++ b/packages/togetherai/src/togetherai-provider.test.ts
@@ -196,6 +196,14 @@ describe('TogetherAIProvider', () => {
 
       expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
     });
+
+    it('should set includeUsage so streaming responses report token usage', () => {
+      const provider = createTogetherAI();
+      provider.chatModel('together-chat-model');
+
+      const config = OpenAICompatibleChatLanguageModelMock.mock.calls[0][1];
+      expect(config.includeUsage).toBe(true);
+    });
   });
 
   describe('completionModel', () => {
@@ -206,6 +214,16 @@ describe('TogetherAIProvider', () => {
       const model = provider.completionModel(modelId);
 
       expect(model).toBeInstanceOf(OpenAICompatibleCompletionLanguageModel);
+    });
+
+    it('should set includeUsage so streaming responses report token usage', () => {
+      const provider = createTogetherAI();
+      provider.completionModel('together-completion-model');
+
+      const config = (
+        OpenAICompatibleCompletionLanguageModel as unknown as Mock
+      ).mock.calls[0][1];
+      expect(config.includeUsage).toBe(true);
     });
   });
 

--- a/packages/togetherai/src/togetherai-provider.ts
+++ b/packages/togetherai/src/togetherai-provider.ts
@@ -148,17 +148,17 @@ export function createTogetherAI(
   });
 
   const createChatModel = (modelId: TogetherAIChatModelId) => {
-    return new OpenAICompatibleChatLanguageModel(
-      modelId,
-      getCommonModelConfig('chat'),
-    );
+    return new OpenAICompatibleChatLanguageModel(modelId, {
+      ...getCommonModelConfig('chat'),
+      includeUsage: true,
+    });
   };
 
   const createCompletionModel = (modelId: TogetherAICompletionModelId) =>
-    new OpenAICompatibleCompletionLanguageModel(
-      modelId,
-      getCommonModelConfig('completion'),
-    );
+    new OpenAICompatibleCompletionLanguageModel(modelId, {
+      ...getCommonModelConfig('completion'),
+      includeUsage: true,
+    });
 
   const createEmbeddingModel = (modelId: TogetherAIEmbeddingModelId) =>
     new OpenAICompatibleEmbeddingModel(


### PR DESCRIPTION
## Summary

The TogetherAI provider never set `includeUsage`, so it never sent `stream_options: { include_usage: true }` on streaming requests. For models that don't return usage by default (e.g. `moonshotai/Kimi-K3`), this means **streaming responses come back with `usage` entirely `undefined`** — no input/output/total tokens. Downstream consumers (incl. AI Gateway cost accounting) then compute a cost of `0`.

Most other models served by TogetherAI (e.g. `Qwen/Qwen3.7-Plus`, `zai-org/GLM-5.2`, `moonshotai/Kimi-K2.6`) include usage in the final chunk regardless, which masked the gap.

Non-streaming requests are unaffected — usage is present in the response body. This is streaming-only.

Fixes [AIG-295](https://linear.app/vercel/issue/AIG-295/togetherai-streaming-requests-report-no-token-usage-for-kimi-k3-bills).

## Root cause

`OpenAICompatibleChatLanguageModel` only emits `stream_options.include_usage` when its config has `includeUsage` truthy:

```ts
stream_options: this.config.includeUsage ? { include_usage: true } : undefined
```

`createTogetherAI` built the chat/completion models from `getCommonModelConfig(...)`, which never sets `includeUsage`, so the flag could not reach the model config.

## Fix

Set `includeUsage: true` on the TogetherAI chat and completion model configs, mirroring `@ai-sdk/fireworks` (fixed in #16087, the identical bug) and `@ai-sdk/moonshotai`. This makes TogetherAI request the usage chunk on streams so token usage is reported for all models.

## Why hardcode it rather than expose a setting

`@ai-sdk/openai` sets `include_usage: true` unconditionally (`packages/openai/src/chat/openai-chat-language-model.ts:438`, no config gate at all). Fireworks and moonshotai hardcode `true`. The cost of always asking is one extra SSE chunk at the end of the stream, and for the 12 Together models that already volunteer usage the A/B below shows the same usage shape with the flag on.

`TogetherAIProviderSettings` exposes only `apiKey`, `baseURL`, `headers` and `fetch`, and `stream_options` is part of the request body the SDK builds, so the provider factory is the only place that can set it. Callers cannot opt in today even if they want usage. `@ai-sdk/alibaba` takes the alternative route of an opt-out (`includeUsage: options.includeUsage ?? true`), which is not used here because the main consumer (AI Gateway cost accounting) needs usage on every request.

## Verification

Direct A/B against `api.together.xyz/v1/chat/completions`, streaming, with and without `stream_options.include_usage`:

| Together model | without `include_usage` | with `include_usage` |
|---|---|---|
| `moonshotai/Kimi-K3` | **no usage** | `prompt_tokens: 86, completion_tokens: 16` (incl. `cached_tokens`, `reasoning_tokens`) |
| `moonshotai/Kimi-K2.5-fp4` | **no usage** | n/a |
| `moonshotai/Kimi-K2.6` | usage present | usage present (unchanged) |
| `moonshotai/Kimi-K2.7-Code` | usage present | usage present (unchanged) |
| `Qwen/Qwen3.7-Plus`, `Qwen/Qwen3.7-Max`, `Qwen/Qwen3.6-Plus` | usage present | usage present (unchanged) |
| `zai-org/GLM-5.2` | usage present | usage present (unchanged) |
| `deepseek-ai/DeepSeek-V4-Pro` | usage present | usage present (unchanged) |
| `openai/gpt-oss-20b`, `openai/gpt-oss-120b` | usage present | usage present (unchanged) |
| `nvidia/nemotron-3-ultra-550b-a55b` | usage present | usage present (unchanged) |
| `MiniMaxAI/MiniMax-M2.7` | usage present | usage present (unchanged) |
| `thinkingmachines/Inkling` | usage present | usage present (unchanged) |

Originally surfaced through AI Gateway (`only: togetherai`, streaming) on `moonshotai/kimi-k3`, which returned `usage` fully `undefined` and `cost: "0"`.

`pnpm test:node` passes (43 tests, incl. new assertions that chat & completion configs set `includeUsage: true`). Both new tests fail without the provider change.

## Backport

All three published `@ai-sdk/togetherai` lines lack `includeUsage`, verified against the exact builds AI Gateway loads:

| Version | AI SDK line | Branch | `includeUsage` present |
|---|---|---|---|
| 3.0.15 | v7 | `main` | no |
| 2.0.67 | v6 | `release-v6.0` | no |
| 1.0.49 | v5 | `release-v5.0` | no |

`release-v6.0` carries the Gateway's public OpenAI-compatible traffic, so it matters most. Labeled `backport` for `release-v6.0`, and the generated PR needs the label again to reach `release-v5.0` (same two-hop path as #16089 / #16090 for Fireworks).
