### PR TITLE
Update Cerebras model IDs and capabilities

### DIFF
--- a/.changeset/quick-llamas-juggle.md
+++ b/.changeset/quick-llamas-juggle.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cerebras': patch
+---
+
+Update Cerebras model ID autocomplete and package documentation to the current public model catalog.

--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -162,9 +162,9 @@ Here are the capabilities of popular models:
 | [Mistral](/providers/ai-sdk-providers/mistral)     | `pixtral-12b-2409`                          | <Check />   | <Check />         | <Check />  | <Check />      |
 | [DeepSeek](/providers/ai-sdk-providers/deepseek)   | `deepseek-chat`                             | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [DeepSeek](/providers/ai-sdk-providers/deepseek)   | `deepseek-reasoner`                         | <Cross />   | <Check />         | <Check />  | <Check />      |
-| [Cerebras](/providers/ai-sdk-providers/cerebras)   | `llama3.1-8b`                               | <Cross />   | <Check />         | <Check />  | <Check />      |
-| [Cerebras](/providers/ai-sdk-providers/cerebras)   | `llama3.1-70b`                              | <Cross />   | <Check />         | <Check />  | <Check />      |
-| [Cerebras](/providers/ai-sdk-providers/cerebras)   | `llama3.3-70b`                              | <Cross />   | <Check />         | <Check />  | <Check />      |
+| [Cerebras](/providers/ai-sdk-providers/cerebras)   | `gpt-oss-120b`                              | <Cross />   | <Check />         | <Check />  | <Check />      |
+| [Cerebras](/providers/ai-sdk-providers/cerebras)   | `zai-glm-4.7`                               | <Cross />   | <Check />         | <Check />  | <Check />      |
+| [Cerebras](/providers/ai-sdk-providers/cerebras)   | `gemma-4-31b`                               | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Groq](/providers/ai-sdk-providers/groq)           | `meta-llama/llama-4-scout-17b-16e-instruct` | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Groq](/providers/ai-sdk-providers/groq)           | `llama-3.3-70b-versatile`                   | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Groq](/providers/ai-sdk-providers/groq)           | `llama-3.1-8b-instant`                      | <Cross />   | <Check />         | <Check />  | <Check />      |

--- a/content/providers/01-ai-sdk-providers/40-cerebras.mdx
+++ b/content/providers/01-ai-sdk-providers/40-cerebras.mdx
@@ -62,7 +62,7 @@ import { cerebras } from '@ai-sdk/cerebras';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: cerebras('llama3.1-8b'),
+  model: cerebras('gpt-oss-120b'),
   prompt: 'Write a vegetarian lasagna recipe for 4 people.',
 });
 ```
@@ -70,22 +70,22 @@ const { text } = await generateText({
 Cerebras language models can be used in the `streamText` function
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
-You can create Cerebras language models using a provider instance. The first argument is the model ID, e.g. `llama-3.3-70b`:
+You can create Cerebras language models using a provider instance. The first argument is the model ID, e.g. `gpt-oss-120b`:
 
 ```ts
-const model = cerebras('llama-3.3-70b');
+const model = cerebras('gpt-oss-120b');
 ```
 
 You can also use the `.languageModel()` and `.chat()` methods:
 
 ```ts
