### PR TITLE
feat(ai): support tool approvals in code mode

### DIFF
--- a/.changeset/fifty-glasses-drive.md
+++ b/.changeset/fifty-glasses-drive.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/provider-utils": patch
+"@ai-sdk/code-mode": patch
+"ai": patch
+---
+
+feat(ai): support tool approvals in code mode

--- a/content/docs/03-ai-sdk-core/18-code-mode.mdx
+++ b/content/docs/03-ai-sdk-core/18-code-mode.mdx
@@ -134,6 +134,70 @@ const user = await tools['lookup-user']({ userId: 'user_123' });
 return { id: user.id, plan: user.plan };
 ```
 
+## Tool Approvals
+
+Use the regular `toolApproval` option to require approval for code mode itself,
+for tools called by code mode, or both. When a nested tool requires manual
+approval, code mode pauses and returns a standard `tool-approval-request`.
+Calling `generateText` or `streamText` again with the approval response resumes
+the same program. A program can pause more than once if it calls multiple tools
+that require approval.
+
+This example requires approval for the generated code and for
+`getInventory`, using the tools defined above:
+
+```ts
+import { generateText, type ModelMessage, type ToolApprovalResponse } from 'ai';
+
+const messages: ModelMessage[] = [
+  {
+    role: 'user',
+    content: 'Compare inventory and demand for product sku_123.',
+  },
+];
+
+while (true) {
+  const result = await generateText({
+    model: __MODEL__,
+    tools,
+    experimental_toolCallers: {
+      getInventory: ['code_mode'],
+      getDemand: ['code_mode'],
+    },
+    toolApproval: {
+      code_mode: 'user-approval',
+      getInventory: 'user-approval',
+    },
+    messages,
+  });
+
+  messages.push(...result.responseMessages);
+
+  const responses: ToolApprovalResponse[] = [];
+  for (const part of result.content) {
+    if (part.type === 'tool-approval-request' && !part.isAutomatic) {
+      responses.push({
+        type: 'tool-approval-response',
+        approvalId: part.approvalId,
+        approved: await requestUserApproval(part.toolCall),
+      });
+    }
+  }
+
+  if (responses.length === 0) {
+    break;
+  }
+
+  messages.push({ role: 'tool', content: responses });
+}
+```
+
+`requestUserApproval` represents your application-specific UI or confirmation
+logic. Omit `code_mode` from `toolApproval` if the generated program may run
+without approval, while still protecting selected nested tools. See
+[Tool Execution Approval](/docs/ai-sdk-core/tools-and-tool-calling#tool-execution-approval)
+for dynamic policies and UI integration.
+
 ## Writing Code Mode Programs
 
 Generated programs support:
@@ -245,5 +309,5 @@ to code mode.
 Tool input schemas are validated before their `execute` functions run. Abort
 signals and AI SDK tool execution context are forwarded to nested tool calls.
 
-Code mode does not currently support approval flows for nested tool calls.
-Tools that require approval are rejected instead of being executed.
+Nested tool calls use the same `toolApproval` configuration as directly called
+tools.

--- a/examples/ai-e2e-next/agent/code-mode/code-mode-tool-approval-agent.ts
+++ b/examples/ai-e2e-next/agent/code-mode/code-mode-tool-approval-agent.ts
@@ -50,6 +50,9 @@ export const codeModeToolApprovalAgent = new ToolLoopAgent({
     'You are a purchasing assistant. Use code mode to coordinate the available tools. ' +
     'When the user asks to buy a product, look up its price, calculate the total, and purchase it. ',
   tools,
+  onStepEnd: result => {
+    console.log(JSON.stringify(result.content, null, 2));
+  },
   experimental_toolCallers: ({ codeMode }) => ({
     getProductPrice: [codeMode],
     purchaseProduct: [codeMode],

--- a/examples/ai-e2e-next/agent/code-mode/code-mode-tool-approval-agent.ts
+++ b/examples/ai-e2e-next/agent/code-mode/code-mode-tool-approval-agent.ts
@@ -17,6 +17,53 @@ const getProductPrice = tool({
   }),
 });
 
+const checkProductInventory = tool({
+  description: 'Check how many units of a product are currently in stock.',
+  inputSchema: z.object({
+    productId: z.string(),
+  }),
+  outputSchema: z.object({
+    productId: z.string(),
+    availableQuantity: z.number(),
+  }),
+  execute: async ({ productId }) => ({
+    productId,
+    availableQuantity: 10,
+  }),
+});
+
+const getCustomerDiscount = tool({
+  description: 'Get the discount percentage available to a customer.',
+  inputSchema: z.object({
+    customerId: z.string(),
+  }),
+  outputSchema: z.object({
+    customerId: z.string(),
+    discountPercentage: z.number(),
+  }),
+  execute: async ({ customerId }) => ({
+    customerId,
+    discountPercentage: 10,
+  }),
+});
+
+const getShippingCost = tool({
+  description: 'Get the shipping cost for a product quantity and postal code.',
+  inputSchema: z.object({
+    productId: z.string(),
+    quantity: z.number(),
+    postalCode: z.string(),
+  }),
+  outputSchema: z.object({
+    productId: z.string(),
+    shippingCost: z.number(),
+  }),
+  execute: async ({ productId }) => ({
+    productId,
+    shippingCost: 8,
+  }),
+});
+
 const purchaseProduct = tool({
   description: 'Purchase a quantity of a product for the provided total.',
   inputSchema: z.object({
@@ -41,26 +88,33 @@ const purchaseProduct = tool({
 const tools = {
   codeMode: codeModeTool(),
   getProductPrice,
+  checkProductInventory,
+  getCustomerDiscount,
+  getShippingCost,
   purchaseProduct,
 } as const;
 
 export const codeModeToolApprovalAgent = new ToolLoopAgent({
   model: 'openai/gpt-5.6-sol',
-  instructions:
-    'You are a purchasing assistant. Use code mode to coordinate the available tools. ' +
-    'When the user asks to buy a product, look up its price, calculate the total, and purchase it. ',
+  instructions: 'You are a purchasing assistant',
   tools,
   onStepEnd: result => {
     console.log(JSON.stringify(result.content, null, 2));
   },
   experimental_toolCallers: {
     getProductPrice: ['codeMode'],
+    checkProductInventory: ['codeMode'],
+    getCustomerDiscount: ['codeMode'],
+    getShippingCost: ['codeMode'],
     purchaseProduct: ['codeMode'],
   },
   toolApproval: {
     codeMode: 'user-approval',
     getProductPrice: 'user-approval',
-    purchaseProduct: 'user-approval',
+    checkProductInventory: 'user-approval',
+    getCustomerDiscount: 'approved',
+    getShippingCost: 'user-approval',
+    purchaseProduct: 'approved',
   },
 });
 

--- a/examples/ai-e2e-next/agent/code-mode/code-mode-tool-approval-agent.ts
+++ b/examples/ai-e2e-next/agent/code-mode/code-mode-tool-approval-agent.ts
@@ -53,10 +53,10 @@ export const codeModeToolApprovalAgent = new ToolLoopAgent({
   onStepEnd: result => {
     console.log(JSON.stringify(result.content, null, 2));
   },
-  experimental_toolCallers: ({ codeMode }) => ({
-    getProductPrice: [codeMode],
-    purchaseProduct: [codeMode],
-  }),
+  experimental_toolCallers: {
+    getProductPrice: ['codeMode'],
+    purchaseProduct: ['codeMode'],
+  },
   toolApproval: {
     codeMode: 'user-approval',
     getProductPrice: 'user-approval',

--- a/examples/ai-e2e-next/agent/code-mode/code-mode-tool-approval-agent.ts
+++ b/examples/ai-e2e-next/agent/code-mode/code-mode-tool-approval-agent.ts
@@ -1,0 +1,66 @@
+import { experimental_codeModeTool as codeModeTool } from '@ai-sdk/code-mode';
+import { ToolLoopAgent, tool, type InferAgentUIMessage } from 'ai';
+import { z } from 'zod';
+
+const getProductPrice = tool({
+  description: 'Get the unit price of a product.',
+  inputSchema: z.object({
+    productId: z.string(),
+  }),
+  outputSchema: z.object({
+    productId: z.string(),
+    unitPrice: z.number(),
+  }),
+  execute: async ({ productId }) => ({
+    productId,
+    unitPrice: 25,
+  }),
+});
+
+const purchaseProduct = tool({
+  description: 'Purchase a quantity of a product for the provided total.',
+  inputSchema: z.object({
+    productId: z.string(),
+    quantity: z.number(),
+    total: z.number(),
+  }),
+  outputSchema: z.object({
+    confirmationId: z.string(),
+    productId: z.string(),
+    quantity: z.number(),
+    total: z.number(),
+  }),
+  execute: async ({ productId, quantity, total }) => ({
+    confirmationId: 'order_123',
+    productId,
+    quantity,
+    total,
+  }),
+});
+
+const tools = {
+  codeMode: codeModeTool(),
+  getProductPrice,
+  purchaseProduct,
+} as const;
+
+export const codeModeToolApprovalAgent = new ToolLoopAgent({
+  model: 'openai/gpt-5.6-sol',
+  instructions:
+    'You are a purchasing assistant. Use code mode to coordinate the available tools. ' +
+    'When the user asks to buy a product, look up its price, calculate the total, and purchase it. ',
+  tools,
+  experimental_toolCallers: ({ codeMode }) => ({
+    getProductPrice: [codeMode],
+    purchaseProduct: [codeMode],
+  }),
+  toolApproval: {
+    codeMode: 'user-approval',
+    getProductPrice: 'user-approval',
+    purchaseProduct: 'user-approval',
+  },
+});
+
+export type CodeModeToolApprovalMessage = InferAgentUIMessage<
+  typeof codeModeToolApprovalAgent
+>;

--- a/examples/ai-e2e-next/app/api/chat/code-mode-tool-approval/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/code-mode-tool-approval/route.ts
@@ -1,0 +1,13 @@
+import { codeModeToolApprovalAgent } from '@/agent/code-mode/code-mode-tool-approval-agent';
+import { createAgentUIStreamResponse } from 'ai';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: Request) {
+  const { messages } = await request.json();
+
+  return createAgentUIStreamResponse({
+    agent: codeModeToolApprovalAgent,
+    uiMessages: messages,
+  });
+}

--- a/examples/ai-e2e-next/app/chat/code-mode-tool-approval/page.tsx
+++ b/examples/ai-e2e-next/app/chat/code-mode-tool-approval/page.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import type { CodeModeToolApprovalMessage } from '@/agent/code-mode/code-mode-tool-approval-agent';
+import { Response } from '@/components/ai-elements/response';
+import ChatInput from '@/components/chat-input';
+import CodeModeToolApprovalView from '@/components/tool/code-mode-tool-approval-view';
+import { useChat } from '@ai-sdk/react';
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithApprovalResponses,
+} from 'ai';
+
+const transport = new DefaultChatTransport({
+  api: '/api/chat/code-mode-tool-approval',
+});
+
+export default function ChatCodeModeToolApproval() {
+  const {
+    error,
+    status,
+    sendMessage,
+    messages,
+    regenerate,
+    addToolApprovalResponse,
+  } = useChat<CodeModeToolApprovalMessage>({
+    transport,
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
+  });
+
+  return (
+    <div className="flex flex-col py-24 mx-auto w-full max-w-xl stretch">
+      <h1 className="mb-4 text-xl font-bold">Code Mode with Tool Approvals</h1>
+      <p className="mb-4 text-sm text-gray-600">
+        The agent writes sandboxed TypeScript to coordinate tools. You approve
+        the generated code and each nested tool call before it executes.
+      </p>
+      <p className="mb-6 text-sm text-gray-500">
+        Try: &quot;Buy 2 units of product sku_123.&quot;
+      </p>
+
+      {messages.map(message => (
+        <div key={message.id} className="mb-4 whitespace-pre-wrap">
+          <strong>{message.role === 'user' ? 'User: ' : 'AI: '}</strong>
+          {message.parts.map((part, index) => {
+            switch (part.type) {
+              case 'text':
+                return <Response key={index}>{part.text}</Response>;
+              case 'tool-codeMode':
+              case 'tool-getProductPrice':
+              case 'tool-purchaseProduct':
+                return (
+                  <CodeModeToolApprovalView
+                    key={index}
+                    invocation={part}
+                    addToolApprovalResponse={addToolApprovalResponse}
+                  />
+                );
+            }
+          })}
+        </div>
+      ))}
+
+      {error && (
+        <div className="mb-4">
+          <div className="text-red-600">An error occurred: {error.message}</div>
+          <button
+            type="button"
+            className="px-4 py-2 mt-3 text-blue-600 rounded-md border border-blue-600"
+            onClick={() => regenerate()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <ChatInput status={status} onSubmit={text => sendMessage({ text })} />
+    </div>
+  );
+}

--- a/examples/ai-e2e-next/app/chat/code-mode-tool-approval/page.tsx
+++ b/examples/ai-e2e-next/app/chat/code-mode-tool-approval/page.tsx
@@ -47,6 +47,9 @@ export default function ChatCodeModeToolApproval() {
                 return <Response key={index}>{part.text}</Response>;
               case 'tool-codeMode':
               case 'tool-getProductPrice':
+              case 'tool-checkProductInventory':
+              case 'tool-getCustomerDiscount':
+              case 'tool-getShippingCost':
               case 'tool-purchaseProduct':
                 return (
                   <CodeModeToolApprovalView

--- a/examples/ai-e2e-next/components/tool/code-mode-tool-approval-view.tsx
+++ b/examples/ai-e2e-next/components/tool/code-mode-tool-approval-view.tsx
@@ -1,0 +1,111 @@
+import type { CodeModeToolApprovalMessage } from '@/agent/code-mode/code-mode-tool-approval-agent';
+import type { ChatAddToolApproveResponseFunction } from 'ai';
+
+type CodeModeApprovalToolPart = Extract<
+  CodeModeToolApprovalMessage['parts'][number],
+  {
+    type: 'tool-codeMode' | 'tool-getProductPrice' | 'tool-purchaseProduct';
+  }
+>;
+
+const toolTitles: Record<CodeModeApprovalToolPart['type'], string> = {
+  'tool-codeMode': 'Code Mode',
+  'tool-getProductPrice': 'Get Product Price',
+  'tool-purchaseProduct': 'Purchase Product',
+};
+
+export default function CodeModeToolApprovalView({
+  invocation,
+  addToolApprovalResponse,
+}: {
+  invocation: CodeModeApprovalToolPart;
+  addToolApprovalResponse: ChatAddToolApproveResponseFunction;
+}) {
+  const title = toolTitles[invocation.type];
+
+  return (
+    <div className="p-4 mb-3 bg-white rounded-xl border border-gray-300 shadow-sm">
+      <div className="mb-3 text-sm font-semibold text-gray-900">{title}</div>
+
+      {invocation.input != null ? (
+        <div className="mb-3">
+          <div className="mb-1 text-xs font-medium text-gray-600">Input</div>
+          <pre className="overflow-x-auto p-3 text-xs text-gray-100 whitespace-pre-wrap bg-gray-900 rounded-lg">
+            {formatValue(invocation.input)}
+          </pre>
+        </div>
+      ) : (
+        <div className="mb-3 text-sm text-gray-500">Generating input...</div>
+      )}
+
+      {invocation.state === 'approval-requested' ? (
+        <div>
+          <div className="mb-3 text-sm text-amber-700">
+            Approval is required before this tool can run.
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="px-4 py-2 text-sm text-white bg-blue-600 rounded hover:bg-blue-700"
+              onClick={() =>
+                addToolApprovalResponse({
+                  id: invocation.approval.id,
+                  approved: true,
+                })
+              }
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              className="px-4 py-2 text-sm text-white bg-red-600 rounded hover:bg-red-700"
+              onClick={() =>
+                addToolApprovalResponse({
+                  id: invocation.approval.id,
+                  approved: false,
+                })
+              }
+            >
+              Deny
+            </button>
+          </div>
+        </div>
+      ) : invocation.state === 'approval-responded' ? (
+        <div
+          className={
+            invocation.approval.approved
+              ? 'text-sm font-medium text-green-700'
+              : 'text-sm font-medium text-red-700'
+          }
+        >
+          {invocation.approval.approved ? 'Approved' : 'Denied'}
+        </div>
+      ) : invocation.state === 'output-available' ? (
+        <div>
+          <div className="mb-1 text-xs font-medium text-gray-600">Output</div>
+          <pre className="overflow-x-auto p-3 text-xs text-gray-900 whitespace-pre-wrap bg-gray-100 rounded-lg">
+            {formatValue(invocation.output)}
+          </pre>
+        </div>
+      ) : invocation.state === 'output-denied' ? (
+        <div className="text-sm font-medium text-red-700">
+          Execution was denied.
+        </div>
+      ) : invocation.state === 'output-error' ? (
+        <div className="text-sm text-red-700">
+          Error: {invocation.errorText}
+        </div>
+      ) : (
+        <div className="text-sm text-gray-500">Preparing tool call...</div>
+      )}
+    </div>
+  );
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return JSON.stringify(value, null, 2) ?? String(value);
+}

--- a/examples/ai-e2e-next/components/tool/code-mode-tool-approval-view.tsx
+++ b/examples/ai-e2e-next/components/tool/code-mode-tool-approval-view.tsx
@@ -4,13 +4,22 @@ import type { ChatAddToolApproveResponseFunction } from 'ai';
 type CodeModeApprovalToolPart = Extract<
   CodeModeToolApprovalMessage['parts'][number],
   {
-    type: 'tool-codeMode' | 'tool-getProductPrice' | 'tool-purchaseProduct';
+    type:
+      | 'tool-codeMode'
+      | 'tool-getProductPrice'
+      | 'tool-checkProductInventory'
+      | 'tool-getCustomerDiscount'
+      | 'tool-getShippingCost'
+      | 'tool-purchaseProduct';
   }
 >;
 
 const toolTitles: Record<CodeModeApprovalToolPart['type'], string> = {
   'tool-codeMode': 'Code Mode',
   'tool-getProductPrice': 'Get Product Price',
+  'tool-checkProductInventory': 'Check Product Inventory',
+  'tool-getCustomerDiscount': 'Get Customer Discount',
+  'tool-getShippingCost': 'Get Shipping Cost',
   'tool-purchaseProduct': 'Purchase Product',
 };
 

--- a/examples/ai-functions/src/generate-text/code-mode/tool-approval.ts
+++ b/examples/ai-functions/src/generate-text/code-mode/tool-approval.ts
@@ -1,0 +1,111 @@
+import { experimental_codeModeTool as codeModeTool } from '@ai-sdk/code-mode';
+import {
+  generateText,
+  isStepCount,
+  tool,
+  type ModelMessage,
+  type ToolApprovalResponse,
+} from 'ai';
+import * as readline from 'node:readline/promises';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+const terminal = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+const getProductPrice = tool({
+  description: 'Get the unit price of a product.',
+  inputSchema: z.object({
+    productId: z.string(),
+  }),
+  execute: async ({ productId }) => ({
+    productId,
+    unitPrice: 25,
+  }),
+});
+
+const purchaseProduct = tool({
+  description: 'Purchase a quantity of a product for the provided total.',
+  inputSchema: z.object({
+    productId: z.string(),
+    quantity: z.number(),
+    total: z.number(),
+  }),
+  execute: async ({ productId, quantity, total }) => ({
+    confirmationId: 'order_123',
+    productId,
+    quantity,
+    total,
+  }),
+});
+
+const tools = {
+  code_mode: codeModeTool(),
+  getProductPrice,
+  purchaseProduct,
+} as const;
+
+run(async () => {
+  const messages: ModelMessage[] = [
+    {
+      role: 'user',
+      content:
+        'I want to purchase 2 units of product sku_123. Look up its price, calculate the total, then purchase it.',
+    },
+  ];
+
+  try {
+    while (true) {
+      const result = await generateText({
+        model: 'moonshotai/kimi-k3',
+        tools,
+        experimental_toolCallers: ({ code_mode }) => ({
+          getProductPrice: [code_mode],
+          purchaseProduct: [code_mode],
+        }),
+        toolApproval: {
+          purchaseProduct: 'user-approval',
+        },
+        stopWhen: isStepCount(10),
+        messages,
+      });
+
+      messages.push(...result.responseMessages);
+      console.log(JSON.stringify(result.content, null, 2));
+
+      const approvals: ToolApprovalResponse[] = [];
+      for (const part of result.content) {
+        if (part.type === 'text') {
+          process.stdout.write(`\nAssistant:\n${part.text}\n`);
+        }
+
+        if (
+          part.type === 'tool-approval-request' &&
+          part.toolCall.toolName === 'purchaseProduct' &&
+          !part.toolCall.dynamic &&
+          !part.isAutomatic
+        ) {
+          const { productId, quantity, total } = part.toolCall.input;
+          const answer = await terminal.question(
+            `Approve purchasing ${quantity} units of ${productId} for $${total} (y/n)? `,
+          );
+          approvals.push({
+            type: 'tool-approval-response',
+            approvalId: part.approvalId,
+            approved:
+              answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes',
+          });
+        }
+      }
+
+      if (approvals.length === 0) {
+        break;
+      }
+      messages.push({ role: 'tool', content: approvals });
+    }
+  } finally {
+    terminal.close();
+  }
+});

--- a/examples/ai-functions/src/generate-text/code-mode/tool-approval.ts
+++ b/examples/ai-functions/src/generate-text/code-mode/tool-approval.ts
@@ -61,10 +61,10 @@ run(async () => {
       const result = await generateText({
         model: 'moonshotai/kimi-k3',
         tools,
-        experimental_toolCallers: ({ code_mode }) => ({
-          getProductPrice: [code_mode],
-          purchaseProduct: [code_mode],
-        }),
+        experimental_toolCallers: {
+          getProductPrice: ['code_mode'],
+          purchaseProduct: ['code_mode'],
+        },
         toolApproval: {
           code_mode: 'user-approval',
           purchaseProduct: 'user-approval',

--- a/examples/ai-functions/src/generate-text/code-mode/tool-approval.ts
+++ b/examples/ai-functions/src/generate-text/code-mode/tool-approval.ts
@@ -66,6 +66,7 @@ run(async () => {
           purchaseProduct: [code_mode],
         }),
         toolApproval: {
+          code_mode: 'user-approval',
           purchaseProduct: 'user-approval',
         },
         stopWhen: isStepCount(10),
@@ -81,15 +82,9 @@ run(async () => {
           process.stdout.write(`\nAssistant:\n${part.text}\n`);
         }
 
-        if (
-          part.type === 'tool-approval-request' &&
-          part.toolCall.toolName === 'purchaseProduct' &&
-          !part.toolCall.dynamic &&
-          !part.isAutomatic
-        ) {
-          const { productId, quantity, total } = part.toolCall.input;
+        if (part.type === 'tool-approval-request' && !part.isAutomatic) {
           const answer = await terminal.question(
-            `Approve purchasing ${quantity} units of ${productId} for $${total} (y/n)? `,
+            `Approve ${part.toolCall.toolName} with this input?\n\n${JSON.stringify(part.toolCall.input, null, 2)}\n\n(y/n)? `,
           );
           approvals.push({
             type: 'tool-approval-response',

--- a/examples/ai-functions/src/stream-text/code-mode/tool-approval.ts
+++ b/examples/ai-functions/src/stream-text/code-mode/tool-approval.ts
@@ -61,10 +61,10 @@ run(async () => {
       const result = streamText({
         model: 'moonshotai/kimi-k3',
         tools,
-        experimental_toolCallers: ({ code_mode }) => ({
-          getProductPrice: [code_mode],
-          purchaseProduct: [code_mode],
-        }),
+        experimental_toolCallers: {
+          getProductPrice: ['code_mode'],
+          purchaseProduct: ['code_mode'],
+        },
         toolApproval: {
           code_mode: 'user-approval',
           purchaseProduct: 'user-approval',

--- a/examples/ai-functions/src/stream-text/code-mode/tool-approval.ts
+++ b/examples/ai-functions/src/stream-text/code-mode/tool-approval.ts
@@ -66,6 +66,7 @@ run(async () => {
           purchaseProduct: [code_mode],
         }),
         toolApproval: {
+          code_mode: 'user-approval',
           purchaseProduct: 'user-approval',
         },
         stopWhen: isStepCount(10),
@@ -80,13 +81,10 @@ run(async () => {
           process.stdout.write(chunk.text);
         } else if (
           chunk.type === 'tool-approval-request' &&
-          chunk.toolCall.toolName === 'purchaseProduct' &&
-          !chunk.toolCall.dynamic &&
           !chunk.isAutomatic
         ) {
-          const { productId, quantity, total } = chunk.toolCall.input;
           const answer = await terminal.question(
-            `\nApprove purchasing ${quantity} units of ${productId} for $${total} (y/n)? `,
+            `\nApprove ${chunk.toolCall.toolName} with this input?\n\n${JSON.stringify(chunk.toolCall.input, null, 2)}\n\n(y/n)? `,
           );
           approvals.push({
             type: 'tool-approval-response',

--- a/examples/ai-functions/src/stream-text/code-mode/tool-approval.ts
+++ b/examples/ai-functions/src/stream-text/code-mode/tool-approval.ts
@@ -1,0 +1,110 @@
+import { experimental_codeModeTool as codeModeTool } from '@ai-sdk/code-mode';
+import {
+  isStepCount,
+  streamText,
+  tool,
+  type ModelMessage,
+  type ToolApprovalResponse,
+} from 'ai';
+import * as readline from 'node:readline/promises';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+const terminal = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+const getProductPrice = tool({
+  description: 'Get the unit price of a product.',
+  inputSchema: z.object({
+    productId: z.string(),
+  }),
+  execute: async ({ productId }) => ({
+    productId,
+    unitPrice: 25,
+  }),
+});
+
+const purchaseProduct = tool({
+  description: 'Purchase a quantity of a product for the provided total.',
+  inputSchema: z.object({
+    productId: z.string(),
+    quantity: z.number(),
+    total: z.number(),
+  }),
+  execute: async ({ productId, quantity, total }) => ({
+    confirmationId: 'order_123',
+    productId,
+    quantity,
+    total,
+  }),
+});
+
+const tools = {
+  code_mode: codeModeTool(),
+  getProductPrice,
+  purchaseProduct,
+} as const;
+
+run(async () => {
+  const messages: ModelMessage[] = [
+    {
+      role: 'user',
+      content:
+        'I want to purchase 2 units of product sku_123. Look up its price, calculate the total, then purchase it.',
+    },
+  ];
+
+  try {
+    while (true) {
+      const result = streamText({
+        model: 'moonshotai/kimi-k3',
+        tools,
+        experimental_toolCallers: ({ code_mode }) => ({
+          getProductPrice: [code_mode],
+          purchaseProduct: [code_mode],
+        }),
+        toolApproval: {
+          purchaseProduct: 'user-approval',
+        },
+        stopWhen: isStepCount(10),
+        messages,
+      });
+
+      const approvals: ToolApprovalResponse[] = [];
+      for await (const chunk of result.stream) {
+        if (chunk.type === 'text-start') {
+          process.stdout.write('\nAssistant:\n');
+        } else if (chunk.type === 'text-delta') {
+          process.stdout.write(chunk.text);
+        } else if (
+          chunk.type === 'tool-approval-request' &&
+          chunk.toolCall.toolName === 'purchaseProduct' &&
+          !chunk.toolCall.dynamic &&
+          !chunk.isAutomatic
+        ) {
+          const { productId, quantity, total } = chunk.toolCall.input;
+          const answer = await terminal.question(
+            `\nApprove purchasing ${quantity} units of ${productId} for $${total} (y/n)? `,
+          );
+          approvals.push({
+            type: 'tool-approval-response',
+            approvalId: chunk.approvalId,
+            approved:
+              answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes',
+          });
+        }
+      }
+      process.stdout.write('\n');
+
+      messages.push(...(await result.responseMessages));
+      if (approvals.length === 0) {
+        break;
+      }
+      messages.push({ role: 'tool', content: approvals });
+    }
+  } finally {
+    terminal.close();
+  }
+});

--- a/examples/ai-functions/src/stream-text/code-mode/tool-approval.ts
+++ b/examples/ai-functions/src/stream-text/code-mode/tool-approval.ts
@@ -68,6 +68,7 @@ run(async () => {
         toolApproval: {
           code_mode: 'user-approval',
           purchaseProduct: 'user-approval',
+          getProductPrice: 'user-approval',
         },
         stopWhen: isStepCount(10),
         messages,

--- a/packages/ai/src/generate-text/continue-tool-caller-approvals.ts
+++ b/packages/ai/src/generate-text/continue-tool-caller-approvals.ts
@@ -43,8 +43,11 @@ export function normalizeToolCallerApprovalMessages({
         part.type === 'tool-approval-request' &&
         part.callerToolCallId != null
       ) {
+        // Track the nested approval so its request and response can be removed.
         callerApprovalIds.add(part.approvalId);
+        // Track the outer caller so only its latest result remains.
         callerToolCallIds.add(part.callerToolCallId);
+        // Track the nested host tool so its call and result can be removed.
         nestedToolCallIds.add(part.toolCallId);
       }
     }

--- a/packages/ai/src/generate-text/continue-tool-caller-approvals.ts
+++ b/packages/ai/src/generate-text/continue-tool-caller-approvals.ts
@@ -1,0 +1,352 @@
+import type { JSONValue } from '@ai-sdk/provider';
+import {
+  experimental_getToolCaller,
+  getErrorMessage,
+  type InferToolSetContext,
+  type ModelMessage,
+  type ToolModelMessage,
+  type ToolResultPart,
+  type ToolSet,
+} from '@ai-sdk/provider-utils';
+import { getOwn } from '../util/get-own';
+import type { CollectedToolApprovals } from './collect-tool-approvals';
+import {
+  getLocalToolsForCaller,
+  getToolCallerApprovalRequest,
+  type ResolvedToolCallers,
+} from './tool-caller-configuration';
+
+export type ContinuedToolCallerApproval<TOOLS extends ToolSet> = {
+  approval: CollectedToolApprovals<TOOLS>;
+  messages: ModelMessage[];
+  responseMessage: ToolModelMessage;
+};
+
+export function normalizeToolCallerApprovalMessages({
+  messages,
+  tools,
+}: {
+  messages: ModelMessage[];
+  tools: ToolSet | undefined;
+}): ModelMessage[] {
+  if (tools == null) {
+    return messages;
+  }
+
+  const resultsByToolCallId = new Map<string, ToolResultPart[]>();
+  for (const message of messages) {
+    if (message.role !== 'tool') {
+      continue;
+    }
+    for (const part of message.content) {
+      if (part.type === 'tool-result') {
+        const results = resultsByToolCallId.get(part.toolCallId) ?? [];
+        results.push(part);
+        resultsByToolCallId.set(part.toolCallId, results);
+      }
+    }
+  }
+
+  let normalized = messages;
+  for (const results of resultsByToolCallId.values()) {
+    const interruptedResult = results.find(part =>
+      getToolCallerApprovalRequest({
+        callerToolName: part.toolName,
+        output: part.output,
+        tools,
+      }),
+    );
+    if (interruptedResult === undefined) {
+      continue;
+    }
+    const request = getToolCallerApprovalRequest({
+      callerToolName: interruptedResult.toolName,
+      output: interruptedResult.output,
+      tools,
+    });
+    const latestResult = results.at(-1);
+    if (
+      request === undefined ||
+      latestResult === undefined ||
+      latestResult === interruptedResult
+    ) {
+      continue;
+    }
+    normalized = collapseResolvedApprovalMessages({
+      messages: normalized,
+      request,
+      replacementOutput: latestResult.output,
+    });
+  }
+  return normalized;
+}
+
+export async function continueToolCallerApprovals<TOOLS extends ToolSet>({
+  approvals,
+  messages,
+  tools,
+  toolCallers,
+  toolsContext,
+  abortSignal,
+}: {
+  approvals: Array<CollectedToolApprovals<TOOLS>>;
+  messages: ModelMessage[];
+  tools: TOOLS;
+  toolCallers: ResolvedToolCallers | undefined;
+  toolsContext: InferToolSetContext<TOOLS>;
+  abortSignal: AbortSignal | undefined;
+}): Promise<{
+  continued: Array<ContinuedToolCallerApproval<TOOLS>>;
+  remaining: Array<CollectedToolApprovals<TOOLS>>;
+  messages: ModelMessage[];
+}> {
+  const continued: Array<ContinuedToolCallerApproval<TOOLS>> = [];
+  const remaining: Array<CollectedToolApprovals<TOOLS>> = [];
+  let currentMessages = messages;
+
+  for (const approval of approvals) {
+    const match = findToolCallerApproval({
+      approval,
+      messages: currentMessages,
+      tools,
+    });
+    if (match === undefined) {
+      remaining.push(approval);
+      continue;
+    }
+
+    const localTools = getLocalToolsForCaller({
+      callerName: match.callerName,
+      tools,
+      toolCallers,
+    });
+    const context = getOwn(toolsContext, match.callerName);
+    let output: unknown;
+    let error: unknown;
+    try {
+      output = await match.caller.continueApproval!({
+        output: match.outerToolResult.output,
+        approvalResponse: approval.approvalResponse,
+        tools: localTools,
+        messages: currentMessages,
+        toolExecutionOptions: {
+          toolCallId: match.request.callerToolCallId,
+          messages: currentMessages,
+          ...(abortSignal !== undefined ? { abortSignal } : {}),
+          ...(context !== undefined ? { context } : {}),
+        },
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    const replacementOutput =
+      error === undefined
+        ? toModelToolOutput(output)
+        : {
+            type: 'error-text' as const,
+            value: getErrorMessage(error),
+          };
+    currentMessages = replaceApprovalMessages({
+      messages: currentMessages,
+      approval,
+      outerToolCallId: match.request.callerToolCallId,
+      replacementOutput,
+    });
+    const responseMessage: ToolModelMessage = {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: match.request.callerToolCallId,
+          toolName: match.callerName,
+          output: replacementOutput,
+        },
+      ],
+    };
+    continued.push({ approval, messages: currentMessages, responseMessage });
+  }
+
+  return { continued, remaining, messages: currentMessages };
+}
+
+function findToolCallerApproval<TOOLS extends ToolSet>({
+  approval,
+  messages,
+  tools,
+}: {
+  approval: CollectedToolApprovals<TOOLS>;
+  messages: ModelMessage[];
+  tools: TOOLS;
+}):
+  | {
+      callerName: string;
+      caller: Extract<
+        NonNullable<ReturnType<typeof experimental_getToolCaller>>,
+        { type: 'local' }
+      >;
+      outerToolResult: ToolResultPart;
+      request: NonNullable<ReturnType<typeof getToolCallerApprovalRequest>>;
+    }
+  | undefined {
+  const latestToolResults = new Map<string, ToolResultPart>();
+  for (const message of messages) {
+    if (message.role !== 'tool') {
+      continue;
+    }
+    for (const part of message.content) {
+      if (part.type === 'tool-result') {
+        latestToolResults.set(part.toolCallId, part);
+      }
+    }
+  }
+
+  for (const outerToolResult of latestToolResults.values()) {
+    const callerName = outerToolResult.toolName;
+    const caller = experimental_getToolCaller(getOwn(tools, callerName));
+    if (caller?.type !== 'local' || caller.continueApproval === undefined) {
+      continue;
+    }
+    const request = getToolCallerApprovalRequest({
+      callerToolName: callerName,
+      output: outerToolResult.output,
+      tools,
+    });
+    if (request?.approvalId === approval.approvalRequest.approvalId) {
+      return { callerName, caller, outerToolResult, request };
+    }
+  }
+  return undefined;
+}
+
+function replaceApprovalMessages<TOOLS extends ToolSet>({
+  messages,
+  approval,
+  outerToolCallId,
+  replacementOutput,
+}: {
+  messages: ModelMessage[];
+  approval: CollectedToolApprovals<TOOLS>;
+  outerToolCallId: string;
+  replacementOutput: ToolResultPart['output'];
+}): ModelMessage[] {
+  const nextMessages: ModelMessage[] = [];
+  for (const message of messages) {
+    if (typeof message.content === 'string') {
+      nextMessages.push(message);
+      continue;
+    }
+
+    const content = message.content
+      .map(part => {
+        if (
+          part.type === 'tool-result' &&
+          part.toolCallId === outerToolCallId
+        ) {
+          return { ...part, output: replacementOutput };
+        }
+        return part;
+      })
+      .filter(part => {
+        if (
+          part.type === 'tool-call' &&
+          part.toolCallId === approval.toolCall.toolCallId
+        ) {
+          return false;
+        }
+        if (
+          part.type === 'tool-approval-request' &&
+          part.approvalId === approval.approvalRequest.approvalId
+        ) {
+          return false;
+        }
+        if (
+          part.type === 'tool-approval-response' &&
+          part.approvalId === approval.approvalResponse.approvalId
+        ) {
+          return false;
+        }
+        return !(
+          part.type === 'tool-result' &&
+          part.toolCallId === approval.toolCall.toolCallId
+        );
+      });
+    if (content.length > 0) {
+      nextMessages.push({ ...message, content } as ModelMessage);
+    }
+  }
+  return nextMessages;
+}
+
+function collapseResolvedApprovalMessages({
+  messages,
+  request,
+  replacementOutput,
+}: {
+  messages: ModelMessage[];
+  request: NonNullable<ReturnType<typeof getToolCallerApprovalRequest>>;
+  replacementOutput: ToolResultPart['output'];
+}): ModelMessage[] {
+  const nextMessages: ModelMessage[] = [];
+  let keptOuterResult = false;
+  for (const message of messages) {
+    if (typeof message.content === 'string') {
+      nextMessages.push(message);
+      continue;
+    }
+    const content = message.content
+      .map(part => {
+        if (
+          part.type === 'tool-result' &&
+          part.toolCallId === request.callerToolCallId
+        ) {
+          if (keptOuterResult) {
+            return undefined;
+          }
+          keptOuterResult = true;
+          return { ...part, output: replacementOutput };
+        }
+        return part;
+      })
+      .filter(part => {
+        if (part === undefined) {
+          return false;
+        }
+        if (
+          part.type === 'tool-call' &&
+          part.toolCallId === request.toolCall.toolCallId
+        ) {
+          return false;
+        }
+        if (
+          part.type === 'tool-approval-request' &&
+          part.approvalId === request.approvalId
+        ) {
+          return false;
+        }
+        if (
+          part.type === 'tool-approval-response' &&
+          part.approvalId === request.approvalId
+        ) {
+          return false;
+        }
+        return !(
+          part.type === 'tool-result' &&
+          part.toolCallId === request.toolCall.toolCallId
+        );
+      });
+    if (content.length > 0) {
+      nextMessages.push({ ...message, content } as ModelMessage);
+    }
+  }
+  return nextMessages;
+}
+
+function toModelToolOutput(value: unknown): ToolResultPart['output'] {
+  return typeof value === 'string'
+    ? { type: 'text', value }
+    : {
+        type: 'json',
+        value: value === undefined ? null : (value as JSONValue),
+      };
+}

--- a/packages/ai/src/generate-text/continue-tool-caller-approvals.ts
+++ b/packages/ai/src/generate-text/continue-tool-caller-approvals.ts
@@ -4,6 +4,7 @@ import {
   getErrorMessage,
   type InferToolSetContext,
   type ModelMessage,
+  type ToolCall,
   type ToolModelMessage,
   type ToolResultPart,
   type ToolSet,
@@ -14,6 +15,7 @@ import {
   getLocalToolsForCaller,
   getToolCallerApprovalRequest,
   type LocalToolCallerApprovalRequest,
+  type LocalToolCallerApprovalStatus,
   type ResolvedToolCallers,
 } from './tool-caller-configuration';
 
@@ -90,6 +92,7 @@ export async function continueToolCallerApprovals<TOOLS extends ToolSet>({
   toolCallers,
   toolsContext,
   abortSignal,
+  resolveToolApproval,
 }: {
   approvals: Array<CollectedToolApprovals<TOOLS>>;
   messages: ModelMessage[];
@@ -97,6 +100,10 @@ export async function continueToolCallerApprovals<TOOLS extends ToolSet>({
   toolCallers: ResolvedToolCallers | undefined;
   toolsContext: InferToolSetContext<TOOLS>;
   abortSignal: AbortSignal | undefined;
+  resolveToolApproval: (
+    toolCall: ToolCall<string, unknown>,
+    messages: ModelMessage[],
+  ) => Promise<LocalToolCallerApprovalStatus>;
 }): Promise<{
   continued: Array<ContinuedToolCallerApproval<TOOLS>>;
   remaining: Array<CollectedToolApprovals<TOOLS>>;
@@ -131,6 +138,8 @@ export async function continueToolCallerApprovals<TOOLS extends ToolSet>({
         approvalResponse: approval.approvalResponse,
         tools: localTools,
         messages: currentMessages,
+        resolveToolApproval: toolCall =>
+          resolveToolApproval(toolCall, currentMessages),
         toolExecutionOptions: {
           toolCallId: match.request.callerToolCallId,
           messages: currentMessages,

--- a/packages/ai/src/generate-text/continue-tool-caller-approvals.ts
+++ b/packages/ai/src/generate-text/continue-tool-caller-approvals.ts
@@ -18,71 +18,75 @@ import {
   type LocalToolCallerApprovalStatus,
   type ResolvedToolCallers,
 } from './tool-caller-configuration';
+import type { ToolOutput } from './tool-output';
 
 export type ContinuedToolCallerApproval<TOOLS extends ToolSet> = {
   approval: CollectedToolApprovals<TOOLS>;
   messages: ModelMessage[];
   responseMessage: ToolModelMessage;
+  toolOutput: ToolOutput<TOOLS>;
   nextApprovalRequest: LocalToolCallerApprovalRequest | undefined;
 };
 
 export function normalizeToolCallerApprovalMessages({
   messages,
-  tools,
 }: {
   messages: ModelMessage[];
-  tools: ToolSet | undefined;
 }): ModelMessage[] {
-  if (tools == null) {
+  const callerApprovalIds = new Map<string, string>();
+  for (const message of messages) {
+    if (message.role !== 'assistant' || typeof message.content === 'string') {
+      continue;
+    }
+    for (const part of message.content) {
+      if (
+        part.type === 'tool-approval-request' &&
+        part.callerToolCallId != null
+      ) {
+        callerApprovalIds.set(part.approvalId, part.callerToolCallId);
+      }
+    }
+  }
+
+  if (callerApprovalIds.size === 0) {
     return messages;
   }
 
-  const resultsByToolCallId = new Map<string, ToolResultPart[]>();
+  const latestToolResults = new Map<string, ToolResultPart>();
   for (const message of messages) {
     if (message.role !== 'tool') {
       continue;
     }
     for (const part of message.content) {
       if (part.type === 'tool-result') {
-        const results = resultsByToolCallId.get(part.toolCallId) ?? [];
-        results.push(part);
-        resultsByToolCallId.set(part.toolCallId, results);
+        latestToolResults.set(part.toolCallId, part);
       }
     }
   }
 
-  let normalized = messages;
-  for (const results of resultsByToolCallId.values()) {
-    const interruptedResult = results.find(part =>
-      getToolCallerApprovalRequest({
-        callerToolName: part.toolName,
-        output: part.output,
-        tools,
-      }),
-    );
-    if (interruptedResult === undefined) {
-      continue;
+  return messages.flatMap(message => {
+    if (typeof message.content === 'string') {
+      return [message];
     }
-    const request = getToolCallerApprovalRequest({
-      callerToolName: interruptedResult.toolName,
-      output: interruptedResult.output,
-      tools,
+    const content = message.content.filter(part => {
+      if ('callerToolCallId' in part && part.callerToolCallId != null) {
+        return false;
+      }
+      if (
+        part.type === 'tool-approval-response' &&
+        callerApprovalIds.has(part.approvalId)
+      ) {
+        return false;
+      }
+      if (part.type !== 'tool-result') {
+        return true;
+      }
+      return latestToolResults.get(part.toolCallId) === part;
     });
-    const latestResult = results.at(-1);
-    if (
-      request === undefined ||
-      latestResult === undefined ||
-      latestResult === interruptedResult
-    ) {
-      continue;
-    }
-    normalized = collapseResolvedApprovalMessages({
-      messages: normalized,
-      request,
-      replacementOutput: latestResult.output,
-    });
-  }
-  return normalized;
+    return content.length === 0
+      ? []
+      : [{ ...message, content } as ModelMessage];
+  });
 }
 
 export async function continueToolCallerApprovals<TOOLS extends ToolSet>({
@@ -120,7 +124,9 @@ export async function continueToolCallerApprovals<TOOLS extends ToolSet>({
       tools,
     });
     if (match === undefined) {
-      remaining.push(approval);
+      if (approval.approvalRequest.callerToolCallId == null) {
+        remaining.push(approval);
+      }
       continue;
     }
 
@@ -160,7 +166,6 @@ export async function continueToolCallerApprovals<TOOLS extends ToolSet>({
           };
     currentMessages = replaceApprovalMessages({
       messages: currentMessages,
-      approval,
       outerToolCallId: match.request.callerToolCallId,
       replacementOutput,
     });
@@ -175,10 +180,19 @@ export async function continueToolCallerApprovals<TOOLS extends ToolSet>({
         },
       ],
     };
+    const toolOutput = {
+      type: error === undefined ? 'tool-result' : 'tool-error',
+      toolCallId: match.request.callerToolCallId,
+      toolName: match.callerName,
+      input: match.outerToolCall.input,
+      ...(error === undefined ? { output } : { error }),
+      dynamic: false,
+    } as ToolOutput<TOOLS>;
     continued.push({
       approval,
       messages: currentMessages,
       responseMessage,
+      toolOutput,
       nextApprovalRequest:
         error === undefined
           ? getToolCallerApprovalRequest({
@@ -208,26 +222,42 @@ function findToolCallerApproval<TOOLS extends ToolSet>({
         NonNullable<ReturnType<typeof experimental_getToolCaller>>,
         { type: 'local' }
       >;
+      outerToolCall: ToolCall<string, unknown>;
       outerToolResult: ToolResultPart;
       request: NonNullable<ReturnType<typeof getToolCallerApprovalRequest>>;
     }
   | undefined {
+  const latestToolCalls = new Map<string, ToolCall<string, unknown>>();
   const latestToolResults = new Map<string, ToolResultPart>();
   for (const message of messages) {
-    if (message.role !== 'tool') {
+    if (typeof message.content === 'string') {
       continue;
     }
     for (const part of message.content) {
-      if (part.type === 'tool-result') {
+      if (part.type === 'tool-call') {
+        latestToolCalls.set(part.toolCallId, part);
+      } else if (part.type === 'tool-result') {
         latestToolResults.set(part.toolCallId, part);
       }
     }
   }
 
-  for (const outerToolResult of latestToolResults.values()) {
+  const callerToolCallId = approval.approvalRequest.callerToolCallId;
+  const candidateResults =
+    callerToolCallId == null
+      ? latestToolResults.values()
+      : [latestToolResults.get(callerToolCallId)].filter(
+          (result): result is ToolResultPart => result != null,
+        );
+
+  for (const outerToolResult of candidateResults) {
     const callerName = outerToolResult.toolName;
     const caller = experimental_getToolCaller(getOwn(tools, callerName));
     if (caller?.type !== 'local' || caller.continueApproval === undefined) {
+      continue;
+    }
+    const outerToolCall = latestToolCalls.get(outerToolResult.toolCallId);
+    if (outerToolCall === undefined) {
       continue;
     }
     const request = getToolCallerApprovalRequest({
@@ -235,134 +265,44 @@ function findToolCallerApproval<TOOLS extends ToolSet>({
       output: outerToolResult.output,
       tools,
     });
-    if (request?.approvalId === approval.approvalRequest.approvalId) {
-      return { callerName, caller, outerToolResult, request };
+    if (
+      request?.approvalId === approval.approvalRequest.approvalId &&
+      request.callerToolCallId === outerToolResult.toolCallId
+    ) {
+      return {
+        callerName,
+        caller,
+        outerToolCall,
+        outerToolResult,
+        request,
+      };
     }
   }
   return undefined;
 }
 
-function replaceApprovalMessages<TOOLS extends ToolSet>({
+function replaceApprovalMessages({
   messages,
-  approval,
   outerToolCallId,
   replacementOutput,
 }: {
   messages: ModelMessage[];
-  approval: CollectedToolApprovals<TOOLS>;
   outerToolCallId: string;
   replacementOutput: ToolResultPart['output'];
 }): ModelMessage[] {
-  const nextMessages: ModelMessage[] = [];
-  for (const message of messages) {
+  return messages.map(message => {
     if (typeof message.content === 'string') {
-      nextMessages.push(message);
-      continue;
+      return message;
     }
-
-    const content = message.content
-      .map(part => {
-        if (
-          part.type === 'tool-result' &&
-          part.toolCallId === outerToolCallId
-        ) {
-          return { ...part, output: replacementOutput };
-        }
-        return part;
-      })
-      .filter(part => {
-        if (
-          part.type === 'tool-call' &&
-          part.toolCallId === approval.toolCall.toolCallId
-        ) {
-          return false;
-        }
-        if (
-          part.type === 'tool-approval-request' &&
-          part.approvalId === approval.approvalRequest.approvalId
-        ) {
-          return false;
-        }
-        if (
-          part.type === 'tool-approval-response' &&
-          part.approvalId === approval.approvalResponse.approvalId
-        ) {
-          return false;
-        }
-        return !(
-          part.type === 'tool-result' &&
-          part.toolCallId === approval.toolCall.toolCallId
-        );
-      });
-    if (content.length > 0) {
-      nextMessages.push({ ...message, content } as ModelMessage);
-    }
-  }
-  return nextMessages;
-}
-
-function collapseResolvedApprovalMessages({
-  messages,
-  request,
-  replacementOutput,
-}: {
-  messages: ModelMessage[];
-  request: NonNullable<ReturnType<typeof getToolCallerApprovalRequest>>;
-  replacementOutput: ToolResultPart['output'];
-}): ModelMessage[] {
-  const nextMessages: ModelMessage[] = [];
-  let keptOuterResult = false;
-  for (const message of messages) {
-    if (typeof message.content === 'string') {
-      nextMessages.push(message);
-      continue;
-    }
-    const content = message.content
-      .map(part => {
-        if (
-          part.type === 'tool-result' &&
-          part.toolCallId === request.callerToolCallId
-        ) {
-          if (keptOuterResult) {
-            return undefined;
-          }
-          keptOuterResult = true;
-          return { ...part, output: replacementOutput };
-        }
-        return part;
-      })
-      .filter(part => {
-        if (part === undefined) {
-          return false;
-        }
-        if (
-          part.type === 'tool-call' &&
-          part.toolCallId === request.toolCall.toolCallId
-        ) {
-          return false;
-        }
-        if (
-          part.type === 'tool-approval-request' &&
-          part.approvalId === request.approvalId
-        ) {
-          return false;
-        }
-        if (
-          part.type === 'tool-approval-response' &&
-          part.approvalId === request.approvalId
-        ) {
-          return false;
-        }
-        return !(
-          part.type === 'tool-result' &&
-          part.toolCallId === request.toolCall.toolCallId
-        );
-      });
-    if (content.length > 0) {
-      nextMessages.push({ ...message, content } as ModelMessage);
-    }
-  }
-  return nextMessages;
+    return {
+      ...message,
+      content: message.content.map(part =>
+        part.type === 'tool-result' && part.toolCallId === outerToolCallId
+          ? { ...part, output: replacementOutput }
+          : part,
+      ),
+    } as ModelMessage;
+  });
 }
 
 function toModelToolOutput(value: unknown): ToolResultPart['output'] {

--- a/packages/ai/src/generate-text/continue-tool-caller-approvals.ts
+++ b/packages/ai/src/generate-text/continue-tool-caller-approvals.ts
@@ -13,6 +13,7 @@ import type { CollectedToolApprovals } from './collect-tool-approvals';
 import {
   getLocalToolsForCaller,
   getToolCallerApprovalRequest,
+  type LocalToolCallerApprovalRequest,
   type ResolvedToolCallers,
 } from './tool-caller-configuration';
 
@@ -20,6 +21,7 @@ export type ContinuedToolCallerApproval<TOOLS extends ToolSet> = {
   approval: CollectedToolApprovals<TOOLS>;
   messages: ModelMessage[];
   responseMessage: ToolModelMessage;
+  nextApprovalRequest: LocalToolCallerApprovalRequest | undefined;
 };
 
 export function normalizeToolCallerApprovalMessages({
@@ -164,7 +166,19 @@ export async function continueToolCallerApprovals<TOOLS extends ToolSet>({
         },
       ],
     };
-    continued.push({ approval, messages: currentMessages, responseMessage });
+    continued.push({
+      approval,
+      messages: currentMessages,
+      responseMessage,
+      nextApprovalRequest:
+        error === undefined
+          ? getToolCallerApprovalRequest({
+              callerToolName: match.callerName,
+              output,
+              tools,
+            })
+          : undefined,
+    });
   }
 
   return { continued, remaining, messages: currentMessages };

--- a/packages/ai/src/generate-text/continue-tool-caller-approvals.ts
+++ b/packages/ai/src/generate-text/continue-tool-caller-approvals.ts
@@ -21,8 +21,6 @@ import {
 import type { ToolOutput } from './tool-output';
 
 export type ContinuedToolCallerApproval<TOOLS extends ToolSet> = {
-  approval: CollectedToolApprovals<TOOLS>;
-  messages: ModelMessage[];
   responseMessage: ToolModelMessage;
   toolOutput: ToolOutput<TOOLS>;
   nextApprovalRequest: LocalToolCallerApprovalRequest | undefined;
@@ -33,7 +31,9 @@ export function normalizeToolCallerApprovalMessages({
 }: {
   messages: ModelMessage[];
 }): ModelMessage[] {
-  const callerApprovalIds = new Map<string, string>();
+  const callerApprovalIds = new Set<string>();
+  const callerToolCallIds = new Set<string>();
+  const nestedToolCallIds = new Set<string>();
   for (const message of messages) {
     if (message.role !== 'assistant' || typeof message.content === 'string') {
       continue;
@@ -43,7 +43,9 @@ export function normalizeToolCallerApprovalMessages({
         part.type === 'tool-approval-request' &&
         part.callerToolCallId != null
       ) {
-        callerApprovalIds.set(part.approvalId, part.callerToolCallId);
+        callerApprovalIds.add(part.approvalId);
+        callerToolCallIds.add(part.callerToolCallId);
+        nestedToolCallIds.add(part.toolCallId);
       }
     }
   }
@@ -58,7 +60,10 @@ export function normalizeToolCallerApprovalMessages({
       continue;
     }
     for (const part of message.content) {
-      if (part.type === 'tool-result') {
+      if (
+        part.type === 'tool-result' &&
+        callerToolCallIds.has(part.toolCallId)
+      ) {
         latestToolResults.set(part.toolCallId, part);
       }
     }
@@ -69,7 +74,16 @@ export function normalizeToolCallerApprovalMessages({
       return [message];
     }
     const content = message.content.filter(part => {
-      if ('callerToolCallId' in part && part.callerToolCallId != null) {
+      if (
+        (part.type === 'tool-call' || part.type === 'tool-result') &&
+        nestedToolCallIds.has(part.toolCallId)
+      ) {
+        return false;
+      }
+      if (
+        part.type === 'tool-approval-request' &&
+        part.callerToolCallId != null
+      ) {
         return false;
       }
       if (
@@ -81,7 +95,10 @@ export function normalizeToolCallerApprovalMessages({
       if (part.type !== 'tool-result') {
         return true;
       }
-      return latestToolResults.get(part.toolCallId) === part;
+      return (
+        !callerToolCallIds.has(part.toolCallId) ||
+        latestToolResults.get(part.toolCallId) === part
+      );
     });
     return content.length === 0
       ? []
@@ -118,15 +135,17 @@ export async function continueToolCallerApprovals<TOOLS extends ToolSet>({
   let currentMessages = messages;
 
   for (const approval of approvals) {
+    if (approval.approvalRequest.callerToolCallId == null) {
+      remaining.push(approval);
+      continue;
+    }
+
     const match = findToolCallerApproval({
       approval,
       messages: currentMessages,
       tools,
     });
     if (match === undefined) {
-      if (approval.approvalRequest.callerToolCallId == null) {
-        remaining.push(approval);
-      }
       continue;
     }
 
@@ -143,7 +162,6 @@ export async function continueToolCallerApprovals<TOOLS extends ToolSet>({
         output: match.outerToolResult.output,
         approvalResponse: approval.approvalResponse,
         tools: localTools,
-        messages: currentMessages,
         resolveToolApproval: toolCall =>
           resolveToolApproval(toolCall, currentMessages),
         toolExecutionOptions: {
@@ -189,8 +207,6 @@ export async function continueToolCallerApprovals<TOOLS extends ToolSet>({
       dynamic: false,
     } as ToolOutput<TOOLS>;
     continued.push({
-      approval,
-      messages: currentMessages,
       responseMessage,
       toolOutput,
       nextApprovalRequest:
@@ -243,40 +259,35 @@ function findToolCallerApproval<TOOLS extends ToolSet>({
   }
 
   const callerToolCallId = approval.approvalRequest.callerToolCallId;
-  const candidateResults =
-    callerToolCallId == null
-      ? latestToolResults.values()
-      : [latestToolResults.get(callerToolCallId)].filter(
-          (result): result is ToolResultPart => result != null,
-        );
-
-  for (const outerToolResult of candidateResults) {
-    const callerName = outerToolResult.toolName;
-    const caller = experimental_getToolCaller(getOwn(tools, callerName));
-    if (caller?.type !== 'local' || caller.continueApproval === undefined) {
-      continue;
-    }
-    const outerToolCall = latestToolCalls.get(outerToolResult.toolCallId);
-    if (outerToolCall === undefined) {
-      continue;
-    }
-    const request = getToolCallerApprovalRequest({
-      callerToolName: callerName,
-      output: outerToolResult.output,
-      tools,
-    });
-    if (
-      request?.approvalId === approval.approvalRequest.approvalId &&
-      request.callerToolCallId === outerToolResult.toolCallId
-    ) {
-      return {
-        callerName,
-        caller,
-        outerToolCall,
-        outerToolResult,
-        request,
-      };
-    }
+  if (callerToolCallId == null) {
+    return undefined;
+  }
+  const outerToolResult = latestToolResults.get(callerToolCallId);
+  const outerToolCall = latestToolCalls.get(callerToolCallId);
+  if (outerToolResult === undefined || outerToolCall === undefined) {
+    return undefined;
+  }
+  const callerName = outerToolResult.toolName;
+  const caller = experimental_getToolCaller(getOwn(tools, callerName));
+  if (caller?.type !== 'local' || caller.continueApproval === undefined) {
+    return undefined;
+  }
+  const request = getToolCallerApprovalRequest({
+    callerToolName: callerName,
+    output: outerToolResult.output,
+    tools,
+  });
+  if (
+    request?.approvalId === approval.approvalRequest.approvalId &&
+    request.callerToolCallId === callerToolCallId
+  ) {
+    return {
+      callerName,
+      caller,
+      outerToolCall,
+      outerToolResult,
+      request,
+    };
   }
   return undefined;
 }

--- a/packages/ai/src/generate-text/execute-tools-from-stream.ts
+++ b/packages/ai/src/generate-text/execute-tools-from-stream.ts
@@ -248,6 +248,8 @@ export function executeToolsFromStream<
                           toolName: nestedToolCall.toolName,
                           input: nestedToolCall.input,
                         });
+
+                        // for code mode execution, when inner tools require approval, we need to surface the tool call along with the approval request for AI SDK core
                         controller.enqueue(nestedToolCall);
                         controller.enqueue({
                           type: 'tool-approval-request',

--- a/packages/ai/src/generate-text/execute-tools-from-stream.ts
+++ b/packages/ai/src/generate-text/execute-tools-from-stream.ts
@@ -15,7 +15,10 @@ import { resolveToolApproval } from './resolve-tool-approval';
 import type { LanguageModelStreamPart } from './stream-language-model-call';
 import { maybeSignApproval } from './tool-approval-signature';
 import type { ToolApprovalConfiguration } from './tool-approval-configuration';
-import { getToolCallerApprovalRequest } from './tool-caller-configuration';
+import {
+  createToolCallerApprovalRequestOutput,
+  getToolCallerApprovalRequest,
+} from './tool-caller-configuration';
 import type { TypedToolCall } from './tool-call';
 import type {
   OnToolExecutionEndCallback,
@@ -236,27 +239,14 @@ export function executeToolsFromStream<
                         tools,
                       });
                       if (callerApproval !== undefined) {
-                        const nestedToolCall = {
-                          type: 'tool-call' as const,
-                          ...callerApproval.toolCall,
-                          dynamic: false as const,
-                        } as TypedToolCall<TOOLS>;
-                        const signature = await maybeSignApproval({
-                          secret: toolApprovalSecret,
-                          approvalId: callerApproval.approvalId,
-                          toolCallId: nestedToolCall.toolCallId,
-                          toolName: nestedToolCall.toolName,
-                          input: nestedToolCall.input,
-                        });
+                        const approvalRequest =
+                          await createToolCallerApprovalRequestOutput<TOOLS>({
+                            request: callerApproval,
+                            toolApprovalSecret,
+                          });
 
-                        // for code mode execution, when inner tools require approval, we need to surface the tool call along with the approval request for AI SDK core
-                        controller.enqueue(nestedToolCall);
-                        controller.enqueue({
-                          type: 'tool-approval-request',
-                          approvalId: callerApproval.approvalId,
-                          toolCall: nestedToolCall,
-                          ...(signature != null ? { signature } : {}),
-                        });
+                        controller.enqueue(approvalRequest.toolCall);
+                        controller.enqueue(approvalRequest);
                       }
                     }
                   }

--- a/packages/ai/src/generate-text/execute-tools-from-stream.ts
+++ b/packages/ai/src/generate-text/execute-tools-from-stream.ts
@@ -15,6 +15,7 @@ import { resolveToolApproval } from './resolve-tool-approval';
 import type { LanguageModelStreamPart } from './stream-language-model-call';
 import { maybeSignApproval } from './tool-approval-signature';
 import type { ToolApprovalConfiguration } from './tool-approval-configuration';
+import { getToolCallerApprovalRequest } from './tool-caller-configuration';
 import type { TypedToolCall } from './tool-call';
 import type {
   OnToolExecutionEndCallback,
@@ -227,6 +228,35 @@ export function executeToolsFromStream<
                       toolExecutionMs: result.toolExecutionMs,
                     });
                     controller.enqueue(result.output);
+
+                    if (result.output.type === 'tool-result') {
+                      const callerApproval = getToolCallerApprovalRequest({
+                        callerToolName: result.output.toolName,
+                        output: result.output.output,
+                        tools,
+                      });
+                      if (callerApproval !== undefined) {
+                        const nestedToolCall = {
+                          type: 'tool-call' as const,
+                          ...callerApproval.toolCall,
+                          dynamic: false as const,
+                        } as TypedToolCall<TOOLS>;
+                        const signature = await maybeSignApproval({
+                          secret: toolApprovalSecret,
+                          approvalId: callerApproval.approvalId,
+                          toolCallId: nestedToolCall.toolCallId,
+                          toolName: nestedToolCall.toolName,
+                          input: nestedToolCall.input,
+                        });
+                        controller.enqueue(nestedToolCall);
+                        controller.enqueue({
+                          type: 'tool-approval-request',
+                          approvalId: callerApproval.approvalId,
+                          toolCall: nestedToolCall,
+                          ...(signature != null ? { signature } : {}),
+                        });
+                      }
+                    }
                   }
                 } catch (error) {
                   controller.enqueue({

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -248,6 +248,108 @@ describe('experimental_toolCallers', () => {
     expect(result.toolResults[0]?.output).toEqual(['getInventory']);
   });
 
+  it('surfaces an initial nested caller approval in the model step', async () => {
+    const localCaller = experimental_toolCaller(
+      tool({
+        inputSchema: z.object({}),
+        execute: async () => undefined,
+      }),
+      {
+        type: 'local',
+        bind: () =>
+          tool({
+            inputSchema: z.object({}),
+            execute: async () => ({ stage: 'pending' }),
+          }),
+        getApprovalRequest: output =>
+          typeof output === 'object' &&
+          output !== null &&
+          'stage' in output &&
+          output.stage === 'pending'
+            ? {
+                approvalId: 'nested-approval',
+                callerToolCallId: 'outer-call',
+                toolCall: {
+                  toolCallId: 'nested-call',
+                  toolName: 'sensitive',
+                  input: { value: 42 },
+                },
+              }
+            : undefined,
+      },
+    );
+    const sensitive = vi.fn(async () => 'executed');
+
+    const result = await generateText({
+      model: new MockLanguageModelV4({
+        doGenerate: async () => ({
+          ...dummyResponseValues,
+          finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+          content: [
+            {
+              type: 'tool-call',
+              toolCallType: 'function',
+              toolCallId: 'outer-call',
+              toolName: 'code_mode',
+              input: '{}',
+            },
+          ],
+        }),
+      }),
+      tools: {
+        code_mode: localCaller,
+        sensitive: tool({
+          inputSchema: z.object({ value: z.number() }),
+          execute: sensitive,
+        }),
+      },
+      experimental_toolCallers: {
+        sensitive: ['code_mode'],
+      },
+      toolApproval: {
+        sensitive: 'user-approval',
+      },
+      prompt: 'Run the program.',
+    });
+
+    expect(sensitive).not.toHaveBeenCalled();
+    expect(
+      result.content.filter(
+        part =>
+          (part.type === 'tool-call' && part.toolCallId === 'nested-call') ||
+          part.type === 'tool-approval-request',
+      ),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "callerToolCallId": "outer-call",
+          "dynamic": false,
+          "input": {
+            "value": 42,
+          },
+          "toolCallId": "nested-call",
+          "toolName": "sensitive",
+          "type": "tool-call",
+        },
+        {
+          "approvalId": "nested-approval",
+          "callerToolCallId": "outer-call",
+          "toolCall": {
+            "callerToolCallId": "outer-call",
+            "dynamic": false,
+            "input": {
+              "value": 42,
+            },
+            "toolCallId": "nested-call",
+            "toolName": "sensitive",
+            "type": "tool-call",
+          },
+          "type": "tool-approval-request",
+        },
+      ]
+    `);
+  });
+
   it('resumes chained caller approvals before returning to the model', async () => {
     const readStage = (output: unknown): 'first' | 'second' | undefined => {
       if (
@@ -313,10 +415,15 @@ describe('experimental_toolCallers', () => {
         },
       },
     );
-    const doGenerate = vi.fn(async () => ({
-      ...dummyResponseValues,
-      content: [{ type: 'text' as const, text: 'complete' }],
-    }));
+    let modelPrompt: LanguageModelV4Prompt | undefined;
+    const doGenerate = vi.fn(async (options: LanguageModelV4CallOptions) => {
+      modelPrompt = options.prompt;
+      return {
+        ...dummyResponseValues,
+        content: [{ type: 'text' as const, text: 'complete' }],
+      };
+    });
+    const onStepEnd = vi.fn();
     const tools = {
       code_mode: localCaller,
       first: tool({
@@ -370,11 +477,17 @@ describe('experimental_toolCallers', () => {
           first: 'user-approval',
           second: 'user-approval',
         },
+        onStepEnd,
         messages,
       });
 
     const firstResult = await generate();
     expect(doGenerate).not.toHaveBeenCalled();
+    expect(firstResult.steps).toHaveLength(1);
+    expect(firstResult.finalStep).toBe(firstResult.steps[0]);
+    expect(firstResult.finalStep.finishReason).toBe('tool-calls');
+    expect(firstResult.finalStep.usage.totalTokens).toBeUndefined();
+    expect(onStepEnd).toHaveBeenLastCalledWith(firstResult.finalStep);
     expect(firstResult.content).toMatchInlineSnapshot(`
       [
         {
@@ -413,6 +526,8 @@ describe('experimental_toolCallers', () => {
 
     const secondResult = await generate();
     expect(doGenerate).not.toHaveBeenCalled();
+    expect(secondResult.steps).toHaveLength(1);
+    expect(secondResult.finalStep.finishReason).toBe('tool-calls');
     expect(secondResult.content).toMatchInlineSnapshot(`
       [
         {
@@ -452,6 +567,151 @@ describe('experimental_toolCallers', () => {
     const finalResult = await generate();
     expect(doGenerate).toHaveBeenCalledTimes(1);
     expect(finalResult.text).toMatchInlineSnapshot(`"complete"`);
+    expect(JSON.stringify(modelPrompt)).not.toContain('first-approval');
+    expect(JSON.stringify(modelPrompt)).not.toContain('second-approval');
+    expect(JSON.stringify(modelPrompt)).not.toContain('"toolName":"first"');
+    expect(JSON.stringify(modelPrompt)).not.toContain('"toolName":"second"');
+    expect(JSON.stringify(modelPrompt)).toContain('"completed":true');
+  });
+
+  it('resumes a denied nested approval without executing the nested tool', async () => {
+    const isPending = (output: unknown): boolean => {
+      if (
+        typeof output === 'object' &&
+        output !== null &&
+        'type' in output &&
+        output.type === 'json' &&
+        'value' in output
+      ) {
+        return isPending(output.value);
+      }
+      return (
+        typeof output === 'object' &&
+        output !== null &&
+        'stage' in output &&
+        output.stage === 'pending'
+      );
+    };
+    const localCaller = experimental_toolCaller(
+      tool({
+        inputSchema: z.object({}),
+        execute: async () => undefined,
+      }),
+      {
+        type: 'local',
+        bind: () =>
+          tool({
+            inputSchema: z.object({}),
+            execute: async () => undefined,
+          }),
+        getApprovalRequest: output =>
+          isPending(output)
+            ? {
+                approvalId: 'nested-approval',
+                callerToolCallId: 'outer-call',
+                toolCall: {
+                  toolCallId: 'nested-call',
+                  toolName: 'sensitive',
+                  input: {},
+                },
+              }
+            : undefined,
+        continueApproval: async ({ approvalResponse }) => {
+          expect(approvalResponse.approved).toBe(false);
+          throw new Error('nested execution denied');
+        },
+      },
+    );
+    const sensitive = vi.fn(async () => 'executed');
+    let modelPrompt: LanguageModelV4Prompt | undefined;
+
+    const result = await generateText({
+      model: new MockLanguageModelV4({
+        doGenerate: async options => {
+          modelPrompt = options.prompt;
+          return {
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: 'The operation was denied.' }],
+          };
+        },
+      }),
+      tools: {
+        code_mode: localCaller,
+        sensitive: tool({
+          inputSchema: z.object({}),
+          execute: sensitive,
+        }),
+      },
+      experimental_toolCallers: {
+        sensitive: ['code_mode'],
+      },
+      toolApproval: {
+        sensitive: 'user-approval',
+      },
+      messages: [
+        { role: 'user', content: 'Run the program.' },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'outer-call',
+              toolName: 'code_mode',
+              input: {},
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'outer-call',
+              toolName: 'code_mode',
+              output: {
+                type: 'json',
+                value: { stage: 'pending' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'nested-call',
+              callerToolCallId: 'outer-call',
+              toolName: 'sensitive',
+              input: {},
+            },
+            {
+              type: 'tool-approval-request',
+              approvalId: 'nested-approval',
+              toolCallId: 'nested-call',
+              callerToolCallId: 'outer-call',
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-approval-response',
+              approvalId: 'nested-approval',
+              approved: false,
+              reason: 'not allowed',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(sensitive).not.toHaveBeenCalled();
+    expect(result.text).toBe('The operation was denied.');
+    expect(JSON.stringify(modelPrompt)).not.toContain('nested-call');
+    expect(JSON.stringify(modelPrompt)).not.toContain('nested-approval');
+    expect(JSON.stringify(modelPrompt)).toContain('nested execution denied');
   });
 
   it('adds provider caller options while preserving direct access', async () => {

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -248,6 +248,158 @@ describe('experimental_toolCallers', () => {
     expect(result.toolResults[0]?.output).toEqual(['getInventory']);
   });
 
+  it('resumes chained caller approvals before returning to the model', async () => {
+    const readStage = (output: unknown): 'first' | 'second' | undefined => {
+      if (
+        typeof output === 'object' &&
+        output !== null &&
+        'type' in output &&
+        (output as { type?: unknown }).type === 'json' &&
+        'value' in output
+      ) {
+        return readStage((output as { value: unknown }).value);
+      }
+      return typeof output === 'object' && output !== null && 'stage' in output
+        ? ((output as { stage?: 'first' | 'second' }).stage ?? undefined)
+        : undefined;
+    };
+    const localCaller = experimental_toolCaller(
+      tool({
+        inputSchema: z.object({}),
+        execute: async () => undefined,
+      }),
+      {
+        type: 'local',
+        bind: () =>
+          tool({
+            inputSchema: z.object({}),
+            execute: async () => ({ stage: 'first' }),
+          }),
+        getApprovalRequest: output => {
+          const stage = readStage(output);
+          return stage === undefined
+            ? undefined
+            : {
+                approvalId: `${stage}-approval`,
+                callerToolCallId: 'outer-call',
+                toolCall: {
+                  toolCallId: `${stage}-call`,
+                  toolName: stage,
+                  input: {},
+                },
+              };
+        },
+        continueApproval: async ({ output, approvalResponse }) => {
+          expect(approvalResponse.approved).toBe(true);
+          return readStage(output) === 'first'
+            ? { stage: 'second' }
+            : { completed: true };
+        },
+      },
+    );
+    const doGenerate = vi.fn(async () => ({
+      ...dummyResponseValues,
+      content: [{ type: 'text' as const, text: 'complete' }],
+    }));
+    const tools = {
+      code_mode: localCaller,
+      first: tool({
+        inputSchema: z.object({}),
+        execute: async () => 'first',
+      }),
+      second: tool({
+        inputSchema: z.object({}),
+        execute: async () => 'second',
+      }),
+    };
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Run the program.' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'outer-call',
+            toolName: 'code_mode',
+            input: {},
+          },
+          {
+            type: 'tool-approval-request',
+            approvalId: 'outer-approval',
+            toolCallId: 'outer-call',
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-approval-response',
+            approvalId: 'outer-approval',
+            approved: true,
+          },
+        ],
+      },
+    ];
+    const generate = async () =>
+      await generateText({
+        model: new MockLanguageModelV4({ doGenerate }),
+        tools,
+        experimental_toolCallers: ({ code_mode }) => ({
+          first: [code_mode],
+          second: [code_mode],
+        }),
+        toolApproval: {
+          code_mode: 'user-approval',
+          first: 'user-approval',
+          second: 'user-approval',
+        },
+        messages,
+      });
+
+    const firstResult = await generate();
+    expect(doGenerate).not.toHaveBeenCalled();
+    expect(firstResult.content).toContainEqual(
+      expect.objectContaining({
+        type: 'tool-approval-request',
+        approvalId: 'first-approval',
+      }),
+    );
+    messages.push(...firstResult.responseMessages, {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-approval-response',
+          approvalId: 'first-approval',
+          approved: true,
+        },
+      ],
+    });
+
+    const secondResult = await generate();
+    expect(doGenerate).not.toHaveBeenCalled();
+    expect(secondResult.content).toContainEqual(
+      expect.objectContaining({
+        type: 'tool-approval-request',
+        approvalId: 'second-approval',
+      }),
+    );
+    messages.push(...secondResult.responseMessages, {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-approval-response',
+          approvalId: 'second-approval',
+          approved: true,
+        },
+      ],
+    });
+
+    const finalResult = await generate();
+    expect(doGenerate).toHaveBeenCalledTimes(1);
+    expect(finalResult.text).toBe('complete');
+  });
+
   it('adds provider caller options while preserving direct access', async () => {
     let modelTools: LanguageModelV4CallOptions['tools'];
 

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -714,6 +714,358 @@ describe('experimental_toolCallers', () => {
     expect(JSON.stringify(modelPrompt)).toContain('nested execution denied');
   });
 
+  it('does not replay a completed nested caller approval', async () => {
+    const isPending = (output: unknown): boolean => {
+      if (
+        typeof output === 'object' &&
+        output !== null &&
+        'type' in output &&
+        output.type === 'json' &&
+        'value' in output
+      ) {
+        return isPending(output.value);
+      }
+      return (
+        typeof output === 'object' &&
+        output !== null &&
+        'stage' in output &&
+        output.stage === 'pending'
+      );
+    };
+    const continueApproval = vi.fn(async () => ({ completed: true }));
+    const localCaller = experimental_toolCaller(
+      tool({
+        inputSchema: z.object({}),
+        execute: async () => undefined,
+      }),
+      {
+        type: 'local',
+        bind: () =>
+          tool({
+            inputSchema: z.object({}),
+            execute: async () => undefined,
+          }),
+        getApprovalRequest: output =>
+          isPending(output)
+            ? {
+                approvalId: 'nested-approval',
+                callerToolCallId: 'outer-call',
+                toolCall: {
+                  toolCallId: 'nested-call',
+                  toolName: 'sensitive',
+                  input: {},
+                },
+              }
+            : undefined,
+        continueApproval,
+      },
+    );
+    const tools = {
+      code_mode: localCaller,
+      sensitive: tool({
+        inputSchema: z.object({}),
+        execute: async () => 'executed',
+      }),
+    };
+    const messages: ModelMessage[] = [
+      { role: 'user', content: 'Run the program.' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'outer-call',
+            toolName: 'code_mode',
+            input: {},
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'outer-call',
+            toolName: 'code_mode',
+            output: {
+              type: 'json',
+              value: { stage: 'pending' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'nested-call',
+            callerToolCallId: 'outer-call',
+            toolName: 'sensitive',
+            input: {},
+          },
+          {
+            type: 'tool-approval-request',
+            approvalId: 'nested-approval',
+            toolCallId: 'nested-call',
+            callerToolCallId: 'outer-call',
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-approval-response',
+            approvalId: 'nested-approval',
+            approved: true,
+          },
+        ],
+      },
+    ];
+    const generate = async () =>
+      await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => ({
+            ...dummyResponseValues,
+            content: [{ type: 'text', text: 'complete' }],
+          }),
+        }),
+        tools,
+        experimental_toolCallers: {
+          sensitive: ['code_mode'],
+        },
+        toolApproval: {
+          sensitive: 'user-approval',
+        },
+        messages,
+      });
+
+    const firstResult = await generate();
+    expect(continueApproval).toHaveBeenCalledOnce();
+
+    messages.push(...firstResult.responseMessages, {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-approval-response',
+          approvalId: 'nested-approval',
+          approved: true,
+        },
+      ],
+    });
+
+    await generate();
+
+    expect(continueApproval).toHaveBeenCalledOnce();
+  });
+
+  it('signs nested caller approvals and rejects tampered inputs or signatures', async () => {
+    const secret = 'nested-approval-test-secret';
+    const originalInput = { value: 'original' };
+    const isPending = (output: unknown): boolean => {
+      if (
+        typeof output === 'object' &&
+        output !== null &&
+        'type' in output &&
+        output.type === 'json' &&
+        'value' in output
+      ) {
+        return isPending(output.value);
+      }
+      return (
+        typeof output === 'object' &&
+        output !== null &&
+        'stage' in output &&
+        output.stage === 'pending'
+      );
+    };
+    const continueApproval = vi.fn(async () => ({ completed: true }));
+    const localCaller = experimental_toolCaller(
+      tool({
+        inputSchema: z.object({}),
+        execute: async () => undefined,
+      }),
+      {
+        type: 'local',
+        bind: () =>
+          tool({
+            inputSchema: z.object({}),
+            execute: async () => ({ stage: 'pending' }),
+          }),
+        getApprovalRequest: output =>
+          isPending(output)
+            ? {
+                approvalId: 'nested-approval',
+                callerToolCallId: 'outer-call',
+                toolCall: {
+                  toolCallId: 'nested-call',
+                  toolName: 'sensitive',
+                  input: originalInput,
+                },
+              }
+            : undefined,
+        continueApproval,
+      },
+    );
+    const tools = {
+      code_mode: localCaller,
+      sensitive: tool({
+        inputSchema: z.object({ value: z.string() }),
+        execute: async () => 'executed',
+      }),
+    };
+
+    const initialResult = await generateText({
+      model: new MockLanguageModelV4({
+        doGenerate: async () => ({
+          ...dummyResponseValues,
+          finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+          content: [
+            {
+              type: 'tool-call',
+              toolCallType: 'function',
+              toolCallId: 'outer-call',
+              toolName: 'code_mode',
+              input: '{}',
+            },
+          ],
+        }),
+      }),
+      tools,
+      experimental_toolCallers: {
+        sensitive: ['code_mode'],
+      },
+      toolApproval: {
+        sensitive: 'user-approval',
+      },
+      experimental_toolApprovalSecret: secret,
+      prompt: 'Run the program.',
+    });
+    const approvalRequest = initialResult.content.find(
+      part => part.type === 'tool-approval-request',
+    );
+    assert(approvalRequest?.type === 'tool-approval-request');
+    assert(approvalRequest.signature != null);
+    const signature = approvalRequest.signature;
+
+    const createMessages = ({
+      input,
+      signature,
+    }: {
+      input: { value: string };
+      signature: string;
+    }): ModelMessage[] => [
+      { role: 'user', content: 'Run the program.' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'outer-call',
+            toolName: 'code_mode',
+            input: {},
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'outer-call',
+            toolName: 'code_mode',
+            output: {
+              type: 'json',
+              value: { stage: 'pending' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'nested-call',
+            callerToolCallId: 'outer-call',
+            toolName: 'sensitive',
+            input,
+          },
+          {
+            type: 'tool-approval-request',
+            approvalId: 'nested-approval',
+            toolCallId: 'nested-call',
+            callerToolCallId: 'outer-call',
+            signature,
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-approval-response',
+            approvalId: 'nested-approval',
+            approved: true,
+          },
+        ],
+      },
+    ];
+    const model = new MockLanguageModelV4({
+      doGenerate: async () => ({
+        ...dummyResponseValues,
+        content: [{ type: 'text', text: 'complete' }],
+      }),
+    });
+    const generate = async (messages: ModelMessage[]) =>
+      await generateText({
+        model,
+        tools,
+        experimental_toolCallers: {
+          sensitive: ['code_mode'],
+        },
+        toolApproval: {
+          sensitive: 'user-approval',
+        },
+        experimental_toolApprovalSecret: secret,
+        messages,
+      });
+
+    await expect(
+      generate(
+        createMessages({
+          input: { value: 'tampered' },
+          signature,
+        }),
+      ),
+    ).rejects.toThrowError(/invalid signature/);
+
+    const tamperedSignature = `${signature.slice(0, -1)}${
+      signature.endsWith('A') ? 'B' : 'A'
+    }`;
+    await expect(
+      generate(
+        createMessages({
+          input: originalInput,
+          signature: tamperedSignature,
+        }),
+      ),
+    ).rejects.toThrowError(/invalid signature/);
+
+    expect(continueApproval).not.toHaveBeenCalled();
+
+    await expect(
+      generate(
+        createMessages({
+          input: originalInput,
+          signature,
+        }),
+      ),
+    ).resolves.toMatchObject({ text: 'complete' });
+    expect(continueApproval).toHaveBeenCalledOnce();
+  });
+
   it('adds provider caller options while preserving direct access', async () => {
     let modelTools: LanguageModelV4CallOptions['tools'];
 

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -378,6 +378,7 @@ describe('experimental_toolCallers', () => {
     expect(firstResult.content).toMatchInlineSnapshot(`
       [
         {
+          "callerToolCallId": "outer-call",
           "dynamic": false,
           "input": {},
           "toolCallId": "first-call",
@@ -386,7 +387,9 @@ describe('experimental_toolCallers', () => {
         },
         {
           "approvalId": "first-approval",
+          "callerToolCallId": "outer-call",
           "toolCall": {
+            "callerToolCallId": "outer-call",
             "dynamic": false,
             "input": {},
             "toolCallId": "first-call",
@@ -413,6 +416,7 @@ describe('experimental_toolCallers', () => {
     expect(secondResult.content).toMatchInlineSnapshot(`
       [
         {
+          "callerToolCallId": "outer-call",
           "dynamic": false,
           "input": {},
           "toolCallId": "second-call",
@@ -421,7 +425,9 @@ describe('experimental_toolCallers', () => {
         },
         {
           "approvalId": "second-approval",
+          "callerToolCallId": "outer-call",
           "toolCall": {
+            "callerToolCallId": "outer-call",
             "dynamic": false,
             "input": {},
             "toolCallId": "second-call",

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -289,11 +289,27 @@ describe('experimental_toolCallers', () => {
                 },
               };
         },
-        continueApproval: async ({ output, approvalResponse }) => {
-          expect(approvalResponse.approved).toBe(true);
-          return readStage(output) === 'first'
-            ? { stage: 'second' }
-            : { completed: true };
+        continueApproval: async ({
+          output,
+          approvalResponse,
+          resolveToolApproval,
+        }) => {
+          expect(approvalResponse.approved).toMatchInlineSnapshot(`true`);
+          if (readStage(output) === 'first') {
+            await expect(
+              resolveToolApproval({
+                toolCallId: 'second-call',
+                toolName: 'second',
+                input: {},
+              }),
+            ).resolves.toMatchInlineSnapshot(`
+              {
+                "type": "user-approval",
+              }
+            `);
+            return { stage: 'second' };
+          }
+          return { completed: true };
         },
       },
     );
@@ -359,12 +375,28 @@ describe('experimental_toolCallers', () => {
 
     const firstResult = await generate();
     expect(doGenerate).not.toHaveBeenCalled();
-    expect(firstResult.content).toContainEqual(
-      expect.objectContaining({
-        type: 'tool-approval-request',
-        approvalId: 'first-approval',
-      }),
-    );
+    expect(firstResult.content).toMatchInlineSnapshot(`
+      [
+        {
+          "dynamic": false,
+          "input": {},
+          "toolCallId": "first-call",
+          "toolName": "first",
+          "type": "tool-call",
+        },
+        {
+          "approvalId": "first-approval",
+          "toolCall": {
+            "dynamic": false,
+            "input": {},
+            "toolCallId": "first-call",
+            "toolName": "first",
+            "type": "tool-call",
+          },
+          "type": "tool-approval-request",
+        },
+      ]
+    `);
     messages.push(...firstResult.responseMessages, {
       role: 'tool',
       content: [
@@ -378,12 +410,28 @@ describe('experimental_toolCallers', () => {
 
     const secondResult = await generate();
     expect(doGenerate).not.toHaveBeenCalled();
-    expect(secondResult.content).toContainEqual(
-      expect.objectContaining({
-        type: 'tool-approval-request',
-        approvalId: 'second-approval',
-      }),
-    );
+    expect(secondResult.content).toMatchInlineSnapshot(`
+      [
+        {
+          "dynamic": false,
+          "input": {},
+          "toolCallId": "second-call",
+          "toolName": "second",
+          "type": "tool-call",
+        },
+        {
+          "approvalId": "second-approval",
+          "toolCall": {
+            "dynamic": false,
+            "input": {},
+            "toolCallId": "second-call",
+            "toolName": "second",
+            "type": "tool-call",
+          },
+          "type": "tool-approval-request",
+        },
+      ]
+    `);
     messages.push(...secondResult.responseMessages, {
       role: 'tool',
       content: [
@@ -397,7 +445,7 @@ describe('experimental_toolCallers', () => {
 
     const finalResult = await generate();
     expect(doGenerate).toHaveBeenCalledTimes(1);
-    expect(finalResult.text).toBe('complete');
+    expect(finalResult.text).toMatchInlineSnapshot(`"complete"`);
   });
 
   it('adds provider caller options while preserving direct access', async () => {

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -361,10 +361,10 @@ describe('experimental_toolCallers', () => {
       await generateText({
         model: new MockLanguageModelV4({ doGenerate }),
         tools,
-        experimental_toolCallers: ({ code_mode }) => ({
-          first: [code_mode],
-          second: [code_mode],
-        }),
+        experimental_toolCallers: {
+          first: ['code_mode'],
+          second: ['code_mode'],
+        },
         toolApproval: {
           code_mode: 'user-approval',
           first: 'user-approval',

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -708,10 +708,7 @@ export async function generateText<
     });
 
     try {
-      let initialMessages = normalizeToolCallerApprovalMessages({
-        messages: initialPrompt.messages,
-        tools,
-      });
+      let initialMessages = initialPrompt.messages;
       const initialResponseMessages: Array<ResponseMessage> = [];
       const callerContinuationResponseMessages: Array<ResponseMessage> = [];
       const pendingToolCallerApprovals: Array<
@@ -807,25 +804,19 @@ export async function generateText<
             ),
           );
           initialResponseMessages.push(...callerContinuationResponseMessages);
-          const continuedApprovalIds = new Set(
-            continuedApprovals.continued.map(
-              continuation => continuation.approval.approvalRequest.approvalId,
-            ),
-          );
-          localApprovedToolApprovals = localApprovedToolApprovals.filter(
-            approval =>
-              !continuedApprovalIds.has(approval.approvalRequest.approvalId),
-          );
-          deniedToolApprovals = deniedToolApprovals.filter(
-            approval =>
-              !continuedApprovalIds.has(approval.approvalRequest.approvalId),
-          );
-          deniedToolApprovalsWithoutResults =
-            deniedToolApprovalsWithoutResults.filter(
-              approval =>
-                !continuedApprovalIds.has(approval.approvalRequest.approvalId),
-            );
         }
+        localApprovedToolApprovals = localApprovedToolApprovals.filter(
+          approval => continuedApprovals.remaining.includes(approval),
+        );
+        deniedToolApprovals = deniedToolApprovals.filter(
+          approval =>
+            approval.existingToolResult != null ||
+            continuedApprovals.remaining.includes(approval),
+        );
+        deniedToolApprovalsWithoutResults =
+          deniedToolApprovalsWithoutResults.filter(approval =>
+            continuedApprovals.remaining.includes(approval),
+          );
       }
 
       if (
@@ -943,6 +934,9 @@ export async function generateText<
       const steps: GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>['steps'] =
         [];
       let instructionsForNextStep = initialPrompt.instructions;
+      initialMessages = normalizeToolCallerApprovalMessages({
+        messages: initialMessages,
+      });
       let messagesForNextStep = [
         ...initialMessages,
         ...initialResponseMessages.filter(

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -775,6 +775,19 @@ export async function generateText<
           toolCallers: resolvedToolCallers,
           toolsContext,
           abortSignal: mergedAbortSignal,
+          resolveToolApproval: async (toolCall, messages) =>
+            await resolveToolApproval({
+              tools,
+              toolCall: {
+                type: 'tool-call',
+                ...toolCall,
+                dynamic: false,
+              } as TypedToolCall<TOOLS>,
+              toolApproval,
+              messages,
+              toolsContext,
+              runtimeContext,
+            }),
         });
         for (const continuation of continuedApprovals.continued) {
           if (continuation.nextApprovalRequest !== undefined) {

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1996,8 +1996,20 @@ function asContent<TOOLS extends ToolSet>({
     }
   }
 
+  const existingToolCallIds = new Set(
+    contentParts
+      .filter(part => part.type === 'tool-call')
+      .map(part => part.toolCallId),
+  );
+
+  // for code mode execution, when inner tools require approval, we need to surface the tool call along with the approval request for AI SDK core
+  const nestedToolCallsRequiringApproval = toolApprovalRequests
+    .map(request => request.toolCall)
+    .filter(toolCall => !existingToolCallIds.has(toolCall.toolCallId));
+
   return [
     ...contentParts,
+    ...nestedToolCallsRequiringApproval,
     ...toolOutputsWithoutApprovalResponses,
     ...toolApprovalRequests,
     ...toolApprovalResponses,

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -50,6 +50,7 @@ import type {
 import {
   addLanguageModelUsage,
   asLanguageModelUsage,
+  createNullLanguageModelUsage,
   type LanguageModelUsage,
 } from '../types/usage';
 import type { DownloadFunction } from '../util/download/download-function';
@@ -112,6 +113,7 @@ import type { ToolApprovalConfiguration } from './tool-approval-configuration';
 import type { ToolApprovalRequestOutput } from './tool-approval-request-output';
 import type { ToolApprovalResponseOutput } from './tool-approval-response-output';
 import {
+  createToolCallerApprovalRequestOutput,
   getToolCallerApprovalRequest,
   prepareToolsForToolCallers,
   resolveToolCallerConfiguration,
@@ -712,6 +714,9 @@ export async function generateText<
       });
       const initialResponseMessages: Array<ResponseMessage> = [];
       const callerContinuationResponseMessages: Array<ResponseMessage> = [];
+      const pendingToolCallerApprovals: Array<
+        ToolApprovalRequestOutput<TOOLS>
+      > = [];
       const { executionTools: initialExecutionTools } =
         prepareToolsForToolCallers({
           tools,
@@ -771,6 +776,16 @@ export async function generateText<
           toolsContext,
           abortSignal: mergedAbortSignal,
         });
+        for (const continuation of continuedApprovals.continued) {
+          if (continuation.nextApprovalRequest !== undefined) {
+            pendingToolCallerApprovals.push(
+              await createToolCallerApprovalRequestOutput({
+                request: continuation.nextApprovalRequest,
+                toolApprovalSecret: experimental_toolApprovalSecret,
+              }),
+            );
+          }
+        }
         if (continuedApprovals.continued.length > 0) {
           initialMessages = continuedApprovals.messages;
           callerContinuationResponseMessages.push(
@@ -841,6 +856,22 @@ export async function generateText<
         // add regular tool results for approved tool calls:
         for (const result of toolResults) {
           const output = result.output;
+          if (output.type === 'tool-result') {
+            const callerApproval = getToolCallerApprovalRequest({
+              callerToolName: output.toolName,
+              output: output.output,
+              tools: initialExecutionTools,
+            });
+            if (callerApproval !== undefined) {
+              pendingToolCallerApprovals.push(
+                await createToolCallerApprovalRequestOutput({
+                  request: callerApproval,
+                  toolApprovalSecret: experimental_toolApprovalSecret,
+                }),
+              );
+            }
+          }
+
           const modelOutput = await createToolModelOutput({
             toolCallId: output.toolCallId,
             input: output.input,
@@ -905,13 +936,31 @@ export async function generateText<
           message => !callerContinuationResponseMessages.includes(message),
         ),
       ];
+      if (pendingToolCallerApprovals.length > 0) {
+        const pendingApprovalStep = await createToolCallerApprovalStep({
+          callId,
+          provider: model.provider,
+          modelId: model.modelId,
+          runtimeContext,
+          toolsContext,
+          approvalRequests: pendingToolCallerApprovals,
+          tools,
+          generateId,
+        });
+        steps.push(pendingApprovalStep);
+        await notify({
+          event: pendingApprovalStep,
+          callbacks: [resolvedOnStepEnd, telemetryDispatcher.onStepEnd],
+        });
+      }
 
       // Track provider-executed tool calls that support deferred results
       // (e.g., code_execution in programmatic tool calling scenarios).
       // These tools may not return their results in the same turn as their call.
       const pendingDeferredToolCalls = new Map<string, { toolName: string }>();
 
-      do {
+      let continueSteps = pendingToolCallerApprovals.length === 0;
+      while (continueSteps) {
         if (steps.length > 0) {
           mergedAbortSignal?.throwIfAborted();
         }
@@ -1389,26 +1438,16 @@ export async function generateText<
                     continue;
                   }
 
-                  const nestedToolCall = {
-                    type: 'tool-call' as const,
-                    ...callerApproval.toolCall,
-                    dynamic: false as const,
-                  } as TypedToolCall<TOOLS>;
-                  const signature = await maybeSignApproval({
-                    secret: experimental_toolApprovalSecret,
-                    approvalId: callerApproval.approvalId,
-                    toolCallId: nestedToolCall.toolCallId,
-                    toolName: nestedToolCall.toolName,
-                    input: nestedToolCall.input,
-                  });
+                  const approvalRequest =
+                    await createToolCallerApprovalRequestOutput<TOOLS>({
+                      request: callerApproval,
+                      toolApprovalSecret: experimental_toolApprovalSecret,
+                    });
+                  const nestedToolCall = approvalRequest.toolCall;
                   stepToolCalls.push(nestedToolCall);
                   clientToolCalls.push(nestedToolCall);
-                  toolApprovalRequests[nestedToolCall.toolCallId] = {
-                    type: 'tool-approval-request',
-                    approvalId: callerApproval.approvalId,
-                    toolCall: nestedToolCall,
-                    ...(signature != null ? { signature } : {}),
-                  };
+                  toolApprovalRequests[nestedToolCall.toolCallId] =
+                    approvalRequest;
                 }
               }
 
@@ -1542,17 +1581,17 @@ export async function generateText<
             clearTimeout(stepTimeoutId);
           }
         }
-      } while (
-        // Continue if:
-        // 1. There are client tool calls that have all been executed or denied, OR
-        // 2. There are pending deferred results from provider-executed tools
-        ((clientToolCalls.length > 0 &&
-          clientToolOutputs.length + deniedToolApprovalResponses.length ===
-            clientToolCalls.length) ||
-          pendingDeferredToolCalls.size > 0) &&
-        // continue until a stop condition is met:
-        !(await isStopConditionMet({ stopConditions, steps }))
-      );
+        continueSteps =
+          // Continue if:
+          // 1. There are client tool calls that have all been executed or denied, OR
+          // 2. There are pending deferred results from provider-executed tools
+          ((clientToolCalls.length > 0 &&
+            clientToolOutputs.length + deniedToolApprovalResponses.length ===
+              clientToolCalls.length) ||
+            pendingDeferredToolCalls.size > 0) &&
+          // continue until a stop condition is met:
+          !(await isStopConditionMet({ stopConditions, steps }));
+      }
 
       const lastStep = steps[steps.length - 1];
 
@@ -1655,6 +1694,67 @@ export async function generateText<
     type: 'generateText',
     event: generateTextStartEvent,
     execute: executeGenerateText,
+  });
+}
+
+async function createToolCallerApprovalStep<
+  TOOLS extends ToolSet,
+  RUNTIME_CONTEXT extends Context,
+>({
+  callId,
+  provider,
+  modelId,
+  runtimeContext,
+  toolsContext,
+  approvalRequests,
+  tools,
+  generateId,
+}: {
+  callId: string;
+  provider: string;
+  modelId: string;
+  runtimeContext: RUNTIME_CONTEXT;
+  toolsContext: InferToolSetContext<TOOLS>;
+  approvalRequests: Array<ToolApprovalRequestOutput<TOOLS>>;
+  tools: TOOLS | undefined;
+  generateId: IdGenerator;
+}): Promise<StepResult<TOOLS, RUNTIME_CONTEXT>> {
+  const content: Array<ContentPart<TOOLS>> = [];
+  for (const approvalRequest of approvalRequests) {
+    content.push(approvalRequest.toolCall, approvalRequest);
+  }
+  const responseMessages = await toResponseMessages({ content, tools });
+
+  return new DefaultStepResult({
+    callId,
+    stepNumber: 0,
+    provider,
+    modelId,
+    runtimeContext,
+    toolsContext,
+    content,
+    finishReason: 'tool-calls',
+    rawFinishReason: undefined,
+    usage: createNullLanguageModelUsage(),
+    performance: {
+      effectiveOutputTokensPerSecond: 0,
+      outputTokensPerSecond: undefined,
+      inputTokensPerSecond: undefined,
+      effectiveTotalTokensPerSecond: 0,
+      stepTimeMs: 0,
+      responseTimeMs: 0,
+      toolExecutionMs: {},
+      timeToFirstOutputMs: undefined,
+    },
+    warnings: [],
+    request: {},
+    response: {
+      id: generateId(),
+      timestamp: new Date(),
+      modelId,
+      messages: cloneModelMessages(responseMessages),
+    },
+    providerMetadata: undefined,
   });
 }
 

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -712,6 +712,24 @@ export async function generateText<
       });
       const initialResponseMessages: Array<ResponseMessage> = [];
       const callerContinuationResponseMessages: Array<ResponseMessage> = [];
+      const { executionTools: initialExecutionTools } =
+        prepareToolsForToolCallers({
+          tools,
+          toolCallers: resolvedToolCallers,
+          resolveToolApproval: async toolCall =>
+            await resolveToolApproval({
+              tools,
+              toolCall: {
+                type: 'tool-call',
+                ...toolCall,
+                dynamic: false,
+              } as TypedToolCall<TOOLS>,
+              toolApproval,
+              messages: initialMessages,
+              toolsContext,
+              runtimeContext,
+            }),
+        });
 
       const {
         approvedToolApprovals,
@@ -725,7 +743,7 @@ export async function generateText<
         approvedToolApprovals: approvedToolApprovals.filter(
           toolApproval => !toolApproval.toolCall.providerExecuted,
         ),
-        tools,
+        tools: initialExecutionTools,
         toolApproval,
         messages: initialMessages,
         toolsContext,
@@ -783,14 +801,15 @@ export async function generateText<
       }
 
       if (
-        deniedToolApprovalsWithoutResults.length > 0 ||
-        localApprovedToolApprovals.length > 0
+        initialExecutionTools != null &&
+        (deniedToolApprovalsWithoutResults.length > 0 ||
+          localApprovedToolApprovals.length > 0)
       ) {
         const toolResults = await executeTools({
           toolCalls: localApprovedToolApprovals.map(
             toolApproval => toolApproval.toolCall,
           ),
-          tools: tools as TOOLS,
+          tools: initialExecutionTools,
           callId,
           messages: initialMessages,
           abortSignal: mergedAbortSignal,
@@ -825,7 +844,7 @@ export async function generateText<
           const modelOutput = await createToolModelOutput({
             toolCallId: output.toolCallId,
             input: output.input,
-            tool: getOwn(tools, output.toolName),
+            tool: getOwn(initialExecutionTools, output.toolName),
             output:
               output.type === 'tool-result' ? output.output : output.error,
             errorMode: output.type === 'tool-error' ? 'text' : 'none',

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -64,6 +64,10 @@ import { VERSION } from '../version';
 import type { ActiveTools } from './active-tools';
 import { calculateTokensPerSecond } from './calculate-tokens-per-second';
 import { collectToolApprovals } from './collect-tool-approvals';
+import {
+  continueToolCallerApprovals,
+  normalizeToolCallerApprovalMessages,
+} from './continue-tool-caller-approvals';
 import type { ContentPart } from './content-part';
 import { executeToolCall } from './execute-tool-call';
 import {
@@ -108,6 +112,7 @@ import type { ToolApprovalConfiguration } from './tool-approval-configuration';
 import type { ToolApprovalRequestOutput } from './tool-approval-request-output';
 import type { ToolApprovalResponseOutput } from './tool-approval-response-output';
 import {
+  getToolCallerApprovalRequest,
   prepareToolsForToolCallers,
   resolveToolCallerConfiguration,
   type Experimental_ToolCallers,
@@ -701,15 +706,19 @@ export async function generateText<
     });
 
     try {
-      const initialMessages = initialPrompt.messages;
+      let initialMessages = normalizeToolCallerApprovalMessages({
+        messages: initialPrompt.messages,
+        tools,
+      });
       const initialResponseMessages: Array<ResponseMessage> = [];
+      const callerContinuationResponseMessages: Array<ResponseMessage> = [];
 
       const {
         approvedToolApprovals,
         deniedToolApprovals: collectedDeniedToolApprovals,
       } = collectToolApprovals<TOOLS>({ messages: initialMessages });
 
-      const {
+      let {
         approvedToolApprovals: localApprovedToolApprovals,
         deniedToolApprovals: revalidationDeniedToolApprovals,
       } = await validateApprovedToolApprovals<TOOLS, RUNTIME_CONTEXT>({
@@ -724,13 +733,54 @@ export async function generateText<
         toolApprovalSecret: experimental_toolApprovalSecret,
       });
 
-      const deniedToolApprovals = [
+      let deniedToolApprovals = [
         ...collectedDeniedToolApprovals,
         ...revalidationDeniedToolApprovals,
       ];
-      const deniedToolApprovalsWithoutResults = deniedToolApprovals.filter(
+      let deniedToolApprovalsWithoutResults = deniedToolApprovals.filter(
         toolApproval => toolApproval.existingToolResult == null,
       );
+
+      if (tools != null) {
+        const continuedApprovals = await continueToolCallerApprovals({
+          approvals: [
+            ...localApprovedToolApprovals,
+            ...deniedToolApprovalsWithoutResults,
+          ],
+          messages: initialMessages,
+          tools,
+          toolCallers: resolvedToolCallers,
+          toolsContext,
+          abortSignal: mergedAbortSignal,
+        });
+        if (continuedApprovals.continued.length > 0) {
+          initialMessages = continuedApprovals.messages;
+          callerContinuationResponseMessages.push(
+            ...continuedApprovals.continued.map(
+              continuation => continuation.responseMessage,
+            ),
+          );
+          initialResponseMessages.push(...callerContinuationResponseMessages);
+          const continuedApprovalIds = new Set(
+            continuedApprovals.continued.map(
+              continuation => continuation.approval.approvalRequest.approvalId,
+            ),
+          );
+          localApprovedToolApprovals = localApprovedToolApprovals.filter(
+            approval =>
+              !continuedApprovalIds.has(approval.approvalRequest.approvalId),
+          );
+          deniedToolApprovals = deniedToolApprovals.filter(
+            approval =>
+              !continuedApprovalIds.has(approval.approvalRequest.approvalId),
+          );
+          deniedToolApprovalsWithoutResults =
+            deniedToolApprovalsWithoutResults.filter(
+              approval =>
+                !continuedApprovalIds.has(approval.approvalRequest.approvalId),
+            );
+        }
+      }
 
       if (
         deniedToolApprovalsWithoutResults.length > 0 ||
@@ -832,7 +882,9 @@ export async function generateText<
       let instructionsForNextStep = initialPrompt.instructions;
       let messagesForNextStep = [
         ...initialMessages,
-        ...initialResponseMessages,
+        ...initialResponseMessages.filter(
+          message => !callerContinuationResponseMessages.includes(message),
+        ),
       ];
 
       // Track provider-executed tool calls that support deferred results
@@ -908,12 +960,27 @@ export async function generateText<
                 tools,
                 activeTools: prepareStepResult?.activeTools ?? activeTools,
               });
+              const stepMessages =
+                prepareStepResult?.messages ?? stepInputMessages;
               const {
                 executionTools: stepExecutionTools,
                 modelTools: stepModelTools,
               } = prepareToolsForToolCallers({
                 tools: stepActiveTools,
                 toolCallers: resolvedToolCallers,
+                resolveToolApproval: async toolCall =>
+                  await resolveToolApproval({
+                    tools: stepActiveTools as TOOLS,
+                    toolCall: {
+                      type: 'tool-call',
+                      ...toolCall,
+                      dynamic: false,
+                    } as TypedToolCall<TOOLS>,
+                    toolApproval,
+                    messages: stepMessages,
+                    toolsContext,
+                    runtimeContext,
+                  }),
               });
               const stepToolOrder = prepareStepResult?.toolOrder ?? toolOrder;
 
@@ -935,9 +1002,6 @@ export async function generateText<
               const stepToolChoice = prepareToolChoice({
                 toolChoice: prepareStepResult?.toolChoice ?? toolChoice,
               });
-
-              const stepMessages =
-                prepareStepResult?.messages ?? stepInputMessages;
 
               const stepProviderOptions = mergeObjects(
                 providerOptions,
@@ -1293,6 +1357,39 @@ export async function generateText<
                   toolExecutionMs[result.output.toolCallId] =
                     result.toolExecutionMs;
                   clientToolOutputs.push(result.output);
+
+                  if (result.output.type !== 'tool-result') {
+                    continue;
+                  }
+                  const callerApproval = getToolCallerApprovalRequest({
+                    callerToolName: result.output.toolName,
+                    output: result.output.output,
+                    tools: stepExecutionTools,
+                  });
+                  if (callerApproval === undefined) {
+                    continue;
+                  }
+
+                  const nestedToolCall = {
+                    type: 'tool-call' as const,
+                    ...callerApproval.toolCall,
+                    dynamic: false as const,
+                  } as TypedToolCall<TOOLS>;
+                  const signature = await maybeSignApproval({
+                    secret: experimental_toolApprovalSecret,
+                    approvalId: callerApproval.approvalId,
+                    toolCallId: nestedToolCall.toolCallId,
+                    toolName: nestedToolCall.toolName,
+                    input: nestedToolCall.input,
+                  });
+                  stepToolCalls.push(nestedToolCall);
+                  clientToolCalls.push(nestedToolCall);
+                  toolApprovalRequests[nestedToolCall.toolCallId] = {
+                    type: 'tool-approval-request',
+                    approvalId: callerApproval.approvalId,
+                    toolCall: nestedToolCall,
+                    ...(signature != null ? { signature } : {}),
+                  };
                 }
               }
 

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -21126,6 +21126,114 @@ describe('streamText', () => {
       );
     });
 
+    it('streams an initial nested caller approval in the model step', async () => {
+      const localCaller = experimental_toolCaller(
+        tool({
+          inputSchema: z.object({}),
+          execute: async () => undefined,
+        }),
+        {
+          type: 'local',
+          bind: () =>
+            tool({
+              inputSchema: z.object({}),
+              execute: async () => ({ stage: 'pending' }),
+            }),
+          getApprovalRequest: output =>
+            typeof output === 'object' &&
+            output !== null &&
+            'stage' in output &&
+            output.stage === 'pending'
+              ? {
+                  approvalId: 'nested-approval',
+                  callerToolCallId: 'outer-call',
+                  toolCall: {
+                    toolCallId: 'nested-call',
+                    toolName: 'sensitive',
+                    input: { value: 42 },
+                  },
+                }
+              : undefined,
+        },
+      );
+      const sensitive = vi.fn(async () => 'executed');
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream([
+              {
+                type: 'tool-call',
+                toolCallId: 'outer-call',
+                toolName: 'code_mode',
+                input: '{}',
+              },
+              {
+                type: 'finish',
+                finishReason: {
+                  unified: 'tool-calls',
+                  raw: 'tool_calls',
+                },
+                usage: testUsage,
+              },
+            ]),
+          }),
+        }),
+        tools: {
+          code_mode: localCaller,
+          sensitive: tool({
+            inputSchema: z.object({ value: z.number() }),
+            execute: sensitive,
+          }),
+        },
+        experimental_toolCallers: {
+          sensitive: ['code_mode'],
+        },
+        toolApproval: {
+          sensitive: 'user-approval',
+        },
+        prompt: 'Run the program.',
+      });
+
+      const parts = await convertAsyncIterableToArray(result.stream);
+
+      expect(sensitive).not.toHaveBeenCalled();
+      expect(
+        parts.filter(
+          part =>
+            (part.type === 'tool-call' && part.toolCallId === 'nested-call') ||
+            part.type === 'tool-approval-request',
+        ),
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "callerToolCallId": "outer-call",
+            "dynamic": false,
+            "input": {
+              "value": 42,
+            },
+            "toolCallId": "nested-call",
+            "toolName": "sensitive",
+            "type": "tool-call",
+          },
+          {
+            "approvalId": "nested-approval",
+            "callerToolCallId": "outer-call",
+            "toolCall": {
+              "callerToolCallId": "outer-call",
+              "dynamic": false,
+              "input": {
+                "value": 42,
+              },
+              "toolCallId": "nested-call",
+              "toolName": "sensitive",
+              "type": "tool-call",
+            },
+            "type": "tool-approval-request",
+          },
+        ]
+      `);
+    });
+
     it('streams chained caller approvals before returning to the model', async () => {
       const readStage = (output: unknown): 'first' | 'second' | undefined => {
         if (
@@ -21250,6 +21358,27 @@ describe('streamText', () => {
       const firstResult = stream();
       const firstParts = await convertAsyncIterableToArray(firstResult.stream);
       expect(doStream).not.toHaveBeenCalled();
+      expect(firstParts.slice(-5).map(part => part.type)).toEqual([
+        'start-step',
+        'tool-call',
+        'tool-approval-request',
+        'finish-step',
+        'finish',
+      ]);
+      expect(firstParts.at(-2)).toMatchObject({
+        type: 'finish-step',
+        finishReason: 'tool-calls',
+        usage: {
+          totalTokens: undefined,
+        },
+      });
+      expect(firstParts.at(-1)).toMatchObject({
+        type: 'finish',
+        finishReason: 'tool-calls',
+        totalUsage: {
+          totalTokens: undefined,
+        },
+      });
       expect(
         firstParts.filter(
           part =>
@@ -21296,6 +21425,13 @@ describe('streamText', () => {
         secondResult.stream,
       );
       expect(doStream).not.toHaveBeenCalled();
+      expect(secondParts.slice(-5).map(part => part.type)).toEqual([
+        'start-step',
+        'tool-call',
+        'tool-approval-request',
+        'finish-step',
+        'finish',
+      ]);
       expect(
         secondParts.filter(
           part =>

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -21169,10 +21169,23 @@ describe('streamText', () => {
                   },
                 };
           },
-          continueApproval: async ({ output }) =>
-            readStage(output) === 'first'
-              ? { stage: 'second' }
-              : { completed: true },
+          continueApproval: async ({ output, resolveToolApproval }) => {
+            if (readStage(output) === 'first') {
+              await expect(
+                resolveToolApproval({
+                  toolCallId: 'second-call',
+                  toolName: 'second',
+                  input: {},
+                }),
+              ).resolves.toMatchInlineSnapshot(`
+                {
+                  "type": "user-approval",
+                }
+              `);
+              return { stage: 'second' };
+            }
+            return { completed: true };
+          },
         },
       );
       const doStream = vi.fn(async (): Promise<never> => {
@@ -21237,12 +21250,33 @@ describe('streamText', () => {
       const firstResult = stream();
       const firstParts = await convertAsyncIterableToArray(firstResult.stream);
       expect(doStream).not.toHaveBeenCalled();
-      expect(firstParts).toContainEqual(
-        expect.objectContaining({
-          type: 'tool-approval-request',
-          approvalId: 'first-approval',
-        }),
-      );
+      expect(
+        firstParts.filter(
+          part =>
+            part.type === 'tool-call' || part.type === 'tool-approval-request',
+        ),
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "dynamic": false,
+            "input": {},
+            "toolCallId": "first-call",
+            "toolName": "first",
+            "type": "tool-call",
+          },
+          {
+            "approvalId": "first-approval",
+            "toolCall": {
+              "dynamic": false,
+              "input": {},
+              "toolCallId": "first-call",
+              "toolName": "first",
+              "type": "tool-call",
+            },
+            "type": "tool-approval-request",
+          },
+        ]
+      `);
       messages.push(...(await firstResult.responseMessages), {
         role: 'tool',
         content: [
@@ -21259,12 +21293,33 @@ describe('streamText', () => {
         secondResult.stream,
       );
       expect(doStream).not.toHaveBeenCalled();
-      expect(secondParts).toContainEqual(
-        expect.objectContaining({
-          type: 'tool-approval-request',
-          approvalId: 'second-approval',
-        }),
-      );
+      expect(
+        secondParts.filter(
+          part =>
+            part.type === 'tool-call' || part.type === 'tool-approval-request',
+        ),
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "dynamic": false,
+            "input": {},
+            "toolCallId": "second-call",
+            "toolName": "second",
+            "type": "tool-call",
+          },
+          {
+            "approvalId": "second-approval",
+            "toolCall": {
+              "dynamic": false,
+              "input": {},
+              "toolCallId": "second-call",
+              "toolName": "second",
+              "type": "tool-call",
+            },
+            "type": "tool-approval-request",
+          },
+        ]
+      `);
     });
 
     it('adds provider caller options while preserving direct access', async () => {

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -21235,10 +21235,10 @@ describe('streamText', () => {
         streamText({
           model: new MockLanguageModelV4({ doStream }),
           tools,
-          experimental_toolCallers: ({ code_mode }) => ({
-            first: [code_mode],
-            second: [code_mode],
-          }),
+          experimental_toolCallers: {
+            first: ['code_mode'],
+            second: ['code_mode'],
+          },
           toolApproval: {
             code_mode: 'user-approval',
             first: 'user-approval',

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -21126,6 +21126,147 @@ describe('streamText', () => {
       );
     });
 
+    it('streams chained caller approvals before returning to the model', async () => {
+      const readStage = (output: unknown): 'first' | 'second' | undefined => {
+        if (
+          typeof output === 'object' &&
+          output !== null &&
+          'type' in output &&
+          (output as { type?: unknown }).type === 'json' &&
+          'value' in output
+        ) {
+          return readStage((output as { value: unknown }).value);
+        }
+        return typeof output === 'object' &&
+          output !== null &&
+          'stage' in output
+          ? ((output as { stage?: 'first' | 'second' }).stage ?? undefined)
+          : undefined;
+      };
+      const localCaller = experimental_toolCaller(
+        tool({
+          inputSchema: z.object({}),
+          execute: async () => undefined,
+        }),
+        {
+          type: 'local',
+          bind: () =>
+            tool({
+              inputSchema: z.object({}),
+              execute: async () => ({ stage: 'first' }),
+            }),
+          getApprovalRequest: output => {
+            const stage = readStage(output);
+            return stage === undefined
+              ? undefined
+              : {
+                  approvalId: `${stage}-approval`,
+                  callerToolCallId: 'outer-call',
+                  toolCall: {
+                    toolCallId: `${stage}-call`,
+                    toolName: stage,
+                    input: {},
+                  },
+                };
+          },
+          continueApproval: async ({ output }) =>
+            readStage(output) === 'first'
+              ? { stage: 'second' }
+              : { completed: true },
+        },
+      );
+      const doStream = vi.fn(async (): Promise<never> => {
+        throw new Error('The model must not run while approval is pending.');
+      });
+      const tools = {
+        code_mode: localCaller,
+        first: tool({
+          inputSchema: z.object({}),
+          execute: async () => 'first',
+        }),
+        second: tool({
+          inputSchema: z.object({}),
+          execute: async () => 'second',
+        }),
+      };
+      const messages: ModelMessage[] = [
+        { role: 'user', content: 'Run the program.' },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'outer-call',
+              toolName: 'code_mode',
+              input: {},
+            },
+            {
+              type: 'tool-approval-request',
+              approvalId: 'outer-approval',
+              toolCallId: 'outer-call',
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-approval-response',
+              approvalId: 'outer-approval',
+              approved: true,
+            },
+          ],
+        },
+      ];
+      const stream = () =>
+        streamText({
+          model: new MockLanguageModelV4({ doStream }),
+          tools,
+          experimental_toolCallers: ({ code_mode }) => ({
+            first: [code_mode],
+            second: [code_mode],
+          }),
+          toolApproval: {
+            code_mode: 'user-approval',
+            first: 'user-approval',
+            second: 'user-approval',
+          },
+          messages,
+        });
+
+      const firstResult = stream();
+      const firstParts = await convertAsyncIterableToArray(firstResult.stream);
+      expect(doStream).not.toHaveBeenCalled();
+      expect(firstParts).toContainEqual(
+        expect.objectContaining({
+          type: 'tool-approval-request',
+          approvalId: 'first-approval',
+        }),
+      );
+      messages.push(...(await firstResult.responseMessages), {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-approval-response',
+            approvalId: 'first-approval',
+            approved: true,
+          },
+        ],
+      });
+
+      const secondResult = stream();
+      const secondParts = await convertAsyncIterableToArray(
+        secondResult.stream,
+      );
+      expect(doStream).not.toHaveBeenCalled();
+      expect(secondParts).toContainEqual(
+        expect.objectContaining({
+          type: 'tool-approval-request',
+          approvalId: 'second-approval',
+        }),
+      );
+    });
+
     it('adds provider caller options while preserving direct access', async () => {
       let modelTools: LanguageModelV4CallOptions['tools'];
 

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -21258,6 +21258,7 @@ describe('streamText', () => {
       ).toMatchInlineSnapshot(`
         [
           {
+            "callerToolCallId": "outer-call",
             "dynamic": false,
             "input": {},
             "toolCallId": "first-call",
@@ -21266,7 +21267,9 @@ describe('streamText', () => {
           },
           {
             "approvalId": "first-approval",
+            "callerToolCallId": "outer-call",
             "toolCall": {
+              "callerToolCallId": "outer-call",
               "dynamic": false,
               "input": {},
               "toolCallId": "first-call",
@@ -21301,6 +21304,7 @@ describe('streamText', () => {
       ).toMatchInlineSnapshot(`
         [
           {
+            "callerToolCallId": "outer-call",
             "dynamic": false,
             "input": {},
             "toolCallId": "second-call",
@@ -21309,7 +21313,9 @@ describe('streamText', () => {
           },
           {
             "approvalId": "second-approval",
+            "callerToolCallId": "outer-call",
             "toolCall": {
+              "callerToolCallId": "outer-call",
               "dynamic": false,
               "input": {},
               "toolCallId": "second-call",

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1679,6 +1679,24 @@ class DefaultStreamTextResult<
       });
       const callerContinuationResponseMessages: Array<ResponseMessage> = [];
       let instructionsForNextStep = initialPrompt.instructions;
+      const { executionTools: initialExecutionTools } =
+        prepareToolsForToolCallers({
+          tools,
+          toolCallers: resolvedToolCallers,
+          resolveToolApproval: async toolCall =>
+            await resolveToolApproval({
+              tools,
+              toolCall: {
+                type: 'tool-call',
+                ...toolCall,
+                dynamic: false,
+              } as TypedToolCall<TOOLS>,
+              toolApproval,
+              messages: initialMessages,
+              toolsContext,
+              runtimeContext,
+            }),
+        });
 
       const { approvedToolApprovals, deniedToolApprovals } =
         collectToolApprovals<TOOLS>({ messages: initialMessages });
@@ -1692,7 +1710,7 @@ class DefaultStreamTextResult<
           approvedToolApprovals: approvedToolApprovals.filter(
             toolApproval => !toolApproval.toolCall.providerExecuted,
           ),
-          tools,
+          tools: initialExecutionTools,
           toolApproval,
           messages: initialMessages,
           toolsContext,
@@ -1790,7 +1808,7 @@ class DefaultStreamTextResult<
             localApprovedToolApprovals.map(async toolApproval => {
               const result = await executeToolCall({
                 toolCall: toolApproval.toolCall,
-                tools,
+                tools: initialExecutionTools,
                 callId,
                 messages: initialMessages,
                 abortSignal,
@@ -1835,7 +1853,7 @@ class DefaultStreamTextResult<
                 output: await createToolModelOutput({
                   toolCallId: output.toolCallId,
                   input: output.input,
-                  tool: getOwn(tools, output.toolName),
+                  tool: getOwn(initialExecutionTools, output.toolName),
                   output:
                     output.type === 'tool-result'
                       ? output.output

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -141,7 +141,10 @@ import type {
 import { toResponseMessages } from './to-response-messages';
 import { resolveToolApproval } from './resolve-tool-approval';
 import type { ToolApprovalConfiguration } from './tool-approval-configuration';
+import type { ToolApprovalRequestOutput } from './tool-approval-request-output';
 import {
+  createToolCallerApprovalRequestOutput,
+  getToolCallerApprovalRequest,
   prepareToolsForToolCallers,
   resolveToolCallerConfiguration,
   type Experimental_ToolCallers,
@@ -1678,6 +1681,9 @@ class DefaultStreamTextResult<
         tools,
       });
       const callerContinuationResponseMessages: Array<ResponseMessage> = [];
+      const pendingToolCallerApprovals: Array<
+        ToolApprovalRequestOutput<TOOLS>
+      > = [];
       let instructionsForNextStep = initialPrompt.instructions;
       const { executionTools: initialExecutionTools } =
         prepareToolsForToolCallers({
@@ -1741,6 +1747,16 @@ class DefaultStreamTextResult<
             toolsContext,
             abortSignal,
           });
+          for (const continuation of continuedApprovals.continued) {
+            if (continuation.nextApprovalRequest !== undefined) {
+              pendingToolCallerApprovals.push(
+                await createToolCallerApprovalRequestOutput({
+                  request: continuation.nextApprovalRequest,
+                  toolApprovalSecret: experimental_toolApprovalSecret,
+                }),
+              );
+            }
+          }
           if (continuedApprovals.continued.length > 0) {
             initialMessages = continuedApprovals.messages;
             callerContinuationResponseMessages.push(
@@ -1831,6 +1847,22 @@ class DefaultStreamTextResult<
               });
 
               if (result != null) {
+                if (result.output.type === 'tool-result') {
+                  const callerApproval = getToolCallerApprovalRequest({
+                    callerToolName: result.output.toolName,
+                    output: result.output.output,
+                    tools: initialExecutionTools,
+                  });
+                  if (callerApproval !== undefined) {
+                    pendingToolCallerApprovals.push(
+                      await createToolCallerApprovalRequestOutput({
+                        request: callerApproval,
+                        toolApprovalSecret: experimental_toolApprovalSecret,
+                      }),
+                    );
+                  }
+                }
+
                 toolExecutionStepStreamController?.enqueue(result.output);
                 toolOutputs.push(result.output);
               }
@@ -1887,6 +1919,55 @@ class DefaultStreamTextResult<
       }
 
       self._initialResponseMessages.resolve(initialResponseMessages);
+      if (pendingToolCallerApprovals.length > 0) {
+        const usage = createNullLanguageModelUsage();
+        self.addStream(
+          new ReadableStream<TextStreamPart<TOOLS>>({
+            start(controller) {
+              controller.enqueue({
+                type: 'start-step',
+                request: {},
+                warnings: [],
+              });
+              for (const approvalRequest of pendingToolCallerApprovals) {
+                controller.enqueue(approvalRequest.toolCall);
+                controller.enqueue(approvalRequest);
+              }
+              controller.enqueue({
+                type: 'finish-step',
+                finishReason: 'tool-calls',
+                rawFinishReason: undefined,
+                usage,
+                performance: {
+                  effectiveOutputTokensPerSecond: 0,
+                  outputTokensPerSecond: undefined,
+                  inputTokensPerSecond: undefined,
+                  effectiveTotalTokensPerSecond: 0,
+                  stepTimeMs: 0,
+                  responseTimeMs: 0,
+                  toolExecutionMs: {},
+                  timeToFirstOutputMs: undefined,
+                },
+                providerMetadata: undefined,
+                response: {
+                  id: generateId(),
+                  timestamp: new Date(),
+                  modelId: model.modelId,
+                },
+              });
+              controller.enqueue({
+                type: 'finish',
+                finishReason: 'tool-calls',
+                rawFinishReason: undefined,
+                totalUsage: usage,
+              });
+              controller.close();
+            },
+          }),
+        );
+        self.closeStream();
+        return;
+      }
 
       async function streamStep({
         currentStep,

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1676,10 +1676,7 @@ class DefaultStreamTextResult<
         callbacks: [onStart, telemetryDispatcher.onStart],
       });
 
-      let initialMessages = normalizeToolCallerApprovalMessages({
-        messages: initialPrompt.messages,
-        tools,
-      });
+      let initialMessages = initialPrompt.messages;
       const callerContinuationResponseMessages: Array<ResponseMessage> = [];
       const pendingToolCallerApprovals: Array<
         ToolApprovalRequestOutput<TOOLS>
@@ -1735,77 +1732,6 @@ class DefaultStreamTextResult<
             toolApproval => toolApproval.existingToolResult == null,
           );
 
-        if (tools != null) {
-          const continuedApprovals = await continueToolCallerApprovals({
-            approvals: [
-              ...localApprovedToolApprovals,
-              ...localDeniedToolApprovalsWithoutResults,
-            ],
-            messages: initialMessages,
-            tools,
-            toolCallers: resolvedToolCallers,
-            toolsContext,
-            abortSignal,
-            resolveToolApproval: async (toolCall, messages) =>
-              await resolveToolApproval({
-                tools,
-                toolCall: {
-                  type: 'tool-call',
-                  ...toolCall,
-                  dynamic: false,
-                } as TypedToolCall<TOOLS>,
-                toolApproval,
-                messages,
-                toolsContext,
-                runtimeContext,
-              }),
-          });
-          for (const continuation of continuedApprovals.continued) {
-            if (continuation.nextApprovalRequest !== undefined) {
-              pendingToolCallerApprovals.push(
-                await createToolCallerApprovalRequestOutput({
-                  request: continuation.nextApprovalRequest,
-                  toolApprovalSecret: experimental_toolApprovalSecret,
-                }),
-              );
-            }
-          }
-          if (continuedApprovals.continued.length > 0) {
-            initialMessages = continuedApprovals.messages;
-            callerContinuationResponseMessages.push(
-              ...continuedApprovals.continued.map(
-                continuation => continuation.responseMessage,
-              ),
-            );
-            initialResponseMessages.push(...callerContinuationResponseMessages);
-            const continuedApprovalIds = new Set(
-              continuedApprovals.continued.map(
-                continuation =>
-                  continuation.approval.approvalRequest.approvalId,
-              ),
-            );
-            localApprovedToolApprovals = localApprovedToolApprovals.filter(
-              approval =>
-                !continuedApprovalIds.has(approval.approvalRequest.approvalId),
-            );
-            localDeniedToolApprovals = localDeniedToolApprovals.filter(
-              approval =>
-                !continuedApprovalIds.has(approval.approvalRequest.approvalId),
-            );
-            localDeniedToolApprovalsWithoutResults =
-              localDeniedToolApprovalsWithoutResults.filter(
-                approval =>
-                  !continuedApprovalIds.has(
-                    approval.approvalRequest.approvalId,
-                  ),
-              );
-          }
-        }
-
-        const deniedProviderExecutedToolApprovals = deniedToolApprovals.filter(
-          toolApproval => toolApproval.toolCall.providerExecuted,
-        );
-
         let toolExecutionStepStreamController:
           | ReadableStreamDefaultController<TextStreamPart<TOOLS>>
           | undefined;
@@ -1820,6 +1746,76 @@ class DefaultStreamTextResult<
         self.addStream(toolExecutionStepStream);
 
         try {
+          if (tools != null) {
+            const continuedApprovals = await continueToolCallerApprovals({
+              approvals: [
+                ...localApprovedToolApprovals,
+                ...localDeniedToolApprovalsWithoutResults,
+              ],
+              messages: initialMessages,
+              tools,
+              toolCallers: resolvedToolCallers,
+              toolsContext,
+              abortSignal,
+              resolveToolApproval: async (toolCall, messages) =>
+                await resolveToolApproval({
+                  tools,
+                  toolCall: {
+                    type: 'tool-call',
+                    ...toolCall,
+                    dynamic: false,
+                  } as TypedToolCall<TOOLS>,
+                  toolApproval,
+                  messages,
+                  toolsContext,
+                  runtimeContext,
+                }),
+            });
+            for (const continuation of continuedApprovals.continued) {
+              if (continuation.nextApprovalRequest !== undefined) {
+                pendingToolCallerApprovals.push(
+                  await createToolCallerApprovalRequestOutput({
+                    request: continuation.nextApprovalRequest,
+                    toolApprovalSecret: experimental_toolApprovalSecret,
+                  }),
+                );
+              }
+            }
+            if (continuedApprovals.continued.length > 0) {
+              initialMessages = continuedApprovals.messages;
+              for (const continuation of continuedApprovals.continued) {
+                toolExecutionStepStreamController?.enqueue(
+                  continuation.toolOutput,
+                );
+              }
+              callerContinuationResponseMessages.push(
+                ...continuedApprovals.continued.map(
+                  continuation => continuation.responseMessage,
+                ),
+              );
+              initialResponseMessages.push(
+                ...callerContinuationResponseMessages,
+              );
+            }
+            localApprovedToolApprovals = localApprovedToolApprovals.filter(
+              approval => continuedApprovals.remaining.includes(approval),
+            );
+            localDeniedToolApprovals = localDeniedToolApprovals.filter(
+              approval =>
+                approval.existingToolResult != null ||
+                continuedApprovals.remaining.includes(approval),
+            );
+            localDeniedToolApprovalsWithoutResults =
+              localDeniedToolApprovalsWithoutResults.filter(approval =>
+                continuedApprovals.remaining.includes(approval),
+              );
+          }
+
+          const deniedProviderExecutedToolApprovals =
+            deniedToolApprovals.filter(
+              toolApproval => toolApproval.toolCall.providerExecuted,
+            );
+
           for (const toolApproval of [
             ...localDeniedToolApprovals,
             ...deniedProviderExecutedToolApprovals,
@@ -1931,6 +1927,9 @@ class DefaultStreamTextResult<
         }
       }
 
+      initialMessages = normalizeToolCallerApprovalMessages({
+        messages: initialMessages,
+      });
       self._initialResponseMessages.resolve(initialResponseMessages);
       if (pendingToolCallerApprovals.length > 0) {
         const usage = createNullLanguageModelUsage();

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -84,6 +84,10 @@ import { prepareRetries } from '../util/prepare-retries';
 import { setAbortTimeout } from '../util/set-abort-timeout';
 import type { ActiveTools } from './active-tools';
 import { collectToolApprovals } from './collect-tool-approvals';
+import {
+  continueToolCallerApprovals,
+  normalizeToolCallerApprovalMessages,
+} from './continue-tool-caller-approvals';
 import type { ContentPart } from './content-part';
 import {
   executeToolsFromStream,
@@ -135,6 +139,7 @@ import type {
   UIMessageStreamOptions,
 } from './stream-text-result';
 import { toResponseMessages } from './to-response-messages';
+import { resolveToolApproval } from './resolve-tool-approval';
 import type { ToolApprovalConfiguration } from './tool-approval-configuration';
 import {
   prepareToolsForToolCallers,
@@ -1668,7 +1673,11 @@ class DefaultStreamTextResult<
         callbacks: [onStart, telemetryDispatcher.onStart],
       });
 
-      const initialMessages = initialPrompt.messages;
+      let initialMessages = normalizeToolCallerApprovalMessages({
+        messages: initialPrompt.messages,
+        tools,
+      });
+      const callerContinuationResponseMessages: Array<ResponseMessage> = [];
       let instructionsForNextStep = initialPrompt.instructions;
 
       const { approvedToolApprovals, deniedToolApprovals } =
@@ -1676,7 +1685,7 @@ class DefaultStreamTextResult<
 
       // initial tool execution step stream
       if (deniedToolApprovals.length > 0 || approvedToolApprovals.length > 0) {
-        const {
+        let {
           approvedToolApprovals: localApprovedToolApprovals,
           deniedToolApprovals: revalidationDeniedToolApprovals,
         } = await validateApprovedToolApprovals<TOOLS, RUNTIME_CONTEXT>({
@@ -1691,16 +1700,60 @@ class DefaultStreamTextResult<
           toolApprovalSecret: experimental_toolApprovalSecret,
         });
 
-        const localDeniedToolApprovals = [
+        let localDeniedToolApprovals = [
           ...deniedToolApprovals.filter(
             toolApproval => !toolApproval.toolCall.providerExecuted,
           ),
           ...revalidationDeniedToolApprovals,
         ];
-        const localDeniedToolApprovalsWithoutResults =
+        let localDeniedToolApprovalsWithoutResults =
           localDeniedToolApprovals.filter(
             toolApproval => toolApproval.existingToolResult == null,
           );
+
+        if (tools != null) {
+          const continuedApprovals = await continueToolCallerApprovals({
+            approvals: [
+              ...localApprovedToolApprovals,
+              ...localDeniedToolApprovalsWithoutResults,
+            ],
+            messages: initialMessages,
+            tools,
+            toolCallers: resolvedToolCallers,
+            toolsContext,
+            abortSignal,
+          });
+          if (continuedApprovals.continued.length > 0) {
+            initialMessages = continuedApprovals.messages;
+            callerContinuationResponseMessages.push(
+              ...continuedApprovals.continued.map(
+                continuation => continuation.responseMessage,
+              ),
+            );
+            initialResponseMessages.push(...callerContinuationResponseMessages);
+            const continuedApprovalIds = new Set(
+              continuedApprovals.continued.map(
+                continuation =>
+                  continuation.approval.approvalRequest.approvalId,
+              ),
+            );
+            localApprovedToolApprovals = localApprovedToolApprovals.filter(
+              approval =>
+                !continuedApprovalIds.has(approval.approvalRequest.approvalId),
+            );
+            localDeniedToolApprovals = localDeniedToolApprovals.filter(
+              approval =>
+                !continuedApprovalIds.has(approval.approvalRequest.approvalId),
+            );
+            localDeniedToolApprovalsWithoutResults =
+              localDeniedToolApprovalsWithoutResults.filter(
+                approval =>
+                  !continuedApprovalIds.has(
+                    approval.approvalRequest.approvalId,
+                  ),
+              );
+          }
+        }
 
         const deniedProviderExecutedToolApprovals = deniedToolApprovals.filter(
           toolApproval => toolApproval.toolCall.providerExecuted,
@@ -1925,7 +1978,9 @@ class DefaultStreamTextResult<
           ];
           const stepInputMessages = stepMessagesForNextStep ?? [
             ...initialMessages,
-            ...initialResponseMessages,
+            ...initialResponseMessages.filter(
+              message => !callerContinuationResponseMessages.includes(message),
+            ),
           ];
 
           const prepareStepResult = await prepareStep?.({
@@ -1956,12 +2011,26 @@ class DefaultStreamTextResult<
             tools,
             activeTools: prepareStepResult?.activeTools ?? activeTools,
           });
+          const stepMessages = prepareStepResult?.messages ?? stepInputMessages;
           const {
             executionTools: stepExecutionTools,
             modelTools: stepModelTools,
           } = prepareToolsForToolCallers({
             tools: stepActiveTools,
             toolCallers: resolvedToolCallers,
+            resolveToolApproval: async toolCall =>
+              await resolveToolApproval({
+                tools: stepActiveTools as TOOLS,
+                toolCall: {
+                  type: 'tool-call',
+                  ...toolCall,
+                  dynamic: false,
+                } as TypedToolCall<TOOLS>,
+                toolApproval,
+                messages: stepMessages,
+                toolsContext,
+                runtimeContext,
+              }),
           });
           const stepToolOrder = prepareStepResult?.toolOrder ?? toolOrder;
 
@@ -1984,7 +2053,6 @@ class DefaultStreamTextResult<
             toolChoice: prepareStepResult?.toolChoice ?? toolChoice,
           });
 
-          const stepMessages = prepareStepResult?.messages ?? stepInputMessages;
           currentStepMessages = stepMessages;
           const stepInstructions =
             prepareStepResult?.instructions ??

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1921,6 +1921,7 @@ class DefaultStreamTextResult<
       self._initialResponseMessages.resolve(initialResponseMessages);
       if (pendingToolCallerApprovals.length > 0) {
         const usage = createNullLanguageModelUsage();
+        stepFinish = new DelayedPromise<void>();
         self.addStream(
           new ReadableStream<TextStreamPart<TOOLS>>({
             start(controller) {

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1746,6 +1746,19 @@ class DefaultStreamTextResult<
             toolCallers: resolvedToolCallers,
             toolsContext,
             abortSignal,
+            resolveToolApproval: async (toolCall, messages) =>
+              await resolveToolApproval({
+                tools,
+                toolCall: {
+                  type: 'tool-call',
+                  ...toolCall,
+                  dynamic: false,
+                } as TypedToolCall<TOOLS>,
+                toolApproval,
+                messages,
+                toolsContext,
+                runtimeContext,
+              }),
           });
           for (const continuation of continuedApprovals.continued) {
             if (continuation.nextApprovalRequest !== undefined) {

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -87,6 +87,7 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
         content.push({
           type: 'tool-call',
           toolCallId: part.toolCallId,
+          callerToolCallId: part.callerToolCallId,
           toolName: part.toolName,
           input:
             part.invalid && typeof part.input !== 'object' ? {} : part.input,
@@ -105,6 +106,7 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
         content.push({
           type: 'tool-result',
           toolCallId: part.toolCallId,
+          callerToolCallId: part.callerToolCallId,
           toolName: part.toolName,
           output,
           providerOptions: part.providerMetadata,
@@ -133,6 +135,7 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
           type: 'tool-approval-request',
           approvalId: part.approvalId,
           toolCallId: part.toolCall.toolCallId,
+          callerToolCallId: part.callerToolCallId,
           isAutomatic: part.isAutomatic,
           ...(part.signature != null ? { signature: part.signature } : {}),
         });

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -87,7 +87,9 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
         content.push({
           type: 'tool-call',
           toolCallId: part.toolCallId,
-          callerToolCallId: part.callerToolCallId,
+          ...(part.callerToolCallId != null
+            ? { callerToolCallId: part.callerToolCallId }
+            : {}),
           toolName: part.toolName,
           input:
             part.invalid && typeof part.input !== 'object' ? {} : part.input,
@@ -106,7 +108,9 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
         content.push({
           type: 'tool-result',
           toolCallId: part.toolCallId,
-          callerToolCallId: part.callerToolCallId,
+          ...(part.callerToolCallId != null
+            ? { callerToolCallId: part.callerToolCallId }
+            : {}),
           toolName: part.toolName,
           output,
           providerOptions: part.providerMetadata,
@@ -135,7 +139,9 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
           type: 'tool-approval-request',
           approvalId: part.approvalId,
           toolCallId: part.toolCall.toolCallId,
-          callerToolCallId: part.callerToolCallId,
+          ...(part.callerToolCallId != null
+            ? { callerToolCallId: part.callerToolCallId }
+            : {}),
           isAutomatic: part.isAutomatic,
           ...(part.signature != null ? { signature: part.signature } : {}),
         });

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -108,9 +108,6 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
         content.push({
           type: 'tool-result',
           toolCallId: part.toolCallId,
-          ...(part.callerToolCallId != null
-            ? { callerToolCallId: part.callerToolCallId }
-            : {}),
           toolName: part.toolName,
           output,
           providerOptions: part.providerMetadata,

--- a/packages/ai/src/generate-text/tool-approval-request-output.ts
+++ b/packages/ai/src/generate-text/tool-approval-request-output.ts
@@ -20,6 +20,11 @@ export type ToolApprovalRequestOutput<TOOLS extends ToolSet> = {
   toolCall: TypedToolCall<TOOLS>;
 
   /**
+   * ID of the local caller tool call that owns this nested approval.
+   */
+  callerToolCallId?: string;
+
+  /**
    * Flag indicating whether the tool was automatically approved or denied.
    *
    * @default false

--- a/packages/ai/src/generate-text/tool-call.ts
+++ b/packages/ai/src/generate-text/tool-call.ts
@@ -6,6 +6,7 @@ import type { ValueOf } from '../util/value-of';
 type BaseToolCall = {
   type: 'tool-call';
   toolCallId: string;
+  callerToolCallId?: string;
   providerExecuted?: boolean;
   providerMetadata?: ProviderMetadata;
   toolMetadata?: JSONObject;

--- a/packages/ai/src/generate-text/tool-caller-configuration.ts
+++ b/packages/ai/src/generate-text/tool-caller-configuration.ts
@@ -218,6 +218,7 @@ export async function createToolCallerApprovalRequestOutput<
   const toolCall = {
     type: 'tool-call' as const,
     ...request.toolCall,
+    callerToolCallId: request.callerToolCallId,
     dynamic: false as const,
   } as TypedToolCall<TOOLS>;
   const signature = await maybeSignApproval({
@@ -231,6 +232,7 @@ export async function createToolCallerApprovalRequestOutput<
     type: 'tool-approval-request',
     approvalId: request.approvalId,
     toolCall,
+    callerToolCallId: request.callerToolCallId,
     ...(signature != null ? { signature } : {}),
   };
 }

--- a/packages/ai/src/generate-text/tool-caller-configuration.ts
+++ b/packages/ai/src/generate-text/tool-caller-configuration.ts
@@ -18,7 +18,7 @@ type LocalToolCallerDefinition = Extract<
   Experimental_ToolCallerDefinition,
   { type: 'local' }
 >;
-type LocalToolCallerApprovalStatus = Awaited<
+export type LocalToolCallerApprovalStatus = Awaited<
   ReturnType<
     Parameters<LocalToolCallerDefinition['bind']>[1]['resolveToolApproval']
   >

--- a/packages/ai/src/generate-text/tool-caller-configuration.ts
+++ b/packages/ai/src/generate-text/tool-caller-configuration.ts
@@ -8,6 +8,9 @@ import {
   type ToolSet,
 } from '@ai-sdk/provider-utils';
 import { InvalidArgumentError } from '../error/invalid-argument-error';
+import { maybeSignApproval } from './tool-approval-signature';
+import type { ToolApprovalRequestOutput } from './tool-approval-request-output';
+import type { TypedToolCall } from './tool-call';
 
 const DIRECT_TOOL_CALL = 'AI_SDK_DIRECT_TOOL_CALL';
 
@@ -20,7 +23,7 @@ type LocalToolCallerApprovalStatus = Awaited<
     Parameters<LocalToolCallerDefinition['bind']>[1]['resolveToolApproval']
   >
 >;
-type LocalToolCallerApprovalRequest = Exclude<
+export type LocalToolCallerApprovalRequest = Exclude<
   ReturnType<NonNullable<LocalToolCallerDefinition['getApprovalRequest']>>,
   undefined
 >;
@@ -201,6 +204,35 @@ export function getToolCallerApprovalRequest({
   return caller?.type === 'local'
     ? caller.getApprovalRequest?.(output)
     : undefined;
+}
+
+export async function createToolCallerApprovalRequestOutput<
+  TOOLS extends ToolSet,
+>({
+  request,
+  toolApprovalSecret,
+}: {
+  request: LocalToolCallerApprovalRequest;
+  toolApprovalSecret: string | Uint8Array | undefined;
+}): Promise<ToolApprovalRequestOutput<TOOLS>> {
+  const toolCall = {
+    type: 'tool-call' as const,
+    ...request.toolCall,
+    dynamic: false as const,
+  } as TypedToolCall<TOOLS>;
+  const signature = await maybeSignApproval({
+    secret: toolApprovalSecret,
+    approvalId: request.approvalId,
+    toolCallId: toolCall.toolCallId,
+    toolName: toolCall.toolName,
+    input: toolCall.input,
+  });
+  return {
+    type: 'tool-approval-request',
+    approvalId: request.approvalId,
+    toolCall,
+    ...(signature != null ? { signature } : {}),
+  };
 }
 
 export function getLocalToolsForCaller({

--- a/packages/ai/src/generate-text/tool-caller-configuration.ts
+++ b/packages/ai/src/generate-text/tool-caller-configuration.ts
@@ -104,7 +104,7 @@ export function prepareToolsForToolCallers<TOOLS extends ToolSet>({
 }: {
   tools: TOOLS | undefined;
   toolCallers: ResolvedToolCallers | undefined;
-  resolveToolApproval?: (
+  resolveToolApproval: (
     toolCall: ToolCall<string, unknown>,
   ) => Promise<LocalToolCallerApprovalStatus>;
 }): {
@@ -172,9 +172,7 @@ export function prepareToolsForToolCallers<TOOLS extends ToolSet>({
 
     const boundCaller = experimental_toolCaller(
       caller.bind(localToolsByCaller.get(callerName) ?? {}, {
-        resolveToolApproval:
-          resolveToolApproval ??
-          (async () => ({ type: 'not-applicable' as const })),
+        resolveToolApproval,
       }),
       caller,
     );

--- a/packages/ai/src/generate-text/tool-caller-configuration.ts
+++ b/packages/ai/src/generate-text/tool-caller-configuration.ts
@@ -94,19 +94,19 @@ export function resolveToolCallerConfiguration<TOOLS extends ToolSet>({
   return resolved;
 }
 
-export function prepareToolsForToolCallers({
+export function prepareToolsForToolCallers<TOOLS extends ToolSet>({
   tools,
   toolCallers,
   resolveToolApproval,
 }: {
-  tools: ToolSet | undefined;
+  tools: TOOLS | undefined;
   toolCallers: ResolvedToolCallers | undefined;
   resolveToolApproval?: (
     toolCall: ToolCall<string, unknown>,
   ) => Promise<LocalToolCallerApprovalStatus>;
 }): {
-  executionTools: ToolSet | undefined;
-  modelTools: ToolSet | undefined;
+  executionTools: TOOLS | undefined;
+  modelTools: TOOLS | undefined;
 } {
   if (tools == null || toolCallers == null) {
     return { executionTools: tools, modelTools: tools };
@@ -182,7 +182,10 @@ export function prepareToolsForToolCallers({
     }
   }
 
-  return { executionTools, modelTools };
+  return {
+    executionTools: executionTools as TOOLS,
+    modelTools: modelTools as TOOLS,
+  };
 }
 
 export function getToolCallerApprovalRequest({

--- a/packages/ai/src/generate-text/tool-caller-configuration.ts
+++ b/packages/ai/src/generate-text/tool-caller-configuration.ts
@@ -1,15 +1,32 @@
 import {
   experimental_getToolCaller,
-  type Experimental_ToolCallerTool,
+  experimental_toolCaller,
+  type Experimental_ToolCallerDefinition,
+  type Experimental_ToolWithCaller,
   type Tool,
+  type ToolCall,
   type ToolSet,
 } from '@ai-sdk/provider-utils';
 import { InvalidArgumentError } from '../error/invalid-argument-error';
 
 const DIRECT_TOOL_CALL = 'AI_SDK_DIRECT_TOOL_CALL';
 
+type LocalToolCallerDefinition = Extract<
+  Experimental_ToolCallerDefinition,
+  { type: 'local' }
+>;
+type LocalToolCallerApprovalStatus = Awaited<
+  ReturnType<
+    Parameters<LocalToolCallerDefinition['bind']>[1]['resolveToolApproval']
+  >
+>;
+type LocalToolCallerApprovalRequest = Exclude<
+  ReturnType<NonNullable<LocalToolCallerDefinition['getApprovalRequest']>>,
+  undefined
+>;
+
 type ToolCallerName<TOOLS extends ToolSet> = {
-  [NAME in keyof TOOLS]: TOOLS[NAME] extends Experimental_ToolCallerTool
+  [NAME in keyof TOOLS]: TOOLS[NAME] extends Experimental_ToolWithCaller
     ? NAME
     : never;
 }[keyof TOOLS] &
@@ -80,9 +97,13 @@ export function resolveToolCallerConfiguration<TOOLS extends ToolSet>({
 export function prepareToolsForToolCallers({
   tools,
   toolCallers,
+  resolveToolApproval,
 }: {
   tools: ToolSet | undefined;
   toolCallers: ResolvedToolCallers | undefined;
+  resolveToolApproval?: (
+    toolCall: ToolCall<string, unknown>,
+  ) => Promise<LocalToolCallerApprovalStatus>;
 }): {
   executionTools: ToolSet | undefined;
   modelTools: ToolSet | undefined;
@@ -146,7 +167,14 @@ export function prepareToolsForToolCallers({
       continue;
     }
 
-    const boundCaller = caller.bind(localToolsByCaller.get(callerName) ?? {});
+    const boundCaller = experimental_toolCaller(
+      caller.bind(localToolsByCaller.get(callerName) ?? {}, {
+        resolveToolApproval:
+          resolveToolApproval ??
+          (async () => ({ type: 'not-applicable' as const })),
+      }),
+      caller,
+    );
     executionTools[callerName] = boundCaller;
 
     if (Object.prototype.hasOwnProperty.call(modelTools, callerName)) {
@@ -155,4 +183,40 @@ export function prepareToolsForToolCallers({
   }
 
   return { executionTools, modelTools };
+}
+
+export function getToolCallerApprovalRequest({
+  callerToolName,
+  output,
+  tools,
+}: {
+  callerToolName: string;
+  output: unknown;
+  tools: ToolSet | undefined;
+}): LocalToolCallerApprovalRequest | undefined {
+  const caller = experimental_getToolCaller(tools?.[callerToolName]);
+  return caller?.type === 'local'
+    ? caller.getApprovalRequest?.(output)
+    : undefined;
+}
+
+export function getLocalToolsForCaller({
+  callerName,
+  tools,
+  toolCallers,
+}: {
+  callerName: string;
+  tools: ToolSet;
+  toolCallers: ResolvedToolCallers | undefined;
+}): ToolSet {
+  if (toolCallers == null) {
+    return {};
+  }
+  const localTools: ToolSet = {};
+  for (const [toolName, callers] of Object.entries(toolCallers)) {
+    if (callers.includes(callerName) && tools[toolName] != null) {
+      localTools[toolName] = tools[toolName];
+    }
+  }
+  return localTools;
 }

--- a/packages/ai/src/generate-text/tool-result.ts
+++ b/packages/ai/src/generate-text/tool-result.ts
@@ -11,7 +11,6 @@ export type StaticToolResult<TOOLS extends ToolSet> = ValueOf<{
   [NAME in keyof TOOLS]: {
     type: 'tool-result';
     toolCallId: string;
-    callerToolCallId?: string;
     toolName: NAME & string;
     input: InferToolInput<TOOLS[NAME]>;
     output: InferToolOutput<TOOLS[NAME]>;
@@ -27,7 +26,6 @@ export type StaticToolResult<TOOLS extends ToolSet> = ValueOf<{
 export type DynamicToolResult = {
   type: 'tool-result';
   toolCallId: string;
-  callerToolCallId?: string;
   toolName: string;
   input: unknown;
   output: unknown;

--- a/packages/ai/src/generate-text/tool-result.ts
+++ b/packages/ai/src/generate-text/tool-result.ts
@@ -11,6 +11,7 @@ export type StaticToolResult<TOOLS extends ToolSet> = ValueOf<{
   [NAME in keyof TOOLS]: {
     type: 'tool-result';
     toolCallId: string;
+    callerToolCallId?: string;
     toolName: NAME & string;
     input: InferToolInput<TOOLS[NAME]>;
     output: InferToolOutput<TOOLS[NAME]>;
@@ -26,6 +27,7 @@ export type StaticToolResult<TOOLS extends ToolSet> = ValueOf<{
 export type DynamicToolResult = {
   type: 'tool-result';
   toolCallId: string;
+  callerToolCallId?: string;
   toolName: string;
   input: unknown;
   output: unknown;

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -20,7 +20,7 @@ export {
   type InferToolOutput,
   type Experimental_SandboxSession,
   type Experimental_SandboxProcess,
-  type Experimental_ToolCallerTool,
+  type Experimental_ToolWithCaller,
   type Schema,
   type Tool,
   type ToolApprovalRequest,

--- a/packages/ai/src/ui-message-stream/to-ui-message-chunk.test.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-chunk.test.ts
@@ -596,6 +596,7 @@ describe('toUIMessageChunk', () => {
       toUIMessageChunk<Tools>({
         type: 'tool-approval-request',
         approvalId: 'approval-1',
+        callerToolCallId: 'caller-call',
         toolCall: {
           type: 'tool-call',
           toolCallId: 'call-5',
@@ -608,6 +609,7 @@ describe('toUIMessageChunk', () => {
       type: 'tool-approval-request',
       approvalId: 'approval-1',
       toolCallId: 'call-5',
+      callerToolCallId: 'caller-call',
       isAutomatic: true,
     });
 

--- a/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
@@ -254,6 +254,9 @@ export function toUIMessageChunk<
         type: 'tool-approval-request',
         approvalId: part.approvalId,
         toolCallId: part.toolCall.toolCallId,
+        ...(part.callerToolCallId != null
+          ? { callerToolCallId: part.callerToolCallId }
+          : {}),
         ...(part.isAutomatic != null ? { isAutomatic: part.isAutomatic } : {}),
         ...(part.signature != null ? { signature: part.signature } : {}),
       };

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -295,6 +295,7 @@ export type UIMessageChunk<
       type: 'tool-approval-request';
       approvalId: string;
       toolCallId: string;
+      callerToolCallId?: string;
       isAutomatic?: boolean;
       signature?: string;
     }

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -740,45 +740,45 @@ describe('convertToModelMessages', () => {
         ]);
 
         expect(result).toMatchInlineSnapshot(`
-        [
-          {
-            "content": [
-              {
-                "text": "Let me calculate that for you.",
-                "type": "text",
-              },
-              {
-                "input": {
-                  "numbers": [
-                    1,
-                    2,
-                  ],
-                  "operation": "add",
+          [
+            {
+              "content": [
+                {
+                  "text": "Let me calculate that for you.",
+                  "type": "text",
                 },
-                "providerExecuted": undefined,
-                "toolCallId": "call1",
-                "toolName": "calculator",
-                "type": "tool-call",
-              },
-            ],
-            "role": "assistant",
-          },
-          {
-            "content": [
-              {
-                "output": {
-                  "type": "error-text",
-                  "value": "Error: Invalid input",
+                {
+                  "input": {
+                    "numbers": [
+                      1,
+                      2,
+                    ],
+                    "operation": "add",
+                  },
+                  "providerExecuted": undefined,
+                  "toolCallId": "call1",
+                  "toolName": "calculator",
+                  "type": "tool-call",
                 },
-                "toolCallId": "call1",
-                "toolName": "calculator",
-                "type": "tool-result",
-              },
-            ],
-            "role": "tool",
-          },
-        ]
-      `);
+              ],
+              "role": "assistant",
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "error-text",
+                    "value": "Error: Invalid input",
+                  },
+                  "toolCallId": "call1",
+                  "toolName": "calculator",
+                  "type": "tool-result",
+                },
+              ],
+              "role": "tool",
+            },
+          ]
+        `);
       });
 
       it('should handle assistant message with tool output error that has no raw input', async () => {
@@ -804,45 +804,45 @@ describe('convertToModelMessages', () => {
         ]);
 
         expect(result).toMatchInlineSnapshot(`
-        [
-          {
-            "content": [
-              {
-                "text": "Let me calculate that for you.",
-                "type": "text",
-              },
-              {
-                "input": {
-                  "numbers": [
-                    1,
-                    2,
-                  ],
-                  "operation": "add",
+          [
+            {
+              "content": [
+                {
+                  "text": "Let me calculate that for you.",
+                  "type": "text",
                 },
-                "providerExecuted": undefined,
-                "toolCallId": "call1",
-                "toolName": "calculator",
-                "type": "tool-call",
-              },
-            ],
-            "role": "assistant",
-          },
-          {
-            "content": [
-              {
-                "output": {
-                  "type": "error-text",
-                  "value": "Error: Invalid input",
+                {
+                  "input": {
+                    "numbers": [
+                      1,
+                      2,
+                    ],
+                    "operation": "add",
+                  },
+                  "providerExecuted": undefined,
+                  "toolCallId": "call1",
+                  "toolName": "calculator",
+                  "type": "tool-call",
                 },
-                "toolCallId": "call1",
-                "toolName": "calculator",
-                "type": "tool-result",
-              },
-            ],
-            "role": "tool",
-          },
-        ]
-      `);
+              ],
+              "role": "assistant",
+            },
+            {
+              "content": [
+                {
+                  "output": {
+                    "type": "error-text",
+                    "value": "Error: Invalid input",
+                  },
+                  "toolCallId": "call1",
+                  "toolName": "calculator",
+                  "type": "tool-result",
+                },
+              ],
+              "role": "tool",
+            },
+          ]
+        `);
       });
     });
 

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -1704,6 +1704,55 @@ describe('convertToModelMessages', () => {
   });
 
   describe('when converting tool approval request responses', () => {
+    it('round-trips a nested caller approval from UI chunks to model messages', async () => {
+      const recordedMessage = await recordAssistantMessageFromChunks([
+        { type: 'start', messageId: 'msg-123' },
+        { type: 'start-step' },
+        {
+          type: 'tool-input-available',
+          toolCallId: 'nested-call',
+          toolName: 'weather',
+          input: { city: 'Tokyo' },
+        },
+        {
+          type: 'tool-approval-request',
+          approvalId: 'nested-approval',
+          toolCallId: 'nested-call',
+          callerToolCallId: 'outer-call',
+        },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      expect(await convertToModelMessages([recordedMessage]))
+        .toMatchInlineSnapshot(`
+          [
+            {
+              "content": [
+                {
+                  "callerToolCallId": "outer-call",
+                  "input": {
+                    "city": "Tokyo",
+                  },
+                  "providerExecuted": undefined,
+                  "toolCallId": "nested-call",
+                  "toolName": "weather",
+                  "type": "tool-call",
+                },
+                {
+                  "approvalId": "nested-approval",
+                  "callerToolCallId": "outer-call",
+                  "isAutomatic": undefined,
+                  "toolCallId": "nested-call",
+                  "type": "tool-approval-request",
+                },
+              ],
+              "role": "assistant",
+            },
+          ]
+        `);
+    });
+
     it('should convert an approved tool approval request (static tool)', async () => {
       const result = await convertToModelMessages([
         {

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -319,12 +319,6 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                     content.push({
                       type: 'tool-approval-response' as const,
                       approvalId: toolPart.approval.id,
-                      ...(toolPart.approval.callerToolCallId != null
-                        ? {
-                            callerToolCallId:
-                              toolPart.approval.callerToolCallId,
-                          }
-                        : {}),
                       approved: toolPart.approval.approved,
                       reason: toolPart.approval.reason,
                       providerExecuted: toolPart.providerExecuted,
@@ -339,12 +333,6 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                     content.push({
                       type: 'tool-result',
                       toolCallId: toolPart.toolCallId,
-                      ...(toolPart.approval.callerToolCallId != null
-                        ? {
-                            callerToolCallId:
-                              toolPart.approval.callerToolCallId,
-                          }
-                        : {}),
                       toolName: getToolName(toolPart),
                       output: {
                         type: 'execution-denied' as const,
@@ -368,12 +356,6 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                       content.push({
                         type: 'tool-result',
                         toolCallId: toolPart.toolCallId,
-                        ...(toolPart.approval?.callerToolCallId != null
-                          ? {
-                              callerToolCallId:
-                                toolPart.approval.callerToolCallId,
-                            }
-                          : {}),
                         toolName: getToolName(toolPart),
                         output: {
                           type: 'error-text' as const,
@@ -394,12 +376,6 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                       content.push({
                         type: 'tool-result',
                         toolCallId: toolPart.toolCallId,
-                        ...(toolPart.approval?.callerToolCallId != null
-                          ? {
-                              callerToolCallId:
-                                toolPart.approval.callerToolCallId,
-                            }
-                          : {}),
                         toolName,
                         output: await createToolModelOutput({
                           toolCallId: toolPart.toolCallId,

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -213,6 +213,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                   content.push({
                     type: 'tool-call' as const,
                     toolCallId: part.toolCallId,
+                    callerToolCallId: part.approval?.callerToolCallId,
                     toolName,
                     input:
                       part.state === 'output-error'
@@ -230,6 +231,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                       type: 'tool-approval-request' as const,
                       approvalId: part.approval.id,
                       toolCallId: part.toolCallId,
+                      callerToolCallId: part.approval.callerToolCallId,
                       isAutomatic: part.approval.isAutomatic,
                       ...(part.approval.signature != null
                         ? { signature: part.approval.signature }
@@ -311,6 +313,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                     content.push({
                       type: 'tool-approval-response' as const,
                       approvalId: toolPart.approval.id,
+                      callerToolCallId: toolPart.approval.callerToolCallId,
                       approved: toolPart.approval.approved,
                       reason: toolPart.approval.reason,
                       providerExecuted: toolPart.providerExecuted,
@@ -325,6 +328,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                     content.push({
                       type: 'tool-result',
                       toolCallId: toolPart.toolCallId,
+                      callerToolCallId: toolPart.approval.callerToolCallId,
                       toolName: getToolName(toolPart),
                       output: {
                         type: 'execution-denied' as const,
@@ -348,6 +352,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                       content.push({
                         type: 'tool-result',
                         toolCallId: toolPart.toolCallId,
+                        callerToolCallId: toolPart.approval.callerToolCallId,
                         toolName: getToolName(toolPart),
                         output: {
                           type: 'error-text' as const,
@@ -368,6 +373,7 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                       content.push({
                         type: 'tool-result',
                         toolCallId: toolPart.toolCallId,
+                        callerToolCallId: toolPart.approval?.callerToolCallId,
                         toolName,
                         output: await createToolModelOutput({
                           toolCallId: toolPart.toolCallId,

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -213,7 +213,9 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                   content.push({
                     type: 'tool-call' as const,
                     toolCallId: part.toolCallId,
-                    callerToolCallId: part.approval?.callerToolCallId,
+                    ...(part.approval?.callerToolCallId != null
+                      ? { callerToolCallId: part.approval.callerToolCallId }
+                      : {}),
                     toolName,
                     input:
                       part.state === 'output-error'
@@ -231,7 +233,11 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                       type: 'tool-approval-request' as const,
                       approvalId: part.approval.id,
                       toolCallId: part.toolCallId,
-                      callerToolCallId: part.approval.callerToolCallId,
+                      ...(part.approval.callerToolCallId != null
+                        ? {
+                            callerToolCallId: part.approval.callerToolCallId,
+                          }
+                        : {}),
                       isAutomatic: part.approval.isAutomatic,
                       ...(part.approval.signature != null
                         ? { signature: part.approval.signature }
@@ -313,7 +319,12 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                     content.push({
                       type: 'tool-approval-response' as const,
                       approvalId: toolPart.approval.id,
-                      callerToolCallId: toolPart.approval.callerToolCallId,
+                      ...(toolPart.approval.callerToolCallId != null
+                        ? {
+                            callerToolCallId:
+                              toolPart.approval.callerToolCallId,
+                          }
+                        : {}),
                       approved: toolPart.approval.approved,
                       reason: toolPart.approval.reason,
                       providerExecuted: toolPart.providerExecuted,
@@ -328,7 +339,12 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                     content.push({
                       type: 'tool-result',
                       toolCallId: toolPart.toolCallId,
-                      callerToolCallId: toolPart.approval.callerToolCallId,
+                      ...(toolPart.approval.callerToolCallId != null
+                        ? {
+                            callerToolCallId:
+                              toolPart.approval.callerToolCallId,
+                          }
+                        : {}),
                       toolName: getToolName(toolPart),
                       output: {
                         type: 'execution-denied' as const,
@@ -352,7 +368,12 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                       content.push({
                         type: 'tool-result',
                         toolCallId: toolPart.toolCallId,
-                        callerToolCallId: toolPart.approval.callerToolCallId,
+                        ...(toolPart.approval?.callerToolCallId != null
+                          ? {
+                              callerToolCallId:
+                                toolPart.approval.callerToolCallId,
+                            }
+                          : {}),
                         toolName: getToolName(toolPart),
                         output: {
                           type: 'error-text' as const,
@@ -373,7 +394,12 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                       content.push({
                         type: 'tool-result',
                         toolCallId: toolPart.toolCallId,
-                        callerToolCallId: toolPart.approval?.callerToolCallId,
+                        ...(toolPart.approval?.callerToolCallId != null
+                          ? {
+                              callerToolCallId:
+                                toolPart.approval.callerToolCallId,
+                            }
+                          : {}),
                         toolName,
                         output: await createToolModelOutput({
                           toolCallId: toolPart.toolCallId,

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -743,6 +743,9 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               toolInvocation.state = 'approval-requested';
               toolInvocation.approval = {
                 id: chunk.approvalId,
+                ...(chunk.callerToolCallId != null
+                  ? { callerToolCallId: chunk.callerToolCallId }
+                  : {}),
                 ...(chunk.isAutomatic === true ? { isAutomatic: true } : {}),
                 ...(chunk.signature != null
                   ? { signature: chunk.signature }

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -313,6 +313,7 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
       callProviderMetadata?: ProviderMetadata;
       approval: {
         id: string;
+        callerToolCallId?: string;
         approved?: never;
         reason?: never;
         isAutomatic?: boolean;
@@ -327,6 +328,7 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
       callProviderMetadata?: ProviderMetadata;
       approval: {
         id: string;
+        callerToolCallId?: string;
         approved: boolean;
         reason?: string;
         isAutomatic?: boolean;
@@ -343,6 +345,7 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
       preliminary?: boolean;
       approval?: {
         id: string;
+        callerToolCallId?: string;
         approved: true;
         reason?: string;
         isAutomatic?: boolean;
@@ -359,6 +362,7 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
       resultProviderMetadata?: ProviderMetadata;
       approval?: {
         id: string;
+        callerToolCallId?: string;
         approved: true;
         reason?: string;
         isAutomatic?: boolean;
@@ -373,6 +377,7 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
       callProviderMetadata?: ProviderMetadata;
       approval: {
         id: string;
+        callerToolCallId?: string;
         approved: false;
         reason?: string;
         isAutomatic?: boolean;
@@ -431,6 +436,7 @@ export type DynamicToolUIPart = {
       callProviderMetadata?: ProviderMetadata;
       approval: {
         id: string;
+        callerToolCallId?: string;
         approved?: never;
         reason?: never;
         isAutomatic?: boolean;
@@ -445,6 +451,7 @@ export type DynamicToolUIPart = {
       callProviderMetadata?: ProviderMetadata;
       approval: {
         id: string;
+        callerToolCallId?: string;
         approved: boolean;
         reason?: string;
         isAutomatic?: boolean;
@@ -461,6 +468,7 @@ export type DynamicToolUIPart = {
       preliminary?: boolean;
       approval?: {
         id: string;
+        callerToolCallId?: string;
         approved: true;
         reason?: string;
         isAutomatic?: boolean;
@@ -476,6 +484,7 @@ export type DynamicToolUIPart = {
       resultProviderMetadata?: ProviderMetadata;
       approval?: {
         id: string;
+        callerToolCallId?: string;
         approved: true;
         reason?: string;
         isAutomatic?: boolean;
@@ -490,6 +499,7 @@ export type DynamicToolUIPart = {
       callProviderMetadata?: ProviderMetadata;
       approval: {
         id: string;
+        callerToolCallId?: string;
         approved: false;
         reason?: string;
         isAutomatic?: boolean;

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -130,6 +130,7 @@ const uiMessagesSchema = lazySchema(() =>
                   callProviderMetadata: providerMetadataSchema.optional(),
                   approval: z.object({
                     id: z.string(),
+                    callerToolCallId: z.string().optional(),
                     approved: z.never().optional(),
                     reason: z.never().optional(),
                     isAutomatic: z.boolean().optional(),
@@ -149,6 +150,7 @@ const uiMessagesSchema = lazySchema(() =>
                   callProviderMetadata: providerMetadataSchema.optional(),
                   approval: z.object({
                     id: z.string(),
+                    callerToolCallId: z.string().optional(),
                     approved: z.boolean(),
                     reason: z.string().optional(),
                     isAutomatic: z.boolean().optional(),
@@ -171,6 +173,7 @@ const uiMessagesSchema = lazySchema(() =>
                   approval: z
                     .object({
                       id: z.string(),
+                      callerToolCallId: z.string().optional(),
                       approved: z.literal(true),
                       reason: z.string().optional(),
                       isAutomatic: z.boolean().optional(),
@@ -194,6 +197,7 @@ const uiMessagesSchema = lazySchema(() =>
                   approval: z
                     .object({
                       id: z.string(),
+                      callerToolCallId: z.string().optional(),
                       approved: z.literal(true),
                       reason: z.string().optional(),
                       isAutomatic: z.boolean().optional(),
@@ -214,6 +218,7 @@ const uiMessagesSchema = lazySchema(() =>
                   callProviderMetadata: providerMetadataSchema.optional(),
                   approval: z.object({
                     id: z.string(),
+                    callerToolCallId: z.string().optional(),
                     approved: z.literal(false),
                     reason: z.string().optional(),
                     isAutomatic: z.boolean().optional(),
@@ -256,6 +261,7 @@ const uiMessagesSchema = lazySchema(() =>
                   callProviderMetadata: providerMetadataSchema.optional(),
                   approval: z.object({
                     id: z.string(),
+                    callerToolCallId: z.string().optional(),
                     approved: z.never().optional(),
                     reason: z.never().optional(),
                     isAutomatic: z.boolean().optional(),
@@ -274,6 +280,7 @@ const uiMessagesSchema = lazySchema(() =>
                   callProviderMetadata: providerMetadataSchema.optional(),
                   approval: z.object({
                     id: z.string(),
+                    callerToolCallId: z.string().optional(),
                     approved: z.boolean(),
                     reason: z.string().optional(),
                     isAutomatic: z.boolean().optional(),
@@ -295,6 +302,7 @@ const uiMessagesSchema = lazySchema(() =>
                   approval: z
                     .object({
                       id: z.string(),
+                      callerToolCallId: z.string().optional(),
                       approved: z.literal(true),
                       reason: z.string().optional(),
                       isAutomatic: z.boolean().optional(),
@@ -317,6 +325,7 @@ const uiMessagesSchema = lazySchema(() =>
                   approval: z
                     .object({
                       id: z.string(),
+                      callerToolCallId: z.string().optional(),
                       approved: z.literal(true),
                       reason: z.string().optional(),
                       isAutomatic: z.boolean().optional(),
@@ -336,6 +345,7 @@ const uiMessagesSchema = lazySchema(() =>
                   callProviderMetadata: providerMetadataSchema.optional(),
                   approval: z.object({
                     id: z.string(),
+                    callerToolCallId: z.string().optional(),
                     approved: z.literal(false),
                     reason: z.string().optional(),
                     isAutomatic: z.boolean().optional(),

--- a/packages/code-mode/src/approval-continuation.test.ts
+++ b/packages/code-mode/src/approval-continuation.test.ts
@@ -1,8 +1,9 @@
-import { tool } from 'ai';
+import { tool, type Experimental_ToolWithCaller } from 'ai';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import {
   CodeModeToolApprovalDeniedError,
+  experimental_codeModeTool as codeModeTool,
   experimental_continueCodeModeApproval as continueCodeModeApproval,
   experimental_continueCodeModeInterrupt as continueCodeModeInterrupt,
   experimental_isCodeModeApprovalInterrupt as isCodeModeApprovalInterrupt,
@@ -199,6 +200,112 @@ describe('code-mode approval continuations', () => {
     ).resolves.toEqual({ first: 'first', second: 'second' });
     expect(first).toHaveBeenCalledTimes(1);
     expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the core approval resolver for new tools after resuming', async () => {
+    const first = vi.fn(async () => 'first');
+    const second = vi.fn(async () => 'second');
+    const tools = {
+      first: tool({
+        inputSchema: z.object({}),
+        execute: first,
+      }),
+      second: tool({
+        inputSchema: z.object({}),
+        execute: second,
+      }),
+    };
+    const callerTool = codeModeTool() as Experimental_ToolWithCaller;
+    const caller = callerTool.experimental_toolCaller;
+    if (caller.type !== 'local') {
+      throw new Error('Expected a local tool caller.');
+    }
+    const boundTool = caller.bind(tools, {
+      resolveToolApproval: async () => ({ type: 'user-approval' }),
+    });
+    const execute = boundTool.execute as unknown as (
+      input: { js: string },
+      options: { toolCallId: string; messages: []; context: {} },
+    ) => Promise<unknown>;
+    const firstPending = await execute(
+      {
+        js: `
+          const first = await tools.first({});
+          const second = await tools.second({});
+          return { first, second };
+        `,
+      },
+      { toolCallId: 'outer', messages: [], context: {} },
+    );
+    expect(
+      isCodeModeApprovalInterrupt(firstPending)
+        ? {
+            type: firstPending.type,
+            toolName: firstPending.toolName,
+            toolCallId: firstPending.toolCallId,
+          }
+        : undefined,
+    ).toMatchInlineSnapshot(`
+      {
+        "toolCallId": "outer:tool-1",
+        "toolName": "first",
+        "type": "code-mode-interrupt",
+      }
+    `);
+
+    const secondPending = await caller.continueApproval!({
+      output: firstPending,
+      approvalResponse: {
+        type: 'tool-approval-response',
+        approvalId: (firstPending as CodeModeApprovalInterrupt).interruptId,
+        approved: true,
+      },
+      tools,
+      messages: [],
+      toolExecutionOptions: { toolCallId: 'outer', messages: [] },
+      resolveToolApproval: async (toolCall: { toolName: string }) =>
+        toolCall.toolName === 'second'
+          ? { type: 'user-approval' }
+          : { type: 'not-applicable' },
+    } as never);
+    expect(
+      isCodeModeApprovalInterrupt(secondPending)
+        ? {
+            type: secondPending.type,
+            toolName: secondPending.toolName,
+            toolCallId: secondPending.toolCallId,
+          }
+        : undefined,
+    ).toMatchInlineSnapshot(`
+      {
+        "toolCallId": "outer:tool-2",
+        "toolName": "second",
+        "type": "code-mode-interrupt",
+      }
+    `);
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).not.toHaveBeenCalled();
+
+    const completed = await caller.continueApproval!({
+      output: secondPending,
+      approvalResponse: {
+        type: 'tool-approval-response',
+        approvalId: (secondPending as CodeModeApprovalInterrupt).interruptId,
+        approved: true,
+      },
+      tools,
+      messages: [],
+      toolExecutionOptions: { toolCallId: 'outer', messages: [] },
+      resolveToolApproval: async () => ({ type: 'not-applicable' }),
+    } as never);
+    expect(completed).toMatchInlineSnapshot(`
+      {
+        "first": "first",
+        "second": "second",
+      }
+    `);
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledOnce();
   });
 
   it('supports generic host interruptions', async () => {

--- a/packages/code-mode/src/code-mode-tool.ts
+++ b/packages/code-mode/src/code-mode-tool.ts
@@ -93,6 +93,7 @@ export function codeModeTool(
       approvalResponse,
       tools,
       toolExecutionOptions,
+      resolveToolApproval,
     }) => {
       const interrupt = getCodeModeInterrupt(
         output,
@@ -109,7 +110,13 @@ export function codeModeTool(
         interrupt,
         approvalResponse,
         tools: tools as CodeModeToolSet,
-        options,
+        options: {
+          ...options,
+          approval: {
+            ...options.approval,
+            resolve: resolveToolApproval,
+          },
+        },
         toolExecutionOptions,
       });
     },

--- a/packages/code-mode/src/code-mode-tool.ts
+++ b/packages/code-mode/src/code-mode-tool.ts
@@ -2,8 +2,13 @@ import {
   experimental_toolCaller,
   jsonSchema,
   tool,
-  type Experimental_ToolCallerTool,
+  type Experimental_ToolWithCaller,
 } from 'ai';
+import {
+  continueCodeModeApproval,
+  isCodeModeApprovalInterrupt,
+} from './approval-continuation.js';
+import { getCodeModeInterrupt } from './interrupt-continuation.js';
 import { runCodeMode } from './run-code-mode.js';
 import { buildCodeModeToolDescription } from './tool-prompt.js';
 import type {
@@ -51,10 +56,62 @@ export function createCodeModeTool(
  */
 export function codeModeTool(
   options: CodeModeOptions = {},
-): Experimental_ToolCallerTool<CodeModeTool> {
+): Experimental_ToolWithCaller<CodeModeTool> {
   return experimental_toolCaller(createCodeModeTool({}, options), {
     type: 'local',
-    bind: tools =>
-      createCodeModeTool(tools as unknown as CodeModeToolSet, options),
+    bind: (tools, context) =>
+      createCodeModeTool(tools as unknown as CodeModeToolSet, {
+        ...options,
+        approval: {
+          ...options.approval,
+          mode: 'interrupt',
+          resolve: context.resolveToolApproval,
+        },
+      }),
+    getApprovalRequest: output => {
+      const interrupt = getCodeModeInterrupt(
+        output,
+        options.continuationSecurity,
+      );
+      if (
+        !isCodeModeApprovalInterrupt(interrupt, options.continuationSecurity)
+      ) {
+        return undefined;
+      }
+      return {
+        approvalId: interrupt.interruptId,
+        callerToolCallId: interrupt.outerToolCallId,
+        toolCall: {
+          toolCallId: interrupt.toolCallId,
+          toolName: interrupt.toolName,
+          input: interrupt.input,
+        },
+      };
+    },
+    continueApproval: async ({
+      output,
+      approvalResponse,
+      tools,
+      toolExecutionOptions,
+    }) => {
+      const interrupt = getCodeModeInterrupt(
+        output,
+        options.continuationSecurity,
+      );
+      if (
+        !isCodeModeApprovalInterrupt(interrupt, options.continuationSecurity)
+      ) {
+        throw new TypeError(
+          'Tool caller output does not contain a code-mode approval interrupt.',
+        );
+      }
+      return await continueCodeModeApproval({
+        interrupt,
+        approvalResponse,
+        tools: tools as CodeModeToolSet,
+        options,
+        toolExecutionOptions,
+      });
+    },
   });
 }

--- a/packages/code-mode/src/tool-invocation.ts
+++ b/packages/code-mode/src/tool-invocation.ts
@@ -87,14 +87,39 @@ export async function invokeHostTool({
     ...(codeModeInterrupt !== undefined ? { codeModeInterrupt } : {}),
   };
 
-  const needsApproval =
+  const approvalRequest = {
+    toolName,
+    input: validation.value,
+    toolCallId,
+  };
+  const injectedApprovalStatus =
+    !skipApproval && codeModeOptions.approval?.resolve != null
+      ? await raceAgainstAbort(
+          codeModeOptions.approval.resolve(approvalRequest),
+          executionOptions.abortSignal,
+        )
+      : undefined;
+  const needsStandaloneApproval =
     !skipApproval &&
+    injectedApprovalStatus === undefined &&
     (await raceAgainstAbort(
       requiresApproval(hostTool, validation.value, executionOptions),
       executionOptions.abortSignal,
     ));
 
-  if (needsApproval) {
+  if (injectedApprovalStatus?.type === 'denied') {
+    throw new CodeModeToolApprovalDeniedError(
+      toolName,
+      validation.value,
+      toolCallId,
+      injectedApprovalStatus.reason,
+    );
+  }
+
+  if (
+    injectedApprovalStatus?.type === 'user-approval' ||
+    needsStandaloneApproval
+  ) {
     if (codeModeOptions.approval?.mode === 'interrupt') {
       return {
         type: 'interrupted',
@@ -107,11 +132,7 @@ export async function invokeHostTool({
 
     const approval = await raceAgainstAbort(
       Promise.resolve(
-        codeModeOptions.approval?.onApprovalRequired?.({
-          toolName,
-          input: validation.value,
-          toolCallId,
-        }),
+        codeModeOptions.approval?.onApprovalRequired?.(approvalRequest),
       ),
       baseExecutionOptions.abortSignal,
     );

--- a/packages/code-mode/src/tool-invocation.ts
+++ b/packages/code-mode/src/tool-invocation.ts
@@ -92,34 +92,30 @@ export async function invokeHostTool({
     input: validation.value,
     toolCallId,
   };
-  const injectedApprovalStatus =
-    !skipApproval && codeModeOptions.approval?.resolve != null
+  const approvalStatus = skipApproval
+    ? { type: 'not-applicable' as const }
+    : codeModeOptions.approval?.resolve != null
       ? await raceAgainstAbort(
           codeModeOptions.approval.resolve(approvalRequest),
           executionOptions.abortSignal,
         )
-      : undefined;
-  const needsStandaloneApproval =
-    !skipApproval &&
-    injectedApprovalStatus === undefined &&
-    (await raceAgainstAbort(
-      requiresApproval(hostTool, validation.value, executionOptions),
-      executionOptions.abortSignal,
-    ));
+      : (await raceAgainstAbort(
+            requiresApproval(hostTool, validation.value, executionOptions),
+            executionOptions.abortSignal,
+          ))
+        ? { type: 'user-approval' as const }
+        : { type: 'not-applicable' as const };
 
-  if (injectedApprovalStatus?.type === 'denied') {
+  if (approvalStatus.type === 'denied') {
     throw new CodeModeToolApprovalDeniedError(
       toolName,
       validation.value,
       toolCallId,
-      injectedApprovalStatus.reason,
+      approvalStatus.reason,
     );
   }
 
-  if (
-    injectedApprovalStatus?.type === 'user-approval' ||
-    needsStandaloneApproval
-  ) {
+  if (approvalStatus.type === 'user-approval') {
     if (codeModeOptions.approval?.mode === 'interrupt') {
       return {
         type: 'interrupted',

--- a/packages/code-mode/src/types.ts
+++ b/packages/code-mode/src/types.ts
@@ -1,5 +1,11 @@
 import type { ModelMessage, Tool } from 'ai';
 
+type CodeModeResolvedApprovalStatus =
+  | { type: 'not-applicable'; reason?: never }
+  | { type: 'approved'; reason?: string }
+  | { type: 'denied'; reason?: string }
+  | { type: 'user-approval'; reason?: never };
+
 /**
  * Host tools made available to sandboxed code through the global `tools` object.
  */
@@ -195,6 +201,14 @@ export interface CodeModeOptions {
     onApprovalRequired?: (
       request: CodeModeApprovalRequest,
     ) => Promise<ApprovalDecision> | ApprovalDecision;
+    /**
+     * Approval resolver injected by the surrounding AI SDK tool-caller runtime.
+     *
+     * @internal
+     */
+    resolve?: (
+      request: CodeModeApprovalRequest,
+    ) => Promise<CodeModeResolvedApprovalStatus>;
   };
 }
 

--- a/packages/provider-utils/src/types/content-part.ts
+++ b/packages/provider-utils/src/types/content-part.ts
@@ -229,11 +229,6 @@ export interface ToolResultPart {
   toolCallId: string;
 
   /**
-   * ID of the local caller tool call that owns this nested tool result.
-   */
-  callerToolCallId?: string;
-
-  /**
    * Name of the tool that generated this result.
    */
   toolName: string;

--- a/packages/provider-utils/src/types/content-part.ts
+++ b/packages/provider-utils/src/types/content-part.ts
@@ -190,6 +190,11 @@ export interface ToolCallPart {
   toolCallId: string;
 
   /**
+   * ID of the local caller tool call that owns this nested tool call.
+   */
+  callerToolCallId?: string;
+
+  /**
    * Name of the tool that is being called.
    */
   toolName: string;
@@ -222,6 +227,11 @@ export interface ToolResultPart {
    * ID of the tool call that this result is associated with.
    */
   toolCallId: string;
+
+  /**
+   * ID of the local caller tool call that owns this nested tool result.
+   */
+  callerToolCallId?: string;
 
   /**
    * Name of the tool that generated this result.

--- a/packages/provider-utils/src/types/index.ts
+++ b/packages/provider-utils/src/types/index.ts
@@ -52,7 +52,7 @@ export {
   getToolCaller as experimental_getToolCaller,
   toolCaller as experimental_toolCaller,
   type ToolCallerDefinition as Experimental_ToolCallerDefinition,
-  type ToolCallerTool as Experimental_ToolCallerTool,
+  type ToolWithCaller as Experimental_ToolWithCaller,
 } from './tool-caller';
 export type {
   ToolExecuteFunction,

--- a/packages/provider-utils/src/types/tool-approval-request.ts
+++ b/packages/provider-utils/src/types/tool-approval-request.ts
@@ -15,6 +15,11 @@ export type ToolApprovalRequest = {
   toolCallId: string;
 
   /**
+   * ID of the local caller tool call that owns this nested approval.
+   */
+  callerToolCallId?: string;
+
+  /**
    * Flag indicating whether the tool was automatically approved or denied.
    *
    * @default false

--- a/packages/provider-utils/src/types/tool-approval-response.ts
+++ b/packages/provider-utils/src/types/tool-approval-response.ts
@@ -10,6 +10,11 @@ export type ToolApprovalResponse = {
   approvalId: string;
 
   /**
+   * ID of the local caller tool call that owns this nested approval.
+   */
+  callerToolCallId?: string;
+
+  /**
    * Flag indicating whether the approval was granted or denied.
    */
   approved: boolean;

--- a/packages/provider-utils/src/types/tool-approval-response.ts
+++ b/packages/provider-utils/src/types/tool-approval-response.ts
@@ -10,11 +10,6 @@ export type ToolApprovalResponse = {
   approvalId: string;
 
   /**
-   * ID of the local caller tool call that owns this nested approval.
-   */
-  callerToolCallId?: string;
-
-  /**
    * Flag indicating whether the approval was granted or denied.
    */
   approved: boolean;

--- a/packages/provider-utils/src/types/tool-caller.ts
+++ b/packages/provider-utils/src/types/tool-caller.ts
@@ -1,5 +1,4 @@
 import type { ProviderOptions } from './provider-options';
-import type { ModelMessage } from './model-message';
 import type { Tool } from './tool';
 import type { ToolApprovalResponse } from './tool-approval-response';
 import type { ToolCall } from './tool-call';
@@ -35,7 +34,6 @@ export type ToolCallerDefinition =
         output: unknown;
         approvalResponse: ToolApprovalResponse;
         tools: ToolSet;
-        messages: ModelMessage[];
         toolExecutionOptions: Partial<ToolExecutionOptions<unknown>>;
         resolveToolApproval: ToolCallerBindContext['resolveToolApproval'];
       }) => Promise<unknown>;

--- a/packages/provider-utils/src/types/tool-caller.ts
+++ b/packages/provider-utils/src/types/tool-caller.ts
@@ -37,6 +37,7 @@ export type ToolCallerDefinition =
         tools: ToolSet;
         messages: ModelMessage[];
         toolExecutionOptions: Partial<ToolExecutionOptions<unknown>>;
+        resolveToolApproval: ToolCallerBindContext['resolveToolApproval'];
       }) => Promise<unknown>;
     }
   | {

--- a/packages/provider-utils/src/types/tool-caller.ts
+++ b/packages/provider-utils/src/types/tool-caller.ts
@@ -1,11 +1,43 @@
 import type { ProviderOptions } from './provider-options';
+import type { ModelMessage } from './model-message';
 import type { Tool } from './tool';
+import type { ToolApprovalResponse } from './tool-approval-response';
+import type { ToolCall } from './tool-call';
+import type { ToolExecutionOptions } from './tool-execute-function';
 import type { ToolSet } from './tool-set';
+
+type ResolvedToolApprovalStatus =
+  | { type: 'not-applicable'; reason?: never }
+  | { type: 'approved'; reason?: string }
+  | { type: 'denied'; reason?: string }
+  | { type: 'user-approval'; reason?: never };
+
+type ToolCallerApprovalRequest = {
+  approvalId: string;
+  callerToolCallId: string;
+  toolCall: ToolCall<string, unknown>;
+};
+
+type ToolCallerBindContext = {
+  resolveToolApproval: (
+    toolCall: ToolCall<string, unknown>,
+  ) => Promise<ResolvedToolApprovalStatus>;
+};
 
 export type ToolCallerDefinition =
   | {
       type: 'local';
-      bind: (tools: ToolSet) => Tool;
+      bind: (tools: ToolSet, context: ToolCallerBindContext) => Tool;
+      getApprovalRequest?: (
+        output: unknown,
+      ) => ToolCallerApprovalRequest | undefined;
+      continueApproval?: (options: {
+        output: unknown;
+        approvalResponse: ToolApprovalResponse;
+        tools: ToolSet;
+        messages: ModelMessage[];
+        toolExecutionOptions: Partial<ToolExecutionOptions<unknown>>;
+      }) => Promise<unknown>;
     }
   | {
       type: 'provider';
@@ -14,21 +46,21 @@ export type ToolCallerDefinition =
       ) => ProviderOptions;
     };
 
-export type ToolCallerTool<TOOL extends Tool = Tool> = TOOL & {
+export type ToolWithCaller<TOOL extends Tool = Tool> = TOOL & {
   readonly experimental_toolCaller: ToolCallerDefinition;
 };
 
 export function toolCaller<TOOL extends Tool>(
   tool: TOOL,
   definition: ToolCallerDefinition,
-): ToolCallerTool<TOOL> {
+): ToolWithCaller<TOOL> {
   return Object.defineProperty({ ...tool }, 'experimental_toolCaller', {
     value: definition,
-  }) as ToolCallerTool<TOOL>;
+  }) as ToolWithCaller<TOOL>;
 }
 
 export function getToolCaller(
   tool: Tool | undefined,
 ): ToolCallerDefinition | undefined {
-  return (tool as ToolCallerTool | undefined)?.experimental_toolCaller;
+  return (tool as ToolWithCaller | undefined)?.experimental_toolCaller;
 }


### PR DESCRIPTION
## Background

towards #18143, following up to https://github.com/vercel/ai/pull/18292

Nested code-mode tool calls bypassed core’s toolApproval flow and failed when approval was required.

## Summary

integrated code-mode interruptions and continuations with AI SDK’s existing tool-approval flow

## End-to-End Verification

- tested with multiturn example `http://localhost:3000/chat/code-mode-tool-approval`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #18143