### PR TITLE
fix(amazon-bedrock): support structured output mode selection

### DIFF
--- a/.changeset/calm-crabs-report.md
+++ b/.changeset/calm-crabs-report.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Add a structured output mode option for choosing native output formats or the JSON tool fallback.

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -465,6 +465,47 @@ The following Bedrock-specific metadata may be returned in `providerMetadata.bed
 - **stopSequence** _string | null_
   The stop sequence that triggered the stop, if any.
 
+## Structured Outputs
+
+For Anthropic models, the `structuredOutputMode` provider option controls how
+schema-constrained output is requested:
+
+- `auto` uses Bedrock's native `output_config.format` when the model supports it
+  and otherwise falls back to a JSON tool. This is the default.
+- `outputFormat` always uses Bedrock's native `output_config.format`.
+- `jsonTool` uses a special `json` tool and forces a tool call. This can be used
+  as an escape hatch when native structured output does not work well for a
+  particular schema or workload.
+
+```ts
+import {
+  amazonBedrock,
+  type AmazonBedrockLanguageModelChatOptions,
+} from '@ai-sdk/amazon-bedrock';
+import { generateText, Output } from 'ai';
+import { z } from 'zod';
+
+const result = await generateText({
+  model: amazonBedrock('anthropic.claude-sonnet-4-6-v1'),
+  prompt: 'Generate a city and country for a travel itinerary.',
+  output: Output.object({
+    schema: z.object({
+      city: z.string(),
+      country: z.string(),
+    }),
+  }),
+  providerOptions: {
+    amazonBedrock: {
+      structuredOutputMode: 'jsonTool',
+    } satisfies AmazonBedrockLanguageModelChatOptions,
+  },
+});
+
+console.log(result.output);
+```
+
+The legacy `providerOptions.bedrock` key also supports this option.
+
 ## Reasoning
 
 Amazon Bedrock supports model creator-specific reasoning features:

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.test.ts
@@ -4,6 +4,33 @@ import {
   type AmazonBedrockLanguageModelChatOptions,
 } from './amazon-bedrock-chat-language-model-options';
 describe('amazonBedrockLanguageModelChatOptions', () => {
+  describe('structuredOutputMode', () => {
+    it('accepts valid structured output modes', () => {
+      const validValues = ['outputFormat', 'jsonTool', 'auto'] as const;
+
+      validValues.forEach(value => {
+        const result = amazonBedrockLanguageModelChatOptions.safeParse({
+          structuredOutputMode: value,
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.data?.structuredOutputMode).toBe(value);
+      });
+    });
+
+    it('rejects invalid structured output modes', () => {
+      const invalidValues = ['native', 'tool', '', 'AUTO'];
+
+      invalidValues.forEach(value => {
+        const result = amazonBedrockLanguageModelChatOptions.safeParse({
+          structuredOutputMode: value,
+        });
+
+        expect(result.success).toBe(false);
+      });
+    });
+  });
+
   describe('serviceTier', () => {
     it('accepts valid service tier values', () => {
       const validValues = ['reserved', 'priority', 'default', 'flex'] as const;
@@ -35,9 +62,11 @@ describe('amazonBedrockLanguageModelChatOptions', () => {
     it('infers AmazonBedrockLanguageModelChatOptions type correctly', () => {
       const options: AmazonBedrockLanguageModelChatOptions = {
         serviceTier: 'priority',
+        structuredOutputMode: 'jsonTool',
       };
 
       expect(options.serviceTier).toBe('priority');
+      expect(options.structuredOutputMode).toBe('jsonTool');
     });
   });
 });

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.ts
@@ -108,6 +108,14 @@ export type AmazonBedrockFilePartProviderOptions = z.infer<
 
 export const amazonBedrockLanguageModelChatOptions = z.object({
   /**
+   * Determines how structured outputs are generated for Anthropic models.
+   *
+   * - `outputFormat`: Use the native `output_config.format` parameter.
+   * - `jsonTool`: Use a special `json` tool.
+   * - `auto`: Use `outputFormat` when supported, otherwise use `jsonTool` (default).
+   */
+  structuredOutputMode: z.enum(['outputFormat', 'jsonTool', 'auto']).optional(),
+  /**
    * Additional inference parameters that the model supports,
    * beyond the base set of inference parameters that Converse
    * supports in the inferenceConfig field

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -5162,7 +5162,7 @@ describe('doGenerate', () => {
     ).toBeUndefined();
   });
 
-  it('should use native output_config.format for models with structured output support even without thinking enabled', async () => {
+  it('should use native output_config.format in auto mode for models with structured output support', async () => {
     server.urls[newerAnthropicGenerateUrl].response = {
       type: 'json-value',
       body: {
@@ -5194,6 +5194,11 @@ describe('doGenerate', () => {
           required: ['name'],
         },
       },
+      providerOptions: {
+        amazonBedrock: {
+          structuredOutputMode: 'auto',
+        },
+      },
     });
 
     const requestBody = await server.calls[0].requestBodyJson;
@@ -5220,6 +5225,155 @@ describe('doGenerate', () => {
         },
       }
     `);
