### PR TITLE
fix(replicate): preserve zero video seed

### DIFF
--- a/.changeset/tiny-dodos-count.md
+++ b/.changeset/tiny-dodos-count.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/replicate': patch
+---
+
+Preserve zero-valued seeds when serializing Replicate video model inputs.

--- a/packages/replicate/src/replicate-video-model.test.ts
+++ b/packages/replicate/src/replicate-video-model.test.ts
@@ -225,7 +225,7 @@ describe('ReplicateVideoModel', () => {
 
       await model.doGenerate({ ...defaultOptions });
 
-      expect(capturedBody).toMatchObject({
+      expect(capturedBody).toStrictEqual({
         input: { prompt },
       });
     });
@@ -277,9 +277,10 @@ describe('ReplicateVideoModel', () => {
       });
     });
 
-    it('should pass seed when provided', async () => {
+    it('should pass a zero seed to a model that supports it', async () => {
       let capturedBody: unknown;
       const model = createMockModel({
+        modelId: 'bytedance/seedance-1-pro',
         pollsUntilDone: 0,
         onRequest: (url, body) => {
           if (
@@ -293,13 +294,13 @@ describe('ReplicateVideoModel', () => {
 
       await model.doGenerate({
         ...defaultOptions,
-        seed: 42,
+        seed: 0,
       });
 
-      expect(capturedBody).toMatchObject({
+      expect(capturedBody).toStrictEqual({
         input: {
           prompt,
-          seed: 42,
+          seed: 0,
         },
       });
     });

--- a/packages/replicate/src/replicate-video-model.ts
+++ b/packages/replicate/src/replicate-video-model.ts
@@ -89,7 +89,7 @@ export class ReplicateVideoModel implements Experimental_VideoModelV4 {
       input.fps = options.fps;
     }
 
-    if (options.seed) {
+    if (options.seed != null) {
       input.seed = options.seed;
     }
 


### PR DESCRIPTION
## What

Preserve `seed: 0` when serializing inputs for Replicate video models that expose a seed parameter, and cover the edge case with a current seed-capable model fixture.

## Why

The generic Replicate video adapter already forwards defined nonzero seeds to model inputs. Its truthiness guard treated zero as absent, preventing users of seed-capable models from selecting that valid value.

## Impact

Replicate video model inputs now preserve every defined numeric seed, including zero. Whether a seed is supported remains model-specific, as with the adapters other standardized inputs.

## Root cause

The request builder guarded `input.seed` with a truthiness check, so JavaScript treated `0` as absent and omitted it from the API payload.

## Checks

- `pnpm exec vitest --config vitest.node.config.js --run src/replicate-video-model.test.ts` (35 tests)
- `pnpm exec vitest --config vitest.edge.config.js --run src/replicate-video-model.test.ts` (35 tests)
- `pnpm type-check` in `packages/replicate`
- `pnpm type-check:full`
- `pnpm exec oxfmt --check packages/replicate/src/replicate-video-model.ts packages/replicate/src/replicate-video-model.test.ts .changeset/tiny-dodos-count.md`
- `pnpm exec oxlint packages/replicate/src/replicate-video-model.ts packages/replicate/src/replicate-video-model.test.ts`