### PR TITLE
feat(ai): support experimental tool callers in ToolLoopAgent

### DIFF
--- a/.changeset/tall-agents-call.md
+++ b/.changeset/tall-agents-call.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): support experimental tool callers in ToolLoopAgent

--- a/.changeset/tall-agents-call.md
+++ b/.changeset/tall-agents-call.md
@@ -1,5 +1,6 @@
 ---
 'ai': patch
+'@ai-sdk/provider-utils': patch
 ---
 
 feat(ai): support experimental tool callers in ToolLoopAgent

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -112,6 +112,13 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
         "Approval configuration for the agent. Pass a `GenericToolApprovalFunction` to handle all tool calls in one callback with `toolCall`, `tools`, `toolsContext`, `messages`, and `runtimeContext`, or pass a per-tool object where each key can be a status (`'not-applicable'`, `'approved'`, `'denied'`, or `'user-approval'`), an object form such as `{ type: 'denied', reason: 'blocked by policy' }`, or a `SingleToolApprovalFunction` that receives the tool input and options `toolCallId`, `messages`, `toolContext`, and `runtimeContext` (same shape as tool execution options without `abortSignal`, with `context` renamed to `toolContext`). The `RUNTIME_CONTEXT` type parameter matches the agent's `runtimeContext`. A `GenericToolApprovalFunction` or `SingleToolApprovalFunction` may return `undefined` for the same effect as `'not-applicable'`. `'not-applicable'` is the default execution path and runs the tool without approval metadata. Use `'approved'`, `'denied'`, or their object forms when you want explicit automatic approval request/response parts in the output. Automatic approvals and denials can include a `reason`, which is forwarded to the emitted approval response. This setting takes precedence over a tool's `needsApproval` default.",
     },
     {
+      name: 'experimental_toolCallers',
+      type: 'Experimental_ToolCallers<TOOLS>',
+      isOptional: true,
+      description:
+        "Configures which caller tools may invoke each tool. The callback receives typed references for caller-capable tools in the agent's `tools` set and returns an object keyed by callee tool name. Include `'direct'` to keep a configured tool directly callable by the model. Local-only callees are hidden from direct model calls and bound to their local caller for each agent step. Provider caller references are translated to provider-native allowed-caller options.",
+    },
+    {
       name: 'output',
       type: 'Output',
       isOptional: true,

--- a/examples/ai-e2e-next/agent/code-mode/code-mode-agent.ts
+++ b/examples/ai-e2e-next/agent/code-mode/code-mode-agent.ts
@@ -1,4 +1,4 @@
-import { experimental_createCodeModeTool as createCodeModeTool } from '@ai-sdk/code-mode';
+import { experimental_codeModeTool as codeModeTool } from '@ai-sdk/code-mode';
 import { ToolLoopAgent, tool, type InferAgentUIMessage } from 'ai';
 import { z } from 'zod';
 
@@ -32,24 +32,26 @@ const getDemand = tool({
   }),
 });
 
-const codeMode = createCodeModeTool(
-  {
-    getInventory,
-    getDemand,
-  },
-  {
+const tools = {
+  codeMode: codeModeTool({
     executionPolicy: {
       timeoutMs: 30_000,
       memoryLimitBytes: 64 * 1024 * 1024,
     },
-  },
-);
+  }),
+  getInventory,
+  getDemand,
+} as const;
 
 export const codeModeAgent = new ToolLoopAgent({
   model: 'moonshotai/kimi-k3',
   instructions:
     'You are an inventory planning assistant. Use code mode to coordinate the available tools when answering inventory questions. Call independent tools in parallel when possible, and explain the result clearly. Use prior messages to answer follow-up questions.',
-  tools: { codeMode },
+  tools,
+  experimental_toolCallers: ({ codeMode }) => ({
+    getInventory: [codeMode],
+    getDemand: [codeMode],
+  }),
 });
 
 export type CodeModeMessage = InferAgentUIMessage<typeof codeModeAgent>;

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -22,6 +22,7 @@ import type { PrepareStepFunction } from '../generate-text/prepare-step';
 import type { StopCondition } from '../generate-text/stop-condition';
 import type { StreamTextInclude } from '../generate-text/stream-text';
 import type { ToolApprovalConfiguration } from '../generate-text/tool-approval-configuration';
