### PR TITLE
fix(harness): avoid placing harness bootstrap files in `/tmp` and instead use sandbox working directory

### DIFF
--- a/.changeset/heavy-guests-fetch.md
+++ b/.changeset/heavy-guests-fetch.md
@@ -1,0 +1,9 @@
+---
+"@ai-sdk/harness-claude-code": patch
+"@ai-sdk/harness-deepagents": patch
+"@ai-sdk/harness-opencode": patch
+"@ai-sdk/harness-codex": patch
+"@ai-sdk/harness": patch
+---
+
+fix(harness): avoid placing harness bootstrap files in `/tmp` and instead use sandbox working directory

--- a/examples/ai-functions/src/harness-agent/prepare-sandbox-for-harness.ts
+++ b/examples/ai-functions/src/harness-agent/prepare-sandbox-for-harness.ts
@@ -4,6 +4,7 @@ import {
   type HarnessAgentAdapter,
   type HarnessAgentSandboxConfig,
 } from '@ai-sdk/harness/agent';
+import type { HarnessV1NetworkSandboxSession } from '@ai-sdk/harness';
 import { claudeCode } from '@ai-sdk/harness-claude-code';
 import { codex } from '@ai-sdk/harness-codex';
 import { deepAgents } from '@ai-sdk/harness-deepagents';
@@ -11,6 +12,7 @@ import { openCode } from '@ai-sdk/harness-opencode';
 import { pi } from '@ai-sdk/harness-pi';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { Sandbox } from '@vercel/sandbox';
+import { posix } from 'node:path';
 import { run } from '../lib/run';
 
 const sandboxTimeout = 10 * 60 * 1000;
