### PR TITLE
docs: add Pisama observability provider

### DIFF
--- a/content/providers/03-observability/index.mdx
+++ b/content/providers/03-observability/index.mdx
@@ -19,6 +19,7 @@ Several LLM observability providers offer integrations with the AI SDK telemetry
 - [Latitude](/providers/observability/latitude)
 - [Maxim](/providers/observability/maxim)
 - [MLflow](/providers/observability/mlflow)
+- [Pisama](/providers/observability/pisama)
 - [PostHog](/providers/observability/posthog)
 - [Raindrop](/providers/observability/raindrop)
 - [Respan](/providers/observability/respan)

--- a/content/providers/03-observability/pisama.mdx
+++ b/content/providers/03-observability/pisama.mdx
@@ -20,42 +20,8 @@ Pisama provides:
 
 ## Setup
 
-Pisama supports two independent paths. Use the middleware if you want per-call wrapping in TypeScript; use OpenTelemetry if you already run an OTel pipeline.
-
-### Middleware
-
-`observe()` wraps a model with the AI SDK's own `wrapLanguageModel`, so it composes with any provider.
-
-**Step 1.** Install the SDK
-
-```bash
-npm i @pisama/sdk
-```
-
-**Step 2.** Wrap your model
-
-```ts filename="app/api/chat/route.ts"
-import { observe } from '@pisama/sdk';
-import { generateText } from 'ai';
-import { openai } from '@ai-sdk/openai';
-
-const result = await generateText({
-  model: observe(openai('gpt-4o')),
-  prompt: 'What is the weather in Helsinki?',
-});
-```
-
-**Step 3.** Set your project id
-
-```bash filename=".env.local"
-PISAMA_PROJECT_ID=ps_yourapp
-```
-
-Detections for that project are then available in the Pisama dashboard.
-
-### OpenTelemetry
-
-Enable [AI SDK telemetry](/docs/ai-sdk-core/telemetry) and point your OTLP exporter at Pisama:
+Pisama ingests AI SDK telemetry over OpenTelemetry. Enable
+[AI SDK telemetry](/docs/ai-sdk-core/telemetry) on the calls you want covered:
 
 ```ts
 const result = await generateText({
@@ -65,11 +31,14 @@ const result = await generateText({
 });
 ```
 
