### PR TITLE
feat(ai): deprecate Experimental_GeneratedImage alias

### DIFF
--- a/.changeset/deprecate-generated-image.md
+++ b/.changeset/deprecate-generated-image.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Deprecate `Experimental_GeneratedImage` in favor of `GeneratedFile`.

--- a/examples/ai-functions/src/lib/present-image.ts
+++ b/examples/ai-functions/src/lib/present-image.ts
@@ -1,4 +1,4 @@
-import type { Experimental_GeneratedImage as GeneratedImage } from 'ai';
+import type { GeneratedFile } from 'ai';
 import fs from 'node:fs';
 import imageType from 'image-type';
 import path from 'node:path';
@@ -13,7 +13,7 @@ const OUTPUT_DIR = 'output';
  * timestamps.
  * @param images - An array of generated images to process and display.
  */
-export async function presentImages(images: GeneratedImage[]) {
+export async function presentImages(images: GeneratedFile[]) {
   const timestamp = Date.now();
   for (const [index, image] of images.entries()) {
     const srcBuffer = image.uint8Array;

--- a/packages/ai/src/generate-text/generated-file.test-d.ts
+++ b/packages/ai/src/generate-text/generated-file.test-d.ts
@@ -1,0 +1,8 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { Experimental_GeneratedImage, GeneratedFile } from './index';
+
+describe('Experimental_GeneratedImage', () => {
+  it('should remain compatible with GeneratedFile', () => {
+    expectTypeOf<Experimental_GeneratedImage>().toEqualTypeOf<GeneratedFile>();
+  });
+});

--- a/packages/ai/src/generate-text/generated-file.ts
+++ b/packages/ai/src/generate-text/generated-file.ts
@@ -25,6 +25,11 @@ export interface GeneratedFile {
   readonly mediaType: string;
 }
 
+/**
+ * @deprecated Use `GeneratedFile` instead. This alias will be removed in v8.
+ */
+export type Experimental_GeneratedImage = GeneratedFile;
+
 export class DefaultGeneratedFile implements GeneratedFile {
   private base64Data: string | undefined;
   private uint8ArrayData: Uint8Array | undefined;

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -23,7 +23,7 @@ export type {
 export type { GenerateTextResult } from './generate-text-result';
 export {
   DefaultGeneratedFile,
-  type GeneratedFile as Experimental_GeneratedImage, // Image for backwards compatibility, TODO remove in v7
+  type Experimental_GeneratedImage,
   type GeneratedFile,
 } from './generated-file';
 export type {


### PR DESCRIPTION
## Summary

- mark `Experimental_GeneratedImage` as a deprecated alias of `GeneratedFile` until v8
- define the alias explicitly so the deprecation marker survives declaration bundling
- migrate the remaining first-party example to `GeneratedFile`
- add type-level compatibility coverage and a patch changeset

## Validation

- `pnpm --filter ai type-check`
- `pnpm --filter ai build`
- verified the bundled `dist/index.d.ts` retains the `@deprecated` annotation
- `pnpm check`
- `pnpm type-check:full`

Closes #18016.
Part of #16562.
