### PR TITLE
fix(openai): reconstruct provider-executed shell history

### DIFF
--- a/.changeset/shells-replay-cleanly.md
+++ b/.changeset/shells-replay-cleanly.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Fix Responses API follow-up requests with `store: false` by reconstructing provider-executed shell and local shell calls alongside their outputs.

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -3864,6 +3864,7 @@ describe('convertToOpenAIResponsesInput', () => {
                   toolCallId: 'call_XWgeTylovOiS8xLNz2TONOgO',
                   toolName: 'local_shell',
                   input: { action: { type: 'exec', command: ['ls'] } },
+                  providerExecuted: true,
                   providerOptions: {
                     openai: {
                       itemId:
@@ -3906,7 +3907,7 @@ describe('convertToOpenAIResponsesInput', () => {
         `);
       });
 
-      it('should convert local shell tool call and result into item reference with store: false', async () => {
+      it('should reconstruct provider-executed local shell call and result with store: false', async () => {
         const result = await convertToOpenAIResponsesInput({
           toolNameMapping: testToolNameMapping,
           prompt: [
@@ -3918,6 +3919,7 @@ describe('convertToOpenAIResponsesInput', () => {
                   toolCallId: 'call_XWgeTylovOiS8xLNz2TONOgO',
                   toolName: 'local_shell',
                   input: { action: { type: 'exec', command: ['ls'] } },
+                  providerExecuted: true,
                   providerOptions: {
                     openai: {
                       itemId:
@@ -3969,6 +3971,86 @@ describe('convertToOpenAIResponsesInput', () => {
             },
           ]
         `);
+      });
+    });
+
+    describe('shell', () => {
+      it('should reconstruct provider-executed shell call and result with store: false', async () => {
+        const result = await convertToOpenAIResponsesInput({
+          toolNameMapping: testToolNameMapping,
+          prompt: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call_abc123def456ghi789jkl012',
+                  toolName: 'shell',
+                  input: {
+                    action: {
+                      commands: ['uname -a'],
+                      timeoutMs: 1000,
+                      maxOutputLength: 4000,
+                    },
+                  },
+                  providerExecuted: true,
+                  providerOptions: {
+                    openai: {
+                      itemId:
+                        'sh_0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e50',
+                    },
+                  },
+                },
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call_abc123def456ghi789jkl012',
+                  toolName: 'shell',
+                  output: {
+                    type: 'json',
+                    value: {
+                      output: [
+                        {
+                          stdout: 'Linux x86_64\n',
+                          stderr: '',
+                          outcome: { type: 'exit', exitCode: 0 },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+          systemMessageMode: 'system',
+          providerOptionsName: 'openai',
+          store: false,
+          hasShellTool: true,
+        });
+
+        expect(result.input).toEqual([
+          {
+            type: 'shell_call',
+            call_id: 'call_abc123def456ghi789jkl012',
+            id: 'sh_0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e50',
+            status: 'completed',
+            action: {
+              commands: ['uname -a'],
+              timeout_ms: 1000,
+              max_output_length: 4000,
+            },
+          },
+          {
+            type: 'shell_call_output',
+            call_id: 'call_abc123def456ghi789jkl012',
+            output: [
+              {
+                stdout: 'Linux x86_64\n',
+                stderr: '',
+                outcome: { type: 'exit', exit_code: 0 },
+              },
+            ],
+          },
+        ]);
       });
     });
 

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -437,8 +437,20 @@ export async function convertToOpenAIResponsesInput({
               if (part.providerExecuted) {
                 if (store && id != null) {
                   input.push({ type: 'item_reference', id });
+                  break;
                 }
-                break;
+
+                // When storage is disabled, shell outputs are reconstructed as
+                // call output items and need their matching call in the input.
+                // Other provider-executed tools remain omitted.
+                const shouldReconstructShellCall =
+                  !store &&
+                  ((hasLocalShellTool && resolvedToolName === 'local_shell') ||
+                    (hasShellTool && resolvedToolName === 'shell'));
+
+                if (!shouldReconstructShellCall) {
+                  break;
+                }
               }
 
               // When chaining with a previous response id, items already part


### PR DESCRIPTION
## Background

With Responses API storage disabled, follow-up prompts can contain a provider-executed `shell` or `local_shell` output without its matching call item. OpenAI rejects that history because it cannot match the output's `call_id`.

## Summary

- reconstruct provider-executed `shell` and `local_shell` calls when `store: false`
- preserve item-reference behavior when storage is enabled
- continue omitting unrelated provider-executed calls
- add focused regressions for both shell variants and a patch changeset

## Contributor Credit

Thanks to @jasonblanchard for the detailed report, root-cause analysis, and workaround in #18134.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #18134.