### PR TITLE
fix(provider/openai): resolve responses doStream at response.in_progress instead of first output token

### DIFF
--- a/.changeset/lucky-pears-brake.md
+++ b/.changeset/lucky-pears-brake.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/test-server': patch
+---
+
+fix(test-server): swallow controller.error rejection in the controlled-stream abort listener when the writer is already closed

--- a/.changeset/olive-lamps-listen.md
+++ b/.changeset/olive-lamps-listen.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(provider/openai): resolve responses doStream at response.in_progress instead of first output token
+
+The early-stream-error peek treated `response.in_progress` as an unknown chunk, so `doStream` did not resolve until the first output item arrived — delaying stream availability (and downstream TTFB for proxies/gateways) by the model's full time-to-first-token. `response.in_progress` is now modeled in the chunk schema and marks the request as accepted: the peek keeps watching for error frames for a short grace window (50ms) so quota/rate-limit errors flushed alongside `response.in_progress` still throw as retryable `APICallError`s, while healthy streams become available right after upstream acknowledges the request.

--- a/packages/openai/src/openai-stream-error.test.ts
+++ b/packages/openai/src/openai-stream-error.test.ts
@@ -1,0 +1,191 @@
+import type { ParseResult } from '@ai-sdk/provider-utils';
+import { describe, expect, it } from 'vitest';
+import { throwIfOpenAIStreamErrorBeforeOutput } from './openai-stream-error';
+
+type TestChunk =
+  | { type: 'created' }
+  | { type: 'accepted' }
+  | { type: 'output'; text: string }
+  | { type: 'error'; message: string };
+
+function ok(chunk: TestChunk): ParseResult<TestChunk> {
+  return { success: true, value: chunk, rawValue: chunk };
+}
+
+function getError(chunk: TestChunk): unknown | undefined {
+  return chunk.type === 'error' ? { error: chunk } : undefined;
+}
+
+function isOutputChunk(chunk: TestChunk): boolean {
+  return chunk.type === 'output';
+}
+
+function isAcceptedChunk(chunk: TestChunk): boolean {
+  return chunk.type === 'accepted';
+}
+
+function createControlledStream(): {
+  stream: ReadableStream<ParseResult<TestChunk>>;
+  enqueue: (chunk: TestChunk) => void;
+  close: () => void;
+} {
+  let controller!: ReadableStreamDefaultController<ParseResult<TestChunk>>;
+  const stream = new ReadableStream<ParseResult<TestChunk>>({
+    start(c) {
+      controller = c;
+    },
+  });
+  return {
+    stream,
+    enqueue: chunk => controller.enqueue(ok(chunk)),
+    close: () => controller.close(),
+  };
+}
+
+async function readAll(
+  stream: ReadableStream<ParseResult<TestChunk>>,
+): Promise<TestChunk[]> {
+  const chunks: TestChunk[] = [];
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value.success) {
+      chunks.push(value.value);
+    }
+  }
+  return chunks;
+}
+
+const baseArgs = {
+  getError,
+  isOutputChunk,
+  url: 'https://api.test.com/v1/responses',
+  requestBodyValues: {},
+};
+
+describe('throwIfOpenAIStreamErrorBeforeOutput', () => {
+  it('should throw when an error frame arrives before output', async () => {
+    const { stream, enqueue, close } = createControlledStream();
+    enqueue({ type: 'created' });
+    enqueue({ type: 'error', message: 'quota exceeded' });
+    close();
+
+    await expect(
+      throwIfOpenAIStreamErrorBeforeOutput({ ...baseArgs, stream }),
+    ).rejects.toMatchObject({
+      responseBody: expect.stringContaining('quota exceeded'),
+    });
+  });
+
+  it('should resolve on the first output chunk and replay all chunks to the consumer', async () => {
+    const { stream, enqueue, close } = createControlledStream();
+    enqueue({ type: 'created' });
+    enqueue({ type: 'output', text: 'hello' });
+    close();
+
+    const checked = await throwIfOpenAIStreamErrorBeforeOutput({
+      ...baseArgs,
+      stream,
+    });
+
+    expect(await readAll(checked)).toEqual([
+      { type: 'created' },
+      { type: 'output', text: 'hello' },
+    ]);
+  });
+
+  it('should keep blocking until output when no accepted-chunk detector is provided', async () => {
+    const { stream, enqueue, close } = createControlledStream();
+    enqueue({ type: 'created' });
+    enqueue({ type: 'accepted' });
+
+    let resolved = false;
+    const promise = throwIfOpenAIStreamErrorBeforeOutput({
+      ...baseArgs,
+      stream,
+    }).then(result => {
+      resolved = true;
+      return result;
+    });
+
+    // give the grace window (which must not be armed here) time to fire:
+    await new Promise(resolve => setTimeout(resolve, 30));
+    expect(resolved).toBe(false);
+
+    enqueue({ type: 'output', text: 'late' });
+    close();
+
+    expect(await readAll(await promise)).toEqual([
+      { type: 'created' },
+      { type: 'accepted' },
+      { type: 'output', text: 'late' },
+    ]);
+  });
+
+  describe('with an accepted-chunk detector', () => {
+    it('should resolve after the grace window when the stream stalls after acceptance', async () => {
+      const { stream, enqueue, close } = createControlledStream();
+      enqueue({ type: 'created' });
+      enqueue({ type: 'accepted' });
+      // no output chunk: the stream stalls (first token still pending)
+
+      const checked = await throwIfOpenAIStreamErrorBeforeOutput({
+        ...baseArgs,
+        stream,
+        isAcceptedChunk,
+        acceptedGraceMs: 10,
+      });
+
+      // chunks that arrive after resolution still reach the consumer:
+      enqueue({ type: 'output', text: 'late token' });
+      close();
+
+      expect(await readAll(checked)).toEqual([
+        { type: 'created' },
+        { type: 'accepted' },
+        { type: 'output', text: 'late token' },
+      ]);
+    });
+
+    it('should still throw when an error frame is flushed together with the accepted chunk', async () => {
+      const { stream, enqueue, close } = createControlledStream();
+      enqueue({ type: 'created' });
+      enqueue({ type: 'accepted' });
+      enqueue({ type: 'error', message: 'insufficient quota' });
+      close();
+
+      await expect(
+        throwIfOpenAIStreamErrorBeforeOutput({
+          ...baseArgs,
+          stream,
+          isAcceptedChunk,
+          acceptedGraceMs: 10,
+        }),
+      ).rejects.toMatchObject({
+        responseBody: expect.stringContaining('insufficient quota'),
+      });
+    });
+
+    it('should resolve immediately on output without waiting for the grace window', async () => {
+      const { stream, enqueue, close } = createControlledStream();
+      enqueue({ type: 'created' });
+      enqueue({ type: 'accepted' });
+      enqueue({ type: 'output', text: 'hello' });
+      close();
+
+      const checked = await throwIfOpenAIStreamErrorBeforeOutput({
+        ...baseArgs,
+        stream,
+        isAcceptedChunk,
+        acceptedGraceMs: 60_000, // must not delay resolution
+      });
+
+      expect(await readAll(checked)).toEqual([
+        { type: 'created' },
+        { type: 'accepted' },
+        { type: 'output', text: 'hello' },
+      ]);
+    });
+  });
+});

