### PR TITLE
fix (harness-pi): dispatch custom model ids through customEnv-registered providers

### DIFF
--- a/.changeset/harness-pi-custom-env-dispatch.md
+++ b/.changeset/harness-pi-custom-env-dispatch.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-pi': patch
+---
+
+fix (harness-pi): dispatch custom model ids through `auth.customEnv`-registered providers and prefer registered providers during model resolution

--- a/packages/harness-pi/src/pi-auth.test.ts
+++ b/packages/harness-pi/src/pi-auth.test.ts
@@ -201,6 +201,7 @@ describe('registerPiProviders', () => {
       apiKey: 'mk',
       baseUrl: 'https://api.mistral.example',
       authHeader: true,
+      api: 'openai-completions',
     });
   });
 

--- a/packages/harness-pi/src/pi-auth.ts
+++ b/packages/harness-pi/src/pi-auth.ts
@@ -26,7 +26,9 @@ export type PiAuthOptions = {
    *  - `ANTHROPIC`  → registers `anthropic` (`ANTHROPIC_AUTH_TOKEN` adds a
    *                   bearer auth header)
    * Any other `<PREFIX>_API_KEY` with a matching `<PREFIX>_BASE_URL` is
-   * registered as the lowercased, dash-separated prefix.
+   * registered as the lowercased, dash-separated prefix. These providers are
+   * assumed to be OpenAI-compatible; a configured model id that is not in
+   * Pi's catalog is dispatched through the registered provider.
    */
   readonly customEnv?: Record<string, string>;
 };
@@ -247,6 +249,11 @@ async function registerCustomProviders({
         apiKey,
         baseUrl,
         authHeader: true,
+        // The `<PREFIX>_API_KEY` / `<PREFIX>_BASE_URL` contract is
+        // OpenAI-compatible. Declaring the wire API lets the model resolver
+        // dispatch model ids that are not in Pi's catalog through this
+        // provider (see `createPiModelResolver`).
+        api: 'openai-completions',
       },
     });
   }

--- a/packages/harness-pi/src/pi-model-resolver.test.ts
+++ b/packages/harness-pi/src/pi-model-resolver.test.ts
@@ -102,4 +102,75 @@ describe('createPiModelResolver', () => {
     });
     expect(resolve(undefined)).toBeUndefined();
   });
+
+  describe('customEnv-registered providers', () => {
+    const customProviderConfig = {
+      apiKey: 'sk-test',
+      baseUrl: 'https://my.provider.example/v1',
+      authHeader: true,
+      api: 'openai-completions',
+    } as const;
+
+    it('prefers a registered provider over an unregistered one sharing the model id', async () => {
+      const registeredModel: PiModel = {
+        ...sampleModel,
+        provider: 'my-provider',
+        baseUrl: customProviderConfig.baseUrl,
+      };
+      const modelRegistry = await makeRegistry([sampleModel, registeredModel]);
+      modelRegistry.registerProvider('my-provider', customProviderConfig);
+      const resolve = createPiModelResolver({ modelRegistry, env: {} });
+      expect(resolve('my/model')).toEqual(registeredModel);
+    });
+
+    it('dispatches an uncataloged model id through the single registered custom provider', async () => {
+      const modelRegistry = await makeRegistry([sampleModel]);
+      modelRegistry.registerProvider('my-provider', customProviderConfig);
+      const resolve = createPiModelResolver({ modelRegistry, env: {} });
+      expect(resolve('my-custom-model')).toEqual({
+        id: 'my-custom-model',
+        name: 'my-custom-model',
+        api: 'openai-completions',
+        provider: 'my-provider',
+        baseUrl: customProviderConfig.baseUrl,
+        reasoning: false,
+        input: ['text'],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 16_384,
+      });
+    });
+
+    it('does not synthesize a model when multiple custom providers are registered', async () => {
+      const modelRegistry = await makeRegistry([sampleModel]);
+      modelRegistry.registerProvider('my-provider', customProviderConfig);
+      modelRegistry.registerProvider('other-provider', {
+        ...customProviderConfig,
+        baseUrl: 'https://other.provider.example/v1',
+      });
+      const resolve = createPiModelResolver({ modelRegistry, env: {} });
+      expect(resolve('my-custom-model')).toBeUndefined();
+    });
+
+    it('does not synthesize a model for providers without a declared api', async () => {
+      const modelRegistry = await makeRegistry([sampleModel]);
+      modelRegistry.registerProvider('my-provider', {
+        apiKey: 'sk-test',
+        baseUrl: customProviderConfig.baseUrl,
+        authHeader: true,
+      });
+      const resolve = createPiModelResolver({ modelRegistry, env: {} });
+      expect(resolve('my-custom-model')).toBeUndefined();
+    });
+
+    it('does not synthesize a model for the gateway default model id', async () => {
+      const modelRegistry = await makeRegistry([sampleModel]);
+      modelRegistry.registerProvider('my-provider', customProviderConfig);
+      const resolve = createPiModelResolver({
+        modelRegistry,
+        env: { AI_GATEWAY_API_KEY: 'sk-test' },
+      });
+      expect(resolve(undefined)).toBeUndefined();
+    });
+  });
 });

