### PR TITLE
chore: centralize response metadata conversion

### DIFF
--- a/.changeset/neat-metadata-shares.md
+++ b/.changeset/neat-metadata-shares.md
@@ -1,0 +1,12 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/deepseek': patch
+'@ai-sdk/groq': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/xai': patch
+'@ai-sdk/perplexity': patch
+---
+
+chore: centralize response metadata conversion

--- a/packages/deepseek/src/chat/get-response-metadata.ts
+++ b/packages/deepseek/src/chat/get-response-metadata.ts
@@ -1,1 +1,1 @@
-export { createOpenAICompatibleResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';
+export { createLanguageModelResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';

--- a/packages/deepseek/src/chat/get-response-metadata.ts
+++ b/packages/deepseek/src/chat/get-response-metadata.ts
@@ -1,15 +1,1 @@
-export function getResponseMetadata({
-  id,
-  model,
-  created,
-}: {
-  id?: string | undefined | null;
-  created?: number | undefined | null;
-  model?: string | undefined | null;
-}) {
-  return {
-    id: id ?? undefined,
-    modelId: model ?? undefined,
-    timestamp: created != null ? new Date(created * 1000) : undefined,
-  };
-}
+export { createOpenAICompatibleResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';

--- a/packages/groq/src/get-response-metadata.ts
+++ b/packages/groq/src/get-response-metadata.ts
@@ -1,1 +1,1 @@
-export { createOpenAICompatibleResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';
+export { createLanguageModelResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';

--- a/packages/groq/src/get-response-metadata.ts
+++ b/packages/groq/src/get-response-metadata.ts
@@ -1,15 +1,1 @@
-export function getResponseMetadata({
-  id,
-  model,
-  created,
-}: {
-  id?: string | undefined | null;
-  created?: number | undefined | null;
-  model?: string | undefined | null;
-}) {
-  return {
-    id: id ?? undefined,
-    modelId: model ?? undefined,
-    timestamp: created != null ? new Date(created * 1000) : undefined,
-  };
-}
+export { createOpenAICompatibleResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';

--- a/packages/mistral/src/get-response-metadata.ts
+++ b/packages/mistral/src/get-response-metadata.ts
@@ -1,1 +1,1 @@
-export { createOpenAICompatibleResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';
+export { createLanguageModelResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';

--- a/packages/mistral/src/get-response-metadata.ts
+++ b/packages/mistral/src/get-response-metadata.ts
@@ -1,15 +1,1 @@
-export function getResponseMetadata({
-  id,
-  model,
-  created,
-}: {
-  id?: string | undefined | null;
-  created?: number | undefined | null;
-  model?: string | undefined | null;
-}) {
-  return {
-    id: id ?? undefined,
-    modelId: model ?? undefined,
-    timestamp: created != null ? new Date(created * 1000) : undefined,
-  };
-}
+export { createOpenAICompatibleResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';

--- a/packages/openai-compatible/src/chat/get-response-metadata.ts
+++ b/packages/openai-compatible/src/chat/get-response-metadata.ts
@@ -1,1 +1,1 @@
-export { createOpenAICompatibleResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';
+export { createLanguageModelResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';

--- a/packages/openai-compatible/src/chat/get-response-metadata.ts
+++ b/packages/openai-compatible/src/chat/get-response-metadata.ts
@@ -1,15 +1,1 @@
-export function getResponseMetadata({
-  id,
-  model,
-  created,
-}: {
-  id?: string | undefined | null;
-  created?: number | undefined | null;
-  model?: string | undefined | null;
-}) {
-  return {
-    id: id ?? undefined,
-    modelId: model ?? undefined,
-    timestamp: created != null ? new Date(created * 1000) : undefined,
-  };
-}
+export { createOpenAICompatibleResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';

--- a/packages/openai-compatible/src/completion/get-response-metadata.ts
+++ b/packages/openai-compatible/src/completion/get-response-metadata.ts
@@ -1,1 +1,1 @@
-export { createOpenAICompatibleResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';
+export { createLanguageModelResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';

--- a/packages/openai-compatible/src/completion/get-response-metadata.ts
+++ b/packages/openai-compatible/src/completion/get-response-metadata.ts
@@ -1,15 +1,1 @@
-export function getResponseMetadata({
-  id,
-  model,
-  created,
-}: {
-  id?: string | undefined | null;
-  created?: number | undefined | null;
-  model?: string | undefined | null;
-}) {
-  return {
-    id: id ?? undefined,
-    modelId: model ?? undefined,
-    timestamp: created != null ? new Date(created * 1000) : undefined,
-  };
-}
+export { createOpenAICompatibleResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';

--- a/packages/openai/src/chat/get-response-metadata.ts
+++ b/packages/openai/src/chat/get-response-metadata.ts
@@ -1,15 +1,1 @@
-export function getResponseMetadata({
-  id,
-  model,
-  created,
-}: {
-  id?: string | undefined | null;
-  created?: number | undefined | null;
-  model?: string | undefined | null;
-}) {
-  return {
-    id: id ?? undefined,
-    modelId: model ?? undefined,
-    timestamp: created ? new Date(created * 1000) : undefined,
-  };
-}
+export { createOpenAICompatibleResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';

--- a/packages/openai/src/chat/get-response-metadata.ts
+++ b/packages/openai/src/chat/get-response-metadata.ts
@@ -1,1 +1,1 @@
-export { createOpenAICompatibleResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';
+export { createLanguageModelResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';

--- a/packages/openai/src/chat/get-response-metadata.ts
+++ b/packages/openai/src/chat/get-response-metadata.ts
@@ -1,1 +1,19 @@
-export { createLanguageModelResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';
+import { createLanguageModelResponseMetadata } from '@ai-sdk/provider-utils';
+
+export function getResponseMetadata({
+  id,
+  model,
+  created,
+}: {
+  id?: string | null;
+  model?: string | null;
+  created?: number | null;
+}) {
+  return createLanguageModelResponseMetadata({
+    id,
+    model,
+    // Azure content-filter chunks use 0 as a placeholder timestamp. Preserve
+    // the previous OpenAI behavior so those chunks are not treated as metadata.
+    created: created || undefined,
+  });
+}

--- a/packages/openai/src/completion/get-response-metadata.ts
+++ b/packages/openai/src/completion/get-response-metadata.ts
@@ -1,1 +1,1 @@
-export { createOpenAICompatibleResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';
+export { createLanguageModelResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';

--- a/packages/openai/src/completion/get-response-metadata.ts
+++ b/packages/openai/src/completion/get-response-metadata.ts
@@ -1,15 +1,1 @@
-export function getResponseMetadata({
-  id,
-  model,
-  created,
-}: {
-  id?: string | undefined | null;
-  created?: number | undefined | null;
-  model?: string | undefined | null;
-}) {
-  return {
-    id: id ?? undefined,
-    modelId: model ?? undefined,
-    timestamp: created != null ? new Date(created * 1000) : undefined,
-  };
-}
+export { createOpenAICompatibleResponseMetadata as getResponseMetadata } from '@ai-sdk/provider-utils';

--- a/packages/perplexity/src/perplexity-language-model.ts
+++ b/packages/perplexity/src/perplexity-language-model.ts
@@ -13,7 +13,7 @@ import {
   createEventSourceResponseHandler,
   createJsonErrorResponseHandler,
   createJsonResponseHandler,
-  createOpenAICompatibleResponseMetadata as getResponseMetadata,
+  createLanguageModelResponseMetadata as getResponseMetadata,
   isCustomReasoning,
   parseProviderOptions,
   postJsonToApi,

--- a/packages/perplexity/src/perplexity-language-model.ts
+++ b/packages/perplexity/src/perplexity-language-model.ts
@@ -13,6 +13,7 @@ import {
   createEventSourceResponseHandler,
   createJsonErrorResponseHandler,
   createJsonResponseHandler,
+  createOpenAICompatibleResponseMetadata as getResponseMetadata,
   isCustomReasoning,
   parseProviderOptions,
   postJsonToApi,
@@ -415,22 +416,6 @@ export class PerplexityLanguageModel implements LanguageModelV4 {
       response: { headers: responseHeaders },
     };
   }
-}
-
-function getResponseMetadata({
-  id,
-  model,
-  created,
-}: {
-  id: string;
-  created: number;
-  model: string;
-}) {
-  return {
-    id,
-    modelId: model,
-    timestamp: new Date(created * 1000),
-  };
 }
 
 const perplexityCostSchema = z.object({

--- a/packages/provider-utils/src/create-language-model-response-metadata.ts
+++ b/packages/provider-utils/src/create-language-model-response-metadata.ts
@@ -1,10 +1,10 @@
 import type { LanguageModelV4ResponseMetadata } from '@ai-sdk/provider';
 
 /**
- * Converts OpenAI-compatible response fields into language model response
+ * Converts common provider response fields into language model response
  * metadata.
  */
-export function createOpenAICompatibleResponseMetadata({
+export function createLanguageModelResponseMetadata({
   id,
   model,
   created,

--- a/packages/provider-utils/src/create-openai-compatible-response-metadata.ts
+++ b/packages/provider-utils/src/create-openai-compatible-response-metadata.ts
@@ -1,0 +1,21 @@
+import type { LanguageModelV4ResponseMetadata } from '@ai-sdk/provider';
+
+/**
+ * Converts OpenAI-compatible response fields into language model response
+ * metadata.
+ */
+export function createOpenAICompatibleResponseMetadata({
+  id,
+  model,
+  created,
+}: {
+  id?: string | null;
+  model?: string | null;
+  created?: number | null;
+}): LanguageModelV4ResponseMetadata {
+  return {
+    id: id ?? undefined,
+    modelId: model ?? undefined,
+    timestamp: created != null ? new Date(created * 1000) : undefined,
+  };
+}

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -9,7 +9,7 @@ export { convertAsyncIteratorToReadableStream } from './convert-async-iterator-t
 export { convertInlineFileDataToUint8Array } from './convert-inline-file-data-to-uint8-array';
 export { convertImageModelFileToDataUri } from './convert-image-model-file-to-data-uri';
 export { convertToFormData } from './convert-to-form-data';
-export { createOpenAICompatibleResponseMetadata } from './create-openai-compatible-response-metadata';
+export { createLanguageModelResponseMetadata } from './create-language-model-response-metadata';
 export {
   createToolNameMapping,
   type ToolNameMapping,

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -9,6 +9,7 @@ export { convertAsyncIteratorToReadableStream } from './convert-async-iterator-t
 export { convertInlineFileDataToUint8Array } from './convert-inline-file-data-to-uint8-array';
 export { convertImageModelFileToDataUri } from './convert-image-model-file-to-data-uri';
 export { convertToFormData } from './convert-to-form-data';
+export { createOpenAICompatibleResponseMetadata } from './create-openai-compatible-response-metadata';
 export {
   createToolNameMapping,
   type ToolNameMapping,

--- a/packages/xai/src/get-response-metadata.ts
+++ b/packages/xai/src/get-response-metadata.ts
@@ -1,4 +1,4 @@
-import { createOpenAICompatibleResponseMetadata } from '@ai-sdk/provider-utils';
+import { createLanguageModelResponseMetadata } from '@ai-sdk/provider-utils';
 
 export function getResponseMetadata({
   id,
@@ -11,7 +11,7 @@ export function getResponseMetadata({
   created_at?: number | undefined | null;
   model?: string | undefined | null;
 }) {
-  return createOpenAICompatibleResponseMetadata({
+  return createLanguageModelResponseMetadata({
     id,
     model,
     created: created ?? created_at,

--- a/packages/xai/src/get-response-metadata.ts
+++ b/packages/xai/src/get-response-metadata.ts
@@ -1,3 +1,5 @@
+import { createOpenAICompatibleResponseMetadata } from '@ai-sdk/provider-utils';
+
 export function getResponseMetadata({
   id,
   model,
@@ -9,11 +11,9 @@ export function getResponseMetadata({
   created_at?: number | undefined | null;
   model?: string | undefined | null;
 }) {
-  const unixTime = created ?? created_at;
-
-  return {
-    id: id ?? undefined,
-    modelId: model ?? undefined,
-    timestamp: unixTime != null ? new Date(unixTime * 1000) : undefined,
-  };
+  return createOpenAICompatibleResponseMetadata({
+    id,
+    model,
+    created: created ?? created_at,
+  });
 }


### PR DESCRIPTION
## Background

a lot of packages duplicated the same OpenAI style response metadata conversion

## Summary

- added `createLanguageModelResponseMetadata` to provider-utils
- re-exported it under existing local names in seven providers

## End-to-End Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)