### PR TITLE
feat(harness-cline): add Cline harness adapter

### DIFF
--- a/.changeset/eighty-otters-code.md
+++ b/.changeset/eighty-otters-code.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-cline": patch
+---
+
+Add the Cline harness adapter (`@ai-sdk/harness-cline`): a host-process HarnessV1 adapter backed by the Cline SDK agent runtime (`@cline/agents`), with sandbox-backed built-in tools (read, write, edit, bash, grep, glob, ls), built-in tool approvals and filtering, host-executed custom tools, skills, and history-based session resume.

--- a/content/docs/03-ai-sdk-harnesses/05-harness-adapters.mdx
+++ b/content/docs/03-ai-sdk-harnesses/05-harness-adapters.mdx
@@ -15,6 +15,7 @@ configuration into the harness contract.
 The AI SDK includes the following harness adapters:
 
 - [Claude Code](/providers/ai-sdk-harnesses/claude-code) (`@ai-sdk/harness-claude-code`)
+- [Cline](/providers/ai-sdk-harnesses/cline) (`@ai-sdk/harness-cline`)
 - [Codex](/providers/ai-sdk-harnesses/codex) (`@ai-sdk/harness-codex`)
 - [Deep Agents](/providers/ai-sdk-harnesses/deepagents) (`@ai-sdk/harness-deepagents`)
 - [OpenCode](/providers/ai-sdk-harnesses/opencode) (`@ai-sdk/harness-opencode`)
@@ -31,6 +32,7 @@ The AI SDK includes the following harness adapters:
 | Adapter                                                | Runtime location | Custom tools | Custom skills | Built-in tool approval | Built-in tool filtering      |
 | ------------------------------------------------------ | ---------------- | ------------ | ------------- | ---------------------- | ---------------------------- |
 | [Claude Code](/providers/ai-sdk-harnesses/claude-code) | Sandbox bridge   | <Check />    | <Check />     | <Check />              | <Check />                    |
+| [Cline](/providers/ai-sdk-harnesses/cline)             | Host process     | <Check />    | <Check />     | <Check />              | <Check />                    |
 | [Codex](/providers/ai-sdk-harnesses/codex)             | Sandbox bridge   | <Check />    | <Check />     | <Cross />              | <Cross />                    |
 | [Deep Agents](/providers/ai-sdk-harnesses/deepagents)  | Sandbox bridge   | <Check />    | <Check />     | <Check />              | <Check /> via auto-rejection |
 | [OpenCode](/providers/ai-sdk-harnesses/opencode)       | Sandbox bridge   | <Check />    | <Check />     | <Check />              | <Check /> via auto-rejection |

--- a/content/providers/02-ai-sdk-harnesses/06-cline.mdx
+++ b/content/providers/02-ai-sdk-harnesses/06-cline.mdx
@@ -1,0 +1,157 @@
+---
+title: Cline
+description: Learn how to use the Cline harness adapter.
+---
+
+# Cline Harness
+
+The Cline harness adapter connects `HarnessAgent` to the
+[Cline SDK](https://docs.cline.bot/sdk/overview) agent runtime
+(`@cline/agents`). The runtime runs as an in-process Node library on the host
+— no bridge — while its built-in tools execute against the session sandbox,
+so the workspace the model reasons about lives entirely inside the sandbox.
+
+<Note>
+  Harness packages are **experimental**. Expect breaking changes between
+  releases as this early API gets further refined.
+</Note>
+
+## Setup
+
+<InstallPackages packages="@ai-sdk/harness @ai-sdk/harness-cline @ai-sdk/sandbox-vercel" />
+
+The Cline runtime has no bootstrap step: nothing is installed inside the
+sandbox when a session starts.
+
+## Import
+
+```ts
+import { cline, createCline } from '@ai-sdk/harness-cline';
+```
+
+`cline` is equivalent to `createCline()` with its default configuration.
+
+## Basic Usage
+
+```ts
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { cline } from '@ai-sdk/harness-cline';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const agent = new HarnessAgent({
+  harness: cline,
+  sandbox: createVercelSandbox({
+    runtime: 'node24',
+  }),
+});
+
+const session = await agent.createSession();
+
+let exitCode = 0;
+try {
+  const result = await agent.stream({
+    session,
+    prompt: 'Check the test failures and fix the production code.',
+  });
+
+  for await (const part of result.stream) {
+    if (part.type === 'text-delta') {
+      process.stdout.write(part.text);
+    }
+  }
+} catch (err) {
+  exitCode = 1;
+  console.error(err);
+} finally {
+  await session.destroy();
+  process.exit(exitCode);
+}
+```
+
+To use this agent, ensure environment variables include `VERCEL_OIDC_TOKEN`
+for Vercel Sandbox and a provider key such as `ANTHROPIC_API_KEY` for the
+Cline runtime's model calls.
+
+## Adapter Settings
+
+Use `createCline()` to configure the runtime:
+
+```ts
+const harness = createCline({
+  providerId: 'anthropic',
+  modelId: 'claude-opus-5',
+});
+```
+
+Settings:
+
+- `providerId`: Cline LLM provider id (e.g. `anthropic`, `openai`, `gemini`).
+  Defaults to `anthropic`.
+- `modelId`: model id for the configured provider. Defaults to
+  `claude-opus-5`.
+- `apiKey`: provider API key. When omitted, the Cline gateway falls back to
+  the provider's environment variable (e.g. `ANTHROPIC_API_KEY`).
+- `baseUrl`: custom provider endpoint.
+- `headers`: extra headers sent to the provider.
+- `systemPrompt`: additional system prompt text appended to the adapter's
+  base system prompt.
+- `maxIterations`: safety cap on agent-loop iterations per turn.
+
+## Sandbox
+
+The Cline runtime runs on the host and does not need sandbox ports, so any
+network sandbox works — including port-less configurations:
+
+```ts
+const sandbox = createVercelSandbox({
+  runtime: 'node24',
+});
+```
+
+All built-in tools operate on the sandbox filesystem through the sandbox
+session's file and exec surface.
+
+## Built-in Tools
+
+The adapter exposes these built-ins through `agent.tools`:
+
+- `read`
+- `write`
+- `edit`
+- `bash`
+- `grep`
+- `glob`
+- `ls`
+
+All built-ins are sandbox-backed: `bash` runs in the session working
+directory, and relative file paths resolve against it.
+
+Cline supports built-in tool approval requests when `permissionMode` is
+`allow-reads` or `allow-edits`, native built-in tool filtering via
+`activeTools`/`inactiveTools`, and host-executed AI SDK tool approvals.
+
+## Skills
+
+Harness-provided skills are written into the sandbox HOME
+(`~/.agents/skills/<name>/SKILL.md`) and advertised to the model through a
+system prompt section; the model loads a skill's full content with the `read`
+tool when the task calls for it.
+
+## Session Lifecycle
+
+Conversation state lives in the host-process runtime. On `detach`/`stop` the
+adapter persists the conversation history into the sandbox workspace
+(`.cline-harness/history.json` in the session working directory), so a future
+process can resume the session after the sandbox provider reattaches. Because
+the runtime is host-resident, suspended turns are rerun-continued from the
+persisted history rather than losslessly attached (same trade-off as the
+[Pi adapter](/providers/ai-sdk-harnesses/pi)).
+
+Manual compaction (`doCompact`) is not supported by the standalone Cline
+runtime and throws `HarnessCapabilityUnsupportedError`.
+
+## Related
+
+- [HarnessAgent](/docs/ai-sdk-harnesses/harness-agent)
+- [Harness tools](/docs/ai-sdk-harnesses/tools)
+- [Harness adapters](/docs/ai-sdk-harnesses/harness-adapters)

--- a/content/providers/02-ai-sdk-harnesses/index.mdx
+++ b/content/providers/02-ai-sdk-harnesses/index.mdx
@@ -17,6 +17,11 @@ and response primitives.
       href: '/providers/ai-sdk-harnesses/claude-code',
     },
     {
+      title: 'Cline',
+      description: 'Use the Cline SDK through the AI SDK harness abstraction.',
+      href: '/providers/ai-sdk-harnesses/cline',
+    },
+    {
       title: 'Codex',
       description: 'Use Codex through the AI SDK harness abstraction.',
       href: '/providers/ai-sdk-harnesses/codex',

--- a/packages/harness-cline/CHANGELOG.md
+++ b/packages/harness-cline/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @ai-sdk/harness-cline

--- a/packages/harness-cline/README.md
+++ b/packages/harness-cline/README.md
@@ -1,0 +1,7 @@
+# AI SDK Cline Harness
+
+The Cline harness connects `HarnessAgent` to the [Cline SDK](https://docs.cline.bot/sdk/overview)
+agent runtime. The runtime runs in the host process; its built-in tools
+execute against the session sandbox.
+
+See the AI SDK documentation for usage.

--- a/packages/harness-cline/package.json
+++ b/packages/harness-cline/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@ai-sdk/harness-cline",
+  "version": "1.0.0",
+  "type": "module",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "source": "./src/index.ts",
+  "files": [
+    "dist/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist *.tsbuildinfo",
+    "type-check": "tsc --build",
+    "test": "pnpm test:node",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/harness": "workspace:*",
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*",
+    "@cline/agents": "^0.0.66"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.19",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "5.8.3",
+    "zod": "3.25.76"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/harness-cline"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai",
+    "harness",
+    "cline"
+  ]
+}

--- a/packages/harness-cline/src/cline-harness.test.ts
+++ b/packages/harness-cline/src/cline-harness.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { cline, createCline } from './index';
+import {
+  resolveActiveClineBuiltinNames,
+  CLINE_NATIVE_BUILTIN_NAMES,
+} from './cline-tools';
+
+describe('createCline', () => {
+  it('returns a harness-v1 spec', () => {
+    const harness = createCline();
+    expect(harness.specificationVersion).toBe('harness-v1');
+    expect(harness.harnessId).toBe('cline');
+    expect(harness.supportsBuiltinToolApprovals).toBe(true);
+    expect(harness.supportsBuiltinToolFiltering).toBe(true);
+  });
+
+  it('declares the seven built-in tools', () => {
+    expect(Object.keys(createCline().builtinTools).sort()).toEqual(
+      [...CLINE_NATIVE_BUILTIN_NAMES].sort(),
+    );
+  });
+
+  it('exports a default instance', () => {
+    expect(cline.harnessId).toBe('cline');
+  });
+
+  it('validates lifecycle state data with its schema', () => {
+    const schema = createCline().lifecycleStateSchema;
+    expect(schema).toBeDefined();
+  });
+});
+
+describe('resolveActiveClineBuiltinNames', () => {
+  it('returns all built-ins without filtering', () => {
+    expect(resolveActiveClineBuiltinNames(undefined)).toEqual(
+      CLINE_NATIVE_BUILTIN_NAMES,
+    );
+  });
+
+  it('applies allow filtering', () => {
+    expect(
+      resolveActiveClineBuiltinNames({
+        mode: 'allow',
+        toolNames: ['read', 'grep'],
+      }),
+    ).toEqual(['read', 'grep']);
+  });
+
+  it('applies deny filtering', () => {
+    expect(
+      resolveActiveClineBuiltinNames({ mode: 'deny', toolNames: ['bash'] }),
+    ).toEqual(['read', 'write', 'edit', 'grep', 'glob', 'ls']);
+  });
+});

--- a/packages/harness-cline/src/cline-harness.ts
+++ b/packages/harness-cline/src/cline-harness.ts
@@ -1,0 +1,181 @@
+import {
+  commonTool,
+  type HarnessV1,
+  type HarnessV1BuiltinTool,
+} from '@ai-sdk/harness';
+import { tool } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { clineResumeStateSchema } from './cline-resume-state';
+import { createClineSession } from './cline-session';
+
+/**
+ * Configuration knobs for `createCline`. The Cline runtime
+ * (`@cline/agents`, part of the Cline SDK) runs as an in-process Node
+ * library — no bridge, so there is no `port` or `startupTimeoutMs` to set.
+ */
+export type ClineHarnessSettings = {
+  /**
+   * Cline LLM provider id (e.g. `'anthropic'`, `'openai'`, `'gemini'`).
+   * Defaults to `'anthropic'`.
+   */
+  readonly providerId?: string;
+  /**
+   * Model id for the configured provider. Defaults to `'claude-opus-5'`.
+   */
+  readonly modelId?: string;
+  /**
+   * Provider API key. When omitted, the Cline gateway falls back to the
+   * provider's environment variable (e.g. `ANTHROPIC_API_KEY`).
+   */
+  readonly apiKey?: string;
+  /** Custom provider endpoint. */
+  readonly baseUrl?: string;
+  /** Extra headers sent to the provider. */
+  readonly headers?: Record<string, string>;
+  /**
+   * Additional system prompt text appended to the adapter's base system
+   * prompt (workspace + sandbox + skills sections).
+   */
+  readonly systemPrompt?: string;
+  /**
+   * Safety cap on agent-loop iterations per turn. Unbounded when omitted.
+   */
+  readonly maxIterations?: number;
+};
+
+const DEFAULT_PROVIDER_ID = 'anthropic';
+const DEFAULT_MODEL_ID = 'claude-opus-5';
+
+/*
+ * The Cline runtime requires snake_case tool names, and each of these
+ * built-ins already matches its cross-harness common name — so native names
+ * and wire names are identical, and `nativeName` mirrors the key. These zod
+ * declarations mirror the JSON schemas handed to the runtime in
+ * `cline-tools.ts` — keep the two in sync.
+ */
+const CLINE_BUILTIN_TOOLS = {
+  read: commonTool('read', {
+    nativeName: 'read',
+    toolUseKind: 'readonly',
+    description: 'Read file contents.',
+    inputSchema: z.object({
+      file_path: z.string(),
+    }),
+  }),
+  write: commonTool('write', {
+    nativeName: 'write',
+    toolUseKind: 'edit',
+    description: 'Overwrite or create a file.',
+    inputSchema: z.object({
+      file_path: z.string(),
+      content: z.string(),
+    }),
+  }),
+  edit: commonTool('edit', {
+    nativeName: 'edit',
+    toolUseKind: 'edit',
+    description: 'Edit a file by exact string replacement.',
+    inputSchema: z.object({
+      file_path: z.string(),
+      old_string: z.string(),
+      new_string: z.string(),
+    }),
+  }),
+  bash: commonTool('bash', {
+    nativeName: 'bash',
+    toolUseKind: 'bash',
+    description: 'Execute a shell command in the sandbox.',
+    inputSchema: z.object({
+      command: z.string(),
+      timeout: z.number().optional(),
+    }),
+  }),
+  grep: commonTool('grep', {
+    nativeName: 'grep',
+    toolUseKind: 'readonly',
+    description: 'Search file contents with regex.',
+    inputSchema: z.object({
+      pattern: z.string(),
+      path: z.string().optional(),
+      glob: z.string().optional(),
+      ignoreCase: z.boolean().optional(),
+      literal: z.boolean().optional(),
+      context: z.number().optional(),
+      limit: z.number().optional(),
+    }),
+  }),
+  glob: commonTool('glob', {
+    nativeName: 'glob',
+    toolUseKind: 'readonly',
+    description: 'Find files matching a glob pattern.',
+    inputSchema: z.object({
+      pattern: z.string(),
+      path: z.string().optional(),
+      limit: z.number().optional(),
+    }),
+  }),
+  ls: {
+    ...tool({
+      description: 'List directory entries.',
+      inputSchema: z.object({
+        path: z.string().optional(),
+        limit: z.number().optional(),
+      }),
+      outputSchema: z.unknown(),
+    }),
+    nativeName: 'ls',
+    toolUseKind: 'readonly',
+  } as HarnessV1BuiltinTool,
+} as const satisfies Record<string, HarnessV1BuiltinTool<any, any>>;
+
+export function createCline(
+  settings: ClineHarnessSettings = {},
+): HarnessV1<typeof CLINE_BUILTIN_TOOLS> {
+  return {
+    specificationVersion: 'harness-v1',
+    harnessId: 'cline',
+    builtinTools: CLINE_BUILTIN_TOOLS,
+    supportsBuiltinToolApprovals: true,
+    supportsBuiltinToolFiltering: true,
+    lifecycleStateSchema: clineResumeStateSchema,
+    doStart: async startOpts => {
+      const lifecycleState = startOpts.continueFrom ?? startOpts.resumeFrom;
+      const resumeData = lifecycleState?.data as
+        | { historyFileName?: string }
+        | undefined;
+
+      return createClineSession({
+        sessionId: startOpts.sessionId,
+        sandboxSession: startOpts.sandboxSession,
+        sessionWorkDir: startOpts.sessionWorkDir,
+        skills: startOpts.skills ?? [],
+        settings: {
+          providerId: settings.providerId ?? DEFAULT_PROVIDER_ID,
+          modelId: settings.modelId ?? DEFAULT_MODEL_ID,
+          ...(settings.apiKey ? { apiKey: settings.apiKey } : {}),
+          ...(settings.baseUrl ? { baseUrl: settings.baseUrl } : {}),
+          ...(settings.headers ? { headers: settings.headers } : {}),
+          ...(settings.systemPrompt
+            ? { systemPrompt: settings.systemPrompt }
+            : {}),
+          ...(settings.maxIterations !== undefined
+            ? { maxIterations: settings.maxIterations }
+            : {}),
+        },
+        isResume: lifecycleState != null,
+        ...(startOpts.permissionMode
+          ? { permissionMode: startOpts.permissionMode }
+          : {}),
+        ...(startOpts.builtinToolFiltering
+          ? { builtinToolFiltering: startOpts.builtinToolFiltering }
+          : {}),
+        ...(resumeData?.historyFileName
+          ? { resumeHistoryFileName: resumeData.historyFileName }
+          : {}),
+        ...(startOpts.abortSignal
+          ? { abortSignal: startOpts.abortSignal }
+          : {}),
+      });
+    },
+  };
+}

--- a/packages/harness-cline/src/cline-remote-ops.test.ts
+++ b/packages/harness-cline/src/cline-remote-ops.test.ts
@@ -1,0 +1,167 @@
+import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { createClineRemoteOps } from './cline-remote-ops';
+
+const WORK_DIR = '/sandbox/work/cline-s1';
+
+function createFakeSandbox({
+  files = new Map<string, string>(),
+  run = vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' })),
+}: {
+  files?: Map<string, string>;
+  run?: ReturnType<typeof vi.fn>;
+} = {}) {
+  const sandbox = {
+    run,
+    readTextFile: async ({ path }: { path: string }) => files.get(path) ?? null,
+    writeTextFile: async ({
+      path,
+      content,
+    }: {
+      path: string;
+      content: string;
+    }) => {
+      files.set(path, content);
+    },
+  } as unknown as Experimental_SandboxSession;
+  return { sandbox, files, run };
+}
+
+describe('resolvePath', () => {
+  it('resolves relative paths against the work dir', () => {
+    const { sandbox } = createFakeSandbox();
+    const ops = createClineRemoteOps({ sandbox, workDir: WORK_DIR });
+    expect(ops.resolvePath('src/index.ts')).toBe(`${WORK_DIR}/src/index.ts`);
+    expect(ops.resolvePath('./a/../b.txt')).toBe(`${WORK_DIR}/b.txt`);
+  });
+
+  it('keeps absolute paths', () => {
+    const { sandbox } = createFakeSandbox();
+    const ops = createClineRemoteOps({ sandbox, workDir: WORK_DIR });
+    expect(ops.resolvePath('/etc/hosts')).toBe('/etc/hosts');
+  });
+});
+
+describe('file operations', () => {
+  it('reads existing files and errors on missing ones', async () => {
+    const { sandbox } = createFakeSandbox({
+      files: new Map([[`${WORK_DIR}/a.txt`, 'contents']]),
+    });
+    const ops = createClineRemoteOps({ sandbox, workDir: WORK_DIR });
+    expect(await ops.readFile('a.txt')).toBe('contents');
+    await expect(ops.readFile('missing.txt')).rejects.toThrow(
+      'File not found: missing.txt',
+    );
+  });
+
+  it('writes files at resolved paths', async () => {
+    const { sandbox, files } = createFakeSandbox();
+    const ops = createClineRemoteOps({ sandbox, workDir: WORK_DIR });
+    await ops.writeFile('nested/b.txt', 'data');
+    expect(files.get(`${WORK_DIR}/nested/b.txt`)).toBe('data');
+  });
+
+  it('edits by exact string replacement (first occurrence)', async () => {
+    const { sandbox, files } = createFakeSandbox({
+      files: new Map([[`${WORK_DIR}/c.txt`, 'one two one']]),
+    });
+    const ops = createClineRemoteOps({ sandbox, workDir: WORK_DIR });
+    await ops.editFile('c.txt', 'one', 'ONE');
+    expect(files.get(`${WORK_DIR}/c.txt`)).toBe('ONE two one');
+  });
+
+  it('errors when the edit target text is missing', async () => {
+    const { sandbox } = createFakeSandbox({
+      files: new Map([[`${WORK_DIR}/c.txt`, 'abc']]),
+    });
+    const ops = createClineRemoteOps({ sandbox, workDir: WORK_DIR });
+    await expect(ops.editFile('c.txt', 'zzz', 'yyy')).rejects.toThrow(
+      'Text to replace was not found in c.txt',
+    );
+  });
+});
+
+describe('bash', () => {
+  it('runs commands in the work dir and returns combined output', async () => {
+    const run = vi.fn(async () => ({
+      exitCode: 3,
+      stdout: 'out',
+      stderr: 'err',
+    }));
+    const { sandbox } = createFakeSandbox({ run });
+    const ops = createClineRemoteOps({ sandbox, workDir: WORK_DIR });
+    const result = await ops.bash('false');
+    expect(result).toEqual({ output: 'outerr', exitCode: 3 });
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'false', workingDirectory: WORK_DIR }),
+    );
+  });
+
+  it('aborts on timeout', async () => {
+    const run = vi.fn(
+      async ({ abortSignal }: { abortSignal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          abortSignal?.addEventListener('abort', () =>
+            reject(new Error('aborted')),
+          );
+        }),
+    );
+    const { sandbox } = createFakeSandbox({ run });
+    const ops = createClineRemoteOps({ sandbox, workDir: WORK_DIR });
+    await expect(ops.bash('sleep 60', { timeout: 0.01 })).rejects.toThrow(
+      'aborted',
+    );
+  });
+});
+
+describe('glob', () => {
+  it('filters find output through the glob pattern', async () => {
+    const run = vi.fn(async () => ({
+      exitCode: 0,
+      stdout: [
+        `${WORK_DIR}/src/index.ts`,
+        `${WORK_DIR}/src/util.js`,
+        `${WORK_DIR}/README.md`,
+      ].join('\n'),
+      stderr: '',
+    }));
+    const { sandbox } = createFakeSandbox({ run });
+    const ops = createClineRemoteOps({ sandbox, workDir: WORK_DIR });
+    expect(await ops.glob('**/*.ts')).toEqual(['src/index.ts']);
+  });
+
+  it('errors when the search path is missing', async () => {
+    const run = vi.fn(async () => ({
+      exitCode: 2,
+      stdout: '__CLINE_FIND_NOT_FOUND__\n',
+      stderr: '',
+    }));
+    const { sandbox } = createFakeSandbox({ run });
+    const ops = createClineRemoteOps({ sandbox, workDir: WORK_DIR });
+    await expect(ops.glob('*', 'missing')).rejects.toThrow(
+      'Path not found: missing',
+    );
+  });
+});
+
+describe('ls', () => {
+  it('lists, strips indicators, sorts, and limits entries', async () => {
+    const run = vi.fn(async () => ({
+      exitCode: 0,
+      stdout: 'b.txt\nsub/\na.sh*\n',
+      stderr: '',
+    }));
+    const { sandbox } = createFakeSandbox({ run });
+    const ops = createClineRemoteOps({ sandbox, workDir: WORK_DIR });
+    expect(await ops.ls('.', 2)).toEqual(['a.sh', 'b.txt']);
+  });
+});
+
+describe('grep', () => {
+  it('returns a friendly message when nothing matches', async () => {
+    const run = vi.fn(async () => ({ exitCode: 1, stdout: '', stderr: '' }));
+    const { sandbox } = createFakeSandbox({ run });
+    const ops = createClineRemoteOps({ sandbox, workDir: WORK_DIR });
+    expect(await ops.grep('needle')).toBe('No matches found');
+  });
+});

