### PR TITLE
fix: refactor handler to include path validation

### DIFF
--- a/examples/ai-e2e-next/app/api/download-container-file/azure/route.ts
+++ b/examples/ai-e2e-next/app/api/download-container-file/azure/route.ts
@@ -1,3 +1,7 @@
+function isSafeAzureId(value: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(value);
+}
+
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const containerId = searchParams.get('container_id');
@@ -6,6 +10,10 @@ export async function GET(req: Request) {
 
   if (!containerId || !fileId) {
     return new Response('Missing container_id or file_id', { status: 400 });
+  }
+
+  if (!isSafeAzureId(containerId) || !isSafeAzureId(fileId)) {
+    return new Response('Invalid container_id or file_id', { status: 400 });
   }
 
   const resourceName = process.env.AZURE_RESOURCE_NAME;
@@ -19,8 +27,10 @@ export async function GET(req: Request) {
   }
 
   try {
+    const safeContainerId = encodeURIComponent(containerId);
+    const safeFileId = encodeURIComponent(fileId);
     const response = await fetch(
-      `https://${resourceName}.openai.azure.com/openai/v1/containers/${containerId}/files/${fileId}/content`,
+      `https://${resourceName}.openai.azure.com/openai/v1/containers/${safeContainerId}/files/${safeFileId}/content`,
       {
         headers: {
           Authorization: `Bearer ${apiKey}`,

--- a/examples/ai-e2e-next/app/api/download-container-file/openai/route.ts
+++ b/examples/ai-e2e-next/app/api/download-container-file/openai/route.ts
@@ -8,20 +8,27 @@ export async function GET(req: Request) {
     return new Response('Missing container_id or file_id', { status: 400 });
   }
 
+  const idPattern = /^[A-Za-z0-9_-]+$/;
+  if (!idPattern.test(containerId) || !idPattern.test(fileId)) {
+    return new Response('Invalid container_id or file_id', { status: 400 });
+  }
+
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
     return new Response('OPENAI_API_KEY not configured', { status: 500 });
   }
 
   try {
-    const response = await fetch(
-      `https://api.openai.com/v1/containers/${containerId}/files/${fileId}/content`,
-      {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-        },
-      },
+    const openaiUrl = new URL(
+      `/v1/containers/${encodeURIComponent(containerId)}/files/${encodeURIComponent(fileId)}/content`,
+      'https://api.openai.com',
     );
+
+    const response = await fetch(openaiUrl.toString(), {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
 
     if (!response.ok) {
       return new Response(`Failed to fetch file: ${response.statusText}`, {
@@ -32,11 +39,12 @@ export async function GET(req: Request) {
     const arrayBuffer = await response.arrayBuffer();
     const contentType =
       response.headers.get('content-type') || 'application/octet-stream';
+    const safeFilename = filename.replace(/[\r\n"]/g, '_');
 
     return new Response(arrayBuffer, {
       headers: {
         'Content-Type': contentType,
-        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Content-Disposition': `attachment; filename="${safeFilename}"`,
       },
     });
   } catch (error) {

--- a/examples/next-openai-kasada-bot-protection/app/149e9513-01fa-4fb0-aad4-566afd725d1b/2d206a39-8ed7-437e-a3be-862e0f06eea3/[[...restpath]]/route.ts
+++ b/examples/next-openai-kasada-bot-protection/app/149e9513-01fa-4fb0-aad4-566afd725d1b/2d206a39-8ed7-437e-a3be-862e0f06eea3/[[...restpath]]/route.ts
@@ -1,12 +1,37 @@
 const KASADA_ENDPOINT = 'FILL_IN.kasadapolyform.io';
 
-async function handler(request: Request) {
-  const url = new URL(request.url);
+type RouteContext = {
+  params?: {
+    restpath?: string[];
+  };
+};
 
-  url.protocol = 'https:';
-  url.host = KASADA_ENDPOINT;
-  url.port = '';
-  url.searchParams.delete('restpath');
+function isSafePathSegment(segment: string): boolean {
+  return (
+    segment.length > 0 &&
+    segment !== '.' &&
+    segment !== '..' &&
+    !segment.includes('/') &&
+    !segment.includes('\\') &&
+    /^[A-Za-z0-9._~-]+$/.test(segment)
+  );
+}
+
+async function handler(request: Request, context: RouteContext) {
+  const incomingUrl = new URL(request.url);
+  const url = new URL(`https://${KASADA_ENDPOINT}`);
+
+  const rawSegments = context.params?.restpath ?? [];
+  if (!rawSegments.every(isSafePathSegment)) {
+    return new Response('Invalid path.', { status: 400 });
+  }
+  url.pathname = `/${rawSegments.join('/')}`;
+
+  incomingUrl.searchParams.forEach((value, key) => {
+    if (key !== 'restpath') {
+      url.searchParams.append(key, value);
+    }
+  });
 
   const headers = new Headers(request.headers);
   headers.set('X-Forwarded-Host', 'FILL_IN');


### PR DESCRIPTION
fix using `request.url` as the base for outbound URL construction. Instead, create a new URL from a trusted base (`https://${KASADA_ENDPOINT}`), then append only validated/sanitized path and query components derived from allowed route params.

Best fix here (without changing intended proxy behavior):  
- In `examples/next-openai-kasada-bot-protection/app/149e9513-01fa-4fb0-aad4-566afd725d1b/2d206a39-8ed7-437e-a3be-862e0f06eea3/[[...restpath]]/route.ts`, update `handler` signature to receive `context` so we can use Next route catch-all params instead of parsing `request.url`.
- Build `url` from a trusted constant base.
- Reconstruct pathname from `context.params.restpath` after per-segment validation (reject empty, `"."`, `".."`, slash-containing, and non-safe characters).
- Keep query forwarding by parsing `request.url` only for search params, removing `restpath` as before.
- Keep existing fetch options/headers unchanged.



## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

