### PR TITLE
fix(ai): avoid adopting previous assistant messages on resume

### DIFF
--- a/.changeset/quiet-lions-resume.md
+++ b/.changeset/quiet-lions-resume.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Prevent resumed streams from adopting assistant messages from previous turns when the stream identifies a different message.

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -1471,6 +1471,133 @@ describe('Chat', () => {
     expect(chat.status).toBe('error');
   });
 
+  describe('resume stream', () => {
+    function createResumeStream(messageId?: string) {
+      return new ReadableStream<UIMessageChunk>({
+        start(controller) {
+          controller.enqueue({
+            type: 'start',
+            ...(messageId == null ? {} : { messageId }),
+          });
+          controller.enqueue({ type: 'start-step' });
+          controller.enqueue({ type: 'text-start', id: 'text-1' });
+          controller.enqueue({
+            type: 'text-delta',
+            id: 'text-1',
+            delta: 'resumed',
+          });
+          controller.enqueue({ type: 'text-end', id: 'text-1' });
+          controller.enqueue({ type: 'finish-step' });
+          controller.enqueue({ type: 'finish', finishReason: 'stop' });
+          controller.close();
+        },
+      });
+    }
+
+    function createChat({
+      messages,
+      messageId,
+    }: {
+      messages: UIMessage[];
+      messageId?: string;
+    }) {
+      return new TestChat({
+        id: '123',
+        messages,
+        generateId: mockId(),
+        transport: {
+          sendMessages: async () => {
+            throw new Error('not implemented');
+          },
+          reconnectToStream: async () => createResumeStream(messageId),
+        },
+      });
+    }
+
+    it('should not adopt an assistant message from a different turn', async () => {
+      const chat = createChat({
+        messages: [
+          {
+            id: 'turn-0',
+            role: 'user',
+            parts: [{ type: 'text', text: 'first question' }],
+          },
+          {
+            id: 'turn-0:reply',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'first answer' }],
+          },
+        ],
+        messageId: 'turn-1:reply',
+      });
+
+      await chat.resumeStream();
+
+      expect(chat.messages).toHaveLength(3);
+      expect(chat.messages[1]).toMatchObject({
+        id: 'turn-0:reply',
+        parts: [{ type: 'text', text: 'first answer' }],
+        role: 'assistant',
+      });
+      expect(chat.messages[2]).toMatchObject({
+        id: 'turn-1:reply',
+        parts: [{ type: 'step-start' }, { type: 'text', text: 'resumed' }],
+        role: 'assistant',
+      });
+    });
+
+    it('should preserve the assistant message when its id matches', async () => {
+      const chat = createChat({
+        messages: [
+          {
+            id: 'turn-1:reply',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'partial response' }],
+          },
+        ],
+        messageId: 'turn-1:reply',
+      });
+
+      await chat.resumeStream();
+
+      expect(chat.messages).toHaveLength(1);
+      expect(chat.messages[0]).toMatchObject({
+        id: 'turn-1:reply',
+        parts: [
+          { type: 'text', text: 'partial response' },
+          { type: 'step-start' },
+          { type: 'text', text: 'resumed' },
+        ],
+        role: 'assistant',
+      });
+    });
+
+    it('should preserve the assistant message when the stream has no message id', async () => {
+      const chat = createChat({
+        messages: [
+          {
+            id: 'turn-0:reply',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'existing response' }],
+          },
+        ],
+      });
+
+      await chat.resumeStream();
+
+      expect(chat.messages).toHaveLength(1);
+      expect(chat.messages[0]).toMatchObject({
+        id: 'turn-0:reply',
+        parts: [
+          { type: 'text', text: 'existing response' },
+          { type: 'step-start' },
+          { type: 'text', text: 'resumed' },
+        ],
+        role: 'assistant',
+      });
+    });
+  });
+
   it('should not throw to console when an overlapped request clears activeResponse before resume-stream finishes', async () => {
     let resumeController!: ReadableStreamDefaultController<UIMessageChunk>;
     const resumeStream = new ReadableStream<UIMessageChunk>({

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -723,6 +723,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
           messageMetadataSchema: this.messageMetadataSchema,
           dataPartSchemas: this.dataPartSchemas,
           runUpdateMessageJob,
+          isResume: trigger === 'resume-stream',
           onError: error => {
             throw error;
           },

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -49,6 +49,20 @@ export type StreamingUIMessageState<UI_MESSAGE extends UIMessage> = {
   finishReason?: FinishReason;
 };
 
+function createEmptyAssistantMessage<UI_MESSAGE extends UIMessage>(
+  messageId: string,
+): UI_MESSAGE {
+  return {
+    id: messageId,
+    metadata: undefined,
+    role: 'assistant',
+    parts: [] as UIMessagePart<
+      InferUIMessageData<UI_MESSAGE>,
+      InferUIMessageTools<UI_MESSAGE>
+    >[],
+  } as UI_MESSAGE;
+}
+
 export function createStreamingUIMessageState<UI_MESSAGE extends UIMessage>({
   lastMessage,
   messageId,
@@ -60,15 +74,7 @@ export function createStreamingUIMessageState<UI_MESSAGE extends UIMessage>({
     message:
       lastMessage?.role === 'assistant'
         ? lastMessage
-        : ({
-            id: messageId,
-            metadata: undefined,
-            role: 'assistant',
-            parts: [] as UIMessagePart<
-              InferUIMessageData<UI_MESSAGE>,
-              InferUIMessageTools<UI_MESSAGE>
-            >[],
-          } as UI_MESSAGE),
+        : createEmptyAssistantMessage<UI_MESSAGE>(messageId),
     activeTextParts: createIdMap(),
     activeReasoningParts: createIdMap(),
     partialToolCalls: createIdMap(),
@@ -83,6 +89,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
   onError,
   onToolCall,
   onData,
+  isResume = false,
 }: {
   // input stream is not fully typed yet:
   stream: ReadableStream<UIMessageChunk>;
@@ -99,6 +106,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
     }) => Promise<void>,
   ) => Promise<void>;
   onError: ErrorHandler;
+  isResume?: boolean;
 }): ReadableStream<InferUIMessageChunk<UI_MESSAGE>> {
   return stream.pipeThrough(
     new TransformStream<UIMessageChunk, InferUIMessageChunk<UI_MESSAGE>>({
@@ -884,7 +892,13 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
 
             case 'start': {
               if (chunk.messageId != null) {
-                state.message.id = chunk.messageId;
+                if (isResume && state.message.id !== chunk.messageId) {
+                  state.message = createEmptyAssistantMessage<UI_MESSAGE>(
+                    chunk.messageId,
+                  );
+                } else {
+                  state.message.id = chunk.messageId;
+                }
               }
 
               await updateMessageMetadata(chunk.messageMetadata);


### PR DESCRIPTION
## Summary

- Prevent `resumeStream()` from adopting an assistant message from a previous turn when the resumed stream identifies a different message.
- Preserve accumulated parts when the resumed stream identifies the same assistant message.
- Preserve existing behavior when the stream does not provide a message ID and for non-resume stream processing.

## Root cause

`createStreamingUIMessageState` initially adopted any trailing assistant message before the resumed stream's identity was known. When the stream later emitted a `start` chunk with a different `messageId`, the processor replaced the adopted message's ID but retained its parts. The chat write path then appended that renamed message, duplicating content from the previous turn.

## Fix

`processUIMessageStream` now accepts an `isResume` option. `AbstractChat` enables it only for the `resume-stream` trigger.

For resumed streams, a `start` chunk whose `messageId` differs from the currently adopted message resets the state to an empty assistant message before applying stream metadata and subsequent parts. The option defaults to `false`, so other callers and existing submit, regenerate, and server-side tool round-trip behavior remain unchanged.

## Tests

Added resume-stream coverage for:

- a different message ID, which leaves the previous assistant unchanged and appends a clean new assistant;
- a matching message ID, which preserves the existing assistant parts;
- no stream message ID, which preserves the existing compatibility behavior.

## Validation

- `pnpm exec vitest --config vitest.node.config.js --run src/ui/chat.test.ts src/ui/process-ui-message-stream.test.ts`
- `pnpm type-check` in `packages/ai`
- `pnpm exec ultracite check packages/ai/src/ui/process-ui-message-stream.ts packages/ai/src/ui/chat.ts packages/ai/src/ui/chat.test.ts`
- `git diff --check`

The full workspace type-check was not completed locally because this checkout used a filtered dependency install; unrelated examples and workspace packages reported missing dependencies. The affected package type-check and focused tests pass.

Fixes #18107
