### PR TITLE
fix(openai): mark failed web searches as errors

### DIFF
--- a/.changeset/calm-searches-report.md
+++ b/.changeset/calm-searches-report.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Mark failed OpenAI web search results as errors.

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -4093,6 +4093,41 @@ describe('OpenAIResponsesLanguageModel', () => {
     });
 
     describe('web search sources schema resilience', () => {
+      it('should mark a failed web search result as an error', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            output: [
+              {
+                type: 'web_search_call',
+                id: 'ws_failed',
+                status: 'failed',
+              },
+            ],
+          },
+        };
+
+        const result = await createModel('gpt-4o').doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'openai.web_search',
+              name: 'webSearch',
+              args: {},
+            },
+          ],
+        });
+
+        expect(result.content).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ws_failed',
+          toolName: 'webSearch',
+          result: {},
+          isError: true,
+        });
+      });
+
       it('should accept api-type sources without throwing', async () => {
         server.urls['https://api.openai.com/v1/responses'].response = {
           type: 'json-value',
@@ -6795,6 +6830,55 @@ describe('OpenAIResponsesLanguageModel', () => {
     });
 
     describe('web search tool', () => {
+      it('should mark a failed streamed web search result as an error', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'stream-chunks',
+          chunks: [
+            `data: ${JSON.stringify({
+              type: 'response.output_item.added',
+              output_index: 0,
+              item: {
+                type: 'web_search_call',
+                id: 'ws_failed',
+                status: 'in_progress',
+              },
+            })}\n\n`,
+            `data: ${JSON.stringify({
+              type: 'response.output_item.done',
+              output_index: 0,
+              item: {
+                type: 'web_search_call',
+                id: 'ws_failed',
+                status: 'failed',
+              },
+            })}\n\n`,
+            'data: [DONE]\n\n',
+          ],
+        };
+
+        const { stream } = await createModel('gpt-5-nano').doStream({
+          tools: [
+            {
+              type: 'provider',
+              id: 'openai.web_search',
+              name: 'webSearch',
+              args: {},
+            },
+          ],
+          prompt: TEST_PROMPT,
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+
+        expect(parts).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ws_failed',
+          toolName: 'webSearch',
+          result: {},
+          isError: true,
+        });
+      });
+
       it('should stream web search results (sources, tool calls, tool results)', async () => {
         prepareChunksFixtureResponse('openai-web-search-tool.1');
 

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -1037,6 +1037,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
               webSearchToolName ?? 'web_search',
             ),
             result: mapWebSearchOutput(part.action),
+            ...(part.status === 'failed' && { isError: true }),
           });
 
           break;
@@ -1770,6 +1771,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
                     webSearchToolName ?? 'web_search',
                   ),
                   result: mapWebSearchOutput(value.item.action),
+                  ...(value.item.status === 'failed' && { isError: true }),
                 });
               } else if (value.item.type === 'computer_call') {
                 ongoingToolCalls[value.output_index] = undefined;


### PR DESCRIPTION
## What

- Mark failed OpenAI Responses API web-search results with `isError: true`.
- Apply the mapping to both non-streaming output items and streamed `response.output_item.done` events.
- Add focused regressions for both paths.

## Why

The Responses API includes a `status` on `web_search_call` items. The provider previously discarded that status when creating the AI SDK tool result, so a failed search was indistinguishable from a successful one.

The root cause was that every web-search output was unconditionally mapped to a normal `tool-result`. This preserves the existing result payload while setting the provider result's standard error flag only when OpenAI reports `status: "failed"`.

Fixes #9270.

## Impact

Consumers can reliably detect failed provider-executed web searches and avoid treating an unsuccessful search as valid tool output.

## Checks

- `pnpm exec vitest --config vitest.node.config.js --run src/responses/openai-responses-language-model.test.ts` (289 tests)
- `pnpm type-check` in `packages/openai`
- `pnpm type-check:full`
- `pnpm exec oxfmt --check packages/openai/src/responses/openai-responses-language-model.ts packages/openai/src/responses/openai-responses-language-model.test.ts .changeset/calm-searches-report.md`
- `pnpm exec oxlint packages/openai/src/responses/openai-responses-language-model.ts packages/openai/src/responses/openai-responses-language-model.test.ts`
