### PR TITLE
fix(xai): read the video status 202 body instead of cancelling it

### DIFF
--- a/.changeset/xai-video-202-no-cancel.md
+++ b/.changeset/xai-video-202-no-cancel.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(xai): video generation no longer hangs while polling status

--- a/packages/xai/src/xai-video-model.test.ts
+++ b/packages/xai/src/xai-video-model.test.ts
@@ -1629,6 +1629,51 @@ describe('XaiVideoModel', () => {
       expect(result.videos[0]?.type).toBe('url');
     });
 
+    it('should reject an oversized HTTP 202 body without hanging', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = ({
+        callNumber,
+      }) =>
+        callNumber === 1
+          ? pending202({ padding: 'x'.repeat(2 * 1024 * 1024) })
+          : { type: 'json-value', body: doneStatusResponse };
+
+      const model = createModel({ fetch: teeingFetch() });
+
+      await expect(model.doGenerate({ ...defaultOptions })).rejects.toThrow(
+        /exceeded/,
+      );
+    });
+
+    it('should honor abort while reading an unfinished HTTP 202 body', async () => {
+      const abortController = new AbortController();
+      // A 202 whose body never finishes. Errors the stream on abort, as fetch
+      // implementations do for an aborted request body.
+      const unfinished202: FetchFunction = async (input, init) => {
+        if (!(input as string).includes('/videos/req-123')) {
+          return globalThis.fetch(input as string, init);
+        }
+        const body = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"status":'));
+            init?.signal?.addEventListener('abort', () => {
+              controller.error(new DOMException('Aborted', 'AbortError'));
+            });
+            queueMicrotask(() => abortController.abort());
+          },
+        });
+        return new Response(body, { status: 202 });
+      };
+
+      const model = createModel({ fetch: unfinished202 });
+
+      await expect(
+        model.doGenerate({
+          ...defaultOptions,
+          abortSignal: abortController.signal,
+        }),
+      ).rejects.toThrow(/abort/i);
+    });
+
     it('should time out while repeatedly receiving empty HTTP 202 responses', async () => {
       server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {
         type: 'empty',

--- a/packages/xai/src/xai-video-model.test.ts
+++ b/packages/xai/src/xai-video-model.test.ts
@@ -1,7 +1,32 @@
 import { InvalidArgumentError } from '@ai-sdk/provider';
+import type { FetchFunction } from '@ai-sdk/provider-utils';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { describe, expect, it } from 'vitest';
 import { XaiVideoModel } from './xai-video-model';
+
+// `json-value` forces status 200, so a 202 with a body must go through `error`.
+function pending202(body: unknown) {
+  return { type: 'error' as const, status: 202, body: JSON.stringify(body) };
+}
+
+// Tees the body and keeps the sibling alive, as `Response.clone()` does inside
+// fetch instrumentation. Explicit so the guard does not rely on msw internals.
+function teeingFetch(): FetchFunction {
+  const siblings: ReadableStream[] = [];
+  return async (input, init) => {
+    const response = await globalThis.fetch(input as string, init);
+    if (!response.body) {
+      return response;
+    }
+    const [caller, sibling] = response.body.tee();
+    siblings.push(sibling);
+    return new Response(caller, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+}
 
 const prompt = 'A chicken flying into the sunset';
 
@@ -45,14 +70,17 @@ const defaultOptions = {
 function createModel({
   headers,
   currentDate,
+  fetch,
 }: {
   headers?: () => Record<string, string>;
   currentDate?: () => Date;
+  fetch?: FetchFunction;
 } = {}) {
   return new XaiVideoModel('grok-imagine-video', {
     provider: 'xai.video',
     baseURL: TEST_BASE_URL,
     headers: headers ?? (() => ({ 'api-key': 'test-key' })),
+    fetch,
     _internal: {
       currentDate,
     },
@@ -1531,6 +1559,75 @@ describe('XaiVideoModel', () => {
         expect(server.calls).toHaveLength(3);
       },
     );
+
+    it('should treat an HTTP 202 carrying a status payload as pending', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = ({
+        callNumber,
+      }) =>
+        callNumber === 1
+          ? pending202({ status: 'pending', progress: 42 })
+          : { type: 'json-value', body: doneStatusResponse };
+
+      const model = createModel();
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      expect(result.videos[0]).toMatchInlineSnapshot(`
+        {
+          "mediaType": "video/mp4",
+          "type": "url",
+          "url": "https://vidgen.x.ai/output/video-001.mp4",
+        }
+      `);
+      expect(server.calls).toHaveLength(3);
+    });
+
+    it('should complete when an HTTP 202 body already carries the video', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response =
+        pending202(doneStatusResponse);
+
+      const model = createModel();
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      expect(result.videos[0]).toMatchInlineSnapshot(`
+        {
+          "mediaType": "video/mp4",
+          "type": "url",
+          "url": "https://vidgen.x.ai/output/video-001.mp4",
+        }
+      `);
+      expect(server.calls).toHaveLength(2);
+    });
+
+    it('should treat an HTTP 202 with an unparseable body as pending', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = ({
+        callNumber,
+      }) =>
+        callNumber === 1
+          ? { type: 'error' as const, status: 202, body: 'not json' }
+          : { type: 'json-value', body: doneStatusResponse };
+
+      const model = createModel();
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      expect(result.videos[0]?.type).toBe('url');
+      expect(server.calls).toHaveLength(3);
+    });
+
+    // Body must be non-empty: an empty 202 has no stream to tee.
+    it('should keep polling past a 202 when the caller fetch tees the response body', async () => {
+      server.urls[`${TEST_BASE_URL}/videos/req-123`].response = ({
+        callNumber,
+      }) =>
+        callNumber === 1
+          ? pending202({ status: 'pending', progress: 10 })
+          : { type: 'json-value', body: doneStatusResponse };
+
+      const model = createModel({ fetch: teeingFetch() });
+
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      expect(result.videos[0]?.type).toBe('url');
+    });
 
     it('should time out while repeatedly receiving empty HTTP 202 responses', async () => {
       server.urls[`${TEST_BASE_URL}/videos/req-123`].response = {

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -1,5 +1,6 @@
 import {
   AISDKError,
+  APICallError,
   type Experimental_VideoModelV4,
   type Experimental_VideoModelV4File,
   type SharedV4Warning,
@@ -549,6 +550,58 @@ const xaiVideoStatusJsonResponseHandler = createJsonResponseHandler(
   xaiVideoStatusResponseSchema,
 );
 
+// Generous bound for a `{status, progress}` payload of ~50 bytes.
+const MAX_PENDING_BODY_BYTES = 1024 * 1024;
+
+const textDecoder = new TextDecoder();
+
+// Bounded replacement for `response.text()`. Throws on overflow without
+// cancelling the body: cancelling a tee branch neither settles nor releases
+// the underlying source while the sibling branch is live.
+async function readPendingBody({
+  response,
+  url,
+  requestBodyValues,
+}: Parameters<ResponseHandler<unknown>>[0]): Promise<string> {
+  if (response.body == null) {
+    return '';
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      totalBytes += value.length;
+      if (totalBytes > MAX_PENDING_BODY_BYTES) {
+        throw new APICallError({
+          message: `xAI video status response exceeded ${MAX_PENDING_BODY_BYTES} bytes`,
+          url,
+          requestBodyValues,
+          statusCode: response.status,
+          responseHeaders: extractResponseHeaders(response),
+        });
+      }
+
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const merged = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return textDecoder.decode(merged);
+}
+
 const xaiVideoStatusResponseHandler: ResponseHandler<
   z.infer<typeof xaiVideoStatusResponseSchema>
 > = async options => {
@@ -557,7 +610,7 @@ const xaiVideoStatusResponseHandler: ResponseHandler<
   // on a tee branch, which `Response.clone()` in fetch instrumentation creates.
   if (options.response.status === 202) {
     const responseHeaders = extractResponseHeaders(options.response);
-    const text = await options.response.text();
+    const text = await readPendingBody(options);
 
     if (text.trim().length === 0) {
       return { responseHeaders, value: { status: 'pending' } };

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -5,7 +5,6 @@ import {
   type SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
-  cancelResponseBody,
   combineHeaders,
   convertUint8ArrayToBase64,
   createJsonResponseHandler,
@@ -15,6 +14,7 @@ import {
   getTopLevelMediaType,
   parseProviderOptions,
   postJsonToApi,
+  safeParseJSON,
   type FetchFunction,
   type ResponseHandler,
 } from '@ai-sdk/provider-utils';
@@ -552,13 +552,25 @@ const xaiVideoStatusJsonResponseHandler = createJsonResponseHandler(
 const xaiVideoStatusResponseHandler: ResponseHandler<
   z.infer<typeof xaiVideoStatusResponseSchema>
 > = async options => {
+  // xAI answers 202 while a generation is still running, sometimes with an
+  // empty body. Read it rather than cancelling: `body.cancel()` never settles
+  // on a tee branch, which `Response.clone()` in fetch instrumentation creates.
   if (options.response.status === 202) {
     const responseHeaders = extractResponseHeaders(options.response);
-    await cancelResponseBody(options.response);
+    const text = await options.response.text();
+
+    if (text.trim().length === 0) {
+      return { responseHeaders, value: { status: 'pending' } };
+    }
+
+    const parsed = await safeParseJSON({
+      text,
+      schema: xaiVideoStatusResponseSchema,
+    });
 
     return {
       responseHeaders,
-      value: { status: 'pending' },
+      value: parsed.success ? parsed.value : { status: 'pending' },
     };
   }
 


### PR DESCRIPTION
## What's wrong

xAI video generation hangs wherever something clones the fetch response. `doGenerate` creates the generation, receives 202 on its first status poll, and never returns.

The 202 branch of the status handler awaits a cancel that never settles ([`xai-video-model.ts:555`](https://github.com/vercel/ai/blob/1e2ae1f818fa92da8038c40056e0d9b233fe4945/packages/xai/src/xai-video-model.ts#L555)):

```ts
if (options.response.status === 202) {
  const responseHeaders = extractResponseHeaders(options.response);
  await cancelResponseBody(options.response);
  return { responseHeaders, value: { status: 'pending' } };
}
```

xAI answers 202 on every poll while a generation runs and 200 once it finishes, so the first poll always lands here.

## Why it hangs

`response.body.cancel()` never settles when the body is one branch of a teed stream whose sibling is still live. [`ReadableStreamTee`](https://streams.spec.whatwg.org/#abstract-opdef-readablestreamtee) gives both branches a single shared cancel promise, resolved only after *both* are cancelled.

[`Response.clone()`](https://fetch.spec.whatwg.org/#dom-response-clone) is specified to tee, so any middleware that clones a response leaves the consumer holding a branch it cannot cancel. Confirmed in two places by instrumenting `tee()` and `clone()`: `@vercel/otel` fetch instrumentation in a Next.js route handler, and `@mswjs/interceptors` in this repo's own xAI test suite. Next.js also tees explicitly in [`cloneResponse`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/clone-response.ts), by code inspection.

## Repro

Pure web streams, Node v24.16.0:

```js
const makeBody = () => new ReadableStream({
  start(c) { c.enqueue(new Uint8Array([1])); c.close(); },
});
const race = res => Promise.race([
  res.body.cancel().then(() => 'resolved'),
  new Promise(r => setTimeout(() => r('HUNG'), 3000)),
]);

await race(new Response(makeBody()));                     // resolved, 0ms
const [b1] = makeBody().tee();
await race(new Response(b1));                             // HUNG
const c = new Response(makeBody()); const _keep = c.clone();
await race(c);                                            // HUNG
```

Cancelling the sibling branch first makes both HUNG cases resolve in 0ms.

## What introduced it

[#17435](https://github.com/vercel/ai/pull/17435) / [`1e2ae1f`](https://github.com/vercel/ai/commit/1e2ae1f818fa92da8038c40056e0d9b233fe4945), released in **`@ai-sdk/xai@4.0.16`** and backported to **`3.0.110`** as `09ecf7b`. Verified against published tarballs: the 202 branch is absent in `4.0.15` and `3.0.109`, present in `4.0.16` and `3.0.110`. Still on `main`; `4.0.19` carries it.

It fixed a real bug: an **empty** 202 body, which `createJsonResponseHandler` cannot parse. Its tests only use `{type: 'empty', status: 202}`, where `response.body` is `null` and `cancelResponseBody` is a no-op. The empty case is the only case that cannot hang, which is why they passed.

## Fix

Read the body instead of cancelling it:

- empty → `{ status: 'pending' }`, preserving #17435's behaviour
- non-empty → parse with the existing `xaiVideoStatusResponseSchema`

The read is capped at 1 MiB (a pending payload is ~50 bytes). On overflow it throws without cancelling: cancelling a tee branch neither settles nor releases the source while the sibling is live. The shared `readResponseWithSizeLimit` was not reused; both of its overflow paths await a cancel and hang on a teed body. Hardening it is a separate change.

xAI returns `{"status":"pending","progress":N}` on those 202s. The cancel path discarded it and substituted a synthetic pending; reading it keeps `progress` and lets a 202 carrying a finished video complete.

`cancelResponseBody` is now unused in this package, but four call sites remain and all use the default `globalThis.fetch`:

- `fetch-with-validated-redirects.ts:126` — on every redirect hop, not a failure branch
- `download.ts`, `download-blob.ts`, `read-response-with-size-limit.ts` — on their failure branches

The redirect call is reachable in normal operation (prompt file downloads go through it). Not reproduced; follow-up.

## Verification

`packages/xai`: 418 pass. Six new tests. Four cover a 202 **with a body** — status payload, body carrying the video, unparseable body, and one behind a `fetch` that tees explicitly — and all four time out against the pre-fix handler:

```
× should treat an HTTP 202 carrying a status payload as pending      8003ms
× should complete when an HTTP 202 body already carries the video    8002ms
× should treat an HTTP 202 with an unparseable body as pending       8003ms
× should keep polling past a 202 when the caller fetch tees the body 8001ms
```

Two more cover the bounded read: an oversized 202 body behind a teeing fetch rejects (an unbounded `response.text()` variant resolves instead), and an abort mid-read of an unfinished 202 body rejects.

End to end: patched package built into a Next.js app (AI Gateway), real generation returns HTTP 200 in 25.7s over 4 polls. The same request on `4.0.19` returns nothing; its outbound calls stop after the first 202:

```
POST /v1/videos/generations  -> 200 (467ms)
GET  /v1/videos/<id>         -> 202 (358ms)
(no further polls)
```
