### PR TITLE
fix(gateway): format structured error messages

### DIFF
--- a/.changeset/curvy-taxis-listen.md
+++ b/.changeset/curvy-taxis-listen.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+Preserve useful messages when Gateway errors contain structured JSON.

--- a/packages/gateway/src/errors/gateway-error-to-message.test.ts
+++ b/packages/gateway/src/errors/gateway-error-to-message.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { gatewayErrorToMessage } from './gateway-error-to-message';
+
+describe('gatewayErrorToMessage', () => {
+  it('returns string errors unchanged', () => {
+    expect(gatewayErrorToMessage('Service unavailable')).toBe(
+      'Service unavailable',
+    );
+  });
+
+  it('extracts messages from Gateway error responses', () => {
+    expect(
+      gatewayErrorToMessage({
+        error: {
+          message: 'Service temporarily unavailable',
+          type: 'internal_server_error',
+        },
+      }),
+    ).toBe('Service temporarily unavailable');
+  });
+
+  it('extracts top-level error messages', () => {
+    expect(
+      gatewayErrorToMessage({
+        message: 'Request failed',
+        status: 500,
+      }),
+    ).toBe('Request failed');
+  });
+
+  it('serializes structured errors without a message', () => {
+    expect(
+      gatewayErrorToMessage({
+        status: 'failed',
+        details: { reason: 'capacity' },
+      }),
+    ).toBe('{"status":"failed","details":{"reason":"capacity"}}');
+  });
+
+  it('serializes primitive errors', () => {
+    expect(gatewayErrorToMessage(null)).toBe('null');
+    expect(gatewayErrorToMessage(500)).toBe('500');
+    expect(gatewayErrorToMessage(true)).toBe('true');
+  });
+});

--- a/packages/gateway/src/errors/gateway-error-to-message.ts
+++ b/packages/gateway/src/errors/gateway-error-to-message.ts
@@ -1,0 +1,27 @@
+export function gatewayErrorToMessage(error: unknown): string {
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    if (
+      'error' in error &&
+      typeof error.error === 'object' &&
+      error.error !== null &&
+      'message' in error.error &&
+      typeof error.error.message === 'string'
+    ) {
+      return error.error.message;
+    }
+
+    if ('message' in error && typeof error.message === 'string') {
+      return error.message;
+    }
+  }
+
+  try {
+    return JSON.stringify(error) ?? String(error);
+  } catch {
+    return String(error);
+  }
+}

--- a/packages/gateway/src/errors/index.ts
+++ b/packages/gateway/src/errors/index.ts
@@ -4,6 +4,7 @@ export {
   type GatewayErrorResponse,
 } from './create-gateway-error';
 export { extractApiCallResponse } from './extract-api-call-response';
+export { gatewayErrorToMessage } from './gateway-error-to-message';
 export { GatewayError } from './gateway-error';
 export { GatewayAuthenticationError } from './gateway-authentication-error';
 export { GatewayFailedDependencyError } from './gateway-failed-dependency-error';

--- a/packages/gateway/src/gateway-embedding-model.ts
+++ b/packages/gateway/src/gateway-embedding-model.ts
@@ -16,7 +16,7 @@ import {
   type Resolvable,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
-import { asGatewayError } from './errors';
+import { asGatewayError, gatewayErrorToMessage } from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
 import type { GatewayConfig } from './gateway-config';
 
@@ -86,7 +86,7 @@ export class GatewayEmbeddingModel implements EmbeddingModelV4 {
         ),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
-          errorToMessage: data => data,
+          errorToMessage: gatewayErrorToMessage,
         }),
         ...(abortSignal && { abortSignal }),
         fetch: this.config.fetch,

--- a/packages/gateway/src/gateway-fetch-metadata.ts
+++ b/packages/gateway/src/gateway-fetch-metadata.ts
@@ -7,7 +7,7 @@ import {
   zodSchema,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
-import { asGatewayError } from './errors';
+import { asGatewayError, gatewayErrorToMessage } from './errors';
 import type { GatewayConfig } from './gateway-config';
 import {
   KNOWN_MODEL_TYPES,
@@ -43,7 +43,7 @@ export class GatewayFetchMetadata {
         ),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
-          errorToMessage: data => data,
+          errorToMessage: gatewayErrorToMessage,
         }),
         fetch: this.config.fetch,
       });
@@ -69,7 +69,7 @@ export class GatewayFetchMetadata {
         ),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
-          errorToMessage: data => data,
+          errorToMessage: gatewayErrorToMessage,
         }),
         fetch: this.config.fetch,
       });