--- a/packages/openai/src/openai-stream-error.test.ts
+++ b/packages/openai/src/openai-stream-error.test.ts
@@ -28,6 +28,7 @@ function createControlledStream(): {
   stream: ReadableStream<ParseResult<TestChunk>>;
   enqueue: (chunk: TestChunk) => void;
   close: () => void;
+  error: (error: Error) => void;
 } {
   let controller!: ReadableStreamDefaultController<ParseResult<TestChunk>>;
   const stream = new ReadableStream<ParseResult<TestChunk>>({
@@ -39,6 +40,7 @@ function createControlledStream(): {
     stream,
     enqueue: chunk => controller.enqueue(ok(chunk)),
     close: () => controller.close(),
+    error: error => controller.error(error),
   };
 }
 
@@ -165,6 +167,27 @@ describe('throwIfOpenAIStreamErrorBeforeOutput', () => {
       ).rejects.toMatchObject({
         responseBody: expect.stringContaining('insufficient quota'),
       });
+    });
+
+    it('should surface a source error to the consumer after grace resolution without unhandled rejections', async () => {
+      const { stream, enqueue, error } = createControlledStream();
+      enqueue({ type: 'created' });
+      enqueue({ type: 'accepted' });
+
+      const checked = await throwIfOpenAIStreamErrorBeforeOutput({
+        ...baseArgs,
+        stream,
+        isAcceptedChunk,
+        acceptedGraceMs: 10,
+      });
+
+      // the source errors after the stream was already handed over (e.g. a
+      // connection reset while waiting for the first token). The consumer
+      // must see the error; the abandoned peek read must not surface as an
+      // unhandled rejection (vitest fails the run if one occurs).
+      error(new Error('connection reset'));
+
+      await expect(readAll(checked)).rejects.toThrow('connection reset');
     });
 
     it('should resolve immediately on output without waiting for the grace window', async () => {

--- a/packages/openai/src/openai-stream-error.test.ts
+++ b/packages/openai/src/openai-stream-error.test.ts
@@ -29,11 +29,16 @@ function createControlledStream(): {
   enqueue: (chunk: TestChunk) => void;
   close: () => void;
   error: (error: Error) => void;
+  cancelReasons: unknown[];
 } {
   let controller!: ReadableStreamDefaultController<ParseResult<TestChunk>>;
+  const cancelReasons: unknown[] = [];
   const stream = new ReadableStream<ParseResult<TestChunk>>({
     start(c) {
       controller = c;
+    },
+    cancel(reason) {
+      cancelReasons.push(reason);
     },
   });
   return {
@@ -41,6 +46,7 @@ function createControlledStream(): {
     enqueue: chunk => controller.enqueue(ok(chunk)),
     close: () => controller.close(),
     error: error => controller.error(error),
+    cancelReasons,
   };
 }
 
@@ -67,17 +73,21 @@ const baseArgs = {
 };
 
 describe('throwIfOpenAIStreamErrorBeforeOutput', () => {
-  it('should throw when an error frame arrives before output', async () => {
-    const { stream, enqueue, close } = createControlledStream();
+  it('should throw when an error frame arrives before output without cancelling the source', async () => {
+    const { stream, enqueue, close, cancelReasons } = createControlledStream();
     enqueue({ type: 'created' });
     enqueue({ type: 'error', message: 'quota exceeded' });
-    close();
 
     await expect(
       throwIfOpenAIStreamErrorBeforeOutput({ ...baseArgs, stream }),
     ).rejects.toMatchObject({
       responseBody: expect.stringContaining('quota exceeded'),
     });
+
+    expect(cancelReasons).toEqual([]);
+
+    enqueue({ type: 'output', text: 'ignored' });
+    close();
   });
 
   it('should resolve on the first output chunk and replay all chunks to the consumer', async () => {

--- a/packages/openai/src/openai-stream-error.ts
+++ b/packages/openai/src/openai-stream-error.ts
@@ -12,6 +12,8 @@ export async function throwIfOpenAIStreamErrorBeforeOutput<T>({
   stream,
   getError,
   isOutputChunk,
+  isAcceptedChunk,
+  acceptedGraceMs = 50,
   url,
   requestBodyValues,
   responseHeaders,
@@ -19,6 +21,21 @@ export async function throwIfOpenAIStreamErrorBeforeOutput<T>({
   stream: ReadableStream<ParseResult<T>>;
   getError: (chunk: T) => unknown | undefined;
   isOutputChunk: (chunk: T) => boolean;
+  /**
+   * Marks a chunk that proves the request was accepted and generation has
+   * started (e.g. the Responses API `response.in_progress` event). Once seen,
+   * the early-error peek stops blocking indefinitely: each subsequent read is
+   * raced against `acceptedGraceMs` so error frames that are flushed together
+   * with the accepted chunk (e.g. `insufficient_quota`) still throw, while a
+   * healthy stream becomes available without waiting for the first output
+   * token.
+   */
+  isAcceptedChunk?: (chunk: T) => boolean;
+  /**
+   * How long to keep peeking for an error frame after an accepted chunk was
+   * seen. Only used when `isAcceptedChunk` is provided.
+   */
+  acceptedGraceMs?: number;
   url: string;
   requestBodyValues: unknown;
   responseHeaders?: Record<string, string>;
@@ -27,8 +44,20 @@ export async function throwIfOpenAIStreamErrorBeforeOutput<T>({
   const reader = streamForEarlyError.getReader();
 
   try {
+    let accepted = false;
+
     while (true) {
-      const result = await reader.read();
+      let result: ReadableStreamReadResult<ParseResult<T>>;
+
+      if (accepted) {
+        const raced = await raceWithTimeout(reader.read(), acceptedGraceMs);
+        if (raced.timedOut) {
+          return streamForConsumer;
+        }
+        result = raced.value;
+      } else {
+        result = await reader.read();
+      }
 
       if (result.done) {
         return streamForConsumer;
@@ -55,10 +84,31 @@ export async function throwIfOpenAIStreamErrorBeforeOutput<T>({
       if (isOutputChunk(chunk.value)) {
         return streamForConsumer;
       }
+
+      if (!accepted && isAcceptedChunk?.(chunk.value) === true) {
+        accepted = true;
+      }
     }
   } finally {
     reader.cancel().catch(() => {});
     reader.releaseLock();
+  }
+}
+
+async function raceWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<{ timedOut: false; value: T } | { timedOut: true }> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(value => ({ timedOut: false as const, value })),
+      new Promise<{ timedOut: true }>(resolve => {
+        timer = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/packages/openai/src/openai-stream-error.ts
+++ b/packages/openai/src/openai-stream-error.ts
@@ -100,13 +100,22 @@ async function raceWithTimeout<T>(
   timeoutMs: number,
 ): Promise<{ timedOut: false; value: T } | { timedOut: true }> {
   let timer: ReturnType<typeof setTimeout> | undefined;
+  const wrapped = promise.then(value => ({ timedOut: false as const, value }));
   try {
-    return await Promise.race([
-      promise.then(value => ({ timedOut: false as const, value })),
+    const raced = await Promise.race([
+      wrapped,
       new Promise<{ timedOut: true }>(resolve => {
         timer = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
       }),
     ]);
+    if (raced.timedOut) {
+      // The losing read settles later (typically when the peek branch is
+      // cancelled after the stream is handed to the consumer, or rejects if
+      // the source errors). Adopt it so it can never surface as an
+      // unhandled rejection; the consumer branch sees the same outcome.
+      wrapped.catch(() => {});
+    }
+    return raced;
   } finally {
     clearTimeout(timer);
   }

--- a/packages/openai/src/openai-stream-error.ts
+++ b/packages/openai/src/openai-stream-error.ts
@@ -42,6 +42,7 @@ export async function throwIfOpenAIStreamErrorBeforeOutput<T>({
 }): Promise<ReadableStream<ParseResult<T>>> {
   const [streamForEarlyError, streamForConsumer] = stream.tee();
   const reader = streamForEarlyError.getReader();
+  let drainAfterError = false;
 
   try {
     let accepted = false;
@@ -72,7 +73,12 @@ export async function throwIfOpenAIStreamErrorBeforeOutput<T>({
       const errorFrame = getError(chunk.value);
 
       if (errorFrame != null) {
-        streamForConsumer.cancel().catch(() => {});
+        // Let the source finish instead of cancelling its transform pipeline.
+        // Node.js 26 can otherwise leave a queued pipe write rejected with
+        // the cancellation reason after the API error has already surfaced.
+        drainAfterError = true;
+        drainReader(reader).catch(() => {});
+        drainReader(streamForConsumer.getReader()).catch(() => {});
         throw createOpenAIStreamError({
           frame: errorFrame,
           url,
@@ -90,7 +96,23 @@ export async function throwIfOpenAIStreamErrorBeforeOutput<T>({
       }
     }
   } finally {
-    reader.cancel().catch(() => {});
+    if (!drainAfterError) {
+      reader.cancel().catch(() => {});
+      reader.releaseLock();
+    }
+  }
+}
+
+async function drainReader<T>(
+  reader: ReadableStreamDefaultReader<T>,
+): Promise<void> {
+  try {
+    while (!(await reader.read()).done) {
+      // Drain the source without retaining its remaining chunks.
+    }
+  } catch {
+    // The API error has already been reported to the caller.
+  } finally {
     reader.releaseLock();
   }
 }

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -799,6 +799,15 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
         }),
       }),
       z.object({
+        type: z.literal('response.in_progress'),
+        response: z.object({
+          id: z.string(),
+          created_at: z.number(),
+          model: z.string(),
+          service_tier: z.string().nullish(),
+        }),
+      }),
+      z.object({
         type: z.literal('response.output_item.added'),
         output_index: z.number(),
         item: z.discriminatedUnion('type', [

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -7889,34 +7889,37 @@ describe('OpenAIResponsesLanguageModel', () => {
           controller,
         };
 
-        controller.write(
+        const streamPromise = createModel('gpt-4o-mini').doStream({
+          prompt: TEST_PROMPT,
+          includeRawChunks: false,
+        });
+
+        await controller.write(
           `data:{"type":"response.created","sequence_number":0,"response":{"id":"resp_in_progress_early","created_at":1741269019,"model":"gpt-4o-2024-07-18","service_tier":null}}\n\n`,
         );
-        controller.write(
+        await controller.write(
           `data:{"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_in_progress_early","created_at":1741269019,"model":"gpt-4o-2024-07-18","service_tier":null}}\n\n`,
         );
         // the stream now stalls: no output item yet (first token pending)
 
         // doStream must resolve via the accepted-chunk grace window instead of
         // blocking until the first output token:
-        const { stream } = await createModel('gpt-4o-mini').doStream({
-          prompt: TEST_PROMPT,
-          includeRawChunks: false,
-        });
+        const { stream } = await streamPromise;
+        const eventsPromise = convertReadableStreamToArray(stream);
 
         // output arrives after doStream already resolved:
-        controller.write(
+        await controller.write(
           `data:{"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_in_progress_early","type":"message"}}\n\n`,
         );
-        controller.write(
+        await controller.write(
           `data:{"type":"response.output_text.delta","sequence_number":3,"item_id":"msg_in_progress_early","output_index":0,"delta":"Hello"}\n\n`,
         );
-        controller.write(
+        await controller.write(
           `data:{"type":"response.completed","sequence_number":4,"response":{"id":"resp_in_progress_early","object":"response","created_at":1741269019,"status":"completed","error":null,"incomplete_details":null,"model":"gpt-4o-2024-07-18","output":[],"service_tier":null,"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":11}}}\n\n`,
         );
-        controller.close();
+        await controller.close();
 
-        const events = await convertReadableStreamToArray(stream);
+        const events = await eventsPromise;
 
         expect(events).toContainEqual({
           type: 'response-metadata',

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -10,7 +10,10 @@ import {
   convertReadableStreamToArray,
   mockId,
 } from '@ai-sdk/provider-utils/test';
-import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import {
+  createTestServer,
+  TestResponseController,
+} from '@ai-sdk/test-server/with-vitest';
 import fs from 'node:fs';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { OpenAIResponsesLanguageModel } from './openai-responses-language-model';
@@ -7876,6 +7879,55 @@ describe('OpenAIResponsesLanguageModel', () => {
           message: 'Rate limit reached',
           statusCode: 429,
           isRetryable: true,
+        });
+      });
+
+      it('should make the stream available after response.in_progress without waiting for the first output token', async () => {
+        const controller = new TestResponseController();
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'controlled-stream',
+          controller,
+        };
+
+        controller.write(
+          `data:{"type":"response.created","sequence_number":0,"response":{"id":"resp_in_progress_early","created_at":1741269019,"model":"gpt-4o-2024-07-18","service_tier":null}}\n\n`,
+        );
+        controller.write(
+          `data:{"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_in_progress_early","created_at":1741269019,"model":"gpt-4o-2024-07-18","service_tier":null}}\n\n`,
+        );
+        // the stream now stalls: no output item yet (first token pending)
+
+        // doStream must resolve via the accepted-chunk grace window instead of
+        // blocking until the first output token:
+        const { stream } = await createModel('gpt-4o-mini').doStream({
+          prompt: TEST_PROMPT,
+          includeRawChunks: false,
+        });
+
+        // output arrives after doStream already resolved:
+        controller.write(
+          `data:{"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_in_progress_early","type":"message"}}\n\n`,
+        );
+        controller.write(
+          `data:{"type":"response.output_text.delta","sequence_number":3,"item_id":"msg_in_progress_early","output_index":0,"delta":"Hello"}\n\n`,
+        );
+        controller.write(
+          `data:{"type":"response.completed","sequence_number":4,"response":{"id":"resp_in_progress_early","object":"response","created_at":1741269019,"status":"completed","error":null,"incomplete_details":null,"model":"gpt-4o-2024-07-18","output":[],"service_tier":null,"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":11}}}\n\n`,
+        );
+        controller.close();
+
+        const events = await convertReadableStreamToArray(stream);
+
+        expect(events).toContainEqual({
+          type: 'response-metadata',
+          id: 'resp_in_progress_early',
+          modelId: 'gpt-4o-2024-07-18',
+          timestamp: new Date('2025-03-06T13:50:19.000Z'),
+        });
+        expect(events).toContainEqual({
+          type: 'text-delta',
+          id: 'msg_in_progress_early',
+          delta: 'Hello',
         });
       });
 

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -1316,6 +1316,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
           ? chunk
           : undefined,
       isOutputChunk: isResponseOutputChunk,
+      isAcceptedChunk: isResponseInProgressChunk,
       url,
       requestBodyValues: body,
       responseHeaders,
@@ -2674,9 +2675,16 @@ function isErrorChunk(
   return chunk.type === 'error';
 }
 
+function isResponseInProgressChunk(
+  chunk: OpenAIResponsesChunk,
+): chunk is OpenAIResponsesChunk & { type: 'response.in_progress' } {
+  return chunk.type === 'response.in_progress';
+}
+
 function isResponseOutputChunk(chunk: OpenAIResponsesChunk): boolean {
   return !(
     chunk.type === 'response.created' ||
+    chunk.type === 'response.in_progress' ||
     chunk.type === 'response.failed' ||
     chunk.type === 'error' ||
     chunk.type === 'unknown_chunk'

--- a/packages/test-server/src/create-test-server.ts
+++ b/packages/test-server/src/create-test-server.ts
@@ -173,9 +173,12 @@ export function createTestServer<
           case 'controlled-stream': {
             if (request.signal) {
               request.signal.addEventListener('abort', () => {
-                response.controller.error(
-                  new DOMException('Aborted', 'AbortError'),
-                );
+                // the writer may already be closed (e.g. the signal aborts
+                // during teardown after the stream completed) — swallow the
+                // rejection so it cannot surface as an unhandled rejection:
+                response.controller
+                  .error(new DOMException('Aborted', 'AbortError'))
+                  .catch(() => {});
               });
             }
 


### PR DESCRIPTION
## Problem

The Responses API acknowledges a streaming request almost immediately: `response.created` and `response.in_progress` arrive together right after headers (~1ms apart), then nothing until the first output item at time-to-first-token. The early-error peek from #15922 (`throwIfOpenAIStreamErrorBeforeOutput`) reads chunks until one passes `isResponseOutputChunk` — but `response.in_progress` was never modeled in `openaiResponsesChunkSchema`, so it parses into the loose `unknown_chunk` fallback, which the peek skips. Net effect: `doStream` doesn't resolve until the first output token.

For `streamText` that just delays stream availability; for anything proxying the SDK stream, client-facing headers + first byte wait out the model's entire TTFT. On `gpt-4o-mini` that's ~350ms of avoidable dead time per request (upstream acks at ~0.3s, first token at ~0.65s).

## Fix

1. Model `response.in_progress` in `openaiResponsesChunkSchema` (same shape as `response.created`). The stream transform ignores it exactly as before — it just no longer parses as `unknown_chunk`.
2. `throwIfOpenAIStreamErrorBeforeOutput` gets optional `isAcceptedChunk` + `acceptedGraceMs` (default 50ms). Once an accepted chunk is seen, each peek read races the grace timer; on timeout the stream goes to the consumer.
3. The responses model passes `isAcceptedChunk` for `response.in_progress`, and `isResponseOutputChunk` now explicitly excludes it so acceptance flows through the grace path instead of counting as output.

Chat Completions / Completions models are untouched — no accepted signal exists there, and upstream holds HTTP headers until first token anyway.

## Why a grace window instead of just resolving at `in_progress`

`__fixtures__/openai-error.1` is a real capture: OpenAI streams `created → in_progress → error(insufficient_quota) → response.failed` on an HTTP 200. #15922 deliberately turns those into thrown retryable 429s, and the error frames flush together with `in_progress`. The 50ms grace keeps that working — the existing fixture test passes unchanged — while healthy streams resolve ~50ms after acknowledgment instead of at first token.

Tradeoff: an error frame that arrives after `in_progress` plus 50ms of silence now surfaces as an in-stream `error` part instead of a throw.

## Tests

- New `openai-stream-error.test.ts` unit suite: error-before-output throws; output resolves; no detector ⇒ blocks until output as before; stall-after-accept resolves within grace and later chunks still reach the consumer; error flushed with the accepted chunk still throws; a huge grace value doesn't delay resolution when output is present.
- New integration test using `controlled-stream`: `doStream` resolves while the stream is stalled after `created` + `in_progress`; output is only written after resolution, so the test cannot pass through the old blocking path.
- 797 package tests green, `type-check` clean, changeset included.