-Send the spans to `https://api.pisama.ai/api/v1/traces/ingest`, authenticated with a
-Pisama API key. See the [integration guide](https://docs.pisama.ai/guides/integrations/vercel-ai-sdk/)
-for the exporter configuration.
+Then point your OTLP exporter at `https://api.pisama.ai/api/v1/traces/ingest`,
+authenticated with a Pisama API key. The
+[integration guide](https://docs.pisama.ai/guides/integrations/vercel-ai-sdk/)
+covers the exporter configuration.
 
-Both attribute vocabularies are read, so prompts, responses, tool calls and token usage all survive ingestion:
+## What Pisama reads
+
+The AI SDK emits two attribute vocabularies. `ai` 6.0.x still uses the legacy `ai.*` names by default; the `gen_ai.*` semantic conventions are an opt-in. Both are handled, so prompts, responses, tool calls and token usage all survive ingestion:
 
 | Content | Legacy | GenAI conventions |
 | --- | --- | --- |
@@ -79,4 +48,13 @@ Both attribute vocabularies are read, so prompts, responses, tool calls and toke
 | Tool calls | `ai.toolCall.name` / `.args` / `.result` | `gen_ai.tool.name`, `gen_ai.tool.call.arguments` / `.result` |
 | Tokens | `ai.usage.promptTokens` / `.completionTokens` | `gen_ai.usage.input_tokens` / `.output_tokens` |
 
-A `generateText` call with one tool produces an outer `ai.generateText` span, a `doGenerate` span per step, and an `ai.toolCall` span. The outer span carries the run's top-level prompt and final response and is identified by `ai.operationId`.
+A `generateText` call with one tool produces four spans:
+
+```
+ai.generateText                outer span, carries ai.prompt and ai.response.text
+  ai.generateText.doGenerate   step 1, returns a tool call
+  ai.toolCall                  the tool executing
+  ai.generateText.doGenerate   step 2, returns final text
+```
+
+The outer `ai.generateText` span carries only `ai.*` attributes and is identified by `ai.operationId`. It holds the run's top-level prompt and final response; the inner `doGenerate` spans hold the per-step detail.

--- a/content/providers/03-observability/pisama.mdx
+++ b/content/providers/03-observability/pisama.mdx
@@ -1,0 +1,82 @@
+---
+title: Pisama
+description: Detect process-level failures in AI SDK applications with Pisama
+---
+
+# Pisama observability
+
+[Pisama](https://pisama.ai) is a failure-detection layer for agent systems. Where tracing shows you what happened and rubric graders score the final artifact, Pisama names what went wrong during the run: loops, state corruption, persona drift, coordination breakdown between agents, tool-failure cascades, and unsupported claims.
+
+Pisama provides:
+
+- [Process-level detectors](https://docs.pisama.ai/detection/overview/), each carrying a readiness tier and, where measured, an F1 on a labelled external corpus
+- [Framework integrations](https://docs.pisama.ai/guides/integrations/vercel-ai-sdk/) for the AI SDK, OpenAI Agents SDK, LangGraph, n8n and Dify
+- Heuristic-first escalation, so most detections resolve without an LLM call
+
+<Note>
+  A version of this guide is available in [Pisama's
+  docs](https://docs.pisama.ai/guides/integrations/vercel-ai-sdk/).
+</Note>
+
+## Setup
+
+Pisama supports two independent paths. Use the middleware if you want per-call wrapping in TypeScript; use OpenTelemetry if you already run an OTel pipeline.
+
+### Middleware
+
+`observe()` wraps a model with the AI SDK's own `wrapLanguageModel`, so it composes with any provider.
+
+**Step 1.** Install the SDK
+
+```bash
+npm i @pisama/sdk
+```
+
+**Step 2.** Wrap your model
+
+```ts filename="app/api/chat/route.ts"
+import { observe } from '@pisama/sdk';
+import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const result = await generateText({
+  model: observe(openai('gpt-4o')),
+  prompt: 'What is the weather in Helsinki?',
+});
+```
+
+**Step 3.** Set your project id
+
+```bash filename=".env.local"
+PISAMA_PROJECT_ID=ps_yourapp
+```
+
+Detections for that project are then available in the Pisama dashboard.
+
+### OpenTelemetry
+
+Enable [AI SDK telemetry](/docs/ai-sdk-core/telemetry) and point your OTLP exporter at Pisama:
+
+```ts
+const result = await generateText({
+  model: openai('gpt-4o'),
+  prompt: 'What is the weather in Helsinki?',
+  experimental_telemetry: { isEnabled: true, functionId: 'weather-agent' },
+});
+```
+
+Send the spans to `https://api.pisama.ai/api/v1/traces/ingest`, authenticated with a
+Pisama API key. See the [integration guide](https://docs.pisama.ai/guides/integrations/vercel-ai-sdk/)
+for the exporter configuration.
+
+Both attribute vocabularies are read, so prompts, responses, tool calls and token usage all survive ingestion:
+
+| Content | Legacy | GenAI conventions |
+| --- | --- | --- |
+| Operation marker | `ai.operationId` | `gen_ai.operation.name` |
+| Prompt | `ai.prompt`, `ai.prompt.messages` | `gen_ai.input.messages` |
+| Response | `ai.response.text` | `gen_ai.output.messages` |
+| Tool calls | `ai.toolCall.name` / `.args` / `.result` | `gen_ai.tool.name`, `gen_ai.tool.call.arguments` / `.result` |
+| Tokens | `ai.usage.promptTokens` / `.completionTokens` | `gen_ai.usage.input_tokens` / `.output_tokens` |
+
+A `generateText` call with one tool produces an outer `ai.generateText` span, a `doGenerate` span per step, and an `ai.toolCall` span. The outer span carries the run's top-level prompt and final response and is identified by `ai.operationId`.


### PR DESCRIPTION
Adds Pisama to the observability providers list, per the invitation on that page: "Do you have an observability integration that supports the AI SDK and has an integration guide? Please open a pull request to add it to the list."

## What Pisama does

[Pisama](https://pisama.ai) is a failure-detection layer for agent systems. Tracing shows what happened and rubric graders score the final artifact; Pisama names what went wrong during the run: loops, state corruption, persona drift, coordination breakdown between agents, tool-failure cascades, and unsupported claims.

## Integration

OpenTelemetry. Enable `experimental_telemetry` and point your OTLP exporter at Pisama's ingest endpoint. Both the legacy `ai.*` attributes and the `gen_ai.*` semantic conventions are handled, including prompts, responses, tool calls and token usage, so the page includes a mapping table for the two vocabularies.

Integration guide: https://docs.pisama.ai/guides/integrations/vercel-ai-sdk/

## Verification

- The ingest endpoint is live and authenticated: an unauthenticated POST to `https://api.pisama.ai/api/v1/traces/ingest` returns 401 rather than 404.
- The attribute mapping table was derived by capturing real AI SDK telemetry rather than transcribed from docs: a `generateText` call with one tool, recorded through a tracer passed to `experimental_telemetry.tracer`, producing the outer `ai.generateText` span, two `doGenerate` spans and one `ai.toolCall` span. The table reflects what `ai` 6.0.172 actually emits.
- Every link on the new page resolves to real content.

## Amended since opening

This PR originally led with a TypeScript middleware path (`npm i @pisama/sdk`, `observe()`). That section has been removed. The published `@pisama/sdk` 0.8.0 posts to `https://api.pisama.ai/api/v1/spans`, a route that no longer exists; it was removed deliberately in a June 2026 product change, and the npm package predates it. The middleware wraps a model correctly but cannot deliver data, so recommending it here would have been wrong. The OpenTelemetry path is unaffected.

Apologies for the churn in an open PR. I would rather correct it than have it merged as written.

## Conventions followed

- New page at `content/providers/03-observability/pisama.mdx`, matching the structure of the neighbouring provider pages.
- Added to `index.mdx` in alphabetical position, between MLflow and PostHog.
- Docs-only, no package changes, so no changeset.