### PR TITLE
fix(openai): clarify unsupported Responses API endpoints

### DIFF
--- a/.changeset/friendly-oranges-chat.md
+++ b/.changeset/friendly-oranges-chat.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Add an actionable error hint when a custom OpenAI base URL does not support the Responses API.

--- a/packages/openai/src/openai-config.ts
+++ b/packages/openai/src/openai-config.ts
@@ -6,6 +6,7 @@ import type {
 export type OpenAIConfig = {
   provider: string;
   url: (options: { modelId: string; path: string }) => string;
+  isCustomBaseURL?: boolean;
   headers?: () => Record<string, string | undefined>;
   fetch?: FetchFunction;
   webSocket?: WebSocketConstructor;

--- a/packages/openai/src/openai-error.ts
+++ b/packages/openai/src/openai-error.ts
@@ -1,5 +1,9 @@
+import { APICallError } from '@ai-sdk/provider';
+import {
+  createJsonErrorResponseHandler,
+  type ResponseHandler,
+} from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
-import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
 
 export const openaiErrorDataSchema = z.object({
   error: z.object({
@@ -20,3 +24,41 @@ export const openaiFailedResponseHandler = createJsonErrorResponseHandler({
   errorSchema: openaiErrorDataSchema,
   errorToMessage: data => data.error.message,
 });
+
+export const createOpenAIResponsesFailedResponseHandler = ({
+  isCustomBaseURL,
+}: {
+  isCustomBaseURL: boolean;
+}): ResponseHandler<APICallError> => {
+  if (!isCustomBaseURL) {
+    return openaiFailedResponseHandler;
+  }
+
+  return async options => {
+    const result = await openaiFailedResponseHandler(options);
+    const error = result.value;
+
+    if (error.statusCode !== 404) {
+      return result;
+    }
+
+    return {
+      ...result,
+      value: new APICallError({
+        message:
+          `${error.message} The default model factory from createOpenAI uses ` +
+          'the Responses API. If this custom base URL only supports Chat ' +
+          'Completions, use provider.chat(modelId) instead. For third-party ' +
+          'OpenAI-compatible providers, use @ai-sdk/openai-compatible.',
+        url: error.url,
+        requestBodyValues: error.requestBodyValues,
+        statusCode: error.statusCode,
+        responseHeaders: error.responseHeaders,
+        responseBody: error.responseBody,
+        cause: error,
+        isRetryable: error.isRetryable,
+        data: error.data,
+      }),
+    };
+  };
+};

--- a/packages/openai/src/openai-provider.test.ts
+++ b/packages/openai/src/openai-provider.test.ts
@@ -154,6 +154,34 @@ describe('createOpenAI', () => {
       expect(call[0]).toBe('https://proxy.openai.example/v1/responses');
     });
 
+    it('suggests the Chat Completions API for a custom base URL that does not support Responses', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response('Not Found', {
+          status: 404,
+          statusText: 'Not Found',
+          headers: { 'Content-Type': 'text/plain' },
+        }),
+      );
+      const provider = createOpenAI({
+        apiKey: 'test-api-key',
+        baseURL: 'https://compatible.example/v1',
+        fetch: fetchMock,
+      });
+
+      await expect(
+        provider('custom-model').doGenerate({
+          prompt: [
+            { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+          ],
+        }),
+      ).rejects.toThrow(
+        'The default model factory from createOpenAI uses the Responses API. ' +
+          'If this custom base URL only supports Chat Completions, use ' +
+          'provider.chat(modelId) instead. For third-party OpenAI-compatible ' +
+          'providers, use @ai-sdk/openai-compatible.',
+      );
+    });
+
     it('uses the Chat Completions API for chat models', async () => {
       const fetchMock = vi.fn().mockResolvedValue(
         new Response(JSON.stringify({ error: { message: 'test error' } }), {

--- a/packages/openai/src/openai-provider.ts
+++ b/packages/openai/src/openai-provider.ts
@@ -189,15 +189,13 @@ export interface OpenAIProviderSettings {
 export function createOpenAI(
   options: OpenAIProviderSettings = {},
 ): OpenAIProvider {
+  const configuredBaseURL = loadOptionalSetting({
+    settingValue: options.baseURL,
+    environmentVariableName: 'OPENAI_BASE_URL',
+  });
   const baseURL =
-    withoutTrailingSlash(
-      validateBaseURL(
-        loadOptionalSetting({
-          settingValue: options.baseURL,
-          environmentVariableName: 'OPENAI_BASE_URL',
-        }),
-      ),
-    ) ?? 'https://api.openai.com/v1';
+    withoutTrailingSlash(validateBaseURL(configuredBaseURL)) ??
+    'https://api.openai.com/v1';
 
   const providerName = options.name ?? 'openai';
 
@@ -304,6 +302,7 @@ export function createOpenAI(
     return new OpenAIResponsesLanguageModel(modelId, {
       provider: `${providerName}.responses`,
       url: ({ path }) => `${baseURL}${path}`,
+      isCustomBaseURL: configuredBaseURL != null,
       headers: getHeaders,
       fetch: options.fetch,
       // Soft-deprecated. TODO: remove in v8

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -30,7 +30,7 @@ import {
   type ParseResult,
 } from '@ai-sdk/provider-utils';
 import type { OpenAIConfig } from '../openai-config';
-import { openaiFailedResponseHandler } from '../openai-error';
+import { createOpenAIResponsesFailedResponseHandler } from '../openai-error';
 import { getOpenAILanguageModelCapabilities } from '../openai-language-model-capabilities';
 import { throwIfOpenAIStreamErrorBeforeOutput } from '../openai-stream-error';
 import type { applyPatchInputSchema } from '../tool/apply-patch';
@@ -639,7 +639,9 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
       url,
       headers: combineHeaders(this.config.headers?.(), options.headers),
       body,
-      failedResponseHandler: openaiFailedResponseHandler,
+      failedResponseHandler: createOpenAIResponsesFailedResponseHandler({
+        isCustomBaseURL: this.config.isCustomBaseURL ?? false,
+      }),
       successfulResponseHandler: createJsonResponseHandler(
         openaiResponsesResponseSchema,
       ),
@@ -1300,7 +1302,9 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
         ...body,
         stream: true,
       },
-      failedResponseHandler: openaiFailedResponseHandler,
+      failedResponseHandler: createOpenAIResponsesFailedResponseHandler({
+        isCustomBaseURL: this.config.isCustomBaseURL ?? false,
+      }),
       successfulResponseHandler: createEventSourceResponseHandler(
         openaiResponsesChunkSchema,
       ),


### PR DESCRIPTION
## Background

The default model factory returned by `createOpenAI` uses the Responses API. When a custom OpenAI-compatible base URL only implements Chat Completions, a request to `/responses` currently fails with an opaque 404.

## Summary

- track whether the Responses model was created with a configured custom base URL
- augment 404 errors from that Responses endpoint with actionable guidance
- recommend `provider.chat(modelId)` and `@ai-sdk/openai-compatible` without changing API selection
- cover the custom-base-URL failure path with a regression test
- add a patch changeset for `@ai-sdk/openai`

## Contributor Credit

Thanks to @Zartharas for reporting the behavior and providing the NVIDIA NIM reproduction in #17944.

## End-to-End Verification

Configured `createOpenAI` with a custom base URL whose `/responses` endpoint returns 404 and confirmed the resulting error identifies the Responses API selection and recommends both supported alternatives. The request continues to target `/responses`, preserving existing behavior.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #17944