--- a/packages/gateway/src/gateway-generation-info.ts
+++ b/packages/gateway/src/gateway-generation-info.ts
@@ -7,7 +7,7 @@ import {
   zodSchema,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
-import { asGatewayError } from './errors';
+import { asGatewayError, gatewayErrorToMessage } from './errors';
 import type { GatewayConfig } from './gateway-config';
 
 export interface GatewayGenerationInfoParams {
@@ -74,7 +74,7 @@ export class GatewayGenerationInfoFetcher {
         ),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
-          errorToMessage: data => data,
+          errorToMessage: gatewayErrorToMessage,
         }),
         fetch: this.config.fetch,
       });

--- a/packages/gateway/src/gateway-image-model.ts
+++ b/packages/gateway/src/gateway-image-model.ts
@@ -17,7 +17,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import type { GatewayConfig } from './gateway-config';
-import { asGatewayError } from './errors';
+import { asGatewayError, gatewayErrorToMessage } from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
 
 type GatewayImageConfig = GatewayConfig & {
@@ -96,7 +96,7 @@ export class GatewayImageModel implements ImageModelV4 {
         ),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
-          errorToMessage: data => data,
+          errorToMessage: gatewayErrorToMessage,
         }),
         ...(abortSignal && { abortSignal }),
         fetch: this.config.fetch,

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -1,6 +1,7 @@
-import type {
-  LanguageModelV4Prompt,
-  LanguageModelV4FilePart,
+import {
+  APICallError,
+  type LanguageModelV4FilePart,
+  type LanguageModelV4Prompt,
 } from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
@@ -524,6 +525,10 @@ describe('GatewayLanguageModel', () => {
         expect(serverError.message).toBe('Database connection failed');
         expect(serverError.statusCode).toBe(500);
         expect(serverError.type).toBe('internal_server_error');
+        expect(APICallError.isInstance(serverError.cause)).toBe(true);
+        expect((serverError.cause as APICallError).message).toBe(
+          'Database connection failed',
+        );
       }
     });
 
@@ -773,6 +778,10 @@ describe('GatewayLanguageModel', () => {
         expect(rateLimitError.message).toBe('Rate limit exceeded');
         expect(rateLimitError.statusCode).toBe(429);
         expect(rateLimitError.type).toBe('rate_limit_exceeded');
+        expect(APICallError.isInstance(rateLimitError.cause)).toBe(true);
+        expect((rateLimitError.cause as APICallError).message).toBe(
+          'Rate limit exceeded',
+        );
       }
     });
 

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -21,7 +21,7 @@ import {
 import { z } from 'zod/v4';
 import type { GatewayConfig } from './gateway-config';
 import type { GatewayModelId } from './gateway-language-model-settings';
-import { asGatewayError } from './errors';
+import { asGatewayError, gatewayErrorToMessage } from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
 
 type GatewayChatConfig = GatewayConfig & {
@@ -92,7 +92,7 @@ export class GatewayLanguageModel implements LanguageModelV4 {
         successfulResponseHandler: createJsonResponseHandler(z.any()),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
-          errorToMessage: data => data,
+          errorToMessage: gatewayErrorToMessage,
         }),
         ...(abortSignal && { abortSignal }),
         fetch: this.config.fetch,
@@ -135,7 +135,7 @@ export class GatewayLanguageModel implements LanguageModelV4 {
         successfulResponseHandler: createEventSourceResponseHandler(z.any()),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
-          errorToMessage: data => data,
+          errorToMessage: gatewayErrorToMessage,
         }),
         ...(abortSignal && { abortSignal }),
         fetch: this.config.fetch,

--- a/packages/gateway/src/gateway-provider.ts
+++ b/packages/gateway/src/gateway-provider.ts
@@ -9,7 +9,11 @@ import {
   type WebSocketConstructor,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
-import { asGatewayError, GatewayAuthenticationError } from './errors';
+import {
+  asGatewayError,
+  gatewayErrorToMessage,
+  GatewayAuthenticationError,
+} from './errors';
 import {
   GATEWAY_AUTH_METHOD_HEADER,
   VERCEL_AI_GATEWAY_TEAM_HEADER,
@@ -372,7 +376,7 @@ export function createGateway(
         ),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
-          errorToMessage: data => data,
+          errorToMessage: gatewayErrorToMessage,
         }),
         fetch: options.fetch,
       });

