### PR TITLE
feat(tools-registry): add brightdata

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -236,6 +236,39 @@ console.log(text);`,
     npmUrl: 'https://www.npmjs.com/package/@tavily/ai-sdk',
   },
   {
+    slug: 'brightdata',
+    name: 'Bright Data',
+    description:
+      'Bright Data gives agents access to the live web with built-in anti-bot bypass. Scrape any page as clean markdown or HTML, run Google, Bing, or Yandex searches, and pull structured data from sites like Amazon, LinkedIn, Instagram, and Facebook.',
+    packageName: '@brightdata/ai-sdk',
+    tags: ['scraping', 'search', 'extraction', 'web'],
+    apiKeyEnvName: 'BRIGHTDATA_API_KEY',
+    installCommand: {
+      pnpm: 'pnpm add @brightdata/ai-sdk',
+      npm: 'npm install @brightdata/ai-sdk',
+      yarn: 'yarn add @brightdata/ai-sdk',
+      bun: 'bun add @brightdata/ai-sdk',
+    },
+    codeExample: `import { generateText, isStepCount } from 'ai';
+import { scrape, search } from '@brightdata/ai-sdk';
+
+const { text } = await generateText({
+  model: 'openai/gpt-5.2',
+  prompt: 'What are the latest AI agent frameworks released this week?',
+  tools: {
+    scrape: scrape(),
+    search: search(),
+  },
+  stopWhen: isStepCount(5),
+});
+
+console.log(text);`,
+    docsUrl: 'https://docs.brightdata.com/integrations/vercel-ai-sdk',
+    apiKeyUrl: 'https://brightdata.com/cp',
+    websiteUrl: 'https://brightdata.com',
+    npmUrl: 'https://www.npmjs.com/package/@brightdata/ai-sdk',
+  },
+  {
     slug: 'firecrawl',
     name: 'Firecrawl',
     description:


### PR DESCRIPTION
## Background

`@brightdata/ai-sdk` is a published npm package of ready-made AI SDK tools for live web
access, but Bright Data is not yet in the tools registry. The registry currently lists
Exa, Tavily, Firecrawl, Parallel and Browserbase in this category; Bright Data covers the
same surface (search + scrape) plus structured extraction from consumer sites, with
anti-bot bypass handled server-side.

This supersedes #12769, which has been open since 2026-02-23. That PR's code example uses
`stepCountIs`, which still resolves in v7 as a deprecated alias of `isStepCount` but is no
longer the convention here: all 16 existing entries use `isStepCount` (32 occurrences, an
import and a `stopWhen` in each), and `vercel[bot]`
flagged exactly this on #14992 (`VADE-CATEGORY: api-compatibility`) before that PR merged.
This PR uses the current name and narrows the scope to the registry file only.

## Summary

Adds a single `brightdata` entry to `content/tools-registry/registry.ts`, placed next to
the other web-data tools (after `tavily`, before `firecrawl`).

- `codeExample` uses `isStepCount` (the `ai@7` helper) and the `'provider/model'` string
  convention established in #11549.
- `tags` reuse the existing registry vocabulary (`scraping`, `search`, `extraction`,
  `web`) and claim only what the package actually exports — no `crawl` tool exists, so
  `crawl` is not claimed.
- `apiKeyEnvName` is `BRIGHTDATA_API_KEY`, matching the variable the package reads.
- No other files are touched, and no changeset is needed (`verify-changesets` only runs
  for `.changeset/*.md` and `packages/**`).

## End-to-End Verification

The `codeExample` was run verbatim, not just type-checked:

- `ai@7.0.40` + `@brightdata/ai-sdk@0.1.0`, Node 22.22.3
- model `openai/gpt-5.2` through the Vercel AI Gateway
- Result: the model called `search` on steps 0 and 1, then finished naturally on step 2
  with `finishReason: 'stop'` and 1004 characters of answer text (19,899 total tokens).

`isStepCount(5)` rather than `(3)` is deliberate: Bright Data's `search` returns a full
SERP as markdown (~16 KB), so a 3-step budget truncates the loop before the model
produces its answer and `text` comes back empty. Verified by running both.

Formatting and types were checked against this repo's own config: `oxfmt --check` with
`.oxfmtrc.jsonc` exits 0, and `tsc --noEmit --strict` on `registry.ts` exits 0.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Supersedes #12769.