### PR TITLE
fix(prodia): warn on unsupported seed call setting

### DIFF
--- a/.changeset/lucky-otters-warn.md
+++ b/.changeset/lucky-otters-warn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/prodia': patch
+---
+
+Warn when the Prodia language model ignores the unsupported `seed` call setting.

--- a/packages/prodia/src/prodia-language-model.test.ts
+++ b/packages/prodia/src/prodia-language-model.test.ts
@@ -386,6 +386,7 @@ describe('ProdiaLanguageModel', () => {
         stopSequences: ['stop'],
         presencePenalty: 0.1,
         frequencyPenalty: 0.2,
+        seed: 42,
         tools: [
           {
             type: 'function',
@@ -409,6 +410,7 @@ describe('ProdiaLanguageModel', () => {
       expect(warningFeatures).toContain('stopSequences');
       expect(warningFeatures).toContain('presencePenalty');
       expect(warningFeatures).toContain('frequencyPenalty');
+      expect(warningFeatures).toContain('seed');
       expect(warningFeatures).toContain('tools');
       expect(warningFeatures).toContain('toolChoice');
       expect(warningFeatures).toContain('responseFormat');

--- a/packages/prodia/src/prodia-language-model.ts
+++ b/packages/prodia/src/prodia-language-model.ts
@@ -86,6 +86,9 @@ export class ProdiaLanguageModel implements LanguageModelV4 {
     if (options.frequencyPenalty !== undefined) {
       warnings.push({ type: 'unsupported', feature: 'frequencyPenalty' });
     }
+    if (options.seed !== undefined) {
+      warnings.push({ type: 'unsupported', feature: 'seed' });
+    }
     if (options.tools !== undefined && options.tools.length > 0) {
       warnings.push({ type: 'unsupported', feature: 'tools' });
     }


### PR DESCRIPTION
## Summary
- `ProdiaLanguageModel.doGenerate()` warns about every unsupported call setting (`temperature`, `topP`, `topK`, `maxOutputTokens`, `stopSequences`, `presencePenalty`, `frequencyPenalty`, `tools`, `toolChoice`, `responseFormat`, `reasoning`) except `seed`, which was silently dropped.
- Adds the missing `{ type: 'unsupported', feature: 'seed' }` warning, matching the pattern used for the sibling settings. `doStream` re-emits `doGenerate`'s warnings, so both paths are fixed together.

Fixes #17938

## Test plan
- [x] Added a `seed: 42` case and matching assertion to the existing "emits warnings for unsupported LLM features" test in `prodia-language-model.test.ts`
- [x] `pnpm test:node` and `pnpm test:edge` in `packages/prodia` pass (56/56 tests each)