### PR TITLE
docs(angular): add tool approval flow

### DIFF
--- a/examples/angular/README.md
+++ b/examples/angular/README.md
@@ -32,9 +32,10 @@ This runs both the Angular frontend (localhost:4200) and Express backend (localh
 - Real-time chat interface
 - Completion + structured object examples
 - Message streaming
-- Fake weather tool (server-side)
+- Fake weather tool (server-side) with user approval
+- Automatic chat continuation after tool approval
 - Reasoning stream (supported models only)
 - Proxy configuration for API requests
 
 Set your preferred model in `chat.component.ts` by changing the `selectedModel` parameter.
-Use AI Gateway model IDs like `openai/gpt-5.4`.
+Use AI Gateway model IDs like `openai/gpt-4o-mini`.

--- a/examples/angular/src/app/chat/chat.component.css
+++ b/examples/angular/src/app/chat/chat.component.css
@@ -103,6 +103,36 @@ details {
   font-size: 0.85rem;
 }
 
+.tool-approval {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.tool-approval-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.tool-approval-actions button {
+  padding: 0.4rem 0.75rem;
+  border: 0;
+  border-radius: 4px;
+  background-color: #007bff;
+  color: white;
+  cursor: pointer;
+}
+
+.tool-approval-actions button.secondary {
+  background-color: #6c757d;
+}
+
+.tool-approval-reason {
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+  color: #6c757d;
+}
+
 .file-part,
 .source-part,
 .data-part {

--- a/examples/angular/src/app/chat/chat.component.html
+++ b/examples/angular/src/app/chat/chat.component.html
@@ -58,6 +58,79 @@
             </div>
           } @else if (part.type === 'step-start') {
             <!-- <div class="step-separator">Step</div> -->
+          } @else if (
+            isToolPart(part) && part.type === 'tool-getWeatherInformation'
+          ) {
+            <div class="tool-call">
+              <div class="tool-name">Tool: getWeatherInformation</div>
+              <div class="tool-status">Status: {{ part.state }}</div>
+
+              @switch (part.state) {
+                @case ('input-streaming') {
+                  <div>Preparing weather request...</div>
+                  @if (part.input !== undefined) {
+                    <pre class="tool-input">{{ part.input | json }}</pre>
+                  }
+                }
+                @case ('input-available') {
+                  <div>Requesting weather information...</div>
+                  <pre class="tool-input">{{ part.input | json }}</pre>
+                }
+                @case ('approval-requested') {
+                  @if (part.approval.isAutomatic) {
+                    <div>Checking approval for this weather request...</div>
+                  } @else {
+                    <div class="tool-approval">
+                      <p>Allow this weather lookup?</p>
+                      <pre class="tool-input">{{ part.input | json }}</pre>
+                      <div class="tool-approval-actions">
+                        <button
+                          type="button"
+                          (click)="approveTool(part.approval.id)"
+                        >
+                          Approve
+                        </button>
+                        <button
+                          type="button"
+                          class="secondary"
+                          (click)="denyTool(part.approval.id)"
+                        >
+                          Deny
+                        </button>
+                      </div>
+                    </div>
+                  }
+                }
+                @case ('approval-responded') {
+                  <div>
+                    Request
+                    {{ part.approval.approved ? 'approved' : 'denied' }}.
+                  </div>
+                  @if (part.approval.reason) {
+                    <div class="tool-approval-reason">
+                      Reason: {{ part.approval.reason }}
+                    </div>
+                  }
+                }
+                @case ('output-available') {
+                  <div class="tool-result-container">
+                    <div class="tool-result-title">Result</div>
+                    <pre class="tool-result">{{ part.output | json }}</pre>
+                  </div>
+                }
+                @case ('output-error') {
+                  <div class="tool-error">{{ part.errorText }}</div>
+                }
+                @case ('output-denied') {
+                  <div>Weather lookup was not performed.</div>
+                  @if (part.approval.reason) {
+                    <div class="tool-approval-reason">
+                      Reason: {{ part.approval.reason }}
+                    </div>
+                  }
+                }
+              }
+            </div>
           } @else if (isToolPart(part)) {
             <div class="tool-call">
               <div class="tool-name">

--- a/examples/angular/src/app/chat/chat.component.ts
+++ b/examples/angular/src/app/chat/chat.component.ts
@@ -9,6 +9,7 @@ import {
 import { Chat } from '@ai-sdk/angular';
 import {
   isToolUIPart,
+  lastAssistantMessageIsCompleteWithApprovalResponses,
   type DataUIPart,
   type ToolUIPart,
   type UIDataTypes,
@@ -24,7 +25,9 @@ import {
 })
 export class ChatComponent {
   private fb = inject(FormBuilder);
-  public chat: Chat = new Chat({});
+  public chat: Chat = new Chat({
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+  });
 
   chatForm: FormGroup;
 
@@ -60,9 +63,24 @@ export class ChatComponent {
       },
       {
         body: {
-          selectedModel: 'openai/gpt-5.6',
+          selectedModel: 'openai/gpt-4o-mini',
         },
       },
     );
+  }
+
+  approveTool(approvalId: string) {
+    void this.chat.addToolApprovalResponse({
+      id: approvalId,
+      approved: true,
+    });
+  }
+
+  denyTool(approvalId: string) {
+    void this.chat.addToolApprovalResponse({
+      id: approvalId,
+      approved: false,
+      reason: 'Denied by the user',
+    });
   }
 }

--- a/examples/angular/src/server.ts
+++ b/examples/angular/src/server.ts
@@ -16,7 +16,8 @@ import { z } from 'zod';
 const app = express();
 app.use(express.json({ strict: false })); // Allow primitives (for analyze endpoint)
 
-const defaultModel = 'openai/gpt-5.6';
+// Use a broadly available Gateway model that supports tool calls.
+const defaultModel = 'openai/gpt-4o-mini';
 
 app.post('/api/chat', async (req: Request, res: Response) => {
   const { messages, selectedModel } = req.body;
@@ -46,6 +47,9 @@ app.post('/api/chat', async (req: Request, res: Response) => {
           return `${city}: ${condition}`;
         },
       },
+    },
+    toolApproval: {
+      getWeatherInformation: 'user-approval',
     },
   });
 

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -103,7 +103,7 @@ export class ChatComponent {
       { text: userInput },
       {
         body: {
-          selectedModel: 'openai/gpt-5.4',
+          selectedModel: 'openai/gpt-4o-mini',
         },
       },
     );
@@ -111,7 +111,7 @@ export class ChatComponent {
 }
 ```
 
-`selectedModel` should be an AI Gateway model ID like `openai/gpt-5.4`.
+`selectedModel` should be an AI Gateway model ID like `openai/gpt-4o-mini`.
 
 ### Constructor Options
 
@@ -139,6 +139,14 @@ interface ChatInit<UI_MESSAGE extends UIMessage = UIMessage> {
 
   /** Maximum conversation steps */
   maxSteps?: number;
+
+  /**
+   * Called when the stream is finished or a tool call is updated to determine
+   * whether the current messages should be resubmitted.
+   */
+  sendAutomaticallyWhen?: (options: {
+    messages: UI_MESSAGE[];
+  }) => boolean | PromiseLike<boolean>;
 
   /** Tool call handler */
   onToolCall?: (params: {
@@ -188,10 +196,17 @@ await chat.resumeStream(options?: {
   headers?: Record<string, string> | Headers;
 });
 
-// Add tool execution result
-chat.addToolResult({
-  toolCallId: string;
-  output: unknown;
+// Add tool execution output
+chat.addToolOutput({
+  tool: 'getLocation',
+  toolCallId,
+  output: location,
+});
+
+// Add tool approval response
+chat.addToolApprovalResponse({
+  id: approvalId,
+  approved: true,
 });
 
 // Stop current generation
@@ -231,6 +246,64 @@ const chat = new Chat({
     }
   },
 });
+```
+
+### Tool Approvals
+
+When a server-side tool requires user approval, the tool part enters the
+`approval-requested` state. Call `addToolApprovalResponse()` for manual
+approvals and configure `sendAutomaticallyWhen` to continue the conversation
+after all approvals have a response.
+
+```typescript
+import { Chat } from '@ai-sdk/angular';
+import { lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai';
+
+const chat = new Chat({
+  sendAutomaticallyWhen:
+    lastAssistantMessageIsCompleteWithApprovalResponses,
+});
+
+chat.addToolApprovalResponse({
+  id: approvalId,
+  approved: true,
+});
+
+chat.addToolApprovalResponse({
+  id: approvalId,
+  approved: false,
+  reason: 'Denied by the user',
+});
+```
+
+```html
+@if (part.type === 'tool-getWeatherInformation') {
+  @switch (part.state) {
+    @case ('approval-requested') {
+      @if (part.approval.isAutomatic) {
+        <div>Checking approval...</div>
+      } @else {
+        <button type="button" (click)="approveTool(part.approval.id)">
+          Approve
+        </button>
+        <button type="button" (click)="denyTool(part.approval.id)">
+          Deny
+        </button>
+      }
+    }
+    @case ('approval-responded') {
+      <div>
+        Request {{ part.approval.approved ? 'approved' : 'denied' }}.
+      </div>
+    }
+    @case ('output-available') {
+      <pre>{{ part.output | json }}</pre>
+    }
+    @case ('output-denied') {
+      <div>Tool execution was denied.</div>
+    }
+  }
+}
 ```
 
 ## Completion
@@ -487,7 +560,7 @@ structuredObject.stop();
 
 ## Server Implementation
 
-When you pass a string model ID (for example `openai/gpt-5.4`), the AI SDK uses
+When you pass a string model ID (for example `openai/gpt-4o-mini`), the AI SDK uses
 AI Gateway as the default provider, so no provider import is required.
 
 ### Express.js Chat Endpoint
@@ -510,7 +583,7 @@ app.post('/api/chat', async (req, res) => {
   const { messages, selectedModel } = req.body;
 
   const result = streamText({
-    model: selectedModel || 'openai/gpt-5.4',
+    model: selectedModel || 'openai/gpt-4o-mini',
     messages: convertToModelMessages(messages),
   });
 
@@ -528,7 +601,7 @@ app.post('/api/completion', async (req, res) => {
   const { prompt } = req.body;
 
   const result = streamText({
-    model: 'openai/gpt-5.4',
+    model: 'openai/gpt-4o-mini',
     prompt,
   });
 
@@ -549,7 +622,7 @@ app.post('/api/analyze', async (req, res) => {
   const input = req.body;
 
   const result = streamObject({
-    model: 'openai/gpt-5.4',
+    model: 'openai/gpt-4o-mini',
     schema: z.object({
       title: z.string(),
       summary: z.string(),

--- a/packages/angular/src/lib/chat.ng.test.ts
+++ b/packages/angular/src/lib/chat.ng.test.ts
@@ -722,7 +722,7 @@ describe('tool invocations', () => {
     ]);
   });
 
-  it('should update tool call to result when addToolResult is called', async () => {
+  it('should update tool call to result when addToolOutput is called', async () => {
     server.urls['/api/chat'].response = {
       type: 'stream-chunks',
       chunks: [
@@ -756,7 +756,7 @@ describe('tool invocations', () => {
       ]);
     });
 
-    chat.addToolResult({
+    chat.addToolOutput({
       tool: 'test-tool',
       toolCallId: 'tool-call-0',
       output: 'test-result',
@@ -834,7 +834,7 @@ describe('tool invocations', () => {
     });
 
     // user submits the tool result
-    chat.addToolResult({
+    chat.addToolOutput({
       tool: 'test-tool',
       toolCallId: 'tool-call-0',
       output: 'test-result',


### PR DESCRIPTION
## Background

  `@ai-sdk/angular` already inherits the core chat APIs for tool approvals, but the Angular README and
  example did not show the approval flow. The README also still referenced the deprecated
  `addToolResult()` API instead of `addToolOutput()`.

  This PR keeps the scope to Angular docs/example parity.

  ## Summary

  - Adds a manual approval flow to the existing Angular chat example weather tool.
  - Configures automatic continuation with `lastAssistantMessageIsCompleteWithApprovalResponses`.
  - Renders approval states in the Angular template, including approve/deny controls and `output-denied`.
  - Updates the Angular README to document `addToolOutput()`, `addToolApprovalResponse()`, approval
  states, and automatic continuation.
  - Updates the Angular example to use `openai/gpt-4o-mini`, a broadly available Gateway model that
  supports tool calls.

  ## End-to-End Verification

  - Manually ran `examples/angular`.
  - Verified approving the weather tool transitions from `approval-requested` to `output-available` and
  automatically continues the chat.
  - Verified denying the weather tool transitions to `output-denied` and automatically continues the chat.

  Build/checks run:

  - `pnpm --dir examples/angular run build:app`
  - `pnpm --dir packages/angular test`
  - `pnpm type-check:full`

  `build:app` emits an existing warning about `packages/ai/dist/src/global.js` and `sideEffects: false`.

  ## Checklist

  - [ ] All commits are signed (PRs with unsigned commits cannot be merged)
  - [ ] Tests have been added / updated (for bug fixes / features)
  - [x] Documentation has been added / updated (for bug fixes / features)
  - [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm
  changeset` in the project root)
  - [x] I have reviewed this pull request (self-review)