### PR TITLE
fix(mistral): preserve reasoning in multi-turn conversations

### DIFF
--- a/.changeset/sharp-hotels-reflect.md
+++ b/.changeset/sharp-hotels-reflect.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mistral": patch
+---
+
+fix (mistral): preserve reasoning in multi-turn conversations

--- a/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.test.ts
@@ -123,13 +123,66 @@ describe('user messages', () => {
     expect(result).toMatchInlineSnapshot(`
       [
         {
-          "content": "Let me think about this...The answer is 42.",
+          "content": [
+            {
+              "closed": true,
+              "thinking": [
+                {
+                  "text": "Let me think about this...",
+                  "type": "text",
+                },
+              ],
+              "type": "thinking",
+            },
+            {
+              "text": "The answer is 42.",
+              "type": "text",
+            },
+          ],
           "prefix": true,
           "role": "assistant",
           "tool_calls": undefined,
         },
       ]
     `);
+  });
+
+  it('should preserve the ordering of interleaved reasoning and text content', () => {
+    const result = convertToMistralChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'First thought.' },
+          { type: 'text', text: 'Partial answer.' },
+          { type: 'reasoning', text: 'Second thought.' },
+          { type: 'text', text: 'Final answer.' },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Continue.' }],
+      },
+    ]);
+
+    expect(result[0]).toEqual({
+      role: 'assistant',
+      content: [
+        {
+          type: 'thinking',
+          thinking: [{ type: 'text', text: 'First thought.' }],
+          closed: true,
+        },
+        { type: 'text', text: 'Partial answer.' },
+        {
+          type: 'thinking',
+          thinking: [{ type: 'text', text: 'Second thought.' }],
+          closed: true,
+        },
+        { type: 'text', text: 'Final answer.' },
+      ],
+      prefix: undefined,
+      tool_calls: undefined,
+    });
   });
 });
 

--- a/packages/mistral/src/convert-to-mistral-chat-messages.ts
+++ b/packages/mistral/src/convert-to-mistral-chat-messages.ts
@@ -3,7 +3,10 @@ import {
   type LanguageModelV4FilePart,
   type LanguageModelV4Prompt,
 } from '@ai-sdk/provider';