--- a/packages/harness-cline/src/cline-remote-ops.ts
+++ b/packages/harness-cline/src/cline-remote-ops.ts
@@ -1,0 +1,243 @@
+import path from 'node:path';
+import { shellQuote } from '@ai-sdk/harness/utils';
+import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
+
+/**
+ * Sandbox-backed implementations of the Cline harness's built-in tools.
+ *
+ * The Cline runtime executes on the host, but the workspace the model reasons
+ * about lives in the sandbox — every file/shell operation goes through the
+ * restricted `SandboxSession` surface. Relative paths resolve against the
+ * per-session working directory the framework created.
+ */
+export interface ClineRemoteOpsOptions {
+  readonly sandbox: Experimental_SandboxSession;
+  /** Absolute sandbox path of the session's working directory. */
+  readonly workDir: string;
+}
+
+export interface ClineRemoteOps {
+  resolvePath(inputPath: string): string;
+  readFile(inputPath: string): Promise<string>;
+  writeFile(inputPath: string, content: string): Promise<void>;
+  editFile(inputPath: string, oldText: string, newText: string): Promise<void>;
+  bash(
+    command: string,
+    input?: {
+      /** Timeout in seconds (the `bash` tool contract). */
+      timeout?: number;
+      signal?: AbortSignal;
+    },
+  ): Promise<{ output: string; exitCode: number }>;
+  grep(
+    pattern: string,
+    input?: {
+      path?: string;
+      glob?: string;
+      ignoreCase?: boolean;
+      literal?: boolean;
+      context?: number;
+      limit?: number;
+    },
+  ): Promise<string>;
+  glob(pattern: string, inputPath?: string, limit?: number): Promise<string[]>;
+  ls(inputPath?: string, limit?: number): Promise<string[]>;
+}
+
+export function createClineRemoteOps(
+  options: ClineRemoteOpsOptions,
+): ClineRemoteOps {
+  const { sandbox, workDir } = options;
+
+  const resolvePath = (inputPath: string): string => {
+    const normalized = path.posix.isAbsolute(inputPath)
+      ? path.posix.normalize(inputPath)
+      : path.posix.normalize(path.posix.join(workDir, inputPath));
+    return normalized;
+  };
+
+  const runShell = async (
+    command: string,
+    input?: { signal?: AbortSignal },
+  ): Promise<{ exitCode: number; output: string }> => {
+    // `sandbox.run({ command })` already wraps in a shell; interpolated
+    // paths/values inside `command` are quoted with `shellQuote` by callers.
+    const result = await sandbox.run({
+      command,
+      workingDirectory: workDir,
+      ...(input?.signal ? { abortSignal: input.signal } : {}),
+    });
+    return {
+      exitCode: result.exitCode,
+      output: `${result.stdout}${result.stderr}`,
+    };
+  };
+
+  const readFile = async (inputPath: string): Promise<string> => {
+    const resolved = resolvePath(inputPath);
+    const content = await sandbox.readTextFile({ path: resolved });
+    if (content == null) {
+      throw new Error(`File not found: ${inputPath}`);
+    }
+    return content;
+  };
+
+  const writeFile = async (
+    inputPath: string,
+    content: string,
+  ): Promise<void> => {
+    const resolved = resolvePath(inputPath);
+    // `writeTextFile` creates parent directories recursively per the
+    // SandboxSession contract, so no explicit mkdir is needed.
+    await sandbox.writeTextFile({ path: resolved, content });
+  };
+
+  const editFile = async (
+    inputPath: string,
+    oldText: string,
+    newText: string,
+  ): Promise<void> => {
+    const current = await readFile(inputPath);
+    const index = current.indexOf(oldText);
+    if (index === -1) {
+      throw new Error(`Text to replace was not found in ${inputPath}`);
+    }
+    const updated = `${current.slice(0, index)}${newText}${current.slice(
+      index + oldText.length,
+    )}`;
+    await writeFile(inputPath, updated);
+  };
+
+  return {
+    resolvePath,
+    readFile,
+    writeFile,
+    editFile,
+
+    async bash(command, input) {
+      const controller = new AbortController();
+      // `input.timeout` is expressed in seconds (the `bash` tool contract),
+      // so convert to milliseconds for `setTimeout`.
+      const timeoutId =
+        typeof input?.timeout === 'number' && input.timeout > 0
+          ? setTimeout(() => controller.abort(), input.timeout * 1000)
+          : undefined;
+
+      const forwardedSignal = input?.signal;
+      const onAbort = () => controller.abort();
+      forwardedSignal?.addEventListener('abort', onAbort, { once: true });
+
+      try {
+        const result = await runShell(command, { signal: controller.signal });
+        return { output: result.output, exitCode: result.exitCode };
+      } finally {
+        forwardedSignal?.removeEventListener('abort', onAbort);
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+      }
+    },
+
+    async grep(pattern, input = {}) {
+      const target = resolvePath(input.path ?? '.');
+      const flags = [
+        '-R',
+        '-n',
+        '--binary-files=without-match',
+        ...(input.ignoreCase ? ['-i'] : []),
+        ...(input.literal ? ['-F'] : []),
+        ...(typeof input.context === 'number' && input.context > 0
+          ? ['-C', String(input.context)]
+          : []),
+        ...(input.glob ? ['--include', input.glob] : []),
+      ];
+      const limit = Math.max(1, input.limit ?? 100);
+      const result = await runShell(
+        [
+          `if [ ! -e ${shellQuote(
+            target,
+          )} ]; then echo "__CLINE_GREP_NOT_FOUND__"; exit 2; fi`,
+          `grep ${flags.map(shellQuote).join(' ')} -- ${shellQuote(
+            pattern,
+          )} ${shellQuote(target)} 2>/dev/null | head -n ${limit}`,
+        ].join('; '),
+      );
+
+      const output = result.output.trim();
+      if (output.includes('__CLINE_GREP_NOT_FOUND__')) {
+        throw new Error(`Path not found: ${input.path ?? '.'}`);
+      }
+      return output || 'No matches found';
+    },
+
+    async glob(pattern, inputPath = '.', limit = 1_000) {
+      const target = resolvePath(inputPath);
+      const result = await runShell(
+        [
+          `if [ ! -e ${shellQuote(
+            target,
+          )} ]; then echo "__CLINE_FIND_NOT_FOUND__"; exit 2; fi`,
+          `if [ -d ${shellQuote(target)} ]; then find ${shellQuote(
+            target,
+          )} -type f -print; else printf '%s\\n' ${shellQuote(target)}; fi`,
+        ].join('; '),
+      );
+
+      const output = result.output.trim();
+      if (output.includes('__CLINE_FIND_NOT_FOUND__')) {
+        throw new Error(`Path not found: ${inputPath}`);
+      }
+
+      return output
+        .split('\n')
+        .filter(Boolean)
+        .map(absolutePath => {
+          if (absolutePath === target) {
+            return path.posix.basename(absolutePath);
+          }
+          return path.posix.relative(target, absolutePath);
+        })
+        .filter(
+          candidate =>
+            candidate.length > 0 && path.matchesGlob(candidate, pattern),
+        )
+        .sort((left, right) =>
+          left.toLowerCase().localeCompare(right.toLowerCase()),
+        )
+        .slice(0, limit);
+    },
+
+    async ls(inputPath = '.', limit = 500) {
+      const target = resolvePath(inputPath);
+      const result = await runShell(
+        [
+          `if [ ! -e ${shellQuote(
+            target,
+          )} ]; then echo "__CLINE_LS_NOT_FOUND__"; exit 2; fi`,
+          `if [ ! -d ${shellQuote(
+            target,
+          )} ]; then echo "__CLINE_LS_NOT_DIR__"; exit 3; fi`,
+          `cd ${shellQuote(target)}`,
+          'ls -1Ap',
+        ].join('; '),
+      );
+
+      const output = result.output.trim();
+      if (output.includes('__CLINE_LS_NOT_FOUND__')) {
+        throw new Error(`Path not found: ${inputPath}`);
+      }
+      if (output.includes('__CLINE_LS_NOT_DIR__')) {
+        throw new Error(`Not a directory: ${inputPath}`);
+      }
+
+      return output
+        .split('\n')
+        .filter(Boolean)
+        .map(line => line.replace(/[*=@|]$/, ''))
+        .sort((left, right) =>
+          left.toLowerCase().localeCompare(right.toLowerCase()),
+        )
+        .slice(0, limit);
+    },
+  };
+}

