### PR TITLE
fix(provider/fireworks): send request body fields as snake_case

### DIFF
--- a/.changeset/fireworks-snake-case-request-body.md
+++ b/.changeset/fireworks-snake-case-request-body.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fireworks': patch
+---
+
+Send `promptCacheKey`, `serviceTier`, `reasoningHistory` and `thinking.budgetTokens` under the snake_case names the Fireworks API defines. Fireworks rejects unknown fields outright, so previously any of these provider options failed the whole request with `400 Extra inputs are not permitted`.

--- a/packages/fireworks/src/fireworks-provider.test.ts
+++ b/packages/fireworks/src/fireworks-provider.test.ts
@@ -134,6 +134,135 @@ describe('FireworksProvider', () => {
       const config = OpenAICompatibleChatLanguageModelMock.mock.calls[0][1];
       expect(config.includeUsage).toBe(true);
     });
+
+    // Fireworks rejects unknown fields outright ("Extra inputs are not
+    // permitted, field: 'promptCacheKey'") rather than ignoring them, so any
+    // option left in camelCase fails the whole request.
+    describe('transformRequestBody', () => {
+      const getTransform = () => {
+        const provider = createFireworks();
+        provider.chatModel('test-model');
+        return OpenAICompatibleChatLanguageModelMock.mock.calls[0][1]
+          .transformRequestBody;
+      };
+
+      it('should pass transformRequestBody that converts thinking options', () => {
+        const result = getTransform()({
+          model: 'test-model',
+          messages: [],
+          thinking: { type: 'enabled', budgetTokens: 2048 },
+          reasoningHistory: 'interleaved',
+        });
+
+        expect(result).toEqual({
+          model: 'test-model',
+          messages: [],
+          thinking: { type: 'enabled', budget_tokens: 2048 },
+          reasoning_history: 'interleaved',
+        });
+      });
+
+      it('should handle thinking without budgetTokens', () => {
+        const result = getTransform()({
+          model: 'test-model',
+          messages: [],
+          thinking: { type: 'enabled' },
+        });
+
+        expect(result).toEqual({
+          model: 'test-model',
+          messages: [],
+          thinking: { type: 'enabled' },
+        });
+      });
+
+      it('should map promptCacheKey to prompt_cache_key', () => {
+        const result = getTransform()({
+          model: 'test-model',
+          messages: [],
+          promptCacheKey: 'session-123',
+        });
+
+        expect(result).toEqual({
+          model: 'test-model',
+          messages: [],
+          prompt_cache_key: 'session-123',
+        });
+        expect(result).not.toHaveProperty('promptCacheKey');
+      });
+
+      it('should prefer promptCacheKey over raw prompt_cache_key', () => {
+        const result = getTransform()({
+          model: 'test-model',
+          messages: [],
+          prompt_cache_key: 'raw-session',
+          promptCacheKey: 'typed-session',
+        });
+
+        expect(result).toEqual({
+          model: 'test-model',
+          messages: [],
+          prompt_cache_key: 'typed-session',
+        });
+      });
+
+      it('should map serviceTier to service_tier', () => {
+        const result = getTransform()({
+          model: 'test-model',
+          messages: [],
+          serviceTier: 'priority',
+        });
+
+        expect(result).toEqual({
+          model: 'test-model',
+          messages: [],
+          service_tier: 'priority',
+        });
+        expect(result).not.toHaveProperty('serviceTier');
+      });
+
+      it('should prefer serviceTier over raw service_tier', () => {
+        const result = getTransform()({
+          model: 'test-model',
+          messages: [],
+          service_tier: 'standard',
+          serviceTier: 'priority',
+        });
+
+        expect(result).toEqual({
+          model: 'test-model',
+          messages: [],
+          service_tier: 'priority',
+        });
+      });
+
+      it('should map reasoningHistory to reasoning_history', () => {
+        const result = getTransform()({
+          model: 'test-model',
+          messages: [],
+          reasoningHistory: 'interleaved',
+        });
+
+        expect(result).toEqual({
+          model: 'test-model',
+          messages: [],
+          reasoning_history: 'interleaved',
+        });
+        expect(result).not.toHaveProperty('reasoningHistory');
+      });
+
+      it('should handle request without thinking options', () => {
+        const result = getTransform()({
+          model: 'test-model',
+          messages: [],
+        });
+
+        expect(result).toEqual({
+          model: 'test-model',
+          messages: [],
+        });
+      });
+    });
   });
 
   describe('completionModel', () => {

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -133,6 +133,43 @@ export function createFireworks(
       ...getCommonModelConfig('chat'),
       includeUsage: true,
       errorStructure: fireworksErrorStructure,
+      transformRequestBody: args => {
+        const thinking = args.thinking as
+          | { type?: string; budgetTokens?: number }
+          | undefined;
+        const reasoningHistory = args.reasoningHistory as string | undefined;
+        const promptCacheKey = args.promptCacheKey as string | undefined;
+        const serviceTier = args.serviceTier as string | undefined;
+
+        const {
+          thinking: _,
+          reasoningHistory: __,
+          promptCacheKey: ___,
+          serviceTier: ____,
+          ...rest
+        } = args;
+
+        return {
+          ...rest,
+          ...(promptCacheKey !== undefined && {
+            prompt_cache_key: promptCacheKey,
+          }),
+          ...(serviceTier !== undefined && {
+            service_tier: serviceTier,
+          }),
+          ...(thinking && {
+            thinking: {
+              type: thinking.type,
+              ...(thinking.budgetTokens !== undefined && {
+                budget_tokens: thinking.budgetTokens,
+              }),
+            },
+          }),
+          ...(reasoningHistory && {
+            reasoning_history: reasoningHistory,
+          }),
+        };
+      },
     });
   };
 


### PR DESCRIPTION
Fireworks rejects unknown body fields outright rather than ignoring them, and names the offending field:

```
400 Extra inputs are not permitted, field: 'promptCacheKey', value: '…'
```

So passing `promptCacheKey`, `serviceTier`, `reasoningHistory` or `thinking.budgetTokens` failed the **entire request**. This renames them to the snake_case names the Fireworks API defines:

| provider option | sent as |
|---|---|
| `promptCacheKey` | `prompt_cache_key` |
| `serviceTier` | `service_tier` |
| `reasoningHistory` | `reasoning_history` |
| `thinking.budgetTokens` | `thinking.budget_tokens` |

The AI SDK 6 provider already does exactly this. The `createChatModel` block here is now byte-identical to the one on `main`, so this is a straight parity port rather than a new implementation.

## Verification

Run against Fireworks with `accounts/fireworks/models/kimi-k3`, one provider option per request:

| case | before | after |
|---|---|---|
| baseline (no extra params) | OK | OK |
| `promptCacheKey` | **400** | OK |
| `serviceTier` | **400** | OK |
| `thinking.budgetTokens` | **400** | OK |
| `reasoningHistory` | **400** `Extra inputs are not permitted` | `400 invalid reasoning_history value: 'none'` |
| `prompt_cache_key` (snake, control) | OK | OK |
| `service_tier` (snake, control) | OK | OK |

The `reasoningHistory` row is the informative one: the error changes from *"unknown field"* to *"invalid value for `reasoning_history`"*, which confirms the rename reaches the wire. `'none'` was simply a bad probe value on my side — this PR doesn't establish which values that field accepts.

25/25 existing package tests pass; `tsc --build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
