### PR TITLE
fix(provider-utils): preserve DNS lookup callback shape

### DIFF
--- a/.changeset/green-maps-lookup.md
+++ b/.changeset/green-maps-lookup.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+Fix validated Node.js downloads when the HTTP connector requests a single DNS address.

--- a/packages/provider-utils/src/safe-node-fetch.test.ts
+++ b/packages/provider-utils/src/safe-node-fetch.test.ts
@@ -4,16 +4,24 @@ import { createSafeLookup } from './safe-node-fetch';
 
 type Address = { address: string; family: number };
 
-function runLookup(addresses: Address[]) {
+function createLookup(addresses: Address[]) {
   const lookup = vi.fn((_hostname, options, callback) => {
     callback(null, addresses);
   });
-  const safeLookup = createSafeLookup(lookup);
+
+  return {
+    lookup,
+    safeLookup: createSafeLookup(lookup),
+  };
+}
+
+function runLookup(addresses: Address[]) {
+  const { lookup, safeLookup } = createLookup(addresses);
 
   return {
     lookup,
     result: new Promise<Address[]>((resolve, reject) => {
-      safeLookup('files.example.com', {}, (error, result) => {
+      safeLookup('files.example.com', { all: true }, (error, result) => {
         if (error) {
           reject(error);
         } else {
@@ -33,6 +41,30 @@ describe('createSafeLookup', () => {
     const { lookup, result } = runLookup(addresses);
 
     await expect(result).resolves.toEqual(addresses);
+    expect(lookup).toHaveBeenCalledWith(
+      'files.example.com',
+      { all: true },
+      expect.any(Function),
+    );
+  });
+
+  it('returns one address when the connector does not request all', async () => {
+    const addresses = [
+      { address: '8.8.8.8', family: 4 },
+      { address: '2606:4700:4700::1111', family: 6 },
+    ];
+    const { lookup, safeLookup } = createLookup(addresses);
+    const result = new Promise<Address>((resolve, reject) => {
+      safeLookup('files.example.com', {}, (error, address, family) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve({ address, family });
+        }
+      });
+    });
+
+    await expect(result).resolves.toEqual(addresses[0]);
     expect(lookup).toHaveBeenCalledWith(
       'files.example.com',
       { all: true },

--- a/packages/provider-utils/src/safe-node-fetch.ts
+++ b/packages/provider-utils/src/safe-node-fetch.ts
@@ -30,31 +30,52 @@ type Lookup = (
   ) => void,
 ) => void;
 
-type LookupCallback = (
+type LookupAllCallback = (
   error: NodeJS.ErrnoException | null,
   addresses: LookupAddress[],
 ) => void;
 
+type LookupOneCallback = (
+  error: NodeJS.ErrnoException | null,
+  address: string,
+  family: number,
+) => void;
+
+type SafeLookup = {
+  (
+    hostname: string,
+    options: LookupOptions & { all: true },
+    callback: LookupAllCallback,
+  ): void;
+  (
+    hostname: string,
+    options: LookupOptions & { all?: false },
+    callback: LookupOneCallback,
+  ): void;
+};
+
 /**
  * Creates a DNS lookup hook that validates every returned address before
- * returning those exact addresses to the HTTP connector. Because resolution
- * and validation happen inside the connector, the socket is pinned to the
- * validated result and DNS rebinding cannot introduce a second lookup.
+ * returning the callback shape requested by the HTTP connector. Because
+ * resolution and validation happen inside the connector, the socket is pinned
+ * to the validated result and DNS rebinding cannot introduce a second lookup.
  */
-export function createSafeLookup(lookup: Lookup) {
-  return (
+export function createSafeLookup(lookup: Lookup): SafeLookup {
+  return ((
     hostname: string,
     options: LookupOptions,
-    callback: LookupCallback,
+    callback: LookupAllCallback | LookupOneCallback,
   ): void => {
     lookup(hostname, { ...options, all: true }, (error, addresses) => {
       if (error) {
-        callback(error, []);
+        (callback as (error: Error) => void)(error);
         return;
       }
 
       try {
-        if (addresses.length === 0) {
+        const [firstAddress] = addresses;
+
+        if (firstAddress == null) {
           throw new Error(`Hostname ${hostname} did not resolve to an address`);
         }
 
@@ -62,12 +83,22 @@ export function createSafeLookup(lookup: Lookup) {
           validateDownloadAddress({ address, family, hostname });
         }
 
-        callback(null, addresses);
+        if (options.all === true) {
+          (callback as LookupAllCallback)(null, addresses);
+        } else {
+          (callback as LookupOneCallback)(
+            null,
+            firstAddress.address,
+            firstAddress.family,
+          );
+        }
       } catch (error) {
-        callback(error instanceof Error ? error : new Error(String(error)), []);
+        (callback as (error: Error) => void)(
+          error instanceof Error ? error : new Error(String(error)),
+        );
       }
     });
-  };
+  }) as SafeLookup;
 }
 
 let safeNodeFetchPromise: Promise<FetchFunction> | undefined;


### PR DESCRIPTION
## Summary

- preserve the single-address DNS callback shape when the HTTP connector does not request all addresses
- continue resolving and validating every address before returning the first validated result
- add regression coverage for both callback modes

Follow-up to #18072 after the compatibility issue was identified while reviewing the v5 and v6 backports.

## Testing

- `pnpm --filter @ai-sdk/provider-utils test:node` — 75 files, 790 tests
- `pnpm --filter @ai-sdk/provider-utils test:edge` — 75 files, 790 tests
- `pnpm --filter @ai-sdk/provider-utils type-check`
- `pnpm check`