### PR TITLE
fix(provider-utils): ignore MIME parameters in extensions

### DIFF
--- a/.changeset/tidy-lions-listen.md
+++ b/.changeset/tidy-lions-listen.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Exclude media type parameters when deriving file extensions.

--- a/packages/provider-utils/src/media-type-to-extension.test.ts
+++ b/packages/provider-utils/src/media-type-to-extension.test.ts
@@ -15,6 +15,9 @@ describe('mediaTypeToExtension()', () => {
     ['audio/x-m4a', 'm4a'],
     ['audio/flac', 'flac'],
     ['audio/aac', 'aac'],
+    // parameters
+    ['audio/webm;codecs=opus', 'webm'],
+    ['audio/mp4; codecs=mp4a.40.2', 'm4a'],
     // upper case
     ['AUDIO/MPEG', 'mp3'],
     ['AUDIO/MP3', 'mp3'],

--- a/packages/provider-utils/src/media-type-to-extension.ts
+++ b/packages/provider-utils/src/media-type-to-extension.ts
@@ -8,7 +8,11 @@
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types
  */
 export function mediaTypeToExtension(mediaType: string) {
-  const [_type, subtype = ''] = mediaType.toLowerCase().split('/');
+  const [_type, subtype = ''] = mediaType
+    .split(';', 1)[0]
+    .trim()
+    .toLowerCase()
+    .split('/');
 
   return (
     {


### PR DESCRIPTION
## Summary

- strip MIME parameters before deriving a file extension
- cover compact and whitespace-separated codec parameters
- add a patch changeset for `@ai-sdk/provider-utils`

## Problem

`mediaTypeToExtension` used the complete subtype text as the extension. Valid media types such as `audio/webm;codecs=opus` therefore produced filenames like `audio.webm;codecs=opus`. Transcription providers use this helper for multipart upload filenames, so browser `MediaRecorder` MIME types could result in malformed or rejected filenames.

## Fix

Normalize only the media type essence before splitting out the subtype. Existing case normalization and special mappings such as `audio/mp4` to `m4a` continue to apply.

## Validation

- `pnpm vitest run src/media-type-to-extension.test.ts` (from `packages/provider-utils`)
- `pnpm exec ultracite check src/media-type-to-extension.ts src/media-type-to-extension.test.ts` (from `packages/provider-utils`)
- `pnpm type-check` (from `packages/provider-utils`)
- `pnpm type-check:full`
