### PR TITLE
[v6.0] fix: report unsupported sampling settings for xAI Responses models

### DIFF
--- a/.changeset/warm-geese-warn.md
+++ b/.changeset/warm-geese-warn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+Warn when xAI Responses models ignore unsupported sampling settings.

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -941,6 +941,41 @@ describe('XaiResponsesLanguageModel', () => {
         `);
       });
 
+      it('should warn about unsupported sampling settings', async () => {
+        prepareJsonResponse({
+          id: 'resp_123',
+          object: 'response',
+          status: 'completed',
+          model: 'grok-4-fast-non-reasoning',
+          output: [],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        });
+
+        const result = await createModel().doGenerate({
+          prompt: TEST_PROMPT,
+          topK: 10,
+          frequencyPenalty: 0.5,
+          presencePenalty: 0.5,
+        });
+
+        expect(result.warnings).toMatchInlineSnapshot(`
+          [
+            {
+              "feature": "topK",
+              "type": "unsupported",
+            },
+            {
+              "feature": "frequencyPenalty",
+              "type": "unsupported",
+            },
+            {
+              "feature": "presencePenalty",
+              "type": "unsupported",
+            },
+          ]
+        `);
+      });
+
       describe('responseFormat', () => {
         it('should send response format json schema', async () => {
           prepareJsonResponse({
@@ -1850,6 +1885,37 @@ describe('XaiResponsesLanguageModel', () => {
   });
 
   describe('doStream', () => {
+    it('should warn about unsupported sampling settings', async () => {
+      prepareChunksFixtureResponse('xai-text-streaming.1');
+
+      const { stream } = await createModel().doStream({
+        prompt: TEST_PROMPT,
+        topK: 10,
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.5,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+
+      expect(parts.find(part => part.type === 'stream-start')?.warnings)
+        .toMatchInlineSnapshot(`
+        [
+          {
+            "feature": "topK",
+            "type": "unsupported",
+          },
+          {
+            "feature": "frequencyPenalty",
+            "type": "unsupported",
+          },
+          {
+            "feature": "presencePenalty",
+            "type": "unsupported",
+          },
+        ]
+      `);
+    });
+
     describe('text streaming', () => {
       it('should stream web search with real response', async () => {
         prepareChunksFixtureResponse('xai-web-search-tool.1');

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -73,6 +73,9 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
     maxOutputTokens,
     temperature,
     topP,
+    topK,
+    frequencyPenalty,
+    presencePenalty,
     stopSequences,
     seed,
     responseFormat,
@@ -88,6 +91,18 @@ export class XaiResponsesLanguageModel implements LanguageModelV3 {
         providerOptions,
         schema: xaiLanguageModelResponsesOptions,
       })) ?? {};
+
+    if (topK != null) {
+      warnings.push({ type: 'unsupported', feature: 'topK' });
+    }
+
+    if (frequencyPenalty != null) {
+      warnings.push({ type: 'unsupported', feature: 'frequencyPenalty' });
+    }
+
+    if (presencePenalty != null) {
+      warnings.push({ type: 'unsupported', feature: 'presencePenalty' });
+    }
 
     if (stopSequences != null) {
       warnings.push({ type: 'unsupported', feature: 'stopSequences' });


### PR DESCRIPTION
## Background

The published @ai-sdk/xai Responses model silently ignored topK, frequencyPenalty, and presencePenalty without informing generateText or streamText callers.

## Root Cause

XaiResponsesLanguageModel.getArgs omitted the three options from destructuring and warning handling; focused reproduction confirmed empty warnings while the request fields were omitted.

## Summary

Added unsupported-feature warnings for topK, frequencyPenalty, and presencePenalty, plus a patch changeset.

## Testing

Added generate and stream regression tests asserting all three unsupported warnings.

## End-to-end Validation

- `pnpm -C packages/xai build` followed by an inline `generateText`/`streamText` smoke test: both paths returned warnings for all three unsupported settings.

## Related Issues

Fixes #17936

Closes #17962

Backport of #17972

Co-Authored-By: Lars Grammel <205036+lgrammel@users.noreply.github.com>