### PR TITLE
fix (ai): distinguish [] from [undefined] in canonicalJSON

### DIFF
--- a/.changeset/plenty-lemons-hammer.md
+++ b/.changeset/plenty-lemons-hammer.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix (ai): serialize undefined array elements as null in canonicalJSON so [] and [undefined] no longer produce the same canonical string and hash

--- a/packages/ai/src/util/canonical-hash.test.ts
+++ b/packages/ai/src/util/canonical-hash.test.ts
@@ -18,6 +18,20 @@ describe('canonicalJSON', () => {
     expect(canonicalJSON('x')).toBe('"x"');
     expect(canonicalJSON(42)).toBe('42');
   });
+
+  it('distinguishes [] from [undefined]', () => {
+    expect(canonicalJSON([])).toBe('[]');
+    expect(canonicalJSON([undefined])).toBe('[null]');
+  });
+
+  it('serializes undefined array elements as null, matching JSON.stringify', () => {
+    expect(canonicalJSON([undefined])).toBe(JSON.stringify([undefined]));
+    expect(canonicalJSON([null])).toBe('[null]');
+    expect(canonicalJSON([1, undefined, 2])).toBe('[1,null,2]');
+    expect(canonicalJSON([1, undefined, 2])).toBe(
+      JSON.stringify([1, undefined, 2]),
+    );
+  });
 });
 
 describe('hashCanonical', () => {
@@ -37,5 +51,13 @@ describe('hashCanonical', () => {
     expect(await hashCanonical({ a: 1 })).not.toBe(
       await hashCanonical({ a: 2 }),
     );
+  });
+
+  it('produces different digests for [] and [undefined]', async () => {
+    expect(await hashCanonical([])).not.toBe(await hashCanonical([undefined]));
+  });
+
+  it('produces the same digest for [null] and [undefined]', async () => {
+    expect(await hashCanonical([null])).toBe(await hashCanonical([undefined]));
   });
 });

--- a/packages/ai/src/util/canonical-hash.ts
+++ b/packages/ai/src/util/canonical-hash.ts
@@ -15,7 +15,13 @@ export function canonicalJSON(value: unknown): string {
     return JSON.stringify(value);
   }
   if (Array.isArray(value)) {
-    return `[${value.map(canonicalJSON).join(',')}]`;
+    // `undefined` elements serialize as `null` (matching `JSON.stringify`).
+    // Recursing would return the JS value `undefined`, which
+    // `Array.prototype.join` coerces to an empty string, colliding e.g.
+    // `[undefined]` with `[]`.
+    return `[${value
+      .map(item => (item === undefined ? 'null' : canonicalJSON(item)))
+      .join(',')}]`;
   }
   const keys = Object.keys(value as Record<string, unknown>).sort();
   const entries = keys.map(


### PR DESCRIPTION
Fixes #18157, reported by @trmxvibs.

`canonicalJSON` collided `[]` with `[undefined]`: `Array.prototype.join` coerces the `undefined` produced for undefined elements to an empty string, so `hashCanonical` produced identical SHA-256 digests for structurally different arrays.

The fix serializes undefined array elements as `null`, matching `JSON.stringify` semantics and the already-correct mirror implementation in `@ai-sdk/mcp` (which coerces via its `value == null` branch and was left untouched; the two are now behaviorally consistent). Call sites checked: neither the tool-approval signature (hashes JSON-round-tripped input) nor the tool fingerprint depends on the old collision. Top-level `canonicalJSON(undefined)` stays `undefined`, pinned by an existing test.

Changeset included (`ai` patch). Four regression tests pin `[]` vs `[undefined]` distinctness (string and digest), `[undefined]` -> `[null]`, the intentional `[null]`/`[undefined]` digest equivalence, and mid-array holes; exactly those 4 fail with the fix reverted. Full package suite: 3040 passed, zero new failures; ultracite clean.