-const model = cerebras.languageModel('llama-3.3-70b');
-const model = cerebras.chat('llama-3.3-70b');
+const model = cerebras.languageModel('gpt-oss-120b');
+const model = cerebras.chat('gpt-oss-120b');
 ```
 
 ### Reasoning Models
 
-Cerebras offers several reasoning models including `gpt-oss-120b`, `qwen-3-32b`, and `zai-glm-4.7` that generate intermediate thinking tokens before their final response. The reasoning output is streamed through the standard AI SDK reasoning parts.
+Cerebras offers reasoning models including `gpt-oss-120b`, `zai-glm-4.7`, and `gemma-4-31b` that generate intermediate thinking tokens before their final response. The reasoning output is streamed through the standard AI SDK reasoning parts.
 
 For `gpt-oss-120b`, you can control the reasoning depth using the `reasoningEffort` provider option:
 
@@ -132,21 +132,8 @@ The following optional provider options are available for Cerebras language mode
 
 ## Model Capabilities
 
-| Model                            | Image Input | Object Generation | Tool Usage | Tool Streaming | Reasoning |
-| -------------------------------- | ----------- | ----------------- | ---------- | -------------- | --------- |
-| `llama3.1-8b`                    | <Cross />   | <Check />         | <Check />  | <Check />      | <Cross /> |
-| `llama-3.3-70b`                  | <Cross />   | <Check />         | <Check />  | <Check />      | <Cross /> |
-| `gpt-oss-120b`                   | <Cross />   | <Check />         | <Check />  | <Check />      | <Check /> |
-| `qwen-3-32b`                     | <Cross />   | <Check />         | <Check />  | <Check />      | <Check /> |
-| `qwen-3-235b-a22b-instruct-2507` | <Cross />   | <Check />         | <Check />  | <Check />      | <Cross /> |
-| `qwen-3-235b-a22b-thinking-2507` | <Cross />   | <Check />         | <Check />  | <Check />      | <Cross /> |
-| `zai-glm-4.6`                    | <Cross />   | <Check />         | <Check />  | <Check />      | <Cross /> |
-| `zai-glm-4.7`                    | <Cross />   | <Check />         | <Check />  | <Check />      | <Check /> |
-
-<Note>
-  The models `qwen-3-32b` and `llama-3.3-70b` are scheduled for deprecation on
-  February 16, 2026. Please see the [Cerebras
-  docs](https://inference-docs.cerebras.ai/introduction) for more details about
-  the available models and migration guidance. You can also pass any available
-  provider model ID as a string if needed.
-</Note>
+| Model          | Image Input | Object Generation | Tool Usage | Tool Streaming | Reasoning |
+| -------------- | ----------- | ----------------- | ---------- | -------------- | --------- |
+| `gpt-oss-120b` | <Cross />   | <Check />         | <Check />  | <Check />      | <Check /> |
+| `zai-glm-4.7`  | <Cross />   | <Check />         | <Check />  | <Check />      | <Check /> |
+| `gemma-4-31b`  | <Check />   | <Check />         | <Check />  | <Check />      | <Check /> |

--- a/content/providers/01-ai-sdk-providers/index.mdx
+++ b/content/providers/01-ai-sdk-providers/index.mdx
@@ -97,9 +97,9 @@ Not all providers support all AI SDK features. Here's a quick comparison of the 
 | [DeepInfra](/providers/ai-sdk-providers/deepinfra)         | `deepseek-ai/DeepSeek-V3`                           | <Cross />   | <Cross />         | <Cross />  | <Cross />      |
 | [DeepInfra](/providers/ai-sdk-providers/deepinfra)         | `deepseek-ai/DeepSeek-R1`                           | <Cross />   | <Cross />         | <Cross />  | <Cross />      |
 | [DeepInfra](/providers/ai-sdk-providers/deepinfra)         | `Qwen/QwQ-32B`                                      | <Cross />   | <Check />         | <Check />  | <Cross />      |
-| [Cerebras](/providers/ai-sdk-providers/cerebras)           | `llama3.3-70b`                                      | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Cerebras](/providers/ai-sdk-providers/cerebras)           | `gpt-oss-120b`                                      | <Cross />   | <Check />         | <Check />  | <Check />      |
-| [Cerebras](/providers/ai-sdk-providers/cerebras)           | `qwen-3-32b`                                        | <Cross />   | <Check />         | <Check />  | <Check />      |
+| [Cerebras](/providers/ai-sdk-providers/cerebras)           | `zai-glm-4.7`                                       | <Cross />   | <Check />         | <Check />  | <Check />      |
+| [Cerebras](/providers/ai-sdk-providers/cerebras)           | `gemma-4-31b`                                       | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Hugging Face](/providers/ai-sdk-providers/huggingface)    | `meta-llama/Llama-3.1-8B-Instruct`                  | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Hugging Face](/providers/ai-sdk-providers/huggingface)    | `moonshotai/Kimi-K2-Instruct`                       | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Baseten](/providers/ai-sdk-providers/baseten)             | `Qwen/Qwen3-235B-A22B-Instruct-2507`                | <Cross />   | <Check />         | <Check />  | <Check />      |

--- a/examples/ai-functions/src/e2e/cerebras.test.ts
+++ b/examples/ai-functions/src/e2e/cerebras.test.ts
@@ -19,9 +19,9 @@ createFeatureTestSuite({
   models: {
     invalidModel: provider.chat('no-such-model'),
     languageModels: [
-      createChatModel('llama3.1-8b'),
-      createChatModel('llama3.1-70b'),
-      createChatModel('llama-3.3-70b'),
+      createChatModel('gpt-oss-120b'),
+      createChatModel('zai-glm-4.7'),
+      createChatModel('gemma-4-31b'),
     ],
   },
   timeout: 30000,

--- a/examples/ai-functions/src/e2e/cerebras.test.ts
+++ b/examples/ai-functions/src/e2e/cerebras.test.ts
@@ -21,7 +21,12 @@ createFeatureTestSuite({
     languageModels: [
       createChatModel('gpt-oss-120b'),
       createChatModel('zai-glm-4.7'),
-      createChatModel('gemma-4-31b'),
+      createLanguageModelWithCapabilities(provider.chat('gemma-4-31b'), [
+        'imageInput',
+        'objectGeneration',
+        'textCompletion',
+        'toolCalls',
+      ]),
     ],
   },
   timeout: 30000,

--- a/examples/ai-functions/src/generate-text/cerebras/basic.ts
+++ b/examples/ai-functions/src/generate-text/cerebras/basic.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: provider.chat('llama-3.1-70b'),
+    model: provider.chat('gpt-oss-120b'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/generate-text/cerebras/tool-call.ts
+++ b/examples/ai-functions/src/generate-text/cerebras/tool-call.ts
@@ -6,7 +6,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: cerebras('llama3.1-8b'),
+    model: cerebras('gpt-oss-120b'),
     maxOutputTokens: 512,
     tools: {
       weather: weatherTool,

--- a/examples/ai-functions/src/stream-text/cerebras/basic.ts
+++ b/examples/ai-functions/src/stream-text/cerebras/basic.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: cerebras('llama3.1-8b'),
+    model: cerebras('gpt-oss-120b'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/stream-text/cerebras/tool-call.ts
+++ b/examples/ai-functions/src/stream-text/cerebras/tool-call.ts
@@ -14,7 +14,7 @@ run(async () => {
   let toolResponseAvailable = false;
 
   const result = streamText({
-    model: cerebras('llama3.1-8b'),
+    model: cerebras('gpt-oss-120b'),
     maxOutputTokens: 512,
     tools: {
       weather: weatherTool,

--- a/packages/cerebras/README.md
+++ b/packages/cerebras/README.md
@@ -40,7 +40,7 @@ import { cerebras } from '@ai-sdk/cerebras';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: cerebras('llama-3.3-70b'),
+  model: cerebras('gpt-oss-120b'),
   prompt: 'Write a JavaScript function that sorts a list:',
 });
 ```
