### PR TITLE
feat(workflow): align stream instruction inputs

### DIFF
--- a/.changeset/workflow-agent-instructions-parity.md
+++ b/.changeset/workflow-agent-instructions-parity.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/workflow": patch
+---
+
+feat(workflow): add stream instructions and initial prepareStep inputs

--- a/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
@@ -472,10 +472,16 @@ const result = await agent.stream({
         'A writable stream that receives raw model stream parts in real-time. Convert to UI message chunks at the response boundary using `createModelCallToUIChunkTransform()`.',
     },
     {
+      name: 'instructions',
+      type: 'Instructions',
+      isOptional: true,
+      description: 'Override the agent instructions for this call.',
+    },
+    {
       name: 'system',
       type: 'string',
       isOptional: true,
-      description: 'Override the system prompt for this call.',
+      description: 'Deprecated. Use `instructions` instead.',
     },
     {
       name: 'stopWhen',
@@ -576,7 +582,8 @@ const result = await agent.stream({
       name: 'prepareStep',
       type: 'PrepareStepCallback',
       isOptional: true,
-      description: 'Per-call prepareStep override.',
+      description:
+        'Per-call prepareStep override. Receives the initial instructions and messages alongside the current step state.',
     },
     {
       name: 'experimental_onStart',

--- a/packages/workflow/src/stream-text-iterator.test.ts
+++ b/packages/workflow/src/stream-text-iterator.test.ts
@@ -14,6 +14,7 @@ import type {
 } from '@ai-sdk/provider';
 import type {
   Experimental_LanguageModelStreamPart,
+  ModelMessage,
   StepResult,
   ToolSet,
 } from 'ai';
@@ -104,6 +105,39 @@ describe('streamTextIterator', () => {
   });
 
   describe('conversation prompt', () => {
+    it('passes initial instructions and messages to prepareStep', async () => {
+      vi.mocked(doStreamStep).mockResolvedValueOnce(
+        createMockDoStreamStepResult(),
+      );
+      const initialMessages: ModelMessage[] = [
+        { role: 'user', content: 'initial message' },
+      ];
+      const prepareStep = vi.fn(() => ({}));
+
+      const iterator = streamTextIterator({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'initial message' }],
+          },
+        ],
+        initialInstructions: 'initial instructions',
+        initialMessages,
+        tools: {},
+        model: vi.fn() as any,
+        prepareStep,
+      });
+
+      await iterator.next();
+
+      expect(prepareStep).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialInstructions: 'initial instructions',
+          initialMessages,
+        }),
+      );
+    });
+
     it('preserves assistant text alongside tool calls for the next step', async () => {
       let capturedPrompt: LanguageModelV4Prompt | undefined;
 

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -9,6 +9,7 @@ import {
   experimental_filterActiveTools as filterActiveTools,
   type Experimental_LanguageModelStreamPart as ModelCallStreamPart,
   type Experimental_SandboxSession as SandboxSession,
+  type Instructions,
   type LanguageModel,
   type LanguageModelUsage,
   type ModelMessage,
@@ -64,6 +65,8 @@ export interface StreamTextIteratorYieldValue {
 // This runs in the workflow context
 export async function* streamTextIterator({
   prompt,
+  initialInstructions,
+  initialMessages = prompt as unknown as ModelMessage[],
   tools = {},
   writable,
   model,
@@ -84,6 +87,8 @@ export async function* streamTextIterator({
   experimental_sandbox: sandbox,
 }: {
   prompt: LanguageModelV4Prompt;
+  initialInstructions?: Instructions;
+  initialMessages?: Array<ModelMessage>;
   tools: ToolSet;
   writable?: WritableStream<ModelCallStreamPart<ToolSet>>;
   model: LanguageModel;
@@ -150,6 +155,8 @@ export async function* streamTextIterator({
     if (prepareStep) {
       const prepareResult = await prepareStep({
         model: currentModel,
+        initialInstructions,
+        initialMessages,
         stepNumber,
         steps,
         messages: conversationPrompt,

--- a/packages/workflow/src/workflow-agent.test-d.ts
+++ b/packages/workflow/src/workflow-agent.test-d.ts
@@ -1,6 +1,10 @@
 import { expectTypeOf, describe, it } from 'vitest';
 import { z } from 'zod/v4';
-import type { Experimental_SandboxSession as SandboxSession } from 'ai';
+import type {
+  Experimental_SandboxSession as SandboxSession,
+  Instructions,
+  ModelMessage,
+} from 'ai';
 import { WorkflowAgent } from './workflow-agent.js';
 
 const model = 'anthropic/claude-sonnet-4-6';
@@ -30,6 +34,31 @@ describe('WorkflowAgent types', () => {
           SandboxSession | undefined
         >();
         return { experimental_sandbox };
+      },
+    });
+  });
+
+  it('exposes initial instructions and messages in prepareStep', () => {
+    new WorkflowAgent({
+      model,
+      prepareStep: ({ initialInstructions, initialMessages }) => {
+        expectTypeOf(initialInstructions).toEqualTypeOf<
+          Instructions | undefined
+        >();
+        expectTypeOf(initialMessages).toEqualTypeOf<Array<ModelMessage>>();
+        return {};
+      },
+    });
+  });
+
+  it('accepts stream-level instructions', () => {
+    const agent = new WorkflowAgent({ model });
+
+    agent.stream({
+      prompt: 'hello',
+      instructions: {
+        role: 'system',
+        content: 'Be concise.',
       },
     });
   });

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -1405,6 +1405,40 @@ describe('WorkflowAgent', () => {
       );
     });
 
+    it('should pass stream instructions and initial messages to prepareStep', async () => {
+      const mockModel = createMockModel();
+
+      const agent = new WorkflowAgent({
+        model: mockModel,
+        instructions: 'constructor instructions',
+        tools: {},
+      });
+
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockReturnValue({
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      } as unknown as MockIterator);
+
+      await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        instructions: 'stream instructions',
+      });
+
+      expect(streamTextIterator).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialInstructions: 'stream instructions',
+          initialMessages: [{ role: 'user', content: 'test' }],
+          prompt: [
+            expect.objectContaining({
+              role: 'system',
+              content: 'stream instructions',
+            }),
+            expect.objectContaining({ role: 'user' }),
+          ],
+        }),
+      );
+    });
+
     it('should allow prepareStep to modify messages', async () => {
       const mockModel = createMockModel();
 

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -257,6 +257,16 @@ export interface PrepareStepInfo<
   model: LanguageModel;
 
   /**
+   * The initial instructions passed to the stream.
+   */
+  initialInstructions: Instructions | undefined;
+
+  /**
+   * The initial messages passed to the stream.
+   */
+  initialMessages: Array<ModelMessage>;
+
+  /**
    * The current step number (0-indexed).
    */
   stepNumber: number;
@@ -837,7 +847,14 @@ export type WorkflowAgentStreamOptions<
       }
   ) & {
     /**
-     * Optional system prompt override. If provided, overrides the system prompt from the constructor.
+     * Instructions override for this stream call.
+     */
+    instructions?: Instructions;
+
+    /**
+     * Optional system prompt override.
+     *
+     * @deprecated Use `instructions` instead.
      */
     system?: string;
 
@@ -1324,7 +1341,8 @@ export class WorkflowAgent<
 
     // Call prepareCall to transform parameters before the agent loop
     let effectiveModel: LanguageModel = this.model;
-    let effectiveInstructions = options.system ?? this.instructions;
+    let effectiveInstructions =
+      options.instructions ?? options.system ?? this.instructions;
     let effectivePrompt: string | Array<ModelMessage> | undefined =
       options.prompt;
     let effectiveMessages: Array<ModelMessage> | undefined = options.messages;
@@ -2100,6 +2118,8 @@ export class WorkflowAgent<
       tools: effectiveTools as ToolSet,
       writable: options.writable,
       prompt: modelPrompt,
+      initialInstructions: effectiveInstructions,
+      initialMessages: prompt.messages,
       stopConditions: options.stopWhen ?? this.stopWhen,
 
       onStepEnd: mergedOnStepEnd as any,


### PR DESCRIPTION
Adds stream-level `instructions` and exposes initial instructions/messages to `prepareStep`.

Tests: workflow Node tests, full type-check, check.

Related to #12164.