### PR TITLE
fix(bytedance): forward zero video seed

### DIFF
--- a/.changeset/quiet-owls-seed.md
+++ b/.changeset/quiet-owls-seed.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/bytedance': patch
+---
+
+Forward a zero video-generation seed to compatible ByteDance models, and warn
+when Seedance 2.0 receives the unsupported option.

--- a/packages/bytedance/src/bytedance-video-model.test.ts
+++ b/packages/bytedance/src/bytedance-video-model.test.ts
@@ -116,12 +116,12 @@ describe('ByteDanceVideoModel', () => {
       });
     });
 
-    it('should pass seed when provided', async () => {
+    it('should pass a zero seed when provided', async () => {
       const model = createBasicModel();
 
       await model.doGenerate({
         ...defaultOptions,
-        seed: 42,
+        seed: 0,
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
@@ -132,7 +132,26 @@ describe('ByteDanceVideoModel', () => {
             text: prompt,
           },
         ],
-        seed: 42,
+        seed: 0,
+      });
+    });
+
+    it.each([
+      'dreamina-seedance-2-0-260128',
+      'dreamina-seedance-2-0-fast-260128',
+    ])('should omit seed and warn for Seedance 2.0 model %s', async modelId => {
+      const model = createBasicModel({ modelId });
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        seed: 0,
+      });
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty('seed');
+      expect(result.warnings).toContainEqual({
+        type: 'unsupported',
+        feature: 'seed',
+        details: 'Seedance 2.0 video models do not support the `seed` option.',
       });
     });
 

--- a/packages/bytedance/src/bytedance-video-model.ts
+++ b/packages/bytedance/src/bytedance-video-model.ts
@@ -281,8 +281,17 @@ export class ByteDanceVideoModel implements Experimental_VideoModelV4 {
       body.duration = options.duration;
     }
 
-    if (options.seed) {
-      body.seed = options.seed;
+    if (options.seed != null) {
+      if (this.modelId.startsWith('dreamina-seedance-2-0')) {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'seed',
+          details:
+            'Seedance 2.0 video models do not support the `seed` option.',
+        });
+      } else {
+        body.seed = options.seed;
+      }
     }
 
     if (options.resolution) {


### PR DESCRIPTION
## Summary

- preserve `seed: 0` in ByteDance video requests for models that support seeds
- omit the unsupported option and return a warning for both Seedance 2.0 variants
- cover the supported and unsupported request shapes with regression tests
- add a patch changeset for `@ai-sdk/bytedance`

## Root cause

The request builder guarded `seed` with a truthiness check. JavaScript treats zero as falsy, so the SDK silently removed a valid seed value from compatible models. A generic presence check alone would be too broad because Seedance 2.0 explicitly does not support the option.

## Impact

Compatible ByteDance video models now receive an explicit zero seed consistently with other numeric values. Seedance 2.0 continues to omit the unsupported field and now reports a standard warning when any seed is supplied.

## Checks

- `pnpm test:node bytedance-video-model.test.ts` (56 tests)
- `pnpm test:edge bytedance-video-model.test.ts` (56 tests)
- `pnpm type-check`
- `pnpm type-check:full`
- `pnpm exec oxfmt --check ...`
- `pnpm exec oxlint ...`