### PR TITLE
fix(amazon-bedrock): preserve provider-executed tool results

### DIFF
--- a/.changeset/quiet-tools-smile.md
+++ b/.changeset/quiet-tools-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Preserve provider-executed tool results when converting assistant messages for Bedrock.

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
@@ -1122,6 +1122,68 @@ describe('assistant messages', () => {
     `);
   });
 
+  it('should preserve provider-executed tool results embedded in an assistant message', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Add two numbers.' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'add',
+            input: { a: 2, b: 2 },
+            providerExecuted: true,
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'add',
+            output: { type: 'json', value: { sum: 4 } },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Now use that result.' }],
+      },
+    ]);
+
+    expect(result.messages).toEqual([
+      {
+        role: 'user',
+        content: [{ text: 'Add two numbers.' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            toolUse: {
+              toolUseId: 'call-1',
+              name: 'add',
+              input: { a: 2, b: 2 },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            toolResult: {
+              toolUseId: 'call-1',
+              content: [{ text: JSON.stringify({ sum: 4 }) }],
+            },
+          },
+          { text: 'Now use that result.' },
+        ],
+      },
+    ]);
+  });
+
   it('should preserve reasoning text with signature in multi-turn tool use', async () => {
     const result = await convertToAmazonBedrockChatMessages([
       {

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -588,6 +588,63 @@ function groupIntoBlocks(
         break;
       }
       case 'assistant': {
+        const providerExecutedToolCallIds = new Set(
+          message.content
+            .filter(
+              (
+                part,
+              ): part is Extract<
+                (typeof message.content)[number],
+                { type: 'tool-call' }
+              > => part.type === 'tool-call' && part.providerExecuted === true,
+            )
+            .map(part => part.toolCallId),
+        );
+        const providerExecutedToolResults = message.content.filter(
+          (
+            part,
+          ): part is Extract<
+            (typeof message.content)[number],
+            { type: 'tool-result' }
+          > =>
+            part.type === 'tool-result' &&
+            providerExecutedToolCallIds.has(part.toolCallId),
+        );
+
+        if (providerExecutedToolResults.length > 0) {
+          const providerExecutedToolResultSet = new Set(
+            providerExecutedToolResults,
+          );
+          const assistantMessage = {
+            ...message,
+            content: message.content.filter(
+              part =>
+                !(
+                  part.type === 'tool-result' &&
+                  providerExecutedToolResultSet.has(part)
+                ),
+            ),
+          };
+
+          if (currentBlock?.type !== 'assistant') {
+            currentBlock = { type: 'assistant', messages: [] };
+            blocks.push(currentBlock);
+          }
+          currentBlock.messages.push(assistantMessage);
+
+          currentBlock = {
+            type: 'user',
+            messages: [
+              {
+                role: 'tool',
+                content: providerExecutedToolResults,
+              },
+            ],
+          };
+          blocks.push(currentBlock);
+          break;
+        }
+
         if (currentBlock?.type !== 'assistant') {
           currentBlock = { type: 'assistant', messages: [] };
           blocks.push(currentBlock);


### PR DESCRIPTION
## Background

Fixes #18149. When `convertToModelMessages` places a provider-executed tool
call and its result in the same assistant message, the Bedrock converter
emitted the `toolUse` but silently discarded the `tool-result`. Bedrock then
rejects the next request because every `toolUse` must be followed by its
matching `toolResult`.

## Summary

- Normalize provider-executed assistant tool results into the following user/tool message block.
- Preserve the existing assistant `toolUse` and all other assistant content.
- Add a regression test covering an embedded provider-executed result followed by another user turn.
- Add the required patch changeset for `@ai-sdk/amazon-bedrock`.

## Contributor Credit

Issue reporter: @jpeters5392

## End-to-End Verification

The conversion regression test verifies the exact Bedrock message sequence,
including the `toolResult` immediately after the assistant `toolUse`. A live
AWS Bedrock request was not run because it requires external credentials; the
provider payload boundary is covered by the converter test.

## Checklist

- [ ] All commits are signed (this environment has no configured signing key)
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated (not applicable to this bugfix)
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request (self-review)

## Future Work

None identified for this focused fix.

## Related Issues

Fixes #18149

## Validation details

- Focused converter test: `65 passed`
- Package type-check: passed
- Oxfmt check on changed TypeScript files: passed
- `git diff --check`: passed
- Full package Node suite: `444 passed`, with two unrelated pre-existing
  reranking snapshot mismatches involving only `content-length` headers; the
  edge suite was not reached because the package script stops after Node
  failures.
