### PR TITLE
feat(provider-utils): add SerializationError

### DIFF
--- a/.changeset/provider-utils-serialization-error.md
+++ b/.changeset/provider-utils-serialization-error.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+feat(provider-utils): add a typed serialization error

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -88,6 +88,7 @@ export {
   type ValidationResult,
 } from './schema';
 export { serializeModelOptions } from './serialize-model-options';
+export { SerializationError } from './serialization-error';
 export { secureJsonParse } from './secure-json-parse';
 export {
   StreamingToolCallTracker,

--- a/packages/provider-utils/src/serialization-error.ts
+++ b/packages/provider-utils/src/serialization-error.ts
@@ -1,0 +1,23 @@
+import { AISDKError } from '@ai-sdk/provider';
+
+const name = 'AI_SerializationError';
+const marker = `vercel.ai.error.${name}`;
+const symbol = Symbol.for(marker);
+
+export class SerializationError extends AISDKError {
+  private readonly [symbol] = true; // used in isInstance
+
+  constructor({
+    message = 'Failed to serialize value.',
+    cause,
+  }: {
+    message?: string;
+    cause?: unknown;
+  } = {}) {
+    super({ name, message, cause });
+  }
+
+  static isInstance(error: unknown): error is SerializationError {
+    return AISDKError.hasMarker(error, marker);
+  }
+}

--- a/packages/provider-utils/src/serialize-model-options.test.ts
+++ b/packages/provider-utils/src/serialize-model-options.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { serializeModelOptions } from './serialize-model-options';
+import { SerializationError } from './serialization-error';
 
 type TestConfig = Record<string, unknown> & {
   headers?: () => Record<string, string | undefined>;
@@ -103,7 +104,7 @@ describe('serializeModelOptions', () => {
           headers: async () => ({ 'x-api-key': 'sk-test' }),
         },
       }),
-    ).toThrow('Promise returned from resolveSync');
+    ).toThrow(SerializationError);
   });
 
   it('throws when headers is a function returning a Promise', () => {
@@ -115,7 +116,24 @@ describe('serializeModelOptions', () => {
           headers: () => Promise.resolve({ 'x-api-key': 'sk-test' }),
         },
       }),
-    ).toThrow('Promise returned from resolveSync');
+    ).toThrow('Cannot serialize asynchronous model options.');
+  });
+
+  it('marks serialization errors for cross-realm detection', () => {
+    let serializationError: unknown;
+
+    try {
+      serializeModelOptions({
+        modelId: 'model',
+        config: {
+          headers: async () => ({}),
+        },
+      });
+    } catch (error) {
+      serializationError = error;
+    }
+
+    expect(SerializationError.isInstance(serializationError)).toBe(true);
   });
 
   it('filters out class instances', () => {

--- a/packages/provider-utils/src/serialize-model-options.ts
+++ b/packages/provider-utils/src/serialize-model-options.ts
@@ -1,6 +1,7 @@
 import type { JSONObject } from '@ai-sdk/provider';
 import { isJSONSerializable } from './is-json-serializable';
 import type { Resolvable } from './resolve';
+import { SerializationError } from './serialization-error';
 
 /**
  * Serializes a model instance for workflow step boundaries.
@@ -53,10 +54,10 @@ function resolveSync<T>(value: Resolvable<T>): T {
     next = (value as () => unknown)();
   }
 
-  // the serialization for workflows currently only supports synchronous values
-  // TODO introduce SerializationError
   if (next instanceof Promise) {
-    throw new Error('Promise returned from resolveSync');
+    throw new SerializationError({
+      message: 'Cannot serialize asynchronous model options.',
+    });
   }
 
   return next as T;


### PR DESCRIPTION
Adds a marker-based SerializationError for unsupported asynchronous model-option serialization.

Tests: provider-utils Node tests, full type-check, check.

Related to #12164.