### PR TITLE
fix(google): generate ids for empty tool calls

### DIFF
--- a/.changeset/tidy-tools-smile.md
+++ b/.changeset/tidy-tools-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Generate usable tool call IDs when Google returns an empty function call ID.

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -3763,6 +3763,50 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should generate a tool call id when the response contains an empty id', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    id: '',
+                    name: 'test-tool',
+                    args: { value: 'test' },
+                  },
+                },
+              ],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+            index: 0,
+            safetyRatings: SAFETY_RATINGS,
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+          totalTokenCount: 30,
+        },
+      },
+    };
+
+    const { content } = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(content).toContainEqual({
+      type: 'tool-call',
+      toolCallId: 'test-id',
+      toolName: 'test-tool',
+      input: '{"value":"test"}',
+      providerMetadata: undefined,
+    });
+  });
+
   it('should support includeThoughts with google generative ai provider', async () => {
     server.urls[TEST_URL_GEMINI_PRO].response = {
       type: 'json-value',
@@ -6422,6 +6466,72 @@ describe('doStream', () => {
         "unified": "tool-calls",
       }
     `);
+  });
+
+  it('should generate a tool call id when a stream chunk contains an empty id', async () => {
+    server.urls[TEST_URL_GEMINI_PRO].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      id: '',
+                      name: 'test-tool',
+                      args: { value: 'example value' },
+                    },
+                  },
+                ],
+                role: 'model',
+              },
+              finishReason: 'STOP',
+              index: 0,
+              safetyRatings: SAFETY_RATINGS,
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 10,
+            candidatesTokenCount: 20,
+            totalTokenCount: 30,
+          },
+        })}\n\n`,
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      tools: [
+        {
+          type: 'function',
+          name: 'test-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+    const toolEvents = events.filter(
+      event =>
+        event.type === 'tool-input-start' ||
+        event.type === 'tool-input-delta' ||
+        event.type === 'tool-input-end' ||
+        event.type === 'tool-call',
+    );
+
+    expect(toolEvents).toHaveLength(4);
+    expect(
+      toolEvents.map(event =>
+        event.type === 'tool-call' ? event.toolCallId : event.id,
+      ),
+    ).toEqual(['test-id', 'test-id', 'test-id', 'test-id']);
   });
 
   it('should omit server-side tool invocation flag for Vertex Gemini 3', async () => {

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -466,7 +466,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
       } else if ('functionCall' in part && part.functionCall.name != null) {
         content.push({
           type: 'tool-call' as const,
-          toolCallId: part.functionCall.id ?? this.config.generateId(),
+          toolCallId: part.functionCall.id || this.config.generateId(),
           toolName: part.functionCall.name,
           input: JSON.stringify(part.functionCall.args ?? {}),
           providerMetadata: part.thoughtSignature
@@ -952,7 +952,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
 
                 if (isStreamingChunk) {
                   if (part.functionCall.name != null) {
-                    const toolCallId = part.functionCall.id ?? generateId();
+                    const toolCallId = part.functionCall.id || generateId();
                     const accumulator = new GoogleJSONAccumulator();
                     activeStreamingToolCalls.push({
                       toolCallId,
@@ -1021,7 +1021,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
                 ) {
                   finishActiveStreamingToolCall(controller);
                 } else if (isCompleteCall) {
-                  const toolCallId = part.functionCall.id ?? generateId();
+                  const toolCallId = part.functionCall.id || generateId();
                   const toolName = part.functionCall.name!;
                   const args =
                     typeof part.functionCall.args === 'string'
@@ -1058,7 +1058,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
 
                   hasToolCalls = true;
                 } else if (isNoArgsCompleteCall) {
-                  const toolCallId = part.functionCall.id ?? generateId();
+                  const toolCallId = part.functionCall.id || generateId();
                   const toolName = part.functionCall.name!;
 
                   controller.enqueue({


### PR DESCRIPTION
## What

- Treat an empty Google `functionCall.id` as missing in both non-streaming and streaming responses.
- Generate one stable SDK tool call ID and reuse it across the streaming tool-input lifecycle.
- Add regressions for `doGenerate` and `doStream`.

## Why

Gemini responses may omit a usable function-call ID. The provider used nullish coalescing, so an explicit empty string was preserved instead of falling back to `generateId()`. Consumers then received an unusable `toolCallId`, which can break matching the call to its result.

This changes only empty IDs; non-empty provider IDs continue to pass through unchanged.

## Scope

This fixes the native `@ai-sdk/google` provider. Issue #7834 reports the analogous symptom through the separate OpenAI-compatible provider and is not closed by this change.

## Impact

Google function calls always expose a usable tool call ID, including models or compatible endpoints that explicitly return an empty ID.

## Checks

- `pnpm exec vitest --config vitest.node.config.js --run src/google-language-model.test.ts` (177 tests)
- `pnpm type-check` in `packages/google`
- `pnpm type-check:full`
- `pnpm exec oxfmt --check packages/google/src/google-language-model.ts packages/google/src/google-language-model.test.ts .changeset/tidy-tools-smile.md`
- `pnpm exec oxlint packages/google/src/google-language-model.ts packages/google/src/google-language-model.test.ts`