### PR TITLE
fix(docs): guard against caching invalid JSON in caching middleware example

### DIFF
--- a/content/docs/06-advanced/04-caching.mdx
+++ b/content/docs/06-advanced/04-caching.mdx
@@ -19,6 +19,7 @@ Let's see how you can use language model middleware to cache responses.
 import { Redis } from '@upstash/redis';
 import {
   type LanguageModelV4,
+  type LanguageModelV4GenerateResult,
   type LanguageModelV4Middleware,
   type LanguageModelV4StreamPart,
   simulateReadableStream,
@@ -28,6 +29,20 @@ const redis = new Redis({
   url: process.env.KV_URL,
   token: process.env.KV_TOKEN,
 });
+
+function isValidJson(result: LanguageModelV4GenerateResult): boolean {
+  const text = result.content
+    .filter(part => part.type === 'text')
+    .map(part => part.text)
+    .join('');
+
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export const cacheMiddleware: LanguageModelV4Middleware = {
   wrapGenerate: async ({ doGenerate, params }) => {
@@ -50,6 +65,14 @@ export const cacheMiddleware: LanguageModelV4Middleware = {
     }
 
     const result = await doGenerate();
+
+    // Skip caching invalid JSON when JSON output was requested (e.g. via
+    // `generateObject`). Otherwise a single malformed response gets cached
+    // and replayed on every subsequent call with the same parameters, even
+    // though a fresh call to the model would likely succeed.
+    if (params.responseFormat?.type === 'json' && !isValidJson(result)) {
+      return result;
+    }
 
     redis.set(cacheKey, result);
 
@@ -108,6 +131,17 @@ export const cacheMiddleware: LanguageModelV4Middleware = {
 <Note>
   This example uses `@upstash/redis` to store and retrieve the assistant's
   responses but you can use any KV storage provider you would like.
+</Note>
+
+<Note>
+  This middleware sits below [`generateObject`](/docs/reference/ai-sdk-core/generate-object),
+  so it caches the model's raw output before `generateObject` validates it
+  against your schema. The `isValidJson` check above only guards against
+  caching output that isn't parseable JSON at all - it does not validate
+  against your schema, since the middleware doesn't have access to it. If
+  you need schema-level validation before caching, validate the result
+  yourself (e.g. with the same schema you pass to `generateObject`) before
+  calling `redis.set`.
 </Note>
 
 `LanguageModelV4Middleware` has two methods: `wrapGenerate` and `wrapStream`. `wrapGenerate` is called when using [`generateText`](/docs/reference/ai-sdk-core/generate-text), while `wrapStream` is called when using [`streamText`](/docs/reference/ai-sdk-core/stream-text).


### PR DESCRIPTION
## Problem

Fixes #9594.

The caching middleware example in `content/docs/06-advanced/04-caching.mdx` stores the raw `doGenerate` result inside `wrapGenerate`, before `generateObject` validates it against the caller’s schema.

If the model returns malformed JSON, that response is cached and replayed on every subsequent call with the same parameters. A single transient bad response therefore becomes a persistent failure, even though another model call might succeed.

## Fix

Before caching structured output, the middleware now extracts the text and checks that it contains valid JSON.

This check runs when `params.responseFormat?.type === 'json'`. It intentionally verifies JSON syntax only-not the caller’s full schema-because `wrapGenerate` doesn’t have access to the original Zod schema. A new `<Note>` explains this limitation and how to add schema validation when needed.

## Verification

I reproduced the issue using an in-memory cache and a mock model that returns malformed JSON on its first call and valid JSON afterward:

* **Before:** The first call fails and caches the malformed response. The second call reads the same response from the cache and fails without calling the model again.
* **After:** The first call still fails, but its response isn’t cached. The second call invokes the model again and succeeds.

This is a docs-only change to `content/docs/06-advanced/04-caching.mdx`, so no changeset is required under `CONTRIBUTING.md`.


## Screenshots

Ran the reproduction as two vitest files (one against the unfixed middleware pattern, one against the fixed pattern) side by side in vitest's UI:

<img width="728" alt="vitest dashboard: 1 pass, 1 fail" src="https://github.com/user-attachments/assets/7d018709-ef32-4f85-ac3f-0c5994360671" />

**Before** - unfixed pattern fails on the second `generateObject` call (replays the cached invalid JSON):

<img width="728" alt="before: failing test detail" src="https://github.com/user-attachments/assets/387f9290-86e5-4e7c-a8d3-519942553fac" />

**After** - fixed pattern succeeds on the second call (invalid JSON was never cached, so it re-generates):

<img width="728" alt="after: passing test detail" src="https://github.com/user-attachments/assets/62987d7e-b440-4ea2-b6cf-7b1428a41b35" />
