### PR TITLE
chore: centralize record type guards in provider-utils

### DIFF
--- a/.changeset/bright-records-share.md
+++ b/.changeset/bright-records-share.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/google': patch
+'@ai-sdk/anthropic': patch
+'@ai-sdk/harness-opencode': patch
+---
+
+chore: centralize record type guards in provider-utils

--- a/packages/anthropic/src/sanitize-json-schema.ts
+++ b/packages/anthropic/src/sanitize-json-schema.ts
@@ -1,4 +1,5 @@
 import type { JSONSchema7, JSONSchema7Definition } from '@ai-sdk/provider';
+import { isRecord } from '@ai-sdk/provider-utils';
 
 const SUPPORTED_STRING_FORMATS = new Set([
   'date-time',
@@ -44,7 +45,7 @@ export function sanitizeJsonSchema(schema: JSONSchema7): JSONSchema7 {
 function sanitizeDefinition(
   definition: JSONSchema7Definition,
 ): JSONSchema7Definition {
-  if (typeof definition === 'boolean' || !isPlainObject(definition)) {
+  if (typeof definition === 'boolean' || !isRecord(definition)) {
     return definition;
   }
 
@@ -196,8 +197,4 @@ function formatConstraintValue(value: unknown): string {
   }
 
   return JSON.stringify(value);
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/google/src/realtime/google-realtime-event-mapper.ts
+++ b/packages/google/src/realtime/google-realtime-event-mapper.ts
@@ -5,7 +5,7 @@ import type {
   Experimental_RealtimeModelV4ServerEvent as RealtimeModelV4ServerEvent,
   Experimental_RealtimeModelV4SessionConfig as RealtimeModelV4SessionConfig,
 } from '@ai-sdk/provider';
-import { safeParseJSON } from '@ai-sdk/provider-utils';
+import { isRecord, safeParseJSON } from '@ai-sdk/provider-utils';
 import { convertJSONSchemaToOpenAPISchema } from '../convert-json-schema-to-openapi-schema';
 import { getModelPath } from '../get-model-path';
 import type { GoogleRealtimeModelOptions } from './google-realtime-model-options';
@@ -45,10 +45,6 @@ type GoogleRealtimeWireEvent = {
     lastConsumedClientMessageIndex?: string;
   };
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
-}
 
 /**
  * Stateful event mapper for Google's Gemini Live API.

--- a/packages/harness-opencode/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-opencode/src/bridge/create-emit-stream-event.ts
@@ -1,4 +1,5 @@
 import type { BridgeTurn } from '@ai-sdk/harness/bridge';
+import { isRecord } from '@ai-sdk/provider-utils';
 import {
   emitLegacyPartDelta,
   emitLegacyTextPartUpdate,
@@ -501,10 +502,6 @@ function nextRetryEventMessage({
   return details.length > 0
     ? `OpenCode session retry: ${details.join('; ')}`
     : 'OpenCode session retry';
-}
-
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 }
 
 export function stringValue(value: unknown): string | undefined {

--- a/packages/harness-opencode/src/bridge/index.ts
+++ b/packages/harness-opencode/src/bridge/index.ts
@@ -3,6 +3,7 @@ import {
   type BridgeEvent,
   type BridgeTurn,
 } from '@ai-sdk/harness/bridge';
+import { isRecord } from '@ai-sdk/provider-utils';
 import { randomUUID } from 'node:crypto';
 import { mkdirSync } from 'node:fs';
 import path from 'node:path';
@@ -22,11 +23,7 @@ import {
   type TranslationState,
   unwrapOpenCodeEvent,
 } from './opencode-events';
-import {
-  createEmitStreamEvent,
-  isRecord,
-  stringValue,
-} from './create-emit-stream-event';
+import { createEmitStreamEvent, stringValue } from './create-emit-stream-event';
 import { mapOpenCodeFinishReason } from './opencode-finish-step';
 import { prependOpenCodeBinToPath } from './opencode-path';
 import {

--- a/packages/harness-opencode/src/bridge/opencode-events.ts
+++ b/packages/harness-opencode/src/bridge/opencode-events.ts
@@ -1,3 +1,5 @@
+import { isRecord } from '@ai-sdk/provider-utils';
+
 export type OpenCodeEvent = {
   id?: string;
   type?: string;
@@ -248,13 +250,7 @@ function stripSyncVersion(type: string): string {
 }
 
 function asRecord(value: unknown): Record<string, any> | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value))
-    return undefined;
-  return value as Record<string, any>;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+  return isRecord(value) ? value : undefined;
 }
 
 function stringValue(value: unknown): string | undefined {

--- a/packages/harness-opencode/src/bridge/opencode-finish-step.ts
+++ b/packages/harness-opencode/src/bridge/opencode-finish-step.ts
@@ -1,4 +1,5 @@
 import type { HarnessV1StreamPart } from '@ai-sdk/harness';
+import { isRecord } from '@ai-sdk/provider-utils';
 import { mapUsage } from './opencode-usage';
 
 type FinishStepEvent = Extract<HarnessV1StreamPart, { type: 'finish-step' }>;
@@ -32,8 +33,4 @@ export function legacyStepFinishPartToFinishStep(
       ? { harnessMetadata: { opencode: { cost: part.cost } } }
       : {}),
   };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 }

--- a/packages/harness-opencode/src/bridge/opencode-usage.ts
+++ b/packages/harness-opencode/src/bridge/opencode-usage.ts
@@ -1,4 +1,5 @@
 import type { HarnessV1StreamPart } from '@ai-sdk/harness';
+import { isRecord } from '@ai-sdk/provider-utils';
 
 type FinishStepEvent = Extract<HarnessV1StreamPart, { type: 'finish-step' }>;
 
@@ -132,9 +133,7 @@ function asTokenGroup(value: unknown): Record<string, number | undefined> {
 }
 
 function asRecord(value: unknown): Record<string, any> | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value))
-    return undefined;
-  return value as Record<string, any>;
+  return isRecord(value) ? value : undefined;
 }
 
 function numberValue(value: unknown): number {

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -39,6 +39,7 @@ export { isBuffer } from './is-buffer';
 export { isSameOrigin } from './is-same-origin';
 export { isNonNullable } from './is-non-nullable';
 export { isProviderReference } from './is-provider-reference';
+export { isRecord } from './is-record';
 export { isUrlSupported } from './is-url-supported';
 export * from './load-api-key';
 export { loadOptionalSetting } from './load-optional-setting';

--- a/packages/provider-utils/src/is-record.test.ts
+++ b/packages/provider-utils/src/is-record.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { isRecord } from './is-record';
+
+describe('isRecord', () => {
+  it('returns true for non-null, non-array objects', () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord(Object.create(null))).toBe(true);
+    expect(isRecord(new Date())).toBe(true);
+  });
+
+  it('returns false for arrays, null, and primitive values', () => {
+    expect(isRecord([])).toBe(false);
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord(undefined)).toBe(false);
+    expect(isRecord('value')).toBe(false);
+    expect(isRecord(42)).toBe(false);
+    expect(isRecord(true)).toBe(false);
+  });
+});

--- a/packages/provider-utils/src/is-record.ts
+++ b/packages/provider-utils/src/is-record.ts
@@ -1,0 +1,6 @@
+/**
+ * Checks whether a value is a non-null, non-array object.
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/provider-utils/src/transcription-stream-envelope.ts
+++ b/packages/provider-utils/src/transcription-stream-envelope.ts
@@ -2,6 +2,7 @@ import type {
   Experimental_TranscriptionModelV4StreamPart as TranscriptionModelV4StreamPart,
   JSONObject,
 } from '@ai-sdk/provider';
+import { isRecord } from './is-record';
 import { secureJsonParse } from './secure-json-parse';
 
 /**
@@ -240,7 +241,7 @@ export function parseTranscriptionStreamPart(
     case 'transcript-delta':
       return isString(part.delta) &&
         isOptional(part.id, isString) &&
-        isOptional(part.providerMetadata, isPlainObject)
+        isOptional(part.providerMetadata, isRecord)
         ? part
         : undefined;
 
@@ -250,7 +251,7 @@ export function parseTranscriptionStreamPart(
         isOptional(part.startSecond, isNumber) &&
         isOptional(part.durationInSeconds, isNumber) &&
         isOptional(part.channelIndex, isNumber) &&
-        isOptional(part.providerMetadata, isPlainObject)
+        isOptional(part.providerMetadata, isRecord)
         ? part
         : undefined;
 
@@ -260,7 +261,7 @@ export function parseTranscriptionStreamPart(
         isOptional(part.startSecond, isNumber) &&
         isOptional(part.endSecond, isNumber) &&
         isOptional(part.channelIndex, isNumber) &&
-        isOptional(part.providerMetadata, isPlainObject)
+        isOptional(part.providerMetadata, isRecord)
         ? part
         : undefined;
 
@@ -270,7 +271,7 @@ export function parseTranscriptionStreamPart(
         part.segments.every(isSegment) &&
         isOptional(part.language, isString) &&
         isOptional(part.durationInSeconds, isNumber) &&
-        isOptional(part.providerMetadata, isPlainObject)
+        isOptional(part.providerMetadata, isRecord)
         ? part
         : undefined;
 
@@ -278,7 +279,7 @@ export function parseTranscriptionStreamPart(
       if (
         !(
           isOptional(part.modelId, isString) &&
-          isOptional(part.headers, isPlainObject)
+          isOptional(part.headers, isRecord)
         )
       ) {
         return undefined;
@@ -323,19 +324,15 @@ function isOptional(
   return value === undefined || check(value);
 }
 
-function isPlainObject(value: unknown): boolean {
-  return typeof value === 'object' && value != null && !Array.isArray(value);
-}
-
 function isWarning(value: unknown): boolean {
-  return isPlainObject(value) && isString((value as { type?: unknown }).type);
+  return isRecord(value) && isString(value.type);
 }
 
 function isSegment(value: unknown): boolean {
   return (
-    isPlainObject(value) &&
-    isString((value as { text?: unknown }).text) &&
-    isNumber((value as { startSecond?: unknown }).startSecond) &&
-    isNumber((value as { endSecond?: unknown }).endSecond)
+    isRecord(value) &&
+    isString(value.text) &&
+    isNumber(value.startSecond) &&
+    isNumber(value.endSecond)
   );
 }


### PR DESCRIPTION
## Background

noticed that there are a lot of equivalent local guards in each different package.
there's scope to unify them into a shared-utility

## Summary

Add and export a shared `isRecord` type guard from `@ai-sdk/provider-utils`

## End-to-End Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)