--- a/packages/harness-cline/src/cline-resume-state.test.ts
+++ b/packages/harness-cline/src/cline-resume-state.test.ts
@@ -1,0 +1,114 @@
+import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
+import { describe, expect, it } from 'vitest';
+import {
+  clineResumeStateSchema,
+  persistHistoryToSandbox,
+  pullHistoryFromSandbox,
+  safeClineHistoryFileName,
+} from './cline-resume-state';
+
+function createFakeSandbox(files: Map<string, string>) {
+  return {
+    writeTextFile: async ({
+      path,
+      content,
+    }: {
+      path: string;
+      content: string;
+    }) => {
+      files.set(path, content);
+    },
+    readTextFile: async ({ path }: { path: string }) => files.get(path) ?? null,
+  } as unknown as Experimental_SandboxSession;
+}
+
+describe('safeClineHistoryFileName', () => {
+  it('accepts plain .json basenames', () => {
+    expect(safeClineHistoryFileName('history.json')).toBe('history.json');
+  });
+
+  it.each(['../evil.json', 'a/b.json', '.hidden.json', 'nope.txt', ''])(
+    'rejects %j',
+    name => {
+      expect(() => safeClineHistoryFileName(name)).toThrow(
+        /Invalid Cline history file name/,
+      );
+    },
+  );
+});
+
+describe('clineResumeStateSchema', () => {
+  it('accepts a valid payload', () => {
+    expect(
+      clineResumeStateSchema.parse({ historyFileName: 'history.json' }),
+    ).toEqual({ historyFileName: 'history.json' });
+  });
+
+  it('accepts an empty payload', () => {
+    expect(clineResumeStateSchema.parse({})).toEqual({});
+  });
+
+  it('rejects unsafe file names', () => {
+    expect(() =>
+      clineResumeStateSchema.parse({ historyFileName: '../evil.json' }),
+    ).toThrow();
+  });
+});
+
+describe('persist/pull history round trip', () => {
+  const messages = [
+    {
+      id: 'm1',
+      role: 'user' as const,
+      content: [{ type: 'text' as const, text: 'hello' }],
+      createdAt: 1,
+    },
+  ];
+
+  it('round-trips history through the sandbox', async () => {
+    const files = new Map<string, string>();
+    const sandbox = createFakeSandbox(files);
+
+    await persistHistoryToSandbox({
+      sandbox,
+      sessionWorkDir: '/sandbox/work/cline-s1',
+      historyFileName: 'history.json',
+      messages,
+    });
+    expect([...files.keys()]).toEqual([
+      '/sandbox/work/cline-s1/.cline-harness/history.json',
+    ]);
+
+    const restored = await pullHistoryFromSandbox({
+      sandbox,
+      sessionWorkDir: '/sandbox/work/cline-s1',
+      historyFileName: 'history.json',
+    });
+    expect(restored).toEqual(messages);
+  });
+
+  it('returns undefined for a missing history file', async () => {
+    const sandbox = createFakeSandbox(new Map());
+    expect(
+      await pullHistoryFromSandbox({
+        sandbox,
+        sessionWorkDir: '/sandbox/work/cline-s1',
+        historyFileName: 'history.json',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for corrupt history content', async () => {
+    const files = new Map([
+      ['/sandbox/work/cline-s1/.cline-harness/history.json', 'not json'],
+    ]);
+    const sandbox = createFakeSandbox(files);
+    expect(
+      await pullHistoryFromSandbox({
+        sandbox,
+        sessionWorkDir: '/sandbox/work/cline-s1',
+        historyFileName: 'history.json',
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/harness-cline/src/cline-resume-state.ts
+++ b/packages/harness-cline/src/cline-resume-state.ts
@@ -1,0 +1,115 @@
+import path from 'node:path';
+import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
+import type { AgentMessage } from '@cline/agents';
+import { z } from 'zod/v4';
+
+const CLINE_HISTORY_FILE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*\.json$/;
+
+export function safeClineHistoryFileName(historyFileName: string): string {
+  if (!CLINE_HISTORY_FILE_NAME_PATTERN.test(historyFileName)) {
+    throw new Error(`Invalid Cline history file name: ${historyFileName}`);
+  }
+  return historyFileName;
+}
+
+const clineHistoryFileNameSchema = z
+  .string()
+  .refine(
+    historyFileName => CLINE_HISTORY_FILE_NAME_PATTERN.test(historyFileName),
+    'Cline historyFileName must be a safe .json basename.',
+  );
+
+/**
+ * Schema for the adapter-specific portion of lifecycle state `data` produced
+ * by the Cline harness's resumable lifecycle methods. Carries the basename of
+ * the serialized conversation history. The actual history bytes live in the
+ * sandbox under `${sessionWorkDir}/.cline-harness/<historyFileName>` so they
+ * survive cross-process resume via the sandbox snapshot.
+ */
+export const clineResumeStateSchema = z.looseObject({
+  historyFileName: clineHistoryFileNameSchema.optional(),
+});
+
+export type ClineResumeStateData = z.infer<typeof clineResumeStateSchema>;
+
+const CLINE_HISTORY_DIR = '.cline-harness';
+
+export const CLINE_DEFAULT_HISTORY_FILE_NAME = 'history.json';
+
+function resolveContainedSandboxPath(input: {
+  readonly sessionWorkDir: string;
+  readonly historyFileName: string;
+}): string {
+  const historyDir = path.posix.resolve(
+    input.sessionWorkDir,
+    CLINE_HISTORY_DIR,
+  );
+  const filePath = path.posix.resolve(
+    historyDir,
+    safeClineHistoryFileName(input.historyFileName),
+  );
+  const relativePath = path.posix.relative(historyDir, filePath);
+  if (
+    relativePath === '' ||
+    relativePath.startsWith('..') ||
+    path.posix.isAbsolute(relativePath)
+  ) {
+    throw new Error(
+      `Invalid Cline history file name: ${input.historyFileName}`,
+    );
+  }
+  return filePath;
+}
+
+/**
+ * Persist the runtime's conversation history into the sandbox workspace so a
+ * future process can resume the session after
+ * `HarnessV1SandboxProvider.resume?.({ sessionId })` reattaches the sandbox.
+ */
+export async function persistHistoryToSandbox(args: {
+  readonly sandbox: Experimental_SandboxSession;
+  readonly sessionWorkDir: string;
+  readonly historyFileName: string;
+  readonly messages: readonly AgentMessage[];
+  readonly abortSignal?: AbortSignal;
+}): Promise<void> {
+  const remotePath = resolveContainedSandboxPath({
+    sessionWorkDir: args.sessionWorkDir,
+    historyFileName: args.historyFileName,
+  });
+  // `writeTextFile` creates parent directories recursively per the
+  // SandboxSession contract.
+  await args.sandbox.writeTextFile({
+    path: remotePath,
+    content: JSON.stringify(args.messages),
+    ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
+  });
+}
+
+/**
+ * Pull a previously persisted conversation history from the sandbox. Returns
+ * `undefined` when the file is missing or unparsable — resume then falls back
+ * to a fresh conversation rather than failing `doStart`.
+ */
+export async function pullHistoryFromSandbox(args: {
+  readonly sandbox: Experimental_SandboxSession;
+  readonly sessionWorkDir: string;
+  readonly historyFileName: string;
+  readonly abortSignal?: AbortSignal;
+}): Promise<AgentMessage[] | undefined> {
+  const remotePath = resolveContainedSandboxPath({
+    sessionWorkDir: args.sessionWorkDir,
+    historyFileName: args.historyFileName,
+  });
+  const content = await args.sandbox.readTextFile({
+    path: remotePath,
+    ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
+  });
+  if (content == null) return undefined;
+  try {
+    const parsed = JSON.parse(content);
+    return Array.isArray(parsed) ? (parsed as AgentMessage[]) : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/harness-cline/src/cline-session.ts
+++ b/packages/harness-cline/src/cline-session.ts
@@ -1,0 +1,691 @@
+import {
+  HarnessCapabilityUnsupportedError,
+  type HarnessV1BuiltinToolFiltering,
+  type HarnessV1ContinueTurnOptions,
+  type HarnessV1ContinueTurnState,
+  type HarnessV1NetworkSandboxSession,
+  type HarnessV1PermissionMode,
+  type HarnessV1PromptControl,
+  type HarnessV1PromptTurnOptions,
+  type HarnessV1ResumeSessionState,
+  type HarnessV1Session,
+  type HarnessV1Skill,
+  type HarnessV1StreamPart,
+  type HarnessV1ToolSpec,
+} from '@ai-sdk/harness';
+import { Agent, type AgentMessage, type AgentRunResult } from '@cline/agents';
+import { createClineRemoteOps } from './cline-remote-ops';
+import {
+  CLINE_DEFAULT_HISTORY_FILE_NAME,
+  persistHistoryToSandbox,
+  pullHistoryFromSandbox,
+  safeClineHistoryFileName,
+} from './cline-resume-state';
+import { renderSkillsPromptSection, writeClineSkills } from './cline-skills';
+import {
+  buildBuiltinAgentTools,
+  buildUserAgentTools,
+  CLINE_NATIVE_TOOL_KINDS,
+  isClineBuiltinToolName,
+  resolveActiveClineBuiltinNames,
+  type PendingToolResult,
+} from './cline-tools';
+import {
+  createClineTranslatorState,
+  finishClineTranslation,
+  toolApprovalParts,
+  translateClineEvent,
+  type ClineTranslatorState,
+} from './cline-translate';
+import {
+  extractUserText,
+  frameInstructions,
+  mapRunFinishReason,
+  usageFromAgentUsage,
+} from './cline-utils';
+
+const HARNESS_ID = 'cline';
+
+/*
+ * The Cline runtime lives in this Node process, not behind an attachable
+ * in-sandbox bridge. During a tool approval pause the turn is still alive and
+ * blocked on a parked promise, so detach must keep that live session for the
+ * next same-process resume instead of stopping it and failing the promise.
+ * Cross-process resume falls back to the history file persisted in the
+ * sandbox.
+ */
+const parkedClineSessions = new Map<string, HarnessV1Session>();
+
+export interface ClineSessionSettings {
+  readonly providerId: string;
+  readonly modelId: string;
+  readonly apiKey?: string;
+  readonly baseUrl?: string;
+  readonly headers?: Record<string, string>;
+  readonly systemPrompt?: string;
+  readonly maxIterations?: number;
+}
+
+export interface CreateClineSessionInput {
+  readonly sessionId: string;
+  readonly sandboxSession: HarnessV1NetworkSandboxSession;
+  readonly sessionWorkDir: string;
+  readonly skills: ReadonlyArray<HarnessV1Skill>;
+  readonly settings: ClineSessionSettings;
+  readonly isResume: boolean;
+  readonly permissionMode?: HarnessV1PermissionMode;
+  readonly builtinToolFiltering?: HarnessV1BuiltinToolFiltering;
+  readonly resumeHistoryFileName?: string;
+  readonly abortSignal?: AbortSignal;
+}
+
+interface PendingToolApproval {
+  resolve: (value: { approved: boolean; reason?: string }) => void;
+}
+
+interface ActiveClineTurn {
+  readonly token: object;
+  readonly done: Promise<void>;
+}
+
+/**
+ * Whether a thrown error is an abort — the expected result of
+ * `doSuspendTurn` aborting the in-flight turn. Only these are safe to swallow
+ * while `suspending`; any other error must surface as an `error` chunk.
+ */
+function isAbortError(value: unknown): boolean {
+  if (value == null) return false;
+  const name = (value as { name?: unknown }).name;
+  if (name === 'AbortError' || name === 'AgentRuntimeAbortError') {
+    return true;
+  }
+  const text =
+    typeof value === 'string'
+      ? value
+      : value instanceof Error
+        ? value.message
+        : String(value);
+  return /\baborted\b|AbortError/i.test(text);
+}
+
+function clineBuiltinToolRequiresApproval(input: {
+  permissionMode: HarnessV1PermissionMode;
+  kind: 'readonly' | 'edit' | 'bash';
+}): boolean {
+  if (input.permissionMode === 'allow-all') return false;
+  if (input.permissionMode === 'allow-edits') return input.kind === 'bash';
+  return input.kind === 'edit' || input.kind === 'bash';
+}
+
+function buildSystemPrompt(input: {
+  sessionWorkDir: string;
+  sandboxDescription: string;
+  skillsSection?: string;
+  extraSystemPrompt?: string;
+}): string {
+  const sections = [
+    'You are Cline, an autonomous coding agent operating inside a sandboxed workspace.',
+    `## Workspace\n\nThe workspace root is \`${input.sessionWorkDir}\`. All relative file paths and shell commands resolve against it. Use the provided tools (read, write, edit, bash, grep, glob, ls) to inspect and modify the workspace.`,
+    `## Sandbox\n\n${input.sandboxDescription}`,
+  ];
+  if (input.skillsSection) {
+    sections.push(input.skillsSection);
+  }
+  if (input.extraSystemPrompt) {
+    sections.push(input.extraSystemPrompt);
+  }
+  return sections.join('\n\n');
+}
+
+export async function createClineSession(
+  input: CreateClineSessionInput,
+): Promise<HarnessV1Session> {
+  if (input.isResume) {
+    const parkedSession = parkedClineSessions.get(input.sessionId);
+    if (parkedSession) {
+      parkedClineSessions.delete(input.sessionId);
+      return {
+        ...parkedSession,
+        isResume: true,
+      };
+    }
+  }
+
+  const sandbox = input.sandboxSession.restricted();
+  const permissionMode = input.permissionMode ?? 'allow-all';
+  const activeBuiltinNames = resolveActiveClineBuiltinNames(
+    input.builtinToolFiltering,
+  );
+
+  const ops = createClineRemoteOps({
+    sandbox,
+    workDir: input.sessionWorkDir,
+  });
+
+  // Materialize harness-provided skills into sandbox HOME (not the workspace)
+  // and advertise them via a system prompt section.
+  let skillsSection: string | undefined;
+  if (input.skills.length > 0) {
+    const skillRootDir = await writeClineSkills({
+      sandbox,
+      skills: input.skills,
+      ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
+    });
+    if (skillRootDir) {
+      skillsSection = renderSkillsPromptSection(input.skills, skillRootDir);
+    }
+  }
+
+  const systemPrompt = buildSystemPrompt({
+    sessionWorkDir: input.sessionWorkDir,
+    sandboxDescription: sandbox.description,
+    ...(skillsSection ? { skillsSection } : {}),
+    ...(input.settings.systemPrompt
+      ? { extraSystemPrompt: input.settings.systemPrompt }
+      : {}),
+  });
+
+  // On resume: pull the persisted conversation history from the sandbox so
+  // the fresh runtime instance starts from the prior transcript.
+  let currentMessages: readonly AgentMessage[] = [];
+  if (input.isResume && input.resumeHistoryFileName) {
+    const restored = await pullHistoryFromSandbox({
+      sandbox,
+      sessionWorkDir: input.sessionWorkDir,
+      historyFileName: safeClineHistoryFileName(input.resumeHistoryFileName),
+      ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
+    });
+    if (restored) {
+      currentMessages = restored;
+    }
+  }
+
+  // Per-session mutable state we hold across prompts.
+  let agent: Agent | undefined;
+  let unsubscribe: (() => void) | undefined;
+  let lastToolsSignature: string | undefined;
+  let agentHasRun = false;
+  let stopped = false;
+  /*
+   * Set by `doSuspendTurn` before it aborts the in-flight turn at a slice
+   * boundary. The turn settles silently when this is set, so the stream
+   * closes cleanly (no spurious `error` chunk) — the next slice
+   * rerun-continues from the persisted history.
+   */
+  let suspending = false;
+  /*
+   * Instructions are prepended to the first user message of a fresh session
+   * only. A resumed session already carried them in its original first
+   * message (preserved in the persisted history), so it starts "applied".
+   */
+  let instructionsApplied = input.isResume;
+  const pendingToolResults = new Map<string, PendingToolResult>();
+  const pendingToolApprovals = new Map<string, PendingToolApproval>();
+  const pendingUserMessages: string[] = [];
+
+  // Emit channel set at the start of every turn and cleared on end.
+  let currentEmit: ((part: HarnessV1StreamPart) => void) | undefined;
+  let translatorState: ClineTranslatorState | undefined;
+  let activeTurn: ActiveClineTurn | undefined;
+
+  function settlePendingToolResults(reason: string): void {
+    for (const pending of pendingToolResults.values()) {
+      pending.resolve({ error: reason });
+    }
+    pendingToolResults.clear();
+  }
+
+  function settlePendingToolApprovals(reason: string): void {
+    for (const pending of pendingToolApprovals.values()) {
+      pending.resolve({ approved: false, reason });
+    }
+    pendingToolApprovals.clear();
+  }
+
+  async function persistHistory(): Promise<void> {
+    const messages = agent?.snapshot().messages ?? currentMessages;
+    await persistHistoryToSandbox({
+      sandbox,
+      sessionWorkDir: input.sessionWorkDir,
+      historyFileName: CLINE_DEFAULT_HISTORY_FILE_NAME,
+      messages,
+    });
+  }
+
+  function requestBuiltinToolApproval(toolCall: {
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+  }): Promise<{ approved: boolean; reason?: string }> {
+    if (translatorState && currentEmit) {
+      for (const part of toolApprovalParts(translatorState, toolCall)) {
+        currentEmit(part);
+      }
+    }
+    return new Promise(resolve => {
+      pendingToolApprovals.set(toolCall.toolCallId, { resolve });
+    });
+  }
+
+  function rebuildAgent(userTools: ReadonlyArray<HarnessV1ToolSpec>): void {
+    unsubscribe?.();
+    unsubscribe = undefined;
+    agent = new Agent({
+      providerId: input.settings.providerId,
+      modelId: input.settings.modelId,
+      ...(input.settings.apiKey ? { apiKey: input.settings.apiKey } : {}),
+      ...(input.settings.baseUrl ? { baseUrl: input.settings.baseUrl } : {}),
+      ...(input.settings.headers ? { headers: input.settings.headers } : {}),
+      sessionId: input.sessionId,
+      systemPrompt,
+      initialMessages: currentMessages,
+      ...(input.settings.maxIterations !== undefined
+        ? { maxIterations: input.settings.maxIterations }
+        : {}),
+      tools: [
+        ...buildBuiltinAgentTools({ ops, activeNames: activeBuiltinNames }),
+        ...buildUserAgentTools({ specs: userTools, pendingToolResults }),
+      ],
+      // Built-in tools whose kind requires approval under the session's
+      // permission mode are marked `autoApprove: false`; the runtime then
+      // routes them through `requestToolApproval` below. User tools are
+      // approved by the harness framework, never by the adapter.
+      toolPolicies: Object.fromEntries(
+        activeBuiltinNames
+          .filter(name =>
+            clineBuiltinToolRequiresApproval({
+              permissionMode,
+              kind: CLINE_NATIVE_TOOL_KINDS[name],
+            }),
+          )
+          .map(name => [name, { autoApprove: false }]),
+      ),
+      requestToolApproval: request => {
+        if (!isClineBuiltinToolName(request.toolName)) {
+          // Custom host-executed tool approvals are handled by the framework
+          // before results are submitted back; the adapter never gates them.
+          return { approved: true };
+        }
+        return requestBuiltinToolApproval({
+          toolCallId: request.toolCallId,
+          toolName: request.toolName,
+          input: request.input,
+        });
+      },
+      // Mid-turn user messages injected via `submitUserMessage` are consumed
+      // by the runtime between loop iterations, before the next model call.
+      consumePendingUserMessage: () => pendingUserMessages.shift(),
+    });
+    agentHasRun = false;
+
+    unsubscribe = agent.subscribe(event => {
+      if (!translatorState || !currentEmit) return;
+      for (const part of translateClineEvent(event, translatorState)) {
+        currentEmit(part);
+      }
+    });
+  }
+
+  function createPromptControl(controlInput: {
+    done: Promise<void>;
+    abortSignal?: AbortSignal;
+  }): HarnessV1PromptControl {
+    const abortHandler = () => {
+      // Settle parked host-tool promises first so the runtime's tool
+      // executions do not dangle, then abort the loop itself.
+      settlePendingToolResults('Turn aborted');
+      settlePendingToolApprovals('Turn aborted');
+      agent?.abort('Turn aborted by caller');
+    };
+    if (controlInput.abortSignal) {
+      controlInput.abortSignal.addEventListener('abort', abortHandler, {
+        once: true,
+      });
+      void controlInput.done.then(
+        () => {
+          controlInput.abortSignal?.removeEventListener('abort', abortHandler);
+        },
+        () => {
+          controlInput.abortSignal?.removeEventListener('abort', abortHandler);
+        },
+      );
+    }
+
+    return {
+      async submitToolResult(args) {
+        const pending = pendingToolResults.get(args.toolCallId);
+        if (!pending) return;
+        pendingToolResults.delete(args.toolCallId);
+        pending.resolve(args.output);
+      },
+      async submitToolApproval(args) {
+        const pending = pendingToolApprovals.get(args.approvalId);
+        if (!pending) return;
+        pendingToolApprovals.delete(args.approvalId);
+        pending.resolve({
+          approved: args.approved,
+          ...(args.reason !== undefined ? { reason: args.reason } : {}),
+        });
+      },
+      async submitUserMessage(text) {
+        pendingUserMessages.push(text);
+      },
+      done: controlInput.done,
+    };
+  }
+
+  /*
+   * Drive one turn against the Cline runtime and return the control surface.
+   * Shared by `doPromptTurn` (a fresh user prompt) and `doContinueTurn`
+   * (no prompt — the runtime continues its own thread after a rerun resume).
+   */
+  function runTurn(turnOpts: {
+    text: string | undefined;
+    tools: ReadonlyArray<HarnessV1ToolSpec>;
+    emit: (part: HarnessV1StreamPart) => void;
+    abortSignal?: AbortSignal;
+  }): HarnessV1PromptControl {
+    if (stopped) {
+      throw new Error('Cline session has been stopped.');
+    }
+
+    const userTools = turnOpts.tools;
+    const signature = JSON.stringify(userTools.map(t => t.name).sort());
+    if (agent == null || signature !== lastToolsSignature) {
+      currentMessages = agent?.snapshot().messages ?? currentMessages;
+      rebuildAgent(userTools);
+      lastToolsSignature = signature;
+    }
+
+    currentEmit = turnOpts.emit;
+    translatorState = createClineTranslatorState({
+      builtinToolNames: activeBuiltinNames,
+    });
+
+    turnOpts.emit({
+      type: 'stream-start',
+      modelId: input.settings.modelId,
+    });
+
+    const turnPromise = (async () => {
+      const runtime = agent!;
+      let result: AgentRunResult;
+      try {
+        // `text` is undefined only on rerun-continue: `continue()` without
+        // input re-drives the loop from the restored transcript instead of
+        // pushing an empty user message.
+        result =
+          turnOpts.text === undefined
+            ? await runtime.continue()
+            : agentHasRun
+              ? await runtime.continue(turnOpts.text)
+              : await runtime.run(turnOpts.text);
+        agentHasRun = true;
+      } catch (error) {
+        // `run` resolves for aborted/failed statuses; a throw here is
+        // unanticipated (e.g. config error). Swallow only the abort our own
+        // suspend caused; surface anything else.
+        if (suspending && isAbortError(error)) return;
+        currentEmit?.({ type: 'error', error });
+        return;
+      }
+
+      currentMessages = result.messages;
+
+      if (translatorState) {
+        for (const part of finishClineTranslation(translatorState)) {
+          currentEmit?.(part);
+        }
+      }
+
+      if (result.status === 'aborted') {
+        /*
+         * A `doSuspendTurn` aborts the in-flight turn on purpose — settle
+         * silently so the stream closes cleanly; the next slice
+         * rerun-continues from the persisted history. Caller-driven aborts
+         * finish the turn with an `other`/aborted reason.
+         */
+        if (suspending) return;
+        currentEmit?.({
+          type: 'finish',
+          finishReason: mapRunFinishReason(result.status),
+          totalUsage: usageFromAgentUsage(result.usage),
+        });
+        return;
+      }
+
+      if (result.status === 'failed') {
+        currentEmit?.({
+          type: 'error',
+          error: result.error ?? new Error('Cline agent run failed'),
+        });
+        return;
+      }
+
+      currentEmit?.({
+        type: 'finish',
+        finishReason: mapRunFinishReason(result.status),
+        totalUsage: usageFromAgentUsage(result.usage),
+      });
+    })();
+
+    const activeTurnToken = {};
+    const done = turnPromise.finally(() => {
+      if (activeTurn?.token === activeTurnToken) {
+        activeTurn = undefined;
+      }
+      currentEmit = undefined;
+    });
+    activeTurn = {
+      token: activeTurnToken,
+      done,
+    };
+
+    return createPromptControl({
+      done,
+      ...(turnOpts.abortSignal ? { abortSignal: turnOpts.abortSignal } : {}),
+    });
+  }
+
+  function teardown(): void {
+    unsubscribe?.();
+    unsubscribe = undefined;
+    agent = undefined;
+  }
+
+  const doStop = async (): Promise<HarnessV1ResumeSessionState> => {
+    if (stopped) {
+      throw new Error('Cline session has been stopped.');
+    }
+    stopped = true;
+    parkedClineSessions.delete(input.sessionId);
+    settlePendingToolResults('Cline session stopped');
+    settlePendingToolApprovals('Cline session stopped');
+
+    // Persist the conversation into the sandbox so a future process can pick
+    // it up after the sandbox provider reattaches.
+    try {
+      await persistHistory();
+    } catch {
+      // Best-effort: a missing history file means resume returns to a fresh
+      // conversation rather than failing stop.
+    }
+
+    agent?.abort('Cline session stopped');
+    teardown();
+
+    return {
+      type: 'resume-session',
+      harnessId: HARNESS_ID,
+      specificationVersion: 'harness-v1',
+      data: { historyFileName: CLINE_DEFAULT_HISTORY_FILE_NAME },
+    };
+  };
+
+  const sessionImpl: HarnessV1Session = {
+    sessionId: input.sessionId,
+    isResume: input.isResume,
+    modelId: input.settings.modelId,
+
+    // The Cline runtime has no bridge to attach to and no in-sandbox event
+    // log to replay; its only cross-process resume path is restoring the
+    // persisted history on a fresh runtime, i.e. `rerun`.
+
+    doPromptTurn: async (
+      promptOpts: HarnessV1PromptTurnOptions,
+    ): Promise<HarnessV1PromptControl> => {
+      let text = extractUserText(promptOpts.prompt);
+      if (!instructionsApplied && promptOpts.instructions) {
+        text = frameInstructions(promptOpts.instructions, text);
+      }
+      instructionsApplied = true;
+
+      return runTurn({
+        text,
+        tools: promptOpts.tools ?? [],
+        emit: promptOpts.emit,
+        ...(promptOpts.abortSignal
+          ? { abortSignal: promptOpts.abortSignal }
+          : {}),
+      });
+    },
+
+    doContinueTurn: async (
+      continueOpts: HarnessV1ContinueTurnOptions,
+    ): Promise<HarnessV1PromptControl> => {
+      if (activeTurn != null) {
+        currentEmit = continueOpts.emit;
+        return createPromptControl({
+          done: activeTurn.done,
+          ...(continueOpts.abortSignal
+            ? { abortSignal: continueOpts.abortSignal }
+            : {}),
+        });
+      }
+
+      /*
+       * The model runs on the host, so there is no live turn to attach to —
+       * the previous slice's turn died with its process. Rerun-continue:
+       * re-drive the runtime from the history restored on resume. Lossy —
+       * work in flight at the slice boundary is recomputed, because a
+       * host-resident runtime cannot do a lossless attach.
+       */
+      return runTurn({
+        text: undefined,
+        tools: continueOpts.tools ?? [],
+        emit: continueOpts.emit,
+        ...(continueOpts.abortSignal
+          ? { abortSignal: continueOpts.abortSignal }
+          : {}),
+      });
+    },
+
+    doCompact: async () => {
+      throw new HarnessCapabilityUnsupportedError({
+        message:
+          'cline: manual compaction is not supported by the standalone Cline runtime.',
+        harnessId: HARNESS_ID,
+      });
+    },
+
+    doDestroy: async () => {
+      if (stopped) return;
+      stopped = true;
+      parkedClineSessions.delete(input.sessionId);
+      settlePendingToolResults('Cline session stopped');
+      settlePendingToolApprovals('Cline session stopped');
+      agent?.abort('Cline session destroyed');
+      teardown();
+    },
+
+    doStop,
+
+    doDetach: async (): Promise<HarnessV1ResumeSessionState> => {
+      if (activeTurn != null || pendingToolResults.size > 0) {
+        parkedClineSessions.set(input.sessionId, sessionImpl);
+        try {
+          await persistHistory();
+        } catch {
+          /*
+           * The parked in-process session is the authoritative continuation
+           * path while the live turn is waiting on host input. Persistence
+           * is only a fallback for later non-live resumes.
+           */
+        }
+        return {
+          type: 'resume-session',
+          harnessId: HARNESS_ID,
+          specificationVersion: 'harness-v1',
+          data: { historyFileName: CLINE_DEFAULT_HISTORY_FILE_NAME },
+        };
+      }
+      return doStop();
+    },
+
+    doSuspendTurn: async (): Promise<HarnessV1ContinueTurnState> => {
+      if (stopped) {
+        throw new Error('Cline session has been stopped.');
+      }
+      if (
+        activeTurn != null &&
+        (pendingToolResults.size > 0 || pendingToolApprovals.size > 0)
+      ) {
+        parkedClineSessions.set(input.sessionId, sessionImpl);
+        try {
+          await persistHistory();
+        } catch {
+          /*
+           * While waiting on host input, the live parked session is the
+           * authoritative same-process continuation path. The sandbox copy
+           * remains a best-effort fallback for a later cold resume.
+           */
+        }
+        return {
+          type: 'continue-turn',
+          harnessId: HARNESS_ID,
+          specificationVersion: 'harness-v1',
+          data: { historyFileName: CLINE_DEFAULT_HISTORY_FILE_NAME },
+        };
+      }
+      /*
+       * The model runs in this host process, which is about to be suspended
+       * at the slice boundary — the in-flight turn cannot survive it. Abort
+       * it (the turn settles silently via the `suspending` guard so the
+       * stream closes cleanly), persist the history into the sandbox, and
+       * tear down host-side resources. The sandbox itself is left running;
+       * the next slice pulls the history after the sandbox provider
+       * reattaches and rerun-continues. The tail in flight at the boundary
+       * is recomputed — a host-resident runtime cannot freeze a live turn
+       * the way a bridge adapter can.
+       */
+      suspending = true;
+      agent?.abort('Cline session suspended');
+      if (activeTurn) {
+        await activeTurn.done.catch(() => {});
+      }
+
+      try {
+        await persistHistory();
+      } catch {
+        // Best-effort: a missing/failed copy leaves the previously persisted
+        // history in place, so the next slice resumes from a slightly older
+        // (still valid) state.
+      }
+
+      stopped = true;
+      parkedClineSessions.delete(input.sessionId);
+      settlePendingToolResults('Cline session suspended');
+      settlePendingToolApprovals('Cline session suspended');
+      teardown();
+
+      return {
+        type: 'continue-turn',
+        harnessId: HARNESS_ID,
+        specificationVersion: 'harness-v1',
+        data: { historyFileName: CLINE_DEFAULT_HISTORY_FILE_NAME },
+      };
+    },
+  };
+
+  return sessionImpl;
+}

--- a/packages/harness-cline/src/cline-skills.ts
+++ b/packages/harness-cline/src/cline-skills.ts
@@ -1,0 +1,61 @@
+import path from 'node:path';
+import type { HarnessV1Skill } from '@ai-sdk/harness';
+import { resolveSandboxHomeDir, writeSkills } from '@ai-sdk/harness/utils';
+import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
+
+/**
+ * Materialize harness-provided skills into the sandbox HOME
+ * (`~/.agents/skills/<name>/SKILL.md` plus any auxiliary files) and return
+ * the root directory they were written to. The Cline runtime has no native
+ * skill loader, so the session surfaces them to the model through a system
+ * prompt section (see `renderSkillsPromptSection`) that points at these files.
+ */
+export async function writeClineSkills({
+  sandbox,
+  skills,
+  abortSignal,
+}: {
+  sandbox: Experimental_SandboxSession;
+  skills: ReadonlyArray<HarnessV1Skill>;
+  abortSignal?: AbortSignal;
+}): Promise<string | undefined> {
+  if (skills.length === 0) return undefined;
+  const sandboxHomeDir = await resolveSandboxHomeDir({
+    sandbox,
+    ...(abortSignal ? { abortSignal } : {}),
+  });
+  const skillRootDir = path.posix.join(sandboxHomeDir, '.agents', 'skills');
+  await writeSkills({
+    sandbox,
+    rootDir: skillRootDir,
+    skills,
+    ...(abortSignal ? { abortSignal } : {}),
+  });
+  return skillRootDir;
+}
+
+/**
+ * Render the system-prompt section that advertises available skills. Only the
+ * name + description sit in context; the model loads the full skill via the
+ * `read` tool when the task calls for it (progressive disclosure).
+ */
+export function renderSkillsPromptSection(
+  skills: ReadonlyArray<HarnessV1Skill>,
+  skillRootDir: string,
+): string {
+  const entries = skills
+    .map(
+      skill =>
+        `- ${skill.name}: ${skill.description}\n  SKILL.md: ${path.posix.join(
+          skillRootDir,
+          skill.name,
+          'SKILL.md',
+        )}`,
+    )
+    .join('\n');
+  return (
+    '## Skills\n\n' +
+    'The following skills are available. When a task matches a skill, read its SKILL.md with the `read` tool and follow its instructions.\n\n' +
+    entries
+  );
+}

--- a/packages/harness-cline/src/cline-tools.ts
+++ b/packages/harness-cline/src/cline-tools.ts
@@ -1,0 +1,327 @@
+import type {
+  HarnessV1BuiltinToolFiltering,
+  HarnessV1ToolSpec,
+} from '@ai-sdk/harness';
+import { createTool, type AgentTool } from '@cline/agents';
+import type { ClineRemoteOps } from './cline-remote-ops';
+import { getErrorText } from './cline-utils';
+
+/**
+ * Native names of the Cline harness's built-in tools. The Cline runtime
+ * requires snake_case tool names, and every one of these already matches its
+ * cross-harness common name, so the public (wire) names and native names are
+ * identical.
+ */
+export const CLINE_NATIVE_BUILTIN_NAMES = [
+  'read',
+  'write',
+  'edit',
+  'bash',
+  'grep',
+  'glob',
+  'ls',
+] as const;
+
+export type ClineNativeBuiltinName =
+  (typeof CLINE_NATIVE_BUILTIN_NAMES)[number];
+
+export const CLINE_NATIVE_TOOL_KINDS: Readonly<
+  Record<ClineNativeBuiltinName, 'readonly' | 'edit' | 'bash'>
+> = {
+  read: 'readonly',
+  write: 'edit',
+  edit: 'edit',
+  bash: 'bash',
+  grep: 'readonly',
+  glob: 'readonly',
+  ls: 'readonly',
+};
+
+export function isClineBuiltinToolName(
+  name: string,
+): name is ClineNativeBuiltinName {
+  return (CLINE_NATIVE_BUILTIN_NAMES as readonly string[]).includes(name);
+}
+
+/**
+ * Resolve which built-in tools stay active for a session under the framework's
+ * `builtinToolFiltering`. Names map 1:1 (native === common), so filtering is a
+ * plain include/exclude.
+ */
+export function resolveActiveClineBuiltinNames(
+  toolFiltering: HarnessV1BuiltinToolFiltering | undefined,
+): ReadonlyArray<ClineNativeBuiltinName> {
+  if (toolFiltering == null) return CLINE_NATIVE_BUILTIN_NAMES;
+  if (toolFiltering.mode === 'allow') {
+    return CLINE_NATIVE_BUILTIN_NAMES.filter(name =>
+      toolFiltering.toolNames.includes(name),
+    );
+  }
+  return CLINE_NATIVE_BUILTIN_NAMES.filter(
+    name => !toolFiltering.toolNames.includes(name),
+  );
+}
+
+export interface PendingToolResult {
+  resolve: (value: unknown) => void;
+}
+
+/*
+ * The Cline runtime treats a thrown tool error as a "mistake" against the
+ * agent's mistake limit, so built-ins catch and return errors as structured
+ * data — the model reads the error and adjusts.
+ */
+async function guarded<T>(
+  run: () => Promise<T>,
+): Promise<T | { error: string }> {
+  try {
+    return await run();
+  } catch (error) {
+    return { error: getErrorText(error) };
+  }
+}
+
+/**
+ * Build the sandbox-backed built-in `AgentTool`s handed to the Cline runtime.
+ * These schemas mirror the zod declarations in `CLINE_BUILTIN_TOOLS`
+ * (cline-harness.ts) — keep the two in sync.
+ */
+export function buildBuiltinAgentTools({
+  ops,
+  activeNames,
+}: {
+  ops: ClineRemoteOps;
+  activeNames: ReadonlyArray<ClineNativeBuiltinName>;
+}): AgentTool<any, any>[] {
+  // biome/eslint: `any` matches the runtime's own `tools?: readonly AgentTool<any, any>[]`.
+  const tools: Partial<Record<ClineNativeBuiltinName, AgentTool<any, any>>> = {
+    read: createTool({
+      name: 'read',
+      description: 'Read file contents.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          file_path: {
+            type: 'string',
+            description: 'Path of the file to read.',
+          },
+        },
+        required: ['file_path'],
+      },
+      execute: async (input: { file_path: string }) =>
+        guarded(() => ops.readFile(input.file_path)),
+    }),
+    write: createTool({
+      name: 'write',
+      description: 'Overwrite or create a file.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          file_path: {
+            type: 'string',
+            description: 'Path of the file to write.',
+          },
+          content: {
+            type: 'string',
+            description: 'Full file content to write.',
+          },
+        },
+        required: ['file_path', 'content'],
+      },
+      execute: async (input: { file_path: string; content: string }) =>
+        guarded(async () => {
+          await ops.writeFile(input.file_path, input.content);
+          return `Wrote ${input.file_path}`;
+        }),
+    }),
+    edit: createTool({
+      name: 'edit',
+      description: 'Edit a file by exact string replacement.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          file_path: {
+            type: 'string',
+            description: 'Path of the file to edit.',
+          },
+          old_string: { type: 'string', description: 'Exact text to replace.' },
+          new_string: { type: 'string', description: 'Replacement text.' },
+        },
+        required: ['file_path', 'old_string', 'new_string'],
+      },
+      execute: async (input: {
+        file_path: string;
+        old_string: string;
+        new_string: string;
+      }) =>
+        guarded(async () => {
+          await ops.editFile(
+            input.file_path,
+            input.old_string,
+            input.new_string,
+          );
+          return `Edited ${input.file_path}`;
+        }),
+    }),
+    bash: createTool({
+      name: 'bash',
+      description:
+        'Execute a shell command in the sandbox workspace. Returns combined stdout/stderr and the exit code.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          command: { type: 'string', description: 'Shell command to execute.' },
+          timeout: {
+            type: 'number',
+            description: 'Optional timeout in seconds.',
+          },
+        },
+        required: ['command'],
+      },
+      execute: async (input: { command: string; timeout?: number }, context) =>
+        guarded(async () => {
+          const result = await ops.bash(input.command, {
+            ...(typeof input.timeout === 'number'
+              ? { timeout: input.timeout }
+              : {}),
+            ...(context.signal ? { signal: context.signal } : {}),
+          });
+          return `${result.output}${
+            result.exitCode != null ? `\n\n(exit ${result.exitCode})` : ''
+          }`.trim();
+        }),
+    }),
+    grep: createTool({
+      name: 'grep',
+      description: 'Search file contents with regex.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          pattern: {
+            type: 'string',
+            description: 'Regex pattern to search for.',
+          },
+          path: { type: 'string', description: 'File or directory to search.' },
+          glob: { type: 'string', description: 'Glob filter for file names.' },
+          ignoreCase: { type: 'boolean' },
+          literal: {
+            type: 'boolean',
+            description: 'Treat pattern as a literal string.',
+          },
+          context: {
+            type: 'number',
+            description: 'Lines of context around matches.',
+          },
+          limit: {
+            type: 'number',
+            description: 'Maximum matching lines to return.',
+          },
+        },
+        required: ['pattern'],
+      },
+      execute: async (input: {
+        pattern: string;
+        path?: string;
+        glob?: string;
+        ignoreCase?: boolean;
+        literal?: boolean;
+        context?: number;
+        limit?: number;
+      }) => guarded(() => ops.grep(input.pattern, input)),
+    }),
+    glob: createTool({
+      name: 'glob',
+      description: 'Find files matching a glob pattern.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          pattern: { type: 'string', description: 'Glob pattern to match.' },
+          path: { type: 'string', description: 'Directory to search from.' },
+          limit: { type: 'number', description: 'Maximum paths to return.' },
+        },
+        required: ['pattern'],
+      },
+      execute: async (input: {
+        pattern: string;
+        path?: string;
+        limit?: number;
+      }) =>
+        guarded(async () => {
+          const matches = await ops.glob(
+            input.pattern,
+            input.path ?? '.',
+            input.limit ?? 1_000,
+          );
+          return matches.length > 0 ? matches.join('\n') : 'No files found';
+        }),
+    }),
+    ls: createTool({
+      name: 'ls',
+      description: 'List directory entries.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Directory to list.' },
+          limit: { type: 'number', description: 'Maximum entries to return.' },
+        },
+      },
+      execute: async (input: { path?: string; limit?: number }) =>
+        guarded(async () => {
+          const entries = await ops.ls(input.path ?? '.', input.limit ?? 500);
+          return entries.join('\n');
+        }),
+    }),
+  };
+
+  return activeNames
+    .map(name => tools[name])
+    .filter((tool): tool is AgentTool<any, any> => tool != null);
+}
+
+/**
+ * Build host-executed user tools. When the model calls one, the tool parks a
+ * promise keyed by the runtime's `toolCallId`; the harness caller supplies the
+ * output via `submitToolResult`, which resolves the promise and lets the loop
+ * continue. The adapter never executes these itself.
+ */
+export function buildUserAgentTools({
+  specs,
+  pendingToolResults,
+}: {
+  specs: ReadonlyArray<HarnessV1ToolSpec>;
+  pendingToolResults: Map<string, PendingToolResult>;
+}): AgentTool<any, any>[] {
+  return specs.map(spec =>
+    createTool({
+      name: spec.name,
+      description: spec.description ?? `User-registered tool ${spec.name}`,
+      inputSchema: (spec.inputSchema as Record<string, unknown>) ?? {
+        type: 'object',
+        properties: {},
+        additionalProperties: true,
+      },
+      execute: async (_input: unknown, context) => {
+        const toolCallId = context.toolCallId;
+        if (!toolCallId) {
+          return { error: 'Tool call is missing a toolCallId.' };
+        }
+        return new Promise<unknown>(resolve => {
+          pendingToolResults.set(toolCallId, { resolve });
+          // If the turn is aborted while waiting for the host, settle so the
+          // runtime's tool execution does not dangle forever.
+          context.signal?.addEventListener(
+            'abort',
+            () => {
+              if (pendingToolResults.delete(toolCallId)) {
+                resolve({
+                  error: 'Turn was aborted before a tool result was submitted.',
+                });
+              }
+            },
+            { once: true },
+          );
+        });
+      },
+    }),
+  );
+}