@@ -51,5 +51,3 @@ For more information about Cerebras' high-speed inference capabilities and API d
 
 - [Cerebras Inference Documentation](https://inference-docs.cerebras.ai/introduction)
 - [Cerebras Website](https://cerebras.ai)
-
-Note: Due to high demand in the early launch phase, context windows are temporarily limited to 8192 tokens in the Free Tier.

--- a/packages/cerebras/src/cerebras-chat-options.ts
+++ b/packages/cerebras/src/cerebras-chat-options.ts
@@ -1,11 +1,8 @@
 // https://inference-docs.cerebras.ai/models/overview
 export type CerebrasChatModelId =
   // production
-  | 'llama3.1-8b'
   | 'gpt-oss-120b'
+  | 'gemma-4-31b'
   // preview
-  | 'qwen-3-235b-a22b-instruct-2507'
-  | 'qwen-3-235b-a22b-thinking-2507'
-  | 'zai-glm-4.6'
   | 'zai-glm-4.7'
   | (string & {});


### PR DESCRIPTION
## Summary

- Updates the Cerebras model type, provider guide, capability table, and end-to-end model list to the three current public model IDs.
- The current public catalog is `gpt-oss-120b`, `zai-glm-4.7`, and `gemma-4-31b`.

## Why

The previous model ID was retired or the fixed catalog was missing a currently available Cerebras model. This could produce failed requests, stale autocomplete, or misleading examples.

## Validation

- JSON-independent TypeScript and MDX diff checks plus comparison with the live Cerebras model endpoint.
- Source of truth: https://api.cerebras.ai/public/v1/models