### PR TITLE
fix(provider-utils): abort WebSocket drain waits promptly

### DIFF
--- a/.changeset/quick-wolves-drain.md
+++ b/.changeset/quick-wolves-drain.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Stop waiting for WebSocket backpressure polling as soon as its signal aborts,
+including in runtimes without a global `DOMException` constructor.

--- a/packages/provider-utils/src/delay.test.ts
+++ b/packages/provider-utils/src/delay.test.ts
@@ -7,6 +7,7 @@ describe('delay', () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -75,6 +76,19 @@ describe('delay', () => {
       controller.abort();
 
       await expect(delayPromise).rejects.toThrow('Delay was aborted');
+    });
+
+    it('should reject with an AbortError when DOMException is unavailable', async () => {
+      vi.stubGlobal('DOMException', undefined);
+      const controller = new AbortController();
+      const delayPromise = delay(1000, { abortSignal: controller.signal });
+
+      controller.abort();
+
+      await expect(delayPromise).rejects.toMatchObject({
+        name: 'AbortError',
+        message: 'Delay was aborted',
+      });
     });
 
     it('should clean up timeout when aborted', async () => {

--- a/packages/provider-utils/src/delay.ts
+++ b/packages/provider-utils/src/delay.ts
@@ -3,7 +3,7 @@
  * @param delayInMs - The delay duration in milliseconds. If null or undefined, resolves immediately.
  * @param signal - Optional AbortSignal to cancel the delay
  * @returns A Promise that resolves after the specified delay
- * @throws {DOMException} When the signal is aborted
+ * @throws {Error} With the name `AbortError` when the signal is aborted
  */
 export async function delay(
   delayInMs?: number | null,
@@ -42,6 +42,12 @@ export async function delay(
   });
 }
 
-function createAbortError(): DOMException {
-  return new DOMException('Delay was aborted', 'AbortError');
+function createAbortError(): Error {
+  if (typeof DOMException === 'function') {
+    return new DOMException('Delay was aborted', 'AbortError');
+  }
+
+  const error = new Error('Delay was aborted');
+  error.name = 'AbortError';
+  return error;
 }

--- a/packages/provider-utils/src/websocket.test.ts
+++ b/packages/provider-utils/src/websocket.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { waitForWebSocketBufferDrain, type WebSocketLike } from './websocket';
 
 function socketWithBuffer(initial: number): WebSocketLike & {
@@ -69,14 +69,24 @@ describe('waitForWebSocketBufferDrain', () => {
   });
 
   it('should resolve when the abort signal fires mid-wait', async () => {
-    const socket = socketWithBuffer(100);
-    const controller = new AbortController();
-    const wait = waitForWebSocketBufferDrain(socket, {
-      highWaterMark: 10,
-      pollIntervalMs: 1,
-      abortSignal: controller.signal,
-    });
-    controller.abort();
-    await expect(wait).resolves.toBeUndefined();
+    vi.useFakeTimers();
+    vi.stubGlobal('DOMException', undefined);
+    try {
+      const socket = socketWithBuffer(100);
+      const controller = new AbortController();
+      const wait = waitForWebSocketBufferDrain(socket, {
+        highWaterMark: 10,
+        pollIntervalMs: 60_000,
+        abortSignal: controller.signal,
+      });
+
+      controller.abort();
+
+      expect(vi.getTimerCount()).toBe(0);
+      await expect(wait).resolves.toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/provider-utils/src/websocket.ts
+++ b/packages/provider-utils/src/websocket.ts
@@ -89,9 +89,13 @@ export async function waitForWebSocketBufferDrain(
     socket.readyState === WEBSOCKET_OPEN_STATE &&
     (socket.bufferedAmount ?? 0) > highWaterMark
   ) {
-    if (abortSignal?.aborted === true) {
-      return;
+    try {
+      await delay(pollIntervalMs, { abortSignal });
+    } catch (error) {
+      if (abortSignal?.aborted === true) {
+        return;
+      }
+      throw error;
     }
-    await delay(pollIntervalMs);
   }
 }


### PR DESCRIPTION
## Summary

- pass the supplied abort signal into WebSocket backpressure polling delays
- resolve the drain wait when that signal cancels an active delay
- make abort-aware delays fall back to an `Error` named `AbortError` when `DOMException` is unavailable
- add focused timer-cleanup and DOMException-less runtime regressions
- add a patch changeset for `@ai-sdk/provider-utils`

## Problem

`waitForWebSocketBufferDrain` checked `abortSignal.aborted` only before starting each polling delay. For callers that provide a signal, cancellation during the delay remained blocked until the full `pollIntervalMs` elapsed. Passing the signal into `delay` also needs to work in runtimes without a global `DOMException` constructor.

## Fix

Make each polling delay abort-aware and treat signal cancellation as successful completion of the drain wait. The shared delay helper now creates a compatible `Error` named `AbortError` when `DOMException` is unavailable. Non-abort delay failures are still rethrown.

## Validation

- focused Node tests for `websocket.test.ts` and `delay.test.ts` (20 tests)
- focused edge-runtime tests for `websocket.test.ts` and `delay.test.ts` (20 tests)
- `pnpm type-check` in `packages/provider-utils`
- `pnpm type-check:full`
- focused formatting and lint checks