+  });
+
+  it('should use the JSON tool when structuredOutputMode is jsonTool on a model with native structured output support', async () => {
+    server.urls[newerAnthropicGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            content: [
+              {
+                toolUse: {
+                  toolUseId: 'json-tool-id',
+                  name: 'json',
+                  input: { name: 'Test' },
+                },
+              },
+            ],
+            role: 'assistant',
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+        stopReason: 'tool_use',
+      },
+    };
+
+    const result = await newerAnthropicModel.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+          required: ['name'],
+          additionalProperties: false,
+        },
+      },
+      providerOptions: {
+        amazonBedrock: {
+          structuredOutputMode: 'jsonTool',
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.toolConfig).toMatchInlineSnapshot(`
+      {
+        "toolChoice": {
+          "any": {},
+        },
+        "tools": [
+          {
+            "toolSpec": {
+              "description": "Respond with a JSON object.",
+              "inputSchema": {
+                "json": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "name",
+                  ],
+                  "type": "object",
+                },
+              },
+              "name": "json",
+            },
+          },
+        ],
+      }
+    `);
+    expect(
+      requestBody.additionalModelRequestFields?.output_config,
+    ).toBeUndefined();
+    expect(requestBody.structuredOutputMode).toBeUndefined();
+    expect(result).toMatchObject({
+      content: [{ type: 'text', text: '{"name":"Test"}' }],
+      finishReason: { unified: 'stop', raw: 'tool_use' },
+      providerMetadata: {
+        amazonBedrock: { isJsonResponseFromTool: true },
+        bedrock: { isJsonResponseFromTool: true },
+      },
+    });
+  });
+
+  it('should force native output_config.format when structuredOutputMode is outputFormat', async () => {
+    server.urls[legacyAnthropic37GenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            content: [{ text: '{"name":"Test"}' }],
+            role: 'assistant',
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+        stopReason: 'end_turn',
+      },
+    };
+
+    await legacyAnthropic37Model.doGenerate({
+      prompt: TEST_PROMPT,
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+          required: ['name'],
+          additionalProperties: false,
+        },
+      },
+      providerOptions: {
+        bedrock: {
+          structuredOutputMode: 'outputFormat',
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.toolConfig).toBeUndefined();
+    expect(requestBody.additionalModelRequestFields?.output_config)
+      .toMatchInlineSnapshot(`
+        {
+          "format": {
+            "schema": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "name",
+              ],
+              "type": "object",
+            },
+            "type": "json_schema",
+          },
+        }
+      `);
+    expect(requestBody.structuredOutputMode).toBeUndefined();
   });
 
   it('should sanitize unsupported JSON schema keywords for native structured output', async () => {

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -194,32 +194,37 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
     const { supportsStructuredOutput: modelSupportsStructuredOutput } =
       getModelCapabilities(this.modelId);
 
+    const structuredOutputMode =
+      amazonBedrockOptions.structuredOutputMode ?? 'auto';
+    const hasStructuredOutputSchema =
+      responseFormat?.type === 'json' && responseFormat.schema != null;
+
     const useNativeStructuredOutput =
       isAnthropicModel &&
-      supportsNativeStructuredOutput(this.modelId) &&
-      (modelSupportsStructuredOutput || isThinkingEnabled) &&
-      responseFormat?.type === 'json' &&
-      responseFormat.schema != null;
+      hasStructuredOutputSchema &&
+      (structuredOutputMode === 'outputFormat' ||
+        (structuredOutputMode === 'auto' &&
+          supportsNativeStructuredOutput(this.modelId) &&
+          (modelSupportsStructuredOutput || isThinkingEnabled)));
 
     const useJsonInstructionForStructuredOutput =
+      structuredOutputMode === 'auto' &&
       isAnthropicModel &&
       (this.modelId.includes('claude-opus-4-7') ||
         this.modelId.includes('claude-opus-4-8')) &&
-      responseFormat?.type === 'json' &&
-      responseFormat.schema != null &&
+      hasStructuredOutputSchema &&
       tools != null &&
       tools.length > 0;
 
     const jsonResponseTool: LanguageModelV4FunctionTool | undefined =
-      responseFormat?.type === 'json' &&
-      responseFormat.schema != null &&
+      hasStructuredOutputSchema &&
       !useNativeStructuredOutput &&
       !useJsonInstructionForStructuredOutput
         ? {
             type: 'function',
             name: 'json',
             description: 'Respond with a JSON object.',
-            inputSchema: responseFormat.schema,
+            inputSchema: responseFormat!.schema!,
           }
         : undefined;
 
@@ -446,6 +451,7 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
       reasoningConfig: _,
       additionalModelRequestFields: __,
       serviceTier: ___,
+      structuredOutputMode: ____,
       ...filteredAmazonBedrockOptions
     } = providerOptions?.amazonBedrock ?? providerOptions?.bedrock ?? {};
 


### PR DESCRIPTION
## Background

Bedrock native structured output can run to the token limit for some Claude Sonnet 4.6 schemas, while the JSON-tool path completes normally. Unlike the direct Anthropic provider, the Bedrock adapter offered no way to select that fallback.

## Summary

- add `structuredOutputMode: "auto" | "outputFormat" | "jsonTool"` to Bedrock chat options
- preserve the existing capability-based behavior in `auto` mode
- allow callers to force the JSON-tool fallback or native `output_config.format`
- keep the provider-only option out of the Bedrock request payload
- add request/response regressions, provider documentation, and a patch changeset

## Contributor Credit

Thanks to @rhamnett for the detailed report in #17881 and to @lgrammel for the live reproduction in #17903.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17881.