### PR TITLE
feat(code-mode): add signed interruption continuations and nested tool replay

### DIFF
--- a/.changeset/quiet-tools-resume.md
+++ b/.changeset/quiet-tools-resume.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/code-mode': patch
+---
+
+feat(code-mode): add signed interruption continuations and deterministic nested tool replay

--- a/packages/code-mode/src/approval-continuation.test.ts
+++ b/packages/code-mode/src/approval-continuation.test.ts
@@ -1,0 +1,233 @@
+import { tool } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import {
+  CodeModeToolApprovalDeniedError,
+  experimental_continueCodeModeApproval as continueCodeModeApproval,
+  experimental_continueCodeModeInterrupt as continueCodeModeInterrupt,
+  experimental_isCodeModeApprovalInterrupt as isCodeModeApprovalInterrupt,
+  experimental_isCodeModeInterrupt as isCodeModeInterrupt,
+  experimental_requestCodeModeInterrupt as requestCodeModeInterrupt,
+  experimental_runCodeMode as runCodeMode,
+  type CodeModeApprovalInterrupt,
+  type CodeModeInterrupt,
+  type CodeModeToolExecutionOptions,
+} from '../dist/index.js';
+
+describe('code-mode approval continuations', () => {
+  it('supports callback approval without interrupting', async () => {
+    const execute = vi.fn(async ({ value }: { value: number }) => value * 2);
+
+    await expect(
+      runCodeMode({
+        js: 'return await tools.sensitive({ value: 2 });',
+        tools: {
+          sensitive: tool({
+            inputSchema: z.object({ value: z.number() }),
+            needsApproval: true,
+            execute,
+          }),
+        },
+        options: {
+          approval: {
+            onApprovalRequired: () => 'approved',
+          },
+        },
+      }),
+    ).resolves.toBe(4);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('replays completed calls without repeating their side effects', async () => {
+    const lookup = vi.fn(async ({ id }: { id: string }) => ({ id }));
+    const sensitive = vi.fn(async ({ id }: { id: string }) => ({
+      id,
+      ok: true,
+    }));
+    const tools = {
+      lookup: tool({
+        inputSchema: z.object({ id: z.string() }),
+        execute: lookup,
+      }),
+      sensitive: tool({
+        inputSchema: z.object({ id: z.string() }),
+        needsApproval: true,
+        execute: sensitive,
+      }),
+    };
+
+    const pending = await runCodeMode({
+      js: `
+        const first = await tools.lookup({ id: 'item-1' });
+        const second = await tools.sensitive({ id: first.id });
+        return { first, second };
+      `,
+      tools,
+      toolExecutionOptions: { toolCallId: 'outer', messages: [] },
+      options: { approval: { mode: 'interrupt' } },
+    });
+
+    expect(isCodeModeApprovalInterrupt(pending)).toBe(true);
+    const interrupt = pending as CodeModeApprovalInterrupt;
+    expect(interrupt.toolName).toBe('sensitive');
+    expect(interrupt.interruptId).toBe('outer:tool-2:interrupt');
+    expect(lookup).toHaveBeenCalledTimes(1);
+    expect(sensitive).not.toHaveBeenCalled();
+
+    await expect(
+      continueCodeModeApproval({
+        interrupt,
+        approvalResponse: {
+          approvalId: interrupt.interruptId,
+          approved: true,
+        },
+        tools,
+      }),
+    ).resolves.toEqual({
+      first: { id: 'item-1' },
+      second: { id: 'item-1', ok: true },
+    });
+    expect(lookup).toHaveBeenCalledTimes(1);
+    expect(sensitive).toHaveBeenCalledTimes(1);
+  });
+
+  it('denies an approval without executing the pending tool', async () => {
+    const execute = vi.fn(async () => 'should not run');
+    const tools = {
+      sensitive: tool({
+        inputSchema: z.object({}),
+        needsApproval: true,
+        execute,
+      }),
+    };
+    const pending = await runCodeMode({
+      js: 'return await tools.sensitive({});',
+      tools,
+      options: { approval: { mode: 'interrupt' } },
+    });
+    expect(isCodeModeApprovalInterrupt(pending)).toBe(true);
+    const interrupt = pending as CodeModeApprovalInterrupt;
+
+    await expect(
+      continueCodeModeApproval({
+        interrupt,
+        approvalResponse: {
+          approvalId: interrupt.interruptId,
+          approved: false,
+          reason: 'not allowed',
+        },
+        tools,
+      }),
+    ).rejects.toBeInstanceOf(CodeModeToolApprovalDeniedError);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects interrupt envelopes that do not match the signed ledger', async () => {
+    const pending = await runCodeMode({
+      js: 'return await tools.sensitive({});',
+      tools: {
+        sensitive: tool({
+          inputSchema: z.object({}),
+          needsApproval: true,
+          execute: async () => 'ok',
+        }),
+      },
+      options: { approval: { mode: 'interrupt' } },
+    });
+    expect(isCodeModeApprovalInterrupt(pending)).toBe(true);
+
+    const forged = {
+      ...(pending as CodeModeApprovalInterrupt),
+      toolName: 'different',
+    };
+    expect(isCodeModeApprovalInterrupt(forged)).toBe(false);
+  });
+
+  it('resumes concurrent approvals one at a time', async () => {
+    const first = vi.fn(async () => 'first');
+    const second = vi.fn(async () => 'second');
+    const tools = {
+      first: tool({
+        inputSchema: z.object({}),
+        needsApproval: true,
+        execute: first,
+      }),
+      second: tool({
+        inputSchema: z.object({}),
+        needsApproval: true,
+        execute: second,
+      }),
+    };
+
+    const pendingFirst = await runCodeMode({
+      js: `
+        const [first, second] = await Promise.all([
+          tools.first({}),
+          tools.second({}),
+        ]);
+        return { first, second };
+      `,
+      tools,
+      toolExecutionOptions: { toolCallId: 'outer', messages: [] },
+      options: { approval: { mode: 'interrupt' } },
+    });
+    expect(isCodeModeApprovalInterrupt(pendingFirst)).toBe(true);
+
+    const firstInterrupt = pendingFirst as CodeModeApprovalInterrupt;
+    const pendingSecond = await continueCodeModeApproval({
+      interrupt: firstInterrupt,
+      approvalResponse: {
+        approvalId: firstInterrupt.interruptId,
+        approved: true,
+      },
+      tools,
+    });
+    expect(isCodeModeApprovalInterrupt(pendingSecond)).toBe(true);
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+
+    const secondInterrupt = pendingSecond as CodeModeApprovalInterrupt;
+    await expect(
+      continueCodeModeApproval({
+        interrupt: secondInterrupt,
+        approvalResponse: {
+          approvalId: secondInterrupt.interruptId,
+          approved: true,
+        },
+        tools,
+      }),
+    ).resolves.toEqual({ first: 'first', second: 'second' });
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports generic host interruptions', async () => {
+    const tools = {
+      connection: tool({
+        inputSchema: z.object({}),
+        execute: async (_input, options) => {
+          const interruption = (options as CodeModeToolExecutionOptions)
+            .codeModeInterrupt;
+          if (interruption === undefined) {
+            requestCodeModeInterrupt({ kind: 'connection-auth' });
+          }
+          return interruption.resolution;
+        },
+      }),
+    };
+
+    const pending = await runCodeMode({
+      js: 'return await tools.connection({});',
+      tools,
+    });
+    expect(isCodeModeInterrupt(pending)).toBe(true);
+
+    await expect(
+      continueCodeModeInterrupt({
+        interrupt: pending as CodeModeInterrupt,
+        resolution: { token: 'ready' },
+        tools,
+      }),
+    ).resolves.toEqual({ token: 'ready' });
+  });
+});

--- a/packages/code-mode/src/approval-continuation.ts
+++ b/packages/code-mode/src/approval-continuation.ts
@@ -1,0 +1,115 @@
+import type { ModelMessage } from 'ai';
+import {
+  assertCodeModeApprovalResponse,
+  CODE_MODE_TOOL_APPROVAL_KIND,
+} from './approval.js';
+import { CodeModeProtocolError } from './errors.js';
+import {
+  continueCodeModeInterrupt,
+  isCodeModeInterrupt,
+} from './interrupt-continuation.js';
+import type {
+  CodeModeApprovalInterrupt,
+  CodeModeApprovalResponse,
+  CodeModeContinuationSecurityOptions,
+  CodeModeOptions,
+  CodeModeToolExecutionOptions,
+  CodeModeToolSet,
+} from './types.js';
+
+export function isCodeModeApprovalInterrupt(
+  value: unknown,
+  continuationSecurity: CodeModeContinuationSecurityOptions = {},
+): value is CodeModeApprovalInterrupt {
+  return (
+    isCodeModeInterrupt(value, continuationSecurity) &&
+    value.payload.kind === CODE_MODE_TOOL_APPROVAL_KIND
+  );
+}
+
+export async function continueCodeModeApproval({
+  interrupt,
+  approvalResponse,
+  tools,
+  options = {},
+  toolExecutionOptions,
+}: {
+  interrupt: CodeModeApprovalInterrupt;
+  approvalResponse: CodeModeApprovalResponse;
+  tools: CodeModeToolSet;
+  options?: CodeModeOptions;
+  toolExecutionOptions?: Partial<CodeModeToolExecutionOptions>;
+}): Promise<unknown> {
+  assertCodeModeApprovalResponse(approvalResponse);
+  if (approvalResponse.approvalId !== interrupt.interruptId) {
+    throw new CodeModeProtocolError(
+      `Approval response ${approvalResponse.approvalId} does not match pending code-mode approval ${interrupt.interruptId}.`,
+    );
+  }
+
+  return await continueCodeModeInterrupt({
+    interrupt,
+    resolution: {
+      approved: approvalResponse.approved,
+      ...(approvalResponse.reason !== undefined
+        ? { reason: approvalResponse.reason }
+        : {}),
+    },
+    tools,
+    options: {
+      ...options,
+      approval: { ...options.approval, mode: 'interrupt' },
+    },
+    ...(toolExecutionOptions !== undefined ? { toolExecutionOptions } : {}),
+  });
+}
+
+export function toCodeModeApprovalMessages(
+  interrupt: CodeModeApprovalInterrupt,
+): ModelMessage[] {
+  return [
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: interrupt.toolCallId,
+          toolName: interrupt.toolName,
+          input: interrupt.input,
+        },
+        {
+          type: 'tool-approval-request',
+          approvalId: interrupt.interruptId,
+          toolCallId: interrupt.toolCallId,
+        },
+      ],
+    },
+  ];
+}
+
+export function getCodeModeApprovalResponse(
+  messages: ModelMessage[],
+  interrupt: CodeModeApprovalInterrupt,
+): CodeModeApprovalResponse | undefined {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message?.role !== 'tool') {
+      continue;
+    }
+    for (const part of message.content) {
+      if (
+        part.type === 'tool-approval-response' &&
+        part.approvalId === interrupt.interruptId &&
+        typeof part.approved === 'boolean' &&
+        (part.reason === undefined || typeof part.reason === 'string')
+      ) {
+        return {
+          approvalId: part.approvalId,
+          approved: part.approved,
+          ...(part.reason !== undefined ? { reason: part.reason } : {}),
+        };
+      }
+    }
+  }
+  return undefined;
+}

