### PR TITLE
fix(harness-opencode): avoid bridge import from provider-utils and rely on more granular types

### DIFF
--- a/.changeset/quiet-lies-joke.md
+++ b/.changeset/quiet-lies-joke.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-opencode": patch
+---
+
+fix(harness-opencode): avoid bridge import from provider-utils and rely on more granular types

--- a/packages/harness-opencode/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-opencode/src/bridge/create-emit-stream-event.test.ts
@@ -176,6 +176,47 @@ describe('createEmitStreamEvent', () => {
     `);
   });
 
+  it('normalizes legacy tool parts before translating them', () => {
+    const { emitted, emitStreamEvent } = createEmitter();
+
+    emitStreamEvent({
+      type: 'message.part.updated',
+      properties: {
+        part: {
+          type: 'tool',
+          callID: 'tool-legacy',
+          tool: 'view',
+          metadata: ['ignored'],
+          state: {
+            status: 'completed',
+            input: { file: 'README.md' },
+            metadata: 'ignored',
+            output: 'contents',
+          },
+        },
+      },
+    });
+
+    expect(emitted).toMatchInlineSnapshot(`
+      [
+        {
+          "input": "{\"file\":\"README.md\"}",
+          "nativeName": "view",
+          "providerExecuted": true,
+          "toolCallId": "tool-legacy",
+          "toolName": "read",
+          "type": "tool-call",
+        },
+        {
+          "result": "contents",
+          "toolCallId": "tool-legacy",
+          "toolName": "read",
+          "type": "tool-result",
+        },
+      ]
+    `);
+  });
+
   it('preserves retry, error, compaction, and file events', () => {
     const { emitted, warnings, errors, emitStreamEvent } = createEmitter();
 

--- a/packages/harness-opencode/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-opencode/src/bridge/create-emit-stream-event.ts
@@ -1,17 +1,21 @@
 import type { BridgeTurn } from '@ai-sdk/harness/bridge';
-import { isRecord } from '@ai-sdk/provider-utils';
 import {
   emitLegacyPartDelta,
   emitLegacyTextPartUpdate,
   emitMissingFinalDelta,
-  type OpenCodeEvent,
+  openCodeMessageInfoFromValue,
   type TranslationState,
 } from './opencode-events';
 import {
-  legacyStepFinishPartToFinishStep,
   mapOpenCodeFinishReason,
+  translateLegacyStepFinishPart,
 } from './opencode-finish-step';
 import { mapUsage } from './opencode-usage';
+import {
+  asOpenCodeObject,
+  type OpenCodeEvent,
+  type OpenCodeEventProperties,
+} from './opencode-types';
 
 type Emit = (message: Record<string, unknown>) => void;
 
@@ -52,8 +56,8 @@ export function createEmitStreamEvent({
     const props = event.properties ?? {};
 
     if (type === 'message.updated') {
-      const info = props.info;
-      if (isRecord(info)) {
+      const info = openCodeMessageInfoFromValue(props.info);
+      if (info) {
         const id = stringValue(info.id);
         const role = stringValue(info.role);
         if (id && role) state.messageRoles.set(id, role);
@@ -238,7 +242,7 @@ export function createEmitStreamEvent({
     }
     if (type === 'session.next.retried') {
       const error = props.error ?? event;
-      if (isRecord(error) && error.isRetryable === false) {
+      if (openCodeErrorFromValue(error)?.isRetryable === false) {
         emitError({
           error,
           message: 'OpenCode session retry failed',
@@ -326,9 +330,9 @@ function emitLegacyStepFinishPart({
   state: TranslationState;
   emit: Emit;
 }): boolean {
-  const event = legacyStepFinishPartToFinishStep(part);
-  if (!event) return false;
-  const id = isRecord(part) ? stringValue(part.id) : undefined;
+  const translated = translateLegacyStepFinishPart(part);
+  if (!translated) return false;
+  const { event, partId: id } = translated;
   if (id) {
     if (state.legacyStepFinishPartIds.has(id)) return true;
     state.legacyStepFinishPartIds.add(id);
@@ -365,17 +369,10 @@ function emitLegacyToolPart({
     input: unknown;
   }) => void;
 }): void {
-  if (!part || typeof part !== 'object') return;
-  const toolPart = part as Record<string, any>;
-  if (toolPart.type !== 'tool') return;
-  const status = legacyToolPartStatus(toolPart);
+  const toolPart = legacyToolPartFromValue(part);
+  if (!toolPart) return;
+  const status = toolPart.status;
   if (status !== 'running' && status !== 'completed' && status !== 'error') {
-    return;
-  }
-  if (
-    typeof toolPart.tool !== 'string' ||
-    typeof toolPart.callID !== 'string'
-  ) {
     return;
   }
   const callID = toolPart.callID;
@@ -402,8 +399,8 @@ function emitLegacyToolPart({
       ...nativeNameField({ nativeName: rawToolName, toolName }),
       input: JSON.stringify(legacyToolPartInput(toolPart)),
       providerExecuted: true,
-      ...(toolPart.provider?.metadata
-        ? { providerMetadata: toolPart.provider.metadata }
+      ...(toolPart.providerMetadata
+        ? { providerMetadata: toolPart.providerMetadata }
         : {}),
     });
   }
@@ -422,33 +419,16 @@ function emitLegacyToolPart({
   }
 }
 
-function legacyToolPartStatus(part: Record<string, any>): string | undefined {
-  return typeof part.state === 'string'
-    ? part.state
-    : typeof part.state === 'object' && part.state !== null
-      ? String(part.state.status ?? '')
-      : undefined;
-}
-
-function legacyToolPartInput(
-  part: Record<string, any>,
-): Record<string, unknown> {
-  const state =
-    typeof part.state === 'object' && part.state !== null
-      ? (part.state as Record<string, any>)
-      : undefined;
+function legacyToolPartInput(part: LegacyToolPart): Record<string, unknown> {
   return {
-    ...(isRecord(part.metadata) ? part.metadata : {}),
-    ...(isRecord(state?.metadata) ? state.metadata : {}),
-    ...(isRecord(state?.input) ? state.input : {}),
+    ...(part.metadata ?? {}),
+    ...(part.state?.metadata ?? {}),
+    ...(part.state?.input ?? {}),
   };
 }
 
-function legacyToolPartOutput(part: Record<string, any>): unknown {
-  const state =
-    typeof part.state === 'object' && part.state !== null
-      ? (part.state as Record<string, any>)
-      : undefined;
+function legacyToolPartOutput(part: LegacyToolPart): unknown {
+  const state = part.state;
   if (state?.status === 'error') {
     return state.error ?? part.error ?? state.result ?? 'tool failed';
   }
@@ -463,7 +443,7 @@ function legacyToolPartOutput(part: Record<string, any>): unknown {
 
 function parseToolInput(
   state: TranslationState,
-  props: Record<string, any>,
+  props: OpenCodeEventProperties,
 ): unknown {
   const text = state.toolInputs.get(String(props.callID ?? ''));
   if (!text) return {};
@@ -487,11 +467,12 @@ function nextRetryEventMessage({
     details.push(`attempt ${props.attempt}`);
   }
   const error = props.error;
-  if (isRecord(error)) {
+  const errorDetails = openCodeErrorFromValue(error);
+  if (errorDetails) {
     const message =
-      stringValue(error.message) ??
-      (isRecord(error.data) ? stringValue(error.data.message) : undefined);
-    const statusCode = error.statusCode;
+      stringValue(errorDetails.message) ??
+      stringValue(errorDetails.data?.message);
+    const statusCode = errorDetails.statusCode;
     if (typeof statusCode === 'number') {
       details.push(`HTTP ${statusCode}`);
     }
@@ -506,4 +487,88 @@ function nextRetryEventMessage({
 
 export function stringValue(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+type LegacyToolState = {
+  status?: string;
+  input?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  output?: unknown;
+  result?: unknown;
+  structured?: unknown;
+  content?: unknown;
+  error?: unknown;
+};
+
+type LegacyToolPart = {
+  type: 'tool';
+  callID: string;
+  tool: string;
+  status?: string;
+  state?: LegacyToolState;
+  metadata?: Record<string, unknown>;
+  providerMetadata?: unknown;
+  error?: unknown;
+};
+
+function legacyToolPartFromValue(value: unknown): LegacyToolPart | undefined {
+  const part = asOpenCodeObject(value);
+  if (
+    !part ||
+    part.type !== 'tool' ||
+    typeof part.tool !== 'string' ||
+    typeof part.callID !== 'string'
+  ) {
+    return undefined;
+  }
+
+  const stateObject = asOpenCodeObject(part.state);
+  const provider = asOpenCodeObject(part.provider);
+  const state = stateObject
+    ? {
+        status: stringValue(stateObject.status),
+        input: asOpenCodeObject(stateObject.input),
+        metadata: asOpenCodeObject(stateObject.metadata),
+        output: stateObject.output,
+        result: stateObject.result,
+        structured: stateObject.structured,
+        content: stateObject.content,
+        error: stateObject.error,
+      }
+    : undefined;
+
+  return {
+    type: 'tool',
+    callID: part.callID,
+    tool: part.tool,
+    status:
+      typeof part.state === 'string'
+        ? part.state
+        : (state?.status ?? undefined),
+    state,
+    metadata: asOpenCodeObject(part.metadata),
+    providerMetadata: provider?.metadata,
+    error: part.error,
+  };
+}
+
+type OpenCodeErrorDetails = {
+  isRetryable?: unknown;
+  message?: unknown;
+  statusCode?: unknown;
+  data?: { message?: unknown };
+};
+
+function openCodeErrorFromValue(
+  value: unknown,
+): OpenCodeErrorDetails | undefined {
+  const error = asOpenCodeObject(value);
+  if (!error) return undefined;
+  const data = asOpenCodeObject(error.data);
+  return {
+    isRetryable: error.isRetryable,
+    message: error.message,
+    statusCode: error.statusCode,
+    data: data ? { message: data.message } : undefined,
+  };
 }

--- a/packages/harness-opencode/src/bridge/index.ts
+++ b/packages/harness-opencode/src/bridge/index.ts
@@ -3,7 +3,6 @@ import {
   type BridgeEvent,
   type BridgeTurn,
 } from '@ai-sdk/harness/bridge';
-import { isRecord } from '@ai-sdk/provider-utils';
 import { randomUUID } from 'node:crypto';
 import { mkdirSync } from 'node:fs';
 import path from 'node:path';
@@ -19,7 +18,6 @@ import {
   emitOpenCodeStreamStart,
   getOpenCodeEventSessionId,
   isStepSettlementEvent,
-  type OpenCodeEvent,
   type TranslationState,
   unwrapOpenCodeEvent,
 } from './opencode-events';
@@ -35,6 +33,11 @@ import {
   type HarnessUsage,
   type OpenCodeTokenUsage,
 } from './opencode-usage';
+import {
+  asOpenCodeObject,
+  type OpenCodeEvent,
+  type OpenCodeObject,
+} from './opencode-types';
 import { startAuthorizedToolRelay, type ToolRelay } from './tool-relay';
 
 type Emit = (msg: Record<string, unknown>) => void;
@@ -834,12 +837,7 @@ async function handlePermissionV2({
       ? props.resources.map(String)
       : [],
     requestID,
-    toolCallId:
-      typeof props.source === 'object' &&
-      props.source !== null &&
-      'callID' in props.source
-        ? String((props.source as { callID?: unknown }).callID)
-        : requestID,
+    toolCallId: String(props.source?.callID ?? requestID),
     permissionMode,
     builtinToolFiltering,
     turn,
@@ -873,16 +871,12 @@ async function handlePermission({
   const props = event.properties ?? {};
   const requestID = String(props.id ?? '');
   if (!requestID) return;
+  const tool = asOpenCodeObject(props.tool);
   const reply = await selectPermissionReply({
     action: String(props.permission ?? ''),
     resources: Array.isArray(props.patterns) ? props.patterns.map(String) : [],
     requestID,
-    toolCallId:
-      typeof props.tool === 'object' &&
-      props.tool !== null &&
-      'callID' in props.tool
-        ? String((props.tool as { callID?: unknown }).callID)
-        : requestID,
+    toolCallId: String(tool?.callID ?? requestID),
     permissionMode,
     builtinToolFiltering,
     turn,
@@ -1302,15 +1296,13 @@ function modelRefFromAssistantSnapshot(
   const direct = modelRefFromValue(assistant);
   if (direct) return direct;
 
-  if (isRecord(assistant.metadata)) {
-    return modelRefFromValue(assistant.metadata.assistant);
-  }
-  return undefined;
+  return modelRefFromValue(asOpenCodeObject(assistant.metadata)?.assistant);
 }
 
 function modelRefFromSessionInfo(data: unknown): OpenCodeModelRef | undefined {
-  if (!isRecord(data)) return undefined;
-  return modelRefFromValue(data.model) ?? modelRefFromValue(data);
+  const session = asOpenCodeObject(data);
+  if (!session) return undefined;
+  return modelRefFromValue(session.model) ?? modelRefFromObject(session);
 }
 
 function modelRefFromStart(start: StartMessage): OpenCodeModelRef | undefined {
@@ -1324,7 +1316,13 @@ function modelRefFromStart(start: StartMessage): OpenCodeModelRef | undefined {
 }
 
 function modelRefFromValue(value: unknown): OpenCodeModelRef | undefined {
-  if (!isRecord(value)) return undefined;
+  const model = asOpenCodeObject(value);
+  return model ? modelRefFromObject(model) : undefined;
+}
+
+function modelRefFromObject(
+  value: OpenCodeObject,
+): OpenCodeModelRef | undefined {
   const providerID = stringValue(value.providerID);
   const modelID = stringValue(value.modelID ?? value.id);
   if (!providerID || !modelID) return undefined;

--- a/packages/harness-opencode/src/bridge/opencode-events.test.ts
+++ b/packages/harness-opencode/src/bridge/opencode-events.test.ts
@@ -59,6 +59,14 @@ describe('OpenCode event helpers', () => {
     });
   });
 
+  it('rejects malformed event envelopes at the raw event boundary', () => {
+    expect(unwrapOpenCodeEvent(null)).toBeUndefined();
+    expect(unwrapOpenCodeEvent([])).toBeUndefined();
+    expect(
+      unwrapOpenCodeEvent({ type: 'sync', syncEvent: 'not-an-event' }),
+    ).toBeUndefined();
+  });
+
   it('finds legacy tool part session ids', () => {
     expect(
       getOpenCodeEventSessionId({
@@ -237,5 +245,21 @@ describe('legacy reasoning part translation', () => {
       { type: 'text-delta', id: 'p2', delta: 'hello world' },
     ]);
     expect(out.some(msg => msg.type === 'reasoning-delta')).toBe(false);
+  });
+
+  it('does not treat a malformed time payload as a completed part', () => {
+    const state = createTranslationState();
+    const out: Array<Record<string, unknown>> = [];
+
+    emitLegacyTextPartUpdate({
+      part: { id: 'p3', type: 'text', text: 'hello', time: 'invalid' },
+      state,
+      emit: msg => out.push(msg),
+    });
+
+    expect(out).toEqual([
+      { type: 'text-start', id: 'p3' },
+      { type: 'text-delta', id: 'p3', delta: 'hello' },
+    ]);
   });
 });

--- a/packages/harness-opencode/src/bridge/opencode-events.ts
+++ b/packages/harness-opencode/src/bridge/opencode-events.ts
@@ -1,10 +1,9 @@
-import { isRecord } from '@ai-sdk/provider-utils';
-
-export type OpenCodeEvent = {
-  id?: string;
-  type?: string;
-  properties?: Record<string, any>;
-};
+import {
+  asOpenCodeObject,
+  type OpenCodeEvent,
+  type OpenCodeEventProperties,
+  type OpenCodeMessageInfo,
+} from './opencode-types';
 
 type Emit = (msg: Record<string, unknown>) => void;
 
@@ -53,10 +52,12 @@ export function emitOpenCodeStreamStart({
   state: TranslationState;
   emit: Emit;
 }): void {
-  if (state.streamStarted || !isRecord(info)) return;
-  if (info.role !== 'assistant' && info.type !== 'assistant') return;
-  const providerID = stringValue(info.providerID);
-  const modelID = stringValue(info.modelID);
+  if (state.streamStarted) return;
+  const message = openCodeMessageInfoFromValue(info);
+  if (!message) return;
+  if (message.role !== 'assistant' && message.type !== 'assistant') return;
+  const providerID = stringValue(message.providerID);
+  const modelID = stringValue(message.modelID);
   const modelId =
     providerID && modelID ? `${providerID}/${modelID}` : undefined;
 
@@ -67,20 +68,24 @@ export function emitOpenCodeStreamStart({
 export function unwrapOpenCodeEvent(
   rawEvent: unknown,
 ): OpenCodeEvent | undefined {
-  if (!rawEvent || typeof rawEvent !== 'object') return undefined;
-  const raw = rawEvent as Record<string, any>;
+  const raw = asOpenCodeObject(rawEvent);
+  if (!raw) return undefined;
   if (raw.type === 'sync' && raw.syncEvent) {
-    const sync = raw.syncEvent as Record<string, any>;
+    const sync = asOpenCodeObject(raw.syncEvent);
+    if (!sync) return undefined;
     return {
       id: String(sync.id ?? raw.id ?? ''),
       type: stripSyncVersion(String(sync.type ?? '')),
-      properties: asRecord(sync.data) ?? {},
+      properties: openCodeEventPropertiesFromValue(sync.data) ?? {},
     };
   }
   return {
     id: typeof raw.id === 'string' ? raw.id : undefined,
     type: typeof raw.type === 'string' ? stripSyncVersion(raw.type) : undefined,
-    properties: asRecord(raw.properties) ?? asRecord(raw.data) ?? {},
+    properties:
+      openCodeEventPropertiesFromValue(raw.properties) ??
+      openCodeEventPropertiesFromValue(raw.data) ??
+      {},
   };
 }
 
@@ -95,14 +100,8 @@ export function getOpenCodeEventSessionId(
     return props.id;
   }
   const part = props.part;
-  if (
-    part &&
-    typeof part === 'object' &&
-    !Array.isArray(part) &&
-    typeof (part as { sessionID?: unknown }).sessionID === 'string'
-  ) {
-    return (part as { sessionID: string }).sessionID;
-  }
+  const partObject = asOpenCodeObject(part);
+  if (typeof partObject?.sessionID === 'string') return partObject.sessionID;
   return undefined;
 }
 
@@ -202,21 +201,21 @@ export function emitLegacyTextPartUpdate({
   state: TranslationState;
   emit: Emit;
 }): boolean {
-  if (!isRecord(part)) return false;
-  if (part.type !== 'text' && part.type !== 'reasoning') return false;
-  const id = stringValue(part.id);
+  const textPart = legacyTextPartFromValue(part);
+  if (!textPart) return false;
+  const id = stringValue(textPart.id);
   if (!id) return true;
 
-  const messageID = stringValue(part.messageID);
+  const messageID = stringValue(textPart.messageID);
   if (messageID && state.messageRoles.get(messageID) === 'user') return true;
 
-  const isReasoning = part.type === 'reasoning';
+  const isReasoning = textPart.type === 'reasoning';
   const ids = isReasoning
     ? state.legacyReasoningPartIds
     : state.legacyTextPartIds;
   const deltaMap = isReasoning ? state.reasoningDeltas : state.textDeltas;
   const deltaType = isReasoning ? 'reasoning-delta' : 'text-delta';
-  const text = typeof part.text === 'string' ? part.text : undefined;
+  const text = typeof textPart.text === 'string' ? textPart.text : undefined;
 
   startLegacyPart({
     ids,
@@ -236,7 +235,7 @@ export function emitLegacyTextPartUpdate({
     deltaMap.set(id, text);
   }
 
-  if (legacyPartEnded(part)) {
+  if (textPart.time?.end != null) {
     ids.delete(id);
     deltaMap.delete(id);
     emit({ type: isReasoning ? 'reasoning-end' : 'text-end', id });
@@ -247,10 +246,6 @@ export function emitLegacyTextPartUpdate({
 
 function stripSyncVersion(type: string): string {
   return type.replace(/\.\d+$/, '');
-}
-
-function asRecord(value: unknown): Record<string, any> | undefined {
-  return isRecord(value) ? value : undefined;
 }
 
 function stringValue(value: unknown): string | undefined {
@@ -283,6 +278,36 @@ function startLegacyPart({
   emit({ type: `${type}-start`, id });
 }
 
-function legacyPartEnded(part: Record<string, unknown>): boolean {
-  return isRecord(part.time) && part.time.end != null;
+export function openCodeMessageInfoFromValue(
+  value: unknown,
+): OpenCodeMessageInfo | undefined {
+  return asOpenCodeObject(value) as OpenCodeMessageInfo | undefined;
+}
+
+function openCodeEventPropertiesFromValue(
+  value: unknown,
+): OpenCodeEventProperties | undefined {
+  return asOpenCodeObject(value) as OpenCodeEventProperties | undefined;
+}
+
+type LegacyTextPart = {
+  type: 'text' | 'reasoning';
+  id?: unknown;
+  messageID?: unknown;
+  text?: unknown;
+  time?: { end?: unknown };
+};
+
+function legacyTextPartFromValue(value: unknown): LegacyTextPart | undefined {
+  const part = asOpenCodeObject(value);
+  if (!part || (part.type !== 'text' && part.type !== 'reasoning')) {
+    return undefined;
+  }
+  return {
+    type: part.type,
+    id: part.id,
+    messageID: part.messageID,
+    text: part.text,
+    time: asOpenCodeObject(part.time),
+  };
 }

--- a/packages/harness-opencode/src/bridge/opencode-finish-step.ts
+++ b/packages/harness-opencode/src/bridge/opencode-finish-step.ts
@@ -1,6 +1,6 @@
 import type { HarnessV1StreamPart } from '@ai-sdk/harness';
-import { isRecord } from '@ai-sdk/provider-utils';
 import { mapUsage } from './opencode-usage';
+import { asOpenCodeObject } from './opencode-types';
 
 type FinishStepEvent = Extract<HarnessV1StreamPart, { type: 'finish-step' }>;
 
@@ -20,9 +20,16 @@ export function mapOpenCodeFinishReason(
 export function legacyStepFinishPartToFinishStep(
   part: unknown,
 ): FinishStepEvent | undefined {
-  if (!isRecord(part) || part.type !== 'step-finish') return undefined;
+  return translateLegacyStepFinishPart(part)?.event;
+}
+
+export function translateLegacyStepFinishPart(
+  value: unknown,
+): { event: FinishStepEvent; partId?: string } | undefined {
+  const part = asOpenCodeObject(value);
+  if (!part || part.type !== 'step-finish') return undefined;
   const rawFinish = typeof part.reason === 'string' ? part.reason : 'stop';
-  return {
+  const event: FinishStepEvent = {
     type: 'finish-step',
     finishReason: {
       unified: mapOpenCodeFinishReason(rawFinish),
@@ -32,5 +39,9 @@ export function legacyStepFinishPartToFinishStep(
     ...(typeof part.cost === 'number'
       ? { harnessMetadata: { opencode: { cost: part.cost } } }
       : {}),
+  };
+  return {
+    event,
+    ...(typeof part.id === 'string' ? { partId: part.id } : {}),
   };
 }

--- a/packages/harness-opencode/src/bridge/opencode-types.ts
+++ b/packages/harness-opencode/src/bridge/opencode-types.ts
@@ -1,0 +1,33 @@
+export type OpenCodeObject = Record<string, unknown>;
+
+export type OpenCodeMessageInfo = {
+  id?: unknown;
+  role?: unknown;
+  type?: unknown;
+  providerID?: unknown;
+  modelID?: unknown;
+  tokens?: unknown;
+};
+
+export type OpenCodeEventProperties = OpenCodeObject & {
+  info?: OpenCodeMessageInfo;
+  provider?: { metadata?: unknown };
+  source?: { callID?: unknown };
+  status?: {
+    type?: unknown;
+    attempt?: unknown;
+    message?: unknown;
+  };
+};
+
+export type OpenCodeEvent = {
+  id?: string;
+  type?: string;
+  properties?: OpenCodeEventProperties;
+};
+
+export function asOpenCodeObject(value: unknown): OpenCodeObject | undefined {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as OpenCodeObject)
+    : undefined;
+}

--- a/packages/harness-opencode/src/bridge/opencode-usage.test.ts
+++ b/packages/harness-opencode/src/bridge/opencode-usage.test.ts
@@ -22,6 +22,17 @@ describe('OpenCode usage helpers', () => {
     );
   });
 
+  it('ignores malformed token envelopes', () => {
+    expect(extractSessionTokens(null)).toBeUndefined();
+    expect(extractSessionTokens([])).toBeUndefined();
+    expect(extractSessionTokens({ data: 'invalid' })).toBeUndefined();
+    expect(
+      extractSessionTokens({
+        tokens: { input: 1, output: 2, reasoning: 0, cache: 'invalid' },
+      }),
+    ).toBeUndefined();
+  });
+
   it('maps the turn-local session token delta to harness usage', () => {
     const delta = subtractSessionTokens({
       before: {

--- a/packages/harness-opencode/src/bridge/opencode-usage.ts
+++ b/packages/harness-opencode/src/bridge/opencode-usage.ts
@@ -1,5 +1,5 @@
 import type { HarnessV1StreamPart } from '@ai-sdk/harness';
-import { isRecord } from '@ai-sdk/provider-utils';
+import { asOpenCodeObject } from './opencode-types';
 
 type FinishStepEvent = Extract<HarnessV1StreamPart, { type: 'finish-step' }>;
 
@@ -40,13 +40,13 @@ export function defaultUsage(): HarnessUsage {
 export function extractSessionTokens(
   value: unknown,
 ): OpenCodeTokenUsage | undefined {
-  const record = asRecord(value);
+  const record = asOpenCodeObject(value) as SessionTokenEnvelope | undefined;
   if (!record) return undefined;
   const tokens =
     extractOpenCodeTokens(record.tokens) ??
-    extractOpenCodeTokens(asRecord(record.info)?.tokens) ??
-    extractOpenCodeTokens(asRecord(record.data)?.tokens) ??
-    extractOpenCodeTokens(asRecord(asRecord(record.data)?.data)?.tokens);
+    extractOpenCodeTokens(record.info?.tokens) ??
+    extractOpenCodeTokens(record.data?.tokens) ??
+    extractOpenCodeTokens(record.data?.data?.tokens);
   return tokens;
 }
 
@@ -105,8 +105,8 @@ export function addUsage({
 }
 
 function extractOpenCodeTokens(value: unknown): OpenCodeTokenUsage | undefined {
-  const record = asRecord(value);
-  const cache = asRecord(record?.cache);
+  const record = asOpenCodeObject(value);
+  const cache = asOpenCodeObject(record?.cache);
   if (!record || !cache) return undefined;
   return {
     input: numberValue(record.input),
@@ -129,11 +129,11 @@ function zeroOpenCodeTokens(): OpenCodeTokenUsage {
 }
 
 function asTokenGroup(value: unknown): Record<string, number | undefined> {
-  return asRecord(value) ?? {};
-}
-
-function asRecord(value: unknown): Record<string, any> | undefined {
-  return isRecord(value) ? value : undefined;
+  return (
+    (asOpenCodeObject(value) as
+      | Record<string, number | undefined>
+      | undefined) ?? {}
+  );
 }
 
 function numberValue(value: unknown): number {
@@ -157,3 +157,12 @@ function add({
     ? undefined
     : (leftNumber ?? 0) + (rightNumber ?? 0);
 }
+
+type SessionTokenEnvelope = {
+  tokens?: unknown;
+  info?: { tokens?: unknown };
+  data?: {
+    tokens?: unknown;
+    data?: { tokens?: unknown };
+  };
+};


### PR DESCRIPTION
## Background

Like other harness bridges, the OpenCode bridge runs from an isolated sandbox directory where regular package dependencies like `@ai-sdk/provider-utils` are unavailable. #18167 refactored the duplication of `isRecord` calls, including breaking them out of this bridge and therefore importing `isRecord` from `@ai-sdk/provider-utils`, causing the bridge to fail at startup.

## Summary

- Replace the runtime `provider-utils` dependency with a local OpenCode boundary model.
- Normalize legacy event, tool, step, and usage payloads before translating them.
- Add regression coverage for malformed envelopes and legacy payloads.

## End-to-End Verification

Ran OpenCode harness e2e examples in `examples/harness-e2e-next`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Add tooling to prevent import of those kinds of dependencies in bridge code, so it would get flagged before merge in the future.
