### PR TITLE
feat(ai): promote repairText option to stable

### DIFF
--- a/.changeset/stable-repair-text.md
+++ b/.changeset/stable-repair-text.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Promote the `repairText` option to stable on `generateObject` and `streamObject`, with a deprecated `experimental_repairText` alias for backwards compatibility.

--- a/packages/ai/src/generate-object/generate-object.test.ts
+++ b/packages/ai/src/generate-object/generate-object.test.ts
@@ -591,7 +591,7 @@ describe('generateObject', () => {
           }),
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_repairText: async ({ text, error }) => {
+          repairText: async ({ text, error }) => {
             expect(error).toBeInstanceOf(JSONParseError);
             expect(text).toStrictEqual(
               '{ "content": "provider metadata test" ',
@@ -622,7 +622,7 @@ describe('generateObject', () => {
           }),
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_repairText: async ({ text, error }) => {
+          repairText: async ({ text, error }) => {
             expect(error).toBeInstanceOf(TypeValidationError);
             expect(text).toStrictEqual(
               '{ "content-a": "provider metadata test" }',
@@ -653,7 +653,7 @@ describe('generateObject', () => {
           }),
           schema: z.object({ content: z.string() }),
           prompt: 'prompt',
-          experimental_repairText: async ({ text, error }) => {
+          repairText: async ({ text, error }) => {
             expect(error).toBeInstanceOf(TypeValidationError);
             expect(text).toStrictEqual(
               '{ "content-a": "provider metadata test" }',
@@ -665,6 +665,51 @@ describe('generateObject', () => {
         await expect(result).rejects.toThrow(
           'No object generated: response did not match schema.',
         );
+      });
+
+      it('should support the deprecated experimental_repairText option', async () => {
+        const result = await generateObject({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => ({
+              ...dummyResponseValues,
+              content: [
+                {
+                  type: 'text',
+                  text: '{ "content": "repaired"',
+                },
+              ],
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+          experimental_repairText: async ({ text }) => text + ' }',
+        });
+
+        expect(result.object).toStrictEqual({ content: 'repaired' });
+      });
+
+      it('should prefer repairText over experimental_repairText', async () => {
+        const result = await generateObject({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => ({
+              ...dummyResponseValues,
+              content: [
+                {
+                  type: 'text',
+                  text: '{ "content": "repaired"',
+                },
+              ],
+            }),
+          }),
+          schema: z.object({ content: z.string() }),
+          prompt: 'prompt',
+          repairText: async ({ text }) => text + ' }',
+          experimental_repairText: async () => {
+            throw new Error('deprecated alias should not be called');
+          },
+        });
+
+        expect(result.object).toStrictEqual({ content: 'repaired' });
       });
     });
 
@@ -784,7 +829,7 @@ describe('generateObject', () => {
             }),
             schema: z.object({ content: z.string() }),
             prompt: 'prompt',
-            experimental_repairText: async ({ text }) => text + '{',
+            repairText: async ({ text }) => text + '{',
           });
 
           fail('must throw error');

--- a/packages/ai/src/generate-object/generate-object.ts
+++ b/packages/ai/src/generate-object/generate-object.ts
@@ -96,8 +96,9 @@ const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
  * - 'enum': The output is an enum.
  * - 'no-schema': The output is not a schema.
  *
- * @param experimental_repairText - A function that attempts to repair the raw output of the model
+ * @param repairText - A function that attempts to repair the raw output of the model
  * to enable JSON parsing.
+ * @param experimental_repairText - Deprecated alias for `repairText`.
  *
  * @param telemetry - Optional telemetry configuration.
  *
@@ -168,6 +169,14 @@ export async function generateObject<
       /**
        * A function that attempts to repair the raw output of the model
        * to enable JSON parsing.
+       */
+      repairText?: RepairTextFunction;
+
+      /**
+       * A function that attempts to repair the raw output of the model
+       * to enable JSON parsing.
+       *
+       * @deprecated Use `repairText` instead.
        */
       experimental_repairText?: RepairTextFunction;
 
@@ -265,7 +274,8 @@ export async function generateObject<
     maxRetries: maxRetriesArg,
     abortSignal,
     headers,
-    experimental_repairText: repairText,
+    experimental_repairText,
+    repairText = experimental_repairText,
     experimental_telemetry,
     telemetry = experimental_telemetry,
     experimental_download: download,

--- a/packages/ai/src/generate-object/stream-object.test.ts
+++ b/packages/ai/src/generate-object/stream-object.test.ts
@@ -1460,7 +1460,7 @@ describe('streamObject', () => {
     });
   });
 
-  describe('options.experimental_repairText', () => {
+  describe('options.repairText', () => {
     it('should be able to repair a JSONParseError', async () => {
       const result = streamObject({
         model: new MockLanguageModelV4({
@@ -1489,7 +1489,7 @@ describe('streamObject', () => {
         }),
         schema: z.object({ content: z.string() }),
         prompt: 'prompt',
-        experimental_repairText: async ({ text, error }) => {
+        repairText: async ({ text, error }) => {
           expect(error).toBeInstanceOf(JSONParseError);
           expect(text).toStrictEqual('{ "content": "provider metadata test" ');
           return text + '}';
@@ -1532,7 +1532,7 @@ describe('streamObject', () => {
         }),
         schema: z.object({ content: z.string() }),
         prompt: 'prompt',
-        experimental_repairText: async ({ text, error }) => {
+        repairText: async ({ text, error }) => {
           expect(error).toBeInstanceOf(TypeValidationError);
           expect(text).toStrictEqual(
             '{ "content-a": "provider metadata test" }',
@@ -1577,7 +1577,7 @@ describe('streamObject', () => {
         }),
         schema: z.object({ content: z.string() }),
         prompt: 'prompt',
-        experimental_repairText: async ({ text, error }) => {
+        repairText: async ({ text, error }) => {
           expect(error).toBeInstanceOf(TypeValidationError);
           expect(text).toStrictEqual(
             '{ "content-a": "provider metadata test" }',
@@ -1622,7 +1622,7 @@ describe('streamObject', () => {
         }),
         schema: z.object({ content: z.string() }),
         prompt: 'prompt',
-        experimental_repairText: async ({ text, error }) => {
+        repairText: async ({ text, error }) => {
           expect(error).toBeInstanceOf(JSONParseError);
           expect(text).toStrictEqual(
             '```json\n{ "content": "test message" }\n```',
@@ -1668,7 +1668,7 @@ describe('streamObject', () => {
         }),
         schema: z.object({ content: z.string() }),
         prompt: 'prompt',
-        experimental_repairText: async ({ text }) => text + '{',
+        repairText: async ({ text }) => text + '{',
       });
 
       try {
@@ -1687,6 +1687,69 @@ describe('streamObject', () => {
           finishReason: 'stop',
         });
       }
+    });
+
+    it('should support the deprecated experimental_repairText option', async () => {
+      const result = streamObject({
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              { type: 'text-start', id: '1' },
+              {
+                type: 'text-delta',
+                id: '1',
+                delta: '{ "content": "repaired"',
+              },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          }),
+        }),
+        schema: z.object({ content: z.string() }),
+        prompt: 'prompt',
+        experimental_repairText: async ({ text }) => text + ' }',
+      });
+
+      await convertAsyncIterableToArray(result.partialObjectStream);
+
+      expect(await result.object).toStrictEqual({ content: 'repaired' });
+    });
+
+    it('should prefer repairText over experimental_repairText', async () => {
+      const result = streamObject({
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              { type: 'text-start', id: '1' },
+              {
+                type: 'text-delta',
+                id: '1',
+                delta: '{ "content": "repaired"',
+              },
+              { type: 'text-end', id: '1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          }),
+        }),
+        schema: z.object({ content: z.string() }),
+        prompt: 'prompt',
+        repairText: async ({ text }) => text + ' }',
+        experimental_repairText: async () => {
+          throw new Error('deprecated alias should not be called');
+        },
+      });
+
+      await convertAsyncIterableToArray(result.partialObjectStream);
+
+      expect(await result.object).toStrictEqual({ content: 'repaired' });
     });
   });
 

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -168,6 +168,10 @@ export type StreamObjectOnFinishCallback<RESULT> = (event: {
  * - 'enum': The output is an enum.
  * - 'no-schema': The output is not a schema.
  *
+ * @param repairText - A function that attempts to repair the raw output of the model
+ * to enable JSON parsing.
+ * @param experimental_repairText - Deprecated alias for `repairText`.
+ *
  * @param telemetry - Optional telemetry configuration.
  *
  * @param providerOptions - Additional provider-specific options. They are passed through
@@ -230,6 +234,14 @@ export function streamObject<
       /**
        * A function that attempts to repair the raw output of the model
        * to enable JSON parsing.
+       */
+      repairText?: RepairTextFunction;
+
+      /**
+       * A function that attempts to repair the raw output of the model
+       * to enable JSON parsing.
+       *
+       * @deprecated Use `repairText` instead.
        */
       experimental_repairText?: RepairTextFunction;
 
@@ -346,7 +358,8 @@ export function streamObject<
     maxRetries,
     abortSignal,
     headers,
-    experimental_repairText: repairText,
+    experimental_repairText,
+    repairText = experimental_repairText,
     experimental_telemetry,
     telemetry = experimental_telemetry,
     experimental_download: download,


### PR DESCRIPTION
## Background

`experimental_repairText` was introduced for `generateObject` in #4937 and extended to `streamObject` in #7640. The option and its stable `RepairTextFunction` type have matured behind the experimental name.

Following the graduation strategy in #16562, this promotes the option to a stable un-prefixed name while retaining the experimental name as a deprecated alias until v8.

## Summary

- Add `repairText` to `generateObject` and `streamObject`.
- Keep `experimental_repairText` as a deprecated alias.
- Prefer `repairText` when both option names are provided.
- Update existing repair tests to use the stable name and add focused deprecated-alias and precedence coverage for both functions.
- Update the shipped API JSDoc and add an `ai` patch changeset.

The public reference pages for `generateObject` and `streamObject` were intentionally deleted in #12707 when both functions were deprecated in favor of `generateText` and `streamText` with `Output`, so this PR does not restore those legacy documentation pages. Adding repair support to `generateText`/`Output` remains tracked separately in #10973.

## Testing

- `pnpm check`
- `pnpm type-check:full`
- `pnpm --filter ai exec vitest --config vitest.node.config.js --run src/generate-object/generate-object.test.ts src/generate-object/stream-object.test.ts`
- `pnpm --filter ai exec vitest --config vitest.edge.config.js --run src/generate-object/generate-object.test.ts src/generate-object/stream-object.test.ts`

## Related Issues

Closes #18011. Part of #16562.
