### PR TITLE
fix(provider-utils): guard missing DOMException

### DIFF
--- a/.changeset/calm-dragons-abort.md
+++ b/.changeset/calm-dragons-abort.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Prevent abort error detection from throwing in runtimes without `DOMException`.

--- a/packages/provider-utils/src/is-abort-error.test.ts
+++ b/packages/provider-utils/src/is-abort-error.test.ts
@@ -1,0 +1,14 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isAbortError } from './is-abort-error';
+
+describe('isAbortError', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns false for non-errors when DOMException is unavailable', () => {
+    vi.stubGlobal('DOMException', undefined);
+
+    expect(isAbortError({ name: 'AbortError' })).toBe(false);
+  });
+});

--- a/packages/provider-utils/src/is-abort-error.ts
+++ b/packages/provider-utils/src/is-abort-error.ts
@@ -1,6 +1,7 @@
 export function isAbortError(error: unknown): error is Error {
   return (
-    (error instanceof Error || error instanceof DOMException) &&
+    (error instanceof Error ||
+      (typeof DOMException !== 'undefined' && error instanceof DOMException)) &&
     (error.name === 'AbortError' ||
       error.name === 'ResponseAborted' || // Next.js
       error.name === 'TimeoutError')


### PR DESCRIPTION
## Summary

- guard the `DOMException` constructor before using it with `instanceof`
- add a regression test for runtimes where `DOMException` is not defined
- add a patch changeset for `@ai-sdk/provider-utils`

## Problem

`isAbortError` always evaluated `error instanceof DOMException` for non-`Error` values. In runtimes that do not expose a global `DOMException`, that check throws and masks the original non-abort error instead of returning `false`.

## Fix

Only perform the `DOMException` instance check when the constructor exists. Existing `Error` and `DOMException` abort detection semantics remain unchanged.

## Validation

- `pnpm vitest run src/is-abort-error.test.ts` (from `packages/provider-utils`)
- `pnpm exec ultracite check src/is-abort-error.ts src/is-abort-error.test.ts` (from `packages/provider-utils`)
- `pnpm type-check:full`