--- a/packages/harness-cline/src/cline-translate.test.ts
+++ b/packages/harness-cline/src/cline-translate.test.ts
@@ -1,0 +1,270 @@
+import type {
+  AgentRuntimeEvent,
+  AgentRuntimeStateSnapshot,
+} from '@cline/agents';
+import { describe, expect, it } from 'vitest';
+import {
+  createClineTranslatorState,
+  finishClineTranslation,
+  toolApprovalParts,
+  translateClineEvent,
+} from './cline-translate';
+
+const snapshot = {} as AgentRuntimeStateSnapshot;
+
+function newState() {
+  return createClineTranslatorState({
+    builtinToolNames: ['read', 'write', 'edit', 'bash', 'grep', 'glob', 'ls'],
+  });
+}
+
+describe('translateClineEvent', () => {
+  it('opens a text block on the first delta and streams subsequent deltas', () => {
+    const state = newState();
+    const first = translateClineEvent(
+      {
+        type: 'assistant-text-delta',
+        snapshot,
+        iteration: 1,
+        text: 'Hel',
+        accumulatedText: 'Hel',
+      },
+      state,
+    );
+    expect(first.map(p => p.type)).toEqual(['text-start', 'text-delta']);
+
+    const second = translateClineEvent(
+      {
+        type: 'assistant-text-delta',
+        snapshot,
+        iteration: 1,
+        text: 'lo',
+        accumulatedText: 'Hello',
+      },
+      state,
+    );
+    expect(second.map(p => p.type)).toEqual(['text-delta']);
+  });
+
+  it('closes an open reasoning block when text starts', () => {
+    const state = newState();
+    translateClineEvent(
+      {
+        type: 'assistant-reasoning-delta',
+        snapshot,
+        iteration: 1,
+        text: 'thinking…',
+        accumulatedText: 'thinking…',
+      },
+      state,
+    );
+    const parts = translateClineEvent(
+      {
+        type: 'assistant-text-delta',
+        snapshot,
+        iteration: 1,
+        text: 'answer',
+        accumulatedText: 'answer',
+      },
+      state,
+    );
+    expect(parts.map(p => p.type)).toEqual([
+      'reasoning-end',
+      'text-start',
+      'text-delta',
+    ]);
+  });
+
+  it('closes open blocks and emits finish-step on assistant-message', () => {
+    const state = newState();
+    translateClineEvent(
+      {
+        type: 'assistant-text-delta',
+        snapshot,
+        iteration: 1,
+        text: 'hi',
+        accumulatedText: 'hi',
+      },
+      state,
+    );
+    const parts = translateClineEvent(
+      {
+        type: 'assistant-message',
+        snapshot,
+        iteration: 1,
+        finishReason: 'tool-calls',
+        message: {
+          id: 'm1',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'hi' }],
+          createdAt: 0,
+          metrics: {
+            inputTokens: 10,
+            outputTokens: 5,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+          },
+        },
+      },
+      state,
+    );
+    expect(parts.map(p => p.type)).toEqual(['text-end', 'finish-step']);
+    const finishStep = parts[1];
+    if (finishStep.type !== 'finish-step')
+      throw new Error('expected finish-step');
+    expect(finishStep.finishReason.unified).toBe('tool-calls');
+    expect(finishStep.usage.inputTokens.total).toBe(10);
+  });
+
+  it('marks built-in tool calls providerExecuted and serializes input', () => {
+    const state = newState();
+    const parts = translateClineEvent(
+      {
+        type: 'tool-started',
+        snapshot,
+        iteration: 1,
+        toolCall: {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'bash',
+          input: { command: 'ls' },
+        },
+      },
+      state,
+    );
+    expect(parts).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'bash',
+        input: JSON.stringify({ command: 'ls' }),
+        providerExecuted: true,
+      },
+    ]);
+  });
+
+  it('does not mark user tool calls providerExecuted', () => {
+    const state = newState();
+    const parts = translateClineEvent(
+      {
+        type: 'tool-started',
+        snapshot,
+        iteration: 1,
+        toolCall: {
+          type: 'tool-call',
+          toolCallId: 'call-2',
+          toolName: 'my_custom_tool',
+          input: {},
+        },
+      },
+      state,
+    );
+    if (parts[0]?.type !== 'tool-call') throw new Error('expected tool-call');
+    expect(parts[0].providerExecuted).toBeUndefined();
+  });
+
+  it('emits tool-result from the tool message', () => {
+    const state = newState();
+    const parts = translateClineEvent(
+      {
+        type: 'tool-finished',
+        snapshot,
+        iteration: 1,
+        toolCall: {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'read',
+          input: { file_path: 'a.txt' },
+        },
+        message: {
+          id: 'm2',
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              toolName: 'read',
+              output: 'file contents',
+            },
+          ],
+          createdAt: 0,
+        },
+      },
+      state,
+    );
+    expect(parts).toEqual([
+      {
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'read',
+        result: 'file contents',
+      },
+    ]);
+  });
+
+  it('ignores lifecycle events handled by the session driver', () => {
+    const state = newState();
+    for (const type of [
+      'run-started',
+      'turn-started',
+      'turn-finished',
+    ] as const) {
+      const event = { type, snapshot, iteration: 1, toolCallCount: 0 };
+      expect(
+        translateClineEvent(event as unknown as AgentRuntimeEvent, state),
+      ).toEqual([]);
+    }
+  });
+});
+
+describe('toolApprovalParts', () => {
+  it('emits tool-call before the approval request and dedupes tool-started', () => {
+    const state = newState();
+    const parts = toolApprovalParts(state, {
+      toolCallId: 'call-9',
+      toolName: 'bash',
+      input: { command: 'rm -rf build' },
+    });
+    expect(parts.map(p => p.type)).toEqual([
+      'tool-call',
+      'tool-approval-request',
+    ]);
+
+    // The runtime's own tool-started for the same call must not re-emit.
+    const later = translateClineEvent(
+      {
+        type: 'tool-started',
+        snapshot,
+        iteration: 1,
+        toolCall: {
+          type: 'tool-call',
+          toolCallId: 'call-9',
+          toolName: 'bash',
+          input: { command: 'rm -rf build' },
+        },
+      },
+      state,
+    );
+    expect(later).toEqual([]);
+  });
+});
+
+describe('finishClineTranslation', () => {
+  it('closes dangling blocks', () => {
+    const state = newState();
+    translateClineEvent(
+      {
+        type: 'assistant-reasoning-delta',
+        snapshot,
+        iteration: 1,
+        text: 'thinking…',
+        accumulatedText: 'thinking…',
+      },
+      state,
+    );
+    expect(finishClineTranslation(state).map(p => p.type)).toEqual([
+      'reasoning-end',
+    ]);
+    expect(finishClineTranslation(state)).toEqual([]);
+  });
+});

