### PR TITLE
fix(fireworks): omit unsupported image dimensions

### DIFF
--- a/.changeset/soft-cats-smile.md
+++ b/.changeset/soft-cats-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fireworks': patch
+---
+
+Omit unsupported image dimensions from Fireworks requests.

--- a/packages/fireworks/src/fireworks-image-model.test.ts
+++ b/packages/fireworks/src/fireworks-image-model.test.ts
@@ -390,7 +390,7 @@ describe('FireworksImageModel', () => {
     });
 
     describe('warnings', () => {
-      it('should return size warning on workflow model', async () => {
+      it('should omit size and return a warning on workflow model', async () => {
         const model = createBasicModel();
 
         const result1 = await model.doGenerate({
@@ -413,9 +413,15 @@ describe('FireworksImageModel', () => {
             },
           ]
         `);
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          prompt,
+          aspect_ratio: '1:1',
+          seed: 123,
+          samples: 1,
+        });
       });
 
-      it('should return aspectRatio warning on size-supporting model', async () => {
+      it('should omit aspectRatio and return a warning on size-supporting model', async () => {
         const sizeModel = createSizeModel();
 
         const result2 = await sizeModel.doGenerate({
@@ -438,6 +444,13 @@ describe('FireworksImageModel', () => {
             },
           ]
         `);
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          prompt,
+          width: '1024',
+          height: '1024',
+          seed: 123,
+          samples: 1,
+        });
       });
     });
 

--- a/packages/fireworks/src/fireworks-image-model.ts
+++ b/packages/fireworks/src/fireworks-image-model.ts
@@ -202,7 +202,9 @@ export class FireworksImageModel implements ImageModelV4 {
       });
     }
 
-    const splitSize = size?.split('x');
+    const splitSize = backendConfig?.supportsSize
+      ? size?.split('x')
+      : undefined;
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
     const combinedHeaders = combineHeaders(this.config.headers?.(), headers);
     const fireworksOptions =
@@ -214,7 +216,7 @@ export class FireworksImageModel implements ImageModelV4 {
 
     const body = {
       prompt,
-      aspect_ratio: aspectRatio,
+      aspect_ratio: backendConfig?.supportsSize ? undefined : aspectRatio,
       seed,
       samples: n,
       ...(inputImage && { input_image: inputImage }),


### PR DESCRIPTION
## What

Only serialize the image dimension option supported by each Fireworks backend:

- workflow models send `aspect_ratio`
- image-generation models send `width` and `height`

The existing warnings remain in place, and regression assertions cover both request shapes.

## Why

The adapter currently warns that `size` or `aspectRatio` is unsupported, but still sends the unsupported fields to Fireworks.

## Impact

Callers can provide both standardized dimension options without an unsupported field causing the provider to reject an otherwise valid request. Supported dimension behavior is unchanged.

## Root cause

Request serialization always derived `width` and `height` from `size` and always assigned `aspect_ratio`, independently of the backend capability already used to produce warnings.

## Checks

- `pnpm exec vitest --config vitest.node.config.js --run src/fireworks-image-model.test.ts` (31 tests)
- `pnpm exec vitest --config vitest.edge.config.js --run src/fireworks-image-model.test.ts` (31 tests)
- `pnpm type-check` in `packages/fireworks`
- `pnpm type-check:full`
- `pnpm exec oxfmt --check packages/fireworks/src/fireworks-image-model.ts packages/fireworks/src/fireworks-image-model.test.ts .changeset/soft-cats-smile.md`
- `pnpm exec oxlint packages/fireworks/src/fireworks-image-model.ts packages/fireworks/src/fireworks-image-model.test.ts`