-import type { MistralPrompt } from './mistral-chat-prompt';
+import type {
+  MistralAssistantMessageContent,
+  MistralPrompt,
+} from './mistral-chat-prompt';
 import {
   convertToBase64,
   getTopLevelMediaType,
@@ -101,6 +104,8 @@ export function convertToMistralChatMessages(
 
       case 'assistant': {
         let text = '';
+        let hasReasoning = false;
+        const contentParts: Array<MistralAssistantMessageContent> = [];
         const toolCalls: Array<{
           id: string;
           type: 'function';
@@ -111,6 +116,7 @@ export function convertToMistralChatMessages(
           switch (part.type) {
             case 'text': {
               text += part.text;
+              contentParts.push({ type: 'text', text: part.text });
               break;
             }
             case 'tool-call': {
@@ -125,7 +131,12 @@ export function convertToMistralChatMessages(
               break;
             }
             case 'reasoning': {
-              text += part.text;
+              hasReasoning = true;
+              contentParts.push({
+                type: 'thinking',
+                thinking: [{ type: 'text', text: part.text }],
+                closed: true,
+              });
               break;
             }
             default: {
@@ -138,7 +149,7 @@ export function convertToMistralChatMessages(
 
         messages.push({
           role: 'assistant',
-          content: text,
+          content: hasReasoning ? contentParts : text,
           prefix: isLastMessage ? true : undefined,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/mistral/src/mistral-chat-prompt.ts
+++ b/packages/mistral/src/mistral-chat-prompt.ts
@@ -23,7 +23,7 @@ export type MistralUserMessageContent =
 
 export interface MistralAssistantMessage {
   role: 'assistant';
-  content: string;
+  content: string | Array<MistralAssistantMessageContent>;
   prefix?: boolean;
   tool_calls?: Array<{
     id: string;
@@ -31,6 +31,14 @@ export interface MistralAssistantMessage {
     function: { name: string; arguments: string };
   }>;
 }
+
+export type MistralAssistantMessageContent =
+  | { type: 'text'; text: string }
+  | {
+      type: 'thinking';
+      thinking: Array<{ type: 'text'; text: string }>;
+      closed: true;
+    };
 
 export interface MistralToolMessage {
   role: 'tool';


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/17930

Mistral returned separate thinking and visible text chunks. When replaying the assistant response, the prompt converter concatenated both into one string. This removed the native thinking structure and `closed: true`, while duplicating the visible answer after the reasoning.

## Summary

The converter now maps reasoning back to Mistral’s native thinking chunks, keeps visible text separate, and preserves part ordering. Plain assistant messages without reasoning remain strings

## End-to-End Verification

verified by running the repro in the original issue and the following scripts:

<details>
<summary>generate text:</summary>

```ts
import { createMistral } from '@ai-sdk/mistral';
import { parseJSON } from '@ai-sdk/provider-utils';
import { generateText, type ModelMessage } from 'ai';
import { print } from '../../lib/print';
import { run } from '../../lib/run';

type MistralMessage = {
  role?: string;
  content?: unknown;
};

type MistralRequest = {
  messages?: MistralMessage[];
};

type MistralResponse = {
  choices?: Array<{ message?: MistralMessage }>;
};

const firstUserMessage: ModelMessage = {
  role: 'user',
  content: 'What is 17 * 23? Reply with only the result.',
};

const secondUserMessage: ModelMessage = {
  role: 'user',
  content: 'Now multiply that result by 3. Reply with only the result.',
};

run(async () => {
  const requests: MistralRequest[] = [];
  const responses: MistralResponse[] = [];

  const recordingFetch: typeof fetch = async (input, init) => {
    if (typeof init?.body === 'string') {
      requests.push((await parseJSON({ text: init.body })) as MistralRequest);
    }

    const response = await fetch(input, init);
    responses.push((await response.clone().json()) as MistralResponse);
    return response;
  };

  const mistral = createMistral({ fetch: recordingFetch });
  const model = mistral('mistral-small-latest');
  const providerOptions = {
    mistral: { reasoningEffort: 'high' as const },
  };

  const first = await generateText({
    model,
    messages: [firstUserMessage],
    providerOptions,
  });

  let secondTurnError: unknown;
  try {
    await generateText({
      model,
      messages: [
        firstUserMessage,
        ...first.response.messages,
        secondUserMessage,
      ],
      providerOptions,
    });
  } catch (error) {
    secondTurnError = error;
  }

  const rawFirstContent = responses[0]?.choices?.[0]?.message?.content;
  const replayedAssistantMessage = requests[1]?.messages?.find(
    message => message.role === 'assistant',
  );

  print('Raw Mistral content from turn 1:', rawFirstContent);
  print(
    '\nAssistant message sent to Mistral in turn 2:',
    replayedAssistantMessage,
  );

  if (!hasClosedThinkingAndText(rawFirstContent)) {
    throw new Error(
      'Inconclusive: turn 1 did not return a closed thinking chunk followed by a text chunk.',
    );
  }

  if (typeof replayedAssistantMessage?.content === 'string') {
    console.error(
      '\nBUG REPRODUCED: turn 2 flattened the thinking and text chunks into one string and lost `closed: true`.',
    );
    process.exitCode = 1;
    return;
  }

  if (!hasClosedThinkingAndText(replayedAssistantMessage?.content)) {
    throw new Error(
      'Inconclusive: turn 2 did not contain either the known flattened string or the expected structured content.',
      { cause: secondTurnError },
    );
  }

  console.log(
    '\nBUG NOT REPRODUCED: turn 2 preserved separate thinking and text chunks with `closed: true`.',
  );
});

function hasClosedThinkingAndText(content: unknown): boolean {
  if (!Array.isArray(content)) {
    return false;
  }

  const thinking = content.find(
    part =>
      typeof part === 'object' &&
      part != null &&
      'type' in part &&
      part.type === 'thinking',
  );
  const text = content.find(
    part =>
      typeof part === 'object' &&
      part != null &&
      'type' in part &&
      part.type === 'text',
  );

  return (
    thinking != null &&
    'closed' in thinking &&
    thinking.closed === true &&
    'thinking' in thinking &&
    Array.isArray(thinking.thinking) &&
    text != null &&
    'text' in text &&
    typeof text.text === 'string'
  );
}

```
</details>

<details>
<summary>stream text:</summary>

```ts
import { createMistral } from '@ai-sdk/mistral';
import { parseJSON } from '@ai-sdk/provider-utils';
import { streamText, type ModelMessage } from 'ai';
import { print } from '../../lib/print';
import { run } from '../../lib/run';

type MistralMessage = {
  role?: string;
  content?: unknown;
};

type MistralRequest = {
  messages?: MistralMessage[];
};

const firstUserMessage: ModelMessage = {
  role: 'user',
  content: 'What is 17 * 23? Reply with only the result.',
};

const secondUserMessage: ModelMessage = {
  role: 'user',
  content: 'Now multiply that result by 3. Reply with only the result.',
};

run(async () => {
  const requests: MistralRequest[] = [];

  const recordingFetch: typeof fetch = async (input, init) => {
    if (typeof init?.body === 'string') {
      requests.push((await parseJSON({ text: init.body })) as MistralRequest);
    }
    return fetch(input, init);
  };

  const mistral = createMistral({ fetch: recordingFetch });
  const model = mistral('mistral-small-latest');
  const providerOptions = {
    mistral: { reasoningEffort: 'high' as const },
  };

  const first = streamText({
    model,
    messages: [firstUserMessage],
    providerOptions,
  });
  await first.consumeStream();

  const firstResponseMessages = (await first.response).messages;

  let secondTurnError: unknown;
  try {
    const second = streamText({
      model,
      messages: [firstUserMessage, ...firstResponseMessages, secondUserMessage],
      providerOptions,
    });
    await second.consumeStream();
  } catch (error) {
    secondTurnError = error;
  }

  const firstAssistantMessage = firstResponseMessages.find(
    message => message.role === 'assistant',
  );
  const replayedAssistantMessage = requests[1]?.messages?.find(
    message => message.role === 'assistant',
  );

  print(
    'AI SDK assistant response message from turn 1:',
    firstAssistantMessage,
  );
  print(
    '\nAssistant message sent to Mistral in turn 2:',
    replayedAssistantMessage,
  );

  if (typeof replayedAssistantMessage?.content === 'string') {
    console.error(
      '\nBUG REPRODUCED: turn 2 flattened the streamed reasoning and text into one string and lost `closed: true`.',
    );
    process.exitCode = 1;
    return;
  }

  if (!hasClosedThinkingAndText(replayedAssistantMessage?.content)) {
    throw new Error(
      'Inconclusive: turn 2 did not contain either the known flattened string or the expected structured content.',
      { cause: secondTurnError },
    );
  }

  console.log(
    '\nBUG NOT REPRODUCED: turn 2 preserved separate thinking and text chunks with `closed: true`.',
  );
});

function hasClosedThinkingAndText(content: unknown): boolean {
  if (!Array.isArray(content)) {
    return false;
  }

  const thinking = content.find(
    part =>
      typeof part === 'object' &&
      part != null &&
      'type' in part &&
      part.type === 'thinking',
  );
  const text = content.find(
    part =>
      typeof part === 'object' &&
      part != null &&
      'type' in part &&
      part.type === 'text',
  );

  return (
    thinking != null &&
    'closed' in thinking &&
    thinking.closed === true &&
    'thinking' in thinking &&
    Array.isArray(thinking.thinking) &&
    text != null &&
    'text' in text &&
    typeof text.text === 'string'
  );
}

```
</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #17930 