+import type { Experimental_ToolCallers } from '../generate-text/tool-caller-configuration';
 import type { ToolCallRepairFunction } from '../generate-text/tool-call-repair-function';
 import type {
   OnToolExecutionEndCallback,
@@ -133,6 +134,11 @@ export type ToolLoopAgentSettings<
      * This configuration takes precedence over tool-defined approval settings.
      */
     toolApproval?: ToolApprovalConfiguration<NoInfer<TOOLS>, RUNTIME_CONTEXT>;
+
+    /**
+     * Configures which caller tools may invoke each tool.
+     */
+    experimental_toolCallers?: Experimental_ToolCallers<NoInfer<TOOLS>>;
 
     /**
      * Optional function that you can use to provide different settings for a step.
@@ -329,6 +335,7 @@ export type ToolLoopAgentSettings<
           | 'activeTools'
           | 'toolOrder'
           | 'toolApproval'
+          | 'experimental_toolCallers'
           | 'providerOptions'
           | 'experimental_download'
           | 'experimental_refineToolInput'
@@ -363,6 +370,7 @@ export type ToolLoopAgentSettings<
         | 'activeTools'
         | 'toolOrder'
         | 'toolApproval'
+        | 'experimental_toolCallers'
         | 'providerOptions'
         | 'experimental_download'
         | 'experimental_refineToolInput'

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -1,9 +1,14 @@
-import { tool, type Context } from '@ai-sdk/provider-utils';
+import {
+  experimental_toolCaller,
+  tool,
+  type Context,
+} from '@ai-sdk/provider-utils';
 import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod/v4';
 import {
   Output,
   type GenerateTextOnEndCallback,
+  type Experimental_ToolCallers,
   type ToolApprovalConfiguration,
   type ToolInputRefinement,
 } from '../generate-text';
@@ -130,6 +135,54 @@ describe('ToolLoopAgent', () => {
           >();
           expectTypeOf(options.experimental_refineToolInput).toEqualTypeOf<
             ToolInputRefinement<typeof tools> | undefined
+          >();
+
+          return {
+            ...options,
+            prompt: 'Hello, world!',
+          };
+        },
+      });
+    });
+
+    it('should type experimental_toolCallers in settings and prepareCall', () => {
+      const codeMode = experimental_toolCaller(
+        tool({
+          inputSchema: z.object({}),
+          execute: async () => undefined,
+        }),
+        {
+          type: 'local',
+          bind: () =>
+            tool({
+              inputSchema: z.object({}),
+              execute: async () => undefined,
+            }),
+        },
+      );
+      const tools = {
+        code_mode: codeMode,
+        getInventory: tool({
+          inputSchema: z.object({ sku: z.string() }),
+          execute: async ({ sku }) => ({ sku }),
+        }),
+      };
+
+      new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+        tools,
+        experimental_toolCallers: callers => {
+          expectTypeOf(callers.code_mode.toolName).toEqualTypeOf<'code_mode'>();
+          // @ts-expect-error regular tools are not caller references
+          callers.getInventory;
+
+          return {
+            getInventory: [callers.code_mode],
+          };
+        },
+        prepareCall: options => {
+          expectTypeOf(options.experimental_toolCallers).toEqualTypeOf<
+            Experimental_ToolCallers<typeof tools> | undefined
           >();
 
           return {

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -1,5 +1,6 @@
 import type { LanguageModelV4CallOptions } from '@ai-sdk/provider';
 import {
+  experimental_toolCaller,
   tool,
   type Experimental_SandboxSession as SandboxSession,
 } from '@ai-sdk/provider-utils';
@@ -100,6 +101,42 @@ describe('ToolLoopAgent', () => {
           },
         }
       `);
+    });
+
+    it('should forward experimental_toolCallers to generateText', async () => {
+      const codeMode = experimental_toolCaller(
+        tool({
+          inputSchema: z.object({}),
+          execute: async () => undefined,
+        }),
+        {
+          type: 'local',
+          bind: tools =>
+            tool({
+              inputSchema: z.object({}),
+              execute: async () => Object.keys(tools),
+            }),
+        },
+      );
+      const agent = new ToolLoopAgent({
+        model: mockModel,
+        tools: {
+          code_mode: codeMode,
+          getInventory: tool({
+            inputSchema: z.object({ sku: z.string() }),
+            execute: async ({ sku }) => ({ sku }),
+          }),
+        },
+        experimental_toolCallers: ({ code_mode }) => ({
+          getInventory: [code_mode],
+        }),
+      });
+
+      await agent.generate({ prompt: 'Hello, world!' });
+
+      expect(doGenerateOptions?.tools?.map(tool => tool.name)).toEqual([
+        'code_mode',
+      ]);
     });
 
     it('should tag the user-agent with the agent identifier', async () => {
@@ -779,6 +816,43 @@ describe('ToolLoopAgent', () => {
         }
       `,
       );
+    });
+
+    it('should forward experimental_toolCallers to streamText', async () => {
+      const codeMode = experimental_toolCaller(
+        tool({
+          inputSchema: z.object({}),
+          execute: async () => undefined,
+        }),
+        {
+          type: 'local',
+          bind: tools =>
+            tool({
+              inputSchema: z.object({}),
+              execute: async () => Object.keys(tools),
+            }),
+        },
+      );
+      const agent = new ToolLoopAgent({
+        model: mockModel,
+        tools: {
+          code_mode: codeMode,
+          getInventory: tool({
+            inputSchema: z.object({ sku: z.string() }),
+            execute: async ({ sku }) => ({ sku }),
+          }),
+        },
+        experimental_toolCallers: ({ code_mode }) => ({
+          getInventory: [code_mode],
+        }),
+      });
+
+      const result = await agent.stream({ prompt: 'Hello, world!' });
+      await result.consumeStream();
+
+      expect(doStreamOptions?.tools?.map(tool => tool.name)).toEqual([
+        'code_mode',
+      ]);
     });
 
     it('should forward toolOrder to streamText', async () => {

--- a/packages/provider-utils/src/types/tool-caller.ts
+++ b/packages/provider-utils/src/types/tool-caller.ts
@@ -2,8 +2,6 @@ import type { ProviderOptions } from './provider-options';
 import type { Tool } from './tool';
 import type { ToolSet } from './tool-set';
 
-const toolCallerSymbol = Symbol.for('vercel.ai.experimental.toolCaller');
-
 export type ToolCallerDefinition =
   | {
       type: 'local';
@@ -17,14 +15,14 @@ export type ToolCallerDefinition =
     };
 
 export type ToolCallerTool<TOOL extends Tool = Tool> = TOOL & {
-  readonly [toolCallerSymbol]: ToolCallerDefinition;
+  readonly experimental_toolCaller: ToolCallerDefinition;
 };
 
 export function toolCaller<TOOL extends Tool>(
   tool: TOOL,
   definition: ToolCallerDefinition,
 ): ToolCallerTool<TOOL> {
-  return Object.defineProperty({ ...tool }, toolCallerSymbol, {
+  return Object.defineProperty({ ...tool }, 'experimental_toolCaller', {
     value: definition,
   }) as ToolCallerTool<TOOL>;
 }
@@ -32,5 +30,5 @@ export function toolCaller<TOOL extends Tool>(
 export function getToolCaller(
   tool: Tool | undefined,
 ): ToolCallerDefinition | undefined {
-  return (tool as ToolCallerTool | undefined)?.[toolCallerSymbol];
+  return (tool as ToolCallerTool | undefined)?.experimental_toolCaller;
 }


### PR DESCRIPTION
## Background

builds on https://github.com/vercel/ai/pull/18227 to add the experimental_toolCallers to `ToolLoopAgent`

## Summary

Added ToolLoopAgent support with `experimental_toolCallers`

## End-to-End Verification

verified by running the e2e example `http://localhost:3000/chat/code-mode`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
