### PR TITLE
fix(harness-codex): set default model back to `gpt-5.5` due to upstream SDK issue with newer models

### DIFF
--- a/.changeset/lovely-scissors-lie.md
+++ b/.changeset/lovely-scissors-lie.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-codex": patch
+---
+
+fix(harness-codex): set default model back to `gpt-5.5` due to upstream SDK issue with newer models

--- a/packages/harness-codex/src/codex-harness.test.ts
+++ b/packages/harness-codex/src/codex-harness.test.ts
@@ -195,7 +195,7 @@ describe('createCodex adapter', () => {
     expect(spawnEnvs.at(0)?.AI_SDK_HARNESS_CLIENT_APP).toBe(
       'ai-sdk/harness-codex/0.0.0-test',
     );
-    expect(session.modelId).toBe('gpt-5.6-sol');
+    expect(session.modelId).toBe('gpt-5.5');
     await session.doDestroy();
   });
 

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -57,15 +57,16 @@ type WriteSkillsResult = {
 };
 
 /*
- * The model the adapter pins when the consumer configures none. The Codex SDK
- * does not report the model it resolves to at runtime (no model field on any
- * event), and exposes no default-model constant, so we pin the latest
- * default model resolved by the bundled `@openai/codex@0.144.5`:
- * `gpt-5.6-sol`. Keep this in sync when bumping the codex SDK/binary. Passing
- * it explicitly makes the resolved model deterministic and the telemetry
- * (`gen_ai.request.model`) accurate.
+ * This intentionally is not the latest Codex model. Newer GPT-5.6 models use
+ * Responses Lite, which does not expose their code-mode tools as callable
+ * through the custom model provider used by the harness. Keep GPT-5.5 as the
+ * default until the upstream bug is resolved:
+ * https://github.com/openai/codex/issues/31894
+ *
+ * Passing the model explicitly keeps the runtime behavior deterministic and
+ * the telemetry (`gen_ai.request.model`) accurate.
  */
-const DEFAULT_CODEX_MODEL = 'gpt-5.6-sol';
+const DEFAULT_CODEX_MODEL = 'gpt-5.5';
 
 /**
  * Value to use in User-Agent and `x-client-app` headers.


### PR DESCRIPTION
## Background

The Codex harness currently defaults to `gpt-5.6-sol` (updated in #17810). However, the newer GPT-5.6 models use Responses Lite, which does not expose their code-mode tools as callable through the custom model provider used by the harness. As a result, Codex sessions currently report that shell and file-editing tools are unavailable.

This is tracked upstream in https://github.com/openai/codex/issues/31894.

## Summary

- Change the default Codex harness model from `gpt-5.6-sol` to `gpt-5.5` until the upstream issue is resolved
  - This is obviously not a proper fix, but the issue is upstream
  - For now a working older model default is better than a broken default
  - Users can still attempt to use the newer models via the `model` field of `createCodex()`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
