### PR TITLE
[v5] fix(provider-utils): prevent DNS alias SSRF in validated downloads

### DIFF
--- a/.changeset/clean-clouds-resolve.md
+++ b/.changeset/clean-clouds-resolve.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+Prevent validated downloads on Node.js from reaching private or internal services through DNS aliases or DNS rebinding by validating and pinning every resolved address at connection time.

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -39,7 +39,8 @@
   "dependencies": {
     "@ai-sdk/provider": "workspace:*",
     "@standard-schema/spec": "^1.0.0",
-    "eventsource-parser": "^3.0.6"
+    "eventsource-parser": "^3.0.6",
+    "undici": "^5.29.0"
   },
   "devDependencies": {
     "@types/node": "20.17.24",

--- a/packages/provider-utils/src/fetch-with-validated-redirects.ts
+++ b/packages/provider-utils/src/fetch-with-validated-redirects.ts
@@ -1,6 +1,7 @@
 import { cancelResponseBody } from './cancel-response-body';
 import { DownloadError } from './download-error';
 import { isBrowserRuntime } from './is-browser-runtime';
+import { getDefaultDownloadFetch } from './safe-node-fetch';
 import { validateDownloadUrl } from './validate-download-url';
 
 const MAX_DOWNLOAD_REDIRECTS = 10;
@@ -24,6 +25,11 @@ const MAX_DOWNLOAD_REDIRECTS = 10;
  *
  * The returned response is the final (non-redirect) response. The caller is
  * responsible for checking `response.ok` and reading the body.
+ *
+ * On Node.js, the default fetch resolves every hostname through a validating
+ * lookup hook and passes those exact addresses to the connector, preventing
+ * hostname-to-private-IP and DNS-rebinding bypasses. Other runtimes should
+ * constrain egress at the network layer when handling untrusted URLs.
  *
  * @throws DownloadError if a hop is unsafe, the redirect limit is exceeded, or
  * a redirect cannot be validated on a non-browser runtime.
@@ -52,6 +58,7 @@ export async function fetchWithValidatedRedirects({
   for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount++) {
     validateDownloadUrl(currentUrl);
 
+    const fetch = await getDefaultDownloadFetch();
     const response = await fetch(currentUrl, {
       ...baseInit,
       redirect: 'manual',

--- a/packages/provider-utils/src/safe-node-fetch.test.ts
+++ b/packages/provider-utils/src/safe-node-fetch.test.ts
@@ -8,16 +8,24 @@ import {
 
 type Address = { address: string; family: number };
 
-function runLookup(addresses: Address[]) {
+function createLookup(addresses: Address[]) {
   const lookup = vi.fn((_hostname, options, callback) => {
     callback(null, addresses);
   });
-  const safeLookup = createSafeLookup(lookup);
+
+  return {
+    lookup,
+    safeLookup: createSafeLookup(lookup),
+  };
+}
+
+function runLookup(addresses: Address[]) {
+  const { lookup, safeLookup } = createLookup(addresses);
 
   return {
     lookup,
     result: new Promise<Address[]>((resolve, reject) => {
-      safeLookup('files.example.com', {}, (error, result) => {
+      safeLookup('files.example.com', { all: true }, (error, result) => {
         if (error) {
           reject(error);
         } else {
@@ -37,6 +45,30 @@ describe('createSafeLookup', () => {
     const { lookup, result } = runLookup(addresses);
 
     await expect(result).resolves.toEqual(addresses);
+    expect(lookup).toHaveBeenCalledWith(
+      'files.example.com',
+      { all: true },
+      expect.any(Function),
+    );
+  });
+
+  it('returns one address when the connector does not request all', async () => {
+    const addresses = [
+      { address: '8.8.8.8', family: 4 },
+      { address: '2606:4700:4700::1111', family: 6 },
+    ];
+    const { lookup, safeLookup } = createLookup(addresses);
+    const result = new Promise<Address>((resolve, reject) => {
+      safeLookup('files.example.com', {}, (error, address, family) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve({ address, family });
+        }
+      });
+    });
+
+    await expect(result).resolves.toEqual(addresses[0]);
     expect(lookup).toHaveBeenCalledWith(
       'files.example.com',
       { all: true },

--- a/packages/provider-utils/src/safe-node-fetch.test.ts
+++ b/packages/provider-utils/src/safe-node-fetch.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DownloadError } from './download-error';
+import {
+  createSafeLookup,
+  getDefaultDownloadFetch,
+  isNodeRuntime,
+} from './safe-node-fetch';
+
+type Address = { address: string; family: number };
+
+function runLookup(addresses: Address[]) {
+  const lookup = vi.fn((_hostname, options, callback) => {
+    callback(null, addresses);
+  });
+  const safeLookup = createSafeLookup(lookup);
+
+  return {
+    lookup,
+    result: new Promise<Address[]>((resolve, reject) => {
+      safeLookup('files.example.com', {}, (error, result) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(result);
+        }
+      });
+    }),
+  };
+}
+
+describe('createSafeLookup', () => {
+  it('returns the validated addresses to the connector', async () => {
+    const addresses = [
+      { address: '8.8.8.8', family: 4 },
+      { address: '2606:4700:4700::1111', family: 6 },
+    ];
+    const { lookup, result } = runLookup(addresses);
+
+    await expect(result).resolves.toEqual(addresses);
+    expect(lookup).toHaveBeenCalledWith(
+      'files.example.com',
+      { all: true },
+      expect.any(Function),
+    );
+  });
+
+  it('blocks a hostname that resolves to a private address', async () => {
+    const { result } = runLookup([{ address: '127.0.0.1', family: 4 }]);
+
+    await expect(result).rejects.toThrow(DownloadError);
+  });
+
+  it('blocks mixed DNS results when any address is private', async () => {
+    const { result } = runLookup([
+      { address: '8.8.8.8', family: 4 },
+      { address: '169.254.169.254', family: 4 },
+    ]);
+
+    await expect(result).rejects.toThrow(
+      'resolved to disallowed IP address 169.254.169.254',
+    );
+  });
+
+  it('blocks private IPv6 DNS results', async () => {
+    const { result } = runLookup([{ address: '::1', family: 6 }]);
+
+    await expect(result).rejects.toThrow(
+      'resolved to disallowed IP address ::1',
+    );
+  });
+});
+
+describe('getDefaultDownloadFetch', () => {
+  it('loads Node modules without process.getBuiltinModule', async () => {
+    if (!isNodeRuntime()) {
+      return;
+    }
+
+    const runtimeProcess = globalThis.process as unknown as {
+      getBuiltinModule: ((id: string) => unknown) | undefined;
+    };
+    const originalGetBuiltinModule = runtimeProcess.getBuiltinModule;
+    runtimeProcess.getBuiltinModule = undefined;
+
+    try {
+      await expect(getDefaultDownloadFetch()).resolves.not.toBe(
+        globalThis.fetch,
+      );
+    } finally {
+      runtimeProcess.getBuiltinModule = originalGetBuiltinModule;
+    }
+  });
+});

--- a/packages/provider-utils/src/safe-node-fetch.ts
+++ b/packages/provider-utils/src/safe-node-fetch.ts
@@ -30,31 +30,52 @@ type Lookup = (
   ) => void,
 ) => void;
 
-type LookupCallback = (
+type LookupAllCallback = (
   error: NodeJS.ErrnoException | null,
   addresses: LookupAddress[],
 ) => void;
 
+type LookupOneCallback = (
+  error: NodeJS.ErrnoException | null,
+  address: string,
+  family: number,
+) => void;
+
+type SafeLookup = {
+  (
+    hostname: string,
+    options: LookupOptions & { all: true },
+    callback: LookupAllCallback,
+  ): void;
+  (
+    hostname: string,
+    options: LookupOptions & { all?: false },
+    callback: LookupOneCallback,
+  ): void;
+};
+
 /**
  * Creates a DNS lookup hook that validates every returned address before
- * returning those exact addresses to the HTTP connector. Because resolution
- * and validation happen inside the connector, the socket is pinned to the
- * validated result and DNS rebinding cannot introduce a second lookup.
+ * returning the callback shape requested by the HTTP connector. Because
+ * resolution and validation happen inside the connector, the socket is pinned
+ * to the validated result and DNS rebinding cannot introduce a second lookup.
  */
-export function createSafeLookup(lookup: Lookup) {
-  return (
+export function createSafeLookup(lookup: Lookup): SafeLookup {
+  return ((
     hostname: string,
     options: LookupOptions,
-    callback: LookupCallback,
+    callback: LookupAllCallback | LookupOneCallback,
   ): void => {
     lookup(hostname, { ...options, all: true }, (error, addresses) => {
       if (error) {
-        callback(error, []);
+        (callback as (error: Error) => void)(error);
         return;
       }
 
       try {
-        if (addresses.length === 0) {
+        const [firstAddress] = addresses;
+
+        if (firstAddress == null) {
           throw new Error(`Hostname ${hostname} did not resolve to an address`);
         }
 
@@ -62,12 +83,22 @@ export function createSafeLookup(lookup: Lookup) {
           validateDownloadAddress({ address, family, hostname });
         }
 
-        callback(null, addresses);
+        if (options.all === true) {
+          (callback as LookupAllCallback)(null, addresses);
+        } else {
+          (callback as LookupOneCallback)(
+            null,
+            firstAddress.address,
+            firstAddress.family,
+          );
+        }
       } catch (error) {
-        callback(error instanceof Error ? error : new Error(String(error)), []);
+        (callback as (error: Error) => void)(
+          error instanceof Error ? error : new Error(String(error)),
+        );
       }
     });
-  };
+  }) as SafeLookup;
 }
 
 let safeNodeFetchPromise: Promise<FetchFunction> | undefined;

--- a/packages/provider-utils/src/safe-node-fetch.ts
+++ b/packages/provider-utils/src/safe-node-fetch.ts
@@ -1,0 +1,178 @@
+import type * as nodeDnsModule from 'node:dns';
+import type * as nodeModule from 'node:module';
+import type * as undiciModule from 'undici';
+import type { FetchFunction } from './fetch-function';
+import { validateDownloadAddress } from './validate-download-url';
+
+type NodeDns = typeof nodeDnsModule;
+type NodeModule = typeof nodeModule;
+type Undici = typeof undiciModule;
+
+type LookupAddress = {
+  address: string;
+  family: number;
+};
+
+type LookupOptions = {
+  all?: boolean;
+  family?: number;
+  hints?: number;
+  order?: 'ipv4first' | 'ipv6first' | 'verbatim';
+  verbatim?: boolean;
+};
+
+type Lookup = (
+  hostname: string,
+  options: LookupOptions & { all: true },
+  callback: (
+    error: NodeJS.ErrnoException | null,
+    addresses: LookupAddress[],
+  ) => void,
+) => void;
+
+type LookupCallback = (
+  error: NodeJS.ErrnoException | null,
+  addresses: LookupAddress[],
+) => void;
+
+/**
+ * Creates a DNS lookup hook that validates every returned address before
+ * returning those exact addresses to the HTTP connector. Because resolution
+ * and validation happen inside the connector, the socket is pinned to the
+ * validated result and DNS rebinding cannot introduce a second lookup.
+ */
+export function createSafeLookup(lookup: Lookup) {
+  return (
+    hostname: string,
+    options: LookupOptions,
+    callback: LookupCallback,
+  ): void => {
+    lookup(hostname, { ...options, all: true }, (error, addresses) => {
+      if (error) {
+        callback(error, []);
+        return;
+      }
+
+      try {
+        if (addresses.length === 0) {
+          throw new Error(`Hostname ${hostname} did not resolve to an address`);
+        }
+
+        for (const { address, family } of addresses) {
+          validateDownloadAddress({ address, family, hostname });
+        }
+
+        callback(null, addresses);
+      } catch (error) {
+        callback(error instanceof Error ? error : new Error(String(error)), []);
+      }
+    });
+  };
+}
+
+let safeNodeFetchPromise: Promise<FetchFunction> | undefined;
+const initialGlobalFetch = globalThis.fetch;
+const initialGlobalFetchIsNodeDefault = isNodeDefaultFetch(initialGlobalFetch);
+
+export function isNodeRuntime(): boolean {
+  const runtimeProcess = globalThis.process as
+    | {
+        release?: { name?: string };
+        versions?: { bun?: string };
+      }
+    | undefined;
+
+  return (
+    runtimeProcess?.release?.name === 'node' &&
+    runtimeProcess.versions?.bun == null
+  );
+}
+
+export async function getDefaultDownloadFetch(): Promise<FetchFunction> {
+  if (
+    !isNodeRuntime() ||
+    !initialGlobalFetchIsNodeDefault ||
+    globalThis.fetch !== initialGlobalFetch
+  ) {
+    return globalThis.fetch;
+  }
+
+  return (safeNodeFetchPromise ??= createSafeNodeFetch());
+}
+
+function isNodeDefaultFetch(fetch: FetchFunction): boolean {
+  const source = Function.prototype.toString.call(fetch);
+  return (
+    source.includes('internal/deps/undici') ||
+    source.includes('lazy loading of undici')
+  );
+}
+
+async function createSafeNodeFetch(): Promise<FetchFunction> {
+  // Node 20.16+ exposes getBuiltinModule; older supported Node versions use an
+  // indirect dynamic import. Keeping the specifier non-literal prevents browser
+  // bundlers from pulling Node built-ins into the provider-utils entry point.
+  const [{ createRequire }, { lookup }] = await Promise.all([
+    loadNodeModule<NodeModule>('node:module'),
+    loadNodeModule<NodeDns>('node:dns'),
+  ]);
+  const { Agent, fetch } = createRequire(getCurrentModulePath())(
+    'undici',
+  ) as Undici;
+
+  const dispatcher = new Agent({
+    connect: {
+      lookup: createSafeLookup(lookup as Lookup) as never,
+    },
+  });
+
+  return ((input, init) =>
+    fetch(
+      input as Parameters<typeof fetch>[0],
+      {
+        ...init,
+        dispatcher,
+      } as Parameters<typeof fetch>[1],
+    ) as unknown as Promise<Response>) satisfies FetchFunction;
+}
+
+async function loadNodeModule<T>(id: string): Promise<T> {
+  const processWithBuiltins = globalThis.process as
+    | {
+        getBuiltinModule?: (id: string) => unknown;
+      }
+    | undefined;
+  const builtinModule = processWithBuiltins?.getBuiltinModule?.(id);
+
+  return builtinModule == null
+    ? ((await importNodeModule(id)) as T)
+    : (builtinModule as T);
+}
+
+function importNodeModule(id: string): Promise<unknown> {
+  return import(id);
+}
+
+function getCurrentModulePath(): string {
+  // `import.meta.url` breaks when provider-utils is rebundled as CommonJS.
+  // The caller frame points at this package when loaded directly and at the
+  // consuming bundle when inlined, giving createRequire the correct base path.
+  const originalPrepareStackTrace = Error.prepareStackTrace;
+
+  try {
+    Error.prepareStackTrace = (_error, callSites) => callSites as never;
+
+    const error = new Error('Capture current module path');
+    Error.captureStackTrace(error, getCurrentModulePath);
+    const [caller] = error.stack as unknown as NodeJS.CallSite[];
+    const fileName = caller?.getFileName();
+
+    if (fileName == null) {
+      throw new Error('Unable to determine the current module path');
+    }
+
+    return fileName;
+  } finally {
+    Error.prepareStackTrace = originalPrepareStackTrace;
+  }
+}

--- a/packages/provider-utils/src/validate-download-url.ts
+++ b/packages/provider-utils/src/validate-download-url.ts
@@ -4,9 +4,8 @@ import { DownloadError } from './download-error';
  * Validates that a URL is safe to download from, blocking private/internal addresses
  * to prevent SSRF attacks.
  *
- * Note: this performs string/literal-IP checks only. It does not resolve DNS, so a
- * hostname that resolves to a private address is not blocked here (see callers, which
- * should additionally constrain egress at the network layer when handling untrusted URLs).
+ * Note: this function performs string/literal-IP checks only. The Node.js
+ * download fetch additionally validates and pins DNS results at connect time.
  *
  * @param url - The URL string to validate.
  * @throws DownloadError if the URL is unsafe.
@@ -80,6 +79,34 @@ export function validateDownloadUrl(url: string): void {
       });
     }
     return;
+  }
+}
+
+/**
+ * Validates an address returned by DNS before it is used to open a socket.
+ * This is intentionally not exported from the package entry point.
+ */
+export function validateDownloadAddress({
+  address,
+  family,
+  hostname,
+}: {
+  address: string;
+  family: number;
+  hostname: string;
+}): void {
+  const isUnsafe =
+    family === 4
+      ? !isIPv4(address) || isPrivateIPv4(address)
+      : family === 6
+        ? isPrivateIPv6(address)
+        : true;
+
+  if (isUnsafe) {
+    throw new DownloadError({
+      url: hostname,
+      message: `Hostname ${hostname} resolved to disallowed IP address ${address}`,
+    });
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2449,6 +2449,9 @@ importers:
       eventsource-parser:
         specifier: ^3.0.6
         version: 3.0.6
+      undici:
+        specifier: ^5.29.0
+        version: 5.29.0
     devDependencies:
       '@types/node':
         specifier: 20.17.24
@@ -18328,6 +18331,10 @@ packages:
 
   undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
+    engines: {node: '>=14.0'}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
   undici@7.22.0:
@@ -38768,6 +38775,10 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici@5.28.4:
+    dependencies:
+      '@fastify/busboy': 2.1.0
+
+  undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.0
 


### PR DESCRIPTION
Backports #18072 to AI SDK v5.

## Summary

- validates every DNS result before a socket is opened
- pins the connector to the validated addresses to prevent DNS rebinding
- preserves injected or replaced fetch implementations and non-Node runtimes
- uses Undici 5.29 to retain the existing Node 18 compatibility contract
- adds patch changesets for ai and @ai-sdk/provider-utils

## Validation

- provider-utils Node suite: 53 files, 450 tests passed
- provider-utils Edge suite: 53 files, 450 tests passed
- provider-utils build and type check passed
- repository check and package-level type check passed
- browser bundle smoke test passed without bundling Undici or Node built-ins
- DNS-alias reproduction resolved 127.0.0.1.nip.io but made zero requests to the loopback server

The full example type check still reports unrelated React 18/19 type conflicts in existing examples; no errors are in the changed packages.