### PR TITLE
[v6.0] fix: preserve sampling-option behavior in Google Interactions

### DIFF
--- a/.changeset/four-dingos-listen.md
+++ b/.changeset/four-dingos-listen.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Forward `topK` through Google Interactions requests and warn when unsupported frequency or presence penalties are provided.

--- a/packages/google/src/interactions/google-interactions-language-model.test.ts
+++ b/packages/google/src/interactions/google-interactions-language-model.test.ts
@@ -634,6 +634,35 @@ describe('GoogleInteractionsLanguageModel.doGenerate', () => {
       expect(body.generation_config?.thinking_summaries).toBe('auto');
     });
 
+    it('forwards topK and warns for unsupported penalties', async () => {
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        topK: 10,
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.5,
+      });
+      const body = (await server.calls[0].requestBodyJson) as {
+        generation_config?: {
+          top_k?: number;
+          frequency_penalty?: number;
+          presence_penalty?: number;
+        };
+      };
+      expect(body.generation_config).toEqual({
+        top_k: 10,
+      });
+      expect(result.warnings).toEqual([
+        {
+          type: 'unsupported',
+          feature: 'frequencyPenalty',
+        },
+        {
+          type: 'unsupported',
+          feature: 'presencePenalty',
+        },
+      ]);
+    });
+
     it('returns interactionId for turn 1 from a captured fixture', async () => {
       prepareJsonFixtureResponse('multi-turn-stateful-turn1');
       const result = await model.doGenerate({
@@ -1435,12 +1464,15 @@ describe('GoogleInteractionsLanguageModel.doGenerate', () => {
       expect(warning).toBeUndefined();
     });
 
-    it('emits a warning and drops generation-config fields (temperature, topP, thinkingLevel) when an agent is set', async () => {
+    it('emits a warning listing every dropped generation-config field when an agent is set', async () => {
       const agentModel = provider.interactions({ agent: AGENT_NAME });
       const result = await agentModel.doGenerate({
         prompt: TEST_PROMPT,
         temperature: 0.5,
         topP: 0.9,
+        topK: 10,
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.5,
         providerOptions: {
           google: { thinkingLevel: 'high' },
         },
@@ -1455,6 +1487,9 @@ describe('GoogleInteractionsLanguageModel.doGenerate', () => {
           w.type === 'other' &&
           (w as { message?: string }).message?.includes('temperature') &&
           (w as { message?: string }).message?.includes('topP') &&
+          (w as { message?: string }).message?.includes('topK') &&
+          (w as { message?: string }).message?.includes('frequencyPenalty') &&
+          (w as { message?: string }).message?.includes('presencePenalty') &&
           (w as { message?: string }).message?.includes('thinkingLevel'),
       );
       expect(warning).toBeDefined();

--- a/packages/google/src/interactions/google-interactions-language-model.ts
+++ b/packages/google/src/interactions/google-interactions-language-model.ts
@@ -129,6 +129,21 @@ export class GoogleInteractionsLanguageModel implements LanguageModelV3 {
 
     const isAgent = this.agent != null;
 
+    if (!isAgent) {
+      if (options.frequencyPenalty != null) {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'frequencyPenalty',
+        });
+      }
+      if (options.presencePenalty != null) {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'presencePenalty',
+        });
+      }
+    }
+
     const hasTools = options.tools != null && options.tools.length > 0;
 
     let toolsForBody: Array<GoogleInteractionsTool> | undefined;
@@ -251,6 +266,11 @@ export class GoogleInteractionsLanguageModel implements LanguageModelV3 {
       const droppedFields: Array<string> = [];
       if (options.temperature != null) droppedFields.push('temperature');
       if (options.topP != null) droppedFields.push('topP');
+      if (options.topK != null) droppedFields.push('topK');
+      if (options.frequencyPenalty != null)
+        droppedFields.push('frequencyPenalty');
+      if (options.presencePenalty != null)
+        droppedFields.push('presencePenalty');
       if (options.seed != null) droppedFields.push('seed');
       if (options.stopSequences != null && options.stopSequences.length > 0) {
         droppedFields.push('stopSequences');
@@ -273,6 +293,7 @@ export class GoogleInteractionsLanguageModel implements LanguageModelV3 {
       generationConfig = pruneUndefined({
         temperature: options.temperature ?? undefined,
         top_p: options.topP ?? undefined,
+        top_k: options.topK ?? undefined,
         seed: options.seed ?? undefined,
         stop_sequences:
           options.stopSequences != null && options.stopSequences.length > 0

--- a/packages/google/src/interactions/google-interactions-prompt.ts
+++ b/packages/google/src/interactions/google-interactions-prompt.ts
@@ -461,6 +461,7 @@ export type GoogleInteractionsResponseFormatEntry =
 export type GoogleInteractionsGenerationConfig = {
   temperature?: number;
   top_p?: number;
+  top_k?: number;
   seed?: number;
   stop_sequences?: Array<string>;
   max_output_tokens?: number;


### PR DESCRIPTION
## Background

Google Interactions silently ignored topK, presencePenalty, and frequencyPenalty, changing published provider behavior without warnings.

## Root Cause

The Interactions generation-config type and request builder omitted top_k, while neither the model warning path nor agent dropped-field list handled the penalty options; focused reproduction confirmed all three were absent from requests and warnings.

## Summary

Forwarded topK as top_k, emitted unsupported warnings for model penalty options, included all three options in agent dropped-field warnings, removed reproduction artifacts, and added a patch changeset.

## Testing

Added regression coverage for topK forwarding, unsupported penalty warnings, and complete agent dropped-field warnings.

## End-to-end Validation

- `pnpm -C packages/google build && pnpm -C examples/ai-functions exec tsx -e "...generateText(...)..."` — live Gemini Interactions request with topK succeeded and returned explicit unsupported warnings for both penalties.

## Related Issues

Fixes #17937

Closes #17966

Backport of #17970

Co-Authored-By: Lars Grammel <205036+lgrammel@users.noreply.github.com>