### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 'lts/*'
+          node-version: '26'
           cache: 'npm'
           cache-dependency-path: .github/workflows/actions/verify-changesets/package.json
       - name: get all changed files


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `22,24,26`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `22,24,26` (using `26` where a concrete pin is needed).

- `.github/workflows/verify-changesets.yml`
  - `node-version: 'lts/*'` → `node-version: '26'`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `22,24,26`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