--- a/packages/gateway/src/gateway-reranking-model.ts
+++ b/packages/gateway/src/gateway-reranking-model.ts
@@ -13,7 +13,7 @@ import {
   type Resolvable,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
-import { asGatewayError } from './errors';
+import { asGatewayError, gatewayErrorToMessage } from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
 import type { GatewayConfig } from './gateway-config';
 
@@ -69,7 +69,7 @@ export class GatewayRerankingModel implements RerankingModelV4 {
         ),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
-          errorToMessage: data => data,
+          errorToMessage: gatewayErrorToMessage,
         }),
         ...(abortSignal && { abortSignal }),
         fetch: this.config.fetch,

--- a/packages/gateway/src/gateway-speech-model.ts
+++ b/packages/gateway/src/gateway-speech-model.ts
@@ -12,7 +12,7 @@ import {
   type Resolvable,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
-import { asGatewayError } from './errors';
+import { asGatewayError, gatewayErrorToMessage } from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
 import type { GatewayConfig } from './gateway-config';
 
@@ -74,7 +74,7 @@ export class GatewaySpeechModel implements SpeechModelV4 {
         ),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
-          errorToMessage: data => data,
+          errorToMessage: gatewayErrorToMessage,
         }),
         ...(abortSignal && { abortSignal }),
         fetch: this.config.fetch,

--- a/packages/gateway/src/gateway-spend-report.ts
+++ b/packages/gateway/src/gateway-spend-report.ts
@@ -7,7 +7,7 @@ import {
   zodSchema,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
-import { asGatewayError } from './errors';
+import { asGatewayError, gatewayErrorToMessage } from './errors';
 import type { GatewayConfig } from './gateway-config';
 
 export interface GatewaySpendReportParams {
@@ -115,7 +115,7 @@ export class GatewaySpendReport {
         ),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
-          errorToMessage: data => data,
+          errorToMessage: gatewayErrorToMessage,
         }),
         fetch: this.config.fetch,
       });

--- a/packages/gateway/src/gateway-transcription-model.ts
+++ b/packages/gateway/src/gateway-transcription-model.ts
@@ -28,7 +28,11 @@ import {
   type WebSocketLike,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
-import { asGatewayError, createGatewayErrorFromResponse } from './errors';
+import {
+  asGatewayError,
+  createGatewayErrorFromResponse,
+  gatewayErrorToMessage,
+} from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
 import type { GatewayConfig } from './gateway-config';
 import { VERCEL_AI_GATEWAY_TEAM_HEADER } from './gateway-headers';
@@ -93,7 +97,7 @@ export class GatewayTranscriptionModel implements TranscriptionModelV4 {
         ),
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
-          errorToMessage: data => data,
+          errorToMessage: gatewayErrorToMessage,
         }),
         ...(abortSignal && { abortSignal }),
         fetch: this.config.fetch,

--- a/packages/gateway/src/gateway-video-model.ts
+++ b/packages/gateway/src/gateway-video-model.ts
@@ -18,7 +18,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import type { GatewayConfig } from './gateway-config';
-import { asGatewayError } from './errors';
+import { asGatewayError, gatewayErrorToMessage } from './errors';
 import { parseAuthMethod } from './errors/parse-auth-method';
 
 export class GatewayVideoModel implements Experimental_VideoModelV4 {
@@ -177,7 +177,7 @@ export class GatewayVideoModel implements Experimental_VideoModelV4 {
         },
         failedResponseHandler: createJsonErrorResponseHandler({
           errorSchema: z.any(),
-          errorToMessage: data => data,
+          errorToMessage: gatewayErrorToMessage,
         }),
         ...(abortSignal && { abortSignal }),
         fetch: this.config.fetch,


### PR DESCRIPTION
## Background

Gateway HTTP error handlers accept arbitrary JSON, but returned that parsed value directly from `errorToMessage`. Structured error bodies were therefore coerced to `[object Object]` inside the nested `APICallError`, obscuring the useful failure message in cause-chain logs.

## Summary

- Add a Gateway-scoped formatter that extracts nested or top-level messages and safely serializes unrecognized JSON shapes.
- Apply it consistently to all 13 Gateway JSON error handlers.
- Cover both language-model generate and stream cause chains, plus strings, common envelopes, arbitrary objects, and primitive values.
- Add an `@ai-sdk/gateway` patch changeset.

## Contributor Credit

Thanks to @AVtheking for the detailed report and stack trace, and to @aqilaziz for the earlier investigation in #16114.

## End-to-End Verification

Exercised non-streaming and streaming Gateway requests against structured HTTP error responses. The typed Gateway errors retain their messages and metadata, while their nested `APICallError` causes now expose readable messages instead of `[object Object]`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #15872.
