### PR TITLE
fix(klingai): warn for unsupported zero seed

### DIFF
--- a/.changeset/sharp-geckos-warn.md
+++ b/.changeset/sharp-geckos-warn.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/klingai': patch
+---
+
+Warn when a zero seed is passed to KlingAI video models instead of silently ignoring it.

--- a/packages/klingai/src/klingai-video-model.test.ts
+++ b/packages/klingai/src/klingai-video-model.test.ts
@@ -394,12 +394,12 @@ describe('KlingAIVideoModel', () => {
       );
     });
 
-    it('should warn about unsupported seed', async () => {
+    it('should warn about an unsupported zero seed', async () => {
       const model = createBasicModel();
 
       const result = await model.doGenerate({
         ...defaultOptions,
-        seed: 42,
+        seed: 0,
       });
 
       expect(result.warnings).toContainEqual(

--- a/packages/klingai/src/klingai-video-model.ts
+++ b/packages/klingai/src/klingai-video-model.ts
@@ -267,7 +267,7 @@ export class KlingAIVideoModel implements Experimental_VideoModelV4 {
       });
     }
 
-    if (options.seed) {
+    if (options.seed != null) {
       warnings.push({
         type: 'unsupported',
         feature: 'seed',


### PR DESCRIPTION
## Summary

- report KlingAI's unsupported-seed warning when the caller supplies `seed: 0`
- cover the falsy seed value with a focused regression test
- add a patch changeset for `@ai-sdk/klingai`

## Root cause

The warning guard used a truthiness check. Zero is a valid SDK-level seed value but is falsy, so KlingAI silently ignored it while warning for every nonzero seed.

## Impact

Callers now receive the expected unsupported-feature warning for all supplied seed values and can detect that KlingAI will not provide deterministic generation.

## Checks

- `pnpm test:node klingai-video-model.test.ts` (96 tests)
- `pnpm test:edge klingai-video-model.test.ts` (96 tests)
- `pnpm type-check`
- `pnpm type-check:full`
- `pnpm exec oxfmt --check ...`
- `pnpm exec oxlint ...`
