### PR TITLE
fix (ai): preserve provider metadata from empty text deltas in streamText

### DIFF
--- a/.changeset/metal-planets-brush.md
+++ b/.changeset/metal-planets-brush.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai): preserve provider metadata from empty text deltas in streamText

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -6428,6 +6428,106 @@ describe('streamText', () => {
   });
 
   describe('result.steps', () => {
+    it('should retain provider metadata from an empty text delta in the step content', async () => {
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'Hello, world!' },
+            {
+              type: 'text-delta',
+              id: '1',
+              delta: '',
+              providerMetadata: {
+                testProvider: { signature: '1234567890' },
+              },
+            },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+            },
+          ]),
+        }),
+        ...defaultSettings(),
+      });
+
+      const steps = await result.steps;
+      const textPart = steps[0].content.find(part => part.type === 'text');
+
+      expect(textPart?.text).toBe('Hello, world!');
+      expect(textPart?.providerMetadata).toStrictEqual({
+        testProvider: { signature: '1234567890' },
+      });
+    });
+
+    it('should retain provider metadata from a text part that only contains an empty text delta', async () => {
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            {
+              type: 'text-delta',
+              id: '1',
+              delta: '',
+              providerMetadata: {
+                testProvider: { signature: '1234567890' },
+              },
+            },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+            },
+          ]),
+        }),
+        ...defaultSettings(),
+      });
+
+      const steps = await result.steps;
+      const textPart = steps[0].content.find(part => part.type === 'text');
+
+      expect(textPart?.text).toBe('');
+      expect(textPart?.providerMetadata).toStrictEqual({
+        testProvider: { signature: '1234567890' },
+      });
+    });
+
+    it('should filter out empty text deltas without provider metadata from the stream', async () => {
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: '' },
+            { type: 'text-delta', id: '1', delta: 'Hello, world!' },
+            { type: 'text-delta', id: '1', delta: '' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+            },
+          ]),
+        }),
+        ...defaultSettings(),
+      });
+
+      const textDeltas = (
+        await convertAsyncIterableToArray(result.stream)
+      ).filter(part => part.type === 'text-delta');
+
+      expect(textDeltas).toStrictEqual([
+        {
+          type: 'text-delta',
+          id: '1',
+          text: 'Hello, world!',
+          providerMetadata: undefined,
+        },
+      ]);
+    });
+
     it('should add the reasoning from the model response to the step result', async () => {
       const result = streamText({
         model: modelWithReasoning,

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -847,6 +847,7 @@ function createOutputTransformStream<
   let text = '';
   let textChunk = '';
   let textProviderMetadata: ProviderMetadata | undefined = undefined;
+  let hasUnpublishedProviderMetadata = false;
   let lastPublishedValue = '';
 
   function publishTextChunk({
@@ -868,6 +869,7 @@ function createOutputTransformStream<
       partialOutput,
     });
     textChunk = '';
+    hasUnpublishedProviderMetadata = false;
   }
 
   return new TransformStream<
@@ -876,7 +878,10 @@ function createOutputTransformStream<
   >({
     async transform(chunk, controller) {
       // ensure that we publish the last text chunk before the step finish:
-      if (chunk.type === 'finish-step' && textChunk.length > 0) {
+      if (
+        chunk.type === 'finish-step' &&
+        (textChunk.length > 0 || hasUnpublishedProviderMetadata)
+      ) {
         publishTextChunk({ controller });
       }
 
@@ -904,7 +909,7 @@ function createOutputTransformStream<
       }
 
       if (chunk.type === 'text-end') {
-        if (textChunk.length > 0) {
+        if (textChunk.length > 0 || hasUnpublishedProviderMetadata) {
           publishTextChunk({ controller });
         }
         controller.enqueue({ part: chunk, partialOutput: undefined });
@@ -913,7 +918,10 @@ function createOutputTransformStream<
 
       text += chunk.text;
       textChunk += chunk.text;
-      textProviderMetadata = chunk.providerMetadata ?? textProviderMetadata;
+      if (chunk.providerMetadata != null) {
+        textProviderMetadata = chunk.providerMetadata;
+        hasUnpublishedProviderMetadata = true;
+      }
 
       // only publish if partial json can be parsed:
       const result = await output.parsePartialOutput({ text });
@@ -2198,7 +2206,13 @@ class DefaultStreamTextResult<
                     }
 
                     case 'text-delta': {
-                      if (chunk.text.length > 0) {
+                      // forward empty text deltas when they carry provider
+                      // metadata so that the metadata is not lost
+                      // (e.g. metadata-only deltas with thought signatures):
+                      if (
+                        chunk.text.length > 0 ||
+                        chunk.providerMetadata != null
+                      ) {
                         controller.enqueue(chunk);
                       }
                       break;


### PR DESCRIPTION
Fixes #18073, filed by @gr2m from @Erobrine2811's report. @gr2m I see you assigned yourself, happy to close this if you already have a fix in progress; posting since it was ready and it surfaced a second drop point beyond the one in the issue.

`streamText` dropped every empty `text-delta` even when it carried `providerMetadata`, so a Gemini `thoughtSignature` arriving on a final empty delta was present in the raw stream but missing from the final `step.content` text part.

Two changes in `packages/ai`, both needed:
- The step transform now forwards empty text deltas when they carry provider metadata (metadata-less empty deltas are still dropped).
- `createOutputTransformStream` had a second swallow point the issue did not mention: it only flushes buffered text at `text-end` when the accumulated chunk is non-empty, so a metadata-only delta was dropped there too. It now tracks unpublished provider metadata and flushes it at `text-end` and the `finish-step` safety flush.

`isOutputChunk` is untouched, so metadata-only deltas stay excluded from semantic-output timeout bookkeeping as requested.

Tests: three new regression tests (metadata on an empty delta after normal text, a text part whose only delta is empty+metadata, and a guard that metadata-less empty deltas are still filtered). stream-text suite: 408 passed under both node and edge configs (baseline 405, no pre-existing failures). Changeset included (`ai` patch).
