### PR TITLE
feat (ai): expose providerMetadata in onLanguageModelCallEnd callback

### DIFF
--- a/.changeset/lazy-planets-attend.md
+++ b/.changeset/lazy-planets-attend.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Expose providerMetadata in the onLanguageModelCallEnd callback event.

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -3080,6 +3080,49 @@ describe('generateText', () => {
         ]
       `);
     });
+
+    it('should expose providerMetadata on model-call end when the model provides it', async () => {
+      let modelCallEndEvent!: LanguageModelCallEndEvent;
+
+      await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => ({
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: 'Hello, world!' }],
+            providerMetadata: {
+              testProvider: { testKey: 'test-value' },
+            },
+          }),
+        }),
+        onLanguageModelCallEnd: async event => {
+          modelCallEndEvent = event;
+        },
+        ...defaultSettings(),
+      });
+
+      expect(modelCallEndEvent.providerMetadata).toStrictEqual({
+        testProvider: { testKey: 'test-value' },
+      });
+    });
+
+    it('should not expose providerMetadata on model-call end when the model does not provide it', async () => {
+      let modelCallEndEvent!: LanguageModelCallEndEvent;
+
+      await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => ({
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: 'Hello, world!' }],
+          }),
+        }),
+        onLanguageModelCallEnd: async event => {
+          modelCallEndEvent = event;
+        },
+        ...defaultSettings(),
+      });
+
+      expect(modelCallEndEvent).not.toHaveProperty('providerMetadata');
+    });
   });
 
   describe('options.onToolExecutionStart', () => {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1024,6 +1024,11 @@ export async function generateText<
                   usage: stepUsage,
                   content: modelCallContent,
                   responseId: currentModelResponse.response.id,
+                  ...(currentModelResponse.providerMetadata != null
+                    ? {
+                        providerMetadata: currentModelResponse.providerMetadata,
+                      }
+                    : {}),
                   performance: {
                     responseTimeMs,
                     effectiveOutputTokensPerSecond: calculateTokensPerSecond({

--- a/packages/ai/src/generate-text/language-model-events.ts
+++ b/packages/ai/src/generate-text/language-model-events.ts
@@ -5,6 +5,7 @@ import type { LanguageModelUsage } from '../types/usage';
 import type { ContentPart } from './content-part';
 import type { StandardizedPrompt } from '../prompt/standardize-prompt';
 import type { LanguageModelCallOptions } from '../prompt';
+import type { ProviderMetadata } from '../types/provider-metadata';
 import type { OutputChunkTimingStats } from './step-result';
 
 /**
@@ -54,6 +55,13 @@ export type LanguageModelCallEndEvent<TOOLS extends ToolSet = ToolSet> =
 
     /** The provider-returned response id for this model call. */
     readonly responseId: string;
+
+    /**
+     * Additional provider-specific metadata. They are passed through
+     * from the provider to the AI SDK and enable provider-specific
+     * results that can be fully encapsulated in the provider.
+     */
+    readonly providerMetadata?: ProviderMetadata;
 
     /** Performance metrics for the model call. */
     readonly performance: {

--- a/packages/ai/src/generate-text/stream-language-model-call.test.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.test.ts
@@ -419,6 +419,65 @@ describe('streamLanguageModelCall', () => {
         }
       `);
     });
+
+    it('should expose providerMetadata on model-call end when the model provides it', async () => {
+      let endEvent!: LanguageModelCallEndEvent;
+
+      const { stream } = await streamLanguageModelCall({
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+                providerMetadata: {
+                  testProvider: { testKey: 'test-value' },
+                },
+              },
+            ]),
+          }),
+        }),
+        prompt: 'test prompt',
+        callId: 'test-telemetry-call-id',
+        onLanguageModelCallEnd: async event => {
+          endEvent = event;
+        },
+      });
+
+      await convertReadableStreamToArray(stream);
+
+      expect(endEvent.providerMetadata).toStrictEqual({
+        testProvider: { testKey: 'test-value' },
+      });
+    });
+
+    it('should not expose providerMetadata on model-call end when the model does not provide it', async () => {
+      let endEvent!: LanguageModelCallEndEvent;
+
+      const { stream } = await streamLanguageModelCall({
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: testUsage,
+              },
+            ]),
+          }),
+        }),
+        prompt: 'test prompt',
+        callId: 'test-telemetry-call-id',
+        onLanguageModelCallEnd: async event => {
+          endEvent = event;
+        },
+      });
+
+      await convertReadableStreamToArray(stream);
+
+      expect(endEvent).not.toHaveProperty('providerMetadata');
+    });
   });
 
   describe('stream-start parts', () => {

--- a/packages/ai/src/generate-text/stream-language-model-call.ts
+++ b/packages/ai/src/generate-text/stream-language-model-call.ts
@@ -595,6 +595,9 @@ function createLanguageModelV4StreamPartToLanguageModelStreamPartTransform<
               usage,
               content: modelCallContent,
               responseId,
+              ...(chunk.providerMetadata != null
+                ? { providerMetadata: chunk.providerMetadata }
+                : {}),
               performance,
             },
             callbacks: onLanguageModelCallEnd,


### PR DESCRIPTION
Implements #18093, filed by @gr2m.

Adds `providerMetadata` to the `onLanguageModelCallEnd` callback event: `generateText` passes it through from the model response, and the streaming path collects it from the final stream parts in `stream-language-model-call`. Field shape and optionality mirror the neighboring fields on the event type.

Changeset included (`ai` patch). Tests cover both paths: the callback receives providerMetadata from a mock model that emits it (generate + stream) and the field is absent when the model provides none. Both new tests fail without the implementation; generate-text and stream-language-model-call suites pass with zero new failures.
