### PR TITLE
fix(google): preserve forced tool choice with strict tools

### DIFF
--- a/.changeset/tidy-tools-stay-forced.md
+++ b/.changeset/tidy-tools-stay-forced.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Preserve required and named Google tool choices when strict tools are present.

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -1412,7 +1412,7 @@ describe('doGenerate', () => {
     ]);
   });
 
-  it('should pass tools and toolChoice', async () => {
+  it('should preserve a named tool choice when another tool is strict', async () => {
     prepareJsonFixtureResponse('google-text');
 
     await model.doGenerate({
@@ -1427,6 +1427,18 @@ describe('doGenerate', () => {
             additionalProperties: false,
             $schema: 'http://json-schema.org/draft-07/schema#',
           },
+        },
+        {
+          type: 'function',
+          name: 'strict-tool',
+          inputSchema: {
+            type: 'object',
+            properties: { value: { type: 'string' } },
+            required: ['value'],
+            additionalProperties: false,
+            $schema: 'http://json-schema.org/draft-07/schema#',
+          },
+          strict: true,
         },
       ],
       toolChoice: {
@@ -1463,6 +1475,21 @@ describe('doGenerate', () => {
               {
                 "description": "",
                 "name": "test-tool",
+                "parameters": {
+                  "properties": {
+                    "value": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "value",
+                  ],
+                  "type": "object",
+                },
+              },
+              {
+                "description": "",
+                "name": "strict-tool",
                 "parameters": {
                   "properties": {
                     "value": {

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -884,97 +884,101 @@ it('should add warnings for google maps on unsupported models', () => {
   `);
 });
 
-it('should use VALIDATED mode when any function tool has strict: true', () => {
-  const result = prepareTools({
-    tools: [
-      {
-        type: 'function',
-        name: 'createMeeting',
-        description: 'Create a meeting',
-        inputSchema: {
-          type: 'object',
-          properties: { title: { type: 'string' } },
-          required: ['title'],
-          additionalProperties: false,
-        },
-        strict: true,
-      },
-    ],
-    modelId: 'gemini-3-flash-preview',
-  });
-  expect(result.toolConfig).toEqual({
-    functionCallingConfig: { mode: 'VALIDATED' },
-  });
-  expect(result.toolWarnings).toEqual([]);
-});
-
-it('should use VALIDATED mode with toolChoice auto when strict: true', () => {
-  const result = prepareTools({
-    tools: [
-      {
-        type: 'function',
-        name: 'getWeather',
-        description: 'Get weather',
-        inputSchema: {
-          type: 'object',
-          properties: { city: { type: 'string' } },
-          required: ['city'],
-          additionalProperties: false,
-        },
-        strict: true,
-      },
-    ],
+const strictToolChoiceCases: Array<{
+  name: string;
+  toolStrictness: Array<'strict' | 'non-strict'>;
+  toolChoice: Parameters<typeof prepareTools>[0]['toolChoice'];
+  expectedToolConfig: ReturnType<typeof prepareTools>['toolConfig'];
+}> = [
+  {
+    name: 'default choice with a strict tool uses VALIDATED',
+    toolStrictness: ['strict'],
+    toolChoice: undefined,
+    expectedToolConfig: { functionCallingConfig: { mode: 'VALIDATED' } },
+  },
+  {
+    name: 'default choice with mixed strict and non-strict tools uses VALIDATED',
+    toolStrictness: ['non-strict', 'strict'],
+    toolChoice: undefined,
+    expectedToolConfig: { functionCallingConfig: { mode: 'VALIDATED' } },
+  },
+  {
+    name: 'auto choice with a strict tool uses VALIDATED',
+    toolStrictness: ['strict'],
     toolChoice: { type: 'auto' },
-    modelId: 'gemini-3-flash-preview',
-  });
-  expect(result.toolConfig).toEqual({
-    functionCallingConfig: { mode: 'VALIDATED' },
-  });
-});
-
-it('should use VALIDATED mode with toolChoice required when strict: true', () => {
-  const result = prepareTools({
-    tools: [
-      {
-        type: 'function',
-        name: 'getWeather',
-        description: 'Get weather',
-        inputSchema: {
-          type: 'object',
-          properties: { city: { type: 'string' } },
-          required: ['city'],
-          additionalProperties: false,
-        },
-        strict: true,
-      },
-    ],
+    expectedToolConfig: { functionCallingConfig: { mode: 'VALIDATED' } },
+  },
+  {
+    name: 'auto choice with mixed strict and non-strict tools uses VALIDATED',
+    toolStrictness: ['non-strict', 'strict'],
+    toolChoice: { type: 'auto' },
+    expectedToolConfig: { functionCallingConfig: { mode: 'VALIDATED' } },
+  },
+  {
+    name: 'required choice with a strict tool uses ANY',
+    toolStrictness: ['strict'],
     toolChoice: { type: 'required' },
-    modelId: 'gemini-3-flash-preview',
-  });
-  expect(result.toolConfig).toEqual({
-    functionCallingConfig: { mode: 'VALIDATED' },
-  });
-});
-
-it('should use AUTO mode when no tools have strict: true', () => {
-  const result = prepareTools({
-    tools: [
-      {
-        type: 'function',
-        name: 'getWeather',
-        description: 'Get weather',
-        inputSchema: {
-          type: 'object',
-          properties: { city: { type: 'string' } },
-          required: ['city'],
-          additionalProperties: false,
-        },
+    expectedToolConfig: { functionCallingConfig: { mode: 'ANY' } },
+  },
+  {
+    name: 'required choice with mixed strict and non-strict tools uses ANY',
+    toolStrictness: ['non-strict', 'strict'],
+    toolChoice: { type: 'required' },
+    expectedToolConfig: { functionCallingConfig: { mode: 'ANY' } },
+  },
+  {
+    name: 'named strict tool choice with mixed strict and non-strict tools uses ANY',
+    toolStrictness: ['strict', 'non-strict'],
+    toolChoice: { type: 'tool', toolName: 'tool-0' },
+    expectedToolConfig: {
+      functionCallingConfig: {
+        mode: 'ANY',
+        allowedFunctionNames: ['tool-0'],
       },
-    ],
-    toolChoice: { type: 'auto' },
-    modelId: 'gemini-3-flash-preview',
-  });
-  expect(result.toolConfig).toEqual({
-    functionCallingConfig: { mode: 'AUTO' },
-  });
-});
+    },
+  },
+  {
+    name: 'named non-strict tool choice with another strict tool uses ANY',
+    toolStrictness: ['non-strict', 'strict'],
+    toolChoice: { type: 'tool', toolName: 'tool-0' },
+    expectedToolConfig: {
+      functionCallingConfig: {
+        mode: 'ANY',
+        allowedFunctionNames: ['tool-0'],
+      },
+    },
+  },
+  {
+    name: 'none choice with mixed strict and non-strict tools uses NONE',
+    toolStrictness: ['non-strict', 'strict'],
+    toolChoice: { type: 'none' },
+    expectedToolConfig: { functionCallingConfig: { mode: 'NONE' } },
+  },
+];
+
+it.each(strictToolChoiceCases)(
+  '$name',
+  ({ toolStrictness, toolChoice, expectedToolConfig }) => {
+    const tools = toolStrictness.map((strictness, index) => ({
+      type: 'function' as const,
+      name: `tool-${index}`,
+      description: `Tool ${index}`,
+      inputSchema: {
+        type: 'object' as const,
+        properties: { value: { type: 'string' as const } },
+        required: ['value'],
+        additionalProperties: false,
+      },
+      strict: strictness === 'strict',
+    }));
+
+    const result = prepareTools({
+      tools,
+      toolChoice,
+      modelId: 'gemini-3-flash-preview',
+    });
+
+    expect(result.toolConfig).toEqual(expectedToolConfig);
+    expect(result.toolWarnings).toEqual([]);
+  },
+);

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -290,7 +290,7 @@ export function prepareTools({
         tools: [{ functionDeclarations }],
         toolConfig: {
           functionCallingConfig: {
-            mode: hasStrictTools ? 'VALIDATED' : 'ANY',
+            mode: 'ANY',
           },
         },
         toolWarnings,
@@ -300,7 +300,7 @@ export function prepareTools({
         tools: [{ functionDeclarations }],
         toolConfig: {
           functionCallingConfig: {
-            mode: hasStrictTools ? 'VALIDATED' : 'ANY',
+            mode: 'ANY',
             allowedFunctionNames: [toolChoice.toolName],
           },
         },


### PR DESCRIPTION
## Background

Google strict tools switched function calling to `VALIDATED` even when `toolChoice` was `required` or named a specific tool. That silently removed the caller's guarantee that a function would be called.

## Summary

- keep `ANY` mode for required and named tool choices, including mixed strict/non-strict tool sets
- retain `VALIDATED` for default and automatic choices with strict tools
- add a nine-case preparation matrix, request-level regression coverage, and a patch changeset

## Contributor Credit

Thanks to @atibhav21 for identifying the regression and tracing it to the strict-tool mode selection in #17658.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17658.