### PR TITLE
feat(provider/gateway): support `vision` in `has` model filtering

### DIFF
--- a/.changeset/gateway-has-vision.md
+++ b/.changeset/gateway-has-vision.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(provider/gateway): support `'vision'` (image input) in the `has` provider option

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -1041,11 +1041,15 @@ The following gateway provider options are available:
 
   The unique identifier for the entity against which quota is tracked. Used for quota management and enforcement purposes.
 
-- **has** _Array&lt;'implicit-caching'&gt;_
+- **has** _Array&lt;'implicit-caching' | 'vision'&gt;_
 
-  Restricts routing to provider models that have all of the specified capabilities. Currently supports `'implicit-caching'`, which limits routing to models that perform automatic (implicit) prompt caching. Applies to both BYOK and system credentials, since the capability is a property of the model rather than the credential. If no provider model for the requested model satisfies the capabilities, the request fails. Unsupported values are rejected.
+  Restricts routing to provider models that have all of the specified capabilities. Applies to both BYOK and system credentials, since the capability is a property of the model rather than the credential. If no provider model for the requested model satisfies the capabilities, the request fails. Unsupported values are rejected.
 
-  Example: `has: ['implicit-caching']` will only route to models that support implicit caching.
+  Supported capabilities:
+  - `'implicit-caching'` — models that perform automatic (implicit) prompt caching.
+  - `'vision'` — models that accept image input.
+
+  Example: `has: ['implicit-caching']` will only route to models that support implicit caching. Example: `has: ['vision']` will only route to models that accept image input.
 
 - **providerTimeouts** _object_
 
@@ -1183,7 +1187,7 @@ const { text } = await generateText({
 
 #### Filtering by Model Capability
 
-Set `has` to restrict routing to provider models that have the specified capabilities. This applies to both BYOK and system credentials, since the capability is a property of the model rather than the credential. Currently `'implicit-caching'` is supported, which limits routing to models that perform automatic prompt caching. If no provider model for the requested model satisfies the capabilities, the request fails.
+Set `has` to restrict routing to provider models that have the specified capabilities. This applies to both BYOK and system credentials, since the capability is a property of the model rather than the credential. `'implicit-caching'` limits routing to models that perform automatic prompt caching, and `'vision'` limits routing to models that accept image input. If no provider model for the requested model satisfies the capabilities, the request fails.
 
 ```ts
 import type { GatewayProviderOptions } from '@ai-sdk/gateway';
@@ -1195,6 +1199,37 @@ const { text } = await generateText({
   providerOptions: {
     gateway: {
       has: ['implicit-caching'],
+    } satisfies GatewayProviderOptions,
+  },
+});
+```
+
+Use `'vision'` when the request sends image input, so the gateway only routes to
+provider models that can accept it:
+
+```ts
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { generateText } from 'ai';
+import fs from 'node:fs';
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-4.6',
+  messages: [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Describe the image in detail.' },
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          data: fs.readFileSync('./data/comic-cat.png'),
+        },
+      ],
+    },
+  ],
+  providerOptions: {
+    gateway: {
+      has: ['vision'],
     } satisfies GatewayProviderOptions,
   },
 });

--- a/examples/ai-functions/src/stream-text/gateway/provider-options-has-vision.ts
+++ b/examples/ai-functions/src/stream-text/gateway/provider-options-has-vision.ts
@@ -1,0 +1,36 @@
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { streamText } from 'ai';
+import fs from 'node:fs';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: 'anthropic/claude-sonnet-4.6',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe the image in detail.' },
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            data: fs.readFileSync('./data/comic-cat.png'),
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      gateway: {
+        has: ['vision'],
+      } satisfies GatewayProviderOptions,
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+});

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -17,9 +17,9 @@ export type GatewayProviderOptions = {
 
   /**
    * Restrict routing to models that have all of the given capabilities.
-   * Currently supports `'implicit-caching'`.
+   * Currently supports `'implicit-caching'` and `'vision'` (image input).
    */
-  has?: Array<'implicit-caching'>;
+  has?: Array<'implicit-caching' | 'vision'>;
 
   /** Array of model slugs specifying fallback models to use in order. */
   models?: string[];


### PR DESCRIPTION
## Background

Extends the gateway `has` provider option to accept `'vision'` (image input) alongside `'implicit-caching'`, so routing can be restricted to provider models that accept image input.

```ts
import { streamText } from 'ai';

const result = streamText({
  model: 'anthropic/claude-sonnet-4.6',
  messages: [
    {
      role: 'user',
      content: [
        { type: 'text', text: 'Describe the image in detail.' },
        { type: 'file', mediaType: 'image/png', data: imageBytes },
      ],
    },
  ],
  providerOptions: {
    gateway: {
      has: ['vision'],
    },
  },
});
```

As with `'implicit-caching'`, the capability is a property of the model, so the filter applies to both BYOK and system credentials. If no provider model for the requested model satisfies the capabilities, the request fails; unsupported values are rejected.

## Changes

- **`@ai-sdk/gateway`** — widen to `has?: Array<'implicit-caching' | 'vision'>`.
- **Docs** — option reference now lists both capabilities; added a `'vision'` example under "Filtering by Model Capability" in `content/providers/01-ai-sdk-providers/00-ai-gateway.mdx`.
- **Example** — `examples/ai-functions/src/stream-text/gateway/provider-options-has-vision.ts`.
- **Changeset** — patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)