### PR TITLE
fix(harness-pi): preserve tool results across process resume

### DIFF
--- a/.changeset/cold-pi-tool-results.md
+++ b/.changeset/cold-pi-tool-results.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-pi': patch
+---
+
+Preserve host tool results when a Pi harness turn resumes in a different process.

--- a/packages/harness-pi/src/pi-session.test.ts
+++ b/packages/harness-pi/src/pi-session.test.ts
@@ -18,6 +18,7 @@ const piMock = vi.hoisted(() => {
     createAgentSession: vi.fn(),
     customTools: [] as FakePiTool[],
     session: undefined as AgentSession | undefined,
+    sessionEntries: [] as unknown[],
   };
 });
 
@@ -40,9 +41,11 @@ vi.mock('@earendil-works/pi-coding-agent', () => {
     SessionManager: {
       create: vi.fn(() => ({
         getSessionFile: () => undefined,
+        getBranch: () => piMock.sessionEntries,
       })),
       open: vi.fn(() => ({
         getSessionFile: () => undefined,
+        getBranch: () => piMock.sessionEntries,
       })),
     },
     SettingsManager: {
@@ -56,6 +59,7 @@ describe('createPiSession', () => {
   beforeEach(() => {
     piMock.customTools = [];
     piMock.session = undefined;
+    piMock.sessionEntries = [];
     piMock.createAgentSession.mockReset();
     piMock.createAgentSession.mockImplementation(async options => {
       piMock.customTools = options.customTools;
@@ -178,6 +182,96 @@ describe('createPiSession', () => {
     );
   });
 
+  it('delivers a tool result after a cold cross-process resume', async () => {
+    piMock.sessionEntries = [
+      {
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'toolCall',
+              id: 'original-tool',
+              name: 'weather',
+              arguments: {},
+            },
+          ],
+        },
+      },
+    ];
+
+    const allowToolExecution = createDeferred<void>();
+    let resolvedToolResult: unknown;
+    const prompt = vi.fn(async () => {
+      await allowToolExecution.promise;
+      const tool = piMock.customTools.find(tool => tool.name === 'weather');
+      if (!tool) throw new Error('Expected weather tool.');
+      const toolResult = await tool.execute(
+        'runtime-tool',
+        {},
+        undefined,
+        undefined,
+        undefined as never,
+      );
+      resolvedToolResult = toolResult;
+    });
+    piMock.session = {
+      abort: vi.fn(async () => {}),
+      compact: vi.fn(async () => {}),
+      dispose: vi.fn(),
+      getSessionStats: () => ({
+        tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      }),
+      prompt,
+      steer: vi.fn(async () => {}),
+      subscribe: vi.fn(() => () => {}),
+    } as unknown as AgentSession;
+
+    const sandboxSession = createSandboxSession({
+      sessionFile: new TextEncoder().encode('persisted session'),
+    });
+    const session = await createPiSession({
+      sessionId: 'cold-session',
+      sandboxSession,
+      sessionWorkDir: '/sandbox/work',
+      skills: [],
+      settings: {},
+      clientApp: 'ai-sdk/harness-pi/0.0.0-test',
+      isResume: true,
+      resumeSessionFileName: 'session.jsonl',
+    });
+    const control = await session.doContinueTurn({
+      tools: [{ name: 'weather' }],
+      emit: vi.fn(),
+    });
+
+    await control.submitToolResult({
+      toolCallId: 'original-tool',
+      output: { weather: 'sunny' },
+    });
+    allowToolExecution.resolve();
+    await control.done;
+
+    expect(resolvedToolResult).toMatchInlineSnapshot(
+      {
+        content: [{ type: 'text', text: '{"weather":"sunny"}' }],
+        details: undefined,
+      },
+      `
+      {
+        "content": [
+          {
+            "text": "{"weather":"sunny"}",
+            "type": "text",
+          },
+        ],
+        "details": undefined,
+      }
+    `,
+    );
+    expect(prompt).toHaveBeenCalledTimes(1);
+  });
+
   it('uses agentDir for auth, models, and settings when provided', async () => {
     vi.mocked(ModelRuntime.create).mockClear();
     vi.mocked(SettingsManager.inMemory).mockClear();
@@ -235,12 +329,14 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
-function createSandboxSession(): HarnessV1NetworkSandboxSession {
+function createSandboxSession(
+  input: { sessionFile?: Uint8Array } = {},
+): HarnessV1NetworkSandboxSession {
   const sandbox = {
     defaultWorkingDirectory: '/sandbox',
     destroy: vi.fn(async () => {}),
     getPortUrl: vi.fn(),
-    readBinaryFile: vi.fn(async () => undefined),
+    readBinaryFile: vi.fn(async () => input.sessionFile),
     restricted: vi.fn(() => sandbox),
     run: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
     stop: vi.fn(async () => {}),

--- a/packages/harness-pi/src/pi-session.ts
+++ b/packages/harness-pi/src/pi-session.ts
@@ -223,6 +223,16 @@ interface PendingToolApproval {
   resolve: (value: { approved: boolean; reason?: string }) => void;
 }
 
+interface ResumedPendingToolCall {
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly input: unknown;
+  runtimeToolCallId?: string;
+  result?: unknown;
+  hasResult?: boolean;
+  approval?: { approved: boolean; reason?: string };
+}
+
 interface ActivePiTurn {
   readonly token: object;
   readonly done: Promise<void>;
@@ -417,6 +427,9 @@ export async function createPiSession(
   let instructionsApplied = input.isResume;
   const pendingToolResults = new Map<string, PendingToolResult>();
   const pendingToolApprovals = new Map<string, PendingToolApproval>();
+  const resumedPendingToolCalls = new Map<string, ResumedPendingToolCall>();
+  const resumedToolCallIds = new Map<string, string>();
+  const originalToolCallIds = new Map<string, string>();
 
   // Emit channel set at the start of every doPromptTurn and cleared on end.
   let currentEmit: ((part: HarnessV1StreamPart) => void) | undefined;
@@ -454,6 +467,45 @@ export async function createPiSession(
     pendingToolApprovals.clear();
   }
 
+  function findResumedToolCall(input: {
+    toolName: string;
+    toolInput?: unknown;
+  }): ResumedPendingToolCall | undefined {
+    const matches = [...resumedPendingToolCalls.values()].filter(call => {
+      if (call.runtimeToolCallId != null) return false;
+      if (call.toolName !== input.toolName) return false;
+      return (
+        input.toolInput === undefined ||
+        stableSerialize(call.input) === stableSerialize(input.toolInput)
+      );
+    });
+    return matches[0];
+  }
+
+  function bindResumedToolCall(input: {
+    runtimeToolCallId: string;
+    toolName: string;
+    toolInput?: unknown;
+  }): ResumedPendingToolCall | undefined {
+    const call =
+      [...resumedPendingToolCalls.values()].find(
+        pending => pending.runtimeToolCallId === input.runtimeToolCallId,
+      ) ?? findResumedToolCall(input);
+    if (!call) return undefined;
+    call.runtimeToolCallId = input.runtimeToolCallId;
+    resumedToolCallIds.set(call.toolCallId, input.runtimeToolCallId);
+    originalToolCallIds.set(input.runtimeToolCallId, call.toolCallId);
+    translatorState?.toolCallIds.set(input.runtimeToolCallId, call.toolCallId);
+    if (call.hasResult) {
+      translatorState?.hostToolResults.set(call.toolCallId, call.result);
+    }
+    return call;
+  }
+
+  function canonicalToolCallId(toolCallId: string): string {
+    return originalToolCallIds.get(toolCallId) ?? toolCallId;
+  }
+
   async function persistSessionFile(): Promise<void> {
     if (!sessionFileName) return;
     await persistSessionFileToSandbox({
@@ -487,27 +539,57 @@ export async function createPiSession(
 
     return {
       async submitToolResult(args) {
-        const pending = pendingToolResults.get(args.toolCallId);
-        if (!pending) return;
-        pendingToolResults.delete(args.toolCallId);
         /*
          * Preserve the original output so the result projection can surface it
-         * unchanged. The tool handler stringifies the output for the runtime
-         * (so the model reads it), and Pi echoes that text back — without this
-         * the consumer-facing result would be the serialized string instead of
-         * the original object.
+         * unchanged. Pi receives serialized text, while consumers should still
+         * receive the original structured value.
          */
-        translatorState?.hostToolResults.set(args.toolCallId, args.output);
-        pending.resolve(args.output);
+        const runtimeToolCallId =
+          resumedToolCallIds.get(args.toolCallId) ?? args.toolCallId;
+        const pending = pendingToolResults.get(runtimeToolCallId);
+        if (pending) {
+          pendingToolResults.delete(runtimeToolCallId);
+          translatorState?.hostToolResults.set(
+            canonicalToolCallId(runtimeToolCallId),
+            args.output,
+          );
+          pending.resolve(args.output);
+          return;
+        }
+        const resumed = resumedPendingToolCalls.get(args.toolCallId);
+        if (!resumed) {
+          throw new Error(
+            `Pi session received a tool result for unknown tool call '${args.toolCallId}'.`,
+          );
+        }
+        resumed.result = args.output;
+        resumed.hasResult = true;
+        if (resumed.runtimeToolCallId != null) {
+          translatorState?.hostToolResults.set(resumed.toolCallId, args.output);
+        }
       },
       async submitToolApproval(args) {
-        const pending = pendingToolApprovals.get(args.approvalId);
-        if (!pending) return;
-        pendingToolApprovals.delete(args.approvalId);
-        pending.resolve({
+        const runtimeToolCallId =
+          resumedToolCallIds.get(args.approvalId) ?? args.approvalId;
+        const pending = pendingToolApprovals.get(runtimeToolCallId);
+        if (pending) {
+          pendingToolApprovals.delete(runtimeToolCallId);
+          pending.resolve({
+            approved: args.approved,
+            reason: args.reason,
+          });
+          return;
+        }
+        const resumed = resumedPendingToolCalls.get(args.approvalId);
+        if (!resumed) {
+          throw new Error(
+            `Pi session received an approval for unknown tool call '${args.approvalId}'.`,
+          );
+        }
+        resumed.approval = {
           approved: args.approved,
           reason: args.reason,
-        });
+        };
       },
       async submitUserMessage(text) {
         await piSession?.steer(text);
@@ -528,19 +610,22 @@ export async function createPiSession(
     ) {
       return { approved: true };
     }
+    const resumed = bindResumedToolCall({
+      runtimeToolCallId: args.toolCallId,
+      toolName: args.nativeName,
+    });
+    const toolCallId = canonicalToolCallId(args.toolCallId);
     currentEmit?.({
       type: 'tool-approval-request',
-      approvalId: args.toolCallId,
-      toolCallId: args.toolCallId,
+      approvalId: toolCallId,
+      toolCallId,
     });
     if (translatorState) {
-      for (const part of finishPiApprovalStep(
-        translatorState,
-        args.toolCallId,
-      )) {
+      for (const part of finishPiApprovalStep(translatorState, toolCallId)) {
         currentEmit?.(part);
       }
     }
+    if (resumed?.approval) return resumed.approval;
     return new Promise(resolve => {
       pendingToolApprovals.set(args.toolCallId, { resolve });
     });
@@ -562,7 +647,16 @@ export async function createPiSession(
         }),
       ),
       ...userTools.map(spec =>
-        buildUserToolDefinition(spec, pendingToolResults),
+        buildUserToolDefinition(
+          spec,
+          pendingToolResults,
+          (runtimeToolCallId, toolInput) =>
+            bindResumedToolCall({
+              runtimeToolCallId,
+              toolName: spec.name,
+              toolInput,
+            }),
+        ),
       ),
     ];
     return {
@@ -601,6 +695,22 @@ export async function createPiSession(
           )
         : SessionManager.create(sessionWorkDir, hostSessionDir);
 
+    if (
+      isFirstBuild &&
+      resumeSessionFilePath &&
+      typeof (sessionManager as { getBranch?: unknown }).getBranch ===
+        'function'
+    ) {
+      for (const call of collectPendingPiToolCalls({
+        sessionManager: sessionManager as {
+          getBranch(): readonly unknown[];
+        },
+        toolNames: new Set(toolNames),
+      })) {
+        resumedPendingToolCalls.set(call.toolCallId, call);
+      }
+    }
+
     const { session } = await createAgentSession({
       cwd: sessionWorkDir,
       agentDir: hostAgentDir,
@@ -635,6 +745,33 @@ export async function createPiSession(
       if (!translatorState) return;
       const event = parseNativeEvent(rawEvent);
       if (!event) return;
+      if (
+        event.type === 'message_end' &&
+        event.message?.role === 'assistant' &&
+        Array.isArray(event.message.content)
+      ) {
+        for (const block of event.message.content) {
+          if (
+            !block ||
+            typeof block !== 'object' ||
+            block.type !== 'toolCall'
+          ) {
+            continue;
+          }
+          bindResumedToolCall({
+            runtimeToolCallId: block.id,
+            toolName: block.name,
+            toolInput: block.arguments,
+          });
+        }
+      }
+      if (event.type === 'tool_execution_start' && event.toolCallId) {
+        bindResumedToolCall({
+          runtimeToolCallId: event.toolCallId,
+          toolName: event.toolName ?? '',
+          toolInput: event.args ?? event.input,
+        });
+      }
       for (const part of translatePiEvent(event, translatorState)) {
         if (currentEmit) {
           currentEmit(part);
@@ -1236,6 +1373,10 @@ function buildBuiltinToolDefinition(input: {
 function buildUserToolDefinition(
   spec: HarnessV1ToolSpec,
   pending: Map<string, PendingToolResult>,
+  onExecute?: (
+    toolCallId: string,
+    input: unknown,
+  ) => ResumedPendingToolCall | undefined,
 ): ToolDefinition {
   const schema = spec.inputSchema ?? {
     type: 'object',
@@ -1247,10 +1388,74 @@ function buildUserToolDefinition(
     label: spec.name,
     description: spec.description ?? `User-registered tool ${spec.name}`,
     parameters: toolSpecToTypeBoxParameters(schema),
-    async execute(toolCallId) {
+    async execute(toolCallId, params) {
+      const resumed = onExecute?.(toolCallId, params);
       return new Promise<unknown>(resolve => {
         pending.set(toolCallId, { resolve });
+        if (resumed?.hasResult) {
+          pending.delete(toolCallId);
+          resolve(resumed.result);
+        }
       }).then(output => asPiToolResult(serializeToolOutput(output)));
     },
   });
+}
+
+function stableSerialize(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableSerialize).join(',')}]`;
+  }
+  return `{${Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map(
+      key =>
+        `${JSON.stringify(key)}:${stableSerialize((value as Record<string, unknown>)[key])}`,
+    )
+    .join(',')}}`;
+}
+
+function collectPendingPiToolCalls(input: {
+  readonly sessionManager: { getBranch(): readonly unknown[] };
+  readonly toolNames: ReadonlySet<string>;
+}): ResumedPendingToolCall[] {
+  const pending = new Map<string, ResumedPendingToolCall>();
+  for (const entry of input.sessionManager.getBranch()) {
+    if (!entry || typeof entry !== 'object') continue;
+    const message = (entry as { message?: unknown }).message;
+    if (!message || typeof message !== 'object') continue;
+    const role = (message as { role?: unknown }).role;
+    if (role === 'assistant') {
+      const content = (message as { content?: unknown }).content;
+      if (!Array.isArray(content)) continue;
+      for (const block of content) {
+        if (!block || typeof block !== 'object') continue;
+        const toolBlock = block as {
+          type?: unknown;
+          id?: unknown;
+          name?: unknown;
+          arguments?: unknown;
+        };
+        if (
+          toolBlock.type !== 'toolCall' ||
+          typeof toolBlock.id !== 'string' ||
+          typeof toolBlock.name !== 'string' ||
+          !input.toolNames.has(toolBlock.name)
+        ) {
+          continue;
+        }
+        pending.set(toolBlock.id, {
+          toolCallId: toolBlock.id,
+          toolName: toolBlock.name,
+          input: toolBlock.arguments ?? {},
+        });
+      }
+    } else if (role === 'toolResult') {
+      const toolCallId = (message as { toolCallId?: unknown }).toolCallId;
+      if (typeof toolCallId === 'string') pending.delete(toolCallId);
+    }
+  }
+  return [...pending.values()];
 }

--- a/packages/harness-pi/src/pi-translate.test.ts
+++ b/packages/harness-pi/src/pi-translate.test.ts
@@ -339,6 +339,60 @@ describe('translatePiEvent', () => {
     });
   });
 
+  it('projects a resumed runtime tool-call id back to its persisted id', () => {
+    const state = createPiTranslatorState();
+    state.toolCallIds.set('runtime-call', 'persisted-call');
+    const submitted = { weather: 'sunny' };
+    state.hostToolResults.set('persisted-call', submitted);
+
+    const out = emit(
+      [
+        { type: 'turn_start' } as PiSessionEvent,
+        {
+          type: 'message_start',
+          message: { role: 'assistant', content: [] },
+        } as PiSessionEvent,
+        {
+          type: 'message_end',
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                type: 'toolCall',
+                id: 'runtime-call',
+                name: 'weather',
+                arguments: { city: 'SF' },
+              },
+            ],
+          },
+        } as PiSessionEvent,
+        {
+          type: 'tool_execution_start',
+          toolCallId: 'runtime-call',
+          toolName: 'weather',
+          args: { city: 'SF' },
+        } as PiSessionEvent,
+        {
+          type: 'tool_execution_end',
+          toolCallId: 'runtime-call',
+          result: JSON.stringify(submitted),
+        } as PiSessionEvent,
+      ],
+      state,
+    );
+
+    expect(out.find(part => part.type === 'tool-call')).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'persisted-call',
+    });
+    expect(out.find(part => part.type === 'tool-result')).toMatchObject({
+      type: 'tool-result',
+      toolCallId: 'persisted-call',
+      result: submitted,
+    });
+    expect(out.at(-1)?.type).toBe('finish-step');
+  });
+
   it('surfaces the original host-submitted output object instead of the echoed text', () => {
     const state = createPiTranslatorState();
     emit(

--- a/packages/harness-pi/src/pi-translate.ts
+++ b/packages/harness-pi/src/pi-translate.ts
@@ -43,6 +43,8 @@ export interface PiTranslatorState {
    * the matching `tool_result`/`tool_execution_end` event is translated.
    */
   hostToolResults: Map<string, unknown>;
+  /** Runtime tool-call ids mapped back to the ids persisted by the harness. */
+  toolCallIds: Map<string, string>;
   /**
    * Names of tools that Pi executes natively (read/write/edit/bash/grep/
    * find/ls). `tool-call` events for these get `providerExecuted: true`
@@ -82,6 +84,7 @@ export function createPiTranslatorState(
     pendingStepToolCallIds: new Set(),
     stepOpen: false,
     hostToolResults: new Map(),
+    toolCallIds: new Map(),
     builtinToolNames: new Set(options.builtinToolNames ?? []),
     nativeToCommonNameMap: map,
   };
@@ -162,7 +165,10 @@ export function finishPiApprovalStep(
   return finishStep(state);
 }
 
-function extractPiToolCallIds(message: PiSessionEvent['message']): string[] {
+function extractPiToolCallIds(
+  message: PiSessionEvent['message'],
+  state: PiTranslatorState,
+): string[] {
   if (!message || message.role !== 'assistant') return [];
   if (!Array.isArray(message.content)) return [];
   return message.content.flatMap(part => {
@@ -170,7 +176,9 @@ function extractPiToolCallIds(message: PiSessionEvent['message']): string[] {
     const block = part as Record<string, unknown>;
     if (block.type !== 'toolCall') return [];
     const id = block.id ?? block.toolCallId;
-    return typeof id === 'string' && id.length > 0 ? [id] : [];
+    return typeof id === 'string' && id.length > 0
+      ? [state.toolCallIds.get(id) ?? id]
+      : [];
   });
 }
 
@@ -293,7 +301,7 @@ export function translatePiEvent(
         state.currentReasoningId = undefined;
       }
       if (event.type === 'message_end') {
-        for (const toolCallId of extractPiToolCallIds(event.message)) {
+        for (const toolCallId of extractPiToolCallIds(event.message, state)) {
           state.pendingStepToolCallIds.add(toolCallId);
         }
       } else {
@@ -305,14 +313,16 @@ export function translatePiEvent(
 
     case 'tool_execution_start': {
       if (!event.toolCallId || !event.toolName) return [];
+      const toolCallId =
+        state.toolCallIds.get(event.toolCallId) ?? event.toolCallId;
       const { wire, native } = resolveToolName(state, event.toolName);
-      state.observedToolNames.set(event.toolCallId, wire);
+      state.observedToolNames.set(toolCallId, wire);
       const providerExecuted = state.builtinToolNames.has(native);
       const input = serializeToolOutput(event.args ?? event.input ?? {});
       return [
         {
           type: 'tool-call',
-          toolCallId: event.toolCallId,
+          toolCallId,
           toolName: wire,
           input,
           ...(wire !== native ? { nativeName: native } : {}),
@@ -324,7 +334,9 @@ export function translatePiEvent(
     case 'tool_execution_end':
     case 'tool_result': {
       if (!event.toolCallId) return [];
-      const recordedName = state.observedToolNames.get(event.toolCallId);
+      const toolCallId =
+        state.toolCallIds.get(event.toolCallId) ?? event.toolCallId;
+      const recordedName = state.observedToolNames.get(toolCallId);
       const nativeName = event.toolName;
       const wire =
         recordedName ??
@@ -336,18 +348,18 @@ export function translatePiEvent(
        * reports as text, are not in the map and fall back to unwrapping the
        * event's text payload.
        */
-      const result = state.hostToolResults.has(event.toolCallId)
-        ? ((state.hostToolResults.get(event.toolCallId) ?? null) as Extract<
+      const result = state.hostToolResults.has(toolCallId)
+        ? ((state.hostToolResults.get(toolCallId) ?? null) as Extract<
             HarnessV1StreamPart,
             { type: 'tool-result' }
           >['result'])
         : unwrapPiToolResult(event);
-      state.hostToolResults.delete(event.toolCallId);
-      state.pendingStepToolCallIds.delete(event.toolCallId);
+      state.hostToolResults.delete(toolCallId);
+      state.pendingStepToolCallIds.delete(toolCallId);
       return [
         {
           type: 'tool-result',
-          toolCallId: event.toolCallId,
+          toolCallId,
           toolName: wire,
           result,
           ...(event.isError ? { isError: true } : {}),


### PR DESCRIPTION
## Summary

Fixes #18018

Pi runs in the host process, so a tool approval continuation can arrive after the session has been recreated from its persisted journal. On a cold resume, the adapter previously kept pending tool results only in an in-process map; `submitToolResult` therefore became a silent no-op and the rerun continued with an empty result.

This change:

- Recovers unresolved Pi tool calls from the persisted session branch during a cold resume.
- Correlates the persisted harness tool-call ID with the fresh runtime ID using the tool name and arguments.
- Preserves the original ID in translated stream parts so the harness does not execute an already-settled host tool twice.
- Delivers tool results and built-in approval decisions whether they arrive before or after the rerun invokes the tool.
- Reports an explicit error for submissions that cannot be correlated instead of silently dropping them.

## Tests

- `corepack pnpm --filter @ai-sdk/harness-pi type-check`
- `vitest --config vitest.node.config.js --run src/pi-session.test.ts -t "cold cross-process"`
- `vitest --config vitest.node.config.js --run src/pi-translate.test.ts -t "persisted id"`
- `oxfmt --check` on all changed TypeScript files
- `oxlint` on all changed TypeScript files

The full package test suite also ran. Twelve test files passed; one existing Windows-specific assertion (`uses agentDir for auth, models, and settings when provided`) expects POSIX separators and fails on Windows before exercising this change.

## Release Notes

A patch changeset for `@ai-sdk/harness-pi` is included.