--- a/packages/code-mode/src/approval.ts
+++ b/packages/code-mode/src/approval.ts
@@ -1,0 +1,60 @@
+import { CodeModeProtocolError } from './errors.js';
+import type {
+  CodeModeApprovalInterruptPayload,
+  CodeModeApprovalResolution,
+  CodeModeApprovalResponse,
+  CodeModeInterruptPayload,
+} from './types.js';
+
+export const CODE_MODE_TOOL_APPROVAL_KIND =
+  'ai-sdk-code-mode/tool-approval' as const;
+
+export function isCodeModeApprovalInterruptPayload(
+  payload: CodeModeInterruptPayload,
+): payload is CodeModeApprovalInterruptPayload {
+  return payload.kind === CODE_MODE_TOOL_APPROVAL_KIND;
+}
+
+export function assertCodeModeApprovalResponse(
+  value: unknown,
+): asserts value is CodeModeApprovalResponse {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    Array.isArray(value) ||
+    typeof (value as { approvalId?: unknown }).approvalId !== 'string' ||
+    typeof (value as { approved?: unknown }).approved !== 'boolean' ||
+    ('reason' in value &&
+      (value as { reason?: unknown }).reason !== undefined &&
+      typeof (value as { reason?: unknown }).reason !== 'string')
+  ) {
+    throw new CodeModeProtocolError(
+      'Code mode approval response is malformed.',
+    );
+  }
+}
+
+export function normalizeApprovalResolution(
+  resolution: unknown,
+): CodeModeApprovalResolution {
+  if (
+    typeof resolution !== 'object' ||
+    resolution === null ||
+    Array.isArray(resolution) ||
+    typeof (resolution as { approved?: unknown }).approved !== 'boolean' ||
+    ('reason' in resolution &&
+      (resolution as { reason?: unknown }).reason !== undefined &&
+      typeof (resolution as { reason?: unknown }).reason !== 'string')
+  ) {
+    throw new CodeModeProtocolError(
+      'Code mode approval resolution must be a boolean approval decision.',
+      { resolution },
+    );
+  }
+
+  const { approved, reason } = resolution as CodeModeApprovalResolution;
+  return {
+    approved,
+    ...(reason !== undefined ? { reason } : {}),
+  };
+}

--- a/packages/code-mode/src/continuation-capability.ts
+++ b/packages/code-mode/src/continuation-capability.ts
@@ -1,0 +1,201 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { CodeModeProtocolError } from './errors.js';
+import type {
+  CodeModeContinuation,
+  CodeModeContinuationAuth,
+  CodeModeContinuationSecurityOptions,
+  UnsignedCodeModeContinuation,
+} from './types.js';
+
+const SIGNATURE_ALGORITHM = 'HMAC-SHA256';
+const DEFAULT_MAX_AGE_MS = 60 * 60 * 1000;
+
+let defaultSigningKey: Uint8Array = randomBytes(32);
+let defaultMaxAgeMs = DEFAULT_MAX_AGE_MS;
+
+export interface ResolvedCodeModeContinuationSecurity {
+  signingKey: Buffer;
+  maxAgeMs: number;
+}
+
+export function setCodeModeContinuationSigningKey(
+  key?: string | Uint8Array,
+  options: { maxAgeMs?: number } = {},
+): void {
+  const resolved = resolveCodeModeContinuationSecurity({
+    signingKey: key ?? randomBytes(32),
+    maxAgeMs: options.maxAgeMs ?? DEFAULT_MAX_AGE_MS,
+  });
+  defaultSigningKey = resolved.signingKey;
+  defaultMaxAgeMs = resolved.maxAgeMs;
+}
+
+export function resolveCodeModeContinuationSecurity(
+  options: CodeModeContinuationSecurityOptions = {},
+): ResolvedCodeModeContinuationSecurity {
+  const signingKey =
+    options.signingKey === undefined
+      ? Buffer.from(defaultSigningKey)
+      : typeof options.signingKey === 'string'
+        ? Buffer.from(options.signingKey)
+        : Buffer.from(options.signingKey);
+  if (signingKey.byteLength === 0) {
+    throw new TypeError('Continuation signing key must not be empty.');
+  }
+
+  const maxAgeMs = options.maxAgeMs ?? defaultMaxAgeMs;
+  if (
+    !Number.isInteger(maxAgeMs) ||
+    !Number.isFinite(maxAgeMs) ||
+    maxAgeMs <= 0
+  ) {
+    throw new TypeError('Continuation maxAgeMs must be a positive integer.');
+  }
+
+  return { signingKey, maxAgeMs };
+}
+
+export function signCodeModeContinuation(
+  continuation: UnsignedCodeModeContinuation,
+  security = resolveCodeModeContinuationSecurity(),
+): CodeModeContinuation {
+  const issuedAtMs = Date.now();
+  const auth: Omit<CodeModeContinuationAuth, 'signature'> = {
+    alg: SIGNATURE_ALGORITHM,
+    nonce: randomBytes(16).toString('hex'),
+    issuedAtMs,
+    expiresAtMs: issuedAtMs + security.maxAgeMs,
+  };
+  return {
+    ...structuredClone(continuation),
+    auth: {
+      ...auth,
+      signature: signContinuationPayload(
+        { ...continuation, auth },
+        security.signingKey,
+      ),
+    },
+  };
+}
+
+export function verifyCodeModeContinuation(
+  continuation: CodeModeContinuation,
+  security: CodeModeContinuationSecurityOptions = {},
+): void {
+  assertAuthShape(continuation.auth);
+  const now = Date.now();
+  if (continuation.auth.expiresAtMs < now) {
+    throw new CodeModeProtocolError('Code mode continuation has expired.', {
+      expiresAtMs: continuation.auth.expiresAtMs,
+      now,
+    });
+  }
+  if (continuation.auth.issuedAtMs > now + 60_000) {
+    throw new CodeModeProtocolError(
+      'Code mode continuation was issued in the future.',
+      { issuedAtMs: continuation.auth.issuedAtMs, now },
+    );
+  }
+
+  const { signingKey } = resolveCodeModeContinuationSecurity(security);
+  const expected = signContinuationPayload(
+    stripSignature(continuation),
+    signingKey,
+  );
+  if (!constantTimeEqual(continuation.auth.signature, expected)) {
+    throw new CodeModeProtocolError(
+      'Code mode continuation signature is invalid.',
+    );
+  }
+}
+
+export function hasValidCodeModeContinuationCapability(
+  value: unknown,
+  security: CodeModeContinuationSecurityOptions = {},
+): value is CodeModeContinuation {
+  try {
+    verifyCodeModeContinuation(value as CodeModeContinuation, security);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function signContinuationPayload(
+  continuation: UnsignedCodeModeContinuation & {
+    auth: Omit<CodeModeContinuationAuth, 'signature'>;
+  },
+  signingKey: Uint8Array,
+): string {
+  return createHmac('sha256', signingKey)
+    .update(canonicalJson(continuation))
+    .digest('base64url');
+}
+
+function stripSignature(
+  continuation: CodeModeContinuation,
+): UnsignedCodeModeContinuation & {
+  auth: Omit<CodeModeContinuationAuth, 'signature'>;
+} {
+  const { auth, ...rest } = continuation;
+  const { signature: _signature, ...unsignedAuth } = auth;
+  return { ...rest, auth: unsignedAuth };
+}
+
+function assertAuthShape(
+  auth: unknown,
+): asserts auth is CodeModeContinuationAuth {
+  if (
+    typeof auth !== 'object' ||
+    auth === null ||
+    Array.isArray(auth) ||
+    (auth as { alg?: unknown }).alg !== SIGNATURE_ALGORITHM ||
+    typeof (auth as { nonce?: unknown }).nonce !== 'string' ||
+    !/^[0-9a-f]{32}$/i.test((auth as { nonce: string }).nonce) ||
+    typeof (auth as { issuedAtMs?: unknown }).issuedAtMs !== 'number' ||
+    !Number.isInteger((auth as { issuedAtMs: number }).issuedAtMs) ||
+    typeof (auth as { expiresAtMs?: unknown }).expiresAtMs !== 'number' ||
+    !Number.isInteger((auth as { expiresAtMs: number }).expiresAtMs) ||
+    (auth as { expiresAtMs: number }).expiresAtMs <=
+      (auth as { issuedAtMs: number }).issuedAtMs ||
+    typeof (auth as { signature?: unknown }).signature !== 'string' ||
+    (auth as { signature: string }).signature.length === 0
+  ) {
+    throw new CodeModeProtocolError(
+      'Code mode continuation is missing valid signed auth metadata.',
+    );
+  }
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  const leftBytes = Buffer.from(left);
+  const rightBytes = Buffer.from(right);
+  return (
+    leftBytes.byteLength === rightBytes.byteLength &&
+    timingSafeEqual(leftBytes, rightBytes)
+  );
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(',')}]`;
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right));
+    return `{${entries
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`)
+      .join(',')}}`;
+  }
+  throw new TypeError('Continuation contains a non-JSON-serializable value.');
+}

--- a/packages/code-mode/src/errors.ts
+++ b/packages/code-mode/src/errors.ts
@@ -112,6 +112,37 @@ export class CodeModeToolError extends CodeModeError {
   }
 }
 
