### PR TITLE
fix(fal): preserve zero video seed

### DIFF
--- a/.changeset/calm-lions-wave.md
+++ b/.changeset/calm-lions-wave.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fal': patch
+---
+
+Pass a zero seed through to fal video generation requests.

--- a/packages/fal/src/fal-video-model.test.ts
+++ b/packages/fal/src/fal-video-model.test.ts
@@ -141,17 +141,17 @@ describe('FalVideoModel', () => {
       });
     });
 
-    it('should pass seed when provided', async () => {
+    it('should pass a zero seed', async () => {
       const model = createBasicModel();
 
       await model.doGenerate({
         ...defaultOptions,
-        seed: 42,
+        seed: 0,
       });
 
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
         prompt,
-        seed: 42,
+        seed: 0,
       });
     });
 

--- a/packages/fal/src/fal-video-model.ts
+++ b/packages/fal/src/fal-video-model.ts
@@ -79,7 +79,7 @@ export class FalVideoModel implements Experimental_VideoModelV4 {
       body.duration = `${options.duration}s`;
     }
 
-    if (options.seed) {
+    if (options.seed != null) {
       body.seed = options.seed;
     }
 


### PR DESCRIPTION
## What

Pass `seed: 0` through when constructing fal video generation requests, and add a regression test for the zero value.

## Why

Zero is a valid deterministic seed, but callers currently cannot use it for fal video generation.

## Impact

fal video requests now preserve all defined numeric seed values, including zero. Other request fields and non-zero seeds are unchanged.

## Root cause

The request builder guarded `body.seed` with a truthiness check, so JavaScript treated `0` as absent and omitted it from the API payload.

## Checks

- `pnpm exec vitest --config vitest.node.config.js --run src/fal-video-model.test.ts` (31 tests)
- `pnpm exec vitest --config vitest.edge.config.js --run src/fal-video-model.test.ts` (31 tests)
- `pnpm type-check` in `packages/fal`
- `pnpm type-check:full`
- `pnpm exec oxfmt --check packages/fal/src/fal-video-model.ts packages/fal/src/fal-video-model.test.ts .changeset/calm-lions-wave.md`
- `pnpm exec oxlint packages/fal/src/fal-video-model.ts packages/fal/src/fal-video-model.test.ts`
