### PR TITLE
fix(google-vertex): forward zero video seed

### DIFF
--- a/.changeset/calm-pandas-seed.md
+++ b/.changeset/calm-pandas-seed.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+Forward a zero video-generation seed to Google Vertex instead of omitting it.

--- a/packages/google-vertex/src/google-vertex-video-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-video-model.test.ts
@@ -167,7 +167,7 @@ describe('GoogleVertexVideoModel', () => {
       });
     });
 
-    it('should pass seed when provided', async () => {
+    it('should pass a zero seed when provided', async () => {
       let capturedBody: unknown;
       const model = createMockModel({
         onRequest: (url, body) => {
@@ -179,12 +179,12 @@ describe('GoogleVertexVideoModel', () => {
 
       await model.doGenerate({
         ...defaultOptions,
-        seed: 42,
+        seed: 0,
       });
 
       expect(capturedBody).toStrictEqual({
         instances: [{ prompt }],
-        parameters: { sampleCount: 1, seed: 42 },
+        parameters: { sampleCount: 1, seed: 0 },
       });
     });
 

--- a/packages/google-vertex/src/google-vertex-video-model.ts
+++ b/packages/google-vertex/src/google-vertex-video-model.ts
@@ -195,7 +195,7 @@ export class GoogleVertexVideoModel implements Experimental_VideoModelV4 {
       parameters.durationSeconds = options.duration;
     }
 
-    if (options.seed) {
+    if (options.seed != null) {
       parameters.seed = options.seed;
     }
 


### PR DESCRIPTION
## Summary

- forward `seed: 0` to Google Vertex video generation requests
- cover the zero-value edge case with a request-body regression test
- add a patch changeset for `@ai-sdk/google-vertex`

## Root cause

The video model used a truthiness check before adding `seed` to the request. Since zero is a valid deterministic seed but is falsy in JavaScript, it was silently omitted and Vertex selected its default seed instead.

## Impact

Applications can now request deterministic Google Vertex video generation with seed zero and receive the same request semantics as other numeric seed values.

## Checks

- `pnpm test:node google-vertex-video-model.test.ts` (37 tests)
- `pnpm test:edge google-vertex-video-model.test.ts` (37 tests)
- `pnpm type-check`
- `pnpm type-check:full`
- `pnpm exec oxfmt --check ...`
- `pnpm exec oxlint ...`