+export class CodeModeToolApprovalRequiredError extends CodeModeToolError {
+  constructor(toolName: string, input: unknown, toolCallId: string) {
+    super(`Tool "${toolName}" requires approval before execution.`, {
+      toolName,
+      input,
+      toolCallId,
+    });
+    this.code = 'CODE_MODE_TOOL_APPROVAL_REQUIRED';
+  }
+}
+
+export class CodeModeToolApprovalDeniedError extends CodeModeToolError {
+  constructor(
+    toolName: string,
+    input: unknown,
+    toolCallId: string,
+    reason?: string,
+  ) {
+    super(
+      `Tool "${toolName}" approval was denied${reason ? `: ${reason}` : '.'}`,
+      {
+        toolName,
+        input,
+        toolCallId,
+        ...(reason !== undefined ? { reason } : {}),
+      },
+    );
+    this.code = 'CODE_MODE_TOOL_APPROVAL_DENIED';
+  }
+}
+
 /**
  * Converts an unknown thrown value into a worker-safe serializable shape.
  *
@@ -246,6 +277,40 @@ export function deserializeError(error: SerializableError): Error {
 
   if (error.code === 'CODE_MODE_PROTOCOL_ERROR') {
     const result = new CodeModeProtocolError(error.message, error.details);
+    restoreStack(result, error);
+    return result;
+  }
+
+  if (error.code === 'CODE_MODE_TOOL_APPROVAL_REQUIRED') {
+    const details = error.details as
+      | { toolName?: string; input?: unknown; toolCallId?: string }
+      | undefined;
+    const result = new CodeModeToolApprovalRequiredError(
+      details?.toolName ?? 'unknown',
+      details?.input,
+      details?.toolCallId ?? 'unknown',
+    );
+    result.message = error.message;
+    restoreStack(result, error);
+    return result;
+  }
+
+  if (error.code === 'CODE_MODE_TOOL_APPROVAL_DENIED') {
+    const details = error.details as
+      | {
+          toolName?: string;
+          input?: unknown;
+          toolCallId?: string;
+          reason?: string;
+        }
+      | undefined;
+    const result = new CodeModeToolApprovalDeniedError(
+      details?.toolName ?? 'unknown',
+      details?.input,
+      details?.toolCallId ?? 'unknown',
+      details?.reason,
+    );
+    result.message = error.message;
     restoreStack(result, error);
     return result;
   }

--- a/packages/code-mode/src/exceptions.test.ts
+++ b/packages/code-mode/src/exceptions.test.ts
@@ -1,7 +1,10 @@
 import { tool } from 'ai';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
-import { experimental_runCodeMode as runCodeMode } from '../dist/index.js';
+import {
+  CodeModeToolApprovalRequiredError,
+  experimental_runCodeMode as runCodeMode,
+} from '../dist/index.js';
 
 describe('exceptions and serialization', () => {
   it('fails clearly for unknown tools', async () => {
@@ -57,7 +60,7 @@ describe('exceptions and serialization', () => {
           }),
         },
       }),
-    ).rejects.toThrow(/requires approval.*does not support/i);
+    ).rejects.toBeInstanceOf(CodeModeToolApprovalRequiredError);
     expect(execute).not.toHaveBeenCalled();
   });
 

--- a/packages/code-mode/src/host-interrupt.ts
+++ b/packages/code-mode/src/host-interrupt.ts
@@ -1,0 +1,49 @@
+import type { CodeModeInterruptPayload } from './types.js';
+
+const CODE_MODE_HOST_INTERRUPT_SIGNAL = Symbol.for(
+  '@ai-sdk/code-mode.host-interrupt',
+);
+
+interface CodeModeHostInterruptSignal extends Error {
+  readonly [CODE_MODE_HOST_INTERRUPT_SIGNAL]: true;
+  readonly payload: CodeModeInterruptPayload;
+}
+
+export function requestCodeModeInterrupt<
+  TPayload extends CodeModeInterruptPayload,
+>(payload: TPayload): never {
+  if (
+    typeof payload !== 'object' ||
+    payload === null ||
+    Array.isArray(payload)
+  ) {
+    throw new TypeError('Code mode interrupt payload must be an object.');
+  }
+  if (typeof payload.kind !== 'string' || payload.kind.length === 0) {
+    throw new TypeError(
+      'Code mode interrupt payload must include a string kind.',
+    );
+  }
+
+  const error = new Error('Code mode host interruption requested.');
+  error.name = 'CodeModeHostInterruptSignal';
+  Object.defineProperties(error, {
+    [CODE_MODE_HOST_INTERRUPT_SIGNAL]: { value: true },
+    payload: { value: payload },
+  });
+  throw error;
+}
+
+export function isCodeModeHostInterruptSignal(
+  value: unknown,
+): value is CodeModeHostInterruptSignal {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { [CODE_MODE_HOST_INTERRUPT_SIGNAL]?: unknown })[
+      CODE_MODE_HOST_INTERRUPT_SIGNAL
+    ] === true &&
+    typeof (value as { payload?: unknown }).payload === 'object' &&
+    (value as { payload?: unknown }).payload !== null
+  );
+}

--- a/packages/code-mode/src/index.ts
+++ b/packages/code-mode/src/index.ts
@@ -3,6 +3,12 @@ export {
   createCodeModeTool as experimental_createCodeModeTool,
 } from './code-mode-tool.js';
 export {
+  continueCodeModeApproval as experimental_continueCodeModeApproval,
+  getCodeModeApprovalResponse as experimental_getCodeModeApprovalResponse,
+  isCodeModeApprovalInterrupt as experimental_isCodeModeApprovalInterrupt,
+  toCodeModeApprovalMessages as experimental_toCodeModeApprovalMessages,
+} from './approval-continuation.js';
+export {
   CodeModeAbortedError,
   CodeModeBridgeLimitError,
   CodeModeConcurrencyError,
@@ -11,16 +17,37 @@ export {
   CodeModeProtocolError,
   CodeModeSourceTooLargeError,
   CodeModeTimeoutError,
+  CodeModeToolApprovalDeniedError,
+  CodeModeToolApprovalRequiredError,
   CodeModeToolError,
 } from './errors.js';
+export { requestCodeModeInterrupt as experimental_requestCodeModeInterrupt } from './host-interrupt.js';
+export {
+  continueCodeModeInterrupt as experimental_continueCodeModeInterrupt,
+  getCodeModeInterrupt as experimental_getCodeModeInterrupt,
+  isCodeModeInterrupt as experimental_isCodeModeInterrupt,
+  unwrapCodeModeResult as experimental_unwrapCodeModeResult,
+} from './interrupt-continuation.js';
 export { runCodeMode as experimental_runCodeMode } from './run-code-mode.js';
+export { setCodeModeContinuationSigningKey as experimental_setCodeModeContinuationSigningKey } from './continuation-capability.js';
 export { setMaxWorkers as experimental_setMaxWorkers } from './runtime/max-workers.js';
 export type {
+  ApprovalDecision,
+  CodeModeApprovalInterrupt,
+  CodeModeApprovalRequest,
+  CodeModeApprovalResponse,
+  CodeModeContinuation,
+  CodeModeContinuationSecurityOptions,
   CodeModeExecutionPolicy,
+  CodeModeInterrupt,
+  CodeModeInterruptExecutionContext,
+  CodeModeInterruptPayload,
+  CodeModeInterruptResolution,
   CodeModeOptions,
   CodeModeTool,
   CodeModeToolExecutionOptions,
   CodeModeToolInput,
   CodeModeToolSet,
+  CodeModeUnwrappedResult,
   RunCodeModeInput,
 } from './types.js';

--- a/packages/code-mode/src/interrupt-continuation.ts
+++ b/packages/code-mode/src/interrupt-continuation.ts
@@ -1,0 +1,173 @@
+import {
+  hasValidCodeModeContinuationCapability,
+  verifyCodeModeContinuation,
+} from './continuation-capability.js';
+import { CodeModeProtocolError } from './errors.js';
+import { runCodeMode } from './run-code-mode.js';
+import type {
+  CodeModeContinuationSecurityOptions,
+  CodeModeInterrupt,
+  CodeModeInterruptPayload,
+  CodeModeInterruptResolution,
+  CodeModeOptions,
+  CodeModeToolExecutionOptions,
+  CodeModeToolSet,
+  CodeModeUnwrappedResult,
+} from './types.js';
+
+export function isCodeModeInterrupt(
+  value: unknown,
+  continuationSecurity: CodeModeContinuationSecurityOptions = {},
+): value is CodeModeInterrupt {
+  if (
+    isRecord(value) &&
+    value.type === 'code-mode-interrupt' &&
+    typeof value.interruptId === 'string' &&
+    typeof value.toolCallId === 'string' &&
+    typeof value.toolName === 'string' &&
+    typeof value.outerToolCallId === 'string' &&
+    isRecord(value.payload) &&
+    typeof value.payload.kind === 'string' &&
+    isRecord(value.continuation) &&
+    hasValidCodeModeContinuationCapability(
+      value.continuation,
+      continuationSecurity,
+    )
+  ) {
+    try {
+      assertInterruptMatchesLedger(value as unknown as CodeModeInterrupt);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+export async function continueCodeModeInterrupt<
+  TPayload extends CodeModeInterruptPayload = CodeModeInterruptPayload,
+  TResolution = unknown,
+>({
+  interrupt,
+  resolution,
+  tools,
+  options = {},
+  toolExecutionOptions,
+}: {
+  interrupt: CodeModeInterrupt<TPayload>;
+  resolution: TResolution;
+  tools: CodeModeToolSet;
+  options?: CodeModeOptions;
+  toolExecutionOptions?: Partial<CodeModeToolExecutionOptions>;
+}): Promise<unknown> {
+  verifyCodeModeContinuation(
+    interrupt.continuation,
+    options.continuationSecurity,
+  );
+  assertInterruptMatchesLedger(interrupt);
+
+  const interruptResolution: CodeModeInterruptResolution<TResolution> = {
+    interruptId: interrupt.interruptId,
+    resolution,
+  };
+  return await runCodeMode({
+    js: interrupt.continuation.js,
+    tools,
+    options,
+    continuation: interrupt.continuation,
+    interruptResolution,
+    ...(toolExecutionOptions !== undefined ? { toolExecutionOptions } : {}),
+  });
+}
+
+export function getCodeModeInterrupt(
+  result: unknown,
+  continuationSecurity: CodeModeContinuationSecurityOptions = {},
+): CodeModeInterrupt | undefined {
+  const direct = readInterruptValue(result, continuationSecurity);
+  if (direct !== undefined) {
+    return direct;
+  }
+  if (!isRecord(result)) {
+    return undefined;
+  }
+
+  for (const key of ['toolResults', 'content'] as const) {
+    const parts = result[key];
+    if (!Array.isArray(parts)) {
+      continue;
+    }
+    for (const part of parts) {
+      if (!isRecord(part)) {
+        continue;
+      }
+      const interrupt = readInterruptValue(part.output, continuationSecurity);
+      if (interrupt !== undefined) {
+        return interrupt;
+      }
+    }
+  }
+  return undefined;
+}
+
+export function unwrapCodeModeResult(
+  result: unknown,
+  continuationSecurity: CodeModeContinuationSecurityOptions = {},
+): CodeModeUnwrappedResult {
+  const interrupt = getCodeModeInterrupt(result, continuationSecurity);
+  return interrupt === undefined
+    ? { status: 'completed', output: result }
+    : { status: 'interrupted', interrupt };
+}
+
+function readInterruptValue(
+  value: unknown,
+  continuationSecurity: CodeModeContinuationSecurityOptions,
+): CodeModeInterrupt | undefined {
+  if (isCodeModeInterrupt(value, continuationSecurity)) {
+    return value;
+  }
+  if (
+    isRecord(value) &&
+    (value.type === 'json' || value.type === 'text') &&
+    'value' in value
+  ) {
+    return readInterruptValue(value.value, continuationSecurity);
+  }
+  return undefined;
+}
+
+function assertInterruptMatchesLedger(interrupt: CodeModeInterrupt): void {
+  if (interrupt.continuation.outerToolCallId !== interrupt.outerToolCallId) {
+    throw new CodeModeProtocolError(
+      'Code-mode interrupt outer tool call id does not match its continuation.',
+    );
+  }
+  const matches = interrupt.continuation.ledger.filter(
+    entry =>
+      entry.status === 'interrupted' &&
+      entry.interruptId === interrupt.interruptId &&
+      entry.toolCallId === interrupt.toolCallId &&
+      entry.name === interrupt.toolName &&
+      jsonEqual(fromJsonPayload(entry.inputJson), interrupt.input) &&
+      jsonEqual(entry.interruptPayload, interrupt.payload),
+  );
+  if (matches.length !== 1) {
+    throw new CodeModeProtocolError(
+      'Code-mode interrupt metadata does not match the signed continuation ledger.',
+      { interruptId: interrupt.interruptId, matches: matches.length },
+    );
+  }
+}
+
+function jsonEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function fromJsonPayload(valueJson: string): unknown {
+  return valueJson === '' ? undefined : JSON.parse(valueJson);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/code-mode/src/runtime/guest-sources.ts
+++ b/packages/code-mode/src/runtime/guest-sources.ts
@@ -90,6 +90,93 @@ const HARDENING_SOURCE = `
 })();
 `;
 
+const DETERMINISTIC_APIS_SOURCE = `
+var __codeModeResetDateNow = (function(config) {
+  var OriginalDate = Date;
+  var dateNowMs = Number(config && config.dateNowMs);
+  if (!Number.isFinite(dateNowMs)) dateNowMs = 0;
+
+  function resetDateNow(value) {
+    var next = Number(value);
+    if (Number.isFinite(next)) dateNowMs = Math.trunc(next);
+  }
+
+  function nextDateMs() {
+    var value = dateNowMs;
+    dateNowMs += 1;
+    return value;
+  }
+
+  function CodeModeDate() {
+    if (new.target) {
+      if (arguments.length === 0) return new OriginalDate(nextDateMs());
+      return Reflect.construct(OriginalDate, arguments, new.target);
+    }
+    return new OriginalDate(nextDateMs()).toString();
+  }
+
+  Object.defineProperty(CodeModeDate, 'prototype', {
+    value: OriginalDate.prototype,
+    writable: false,
+    configurable: false,
+  });
+  Object.defineProperty(OriginalDate.prototype, 'constructor', {
+    value: CodeModeDate,
+    writable: false,
+    configurable: false,
+  });
+  Object.defineProperty(CodeModeDate, 'now', {
+    value: nextDateMs,
+    writable: false,
+    configurable: false,
+  });
+  Object.defineProperty(CodeModeDate, 'parse', {
+    value: OriginalDate.parse,
+    writable: false,
+    configurable: false,
+  });
+  Object.defineProperty(CodeModeDate, 'UTC', {
+    value: OriginalDate.UTC,
+    writable: false,
+    configurable: false,
+  });
+  Object.defineProperty(globalThis, 'Date', {
+    value: CodeModeDate,
+    writable: false,
+    configurable: false,
+  });
+
+  var randomSeed = String(config && config.randomSeed || '');
+  var mask64 = (1n << 64n) - 1n;
+  function readSeedPart(offset, fallback) {
+    var part = randomSeed.slice(offset, offset + 16);
+    return /^[0-9a-fA-F]{16}$/.test(part) ? BigInt('0x' + part) : fallback;
+  }
+  var randomState0 = readSeedPart(0, 0x243f6a8885a308d3n);
+  var randomState1 = readSeedPart(16, 0x13198a2e03707344n);
+  if ((randomState0 | randomState1) === 0n) {
+    randomState1 = 0x9e3779b97f4a7c15n;
+  }
+  function nextRandom64() {
+    var s1 = randomState0;
+    var s0 = randomState1;
+    randomState0 = s0;
+    s1 = (s1 ^ ((s1 << 23n) & mask64)) & mask64;
+    randomState1 = (s1 ^ s0 ^ (s1 >> 17n) ^ (s0 >> 26n)) & mask64;
+    return (randomState1 + s0) & mask64;
+  }
+  Object.defineProperty(Math, 'random', {
+    value: function() {
+      return Number(nextRandom64() >> 11n) / 9007199254740992;
+    },
+    writable: false,
+    configurable: false,
+  });
+
+  return resetDateNow;
+})(__codeModeDeterminism);
+`;
+
 const BRIDGE_TRACKING_SOURCE = `
 (function() {
   var nextRecordId = 0;
@@ -242,11 +329,15 @@ const SERIALIZATION_GUARD_SOURCE = `
 
 export function buildGuestRuntimeSetupSource(): string {
   return `
-(function(__codeModeInvokeTool) {
+(function(__codeModeInvokeTool, __codeModeDeterminism) {
+${DETERMINISTIC_APIS_SOURCE}
 ${HARDENING_SOURCE}
 ${BRIDGE_TRACKING_SOURCE}
 ${TOOLS_PROXY_SOURCE}
 ${SERIALIZATION_GUARD_SOURCE}
+return Object.freeze({
+  resetDateNow: __codeModeResetDateNow,
+});
 })
 `;
 }

--- a/packages/code-mode/src/runtime/manager.ts
+++ b/packages/code-mode/src/runtime/manager.ts
@@ -1,6 +1,17 @@
 import { AsyncResource } from 'node:async_hooks';
 import { Buffer } from 'node:buffer';
+import { randomBytes } from 'node:crypto';
 import { Worker } from 'node:worker_threads';
+import {
+  isCodeModeApprovalInterruptPayload,
+  normalizeApprovalResolution,
+} from '../approval.js';
+import {
+  resolveCodeModeContinuationSecurity,
+  signCodeModeContinuation,
+  verifyCodeModeContinuation,
+  type ResolvedCodeModeContinuationSecurity,
+} from '../continuation-capability.js';
 import {
   CodeModeAbortedError,
   CodeModeBridgeLimitError,
@@ -8,6 +19,7 @@ import {
   CodeModeDetachedBridgeRequestError,
   CodeModeProtocolError,
   CodeModeTimeoutError,
+  CodeModeToolApprovalDeniedError,
   deserializeError,
   serializeBridgeErrorForGuest,
 } from '../errors.js';
@@ -15,6 +27,9 @@ import { invokeHostTool } from '../tool-invocation.js';
 import { normalizeOptions } from '../utils/options.js';
 import { assertSourceSize, transformSource } from '../utils/source-cache.js';
 import type {
+  CodeModeContinuationLedgerEntry,
+  CodeModeInterrupt,
+  CodeModeInterruptExecutionContext,
   CodeModeToolExecutionOptions,
   NormalizedCodeModeOptions,
   RunCodeModeInput,
@@ -22,7 +37,6 @@ import type {
 import { getMaxWorkers } from './max-workers.js';
 import type {
   MainToWorkerMessage,
-  WorkerBridgeResponse,
   WorkerReadyMessage,
   WorkerResultMessage,
   WorkerToolRequest,
@@ -48,6 +62,9 @@ export async function runManagedCodeMode(
   input: RunCodeModeInput,
 ): Promise<unknown> {
   const normalizedOptions = normalizeOptions(input.options);
+  const continuationSecurity = resolveCodeModeContinuationSecurity(
+    input.options?.continuationSecurity,
+  );
   const maxWorkers = getMaxWorkers({
     memoryLimitBytes: normalizedOptions.memoryLimitBytes,
     activeWorkers: activeInvocations,
@@ -63,11 +80,19 @@ export async function runManagedCodeMode(
     }
 
     assertSourceSize(input.js, normalizedOptions.maxSourceBytes);
+    const js = transformSource(input.js);
+    assertContinuationInput({
+      js,
+      continuation: input.continuation,
+      interruptResolution: input.interruptResolution,
+      continuationSecurity,
+    });
     const run = startWorkerRun({
       ...input,
-      js: transformSource(input.js),
+      js,
       normalizedOptions,
       maxWorkers,
+      continuationSecurity,
     });
     return await run.result;
   } finally {
@@ -79,11 +104,16 @@ function startWorkerRun({
   js,
   tools,
   toolExecutionOptions,
+  options,
+  continuation,
+  interruptResolution,
   normalizedOptions,
   maxWorkers,
+  continuationSecurity,
 }: RunCodeModeInput & {
   normalizedOptions: NormalizedCodeModeOptions;
   maxWorkers: number;
+  continuationSecurity: ResolvedCodeModeContinuationSecurity;
 }): ManagedWorkerRun {
   const invocationId = `code-mode-${++invocationCounter}`;
   const pooledWorker = acquireWorker(maxWorkers);
@@ -99,12 +129,16 @@ function startWorkerRun({
 
   const outerAbortSignal = toolExecutionOptions?.abortSignal;
   const invocationAbortController = new AbortController();
+  let nestedToolCounter = getMaxNestedToolCounter(continuation?.ledger ?? []);
   const forwardedContext =
     toolExecutionOptions?.context ?? toolExecutionOptions?.experimental_context;
   const forwardedExperimentalContext =
     toolExecutionOptions?.experimental_context ?? toolExecutionOptions?.context;
   const baseExecutionOptions: CodeModeToolExecutionOptions = {
-    toolCallId: toolExecutionOptions?.toolCallId ?? invocationId,
+    toolCallId:
+      toolExecutionOptions?.toolCallId ??
+      continuation?.outerToolCallId ??
+      invocationId,
     messages: toolExecutionOptions?.messages ?? [],
     abortSignal: invocationAbortController.signal,
     ...(forwardedExperimentalContext !== undefined
@@ -119,7 +153,13 @@ function startWorkerRun({
   let workerCleanedUp = false;
   let totalBridgeRequests = 0;
   let inFlightBridgeRequests = 0;
+  let interruptEntryIndex: number | undefined;
+  let interruptDrainCounter = 0;
+  let pendingInterruptDrainId: string | undefined;
+  let interruptResolutionConsumed = interruptResolution === undefined;
   const seenWorkerRequestIds = new Set<string>();
+  const bridgeLedger = cloneLedger(continuation?.ledger ?? []);
+  const determinism = continuation?.determinism ?? createDeterminismState();
 
   let resolveResult!: (value: unknown) => void;
   let rejectResult!: (reason?: unknown) => void;
@@ -219,6 +259,30 @@ function startWorkerRun({
       return;
     }
 
+    if (message.type === 'bridge-drained') {
+      if (
+        pendingInterruptDrainId === undefined ||
+        message.drainId !== pendingInterruptDrainId
+      ) {
+        failTerminal(
+          new CodeModeProtocolError(
+            `Worker sent unexpected bridge drain acknowledgement ${message.drainId}.`,
+            {
+              invocationId,
+              expectedDrainId: pendingInterruptDrainId,
+              receivedDrainId: message.drainId,
+            },
+          ),
+        );
+        return;
+      }
+      pendingInterruptDrainId = undefined;
+      if (inFlightBridgeRequests === 0) {
+        settleInterrupt();
+      }
+      return;
+    }
+
     const bridgeIndex = markWorkerRequest(message);
     if (bridgeIndex !== undefined) {
       void handleToolRequest(message, bridgeIndex);
@@ -251,6 +315,7 @@ function startWorkerRun({
     type: 'run',
     invocationId,
     js,
+    determinism,
     options: {
       timeoutMs: normalizedOptions.timeoutMs,
       memoryLimitBytes: normalizedOptions.memoryLimitBytes,
@@ -321,37 +386,286 @@ function startWorkerRun({
     message: WorkerToolRequest,
     bridgeIndex: number,
   ): Promise<void> {
+    const replayEntry = bridgeLedger[bridgeIndex - 1];
     try {
-      const valueJson = await invokeHostTool({
+      if (replayEntry !== undefined) {
+        assertReplayEntryMatches(replayEntry, message, bridgeIndex);
+
+        if (replayEntry.status === 'fulfilled') {
+          postBridgeResponse({
+            type: 'bridge-response',
+            invocationId,
+            requestId: message.requestId,
+            success: true,
+            dateNowMs: replayEntry.dateNowMs,
+            valueJson: replayEntry.valueJson,
+          });
+          return;
+        }
+
+        if (replayEntry.status === 'rejected') {
+          postBridgeResponse({
+            type: 'bridge-response',
+            invocationId,
+            requestId: message.requestId,
+            success: false,
+            dateNowMs: replayEntry.dateNowMs,
+            error: replayEntry.error,
+          });
+          return;
+        }
+
+        if (interruptResolution?.interruptId !== replayEntry.interruptId) {
+          requestInterrupt(bridgeIndex - 1);
+          return;
+        }
+
+        interruptResolutionConsumed = true;
+        const isApproval = isCodeModeApprovalInterruptPayload(
+          replayEntry.interruptPayload,
+        );
+        if (isApproval) {
+          const decision = normalizeApprovalResolution(
+            interruptResolution.resolution,
+          );
+          if (!decision.approved) {
+            const error = new CodeModeToolApprovalDeniedError(
+              replayEntry.name,
+              fromJsonPayload(message.inputJson),
+              replayEntry.toolCallId,
+              decision.reason,
+            );
+            const dateNowMs = Date.now();
+            const guestError = serializeBridgeErrorForGuest(error, 'tool');
+            bridgeLedger[bridgeIndex - 1] = {
+              kind: 'tool',
+              name: message.toolName,
+              inputJson: message.inputJson,
+              toolCallId: replayEntry.toolCallId,
+              status: 'rejected',
+              dateNowMs,
+              error: guestError,
+            };
+            postBridgeResponse({
+              type: 'bridge-response',
+              invocationId,
+              requestId: message.requestId,
+              success: false,
+              dateNowMs,
+              error: guestError,
+            });
+            return;
+          }
+        }
+
+        const codeModeInterrupt: CodeModeInterruptExecutionContext | undefined =
+          isApproval
+            ? undefined
+            : {
+                interruptId: replayEntry.interruptId,
+                payload: replayEntry.interruptPayload,
+                resolution: interruptResolution.resolution,
+              };
+        const outcome = await invokeHostTool({
+          toolName: message.toolName,
+          inputJson: message.inputJson,
+          tools,
+          baseExecutionOptions,
+          codeModeOptions: options ?? {},
+          maxToolInputBytes: normalizedOptions.maxToolInputBytes,
+          maxToolOutputBytes: normalizedOptions.maxToolOutputBytes,
+          toolCallId: replayEntry.toolCallId,
+          ...(codeModeInterrupt !== undefined ? { codeModeInterrupt } : {}),
+          skipApproval: true,
+        });
+        if (outcome.type === 'interrupted') {
+          bridgeLedger[bridgeIndex - 1] = {
+            kind: 'tool',
+            name: message.toolName,
+            inputJson: message.inputJson,
+            toolCallId: replayEntry.toolCallId,
+            interruptId: `${replayEntry.toolCallId}:interrupt`,
+            interruptPayload: outcome.payload,
+            status: 'interrupted',
+          };
+          requestInterrupt(bridgeIndex - 1);
+          return;
+        }
+
+        const dateNowMs = Date.now();
+        bridgeLedger[bridgeIndex - 1] = {
+          kind: 'tool',
+          name: message.toolName,
+          inputJson: message.inputJson,
+          toolCallId: replayEntry.toolCallId,
+          status: 'fulfilled',
+          dateNowMs,
+          valueJson: outcome.valueJson,
+        };
+        postBridgeResponse({
+          type: 'bridge-response',
+          invocationId,
+          requestId: message.requestId,
+          success: true,
+          dateNowMs,
+          valueJson: outcome.valueJson,
+        });
+        return;
+      }
+
+      const toolCallId = `${baseExecutionOptions.toolCallId}:tool-${++nestedToolCounter}`;
+      const outcome = await invokeHostTool({
         toolName: message.toolName,
         inputJson: message.inputJson,
         tools,
         baseExecutionOptions,
+        codeModeOptions: options ?? {},
         maxToolInputBytes: normalizedOptions.maxToolInputBytes,
         maxToolOutputBytes: normalizedOptions.maxToolOutputBytes,
-        toolCallId: `${baseExecutionOptions.toolCallId}:tool-${bridgeIndex}`,
+        toolCallId,
       });
+      if (outcome.type === 'interrupted') {
+        bridgeLedger[bridgeIndex - 1] = {
+          kind: 'tool',
+          name: message.toolName,
+          inputJson: message.inputJson,
+          toolCallId,
+          interruptId: `${toolCallId}:interrupt`,
+          interruptPayload: outcome.payload,
+          status: 'interrupted',
+        };
+        requestInterrupt(bridgeIndex - 1);
+        return;
+      }
+
+      const dateNowMs = Date.now();
+      bridgeLedger[bridgeIndex - 1] = {
+        kind: 'tool',
+        name: message.toolName,
+        inputJson: message.inputJson,
+        toolCallId,
+        status: 'fulfilled',
+        dateNowMs,
+        valueJson: outcome.valueJson,
+      };
       postBridgeResponse({
         type: 'bridge-response',
         invocationId,
         requestId: message.requestId,
         success: true,
-        valueJson,
+        dateNowMs,
+        valueJson: outcome.valueJson,
       });
     } catch (error) {
+      if (error instanceof CodeModeProtocolError) {
+        failTerminal(error);
+        return;
+      }
+      const dateNowMs = Date.now();
+      const guestError = serializeBridgeErrorForGuest(error, 'tool');
+      const toolCallId =
+        replayEntry?.toolCallId ??
+        `${baseExecutionOptions.toolCallId}:tool-${nestedToolCounter}`;
+      if (
+        replayEntry === undefined ||
+        (replayEntry.status === 'interrupted' &&
+          interruptResolution?.interruptId === replayEntry.interruptId)
+      ) {
+        bridgeLedger[bridgeIndex - 1] = {
+          kind: 'tool',
+          name: message.toolName,
+          inputJson: message.inputJson,
+          toolCallId,
+          status: 'rejected',
+          dateNowMs,
+          error: guestError,
+        };
+      }
       postBridgeResponse({
         type: 'bridge-response',
         invocationId,
         requestId: message.requestId,
         success: false,
-        error: serializeBridgeErrorForGuest(error, 'tool'),
+        dateNowMs,
+        error: guestError,
       });
     } finally {
       inFlightBridgeRequests--;
+      settleInterruptIfReady();
     }
   }
 
-  function postBridgeResponse(message: WorkerBridgeResponse): void {
+  function requestInterrupt(entryIndex: number): void {
+    interruptEntryIndex ??= entryIndex;
+  }
+
+  function settleInterruptIfReady(): void {
+    if (
+      interruptEntryIndex === undefined ||
+      terminalReached ||
+      inFlightBridgeRequests > 0 ||
+      pendingInterruptDrainId !== undefined ||
+      !interruptResolutionConsumed
+    ) {
+      return;
+    }
+    pendingInterruptDrainId = `${invocationId}:drain-${++interruptDrainCounter}`;
+    postBridgeResponse({
+      type: 'bridge-drain',
+      invocationId,
+      drainId: pendingInterruptDrainId,
+    });
+  }
+
+  function settleInterrupt(): void {
+    if (
+      interruptEntryIndex === undefined ||
+      terminalReached ||
+      inFlightBridgeRequests > 0 ||
+      !interruptResolutionConsumed
+    ) {
+      return;
+    }
+
+    const entry = bridgeLedger[interruptEntryIndex];
+    if (entry === undefined || entry.status !== 'interrupted') {
+      failTerminal(
+        new CodeModeProtocolError(
+          'Code mode interruption references a missing or resolved ledger entry.',
+          { invocationId, interruptEntryIndex },
+        ),
+      );
+      return;
+    }
+
+    const continuationState = signCodeModeContinuation(
+      {
+        version: 1,
+        js,
+        outerToolCallId: baseExecutionOptions.toolCallId,
+        determinism: { ...determinism },
+        ledger: cloneLedger(bridgeLedger),
+      },
+      continuationSecurity,
+    );
+    const interrupt: CodeModeInterrupt = {
+      type: 'code-mode-interrupt',
+      interruptId: entry.interruptId,
+      toolName: entry.name,
+      toolCallId: entry.toolCallId,
+      outerToolCallId: continuationState.outerToolCallId,
+      input: fromJsonPayload(entry.inputJson),
+      payload: structuredClone(entry.interruptPayload),
+      continuation: continuationState,
+    };
+
+    terminalReached = true;
+    abortInvocation(interrupt);
+    cleanupWorker(false);
+    settleCaller(() => resolveResult(interrupt));
+  }
+
+  function postBridgeResponse(message: MainToWorkerMessage): void {
     if (terminalReached) {
       return;
     }
@@ -367,11 +681,40 @@ function startWorkerRun({
     if (terminalReached) {
       return;
     }
+    if (interruptEntryIndex !== undefined) {
+      settleInterruptIfReady();
+      return;
+    }
     if (resultMessage === undefined) {
       failTerminal(
         new CodeModeProtocolError(
           `Code mode worker became ready without a result for ${message.invocationId}.`,
           { invocationId: message.invocationId },
+        ),
+      );
+      return;
+    }
+
+    if (!interruptResolutionConsumed) {
+      failTerminal(
+        new CodeModeProtocolError(
+          'Code mode continuation completed without consuming its interrupt resolution.',
+          { interruptId: interruptResolution?.interruptId },
+        ),
+      );
+      return;
+    }
+    if (
+      continuation !== undefined &&
+      totalBridgeRequests < bridgeLedger.length
+    ) {
+      failTerminal(
+        new CodeModeProtocolError(
+          'Code mode continuation returned before replaying the full bridge ledger.',
+          {
+            replayedBridgeRequests: totalBridgeRequests,
+            ledgerEntries: bridgeLedger.length,
+          },
         ),
       );
       return;
@@ -401,6 +744,128 @@ function startWorkerRun({
       settleWithResultMessage(finalResultMessage, resolveResult, rejectResult),
     );
   }
+}
+
+function assertContinuationInput({
+  js,
+  continuation,
+  interruptResolution,
+  continuationSecurity,
+}: {
+  js: string;
+  continuation: RunCodeModeInput['continuation'];
+  interruptResolution: RunCodeModeInput['interruptResolution'];
+  continuationSecurity: ResolvedCodeModeContinuationSecurity;
+}): void {
+  if (continuation === undefined) {
+    if (interruptResolution !== undefined) {
+      throw new CodeModeProtocolError(
+        'A code-mode interrupt resolution was provided without continuation state.',
+      );
+    }
+    return;
+  }
+
+  verifyCodeModeContinuation(continuation, continuationSecurity);
+  if (continuation.version !== 1) {
+    throw new CodeModeProtocolError(
+      'Unsupported code-mode continuation version.',
+    );
+  }
+  if (continuation.js !== js) {
+    throw new CodeModeProtocolError(
+      'Code mode continuation source does not match the resumed source.',
+    );
+  }
+  if (
+    !Number.isInteger(continuation.determinism.dateNowMs) ||
+    !/^[0-9a-f]{32}$/i.test(continuation.determinism.randomSeed)
+  ) {
+    throw new CodeModeProtocolError(
+      'Code mode continuation determinism state is malformed.',
+    );
+  }
+  for (const entry of continuation.ledger) {
+    if (
+      entry.kind !== 'tool' ||
+      typeof entry.name !== 'string' ||
+      typeof entry.inputJson !== 'string' ||
+      typeof entry.toolCallId !== 'string'
+    ) {
+      throw new CodeModeProtocolError(
+        'Code mode continuation ledger is malformed.',
+      );
+    }
+  }
+  if (interruptResolution !== undefined) {
+    const matches = continuation.ledger.filter(
+      entry =>
+        entry.status === 'interrupted' &&
+        entry.interruptId === interruptResolution.interruptId,
+    );
+    if (matches.length !== 1) {
+      throw new CodeModeProtocolError(
+        'Interrupt resolution does not match exactly one pending continuation ledger entry.',
+        {
+          interruptId: interruptResolution.interruptId,
+          matches: matches.length,
+        },
+      );
+    }
+  }
+}
+
+function assertReplayEntryMatches(
+  entry: CodeModeContinuationLedgerEntry,
+  message: WorkerToolRequest,
+  bridgeIndex: number,
+): void {
+  if (
+    entry.name !== message.toolName ||
+    entry.inputJson !== message.inputJson
+  ) {
+    throw new CodeModeProtocolError(
+      'Code mode continuation replay diverged from its bridge ledger.',
+      {
+        bridgeIndex,
+        expectedToolName: entry.name,
+        receivedToolName: message.toolName,
+      },
+    );
+  }
+}
+
+function createDeterminismState(): {
+  dateNowMs: number;
+  randomSeed: string;
+} {
+  return {
+    dateNowMs: Date.now(),
+    randomSeed: randomBytes(16).toString('hex'),
+  };
+}
+
+function cloneLedger(
+  ledger: CodeModeContinuationLedgerEntry[],
+): CodeModeContinuationLedgerEntry[] {
+  return structuredClone(ledger);
+}
+
+function getMaxNestedToolCounter(
+  ledger: CodeModeContinuationLedgerEntry[],
+): number {
+  let max = 0;
+  for (const entry of ledger) {
+    const match = /:tool-(\d+)$/u.exec(entry.toolCallId);
+    if (match !== null) {
+      max = Math.max(max, Number(match[1]));
+    }
+  }
+  return max;
+}
+
+function fromJsonPayload(valueJson: string): unknown {
+  return valueJson === '' ? undefined : JSON.parse(valueJson);
 }
 
 function acquireWorker(maxPoolSize: number): PooledWorker {

--- a/packages/code-mode/src/runtime/protocol.test.ts
+++ b/packages/code-mode/src/runtime/protocol.test.ts
@@ -14,6 +14,10 @@ const WORKER_OPTIONS = {
   maxResultBytes: 1024 * 1024,
   maxConsoleOutputBytes: 64 * 1024,
 };
+const DETERMINISM = {
+  dateNowMs: 1_700_000_000_000,
+  randomSeed: '00000000000000000000000000000001',
+};
 
 describe('worker protocol hardening', () => {
   it('rejects bridge responses with unknown request IDs', async () => {
@@ -25,6 +29,7 @@ describe('worker protocol hardening', () => {
         invocationId: 'invocation-a',
         requestId: 'missing-request',
         success: true,
+        dateNowMs: DETERMINISM.dateNowMs,
         valueJson: '"accepted"',
       }); // eslint-disable-line unicorn/require-post-message-target-origin -- Node.js Worker has no targetOrigin parameter.
 
@@ -51,6 +56,7 @@ describe('worker protocol hardening', () => {
         type: 'run',
         invocationId: 'invocation-a',
         js: 'return await tools.echo({ value: 1 });',
+        determinism: DETERMINISM,
         options: WORKER_OPTIONS,
       }); // eslint-disable-line unicorn/require-post-message-target-origin -- Node.js Worker has no targetOrigin parameter.
 
@@ -60,6 +66,7 @@ describe('worker protocol hardening', () => {
         invocationId: 'invocation-b',
         requestId: request.requestId,
         success: true,
+        dateNowMs: DETERMINISM.dateNowMs,
         valueJson: '{"value":1}',
       }); // eslint-disable-line unicorn/require-post-message-target-origin -- Node.js Worker has no targetOrigin parameter.
 
@@ -86,6 +93,7 @@ describe('worker protocol hardening', () => {
         type: 'run',
         invocationId: 'invocation-a',
         js: 'return await tools.echo({});',
+        determinism: DETERMINISM,
         options: WORKER_OPTIONS,
       }); // eslint-disable-line unicorn/require-post-message-target-origin -- Node.js Worker has no targetOrigin parameter.
       await requestPromise;
@@ -94,6 +102,7 @@ describe('worker protocol hardening', () => {
         type: 'run',
         invocationId: 'invocation-b',
         js: "return 'should not run';",
+        determinism: DETERMINISM,
         options: WORKER_OPTIONS,
       }); // eslint-disable-line unicorn/require-post-message-target-origin -- Node.js Worker has no targetOrigin parameter.
 

--- a/packages/code-mode/src/runtime/protocol.ts
+++ b/packages/code-mode/src/runtime/protocol.ts
@@ -1,9 +1,14 @@
-import type { NormalizedCodeModeOptions, SerializableError } from '../types.js';
+import type {
+  CodeModeDeterminismState,
+  NormalizedCodeModeOptions,
+  SerializableError,
+} from '../types.js';
 
 export interface WorkerRunMessage {
   type: 'run';
   invocationId: string;
   js: string;
+  determinism: CodeModeDeterminismState;
   options: Pick<
     NormalizedCodeModeOptions,
     | 'timeoutMs'
@@ -27,8 +32,21 @@ export interface WorkerBridgeResponse {
   invocationId: string;
   requestId: string;
   success: boolean;
+  dateNowMs: number;
   valueJson?: string;
   error?: SerializableError;
+}
+
+export interface WorkerBridgeDrainRequest {
+  type: 'bridge-drain';
+  invocationId: string;
+  drainId: string;
+}
+
+export interface WorkerBridgeDrainedMessage {
+  type: 'bridge-drained';
+  invocationId: string;
+  drainId: string;
 }
 
 export interface WorkerResultMessage {
@@ -46,7 +64,11 @@ export interface WorkerReadyMessage {
 
 export type WorkerToMainMessage =
   | WorkerToolRequest
+  | WorkerBridgeDrainedMessage
   | WorkerResultMessage
   | WorkerReadyMessage;
 
-export type MainToWorkerMessage = WorkerRunMessage | WorkerBridgeResponse;
+export type MainToWorkerMessage =
+  | WorkerRunMessage
+  | WorkerBridgeResponse
+  | WorkerBridgeDrainRequest;

--- a/packages/code-mode/src/runtime/worker.ts
+++ b/packages/code-mode/src/runtime/worker.ts
@@ -28,6 +28,7 @@ const pendingBridgeRequests = new Map<
     context: QuickJSAsyncContext;
     deferred: QuickJSDeferredPromise;
     invocationId: string;
+    resetDateNow?: QuickJSHandle;
   }
 >();
 let activeInvocationId: string | undefined;
@@ -35,6 +36,20 @@ let bridgeRequestCounter = 0;
 let embeddedQuickJsWasmModulePromise: Promise<WebAssembly.Module> | undefined;
 
 parentPort.on('message', (message: MainToWorkerMessage) => {
+  if (message.type === 'bridge-drain') {
+    if (message.invocationId !== activeInvocationId) {
+      throw new CodeModeProtocolError(
+        `Bridge drain invocationId mismatch: expected ${activeInvocationId ?? 'no active invocation'}, received ${message.invocationId}.`,
+      );
+    }
+    parentPort?.postMessage({
+      type: 'bridge-drained',
+      invocationId: message.invocationId,
+      drainId: message.drainId,
+    });
+    return;
+  }
+
   if (message.type === 'bridge-response') {
     const pending = pendingBridgeRequests.get(message.requestId);
     if (!pending) {
@@ -59,7 +74,12 @@ parentPort.on('message', (message: MainToWorkerMessage) => {
     }
 
     pendingBridgeRequests.delete(message.requestId);
-    resolveBridgeResponse(pending.context, pending.deferred, message);
+    resolveBridgeResponse(
+      pending.context,
+      pending.deferred,
+      message,
+      pending.resetDateNow,
+    );
     return;
   }
 
@@ -111,6 +131,8 @@ async function execute(message: WorkerRunMessage): Promise<string> {
   const deadline = Date.now() + message.options.timeoutMs;
   let interruptChecks = 0;
   let bridgeFunctions: { invokeTool: QuickJSHandle } | undefined;
+  let determinismHandle: QuickJSHandle | undefined;
+  let resetDateNowHandle: QuickJSHandle | undefined;
 
   runtime.setMemoryLimit(message.options.memoryLimitBytes);
   runtime.setMaxStackSize(message.options.maxStackSizeBytes);
@@ -121,7 +143,12 @@ async function execute(message: WorkerRunMessage): Promise<string> {
 
   try {
     installConsole(context, message.options.maxConsoleOutputBytes);
-    bridgeFunctions = createBridgeFunctions(context, message);
+    bridgeFunctions = createBridgeFunctions(
+      context,
+      message,
+      () => resetDateNowHandle,
+    );
+    determinismHandle = jsToHandle(context, message.determinism);
     const setupSource = buildGuestRuntimeSetupSource();
     const setupEvalResult = await context.evalCodeAsync(
       setupSource,
@@ -139,6 +166,7 @@ async function execute(message: WorkerRunMessage): Promise<string> {
         setupEvalResult.value,
         context.undefined,
         bridgeFunctions.invokeTool,
+        determinismHandle,
       );
       if (setupCallResult.error) {
         const error = context.dump(setupCallResult.error);
@@ -148,6 +176,10 @@ async function execute(message: WorkerRunMessage): Promise<string> {
         throw toError(error);
       }
       if (setupCallResult.value.alive) {
+        resetDateNowHandle = context.getProp(
+          setupCallResult.value,
+          'resetDateNow',
+        );
         setupCallResult.value.dispose();
       }
     } finally {
@@ -209,6 +241,12 @@ async function execute(message: WorkerRunMessage): Promise<string> {
     pendingBridgeRequests.clear();
     if (bridgeFunctions?.invokeTool.alive) {
       bridgeFunctions.invokeTool.dispose();
+    }
+    if (determinismHandle?.alive) {
+      determinismHandle.dispose();
+    }
+    if (resetDateNowHandle?.alive) {
+      resetDateNowHandle.dispose();
     }
     context.dispose();
   }
@@ -339,16 +377,19 @@ function dumpConsoleArg(
 function createBridgeFunctions(
   context: QuickJSAsyncContext,
   message: WorkerRunMessage,
+  getResetDateNow: () => QuickJSHandle | undefined,
 ): { invokeTool: QuickJSHandle } {
   const invokeTool = context.newFunction(
     '__codeModeInvokeTool',
     (toolNameHandle: QuickJSHandle, inputJsonHandle: QuickJSHandle) => {
       const toolName = context.getString(toolNameHandle);
       const inputJson = context.getString(inputJsonHandle);
-      return requestHost(context, message.invocationId, {
-        toolName,
-        inputJson,
-      });
+      return requestHost(
+        context,
+        message.invocationId,
+        { toolName, inputJson },
+        getResetDateNow(),
+      );
     },
   );
 
@@ -359,6 +400,7 @@ function requestHost(
   context: QuickJSAsyncContext,
   invocationId: string,
   payload: Record<string, unknown>,
+  resetDateNow: QuickJSHandle | undefined,
 ): QuickJSHandle {
   const requestId = `${invocationId}:bridge-${++bridgeRequestCounter}`;
   const deferred = context.newPromise();
@@ -366,6 +408,7 @@ function requestHost(
     context,
     deferred,
     invocationId,
+    ...(resetDateNow !== undefined ? { resetDateNow } : {}),
   });
   deferred.settled.then(() => {
     context.runtime.executePendingJobs();
@@ -384,7 +427,9 @@ function resolveBridgeResponse(
   context: QuickJSAsyncContext,
   deferred: QuickJSDeferredPromise,
   message: WorkerBridgeResponse,
+  resetDateNow?: QuickJSHandle,
 ): void {
+  resetGuestDateNow(context, resetDateNow, message.dateNowMs);
   if (message.success) {
     const value = context.newString(message.valueJson ?? '');
     deferred.resolve(value);
@@ -394,6 +439,32 @@ function resolveBridgeResponse(
   const error = createBridgeErrorHandle(context, message.error);
   deferred.reject(error);
   error.dispose();
+}
+
+function resetGuestDateNow(
+  context: QuickJSAsyncContext,
+  resetDateNow: QuickJSHandle | undefined,
+  dateNowMs: number,
+): void {
+  if (resetDateNow === undefined) {
+    return;
+  }
+  const value = context.newNumber(dateNowMs);
+  try {
+    const result = context.callFunction(resetDateNow, context.undefined, value);
+    if (result.error) {
+      const error = context.dump(result.error);
+      if (result.error.alive) {
+        result.error.dispose();
+      }
+      throw toError(error);
+    }
+    if (result.value.alive) {
+      result.value.dispose();
+    }
+  } finally {
+    value.dispose();
+  }
 }
 
 function drainPendingJobs(context: QuickJSAsyncContext): void {
@@ -494,4 +565,43 @@ function createBridgeErrorHandle(
     code.dispose();
   }
   return handle;
+}
+
+function jsToHandle(
+  context: QuickJSAsyncContext,
+  value: unknown,
+): QuickJSHandle {
+  if (value === null || value === undefined) {
+    return context.undefined;
+  }
+  if (typeof value === 'string') {
+    return context.newString(value);
+  }
+  if (typeof value === 'number') {
+    return context.newNumber(value);
+  }
+  if (typeof value === 'boolean') {
+    return value ? context.true : context.false;
+  }
+  if (Array.isArray(value)) {
+    const array = context.newArray();
+    value.forEach((item, index) => {
+      const itemHandle = jsToHandle(context, item);
+      context.setProp(array, index, itemHandle);
+      itemHandle.dispose();
+    });
+    return array;
+  }
+  if (typeof value === 'object') {
+    const object = context.newObject();
+    for (const [key, item] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      const itemHandle = jsToHandle(context, item);
+      context.setProp(object, key, itemHandle);
+      itemHandle.dispose();
+    }
+    return object;
+  }
+  return context.undefined;
 }

--- a/packages/code-mode/src/tool-invocation.ts
+++ b/packages/code-mode/src/tool-invocation.ts
@@ -1,28 +1,57 @@
 import { asSchema } from 'ai';
-import { CodeModeToolError } from './errors.js';
-import type { CodeModeToolExecutionOptions, CodeModeToolSet } from './types.js';
+import { CODE_MODE_TOOL_APPROVAL_KIND } from './approval.js';
+import {
+  CodeModeProtocolError,
+  CodeModeToolApprovalDeniedError,
+  CodeModeToolApprovalRequiredError,
+  CodeModeToolError,
+} from './errors.js';
+import { isCodeModeHostInterruptSignal } from './host-interrupt.js';
+import type {
+  CodeModeInterruptExecutionContext,
+  CodeModeInterruptPayload,
+  CodeModeOptions,
+  CodeModeToolExecutionOptions,
+  CodeModeToolSet,
+} from './types.js';
 import {
   assertJsonSerializable,
   toJsonPayload,
 } from './utils/serialization.js';
+
+export type HostToolInvocationResult =
+  | { type: 'success'; valueJson: string }
+  | {
+      type: 'interrupted';
+      toolName: string;
+      input: unknown;
+      toolCallId: string;
+      payload: CodeModeInterruptPayload;
+    };
 
 export async function invokeHostTool({
   toolName,
   inputJson,
   tools,
   baseExecutionOptions,
+  codeModeOptions,
   maxToolInputBytes,
   maxToolOutputBytes,
   toolCallId,
+  codeModeInterrupt,
+  skipApproval = false,
 }: {
   toolName: string;
   inputJson: string;
   tools: CodeModeToolSet;
   baseExecutionOptions: CodeModeToolExecutionOptions;
+  codeModeOptions: CodeModeOptions;
   maxToolInputBytes: number;
   maxToolOutputBytes: number;
   toolCallId: string;
-}): Promise<string> {
+  codeModeInterrupt?: CodeModeInterruptExecutionContext;
+  skipApproval?: boolean;
+}): Promise<HostToolInvocationResult> {
   throwIfAborted(baseExecutionOptions.abortSignal);
 
   const hostTool = tools[toolName];
@@ -55,28 +84,100 @@ export async function invokeHostTool({
   const executionOptions: CodeModeToolExecutionOptions = {
     ...baseExecutionOptions,
     toolCallId,
+    ...(codeModeInterrupt !== undefined ? { codeModeInterrupt } : {}),
   };
 
-  if (
-    await raceAgainstAbort(
+  const needsApproval =
+    !skipApproval &&
+    (await raceAgainstAbort(
       requiresApproval(hostTool, validation.value, executionOptions),
       executionOptions.abortSignal,
-    )
-  ) {
-    throw new CodeModeToolError(
-      `Tool "${toolName}" requires approval, which code mode does not support yet.`,
-      { toolName, input: validation.value, toolCallId },
+    ));
+
+  if (needsApproval) {
+    if (codeModeOptions.approval?.mode === 'interrupt') {
+      return {
+        type: 'interrupted',
+        toolName,
+        input: validation.value,
+        toolCallId,
+        payload: { kind: CODE_MODE_TOOL_APPROVAL_KIND },
+      };
+    }
+
+    const approval = await raceAgainstAbort(
+      Promise.resolve(
+        codeModeOptions.approval?.onApprovalRequired?.({
+          toolName,
+          input: validation.value,
+          toolCallId,
+        }),
+      ),
+      baseExecutionOptions.abortSignal,
     );
+    if (approval === undefined) {
+      throw new CodeModeToolApprovalRequiredError(
+        toolName,
+        validation.value,
+        toolCallId,
+      );
+    }
+    const approved =
+      typeof approval === 'string'
+        ? approval === 'approved'
+        : approval?.approved;
+    const reason = typeof approval === 'string' ? undefined : approval?.reason;
+    if (typeof approved !== 'boolean') {
+      throw new CodeModeProtocolError(
+        `Tool "${toolName}" approval callback returned a malformed approval decision.`,
+        { toolName, toolCallId },
+      );
+    }
+    if (reason !== undefined && typeof reason !== 'string') {
+      throw new CodeModeProtocolError(
+        `Tool "${toolName}" approval callback returned a malformed approval reason.`,
+        { toolName, toolCallId },
+      );
+    }
+    if (!approved) {
+      throw new CodeModeToolApprovalDeniedError(
+        toolName,
+        validation.value,
+        toolCallId,
+        reason,
+      );
+    }
   }
 
-  const output = await raceAgainstAbort(
-    executeHostTool(hostTool.execute.bind(hostTool), {
-      input: validation.value,
-      options: executionOptions,
-    }),
-    executionOptions.abortSignal,
-  );
-  return toJsonPayload(output, maxToolOutputBytes, `Tool "${toolName}" output`);
+  let output: unknown;
+  try {
+    output = await raceAgainstAbort(
+      executeHostTool(hostTool.execute.bind(hostTool), {
+        input: validation.value,
+        options: executionOptions,
+      }),
+      executionOptions.abortSignal,
+    );
+  } catch (error) {
+    if (isCodeModeHostInterruptSignal(error)) {
+      return {
+        type: 'interrupted',
+        toolName,
+        input: validation.value,
+        toolCallId,
+        payload: error.payload,
+      };
+    }
+    throw error;
+  }
+  return {
+    type: 'success',
+    valueJson: toJsonPayload(
+      output,
+      maxToolOutputBytes,
+      `Tool "${toolName}" output`,
+    ),
+  };
 }
 
 async function requiresApproval(

--- a/packages/code-mode/src/types.ts
+++ b/packages/code-mode/src/types.ts
@@ -14,6 +14,7 @@ export interface CodeModeToolExecutionOptions {
   abortSignal?: AbortSignal;
   experimental_context?: unknown;
   context?: unknown;
+  codeModeInterrupt?: CodeModeInterruptExecutionContext;
 }
 
 /**
@@ -35,6 +36,124 @@ export interface CodeModeToolInput {
    */
   js: string;
 }
