### PR TITLE
Backport: feat(provider/gateway): add `has` model capability filtering (`implicit-caching`, `vision`)

### DIFF
--- a/.changeset/gateway-has-vision.md
+++ b/.changeset/gateway-has-vision.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(provider/gateway): add `has` provider option for model capability filtering, supporting `'implicit-caching'` and `'vision'` (image input)

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -804,6 +804,17 @@ The following gateway provider options are available:
 
   The unique identifier for the entity against which quota is tracked. Used for quota management and enforcement purposes.
 
+- **has** _Array&lt;'implicit-caching' | 'vision'&gt;_
+
+  Restricts routing to provider models that have all of the specified capabilities. Applies to both BYOK and system credentials, since the capability is a property of the model rather than the credential. If no provider model for the requested model satisfies the capabilities, the request fails. Unsupported values are rejected.
+
+  Supported capabilities:
+
+  - `'implicit-caching'` — models that perform automatic (implicit) prompt caching.
+  - `'vision'` — models that accept image input.
+
+  Example: `has: ['implicit-caching']` will only route to models that support implicit caching. Example: `has: ['vision']` will only route to models that accept image input.
+
 - **providerTimeouts** _object_
 
   Per-provider timeouts for BYOK credentials in milliseconds. Controls how long to wait for a provider to start responding before falling back to the next available provider.
@@ -907,6 +918,56 @@ const { text } = await generateText({
   providerOptions: {
     gateway: {
       quotaEntityId: "org-123",
+    } satisfies GatewayProviderOptions,
+  },
+});
+```
+
+#### Filtering by Model Capability
+
+Set `has` to restrict routing to provider models that have the specified capabilities. This applies to both BYOK and system credentials, since the capability is a property of the model rather than the credential. `'implicit-caching'` limits routing to models that perform automatic prompt caching, and `'vision'` limits routing to models that accept image input. If no provider model for the requested model satisfies the capabilities, the request fails.
+
+```ts
+import type { GatewayProviderOptions } from "@ai-sdk/gateway";
+import { generateText } from "ai";
+
+const { text } = await generateText({
+  model: "openai/gpt-5.5",
+  prompt: "Summarize this report...",
+  providerOptions: {
+    gateway: {
+      has: ["implicit-caching"],
+    } satisfies GatewayProviderOptions,
+  },
+});
+```
+
+Use `'vision'` when the request sends image input, so the gateway only routes to
+provider models that can accept it:
+
+```ts
+import type { GatewayProviderOptions } from "@ai-sdk/gateway";
+import { generateText } from "ai";
+import fs from "node:fs";
+
+const { text } = await generateText({
+  model: "anthropic/claude-sonnet-4.6",
+  messages: [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "Describe the image in detail." },
+        {
+          type: "file",
+          mediaType: "image/png",
+          data: fs.readFileSync("./data/comic-cat.png"),
+        },
+      ],
+    },
+  ],
+  providerOptions: {
+    gateway: {
+      has: ["vision"],
     } satisfies GatewayProviderOptions,
   },
 });

--- a/examples/ai-core/src/stream-text/gateway-provider-options-has-vision.ts
+++ b/examples/ai-core/src/stream-text/gateway-provider-options-has-vision.ts
@@ -1,0 +1,36 @@
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { streamText } from 'ai';
+import fs from 'node:fs';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: 'anthropic/claude-sonnet-4.6',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe the image in detail.' },
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            data: fs.readFileSync('./data/comic-cat.png'),
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      gateway: {
+        has: ['vision'],
+      } satisfies GatewayProviderOptions,
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+});