--- a/packages/harness-cline/src/cline-translate.ts
+++ b/packages/harness-cline/src/cline-translate.ts
@@ -1,0 +1,207 @@
+import type { HarnessV1StreamPart } from '@ai-sdk/harness';
+import type { AgentRuntimeEvent, AgentToolResult } from '@cline/agents';
+import {
+  mapModelFinishReason,
+  toToolResultValue,
+  usageFromMessageMetrics,
+} from './cline-utils';
+
+/**
+ * Per-turn translator state. Tracks open text/reasoning blocks (the Cline
+ * runtime streams flat deltas; the harness contract wants explicit
+ * start/delta/end block framing) and which tool calls have already been
+ * surfaced — an approval request can emit a `tool-call` part before the
+ * runtime's own `tool-started` event fires for it.
+ */
+export interface ClineTranslatorState {
+  readonly builtinToolNames: ReadonlySet<string>;
+  openTextBlockId?: string;
+  openReasoningBlockId?: string;
+  emittedToolCalls: Set<string>;
+  blockCounter: number;
+}
+
+export function createClineTranslatorState({
+  builtinToolNames,
+}: {
+  builtinToolNames: Iterable<string>;
+}): ClineTranslatorState {
+  return {
+    builtinToolNames: new Set(builtinToolNames),
+    emittedToolCalls: new Set(),
+    blockCounter: 0,
+  };
+}
+
+function closeOpenBlocks(state: ClineTranslatorState): HarnessV1StreamPart[] {
+  const parts: HarnessV1StreamPart[] = [];
+  if (state.openReasoningBlockId) {
+    parts.push({ type: 'reasoning-end', id: state.openReasoningBlockId });
+    state.openReasoningBlockId = undefined;
+  }
+  if (state.openTextBlockId) {
+    parts.push({ type: 'text-end', id: state.openTextBlockId });
+    state.openTextBlockId = undefined;
+  }
+  return parts;
+}
+
+function toolCallPart(
+  state: ClineTranslatorState,
+  toolCall: { toolCallId: string; toolName: string; input: unknown },
+): HarnessV1StreamPart {
+  return {
+    type: 'tool-call',
+    toolCallId: toolCall.toolCallId,
+    toolName: toolCall.toolName,
+    input: JSON.stringify(toolCall.input ?? {}),
+    // Built-ins are executed by the Cline runtime (against the sandbox);
+    // user tools wait for host dispatch via `submitToolResult`.
+    ...(state.builtinToolNames.has(toolCall.toolName)
+      ? { providerExecuted: true }
+      : {}),
+  };
+}
+
+/**
+ * Emit the `tool-call` + `tool-approval-request` pair for a built-in tool
+ * that requires approval. The Cline runtime asks for approval *before* its
+ * `tool-started` event fires, so the `tool-call` part is emitted here and
+ * deduplicated when `tool-started` arrives.
+ */
+export function toolApprovalParts(
+  state: ClineTranslatorState,
+  toolCall: { toolCallId: string; toolName: string; input: unknown },
+): HarnessV1StreamPart[] {
+  const parts: HarnessV1StreamPart[] = [];
+  if (!state.emittedToolCalls.has(toolCall.toolCallId)) {
+    state.emittedToolCalls.add(toolCall.toolCallId);
+    parts.push(toolCallPart(state, toolCall));
+  }
+  parts.push({
+    type: 'tool-approval-request',
+    approvalId: toolCall.toolCallId,
+    toolCallId: toolCall.toolCallId,
+  });
+  return parts;
+}
+
+/**
+ * Translate one Cline runtime event into zero or more harness stream parts.
+ * Terminal events (`run-finished`, `run-failed`) are intentionally not
+ * translated here — the session driver emits `finish`/`error` after the
+ * runtime's promise settles, so a suspend can close the stream cleanly.
+ */
+export function translateClineEvent(
+  event: AgentRuntimeEvent,
+  state: ClineTranslatorState,
+): HarnessV1StreamPart[] {
+  switch (event.type) {
+    case 'assistant-reasoning-delta': {
+      const parts: HarnessV1StreamPart[] = [];
+      if (!state.openReasoningBlockId) {
+        state.openReasoningBlockId = `reasoning-${++state.blockCounter}`;
+        parts.push({ type: 'reasoning-start', id: state.openReasoningBlockId });
+      }
+      parts.push({
+        type: 'reasoning-delta',
+        id: state.openReasoningBlockId,
+        delta: event.text,
+      });
+      return parts;
+    }
+
+    case 'assistant-text-delta': {
+      const parts: HarnessV1StreamPart[] = [];
+      if (state.openReasoningBlockId) {
+        parts.push({ type: 'reasoning-end', id: state.openReasoningBlockId });
+        state.openReasoningBlockId = undefined;
+      }
+      if (!state.openTextBlockId) {
+        state.openTextBlockId = `text-${++state.blockCounter}`;
+        parts.push({ type: 'text-start', id: state.openTextBlockId });
+      }
+      parts.push({
+        type: 'text-delta',
+        id: state.openTextBlockId,
+        delta: event.text,
+      });
+      return parts;
+    }
+
+    case 'assistant-message': {
+      const parts = closeOpenBlocks(state);
+      parts.push({
+        type: 'finish-step',
+        finishReason: mapModelFinishReason(event.finishReason),
+        usage: usageFromMessageMetrics(event.message.metrics),
+      });
+      return parts;
+    }
+
+    case 'tool-started': {
+      if (state.emittedToolCalls.has(event.toolCall.toolCallId)) {
+        return [];
+      }
+      state.emittedToolCalls.add(event.toolCall.toolCallId);
+      return [toolCallPart(state, event.toolCall)];
+    }
+
+    case 'tool-finished': {
+      // The tool message carries the runtime's recorded result for this call.
+      const resultPart = event.message.content.find(
+        (part): part is Extract<typeof part, { type: 'tool-result' }> =>
+          part.type === 'tool-result' &&
+          part.toolCallId === event.toolCall.toolCallId,
+      );
+      const output = resultPart?.output as AgentToolResult['output'] | unknown;
+      return [
+        {
+          type: 'tool-result',
+          toolCallId: event.toolCall.toolCallId,
+          toolName: event.toolCall.toolName,
+          result: toToolResultValue(output),
+          ...(resultPart?.isError ? { isError: true } : {}),
+        },
+      ];
+    }
+
+    case 'tool-updated':
+      return [
+        {
+          type: 'raw',
+          rawValue: {
+            type: 'tool-updated',
+            toolCallId: event.toolCall.toolCallId,
+            toolName: event.toolCall.toolName,
+            update: event.update,
+          },
+        },
+      ];
+
+    case 'status-notice':
+      return [
+        {
+          type: 'raw',
+          rawValue: {
+            type: 'status-notice',
+            message: event.message,
+            ...(event.metadata ? { metadata: event.metadata } : {}),
+          },
+        },
+      ];
+
+    default:
+      return [];
+  }
+}
+
+/**
+ * Close any blocks still open when the turn ends (e.g. an aborted turn whose
+ * `assistant-message` never arrived).
+ */
+export function finishClineTranslation(
+  state: ClineTranslatorState,
+): HarnessV1StreamPart[] {
+  return closeOpenBlocks(state);
+}

--- a/packages/harness-cline/src/cline-utils.test.ts
+++ b/packages/harness-cline/src/cline-utils.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractUserText,
+  frameInstructions,
+  mapModelFinishReason,
+  mapRunFinishReason,
+  toToolResultValue,
+  usageFromAgentUsage,
+} from './cline-utils';
+
+describe('extractUserText', () => {
+  it('passes plain strings through', () => {
+    expect(extractUserText('hello')).toBe('hello');
+  });
+
+  it('extracts string content from a user message', () => {
+    expect(extractUserText({ role: 'user', content: 'hello' })).toBe('hello');
+  });
+
+  it('joins text parts with blank lines', () => {
+    expect(
+      extractUserText({
+        role: 'user',
+        content: [
+          { type: 'text', text: 'first' },
+          { type: 'text', text: 'second' },
+        ],
+      }),
+    ).toBe('first\n\nsecond');
+  });
+
+  it('rejects non-text parts', () => {
+    expect(() =>
+      extractUserText({
+        role: 'user',
+        content: [
+          {
+            type: 'image',
+            image: new Uint8Array([1]),
+            mediaType: 'image/png',
+          },
+        ],
+      }),
+    ).toThrow(/only text user-message parts/);
+  });
+});
+
+describe('frameInstructions', () => {
+  it('wraps instructions and user text in labeled blocks', () => {
+    const framed = frameInstructions('be terse', 'do the thing');
+    expect(framed).toContain('<session-instructions>');
+    expect(framed).toContain('be terse');
+    expect(framed).toContain('<user-message>\ndo the thing\n</user-message>');
+  });
+});
+
+describe('toToolResultValue', () => {
+  it('passes strings through', () => {
+    expect(toToolResultValue('output')).toBe('output');
+  });
+
+  it('maps undefined and null to null', () => {
+    expect(toToolResultValue(undefined)).toBe(null);
+    expect(toToolResultValue(null)).toBe(null);
+  });
+
+  it('round-trips JSON-serializable objects', () => {
+    expect(toToolResultValue({ a: 1, b: ['x'] })).toEqual({ a: 1, b: ['x'] });
+  });
+
+  it('stringifies values that cannot be serialized', () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(typeof toToolResultValue(cyclic)).toBe('string');
+  });
+});
+
+describe('finish reason mapping', () => {
+  it('maps model finish reasons', () => {
+    expect(mapModelFinishReason('stop')).toEqual({
+      unified: 'stop',
+      raw: 'stop',
+    });
+    expect(mapModelFinishReason('tool-calls')).toEqual({
+      unified: 'tool-calls',
+      raw: 'tool-calls',
+    });
+    expect(mapModelFinishReason('max-tokens')).toEqual({
+      unified: 'length',
+      raw: 'max-tokens',
+    });
+    expect(mapModelFinishReason('aborted')).toEqual({
+      unified: 'other',
+      raw: 'aborted',
+    });
+    expect(mapModelFinishReason('error')).toEqual({
+      unified: 'error',
+      raw: 'error',
+    });
+  });
+
+  it('maps run statuses', () => {
+    expect(mapRunFinishReason('completed').unified).toBe('stop');
+    expect(mapRunFinishReason('aborted').unified).toBe('other');
+    expect(mapRunFinishReason('failed').unified).toBe('error');
+  });
+});
+
+describe('usageFromAgentUsage', () => {
+  it('converts cumulative usage', () => {
+    expect(
+      usageFromAgentUsage({
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 30,
+        cacheWriteTokens: 10,
+        totalCost: 0.42,
+      }),
+    ).toEqual({
+      inputTokens: {
+        total: 100,
+        noCache: undefined,
+        cacheRead: 30,
+        cacheWrite: 10,
+      },
+      outputTokens: { total: 50, text: undefined, reasoning: undefined },
+      raw: { totalCost: 0.42 },
+    });
+  });
+
+  it('omits raw when no cost is reported', () => {
+    const usage = usageFromAgentUsage({
+      inputTokens: 1,
+      outputTokens: 2,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+    expect('raw' in usage).toBe(false);
+  });
+});

--- a/packages/harness-cline/src/cline-utils.ts
+++ b/packages/harness-cline/src/cline-utils.ts
@@ -1,0 +1,167 @@
+import type {
+  JSONValue,
+  LanguageModelV4FinishReason,
+  LanguageModelV4Usage,
+} from '@ai-sdk/provider';
+import {
+  HarnessCapabilityUnsupportedError,
+  type HarnessV1Prompt,
+} from '@ai-sdk/harness';
+import type { AgentMessage, AgentUsage } from '@cline/agents';
+
+const HARNESS_ID = 'cline';
+
+/**
+ * Extract a single user text string from a `HarnessV1Prompt`. The Cline
+ * runtime's `run`/`continue` accept a plain string; multimodal user content
+ * is not supported in this foundational version.
+ */
+export function extractUserText(prompt: HarnessV1Prompt): string {
+  if (typeof prompt === 'string') {
+    return prompt;
+  }
+
+  const { content } = prompt;
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  const parts: string[] = [];
+  for (const part of content) {
+    if (part.type !== 'text') {
+      throw new HarnessCapabilityUnsupportedError({
+        message: `cline: only text user-message parts are supported; got '${part.type}'.`,
+        harnessId: HARNESS_ID,
+      });
+    }
+    parts.push(part.text);
+  }
+  return parts.join('\n\n');
+}
+
+/*
+ * Frame session instructions and the user's text so the runtime treats the
+ * instructions as system-provided operating guidance, not something the user
+ * wrote. Without the wrapper the agent can echo the prepended text back as if
+ * the user had asked for it, which is confusing since the user never typed it.
+ * Applied only to the first user message of a fresh session.
+ */
+export function frameInstructions(
+  instructions: string,
+  userText: string,
+): string {
+  return (
+    '<session-instructions>\n' +
+    'The block below is operating guidance from the system, not a message from the user — follow it, but do not mention it or attribute it to the user.\n\n' +
+    `${instructions}\n` +
+    '</session-instructions>\n\n' +
+    `<user-message>\n${userText}\n</user-message>`
+  );
+}
+
+export function getErrorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Coerce an arbitrary tool output into a JSON-safe value for a `tool-result`
+ * stream part. Strings and JSON-serializable objects pass through; anything
+ * that can't survive `JSON.stringify` round-tripping (functions, cycles) is
+ * stringified. `undefined` becomes `null` — the runtime schema deliberately
+ * accepts `null` for tools with no output.
+ */
+export function toToolResultValue(output: unknown): NonNullable<JSONValue> {
+  if (output === undefined || output === null) {
+    return null as unknown as NonNullable<JSONValue>;
+  }
+  if (typeof output === 'string') {
+    return output;
+  }
+  try {
+    return JSON.parse(JSON.stringify(output)) as NonNullable<JSONValue>;
+  } catch {
+    return String(output);
+  }
+}
+
+/**
+ * Map the Cline model-level finish reason (`AgentModelFinishReason`) onto the
+ * V4 unified finish-reason vocabulary. Used for `finish-step` parts.
+ */
+export function mapModelFinishReason(
+  reason: string,
+): LanguageModelV4FinishReason {
+  switch (reason) {
+    case 'stop':
+      return { unified: 'stop', raw: reason };
+    case 'tool-calls':
+      return { unified: 'tool-calls', raw: reason };
+    case 'max-tokens':
+      return { unified: 'length', raw: reason };
+    case 'error':
+      return { unified: 'error', raw: reason };
+    default:
+      return { unified: 'other', raw: reason };
+  }
+}
+
+/**
+ * Map a completed run's status onto the V4 unified finish reason. Used for
+ * the terminal `finish` part.
+ */
+export function mapRunFinishReason(
+  status: 'completed' | 'aborted' | 'failed',
+): LanguageModelV4FinishReason {
+  switch (status) {
+    case 'completed':
+      return { unified: 'stop', raw: status };
+    case 'aborted':
+      return { unified: 'other', raw: status };
+    case 'failed':
+      return { unified: 'error', raw: status };
+  }
+}
+
+/**
+ * Convert the Cline runtime's cumulative `AgentUsage` into the V4 usage shape.
+ */
+export function usageFromAgentUsage(usage: AgentUsage): LanguageModelV4Usage {
+  return {
+    inputTokens: {
+      total: usage.inputTokens,
+      noCache: undefined,
+      cacheRead: usage.cacheReadTokens,
+      cacheWrite: usage.cacheWriteTokens,
+    },
+    outputTokens: {
+      total: usage.outputTokens,
+      text: undefined,
+      reasoning: usage.reasoningTokenCount,
+    },
+    ...(usage.totalCost !== undefined
+      ? { raw: { totalCost: usage.totalCost } }
+      : {}),
+  };
+}
+
+/**
+ * Convert a single assistant message's per-call metrics into the V4 usage
+ * shape. Metrics may be absent; all fields stay optional in that case.
+ */
+export function usageFromMessageMetrics(
+  metrics: AgentMessage['metrics'],
+): LanguageModelV4Usage {
+  return {
+    inputTokens: {
+      total: metrics?.inputTokens,
+      noCache: undefined,
+      cacheRead: metrics?.cacheReadTokens,
+      cacheWrite: metrics?.cacheWriteTokens,
+    },
+    outputTokens: {
+      total: metrics?.outputTokens,
+      text: undefined,
+      reasoning: metrics?.reasoningTokenCount,
+    },
+  };
+}

--- a/packages/harness-cline/src/index.ts
+++ b/packages/harness-cline/src/index.ts
@@ -1,0 +1,12 @@
+import { createCline } from './cline-harness';
+
+/**
+ * Default `cline` harness instance with no overrides — suitable for the
+ * common case where the Cline SDK's defaults are fine. Equivalent to
+ * `createCline()`.
+ */
+export const cline = createCline();
+
+export { createCline } from './cline-harness';
+export { VERSION } from './version';
+export type { ClineHarnessSettings } from './cline-harness';

--- a/packages/harness-cline/src/version.ts
+++ b/packages/harness-cline/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/harness-cline/tsconfig.build.json
+++ b/packages/harness-cline/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/harness-cline/tsconfig.json
+++ b/packages/harness-cline/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": ["dist", "build", "node_modules", "tsup.config.ts"],
+  "references": [
+    { "path": "../harness" },
+    { "path": "../provider" },
+    { "path": "../provider-utils" }
+  ]
+}

--- a/packages/harness-cline/tsup.config.ts
+++ b/packages/harness-cline/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+const packageVersion = JSON.stringify(
+  (await import('./package.json', { with: { type: 'json' } })).default.version,
+);
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  target: 'es2022',
+  dts: true,
+  sourcemap: true,
+  define: {
+    __PACKAGE_VERSION__: packageVersion,
+  },
+});