@@ -77,6 +79,8 @@ async function createPreparedSnapshot(
     console.log('recipe identities:', result.recipeIdentities);
     console.log('skipped harnesses:', result.skippedHarnessIds);
 
+    await assertBootstrapAssets({ session, harnesses });
+
     const stopResult = await preparedSandbox.stop();
     const snapshotId = stopResult.snapshot?.id;
     if (snapshotId == null) {
@@ -103,12 +107,21 @@ async function runHarnessFromSnapshot({
     ports: [bridgePort],
     timeout: sandboxTimeout,
   });
+  const provider = createVercelSandbox({
+    sandbox,
+    bridgePorts: [bridgePort],
+  });
+  const restoredSession = await provider.createSession();
+  await assertBootstrapAssets({
+    session: restoredSession,
+    harnesses: [{ name, harness }],
+  }).catch(async error => {
+    await sandbox.stop().catch(() => {});
+    throw error;
+  });
   const agent = new HarnessAgent({
     harness,
-    sandbox: createVercelSandbox({
-      sandbox,
-      bridgePorts: [bridgePort],
-    }),
+    sandbox: provider,
     sandboxConfig,
   });
   const session = await agent.createSession().catch(async error => {
@@ -125,5 +138,34 @@ async function runHarnessFromSnapshot({
   } finally {
     await session.destroy().catch(() => {});
     await sandbox.stop().catch(() => {});
+  }
+}
+
+async function assertBootstrapAssets({
+  session,
+  harnesses,
+}: {
+  readonly session: HarnessV1NetworkSandboxSession;
+  readonly harnesses: ReadonlyArray<{
+    name: string;
+    harness: HarnessAgentAdapter;
+  }>;
+}): Promise<void> {
+  for (const { name, harness } of harnesses) {
+    const recipe = await harness.getBootstrap?.();
+    if (recipe == null) {
+      continue;
+    }
+
+    for (const file of recipe.files) {
+      const filePath = posix.isAbsolute(file.path)
+        ? file.path
+        : posix.resolve(session.defaultWorkingDirectory, file.path);
+      if ((await session.readTextFile({ path: filePath })) != null) {
+        continue;
+      }
+
+      throw new Error(`Missing ${name} bootstrap asset: ${filePath}`);
+    }
   }
 }

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -261,7 +261,7 @@ describe('createClaudeCode adapter', () => {
       "mkdir -p '/vercel/sandbox/claude-code-s1; env > /tmp/workdir-leak #' '/vercel/sandbox/.agent-runs/s1; env > /tmp/leak #/bridge'",
     );
     expect(spawns).toEqual([
-      "node /tmp/harness/claude-code/bridge.mjs --workdir '/vercel/sandbox/claude-code-s1; env > /tmp/workdir-leak #' --bridge-state-dir '/vercel/sandbox/.agent-runs/s1; env > /tmp/leak #/bridge'",
+      "node '/vercel/sandbox/.harness-bootstrap/claude-code/bridge.mjs' --workdir '/vercel/sandbox/claude-code-s1; env > /tmp/workdir-leak #' --bridge-state-dir '/vercel/sandbox/.agent-runs/s1; env > /tmp/leak #/bridge'",
     ]);
     expect(spawnEnvs.at(0)?.CLAUDE_AGENT_SDK_CLIENT_APP).toBe(
       'ai-sdk/harness-claude-code/0.0.0-test',
@@ -477,7 +477,7 @@ describe('createClaudeCode adapter', () => {
       expect(harness.getBootstrap).toBeDefined();
       const recipe = await harness.getBootstrap!();
       expect(recipe.harnessId).toBe('claude-code');
-      expect(recipe.bootstrapDir).toBe('/tmp/harness/claude-code');
+      expect(recipe.bootstrapDir).toBe('.harness-bootstrap/claude-code');
     });
 
     it('includes bridge.mjs, package.json, and pnpm-lock.yaml under the bootstrap dir', async () => {
@@ -485,23 +485,25 @@ describe('createClaudeCode adapter', () => {
       const recipe = await harness.getBootstrap!();
       const paths = recipe.files.map(f => f.path).sort();
       expect(paths).toEqual([
-        '/tmp/harness/claude-code/bridge.mjs',
-        '/tmp/harness/claude-code/package.json',
-        '/tmp/harness/claude-code/pnpm-lock.yaml',
+        '.harness-bootstrap/claude-code/bridge.mjs',
+        '.harness-bootstrap/claude-code/package.json',
+        '.harness-bootstrap/claude-code/pnpm-lock.yaml',
       ]);
       for (const file of recipe.files) {
         expect(file.content.length).toBeGreaterThan(0);
       }
     });
 
-    it('declares mkdir, pnpm install, and claude post-install commands', async () => {
+    it('declares pnpm install and claude post-install commands for the bootstrap cwd', async () => {
       const harness = createClaudeCode();
       const recipe = await harness.getBootstrap!();
       const commands = recipe.commands.map(c => c.command);
-      expect(commands[0]).toContain('mkdir -p /tmp/harness/claude-code');
-      expect(commands[1]).toContain('pnpm');
-      expect(commands[1]).toContain('install --frozen-lockfile');
-      expect(commands[2]).toContain('claude --version');
+      expect(commands).toHaveLength(2);
+      expect(commands[0]).toBe(
+        'pnpm install --frozen-lockfile --store-dir .pnpm-store',
+      );
+      expect(commands[1]).toContain('claude --version');
+      expect(commands[1]).not.toContain('cd ');
     });
 
     it('caches the recipe across calls', async () => {

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
+import { posix } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   commonTool,
@@ -388,9 +389,9 @@ const CLAUDE_CODE_BUILTIN_TOOLS = {
 } as const satisfies Record<string, HarnessV1BuiltinTool<any, any>>;
 
 /*
- * Bootstrap lives in /tmp because it's pure derived state — the harness can
- * reinstall the CLI and bridge files on any fresh sandbox from the recipe.
- * Persistence comes from the sandbox provider's snapshot, not the path.
+ * Bootstrap is derived state stored under the sandbox's default working
+ * directory so snapshot-capable providers can preserve the installed CLI,
+ * bridge, and recipe marker without requiring root filesystem access.
  *
  * The session work dir (`startOpts.sessionWorkDir`) and the bridge-state dir
  * derived from `sandboxSession.defaultWorkingDirectory` both live under the sandbox's
@@ -399,7 +400,7 @@ const CLAUDE_CODE_BUILTIN_TOOLS = {
  * history is keyed by working directory) and the bridge state files survive
  * both detach -> attach/replay and stop -> snapshot -> resume cycles.
  */
-const BOOTSTRAP_DIR = '/tmp/harness/claude-code';
+const BOOTSTRAP_DIR = '.harness-bootstrap/claude-code';
 
 /**
  * Live bridge coordinates returned by `doDetach()` and `doSuspendTurn()`. A
@@ -460,12 +461,12 @@ export function createClaudeCode(
           { path: `${BOOTSTRAP_DIR}/bridge.mjs`, content: bridge },
         ],
         commands: [
-          { command: `mkdir -p ${BOOTSTRAP_DIR}` },
           {
-            command: `pnpm --dir ${BOOTSTRAP_DIR} install --frozen-lockfile --store-dir ${BOOTSTRAP_DIR}/.pnpm-store`,
+            command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
           },
           {
-            command: `cd ${BOOTSTRAP_DIR} && if [ -f node_modules/@anthropic-ai/claude-code/install.cjs ]; then node node_modules/@anthropic-ai/claude-code/install.cjs; fi && ./node_modules/.bin/claude --version`,
+            command:
+              'if [ -f node_modules/@anthropic-ai/claude-code/install.cjs ]; then node node_modules/@anthropic-ai/claude-code/install.cjs; fi && ./node_modules/.bin/claude --version',
           },
         ],
       };
@@ -475,6 +476,10 @@ export function createClaudeCode(
       const sandboxSession = startOpts.sandboxSession;
       const session = sandboxSession.restricted();
       const sandboxId = sandboxSession.id;
+      const bootstrapDir = posix.resolve(
+        sandboxSession.defaultWorkingDirectory,
+        BOOTSTRAP_DIR,
+      );
       const lifecycleState = startOpts.continueFrom ?? startOpts.resumeFrom;
       const isResume = lifecycleState != null;
       const isContinue = startOpts.continueFrom != null;
@@ -644,7 +649,7 @@ export function createClaudeCode(
       });
 
       const proc = await session.spawn({
-        command: `node ${BOOTSTRAP_DIR}/bridge.mjs --workdir ${shellQuote(workDir)} --bridge-state-dir ${shellQuote(bridgeStateDir)}`,
+        command: `node ${shellQuote(`${bootstrapDir}/bridge.mjs`)} --workdir ${shellQuote(workDir)} --bridge-state-dir ${shellQuote(bridgeStateDir)}`,
         env,
         abortSignal: startOpts.abortSignal,
       });

--- a/packages/harness-codex/src/codex-harness.test.ts
+++ b/packages/harness-codex/src/codex-harness.test.ts
@@ -190,7 +190,7 @@ describe('createCodex adapter', () => {
       "mkdir -p '/vercel/sandbox/codex-s1; env > /tmp/workdir-leak #' '/vercel/sandbox/.agent-runs/s1; env > /tmp/leak #/bridge'",
     );
     expect(spawns).toEqual([
-      "node /tmp/harness/codex/bridge.mjs --workdir '/vercel/sandbox/codex-s1; env > /tmp/workdir-leak #' --bridge-state-dir '/vercel/sandbox/.agent-runs/s1; env > /tmp/leak #/bridge' --cli-shim-dir '/vercel/sandbox/.agent-runs/s1; env > /tmp/leak #/codex'",
+      "node '/vercel/sandbox/.harness-bootstrap/codex/bridge.mjs' --workdir '/vercel/sandbox/codex-s1; env > /tmp/workdir-leak #' --bridge-state-dir '/vercel/sandbox/.agent-runs/s1; env > /tmp/leak #/bridge' --cli-shim-dir '/vercel/sandbox/.agent-runs/s1; env > /tmp/leak #/codex'",
     ]);
     expect(spawnEnvs.at(0)?.AI_SDK_HARNESS_CLIENT_APP).toBe(
       'ai-sdk/harness-codex/0.0.0-test',
@@ -205,7 +205,7 @@ describe('createCodex adapter', () => {
       expect(harness.getBootstrap).toBeDefined();
       const recipe = await harness.getBootstrap!();
       expect(recipe.harnessId).toBe('codex');
-      expect(recipe.bootstrapDir).toBe('/tmp/harness/codex');
+      expect(recipe.bootstrapDir).toBe('.harness-bootstrap/codex');
     });
 
     it('includes bridge.mjs, package.json, and pnpm-lock.yaml under the bootstrap dir', async () => {
@@ -213,22 +213,22 @@ describe('createCodex adapter', () => {
       const recipe = await harness.getBootstrap!();
       const paths = recipe.files.map(f => f.path).sort();
       expect(paths).toEqual([
-        '/tmp/harness/codex/bridge.mjs',
-        '/tmp/harness/codex/package.json',
-        '/tmp/harness/codex/pnpm-lock.yaml',
+        '.harness-bootstrap/codex/bridge.mjs',
+        '.harness-bootstrap/codex/package.json',
+        '.harness-bootstrap/codex/pnpm-lock.yaml',
       ]);
       for (const file of recipe.files) {
         expect(file.content.length).toBeGreaterThan(0);
       }
     });
 
-    it('declares mkdir and pnpm install commands', async () => {
+    it('declares a pnpm install command for the bootstrap cwd', async () => {
       const harness = createCodex();
       const recipe = await harness.getBootstrap!();
       const commands = recipe.commands.map(c => c.command);
-      expect(commands[0]).toContain('mkdir -p /tmp/harness/codex');
-      expect(commands[1]).toContain('pnpm');
-      expect(commands[1]).toContain('install --frozen-lockfile');
+      expect(commands).toEqual([
+        'pnpm install --frozen-lockfile --store-dir .pnpm-store',
+      ]);
     });
 
     it('caches the recipe across calls', async () => {

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -125,9 +125,9 @@ const CODEX_BUILTIN_TOOLS = {
 } as const satisfies Record<string, HarnessV1BuiltinTool<any, any>>;
 
 /*
- * Bootstrap lives in /tmp because it's pure derived state — the harness can
- * reinstall the CLI and bridge files on any fresh sandbox from the recipe.
- * Persistence comes from the sandbox provider's snapshot, not the path.
+ * Bootstrap is derived state stored under the sandbox's default working
+ * directory so snapshot-capable providers can preserve the installed CLI,
+ * bridge, and recipe marker without requiring root filesystem access.
  *
  * The session work dir (`startOpts.sessionWorkDir`) lives under the sandbox's
  * default working directory — the provider's persistent mount — so any files
@@ -135,7 +135,7 @@ const CODEX_BUILTIN_TOOLS = {
  * cycles. Harness infra derived from `sandboxSession.defaultWorkingDirectory`
  * lives under `.agent-runs`, outside the agent workdir.
  */
-const BOOTSTRAP_DIR = '/tmp/harness/codex';
+const BOOTSTRAP_DIR = '.harness-bootstrap/codex';
 
 /**
  * Live bridge coordinates returned by `doDetach()` and `doSuspendTurn()`. A
@@ -191,9 +191,8 @@ export function createCodex(
           { path: `${BOOTSTRAP_DIR}/bridge.mjs`, content: bridge },
         ],
         commands: [
-          { command: `mkdir -p ${BOOTSTRAP_DIR}` },
           {
-            command: `pnpm --dir ${BOOTSTRAP_DIR} install --frozen-lockfile --store-dir ${BOOTSTRAP_DIR}/.pnpm-store`,
+            command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
           },
         ],
       };
@@ -220,6 +219,10 @@ export function createCodex(
       const sandboxSession = startOpts.sandboxSession;
       const session = sandboxSession.restricted();
       const sandboxId = sandboxSession.id;
+      const bootstrapDir = path.posix.resolve(
+        sandboxSession.defaultWorkingDirectory,
+        BOOTSTRAP_DIR,
+      );
       const lifecycleState = startOpts.continueFrom ?? startOpts.resumeFrom;
       const isResume = lifecycleState != null;
       const isContinue = startOpts.continueFrom != null;
@@ -373,7 +376,7 @@ export function createCodex(
       });
 
       const proc = await session.spawn({
-        command: `node ${BOOTSTRAP_DIR}/bridge.mjs --workdir ${shellQuote(workDir)} --bridge-state-dir ${shellQuote(bridgeStateDir)} --cli-shim-dir ${shellQuote(cliShimDir)}`,
+        command: `node ${shellQuote(`${bootstrapDir}/bridge.mjs`)} --workdir ${shellQuote(workDir)} --bridge-state-dir ${shellQuote(bridgeStateDir)} --cli-shim-dir ${shellQuote(cliShimDir)}`,
         env,
         abortSignal: startOpts.abortSignal,
       });

--- a/packages/harness-deepagents/src/deepagents-harness.test.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.test.ts
@@ -57,18 +57,23 @@ function textStream(text: string): ReadableStream<Uint8Array> {
 
 function fakeSandboxSession({
   spawnEnvs,
+  spawns,
 }: {
   spawnEnvs?: Array<Record<string, string | undefined>>;
+  spawns?: string[];
 } = {}): HarnessV1NetworkSandboxSession {
   const session = {
     run: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
     readTextFile: async () => null,
     writeTextFile: async () => {},
     spawn: async ({
+      command,
       env,
     }: {
+      command: string;
       env?: Record<string, string | undefined>;
-    } = {}) => {
+    }) => {
+      spawns?.push(command);
       if (env) spawnEnvs?.push(env);
       return {
         stdout: textStream('{"type":"bridge-ready","port":4319}\n'),
@@ -119,17 +124,18 @@ describe('createDeepAgents', () => {
     const harness = createDeepAgents();
     const bootstrap = await harness.getBootstrap!();
     expect(bootstrap.harnessId).toBe('deepagents');
+    expect(bootstrap.bootstrapDir).toBe('.harness-bootstrap/deepagents');
     const paths = bootstrap.files.map(f => f.path);
-    expect(paths).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('bridge.mjs'),
-        expect.stringContaining('package.json'),
-        expect.stringContaining('pnpm-lock.yaml'),
-      ]),
-    );
+    expect(paths).toEqual([
+      '.harness-bootstrap/deepagents/bridge.mjs',
+      '.harness-bootstrap/deepagents/package.json',
+      '.harness-bootstrap/deepagents/pnpm-lock.yaml',
+    ]);
     const commands = bootstrap.commands.map(c => c.command).join('\n');
-    expect(commands).toContain('pnpm');
-    expect(commands).toContain('install');
+    expect(commands).toContain(
+      'pnpm install --frozen-lockfile --store-dir .pnpm-store',
+    );
+    expect(commands).not.toContain('mkdir -p .harness-bootstrap/deepagents');
   });
 
   it('caches the bootstrap across calls', async () => {
@@ -146,15 +152,22 @@ describe('createDeepAgents', () => {
 
   it('passes the harness client app to the bridge environment', async () => {
     const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const spawns: string[] = [];
     const harness = createDeepAgents();
     const session = await harness.doStart({
       sessionId: 'test-session',
       sessionWorkDir: '/vercel/sandbox/deepagents-test-session',
-      sandboxSession: fakeSandboxSession({ spawnEnvs }),
+      sandboxSession: fakeSandboxSession({ spawnEnvs, spawns }),
     } as unknown as Parameters<typeof harness.doStart>[0]);
 
     expect(spawnEnvs.at(0)?.AI_SDK_HARNESS_CLIENT_APP).toBe(
       'ai-sdk/harness-deepagents/0.0.0-test',
+    );
+    expect(spawns.at(0)).toContain(
+      "node '/vercel/sandbox/.harness-bootstrap/deepagents/bridge.mjs'",
+    );
+    expect(spawns.at(0)).toContain(
+      "--bootstrap-dir '/vercel/sandbox/.harness-bootstrap/deepagents'",
     );
 
     await session.doDestroy();

--- a/packages/harness-deepagents/src/deepagents-harness.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
+import { posix } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   commonTool,
@@ -47,8 +48,12 @@ import { VERSION } from './version';
 
 type DeepAgentsChannel = SandboxChannel<OutboundMessage, InboundMessage>;
 
-// Pure derived state in /tmp; reinstalled per sandbox, persistence is the provider snapshot.
-const BOOTSTRAP_DIR = '/tmp/harness/deepagents';
+/*
+ * Bootstrap is derived state stored under the sandbox's default working
+ * directory so snapshot-capable providers preserve its installation and
+ * recipe marker without requiring root filesystem access.
+ */
+const BOOTSTRAP_DIR = '.harness-bootstrap/deepagents';
 /**
  * Value to use in User-Agent and `x-client-app` headers.
  */
@@ -198,10 +203,9 @@ export function createDeepAgents(
           { path: `${BOOTSTRAP_DIR}/pnpm-lock.yaml`, content: lock },
         ],
         commands: [
-          { command: `mkdir -p ${BOOTSTRAP_DIR}` },
           { command: installRipgrepCommand() },
           {
-            command: `pnpm --dir ${BOOTSTRAP_DIR} install --frozen-lockfile --store-dir ${BOOTSTRAP_DIR}/.pnpm-store`,
+            command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
           },
         ],
       };
@@ -212,6 +216,10 @@ export function createDeepAgents(
       const sandboxSession = startOpts.sandboxSession;
       const session = sandboxSession.restricted();
       const sandboxId = sandboxSession.id;
+      const bootstrapDir = posix.resolve(
+        sandboxSession.defaultWorkingDirectory,
+        BOOTSTRAP_DIR,
+      );
 
       const lifecycleState = startOpts.continueFrom ?? startOpts.resumeFrom;
       const isResume = lifecycleState != null;
@@ -318,7 +326,7 @@ export function createDeepAgents(
       });
 
       const proc = await session.spawn({
-        command: `node ${BOOTSTRAP_DIR}/bridge.mjs --workdir ${shellQuote(workDir)} --bridge-state-dir ${shellQuote(bridgeStateDir)} --bootstrap-dir ${shellQuote(BOOTSTRAP_DIR)}`,
+        command: `node ${shellQuote(`${bootstrapDir}/bridge.mjs`)} --workdir ${shellQuote(workDir)} --bridge-state-dir ${shellQuote(bridgeStateDir)} --bootstrap-dir ${shellQuote(bootstrapDir)}`,
         env,
         abortSignal: startOpts.abortSignal,
       });

--- a/packages/harness-opencode/src/opencode-harness.test.ts
+++ b/packages/harness-opencode/src/opencode-harness.test.ts
@@ -241,6 +241,12 @@ describe('createOpenCode adapter', () => {
       'ai-sdk/harness-opencode/0.0.0-test',
     );
     expect(spawns.at(-1)?.command).toContain(
+      "node '/workspace/.harness-bootstrap/opencode/bridge.mjs'",
+    );
+    expect(spawns.at(-1)?.command).toContain(
+      "--bootstrap-dir '/workspace/.harness-bootstrap/opencode'",
+    );
+    expect(spawns.at(-1)?.command).toContain(
       "--skills-dir '/home/vercel-sandbox/.agents/skills'",
     );
   });
@@ -313,7 +319,7 @@ describe('createOpenCode adapter', () => {
       expect(harness.getBootstrap).toBeDefined();
       const recipe = await harness.getBootstrap!();
       expect(recipe.harnessId).toBe('opencode');
-      expect(recipe.bootstrapDir).toBe('/tmp/harness/opencode');
+      expect(recipe.bootstrapDir).toBe('.harness-bootstrap/opencode');
     });
 
     it('includes bridge assets under the bootstrap dir', async () => {
@@ -321,10 +327,10 @@ describe('createOpenCode adapter', () => {
       const recipe = await harness.getBootstrap!();
       const paths = recipe.files.map(file => file.path).sort();
       expect(paths).toEqual([
-        '/tmp/harness/opencode/bridge.mjs',
-        '/tmp/harness/opencode/host-tool-mcp.mjs',
-        '/tmp/harness/opencode/package.json',
-        '/tmp/harness/opencode/pnpm-lock.yaml',
+        '.harness-bootstrap/opencode/bridge.mjs',
+        '.harness-bootstrap/opencode/host-tool-mcp.mjs',
+        '.harness-bootstrap/opencode/package.json',
+        '.harness-bootstrap/opencode/pnpm-lock.yaml',
       ]);
       for (const file of recipe.files) {
         expect(file.content.length).toBeGreaterThan(0);
@@ -334,9 +340,12 @@ describe('createOpenCode adapter', () => {
     it('runs the OpenCode CLI postinstall during bootstrap', async () => {
       const harness = createOpenCode();
       const recipe = await harness.getBootstrap!();
+      expect(recipe.commands[0]).toEqual({
+        command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
+      });
       expect(recipe.commands).toContainEqual({
         command:
-          'cd /tmp/harness/opencode && node node_modules/opencode-ai/postinstall.mjs && ./node_modules/.bin/opencode --version',
+          'node node_modules/opencode-ai/postinstall.mjs && ./node_modules/.bin/opencode --version',
       });
     });
   });

--- a/packages/harness-opencode/src/opencode-harness.ts
+++ b/packages/harness-opencode/src/opencode-harness.ts
@@ -182,7 +182,7 @@ const OPENCODE_BUILTIN_TOOLS = {
   }),
 } as const satisfies Record<string, HarnessV1BuiltinTool<any, any>>;
 
-const BOOTSTRAP_DIR = '/tmp/harness/opencode';
+const BOOTSTRAP_DIR = '.harness-bootstrap/opencode';
 
 const openCodeBridgeCoordsSchema = z.object({
   port: z.number(),
@@ -230,12 +230,12 @@ export function createOpenCode(
           },
         ],
         commands: [
-          { command: `mkdir -p ${BOOTSTRAP_DIR}` },
           {
-            command: `pnpm --dir ${BOOTSTRAP_DIR} install --frozen-lockfile --store-dir ${BOOTSTRAP_DIR}/.pnpm-store`,
+            command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
           },
           {
-            command: `cd ${BOOTSTRAP_DIR} && node node_modules/opencode-ai/postinstall.mjs && ./node_modules/.bin/opencode --version`,
+            command:
+              'node node_modules/opencode-ai/postinstall.mjs && ./node_modules/.bin/opencode --version',
           },
         ],
       };
@@ -245,6 +245,10 @@ export function createOpenCode(
       const sandboxSession = startOpts.sandboxSession;
       const session = sandboxSession.restricted();
       const sandboxId = sandboxSession.id;
+      const bootstrapDir = path.posix.resolve(
+        sandboxSession.defaultWorkingDirectory,
+        BOOTSTRAP_DIR,
+      );
       const lifecycleState = startOpts.continueFrom ?? startOpts.resumeFrom;
       const isResume = lifecycleState != null;
       const isContinue = startOpts.continueFrom != null;
@@ -388,7 +392,7 @@ export function createOpenCode(
       });
 
       const proc = await session.spawn({
-        command: `node ${BOOTSTRAP_DIR}/bridge.mjs --workdir ${shellQuote(workDir)} --bridge-state-dir ${shellQuote(bridgeStateDir)} --bootstrap-dir ${shellQuote(BOOTSTRAP_DIR)}${skillSetup ? ` --skills-dir ${shellQuote(skillSetup.skillsDir)}` : ''}`,
+        command: `node ${shellQuote(`${bootstrapDir}/bridge.mjs`)} --workdir ${shellQuote(workDir)} --bridge-state-dir ${shellQuote(bridgeStateDir)} --bootstrap-dir ${shellQuote(bootstrapDir)}${skillSetup ? ` --skills-dir ${shellQuote(skillSetup.skillsDir)}` : ''}`,
         env,
         abortSignal: startOpts.abortSignal,
       });

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -111,6 +111,15 @@ See the [harness adapters documentation](https://ai-sdk.dev/v7/docs/ai-sdk-harne
 
 Implement the `HarnessV1` factory and a `HarnessV1Session` whose `doPromptTurn` emits events; the agent surface, streaming, tool execution, and multi-turn state are handled for you. Read `startOpts.sandboxSession` for the network sandbox session the agent created and will stop on cleanup. Call `sandboxSession.restricted()` for the tool-safe file-IO/exec/spawn surface.
 
+Bootstrap recipe paths may be absolute or relative. Relative `bootstrapDir` and
+file paths are resolved against `sandboxSession.defaultWorkingDirectory`.
+The framework creates `bootstrapDir` before writing files, and bootstrap
+commands run from that directory by default. A relative command
+`workingDirectory` override is resolved against the sandbox's default working
+directory. Prefer a relative directory such as
+`.harness-bootstrap/my-harness` so bootstrap assets are kept with the sandbox's
+snapshot-persistent working tree.
+
 ```ts
 import type { HarnessV1, HarnessV1Session } from '@ai-sdk/harness';
 

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -1397,7 +1397,7 @@ describe('HarnessAgent', () => {
     const base = mockHarness({ script: () => [] });
     const recipe: HarnessV1Bootstrap = {
       harnessId: 'mock',
-      bootstrapDir: '/tmp/mock-bootstrap',
+      bootstrapDir: '.harness-bootstrap/mock',
       files: [],
       commands: [],
     };
@@ -1407,7 +1407,11 @@ describe('HarnessAgent', () => {
     };
     const readTextFile = vi.fn(async () => null);
     const writeTextFile = vi.fn(async () => {});
-    const run = vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' }));
+    const run = vi.fn(async (args: { command: string }) => ({
+      exitCode: 0,
+      stdout: args.command === 'pwd' ? '/work\n' : '',
+      stderr: '',
+    }));
     const restrictedSession = {
       run,
       readTextFile,
@@ -1446,7 +1450,7 @@ describe('HarnessAgent', () => {
     >;
     const markerWrite = writeCalls.at(-1)?.[0];
     expect(markerWrite?.path).toMatch(
-      /^\/tmp\/mock-bootstrap\/\.bootstrap-[0-9a-f]{16}\.ok$/,
+      /^\/work\/\.harness-bootstrap\/mock\/\.bootstrap-[0-9a-f]{16}\.ok$/,
     );
 
     await session.destroy();

--- a/packages/harness/src/agent/harness-agent.ts
+++ b/packages/harness/src/agent/harness-agent.ts
@@ -310,12 +310,13 @@ export class HarnessAgent<
         sandboxBootstrapPlan.recipe != null &&
         sandboxBootstrapPlan.recipeIdentity != null
       ) {
-        await applyBootstrapRecipe(
-          sandboxSession.restricted(),
-          sandboxBootstrapPlan.recipe,
-          sandboxBootstrapPlan.recipeIdentity,
-          { abortSignal },
-        );
+        await applyBootstrapRecipe({
+          session: sandboxSession.restricted(),
+          recipe: sandboxBootstrapPlan.recipe,
+          identity: sandboxBootstrapPlan.recipeIdentity,
+          defaultWorkingDirectory: sandboxSession.defaultWorkingDirectory,
+          abortSignal,
+        });
       }
       await ensureSandboxDirectory({
         session: sandboxSession,

--- a/packages/harness/src/agent/internal/bootstrap-recipe.test.ts
+++ b/packages/harness/src/agent/internal/bootstrap-recipe.test.ts
@@ -15,8 +15,9 @@ const baseRecipe: HarnessV1Bootstrap = {
     { path: '/tmp/harness/demo/a.txt', content: 'one' },
     { path: '/tmp/harness/demo/b.txt', content: 'two' },
   ],
-  commands: [{ command: 'mkdir -p /tmp/harness/demo' }, { command: 'echo ok' }],
+  commands: [{ command: 'echo first' }, { command: 'echo second' }],
 };
+const defaultWorkingDirectory = '/work';
 
 describe('hashHarnessBootstrap', () => {
   it('produces a deterministic 16-char hex id for the same recipe', async () => {
@@ -79,9 +80,26 @@ describe('hashHarnessBootstrap', () => {
 
 describe('bootstrapMarkerPath', () => {
   it('embeds the identity in the filename under bootstrapDir', () => {
-    expect(bootstrapMarkerPath(baseRecipe, 'abc1234567890def')).toBe(
-      '/tmp/harness/demo/.bootstrap-abc1234567890def.ok',
-    );
+    expect(
+      bootstrapMarkerPath({
+        recipe: baseRecipe,
+        identity: 'abc1234567890def',
+        defaultWorkingDirectory,
+      }),
+    ).toBe('/tmp/harness/demo/.bootstrap-abc1234567890def.ok');
+  });
+
+  it('resolves a relative bootstrapDir against the default working directory', () => {
+    expect(
+      bootstrapMarkerPath({
+        recipe: {
+          ...baseRecipe,
+          bootstrapDir: '.harness-bootstrap/demo',
+        },
+        identity: 'abc1234567890def',
+        defaultWorkingDirectory,
+      }),
+    ).toBe('/work/.harness-bootstrap/demo/.bootstrap-abc1234567890def.ok');
   });
 });
 
@@ -90,6 +108,7 @@ describe('applyBootstrapRecipe', () => {
 
   function makeMockSession(opts?: {
     markerExists?: boolean;
+    directoryExitCode?: number;
     commandExitCode?: number;
     runFailureMessage?: string;
   }): {
@@ -98,17 +117,33 @@ describe('applyBootstrapRecipe', () => {
     writeTextFile: ReturnType<typeof vi.fn>;
     run: ReturnType<typeof vi.fn>;
   } {
-    const markerPath = bootstrapMarkerPath(baseRecipe, identity);
+    const markerPath = bootstrapMarkerPath({
+      recipe: baseRecipe,
+      identity,
+      defaultWorkingDirectory,
+    });
     const readTextFile = vi.fn(async (args: { path: string }) => {
       if (args.path === markerPath && opts?.markerExists) return '';
       return null;
     });
-    const writeTextFile = vi.fn(async () => {});
-    const run = vi.fn(async () => ({
-      exitCode: opts?.commandExitCode ?? 0,
-      stdout: 'ok',
-      stderr: opts?.runFailureMessage ?? '',
-    }));
+    const writeTextFile = vi.fn(async (_args: { path: string }) => {});
+    const run = vi.fn(
+      async (args: {
+        command: string;
+        workingDirectory?: string;
+        env?: Record<string, string>;
+      }) => {
+        const isDirectoryCreation =
+          args.command === 'mkdir -p "$BOOTSTRAP_DIR"';
+        return {
+          exitCode: isDirectoryCreation
+            ? (opts?.directoryExitCode ?? 0)
+            : (opts?.commandExitCode ?? 0),
+          stdout: 'ok',
+          stderr: opts?.runFailureMessage ?? '',
+        };
+      },
+    );
     const session = {
       description: 'mock',
       readTextFile,
@@ -122,21 +157,92 @@ describe('applyBootstrapRecipe', () => {
     const { session, readTextFile, writeTextFile, run } = makeMockSession({
       markerExists: true,
     });
-    await applyBootstrapRecipe(session, baseRecipe, identity);
+    await applyBootstrapRecipe({
+      session,
+      recipe: baseRecipe,
+      identity,
+      defaultWorkingDirectory,
+    });
     expect(readTextFile).toHaveBeenCalledTimes(1);
     expect(writeTextFile).not.toHaveBeenCalled();
     expect(run).not.toHaveBeenCalled();
   });
 
-  it('writes files, runs commands, and writes the marker on cold run', async () => {
+  it('creates the bootstrap directory, writes files, runs commands there, and writes the marker', async () => {
     const { session, writeTextFile, run } = makeMockSession();
-    await applyBootstrapRecipe(session, baseRecipe, identity);
+    await applyBootstrapRecipe({
+      session,
+      recipe: baseRecipe,
+      identity,
+      defaultWorkingDirectory,
+    });
     expect(writeTextFile).toHaveBeenCalledTimes(
       baseRecipe.files.length + 1, // recipe files + marker
     );
-    expect(run).toHaveBeenCalledTimes(baseRecipe.commands.length);
+    expect(run).toHaveBeenCalledTimes(baseRecipe.commands.length + 1);
+    expect(run).toHaveBeenNthCalledWith(1, {
+      command: 'mkdir -p "$BOOTSTRAP_DIR"',
+      workingDirectory: defaultWorkingDirectory,
+      env: { BOOTSTRAP_DIR: '/tmp/harness/demo' },
+      abortSignal: undefined,
+    });
+    expect(run.mock.calls.map(([args]) => args.workingDirectory)).toEqual([
+      defaultWorkingDirectory,
+      '/tmp/harness/demo',
+      '/tmp/harness/demo',
+    ]);
+    expect(run.mock.invocationCallOrder[0]!).toBeLessThan(
+      writeTextFile.mock.invocationCallOrder[0]!,
+    );
     const lastWrite = writeTextFile.mock.calls.at(-1)![0];
-    expect(lastWrite.path).toBe(bootstrapMarkerPath(baseRecipe, identity));
+    expect(lastWrite.path).toBe(
+      bootstrapMarkerPath({
+        recipe: baseRecipe,
+        identity,
+        defaultWorkingDirectory,
+      }),
+    );
+  });
+
+  it('resolves relative file paths and command working directories', async () => {
+    const relativeRecipe: HarnessV1Bootstrap = {
+      harnessId: 'demo',
+      bootstrapDir: '.harness-bootstrap/demo',
+      files: [
+        {
+          path: '.harness-bootstrap/demo/file.txt',
+          content: 'content',
+        },
+      ],
+      commands: [
+        { command: 'echo default' },
+        { command: 'echo relative', workingDirectory: 'tools' },
+        { command: 'echo absolute', workingDirectory: '/opt/tools' },
+      ],
+    };
+    const { session, readTextFile, writeTextFile, run } = makeMockSession();
+
+    await applyBootstrapRecipe({
+      session,
+      recipe: relativeRecipe,
+      identity,
+      defaultWorkingDirectory,
+    });
+
+    expect(readTextFile).toHaveBeenCalledWith({
+      path: '/work/.harness-bootstrap/demo/.bootstrap-idtest1234567890.ok',
+      abortSignal: undefined,
+    });
+    expect(writeTextFile.mock.calls.map(([args]) => args.path)).toEqual([
+      '/work/.harness-bootstrap/demo/file.txt',
+      '/work/.harness-bootstrap/demo/.bootstrap-idtest1234567890.ok',
+    ]);
+    expect(run.mock.calls.map(([args]) => args.workingDirectory)).toEqual([
+      '/work',
+      '/work/.harness-bootstrap/demo',
+      '/work/tools',
+      '/opt/tools',
+    ]);
   });
 
   it('throws when a command exits non-zero and skips the marker write', async () => {
@@ -145,13 +251,44 @@ describe('applyBootstrapRecipe', () => {
       runFailureMessage: 'boom',
     });
     await expect(
-      applyBootstrapRecipe(session, baseRecipe, identity),
+      applyBootstrapRecipe({
+        session,
+        recipe: baseRecipe,
+        identity,
+        defaultWorkingDirectory,
+      }),
     ).rejects.toThrow(/Bootstrap command failed.*exit 7.*boom/s);
-    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledTimes(2);
     const markerWrites = writeTextFile.mock.calls.filter(
-      ([args]) => args.path === bootstrapMarkerPath(baseRecipe, identity),
+      ([args]) =>
+        args.path ===
+        bootstrapMarkerPath({
+          recipe: baseRecipe,
+          identity,
+          defaultWorkingDirectory,
+        }),
     );
     expect(markerWrites).toHaveLength(0);
+  });
+
+  it('stops before writing files when bootstrap directory creation fails', async () => {
+    const { session, writeTextFile, run } = makeMockSession({
+      directoryExitCode: 9,
+      runFailureMessage: 'mkdir failed',
+    });
+
+    await expect(
+      applyBootstrapRecipe({
+        session,
+        recipe: baseRecipe,
+        identity,
+        defaultWorkingDirectory,
+      }),
+    ).rejects.toThrow(
+      /Failed to create bootstrap directory.*exit 9.*mkdir failed/s,
+    );
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(writeTextFile).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/harness/src/agent/internal/bootstrap-recipe.ts
+++ b/packages/harness/src/agent/internal/bootstrap-recipe.ts
@@ -1,3 +1,4 @@
+import { posix } from 'node:path';
 import type { Experimental_SandboxSession as SandboxSession } from '@ai-sdk/provider-utils';
 import type { HarnessV1Bootstrap } from '../../v1';
 
@@ -59,55 +60,102 @@ export async function hashHarnessBootstrap(
 
 /**
  * Absolute path of the marker file the framework writes after a recipe runs
- * successfully. Presence of this path inside the sandbox indicates the
- * recipe with the matching `identity` has already been applied.
+ * successfully. Presence of this path inside the sandbox indicates the recipe
+ * with the matching `identity` has already been applied.
  */
-export function bootstrapMarkerPath(
-  recipe: HarnessV1Bootstrap,
-  identity: string,
-): string {
-  return `${recipe.bootstrapDir}/.bootstrap-${identity}.ok`;
+export function bootstrapMarkerPath({
+  recipe,
+  identity,
+  defaultWorkingDirectory,
+}: {
+  recipe: HarnessV1Bootstrap;
+  identity: string;
+  defaultWorkingDirectory: string;
+}): string {
+  return posix.join(
+    resolveBootstrapPath({
+      path: recipe.bootstrapDir,
+      defaultWorkingDirectory,
+    }),
+    `.bootstrap-${identity}.ok`,
+  );
 }
 
 /**
  * Apply a bootstrap recipe to a sandbox session idempotently. Reads the
- * marker file; if it exists, returns immediately. Otherwise writes the
- * recipe's files, runs its commands sequentially, and writes the marker
- * on success.
+ * marker file; if it exists, returns immediately. Otherwise creates the
+ * bootstrap directory, writes the recipe's files, runs its commands
+ * sequentially, and writes the marker on success.
  *
  * Safe to call multiple times. For sandboxes that already contain the
  * recipe (resumed from snapshot, reused across sessions, or applied by
  * an earlier process) this is a single fast read.
  */
-export async function applyBootstrapRecipe(
-  session: SandboxSession,
-  recipe: HarnessV1Bootstrap,
-  identity: string,
-  options?: { abortSignal?: AbortSignal },
-): Promise<void> {
-  const markerPath = bootstrapMarkerPath(recipe, identity);
+export async function applyBootstrapRecipe({
+  session,
+  recipe,
+  identity,
+  defaultWorkingDirectory,
+  abortSignal,
+}: {
+  session: SandboxSession;
+  recipe: HarnessV1Bootstrap;
+  identity: string;
+  defaultWorkingDirectory: string;
+  abortSignal?: AbortSignal;
+}): Promise<void> {
+  const markerPath = bootstrapMarkerPath({
+    recipe,
+    identity,
+    defaultWorkingDirectory,
+  });
 
   const existingMarker = await session.readTextFile({
     path: markerPath,
-    abortSignal: options?.abortSignal,
+    abortSignal,
   });
   if (existingMarker !== null) {
     return;
   }
 
+  const bootstrapDir = resolveBootstrapPath({
+    path: recipe.bootstrapDir,
+    defaultWorkingDirectory,
+  });
+  const mkdirResult = await session.run({
+    command: 'mkdir -p "$BOOTSTRAP_DIR"',
+    workingDirectory: defaultWorkingDirectory,
+    env: { BOOTSTRAP_DIR: bootstrapDir },
+    abortSignal,
+  });
+  if (mkdirResult.exitCode !== 0) {
+    throw new Error(
+      `Failed to create bootstrap directory for harness '${recipe.harnessId}' (exit ${mkdirResult.exitCode}): ${bootstrapDir}\n${mkdirResult.stderr || mkdirResult.stdout}`,
+    );
+  }
+
   for (const file of recipe.files) {
     await session.writeTextFile({
-      path: file.path,
+      path: resolveBootstrapPath({
+        path: file.path,
+        defaultWorkingDirectory,
+      }),
       content: file.content,
-      abortSignal: options?.abortSignal,
+      abortSignal,
     });
   }
 
   for (const cmd of recipe.commands) {
     const result = await session.run({
       command: cmd.command,
-      workingDirectory: cmd.workingDirectory,
-      abortSignal: options?.abortSignal,
+      workingDirectory:
+        cmd.workingDirectory == null
+          ? bootstrapDir
+          : resolveBootstrapPath({
+              path: cmd.workingDirectory,
+              defaultWorkingDirectory,
+            }),
+      abortSignal,
     });
     if (result.exitCode !== 0) {
       throw new Error(
@@ -119,6 +167,18 @@ export async function applyBootstrapRecipe(
   await session.writeTextFile({
     path: markerPath,
     content: '',
-    abortSignal: options?.abortSignal,
+    abortSignal,
   });
+}
+
+function resolveBootstrapPath({
+  path,
+  defaultWorkingDirectory,
+}: {
+  path: string;
+  defaultWorkingDirectory: string;
+}): string {
+  return posix.isAbsolute(path)
+    ? path
+    : posix.resolve(defaultWorkingDirectory, path);
 }

--- a/packages/harness/src/agent/internal/sandbox-bootstrap.test.ts
+++ b/packages/harness/src/agent/internal/sandbox-bootstrap.test.ts
@@ -12,8 +12,8 @@ import {
 
 const recipe: HarnessV1Bootstrap = {
   harnessId: 'demo',
-  bootstrapDir: '/tmp/harness/demo',
-  files: [{ path: '/tmp/harness/demo/a.txt', content: 'one' }],
+  bootstrapDir: '.harness-bootstrap/demo',
+  files: [{ path: '.harness-bootstrap/demo/a.txt', content: 'one' }],
   commands: [{ command: 'echo ok' }],
 };
 
@@ -23,12 +23,14 @@ function makeSession(): {
   readTextFile: ReturnType<typeof vi.fn>;
   writeTextFile: ReturnType<typeof vi.fn>;
 } {
-  const run = vi.fn(async (args: { command: string }) => {
-    if (args.command === 'pwd') {
-      return { exitCode: 0, stdout: '/work\n', stderr: '' };
-    }
-    return { exitCode: 0, stdout: '', stderr: '' };
-  });
+  const run = vi.fn(
+    async (args: { command: string; workingDirectory?: string }) => {
+      if (args.command === 'pwd') {
+        return { exitCode: 0, stdout: '/work\n', stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    },
+  );
   const readTextFile = vi.fn(async () => null);
   const writeTextFile = vi.fn(async () => {});
   return {
@@ -143,7 +145,7 @@ describe('resolveSessionWorkDir', () => {
 
 describe('runSandboxBootstrap', () => {
   it('runs built-in bootstrap before caller bootstrap', async () => {
-    const { session, run } = makeSession();
+    const { session, run, readTextFile, writeTextFile } = makeSession();
     const onSandboxBootstrap = vi.fn(async () => {});
     const recipeIdentity = await hashHarnessBootstrap(recipe);
 
@@ -161,11 +163,23 @@ describe('runSandboxBootstrap', () => {
       abortSignal: undefined,
     });
     expect(run.mock.calls.map(([args]) => args.command)).toEqual([
-      'echo ok',
       'pwd',
+      'mkdir -p "$BOOTSTRAP_DIR"',
+      'echo ok',
       'mkdir -p "$WORK_DIR"',
     ]);
-    expect(run.mock.invocationCallOrder[0]!).toBeLessThan(
+    expect(readTextFile).toHaveBeenCalledWith({
+      path: expect.stringMatching(
+        /^\/work\/\.harness-bootstrap\/demo\/\.bootstrap-[0-9a-f]{16}\.ok$/,
+      ),
+      abortSignal: undefined,
+    });
+    expect(writeTextFile).toHaveBeenCalledWith({
+      path: '/work/.harness-bootstrap/demo/a.txt',
+      content: 'one',
+      abortSignal: undefined,
+    });
+    expect(run.mock.invocationCallOrder[2]!).toBeLessThan(
       onSandboxBootstrap.mock.invocationCallOrder[0]!,
     );
   });

--- a/packages/harness/src/agent/internal/sandbox-bootstrap.ts
+++ b/packages/harness/src/agent/internal/sandbox-bootstrap.ts
@@ -133,6 +133,7 @@ export async function runSandboxBootstrap({
   recipeIdentity,
   workDir,
   onBootstrap,
+  defaultWorkingDirectory,
   abortSignal,
 }: {
   readonly session: SandboxSession;
@@ -140,25 +141,35 @@ export async function runSandboxBootstrap({
   readonly recipeIdentity?: string;
   readonly workDir?: string;
   readonly onBootstrap?: SandboxBootstrapSettings['onBootstrap'];
+  readonly defaultWorkingDirectory?: string;
   readonly abortSignal?: AbortSignal;
 }): Promise<void> {
+  if (recipe == null && onBootstrap == null) return;
+
+  const resolvedDefaultWorkingDirectory =
+    defaultWorkingDirectory ??
+    (await resolveDefaultWorkingDirectory({
+      session,
+      abortSignal,
+    }));
+
   if (recipe != null && recipeIdentity != null) {
-    await applyBootstrapRecipe(session, recipe, recipeIdentity, {
+    await applyBootstrapRecipe({
+      session,
+      recipe,
+      identity: recipeIdentity,
+      defaultWorkingDirectory: resolvedDefaultWorkingDirectory,
       abortSignal,
     });
   }
 
   if (onBootstrap == null) return;
 
-  const defaultWorkingDirectory = await resolveDefaultWorkingDirectory({
-    session,
-    abortSignal,
-  });
   const bootstrapWorkDir =
     workDir == null
-      ? defaultWorkingDirectory
+      ? resolvedDefaultWorkingDirectory
       : joinSandboxPath({
-          base: defaultWorkingDirectory,
+          base: resolvedDefaultWorkingDirectory,
           path: workDir,
         });
 

--- a/packages/harness/src/agent/prepare-harness-sandbox-template.ts
+++ b/packages/harness/src/agent/prepare-harness-sandbox-template.ts
@@ -50,14 +50,13 @@ export async function prepareHarnessSandboxTemplate(options: {
 
   try {
     if (bootstrapPlan.recipe != null && bootstrapPlan.recipeIdentity != null) {
-      await applyBootstrapRecipe(
-        sandboxSession.restricted(),
-        bootstrapPlan.recipe,
-        bootstrapPlan.recipeIdentity,
-        {
-          abortSignal: options.abortSignal,
-        },
-      );
+      await applyBootstrapRecipe({
+        session: sandboxSession.restricted(),
+        recipe: bootstrapPlan.recipe,
+        identity: bootstrapPlan.recipeIdentity,
+        defaultWorkingDirectory: sandboxSession.defaultWorkingDirectory,
+        abortSignal: options.abortSignal,
+      });
     }
   } finally {
     await Promise.resolve(sandboxSession.stop()).catch(() => {});

--- a/packages/harness/src/agent/prepare-sandbox-for-harness.test.ts
+++ b/packages/harness/src/agent/prepare-sandbox-for-harness.test.ts
@@ -7,10 +7,10 @@ import { prepareSandboxForHarness } from './prepare-sandbox-for-harness';
 function makeRecipe(harnessId: string): HarnessV1Bootstrap {
   return {
     harnessId,
-    bootstrapDir: `/tmp/harness/${harnessId}`,
+    bootstrapDir: `.harness-bootstrap/${harnessId}`,
     files: [
       {
-        path: `/tmp/harness/${harnessId}/file.txt`,
+        path: `.harness-bootstrap/${harnessId}/file.txt`,
         content: harnessId,
       },
     ],
@@ -91,9 +91,11 @@ describe('prepareSandboxForHarness', () => {
       skippedHarnessIds: [],
     });
     expect(run.mock.calls.map(([args]) => args.command)).toEqual([
-      'echo alpha',
-      'echo beta',
       'pwd',
+      'mkdir -p "$BOOTSTRAP_DIR"',
+      'echo alpha',
+      'mkdir -p "$BOOTSTRAP_DIR"',
+      'echo beta',
       'mkdir -p "$WORK_DIR"',
     ]);
     expect(onBootstrap).toHaveBeenCalledWith({

--- a/packages/harness/src/agent/prepare-sandbox-for-harness.ts
+++ b/packages/harness/src/agent/prepare-sandbox-for-harness.ts
@@ -7,6 +7,7 @@ import {
 } from './internal/bootstrap-recipe';
 import {
   normalizeSandboxWorkDir,
+  resolveDefaultWorkingDirectory,
   runSandboxBootstrap,
   validateSandboxBootstrapSettings,
 } from './internal/sandbox-bootstrap';
@@ -62,6 +63,7 @@ export async function prepareSandboxForHarness(options: {
       : normalizeSandboxWorkDir(sandboxConfig.workDir);
   const recipeIdentities: Record<string, string> = {};
   const skippedHarnessIds: string[] = [];
+  let defaultWorkingDirectory: string | undefined;
 
   for (const harness of harnesses) {
     const recipe = await harness.getBootstrap?.({
@@ -74,7 +76,15 @@ export async function prepareSandboxForHarness(options: {
 
     const recipeIdentity = await hashHarnessBootstrap(recipe);
     recipeIdentities[harness.harnessId] = recipeIdentity;
-    await applyBootstrapRecipe(options.session, recipe, recipeIdentity, {
+    defaultWorkingDirectory ??= await resolveDefaultWorkingDirectory({
+      session: options.session,
+      abortSignal: options.abortSignal,
+    });
+    await applyBootstrapRecipe({
+      session: options.session,
+      recipe,
+      identity: recipeIdentity,
+      defaultWorkingDirectory,
       abortSignal: options.abortSignal,
     });
   }
@@ -84,6 +94,7 @@ export async function prepareSandboxForHarness(options: {
       session: options.session,
       workDir,
       onBootstrap: sandboxConfig.onBootstrap,
+      defaultWorkingDirectory,
       abortSignal: options.abortSignal,
     });
   }

--- a/packages/harness/src/v1/harness-v1-bootstrap.ts
+++ b/packages/harness/src/v1/harness-v1-bootstrap.ts
@@ -1,6 +1,8 @@
 /**
  * One file to write into the sandbox as part of an adapter's bootstrap recipe.
- * Paths should live under {@link HarnessV1Bootstrap.bootstrapDir}.
+ * Absolute paths are used as-is. Relative paths are resolved against the
+ * sandbox's default working directory. Paths should live under
+ * {@link HarnessV1Bootstrap.bootstrapDir}.
  */
 export interface HarnessV1BootstrapFile {
   readonly path: string;
@@ -14,6 +16,11 @@ export interface HarnessV1BootstrapFile {
  */
 export interface HarnessV1BootstrapCommand {
   readonly command: string;
+  /**
+   * Absolute working directories are used as-is. Relative working directories
+   * are resolved against the sandbox's default working directory. When
+   * omitted, the command runs from the recipe's bootstrap directory.
+   */
   readonly workingDirectory?: string;
 }
 
@@ -31,16 +38,17 @@ export interface HarnessV1Bootstrap {
   readonly harnessId: string;
 
   /**
-   * Absolute path inside the sandbox where this recipe writes its state.
-   * The marker file lives directly under it. Files declared in {@link files}
-   * should also use this prefix so an adapter upgrade can sweep stale state
-   * by clearing the directory.
+   * Path inside the sandbox where this recipe writes its state. Absolute paths
+   * are used as-is. Relative paths are resolved against the sandbox's default
+   * working directory. The marker file lives directly under it. Files
+   * declared in {@link files} should also use this prefix so an adapter upgrade
+   * can sweep stale state by clearing the directory.
    */
   readonly bootstrapDir: string;
 
   /** Files to write into the sandbox before any command runs. */
   readonly files: ReadonlyArray<HarnessV1BootstrapFile>;
 
-  /** Commands to run after files are written, in order. */
+  /** Commands to run from the bootstrap directory after files are written. */
   readonly commands: ReadonlyArray<HarnessV1BootstrapCommand>;
 }


### PR DESCRIPTION
## Background

MicroVM sandbox providers commonly mount `/tmp` as tmpfs, so bootstrap files stored there are excluded from disk snapshots and therefore cause repeated expensive harness installation processes for every session.

## Summary

Bootstrap recipes can now use paths relative to the sandbox's default working directory while existing absolute paths remain supported.

- Create each recipe's bootstrap directory in the harness layer and run commands from it by default.
- Resolve relative bootstrap, file, and explicit command working-directory paths against the sandbox's default working directory.
- Store Claude Code, Codex, DeepAgents, and OpenCode bootstrap assets under `.harness-bootstrap/<id>`.
- Update tests, documentation, and the snapshot preparation example for the new behavior.

## Contributor Credit

Thanks to @Flo5k5 for the issue report, microsandbox reproduction, and performance measurements.

## End-to-End Verification

- Ran `examples/ai-functions/src/harness-agent/prepare-sandbox-for-harness.ts` and confirmed bootstrap assets for all four changed adapters existed before snapshotting and after snapshot restore.
- Ran fresh sessions with all bridge harnesses in `examples/harness-e2e-next` and confirmed their bridge runs from the new location.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #18210
