### PR TITLE
fix(otel): include runtime context in tool spans

### DIFF
--- a/.changeset/warm-tools-share-context.md
+++ b/.changeset/warm-tools-share-context.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/otel': patch
+---
+
+include filtered runtime context attributes on tool execution spans

--- a/packages/otel/src/legacy-open-telemetry.test.ts
+++ b/packages/otel/src/legacy-open-telemetry.test.ts
@@ -562,6 +562,17 @@ describe('LegacyOpenTelemetry', () => {
       expect(attrs['ai.toolCall.id']).toBe('tool-call-1');
     });
 
+    it('includes filtered runtime context attributes', () => {
+      const runtimeContext = { requestId: 'request-123' };
+
+      otelIntegration.onStart!(makeOnStartEvent({ runtimeContext }));
+      otelIntegration.onStepStart!(makeStepStartEvent({ runtimeContext }));
+      otelIntegration.onToolExecutionStart!(makeToolCallStartEvent());
+
+      const attrs = getStartSpanAttributes(tracer, 2);
+      expect(attrs['ai.settings.context.requestId']).toBe('request-123');
+    });
+
     it('sets tool call args as output attribute', () => {
       otelIntegration.onStart!(makeOnStartEvent());
       otelIntegration.onStepStart!(makeStepStartEvent());

--- a/packages/otel/src/legacy-open-telemetry.ts
+++ b/packages/otel/src/legacy-open-telemetry.ts
@@ -40,6 +40,7 @@ import { assembleOperationName } from './assemble-operation-name';
 import { getBaseTelemetryAttributes } from './get-base-telemetry-attributes';
 import { sanitizeAttributeValue } from './sanitize-attribute-value';
 import { stringifyForTelemetry } from './stringify-for-telemetry';
+import { getRuntimeContextAttributes } from './supplemental-attributes';
 
 function recordSpanError(span: Span, error: unknown): void {
   if (error instanceof Error) {
@@ -138,6 +139,7 @@ interface CallState {
   rerankSpan: { span: Span; context: OpenTelemetryContext } | undefined;
   toolSpans: Map<string, { span: Span; context: OpenTelemetryContext }>;
   baseTelemetryAttributes: Attributes;
+  runtimeContextAttributes?: Attributes;
   settings: Record<string, unknown>;
 }
 
@@ -297,6 +299,12 @@ export class LegacyOpenTelemetry implements Telemetry {
       rerankSpan: undefined,
       toolSpans: new Map(),
       baseTelemetryAttributes,
+      runtimeContextAttributes: selectAttributes(
+        telemetry,
+        getRuntimeContextAttributes(
+          event.runtimeContext as Record<string, unknown> | undefined,
+        ),
+      ),
       settings,
     });
   }
@@ -540,6 +548,12 @@ export class LegacyOpenTelemetry implements Telemetry {
     if (!state?.rootSpan || !state.rootContext) return;
 
     const { telemetry } = state;
+    state.runtimeContextAttributes = selectAttributes(
+      telemetry,
+      getRuntimeContextAttributes(
+        event.runtimeContext as Record<string, unknown> | undefined,
+      ),
+    );
 
     const stepOperationId =
       state.operationId === 'ai.streamText'
@@ -612,6 +626,7 @@ export class LegacyOpenTelemetry implements Telemetry {
         operationId: 'ai.toolCall',
         telemetry,
       }),
+      ...state.runtimeContextAttributes,
       'ai.toolCall.name': toolCall.toolName,
       'ai.toolCall.id': toolCall.toolCallId,
       'ai.toolCall.args': {

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -1228,6 +1228,21 @@ describe('OpenTelemetry', () => {
   });
 
   describe('supplemental attributes', () => {
+    it('exports runtime context attributes on tool spans', () => {
+      integration = new OpenTelemetry({
+        tracer,
+        runtimeContext: true,
+      });
+
+      const runtimeContext = { requestId: 'request-123' };
+      integration.onStart!(makeOnStartEvent({ runtimeContext }));
+      integration.onStepStart!(makeStepStartEvent({ runtimeContext }));
+      integration.onToolExecutionStart!(makeToolCallStartEvent());
+
+      const attrs = getStartSpanAttributes(tracer, 2);
+      expect(attrs['ai.settings.context.requestId']).toBe('request-123');
+    });
+
     it('exports flat runtime context attribute keys', () => {
       const sdkTrace = createSdkTracer();
       integration = new OpenTelemetry({
@@ -1411,6 +1426,8 @@ describe('OpenTelemetry', () => {
           {
             "ended": true,
             "initAttributes": {
+              "ai.request.headers.x-request-id": "request-123",
+              "ai.settings.context.userId": "user-123",
               "gen_ai.operation.name": "execute_tool",
               "gen_ai.tool.call.arguments": "{"query":"test"}",
               "gen_ai.tool.call.id": "tool-call-1",
@@ -1511,6 +1528,7 @@ describe('OpenTelemetry', () => {
           {
             "ended": true,
             "initAttributes": {
+              "ai.settings.context.userId": "user-123",
               "gen_ai.operation.name": "execute_tool",
               "gen_ai.tool.call.arguments": "{"query":"test"}",
               "gen_ai.tool.call.id": "tool-call-1",

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -784,6 +784,7 @@ export class OpenTelemetry implements Telemetry {
 
     const attributes = selectAttributes(telemetry, {
       'gen_ai.operation.name': 'execute_tool',
+      ...state.baseSupplementalAttributes,
       'gen_ai.tool.name': toolCall.toolName,
       'gen_ai.tool.call.id': toolCall.toolCallId,
       'gen_ai.tool.type': 'function',


### PR DESCRIPTION
## Summary

- include telemetry-filtered runtime context attributes on legacy `ai.toolCall` spans
- include enabled supplemental runtime context and header attributes on GenAI `execute_tool` spans
- cover both OpenTelemetry integrations with focused regression tests

## Root cause

Tool spans were created without the call-level context attributes retained by their parent operation and step spans. As a result, request identifiers and other explicitly included runtime context could not be used to correlate or filter tool executions.

## Validation

- `pnpm -C packages/otel test` — 199 tests passed
- `pnpm -C packages/otel type-check`
- `pnpm check`
- `pnpm type-check:full`

Closes #8529.