--- a/packages/harness-pi/src/pi-model-resolver.ts
+++ b/packages/harness-pi/src/pi-model-resolver.ts
@@ -32,6 +32,40 @@ export function createPiModelResolver({
     return cachedModels;
   };
 
+  // Providers registered through `auth.customEnv` contribute credentials but
+  // no catalog entries, so a custom model id served by such a provider can
+  // never match `getAll()`. When exactly one registered provider declares its
+  // wire `api` and `baseUrl` (the generic `<PREFIX>_API_KEY` /
+  // `<PREFIX>_BASE_URL` pattern), dispatch the requested id through it
+  // instead of letting Pi silently fall back to its own default model.
+  const synthesizeRegisteredProviderModel = (
+    modelId: string,
+  ): PiModel | undefined => {
+    const candidates = modelRegistry
+      .getRegisteredProviderIds()
+      .flatMap(provider => {
+        const config = modelRegistry.getRegisteredProviderConfig(provider);
+        return config?.api && config.baseUrl
+          ? [{ provider, api: config.api, baseUrl: config.baseUrl }]
+          : [];
+      });
+    if (candidates.length !== 1) return undefined;
+    const [{ provider, api, baseUrl }] = candidates;
+    return {
+      id: modelId,
+      name: modelId,
+      api,
+      provider,
+      baseUrl,
+      // Mirrors Pi's own defaults for custom `models.json` model entries.
+      reasoning: false,
+      input: ['text'],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 16_384,
+    };
+  };
+
   return (modelId: string | undefined): PiModel | undefined => {
     const useGateway = Boolean(getAiGatewayAuthFromEnv({ env }).apiKey);
     const effectiveId =
@@ -42,15 +76,28 @@ export function createPiModelResolver({
     const matches = (m: PiModel) =>
       m.id === effectiveId || m.name === effectiveId;
 
+    const registeredProviders = new Set(
+      modelRegistry.getRegisteredProviderIds(),
+    );
+
     // When gateway creds are present, prefer the gateway-routed entry for the
     // given id. Pi's catalog lists the same model id under multiple providers
     // (e.g. `anthropic/claude-sonnet-4.6` exists under both `openrouter` and
     // `vercel-ai-gateway`); without this preference Pi would dispatch through
     // a provider we didn't register, which fails with "No API key found".
-    return (
+    // The same applies to any other provider registered for this session
+    // (e.g. `openai` via `auth.customEnv`): prefer entries whose provider was
+    // actually authenticated over entries that merely share the model id.
+    const resolved =
       (useGateway &&
         models.find(m => m.provider === 'vercel-ai-gateway' && matches(m))) ||
-      models.find(matches)
-    );
+      models.find(m => registeredProviders.has(m.provider) && matches(m)) ||
+      models.find(matches);
+    if (resolved) return resolved;
+
+    // Only an explicitly configured model id may target a custom provider;
+    // the gateway default id never should.
+    if (modelId == null) return undefined;
+    return synthesizeRegisteredProviderModel(modelId);
   };
 }


### PR DESCRIPTION
Fixes #18147, reported by @Leonezz.

Providers registered through `auth.customEnv` contributed credentials but no catalog entries, so a custom model id matched nothing and Pi silently swapped in its own default model, then failed with a misleading "No API key found".

Three changes in harness-pi: generic `<PREFIX>_API_KEY`/`<PREFIX>_BASE_URL` providers now register with `api: 'openai-completions'` (the pattern's contract); the resolver prefers catalog matches whose provider is actually registered for the session (generalizing the existing vercel-ai-gateway preference); and when an explicitly configured model id matches no catalog entry and exactly one registered provider declares `api` + `baseUrl`, the resolver synthesizes a model entry for it (Pi's own custom-models.json defaults), so the request dispatches to the user's endpoint. Ambiguous multi-provider cases intentionally keep current behavior; that design belongs to #16099.

Changeset included (`@ai-sdk/harness-pi` patch). Five new tests; 3 fail with the fix reverted. Package suite: 122 passed (baseline 117, zero new failures). tsc/oxlint/oxfmt clean.