--- a/packages/harness-cline/turbo.json
+++ b/packages/harness-cline/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["**/dist/**"]
+    }
+  }
+}

--- a/packages/harness-cline/vitest.node.config.js
+++ b/packages/harness-cline/vitest.node.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,7 +723,7 @@ importers:
         version: 2.1.1
       next:
         specifier: ^15.5.21
-        version: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+        version: 15.5.21(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -741,7 +741,7 @@ importers:
         version: 1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       workflow:
         specifier: 4.2.1
-        version: 4.2.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(typescript@5.8.3)
+        version: 4.2.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(next@15.5.21(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(typescript@5.8.3)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -1228,7 +1228,7 @@ importers:
         version: link:../../packages/react
       '@vercel/functions':
         specifier: ^3.6.0
-        version: 3.6.0(@aws-sdk/credential-provider-web-identity@3.972.65)
+        version: 3.6.0(@aws-sdk/credential-provider-web-identity@3.972.67)
       ai:
         specifier: workspace:*
         version: link:../../packages/ai
@@ -1611,7 +1611,7 @@ importers:
         version: 3.5.12
       nuxt:
         specifier: 3.21.7
-        version: 3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0)
       tailwindcss:
         specifier: 3.4.15
         version: 3.4.15(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.9.3))
@@ -2688,6 +2688,37 @@ importers:
       '@types/ws':
         specifier: ^8.5.13
         version: 8.18.1
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.20)(tsx@4.22.0)(typescript@5.8.3)(yaml@2.9.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
+  packages/harness-cline:
+    dependencies:
+      '@ai-sdk/harness':
+        specifier: workspace:*
+        version: link:../harness
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+      '@cline/agents':
+        specifier: ^0.0.66
+        version: 0.0.66(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
+    devDependencies:
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
       '@vercel/ai-tsconfig':
         specifier: workspace:*
         version: link:../../tools/tsconfig
@@ -4088,8 +4119,56 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
+  '@ai-sdk/amazon-bedrock@4.0.143':
+    resolution: {integrity: sha512-kFsgsumbFBKkEmNAlRMATE3wJ1759aLUR5DTW5ik9xdas97c5pSUfh6/Afi1IDX88IieQ6I8/2c1Qg+BoLVzsg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/anthropic@3.0.103':
+    resolution: {integrity: sha512-aefFtdBHYowKccDaQdf2hX6kvIiqeShaOAPo3DujsaGH7m8lSW5GficJOhMCXpPBBv+4lZnEWrnIIyV5YeouDw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.145':
     resolution: {integrity: sha512-cqSQ+I0Bjj2W9g1oFyE1O1mSowsWXb+U1wK9vtg5kRQqB95iWVIKbtdr14gGf46cueJSiBlKfPTT24gDDVuFmw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google-vertex@4.0.173':
+    resolution: {integrity: sha512-XCb/b71UtEAPcrnjnHXgXC0B709NscS2d+Q5584f18qEQHH7epUx/kFn9gxvtTeF1ZlrnXg+6wzckcxBlzKh5g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google@3.0.102':
+    resolution: {integrity: sha512-RFdIMqeVF2DsGQdf30/EwW+zeRSte2+3VrRrm3jxfpWKY3bjTao6J+4qRG4V8/MD028Mb6oJthGb4g53GRQ1Cg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/mistral@3.0.52':
+    resolution: {integrity: sha512-f1V7RR+agJ9HTgRp6vsyrUri8ux+n2T+kZJECi7uVUUlyxICMyP+3FFoJnXir9uJ85IAFp7Ns1ZljKnWahUAFg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@2.0.62':
+    resolution: {integrity: sha512-lRe54zvyIS1a60N8UVhnwKZRI5I+GSV8uhKkPpId+aiKO7z7UgSbNqFmXkBBMD3yc9UrLnQnATV2EQyXNhzEkA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.89':
+    resolution: {integrity: sha512-G5Brp7duF/pPxaY1wa3pR4mV18qcEVtcrfZT4YxzheR2iP672auUdHoddCqyKS9RxTtZQyxXQ6bNiTcKvaWgIg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@3.0.30':
+    resolution: {integrity: sha512-NCJ9JKow5ENAgEZxzvEvF20thwDiH+hutvzmrUDbloRX0azpJHNst8+7pZIVryYhLM9wgpT5/ShTSjPTFhkxEQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -4100,8 +4179,22 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.40':
+    resolution: {integrity: sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@2.0.3':
+    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
+    engines: {node: '>=18'}
+
   '@ai-sdk/provider@3.0.13':
     resolution: {integrity: sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.14':
+    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@3.0.223':
@@ -4514,32 +4607,68 @@ packages:
     resolution: {integrity: sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.977.1':
+    resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.60':
+    resolution: {integrity: sha512-16Fxa3veKIO6nHJr+vN76z3BkSU7725lzruc5S2SQSTUTbK4TXtmi8033WQljZj4k1+383UsMaNOHN6B76fK5A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.59':
     resolution: {integrity: sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.61':
+    resolution: {integrity: sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.61':
     resolution: {integrity: sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.63':
+    resolution: {integrity: sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.973.4':
     resolution: {integrity: sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.6':
+    resolution: {integrity: sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.66':
     resolution: {integrity: sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.68':
+    resolution: {integrity: sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.70':
     resolution: {integrity: sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.72':
+    resolution: {integrity: sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.59':
     resolution: {integrity: sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.61':
+    resolution: {integrity: sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.973.3':
     resolution: {integrity: sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.5':
+    resolution: {integrity: sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.13':
@@ -4552,6 +4681,14 @@ packages:
 
   '@aws-sdk/credential-provider-web-identity@3.972.65':
     resolution: {integrity: sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.67':
+    resolution: {integrity: sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-providers@3.1095.0':
+    resolution: {integrity: sha512-hcL4iILqep+AieTjJ+eYpBoThcirhlr0rzOqyDKSlFeV15qy8FnvwZFlNmVUFFwHnZjvQz5M9MsRe4XbC6eDfw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/eventstream-handler-node@3.972.29':
@@ -4570,8 +4707,16 @@ packages:
     resolution: {integrity: sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.35':
+    resolution: {integrity: sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.41':
     resolution: {integrity: sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.42':
+    resolution: {integrity: sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1048.0':
@@ -4580,6 +4725,10 @@ packages:
 
   '@aws-sdk/token-providers@3.1088.0':
     resolution: {integrity: sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1095.0':
+    resolution: {integrity: sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.974.2':
@@ -4592,6 +4741,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.36':
     resolution: {integrity: sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.3.0':
@@ -5615,6 +5768,29 @@ packages:
   '@clack/prompts@1.6.0':
     resolution: {integrity: sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==}
     engines: {node: '>= 20.12.0'}
+
+  '@cline/agents@0.0.66':
+    resolution: {integrity: sha512-kITcQs55qTAl2+bxhtRuLnASwJMfOgb4MGUcFLZ/bBFGSlcEA6lMq7e787P4Hza28A/9XnZwhmcrVvZybltdWw==}
+    engines: {node: '>=22'}
+
+  '@cline/llms@0.0.66':
+    resolution: {integrity: sha512-0D91D7MTQuk79nxafMYigEEQ0pu5R5C3UQKvzAgZtgLrUbYQ/CNu9d9knlsMlzCvPWX15B6GYnYyGAX9Cm8EPQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@aws-sdk/client-bedrock-runtime': ^3.0.0
+      ai-sdk-provider-claude-code: ^3.4.3
+      ai-sdk-provider-codex-cli: ^1.1.0
+    peerDependenciesMeta:
+      '@aws-sdk/client-bedrock-runtime':
+        optional: true
+      ai-sdk-provider-claude-code:
+        optional: true
+      ai-sdk-provider-codex-cli:
+        optional: true
+
+  '@cline/shared@0.0.66':
+    resolution: {integrity: sha512-seUrxzguCqIRjL/0172pkKDVL/SJcYoaBhzavv6k7efboL3otjm5x6D2cFlJt1QN5ucMeFTgz21L83zY/qAjgA==}
+    engines: {node: '>=22'}
 
   '@cloudflare/kv-asset-handler@0.4.2':
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
@@ -7235,6 +7411,12 @@ packages:
   '@istanbuljs/schema@0.1.6':
     resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
     engines: {node: '>=8'}
+
+  '@jerome-benoit/sap-ai-provider@4.8.0':
+    resolution: {integrity: sha512-rJvAW9eDFj+IFTJQ+UK0CrPyq78BG+PF6AgmHE5C0bHAalJewT119rryHqttITVpCNuX49k2ajBSax8r0+SXcg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      ai: ^5.0.0 || ^6.0.0
 
   '@jest/console@29.7.0':
     resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
@@ -12100,6 +12282,44 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sap-ai-sdk/ai-api@2.13.0':
+    resolution: {integrity: sha512-yYmk19ww2cZnYZCA5UGSWGKlpB2RnyDgxjNvi43ZwYHRm5ejWuM8m4gU/qj+FIwmhnDHp6BG2ClWfLTH/hOoJw==}
+
+  '@sap-ai-sdk/core@2.13.0':
+    resolution: {integrity: sha512-tGx/XJxGsdEBQknwIpZc5/gpxDUmRwP3E68WgoI6/oj39+YecgWYynGnG6XIr+MTGo23RwXFEw518q9HuPWk/Q==}
+
+  '@sap-ai-sdk/foundation-models@2.13.0':
+    resolution: {integrity: sha512-lPT2fWXkKSN+lsUAGy6H3gTgkWbjb8uT7ccfxCuQyx1Fjmts+1pBSvOxFyWYqvMglF58gO0i1HKwdkLsG2b+Cg==}
+
+  '@sap-ai-sdk/orchestration@2.13.0':
+    resolution: {integrity: sha512-gM8QQA4DXXICBuECvNTzcD40AU6MQrPGeagesDzUwgr2Nc5AWbyQylnTvXqb7JvlClQZvBSkBhYARI6oYXoiIA==}
+
+  '@sap-ai-sdk/prompt-registry@2.13.0':
+    resolution: {integrity: sha512-J74gi/bZFVztVlCCpfrD95/XblPBspema7QmS+w6UEFN1AVEJJluYjRqVsqwHMH5OfXmBvuNXQMpk0Ex2/IjRg==}
+
+  '@sap-cloud-sdk/connectivity@4.8.0':
+    resolution: {integrity: sha512-y8H0AKgDecm7+A8wxx+J1oxJTzYEs+4Hy7ghfrBD57e9MdRRFI5FryYqokZbDcMjEnsbvZ+giShm/A2UXmeHyg==}
+
+  '@sap-cloud-sdk/http-client@4.8.0':
+    resolution: {integrity: sha512-ruQd7d0nObshm0fNkhUE1fp1qxevEYxblhM/X0rG1goN9r4nQiT6LgZUG5s+QeR1R2LdIHBXtsIycBfz/4kOog==}
+
+  '@sap-cloud-sdk/openapi@4.8.0':
+    resolution: {integrity: sha512-AuCK7hFXhbLh58zh27ILdAGHLWbFd/9DqNGsVgNXxMWGy55D/8JsWqkmn6TAwRTnYtKMmb8WeoUtC/Cmq2Vvqw==}
+
+  '@sap-cloud-sdk/resilience@4.8.0':
+    resolution: {integrity: sha512-/XclOtUHhdN39acKH1otJdMILAm+HJkQ6wjpUvqBx7RNiQ1GQwe34qSqy8wGDJr5MbcxuhENYGWJRLE4P4OHqw==}
+
+  '@sap-cloud-sdk/util@4.8.0':
+    resolution: {integrity: sha512-wLWxgxYwAL1N5dh+m8XGZTZ2vzooDHXKXrkay3rBpYSFHhZjsD2V37ezbAhbBKlFIELZA03C+Eb9o4YgHpvTKg==}
+
+  '@sap/xsenv@6.2.1':
+    resolution: {integrity: sha512-R1p7VdD3N3jvdkL8av4vLqF+cTQihTz9mCqqF+oa9rVZvgLaCb4ODyZ1dln5/fBgg1OSuch0ESxu3AqZrXVknw==}
+    engines: {node: ^20.0.0  || ^22.0.0 || ^24.0.0}
+
+  '@sap/xssec@4.13.3':
+    resolution: {integrity: sha512-op5wFTpJGJFdwFcEFRDX30yKbB2Kknk+LJqXDcrHyPNLqvSqerTWXFdFnylhiIhoAdGFSccC6NimUhqFxIrUsA==}
+    engines: {node: '>=18'}
+
   '@schematics/angular@20.3.28':
     resolution: {integrity: sha512-E9IwxeIHprqOtkxwvzY/OJa4DMvb+z0gPDAGDzAEoscj2qLETi9kmj/p0c/MDtHa5oyeb0GaRxifAkNOLtS/nA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
@@ -12357,12 +12577,24 @@ packages:
     resolution: {integrity: sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.30.0':
+    resolution: {integrity: sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.10':
     resolution: {integrity: sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/credential-provider-imds@4.4.14':
+    resolution: {integrity: sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/eventstream-codec@4.3.3':
     resolution: {integrity: sha512-sXa/zJrKDY2XtuS6bcxUpnSasItoawGi+ru54fNUzvQtJH51+gF0fJ+3Q0fm5e8zQWgibFhkPzRh1K4vxmI78A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.11':
+    resolution: {integrity: sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.6.7':
@@ -12377,6 +12609,10 @@ packages:
     resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.9.11':
+    resolution: {integrity: sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-http-handler@4.9.7':
     resolution: {integrity: sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==}
     engines: {node: '>=18.0.0'}
@@ -12387,6 +12623,10 @@ packages:
 
   '@smithy/shared-ini-file-loader@4.5.3':
     resolution: {integrity: sha512-9fgVSJBB1k79oZkT5eLHaPx289LZg8wDi2xNEDKlD2Wy2GpPQfvUhnzJCXEWQxIJ5hhj+peI/todWUFBXhi86w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.10':
+    resolution: {integrity: sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.6.6':
@@ -12433,6 +12673,9 @@ packages:
     resolution: {integrity: sha512-i7HTNuDgZWb+VdrNVOam9gQhIc5MSSDXKWXgbUrn/4vSRaSMM+Rtl10MQj4wLWPNpF7p80waJsAqFP8HZfb0Jg==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
+
+  '@streamparser/json@0.0.21':
+    resolution: {integrity: sha512-v+49JBiG1kmc/9Ug79Lz9wyKaRocBgCnpRaLpdy7p0d3ICKtOAfc/H/Epa1j3F6YdnzjnZKKrnJ8xnh/v1P8Aw==}
 
   '@sveltejs/acorn-typescript@1.0.9':
     resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
@@ -14096,6 +14339,18 @@ packages:
     resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
     engines: {node: '>=12'}
 
+  ai-sdk-ollama@3.8.8:
+    resolution: {integrity: sha512-peWelPf6sVsRULQyYhfyu1dMZhwewRszsbQVfbuhNLflh+ncRXn6pe1BRE3NAcSsWd7JMRZAV5RzcuR3R9ZfaQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      ai: ^6.0.197
+
+  ai-sdk-provider-opencode-sdk@3.0.6:
+    resolution: {integrity: sha512-CZ2I5z96HUdEKAT1ExhdxLE1bjD8efzT7I5GjBevWgwNGgYZjMPE7ZfQCJFVAzWqODwdTdxp7KSZjnmcd4h1Bw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   ai@6.0.221:
     resolution: {integrity: sha512-cB7qJbNTMuD5spdJEo+guejX0rkjhSQpc4PHITNB+iBFBnGYHLUZOM+uSeIkY4mS4sVVKBKm3kSQQoI5cUwU3g==}
     engines: {node: '>=18'}
@@ -14284,6 +14539,13 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -14359,6 +14621,9 @@ packages:
 
   aws4fetch@1.0.20:
     resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
+
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -14889,6 +15154,10 @@ packages:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
 
+  clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
+
   cloudflare-video-element@1.3.5:
     resolution: {integrity: sha512-zj9gjJa6xW8MNrfc4oKuwgGS0njRLpOlQjdifbuNxvy8k4Y3pKCyKCMG2XIsjd2iQGhgjS57b1P5VWdJlxcXBw==}
 
@@ -15147,6 +15416,9 @@ packages:
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
+
+  core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -15755,6 +16027,9 @@ packages:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
+  dify-ai-provider@1.1.1:
+    resolution: {integrity: sha512-a32UiyP6AjElbic6Aao7opBCCM+5RwD34TP5YczE70UW/UvwucRAK76UMDVMAM6gqhc3FvaBeSu3NcK+NAUg4g==}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -16227,6 +16502,10 @@ packages:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
     hasBin: true
+
+  extsprintf@1.4.1:
+    resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
+    engines: {'0': node >=0.6.0}
 
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
@@ -17743,6 +18022,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jks-js@1.1.7:
+    resolution: {integrity: sha512-BeiDRKsAi1NwEwgx2JB/9/0tar5BNGIv+foGm1G5GgiyR35s/iUnfd/BWqYd16mLDD8qTaAVBrIcOOuVqXJZNQ==}
+
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
@@ -17878,6 +18160,14 @@ packages:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
 
+  jsonrepair@3.15.0:
+    resolution: {integrity: sha512-wy8OTjwsJwQRnQJkKnMJJ9vcytRdBPAgIF/Hy6+s1dAj42BHMKiyL8JzEieIl3JY7idt8eyHwBWTO8mh/+mtwA==}
+    hasBin: true
+
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
   just-bash@2.14.5:
     resolution: {integrity: sha512-MCBGnRlDeZ/MM7mcw+ZuSGFMBsggajrmKz6e/hrOAN7syvVZkjiY+Vh2wyCwN/CdcnAX5SxbiQB51n5nrQuX+g==}
     hasBin: true
@@ -17887,6 +18177,10 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
 
   karma-source-map-support@1.4.0:
     resolution: {integrity: sha512-RsBECncGO17KAoJCYXjv+ckIz+Ii9NCi+9enk+rq6XC81ezYkb4/RHE6CTXdA7IOJqoF3wcaLfVG0CPmE5ca6A==}
@@ -18237,11 +18531,32 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
@@ -18999,6 +19314,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   nanoid@5.1.6:
     resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
     engines: {node: ^18 || >=20}
@@ -19111,6 +19431,10 @@ packages:
     resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
     engines: {node: ^18 || ^20 || >= 21}
 
+  node-cache@5.1.2:
+    resolution: {integrity: sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==}
+    engines: {node: '>= 8.0.0'}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -19169,6 +19493,9 @@ packages:
 
   node-releases@2.0.44:
     resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
+  node-rsa@1.1.1:
+    resolution: {integrity: sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==}
 
   nopt@7.2.1:
     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
@@ -19344,6 +19671,9 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  ollama@0.6.3:
+    resolution: {integrity: sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==}
+
   omggif@1.0.10:
     resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
 
@@ -19429,6 +19759,10 @@ packages:
         optional: true
       zod:
         optional: true
+
+  opossum@10.0.0:
+    resolution: {integrity: sha512-sghtqL8Usj+et06Zui0nyn0R6FFsl7cyuoU+d7MctYU0nbS7Htzjleh+tWohFqk1Rp1srrFwbFa8Vxd0O64w6A==}
+    engines: {node: ^26 || ^24 || ^22}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -20276,6 +20610,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
@@ -22594,6 +22932,10 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
+  verror@1.10.1:
+    resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
+    engines: {node: '>=0.6.0'}
+
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
@@ -22936,6 +23278,9 @@ packages:
       jsdom:
         optional: true
 
+  voca@1.4.1:
+    resolution: {integrity: sha512-NJC/BzESaHT1p4B5k4JykxedeltmNbau4cummStd4RjFojgq/kLew5TzYge9N2geeWyI2w8T30wUET5v+F7ZHA==}
+
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
@@ -23101,6 +23446,9 @@ packages:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -23439,12 +23787,72 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@ai-sdk/amazon-bedrock@4.0.143(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/anthropic': 3.0.103(zod@4.4.3)
+      '@ai-sdk/openai': 3.0.89(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
+      '@smithy/eventstream-codec': 4.3.3
+      '@smithy/util-utf8': 4.3.3
+      aws4fetch: 1.0.20
+      zod: 4.4.3
+
+  '@ai-sdk/anthropic@3.0.103(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/gateway@3.0.145(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.13
       '@ai-sdk/provider-utils': 4.0.37(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
+
+  '@ai-sdk/google-vertex@4.0.173(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/anthropic': 3.0.103(zod@4.4.3)
+      '@ai-sdk/google': 3.0.102(zod@4.4.3)
+      '@ai-sdk/openai-compatible': 2.0.62(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
+      google-auth-library: 10.9.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ai-sdk/google@3.0.102(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/mistral@3.0.52(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/openai-compatible@2.0.62(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/openai@3.0.89(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@3.0.30(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.37(zod@4.4.3)':
     dependencies:
@@ -23453,7 +23861,22 @@ snapshots:
       eventsource-parser: 3.0.8
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@4.0.40(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
+
+  '@ai-sdk/provider@2.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
   '@ai-sdk/provider@3.0.13':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.14':
     dependencies:
       json-schema: 0.4.0
 
@@ -23935,6 +24358,13 @@ snapshots:
     optionalDependencies:
       zod: 3.25.76
 
+  '@anthropic-ai/sdk@0.103.0(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
+
   '@anthropic-ai/sdk@0.91.1(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
@@ -24015,11 +24445,38 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.1':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.30.0
+      '@smithy/signature-v4': 5.6.10
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.60':
+    dependencies:
+      '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.59':
     dependencies:
       '@aws-sdk/core': 3.975.3
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -24030,6 +24487,16 @@ snapshots:
       '@smithy/core': 3.29.5
       '@smithy/fetch-http-handler': 5.6.7
       '@smithy/node-http-handler': 4.9.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.63':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -24049,12 +24516,37 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.6':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/credential-provider-env': 3.972.61
+      '@aws-sdk/credential-provider-http': 3.972.63
+      '@aws-sdk/credential-provider-login': 3.972.68
+      '@aws-sdk/credential-provider-process': 3.972.61
+      '@aws-sdk/credential-provider-sso': 3.973.5
+      '@aws-sdk/credential-provider-web-identity': 3.972.67
+      '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/credential-provider-imds': 4.4.14
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.66':
     dependencies:
       '@aws-sdk/core': 3.975.3
       '@aws-sdk/nested-clients': 3.997.33
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.68':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -24072,11 +24564,33 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.72':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.61
+      '@aws-sdk/credential-provider-http': 3.972.63
+      '@aws-sdk/credential-provider-ini': 3.973.6
+      '@aws-sdk/credential-provider-process': 3.972.61
+      '@aws-sdk/credential-provider-sso': 3.973.5
+      '@aws-sdk/credential-provider-web-identity': 3.972.67
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/credential-provider-imds': 4.4.14
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.59':
     dependencies:
       '@aws-sdk/core': 3.975.3
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -24087,6 +24601,16 @@ snapshots:
       '@aws-sdk/token-providers': 3.1088.0
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.5':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/token-providers': 3.1095.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -24115,6 +24639,34 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.33
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.67':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-providers@3.1095.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/credential-provider-cognito-identity': 3.972.60
+      '@aws-sdk/credential-provider-env': 3.972.61
+      '@aws-sdk/credential-provider-http': 3.972.63
+      '@aws-sdk/credential-provider-ini': 3.973.6
+      '@aws-sdk/credential-provider-login': 3.972.68
+      '@aws-sdk/credential-provider-node': 3.972.72
+      '@aws-sdk/credential-provider-process': 3.972.61
+      '@aws-sdk/credential-provider-sso': 3.973.5
+      '@aws-sdk/credential-provider-web-identity': 3.972.67
+      '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/credential-provider-imds': 4.4.14
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -24153,10 +24705,28 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.35':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.42
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/fetch-http-handler': 5.6.11
+      '@smithy/node-http-handler': 4.9.11
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.41':
     dependencies:
       '@aws-sdk/types': 3.974.2
       '@smithy/signature-v4': 5.6.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.42':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.10
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -24178,6 +24748,15 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1095.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.35
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.974.2':
     dependencies:
       '@smithy/types': 4.16.1
@@ -24188,6 +24767,11 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.36':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
     dependencies:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
@@ -26148,6 +26732,60 @@ snapshots:
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
 
+  '@cline/agents@0.0.66(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@cline/llms': 0.0.66(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
+      '@cline/shared': 0.0.66
+      nanoid: 5.1.16
+    transitivePeerDependencies:
+      - '@aws-sdk/client-bedrock-runtime'
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/sdk-trace-base'
+      - ai-sdk-provider-claude-code
+      - ai-sdk-provider-codex-cli
+      - debug
+      - supports-color
+
+  '@cline/llms@0.0.66(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@ai-sdk/amazon-bedrock': 4.0.143(zod@4.4.3)
+      '@ai-sdk/anthropic': 3.0.103(zod@4.4.3)
+      '@ai-sdk/google': 3.0.102(zod@4.4.3)
+      '@ai-sdk/google-vertex': 4.0.173(zod@4.4.3)
+      '@ai-sdk/mistral': 3.0.52(zod@4.4.3)
+      '@ai-sdk/openai': 3.0.89(zod@4.4.3)
+      '@ai-sdk/openai-compatible': 2.0.62(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.13
+      '@aws-sdk/credential-providers': 3.1095.0
+      '@cline/shared': 0.0.66
+      '@jerome-benoit/sap-ai-provider': 4.8.0(ai@6.0.221(zod@4.4.3))
+      '@langfuse/otel': 4.6.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/sdk-trace-node': 2.8.0(@opentelemetry/api@1.9.1)
+      '@streamparser/json': 0.0.21
+      ai: 6.0.221(zod@4.4.3)
+      ai-sdk-ollama: 3.8.8(ai@6.0.221(zod@4.4.3))(zod@4.4.3)
+      ai-sdk-provider-opencode-sdk: 3.0.6(zod@4.4.3)
+      dify-ai-provider: 1.1.1
+      nanoid: 5.1.16
+      zod: 4.4.3
+    optionalDependencies:
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/sdk-trace-base'
+      - debug
+      - supports-color
+
+  '@cline/shared@0.0.66':
+    dependencies:
+      aws4fetch: 1.0.20
+      jsonrepair: 3.15.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
   '@colordx/core@5.4.3': {}
@@ -27262,6 +27900,18 @@ snapshots:
 
   '@istanbuljs/schema@0.1.6': {}
 
+  '@jerome-benoit/sap-ai-provider@4.8.0(ai@6.0.221(zod@4.4.3))':
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider-utils': 4.0.37(zod@4.4.3)
+      '@sap-ai-sdk/foundation-models': 2.13.0
+      '@sap-ai-sdk/orchestration': 2.13.0
+      ai: 6.0.221(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
@@ -28132,9 +28782,9 @@ snapshots:
 
   '@langchain/anthropic@1.5.0(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.21.0)(zod@3.25.76))(ws@8.21.0))':
     dependencies:
-      '@anthropic-ai/sdk': 0.103.0(zod@3.25.76)
+      '@anthropic-ai/sdk': 0.103.0(zod@4.4.3)
       '@langchain/core': 1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.21.0)(zod@3.25.76))(ws@8.21.0)
-      zod: 3.25.76
+      zod: 4.4.3
 
   '@langchain/core@1.1.46(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.21.0)(zod@3.25.76))(ws@8.21.0)':
     dependencies:
@@ -29360,7 +30010,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@3.21.7(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.132.0)(srvx@0.11.16)(typescript@5.9.3)':
+  '@nuxt/nitro-server@3.21.7(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.132.0)(srvx@0.11.16)(typescript@5.9.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 3.21.7(magicast@0.5.3)
@@ -29377,8 +30027,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(encoding@0.1.13)(oxc-parser@0.132.0)(srvx@0.11.16)
-      nuxt: 3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0)
+      nitropack: 2.13.4(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(aws4fetch@1.0.20)(encoding@0.1.13)(oxc-parser@0.132.0)(srvx@0.11.16)
+      nuxt: 3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0)
       ohash: 2.0.11
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -29386,7 +30036,7 @@ snapshots:
       std-env: 4.1.0
       ufo: 1.6.4
       unctx: 2.5.0
-      unstorage: 1.17.5(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)
+      unstorage: 1.17.5(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)
       vue: 3.5.38(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
@@ -29459,7 +30109,7 @@ snapshots:
 
   '@nuxt/ui-templates@1.3.4': {}
 
-  '@nuxt/vite-builder@3.21.7(@types/node@22.19.19)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@3.21.7(@types/node@22.19.19)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 3.21.7(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.62.2)
@@ -29478,7 +30128,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.7
       ohash: 2.0.11
       pathe: 2.0.3
@@ -32785,6 +33435,127 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@sap-ai-sdk/ai-api@2.13.0':
+    dependencies:
+      '@sap-ai-sdk/core': 2.13.0
+      '@sap-cloud-sdk/connectivity': 4.8.0
+      '@sap-cloud-sdk/util': 4.8.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap-ai-sdk/core@2.13.0':
+    dependencies:
+      '@sap-cloud-sdk/connectivity': 4.8.0
+      '@sap-cloud-sdk/http-client': 4.8.0
+      '@sap-cloud-sdk/openapi': 4.8.0
+      '@sap-cloud-sdk/util': 4.8.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap-ai-sdk/foundation-models@2.13.0':
+    dependencies:
+      '@sap-ai-sdk/ai-api': 2.13.0
+      '@sap-ai-sdk/core': 2.13.0
+      '@sap-cloud-sdk/connectivity': 4.8.0
+      '@sap-cloud-sdk/http-client': 4.8.0
+      '@sap-cloud-sdk/util': 4.8.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap-ai-sdk/orchestration@2.13.0':
+    dependencies:
+      '@sap-ai-sdk/ai-api': 2.13.0
+      '@sap-ai-sdk/core': 2.13.0
+      '@sap-ai-sdk/prompt-registry': 2.13.0
+      '@sap-cloud-sdk/util': 4.8.0
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap-ai-sdk/prompt-registry@2.13.0':
+    dependencies:
+      '@sap-ai-sdk/core': 2.13.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap-cloud-sdk/connectivity@4.8.0':
+    dependencies:
+      '@sap-cloud-sdk/resilience': 4.8.0
+      '@sap-cloud-sdk/util': 4.8.0
+      '@sap/xsenv': 6.2.1
+      '@sap/xssec': 4.13.3
+      async-retry: 1.3.3
+      axios: 1.18.1
+      jks-js: 1.1.7
+      jsonwebtoken: 9.0.3
+      safe-stable-stringify: 2.5.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap-cloud-sdk/http-client@4.8.0':
+    dependencies:
+      '@sap-cloud-sdk/connectivity': 4.8.0
+      '@sap-cloud-sdk/resilience': 4.8.0
+      '@sap-cloud-sdk/util': 4.8.0
+      axios: 1.18.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap-cloud-sdk/openapi@4.8.0':
+    dependencies:
+      '@sap-cloud-sdk/connectivity': 4.8.0
+      '@sap-cloud-sdk/http-client': 4.8.0
+      '@sap-cloud-sdk/resilience': 4.8.0
+      '@sap-cloud-sdk/util': 4.8.0
+      axios: 1.18.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap-cloud-sdk/resilience@4.8.0':
+    dependencies:
+      '@sap-cloud-sdk/util': 4.8.0
+      async-retry: 1.3.3
+      axios: 1.18.1
+      opossum: 10.0.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap-cloud-sdk/util@4.8.0':
+    dependencies:
+      axios: 1.18.1
+      logform: 2.7.0
+      voca: 1.4.1
+      winston: 3.19.0
+      winston-transport: 4.9.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap/xsenv@6.2.1':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      node-cache: 5.1.2
+      verror: 1.10.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sap/xssec@4.13.3':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      jwt-decode: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@schematics/angular@20.3.28(chokidar@4.0.3)':
     dependencies:
       '@angular-devkit/core': 20.3.28(chokidar@4.0.3)
@@ -33125,15 +33896,32 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/core@3.30.0':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.10':
     dependencies:
       '@smithy/core': 3.29.5
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/credential-provider-imds@4.4.14':
+    dependencies:
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/eventstream-codec@4.3.3':
     dependencies:
       '@smithy/core': 3.24.6
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.11':
+    dependencies:
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.6.7':
@@ -33152,6 +33940,12 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.9.11':
+    dependencies:
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/node-http-handler@4.9.7':
     dependencies:
       '@smithy/core': 3.29.5
@@ -33166,6 +33960,12 @@ snapshots:
   '@smithy/shared-ini-file-loader@4.5.3':
     dependencies:
       '@smithy/core': 3.29.5
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.10':
+    dependencies:
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.6.6':
@@ -33223,6 +34023,8 @@ snapshots:
     dependencies:
       react: 19.2.6
       shiki: 3.23.0
+
+  '@streamparser/json@0.0.21': {}
 
   '@sveltejs/acorn-typescript@1.0.9(acorn@8.17.0)':
     dependencies:
@@ -34131,11 +34933,11 @@ snapshots:
     optionalDependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.13
 
-  '@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.65)':
+  '@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.67)':
     dependencies:
       '@vercel/oidc': 3.4.1
     optionalDependencies:
-      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/credential-provider-web-identity': 3.972.67
 
   '@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.1)':
     dependencies:
@@ -34144,11 +34946,11 @@ snapshots:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
       ws: 8.21.1
 
-  '@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1)':
+  '@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1)':
     dependencies:
       '@vercel/oidc': 3.8.0
     optionalDependencies:
-      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/credential-provider-web-identity': 3.972.67
       ws: 8.21.1
     optional: true
 
@@ -34658,7 +35460,7 @@ snapshots:
       '@vue/devtools-kit': 7.6.4
       '@vue/devtools-shared': 7.7.9
       mitt: 3.0.1
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       pathe: 1.1.2
       vite-hot-client: 0.2.4(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))
       vue: 3.5.13(typescript@5.9.3)
@@ -34856,13 +35658,13 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@workflow/astro@4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+  '@workflow/astro@4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
-      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
-      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -34918,10 +35720,10 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@workflow/builders@4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+  '@workflow/builders@4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.1)
       '@workflow/errors': 4.1.0
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
       '@workflow/utils': 4.1.0
@@ -34976,21 +35778,21 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/cli@4.2.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+  '@workflow/cli@4.2.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
     dependencies:
       '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
       '@vercel/cli-auth': 0.0.1
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
-      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.1)
       '@workflow/errors': 4.1.0
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
       '@workflow/utils': 4.1.0
       '@workflow/web': 4.1.0
       '@workflow/world': 4.1.0(zod@4.3.6)
-      '@workflow/world-local': 4.1.0(@opentelemetry/api@1.9.0)
-      '@workflow/world-vercel': 4.1.0(@opentelemetry/api@1.9.0)
+      '@workflow/world-local': 4.1.0(@opentelemetry/api@1.9.1)
+      '@workflow/world-vercel': 4.1.0(@opentelemetry/api@1.9.1)
       boxen: 8.0.1
       builtin-modules: 5.0.0
       chalk: 5.6.2
@@ -35114,7 +35916,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@workflow/core@4.2.1(@opentelemetry/api@1.9.0)':
+  '@workflow/core@4.2.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -35125,8 +35927,8 @@ snapshots:
       '@workflow/serde': 4.1.0
       '@workflow/utils': 4.1.0
       '@workflow/world': 4.1.0(zod@4.3.6)
-      '@workflow/world-local': 4.1.0(@opentelemetry/api@1.9.0)
-      '@workflow/world-vercel': 4.1.0(@opentelemetry/api@1.9.0)
+      '@workflow/world-local': 4.1.0(@opentelemetry/api@1.9.1)
+      '@workflow/world-vercel': 4.1.0(@opentelemetry/api@1.9.1)
       debug: 4.4.3(supports-color@8.1.1)
       devalue: 5.6.3
       ms: 2.1.3
@@ -35136,7 +35938,7 @@ snapshots:
       ulid: 3.0.2
       zod: 4.3.6
     optionalDependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
     transitivePeerDependencies:
       - supports-color
 
@@ -35208,13 +36010,13 @@ snapshots:
       '@workflow/utils': 4.1.3
       ms: 2.1.3
 
-  '@workflow/nest@0.0.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)':
+  '@workflow/nest@0.0.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)':
     dependencies:
       '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@swc/cli': 0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -35251,16 +36053,16 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/next@4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))':
+  '@workflow/next@4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
-      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.1)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
       semver: 7.7.4
       watchpack: 2.5.1
     optionalDependencies:
-      next: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+      next: 15.5.21(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -35312,14 +36114,14 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/nitro@4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+  '@workflow/nitro@4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
-      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
-      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.1)
+      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
-      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -35370,10 +36172,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/nuxt@4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(magicast@0.5.3)':
+  '@workflow/nuxt@4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.3)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.3)
-      '@workflow/nitro': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/nitro': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -35401,10 +36203,10 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@workflow/rollup@4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+  '@workflow/rollup@4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
       exsolve: 1.0.7
     transitivePeerDependencies:
@@ -35443,13 +36245,13 @@ snapshots:
 
   '@workflow/serde@4.1.2': {}
 
-  '@workflow/sveltekit@4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+  '@workflow/sveltekit@4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
-      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
-      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
       exsolve: 1.0.8
       fs-extra: 11.3.5
       pathe: 2.0.3
@@ -35521,9 +36323,9 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  '@workflow/vite@4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+  '@workflow/vite@4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
     dependencies:
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -35580,19 +36382,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@workflow/world-local@4.1.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@vercel/queue': 0.1.4
-      '@workflow/errors': 4.1.0
-      '@workflow/utils': 4.1.0
-      '@workflow/world': 4.1.0(zod@4.3.6)
-      async-sema: 3.1.1
-      ulid: 3.0.2
-      undici: 7.22.0
-      zod: 4.3.6
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-
   '@workflow/world-local@4.1.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@vercel/queue': 0.1.4
@@ -35631,18 +36420,6 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-
-  '@workflow/world-vercel@4.1.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@vercel/oidc': 3.2.0
-      '@vercel/queue': 0.1.4
-      '@workflow/errors': 4.1.0
-      '@workflow/world': 4.1.0(zod@4.3.6)
-      cbor-x: 1.6.0
-      undici: 7.22.0
-      zod: 4.3.6
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
 
   '@workflow/world-vercel@4.1.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -35863,6 +36640,23 @@ snapshots:
       clean-stack: 4.2.0
       indent-string: 5.0.0
 
+  ai-sdk-ollama@3.8.8(ai@6.0.221(zod@4.4.3))(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider-utils': 4.0.37(zod@4.4.3)
+      ai: 6.0.221(zod@4.4.3)
+      jsonrepair: 3.15.0
+      ollama: 0.6.3
+    transitivePeerDependencies:
+      - zod
+
+  ai-sdk-provider-opencode-sdk@3.0.6(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider-utils': 4.0.37(zod@4.4.3)
+      '@opencode-ai/sdk': 1.18.3
+      zod: 4.4.3
+
   ai@6.0.221(zod@4.4.3):
     dependencies:
       '@ai-sdk/gateway': 3.0.145(zod@4.4.3)
@@ -36071,6 +36865,12 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  assert-plus@1.0.0: {}
+
   assertion-error@2.0.1: {}
 
   ast-kit@2.2.0:
@@ -36149,6 +36949,16 @@ snapshots:
       fastq: 1.20.1
 
   aws4fetch@1.0.20: {}
+
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0(debug@4.4.3)
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -36804,6 +37614,8 @@ snapshots:
 
   clone@1.0.4: {}
 
+  clone@2.1.2: {}
+
   cloudflare-video-element@1.3.5: {}
 
   clsx@2.1.1: {}
@@ -37019,6 +37831,8 @@ snapshots:
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.2
+
+  core-util-is@1.0.2: {}
 
   core-util-is@1.0.3: {}
 
@@ -37656,6 +38470,12 @@ snapshots:
   diff@7.0.0: {}
 
   diff@8.0.4: {}
+
+  dify-ai-provider@1.1.1:
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.30(zod@3.25.76)
+      zod: 3.25.76
 
   dir-glob@3.0.1:
     dependencies:
@@ -38404,6 +39224,8 @@ snapshots:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
+
+  extsprintf@1.4.1: {}
 
   fast-check@3.23.2:
     dependencies:
@@ -40362,6 +41184,12 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jks-js@1.1.7:
+    dependencies:
+      node-forge: 1.4.0
+      node-int64: 0.4.0
+      node-rsa: 1.1.1
+
   jose@5.10.0: {}
 
   jose@6.2.3: {}
@@ -40530,6 +41358,21 @@ snapshots:
 
   jsonparse@1.3.1: {}
 
+  jsonrepair@3.15.0: {}
+
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.8.5
+
   just-bash@2.14.5:
     dependencies:
       diff: 8.0.4
@@ -40563,6 +41406,8 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
+
+  jwt-decode@4.0.0: {}
 
   karma-source-map-support@1.4.0:
     dependencies:
@@ -40992,9 +41837,23 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   lodash.sortby@4.7.0: {}
 
@@ -42128,6 +42987,8 @@ snapshots:
 
   nanoid@3.3.16: {}
 
+  nanoid@5.1.16: {}
+
   nanoid@5.1.6: {}
 
   nanotar@0.3.0: {}
@@ -42177,32 +43038,6 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 15.5.21
       '@next/swc-win32-x64-msvc': 15.5.21
       '@opentelemetry/api': 1.9.1
-      '@playwright/test': 1.61.1
-      sass: 1.90.0
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
-  next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0):
-    dependencies:
-      '@next/env': 15.5.21
-      '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001799
-      postcss: 8.4.31
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@18.3.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.21
-      '@next/swc-darwin-x64': 15.5.21
-      '@next/swc-linux-arm64-gnu': 15.5.21
-      '@next/swc-linux-arm64-musl': 15.5.21
-      '@next/swc-linux-x64-gnu': 15.5.21
-      '@next/swc-linux-x64-musl': 15.5.21
-      '@next/swc-win32-arm64-msvc': 15.5.21
-      '@next/swc-win32-x64-msvc': 15.5.21
-      '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.61.1
       sass: 1.90.0
       sharp: 0.34.5
@@ -42289,7 +43124,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nitropack@2.13.4(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(encoding@0.1.13)(oxc-parser@0.132.0)(srvx@0.11.16):
+  nitropack@2.13.4(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(aws4fetch@1.0.20)(encoding@0.1.13)(oxc-parser@0.132.0)(srvx@0.11.16):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.62.2)
@@ -42356,7 +43191,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.3.0(oxc-parser@0.132.0)
       unplugin-utils: 0.3.1
-      unstorage: 1.17.5(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)
+      unstorage: 1.17.5(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -42408,6 +43243,10 @@ snapshots:
 
   node-addon-api@8.7.0:
     optional: true
+
+  node-cache@5.1.2:
+    dependencies:
+      clone: 2.1.2
 
   node-domexception@1.0.0: {}
 
@@ -42467,6 +43306,10 @@ snapshots:
   node-mock-http@1.0.4: {}
 
   node-releases@2.0.44: {}
+
+  node-rsa@1.1.1:
+    dependencies:
+      asn1: 0.2.6
 
   nopt@7.2.1:
     dependencies:
@@ -42580,16 +43423,16 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0):
+  nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@5.9.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@3.21.7)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(vue@3.5.38(typescript@5.9.3))
       '@nuxt/kit': 3.21.7(magicast@0.5.3)
-      '@nuxt/nitro-server': 3.21.7(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.132.0)(srvx@0.11.16)(typescript@5.9.3)
+      '@nuxt/nitro-server': 3.21.7(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(oxc-parser@0.132.0)(srvx@0.11.16)(typescript@5.9.3)
       '@nuxt/schema': 3.21.7
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@3.21.7(magicast@0.5.3))
-      '@nuxt/vite-builder': 3.21.7(@types/node@22.19.19)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))(yaml@2.9.0)
+      '@nuxt/vite-builder': 3.21.7(@types/node@22.19.19)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.5(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.2))(rollup@4.62.2)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vue@3.5.38(typescript@5.9.3))(yaml@2.9.0)
       '@unhead/vue': 2.1.15(vue@3.5.38(typescript@5.9.3))
       '@vue/shared': 3.5.38
       c12: 3.3.4(magicast@0.5.3)
@@ -42767,6 +43610,10 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  ollama@0.6.3:
+    dependencies:
+      whatwg-fetch: 3.6.20
+
   omggif@1.0.10: {}
 
   on-change@6.0.2: {}
@@ -42857,6 +43704,8 @@ snapshots:
       ws: 8.21.1
       zod: 4.4.3
     optional: true
+
+  opossum@10.0.0: {}
 
   optionator@0.9.4:
     dependencies:
@@ -43669,13 +44518,13 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.12:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -43802,6 +44651,8 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@1.1.0: {}
+
+  proxy-from-env@2.1.0: {}
 
   prr@1.0.1:
     optional: true
@@ -46592,7 +47443,7 @@ snapshots:
       picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
-  unstorage@1.17.5(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1):
+  unstorage@1.17.5(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.11.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -46604,7 +47455,7 @@ snapshots:
       ufo: 1.6.4
     optionalDependencies:
       '@upstash/redis': 1.38.0
-      '@vercel/functions': 3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1)
+      '@vercel/functions': 3.7.5(@aws-sdk/credential-provider-web-identity@3.972.67)(ws@8.21.1)
       aws4fetch: 1.0.20
       db0: 0.3.4
       ioredis: 5.11.1
@@ -46737,6 +47588,12 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  verror@1.10.1:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.4.1
 
   vfile-location@5.0.3:
     dependencies:
@@ -47233,6 +48090,8 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  voca@1.4.1: {}
+
   vscode-uri@3.1.0: {}
 
   vue-bundle-renderer@2.2.0:
@@ -47610,6 +48469,8 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
 
+  whatwg-fetch@3.6.20: {}
+
   whatwg-mimetype@4.0.0: {}
 
   whatwg-url@14.2.0:
@@ -47719,23 +48580,23 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workflow@4.2.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(typescript@5.8.3):
+  workflow@4.2.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(next@15.5.21(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(typescript@5.8.3):
     dependencies:
-      '@workflow/astro': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
-      '@workflow/cli': 4.2.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
-      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
+      '@workflow/astro': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/cli': 4.2.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.1)
       '@workflow/errors': 4.1.0
-      '@workflow/nest': 0.0.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)
-      '@workflow/next': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))
-      '@workflow/nitro': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
-      '@workflow/nuxt': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(magicast@0.5.3)
-      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
-      '@workflow/sveltekit': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/nest': 0.0.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)
+      '@workflow/next': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))
+      '@workflow/nitro': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/nuxt': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.3)
+      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/sveltekit': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
       '@workflow/typescript-plugin': 4.0.1(typescript@5.8.3)
       '@workflow/utils': 4.1.0
       ms: 2.1.3
     optionalDependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
     transitivePeerDependencies:
       - '@nestjs/common'
       - '@nestjs/core'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,7 +723,7 @@ importers:
         version: 2.1.1
       next:
         specifier: ^15.5.21
-        version: 15.5.21(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+        version: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -741,7 +741,7 @@ importers:
         version: 1.0.7(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
       workflow:
         specifier: 4.2.1
-        version: 4.2.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(next@15.5.21(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(typescript@5.8.3)
+        version: 4.2.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(typescript@5.8.3)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -35658,13 +35658,13 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@workflow/astro@4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
+  '@workflow/astro@4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
-      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
-      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -35720,10 +35720,10 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@workflow/builders@4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
+  '@workflow/builders@4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.1)
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
       '@workflow/errors': 4.1.0
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
       '@workflow/utils': 4.1.0
@@ -35778,21 +35778,21 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/cli@4.2.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
+  '@workflow/cli@4.2.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
     dependencies:
       '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
       '@vercel/cli-auth': 0.0.1
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
-      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.1)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
       '@workflow/errors': 4.1.0
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
       '@workflow/utils': 4.1.0
       '@workflow/web': 4.1.0
       '@workflow/world': 4.1.0(zod@4.3.6)
-      '@workflow/world-local': 4.1.0(@opentelemetry/api@1.9.1)
-      '@workflow/world-vercel': 4.1.0(@opentelemetry/api@1.9.1)
+      '@workflow/world-local': 4.1.0(@opentelemetry/api@1.9.0)
+      '@workflow/world-vercel': 4.1.0(@opentelemetry/api@1.9.0)
       boxen: 8.0.1
       builtin-modules: 5.0.0
       chalk: 5.6.2
@@ -35916,7 +35916,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@workflow/core@4.2.1(@opentelemetry/api@1.9.1)':
+  '@workflow/core@4.2.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -35927,8 +35927,8 @@ snapshots:
       '@workflow/serde': 4.1.0
       '@workflow/utils': 4.1.0
       '@workflow/world': 4.1.0(zod@4.3.6)
-      '@workflow/world-local': 4.1.0(@opentelemetry/api@1.9.1)
-      '@workflow/world-vercel': 4.1.0(@opentelemetry/api@1.9.1)
+      '@workflow/world-local': 4.1.0(@opentelemetry/api@1.9.0)
+      '@workflow/world-vercel': 4.1.0(@opentelemetry/api@1.9.0)
       debug: 4.4.3(supports-color@8.1.1)
       devalue: 5.6.3
       ms: 2.1.3
@@ -35938,7 +35938,7 @@ snapshots:
       ulid: 3.0.2
       zod: 4.3.6
     optionalDependencies:
-      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - supports-color
 
@@ -36010,13 +36010,13 @@ snapshots:
       '@workflow/utils': 4.1.3
       ms: 2.1.3
 
-  '@workflow/nest@0.0.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)':
+  '@workflow/nest@0.0.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)':
     dependencies:
       '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@swc/cli': 0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -36053,16 +36053,16 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/next@4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))':
+  '@workflow/next@4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
-      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.1)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
       semver: 7.7.4
       watchpack: 2.5.1
     optionalDependencies:
-      next: 15.5.21(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+      next: 15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -36114,14 +36114,14 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/nitro@4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
+  '@workflow/nitro@4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
-      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.1)
-      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
+      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
-      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -36172,10 +36172,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/nuxt@4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.3)':
+  '@workflow/nuxt@4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(magicast@0.5.3)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.3)
-      '@workflow/nitro': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/nitro': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -36203,10 +36203,10 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@workflow/rollup@4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
+  '@workflow/rollup@4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
       exsolve: 1.0.7
     transitivePeerDependencies:
@@ -36245,13 +36245,13 @@ snapshots:
 
   '@workflow/serde@4.1.2': {}
 
-  '@workflow/sveltekit@4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
+  '@workflow/sveltekit@4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
-      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/swc-plugin': 4.1.0(@swc/core@1.15.3(@swc/helpers@0.5.21))
-      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/vite': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       exsolve: 1.0.8
       fs-extra: 11.3.5
       pathe: 2.0.3
@@ -36323,9 +36323,9 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  '@workflow/vite@4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)':
+  '@workflow/vite@4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
     dependencies:
-      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -36382,6 +36382,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@workflow/world-local@4.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@vercel/queue': 0.1.4
+      '@workflow/errors': 4.1.0
+      '@workflow/utils': 4.1.0
+      '@workflow/world': 4.1.0(zod@4.3.6)
+      async-sema: 3.1.1
+      ulid: 3.0.2
+      undici: 7.22.0
+      zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@workflow/world-local@4.1.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@vercel/queue': 0.1.4
@@ -36420,6 +36433,18 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
+
+  '@workflow/world-vercel@4.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@vercel/queue': 0.1.4
+      '@workflow/errors': 4.1.0
+      '@workflow/world': 4.1.0(zod@4.3.6)
+      cbor-x: 1.6.0
+      undici: 7.22.0
+      zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
 
   '@workflow/world-vercel@4.1.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -43045,6 +43070,32 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0):
+    dependencies:
+      '@next/env': 15.5.21
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001799
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@18.3.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.21
+      '@next/swc-darwin-x64': 15.5.21
+      '@next/swc-linux-arm64-gnu': 15.5.21
+      '@next/swc-linux-arm64-musl': 15.5.21
+      '@next/swc-linux-x64-gnu': 15.5.21
+      '@next/swc-linux-x64-musl': 15.5.21
+      '@next/swc-win32-arm64-msvc': 15.5.21
+      '@next/swc-win32-x64-msvc': 15.5.21
+      '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.61.1
+      sass: 1.90.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   next@15.5.21(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0):
     dependencies:
       '@next/env': 15.5.21
@@ -48580,23 +48631,23 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workflow@4.2.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(next@15.5.21(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(typescript@5.8.3):
+  workflow@4.2.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(typescript@5.8.3):
     dependencies:
-      '@workflow/astro': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
-      '@workflow/cli': 4.2.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
-      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.1)
+      '@workflow/astro': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/cli': 4.2.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/core': 4.2.1(@opentelemetry/api@1.9.0)
       '@workflow/errors': 4.1.0
-      '@workflow/nest': 0.0.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)
-      '@workflow/next': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))
-      '@workflow/nitro': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
-      '@workflow/nuxt': 4.0.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.3)
-      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
-      '@workflow/sveltekit': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/nest': 0.0.1(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)
+      '@workflow/next': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))
+      '@workflow/nitro': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/nuxt': 4.0.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(magicast@0.5.3)
+      '@workflow/rollup': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/sveltekit': 4.0.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/typescript-plugin': 4.0.1(typescript@5.8.3)
       '@workflow/utils': 4.1.0
       ms: 2.1.3
     optionalDependencies:
-      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - '@nestjs/common'
       - '@nestjs/core'
@@ -48893,3 +48944,5 @@ snapshots:
     optional: true
 
   zwitch@2.0.4: {}
+
+time: {}

--- a/tools/verify-harness-adapter-deps.mjs
+++ b/tools/verify-harness-adapter-deps.mjs
@@ -20,6 +20,12 @@ const adapterConfigs = [
     ],
   },
   {
+    name: 'Cline',
+    packageDir: 'packages/harness-cline',
+    primarySdk: '@cline/agents',
+    sdkPackages: ['@cline/agents'],
+  },
+  {
     name: 'Codex',
     packageDir: 'packages/harness-codex',
     primarySdk: '@openai/codex-sdk',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -82,6 +82,9 @@
       "path": "packages/harness-claude-code"
     },
     {
+      "path": "packages/harness-cline"
+    },
+    {
       "path": "packages/harness-codex"
     },
     {


### PR DESCRIPTION
This adds `@ai-sdk/harness-cline` — a `HarnessV1` adapter that connects `HarnessAgent` to the [Cline SDK](https://docs.cline.bot/sdk/overview) agent runtime (`@cline/agents`). We (the Cline team) built and maintain it, and we're happy to keep maintaining it in-tree — treat us as the owning team for this package the way the Coming Soon adapters (Amp/Goose/Mastra) presumably have owning teams.

### Architecture: host-process, like Pi

Of the two adapter shapes in the codebase, Cline is a natural fit for the **host-process** model rather than a sandbox bridge. The Cline SDK's `Agent` runtime is a plain in-process TypeScript library — there's no CLI to install into the sandbox, no bridge bootstrap, no WebSocket relay, no pinned bridge lockfile. The adapter is ~1/3 the surface of the OpenCode adapter for that reason.

The split mirrors `harness-pi`:

- The **agent loop and model calls run on the host** via `new Agent({ providerId, modelId, ... })`.
- The **workspace lives entirely in the sandbox**: every built-in tool (`read`, `write`, `edit`, `bash`, `grep`, `glob`, `ls`) is implemented against the restricted `SandboxSession` surface (`readTextFile`/`writeTextFile`/`run`), with relative paths resolved against `sessionWorkDir` and `bash` executing there.

Unlike Pi, there's no host-side workspace mirror/VFS: the Cline runtime keeps its conversation in memory and has no fs-based resource discovery, so nothing on the host filesystem needs to impersonate the sandbox path. That deleted an entire subsystem (Pi's `pi-workspace-vfs` + `pi-workspace-mirror` + path mapper) from the design.

### How each harness feature maps onto the Cline runtime

- **Streaming**: `agent.subscribe()` events (`assistant-text-delta`, `assistant-reasoning-delta`, `assistant-message`, `tool-started`, `tool-finished`) are translated into harness stream parts in `cline-translate.ts`. The runtime streams flat deltas, so the translator owns text/reasoning block framing (start/delta/end) and emits a `finish-step` per model call using the assistant message's per-call `metrics`.
- **Built-in tool approvals** (`supportsBuiltinToolApprovals`): this uses the Cline runtime's *native* approval mechanism rather than gating inside tool `execute` functions. The harness `permissionMode` is compiled into runtime `toolPolicies` (`allow-edits` → `bash` needs approval; `allow-reads` → `write`/`edit`/`bash` need approval), and the runtime's `requestToolApproval` callback emits `tool-approval-request` and parks a promise resolved by `submitToolApproval`. One ordering subtlety: the Cline runtime asks for approval *before* it emits `tool-started`, but the harness contract implies a `tool-call` part exists before its approval request. The approval path therefore emits the `tool-call` part itself and the translator dedupes the later `tool-started` by `toolCallId` (there's a test asserting exactly this sequence).
- **Built-in tool filtering** (`supportsBuiltinToolFiltering`): native — filtered tools are simply never registered with the runtime, so the model never sees them.
- **Custom host-executed tools** (`HarnessV1ToolSpec`): each spec becomes a runtime tool whose `execute` parks a promise keyed by the runtime-provided `toolCallId`; `submitToolResult` resolves it. The execute also listens on the runtime's per-call abort signal so an aborted turn can't leave the loop dangling on a parked promise (the runtime awaits tool executions before it re-checks abort).
- **Mid-turn `submitUserMessage`**: wired to the runtime's `consumePendingUserMessage` hook — queued messages are injected between loop iterations, before the next model call.
- **Skills**: written into sandbox HOME (`~/.agents/skills/<name>/SKILL.md` via the shared `writeSkills` util) and advertised through a system-prompt section that tells the model to `read` a SKILL.md when relevant — progressive disclosure, since the standalone runtime has no native skill loader.
- **Lifecycle/resume**: conversation state is the runtime's message transcript. `doStop`/`doDetach` persist it as JSON into the sandbox workspace (`.cline-harness/history.json` under `sessionWorkDir`, path-containment-checked), so cross-process resume survives via the sandbox snapshot; `doStart({ resumeFrom })` restores it with `initialMessages`. Same-process detach during a live approval/tool wait parks the session in a module map (Pi's `parkedPiSessions` pattern) so the parked promise survives. `doSuspendTurn` is the lossy host-process variant: abort silently (a `suspending` flag suppresses the spurious `error`/`finish` parts), persist history, rerun-continue next slice via `agent.continue()` with no input.
- **`doCompact`**: throws `HarnessCapabilityUnsupportedError` — the standalone Cline runtime has no manual compaction trigger (Codex-over-exec precedent).

### Defaults & auth

`createCline()` defaults to `providerId: 'anthropic'`, `modelId: 'claude-opus-5'`; `apiKey` falls back to the provider's env var (e.g. `ANTHROPIC_API_KEY`) through the Cline gateway. `cline` is exported as the zero-config instance, matching `pi`/`openCode`.

### Testing

53 unit tests across the translator (block framing, approval ordering/dedupe, providerExecuted semantics), sandbox-backed ops (path resolution, edit-by-replacement, bash timeout/abort, glob filtering), resume-state round-trip + path-traversal rejection, and the harness surface. `pnpm build`, `pnpm type-check`, and `pnpm test` are green in `packages/harness-cline`.