+
+export type ApprovalDecision =
+  | 'approved'
+  | 'denied'
+  | { approved: boolean; reason?: string };
+
+export interface CodeModeApprovalRequest {
+  toolName: string;
+  input: unknown;
+  toolCallId: string;
+}
+
+export interface CodeModeApprovalResponse {
+  approvalId: string;
+  approved: boolean;
+  reason?: string;
+}
+
+export interface CodeModeApprovalResolution {
+  approved: boolean;
+  reason?: string;
+}
+
+export interface CodeModeInterruptPayload {
+  kind: string;
+  [key: string]: unknown;
+}
+
+export interface CodeModeInterruptResolution<TResolution = unknown> {
+  interruptId: string;
+  resolution: TResolution;
+}
+
+export interface CodeModeInterruptExecutionContext<
+  TPayload extends CodeModeInterruptPayload = CodeModeInterruptPayload,
+  TResolution = unknown,
+> {
+  interruptId: string;
+  payload: TPayload;
+  resolution: TResolution;
+}
+
+export type CodeModeContinuationLedgerEntry =
+  | {
+      kind: 'tool';
+      name: string;
+      inputJson: string;
+      toolCallId: string;
+      status: 'fulfilled';
+      dateNowMs: number;
+      valueJson: string;
+    }
+  | {
+      kind: 'tool';
+      name: string;
+      inputJson: string;
+      toolCallId: string;
+      status: 'rejected';
+      dateNowMs: number;
+      error: SerializableError;
+    }
+  | {
+      kind: 'tool';
+      name: string;
+      inputJson: string;
+      toolCallId: string;
+      interruptId: string;
+      interruptPayload: CodeModeInterruptPayload;
+      status: 'interrupted';
+    };
+
+export interface CodeModeDeterminismState {
+  dateNowMs: number;
+  randomSeed: string;
+}
+
+export interface CodeModeContinuationAuth {
+  alg: 'HMAC-SHA256';
+  nonce: string;
+  issuedAtMs: number;
+  expiresAtMs: number;
+  signature: string;
+}
+
+export interface CodeModeContinuation {
+  version: 1;
+  js: string;
+  outerToolCallId: string;
+  determinism: CodeModeDeterminismState;
+  ledger: CodeModeContinuationLedgerEntry[];
+  auth: CodeModeContinuationAuth;
+}
+
+export type UnsignedCodeModeContinuation = Omit<CodeModeContinuation, 'auth'>;
+
+export interface CodeModeInterrupt<
+  TPayload extends CodeModeInterruptPayload = CodeModeInterruptPayload,
+> {
+  type: 'code-mode-interrupt';
+  interruptId: string;
+  toolName: string;
+  toolCallId: string;
+  outerToolCallId: string;
+  input: unknown;
+  payload: TPayload;
+  continuation: CodeModeContinuation;
+}
+
+export type CodeModeUnwrappedResult =
+  | { status: 'completed'; output: unknown }
+  | { status: 'interrupted'; interrupt: CodeModeInterrupt };
+
+export interface CodeModeApprovalInterruptPayload extends CodeModeInterruptPayload {
+  kind: 'ai-sdk-code-mode/tool-approval';
+}
+
+export type CodeModeApprovalInterrupt =
+  CodeModeInterrupt<CodeModeApprovalInterruptPayload>;
 
 /**
  * Execution limits applied to each sandbox invocation.
@@ -67,6 +186,24 @@ export interface CodeModeExecutionPolicy {
  */
 export interface CodeModeOptions {
   executionPolicy?: CodeModeExecutionPolicy;
+  continuationSecurity?: CodeModeContinuationSecurityOptions;
+  approval?: {
+    /**
+     * @defaultValue `'callback'`
+     */
+    mode?: 'callback' | 'interrupt';
+    onApprovalRequired?: (
+      request: CodeModeApprovalRequest,
+    ) => Promise<ApprovalDecision> | ApprovalDecision;
+  };
+}
+
+export interface CodeModeContinuationSecurityOptions {
+  signingKey?: string | Uint8Array;
+  /**
+   * @defaultValue `60 * 60 * 1000`
+   */
+  maxAgeMs?: number;
 }
 
 /**
@@ -77,6 +214,8 @@ export interface RunCodeModeInput {
   tools: CodeModeToolSet;
   toolExecutionOptions?: Partial<CodeModeToolExecutionOptions>;
   options?: CodeModeOptions;
+  continuation?: CodeModeContinuation;
+  interruptResolution?: CodeModeInterruptResolution;
 }
 
 /**


### PR DESCRIPTION
## Background

#18143

Code mode can call multiple nested tools in one sandbox execution. We needed a way to pause at a sensitive tool, wait for approval and later continue without repeating tools that already executed

## Summary

added signed, expiring continuations that let code-mode pause for nested tool approval and resume through deterministic replay without repeating completed tool calls.

## End-to-End Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

wire it with ai core approvals flow

## Related Issues

towards #18143 