### PR TITLE
[v6.0] docs: clarify that textStream does not surface error parts

### DIFF
--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -2815,7 +2815,7 @@ To see `streamText` in action, check out [these examples](#examples).
       name: 'textStream',
       type: 'AsyncIterableStream<string>',
       description:
-        'A text stream that returns only the generated text deltas. You can use it as either an AsyncIterable or a ReadableStream. When an error occurs, the stream will throw the error.',
+        'A text stream that returns only the generated text deltas. You can use it as either an AsyncIterable or a ReadableStream. Error parts are not surfaced in this stream. Use the `onError` callback or `stream` to observe them.',
     },
     {
       name: 'fullStream',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -2815,7 +2815,7 @@ To see `streamText` in action, check out [these examples](#examples).
       name: 'textStream',
       type: 'AsyncIterableStream<string>',
       description:
-        'A text stream that returns only the generated text deltas. You can use it as either an AsyncIterable or a ReadableStream. Error parts are not surfaced in this stream. Use the `onError` callback or `stream` to observe them.',
+        'A text stream that returns only the generated text deltas. You can use it as either an AsyncIterable or a ReadableStream. Error parts are not surfaced in this stream. Use the `onError` callback or `fullStream` to observe them.',
     },
     {
       name: 'fullStream',

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -279,8 +279,9 @@ export interface StreamTextResult<
 
   /**
    * A text stream that returns only the generated text deltas. You can use it
-   * as either an AsyncIterable or a ReadableStream. When an error occurs, the
-   * stream will throw the error.
+   * as either an AsyncIterable or a ReadableStream. Error parts are not
+   * surfaced in this stream. Use the `onError` callback or `stream` to observe
+   * them.
    */
   readonly textStream: AsyncIterableStream<string>;
 

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -280,8 +280,8 @@ export interface StreamTextResult<
   /**
    * A text stream that returns only the generated text deltas. You can use it
    * as either an AsyncIterable or a ReadableStream. Error parts are not
-   * surfaced in this stream. Use the `onError` callback or `stream` to observe
-   * them.
+   * surfaced in this stream. Use the `onError` callback or `fullStream` to
+   * observe them.
    */
   readonly textStream: AsyncIterableStream<string>;
 


### PR DESCRIPTION
## Background

The textStream documentation incorrectly promised that model error parts are thrown, although the stream intentionally filters them out, potentially misleading readers into relying on ineffective try/catch handling.

## Summary

Updated the StreamTextResult JSDoc and streamText API reference to state that error parts are not surfaced through textStream and should be observed with onError or stream.

## Testing

Focused text-stream and streamText error-handling tests passed; package type-checking and documentation validation also passed.

## Related Issues

Fixes #17974

Backport of #17994

Co-Authored-By: Gregor Martynus <39992+gr2m@users.noreply.github.com>