--- a/examples/ai-core/src/stream-text/gateway-provider-options-has.ts
+++ b/examples/ai-core/src/stream-text/gateway-provider-options-has.ts
@@ -1,0 +1,27 @@
+import type { GatewayProviderOptions } from '@ai-sdk/gateway';
+import { streamText } from 'ai';
+import { run } from '../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: 'deepseek/deepseek-v4-flash',
+    prompt: 'Tell me the history of the tenrec in a few sentences.',
+    providerOptions: {
+      gateway: {
+        has: ['implicit-caching'],
+      } satisfies GatewayProviderOptions,
+    },
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+  console.log(
+    'Provider metadata:',
+    JSON.stringify(await result.providerMetadata, null, 2),
+  );
+});

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -95,6 +95,19 @@ const gatewayProviderOptions = lazyValidator(() =>
           byok: z.record(z.string(), z.number().int().min(1000)).optional(),
         })
         .optional(),
+      /**
+       * Restrict routing to provider models that have all of the given
+       * capabilities:
+       *
+       * - `'implicit-caching'`: models that perform automatic (implicit)
+       *   prompt caching
+       * - `'vision'`: models that accept image input
+       *
+       * The capability is a property of the model, so the filter applies to
+       * both BYOK and system credentials. If no provider model for the
+       * requested model satisfies the capabilities, the request fails.
+       */
+      has: z.array(z.enum(['implicit-caching', 'vision'])).optional(),
     }),
   ),
 );


### PR DESCRIPTION
Manual backport of #18305 to the `release-v5.0` branch (companion to #18313, the `release-v6.0` backport).

## Backport scope

#18305 widened the gateway `has` provider option to accept `'vision'`. Neither that PR nor #16103 — which introduced `has` in the first place — was ever backported to `release-v5.0`, so **this PR adds the option itself, with both capabilities**:

- `'implicit-caching'` — models that perform automatic (implicit) prompt caching.
- `'vision'` — models that accept image input.

## Background

`has` restricts AI Gateway routing to provider models that have all of the given capabilities.

```ts
import { streamText } from 'ai';

const result = streamText({
  model: 'anthropic/claude-sonnet-4.6',
  messages: [
    {
      role: 'user',
      content: [
        { type: 'text', text: 'Describe the image in detail.' },
        { type: 'file', mediaType: 'image/png', data: imageBytes },
      ],
    },
  ],
  providerOptions: {
    gateway: {
      has: ['vision'],
    },
  },
});
```

The capability is a property of the model, so the filter applies to both BYOK and system credentials. If no provider model for the requested model satisfies the capabilities, the request fails; unsupported values are rejected.

## Changes

- **`@ai-sdk/gateway`** — add `has?: Array<'implicit-caching' | 'vision'>` to `GatewayProviderOptions`.
- **Docs** — option reference entry plus a "Filtering by Model Capability" section covering both capabilities, in `content/providers/01-ai-sdk-providers/00-ai-gateway.mdx`.
- **Examples** — `examples/ai-core/src/stream-text/gateway-provider-options-has.ts` and `gateway-provider-options-has-vision.ts`.
- **Changeset** — patch.

## Adaptations for `release-v5.0`

The upstream commits do not apply cleanly, so this was reimplemented rather than cherry-picked:

- **`packages/gateway/src/gateway-provider-options.ts`** — this branch derives `GatewayProviderOptions` from a zod schema via `InferValidator` (`InferSchema` on `release-v6.0`, a hand-written type on `main`). `has` is therefore added as a schema field, `z.array(z.enum(['implicit-caching', 'vision'])).optional()`, appended after `providerTimeouts`.
- **Examples** — this branch uses the flat `examples/ai-core/src/stream-text/gateway-*.ts` layout, not `examples/ai-functions/src/stream-text/gateway/`. Both examples follow the local `run()` helper convention.
- **Docs** — new code blocks use this file's double-quote style.

## Verification

- `turbo build --filter=@ai-sdk/gateway...` succeeds; the emitted `.d.ts` has `has?: ("implicit-caching" | "vision")[] | undefined`.
- `packages/gateway` tests: 317 passed (node) and 317 passed (edge).
- `oxlint` and `oxfmt --check` clean on all changed files.
- Both examples run against the live gateway: `has: ['vision']` streams an image description via `anthropic/claude-sonnet-4.6`, and `has: ['implicit-caching']` routes to `deepseek/deepseek-v4-flash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
