### PR TITLE
fix(harness): remove unused and unnecessary `workingDirectory` property from `HarnessV1BootstrapCommand`

### DIFF
--- a/.changeset/long-spiders-eat.md
+++ b/.changeset/long-spiders-eat.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness": patch
+---
+
+fix(harness): remove unused and unnecessary `workingDirectory` property from `HarnessV1BootstrapCommand`

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -114,9 +114,7 @@ Implement the `HarnessV1` factory and a `HarnessV1Session` whose `doPromptTurn` 
 Bootstrap recipe paths may be absolute or relative. Relative `bootstrapDir` and
 file paths are resolved against `sandboxSession.defaultWorkingDirectory`.
 The framework creates `bootstrapDir` before writing files, and bootstrap
-commands run from that directory by default. A relative command
-`workingDirectory` override is resolved against the sandbox's default working
-directory. Prefer a relative directory such as
+commands always run from that directory. Prefer a relative directory such as
 `.harness-bootstrap/my-harness` so bootstrap assets are kept with the sandbox's
 snapshot-persistent working tree.
 

--- a/packages/harness/src/agent/internal/bootstrap-recipe.test.ts
+++ b/packages/harness/src/agent/internal/bootstrap-recipe.test.ts
@@ -204,7 +204,7 @@ describe('applyBootstrapRecipe', () => {
     );
   });
 
-  it('resolves relative file paths and command working directories', async () => {
+  it('resolves relative paths and runs commands from the bootstrap directory', async () => {
     const relativeRecipe: HarnessV1Bootstrap = {
       harnessId: 'demo',
       bootstrapDir: '.harness-bootstrap/demo',
@@ -214,11 +214,7 @@ describe('applyBootstrapRecipe', () => {
           content: 'content',
         },
       ],
-      commands: [
-        { command: 'echo default' },
-        { command: 'echo relative', workingDirectory: 'tools' },
-        { command: 'echo absolute', workingDirectory: '/opt/tools' },
-      ],
+      commands: [{ command: 'echo first' }, { command: 'echo second' }],
     };
     const { session, readTextFile, writeTextFile, run } = makeMockSession();
 
@@ -240,8 +236,7 @@ describe('applyBootstrapRecipe', () => {
     expect(run.mock.calls.map(([args]) => args.workingDirectory)).toEqual([
       '/work',
       '/work/.harness-bootstrap/demo',
-      '/work/tools',
-      '/opt/tools',
+      '/work/.harness-bootstrap/demo',
     ]);
   });
 

--- a/packages/harness/src/agent/internal/bootstrap-recipe.ts
+++ b/packages/harness/src/agent/internal/bootstrap-recipe.ts
@@ -148,13 +148,7 @@ export async function applyBootstrapRecipe({
   for (const cmd of recipe.commands) {
     const result = await session.run({
       command: cmd.command,
-      workingDirectory:
-        cmd.workingDirectory == null
-          ? bootstrapDir
-          : resolveBootstrapPath({
-              path: cmd.workingDirectory,
-              defaultWorkingDirectory,
-            }),
+      workingDirectory: bootstrapDir,
       abortSignal,
     });
     if (result.exitCode !== 0) {

--- a/packages/harness/src/v1/harness-v1-bootstrap.ts
+++ b/packages/harness/src/v1/harness-v1-bootstrap.ts
@@ -16,12 +16,6 @@ export interface HarnessV1BootstrapFile {
  */
 export interface HarnessV1BootstrapCommand {
   readonly command: string;
-  /**
-   * Absolute working directories are used as-is. Relative working directories
-   * are resolved against the sandbox's default working directory. When
-   * omitted, the command runs from the recipe's bootstrap directory.
-   */
-  readonly workingDirectory?: string;
 }
 
 /**


### PR DESCRIPTION
## Background

`HarnessV1BootstrapCommand.workingDirectory` was unused and allowed individual commands to bypass the centrally controlled bootstrap directory.

## Summary

- Remove `workingDirectory` from `HarnessV1BootstrapCommand`.
- Always run bootstrap commands from the resolved recipe `bootstrapDir`.
- Update bootstrap tests and documentation to reflect the invariant.

While this is a spec change, the harness layer is still experimental and this is extremely low-level. It was never encouraged or documented anywhere and therefore should be safe to remove without a deprecation strategy, also because it could only affect external harness implementations, not users of `HarnessAgent`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
