### PR TITLE
fix(examples/fireworks): await `consumeStream` in error message test

### DIFF
--- a/examples/ai-functions/src/stream-text/fireworks/error-message.ts
+++ b/examples/ai-functions/src/stream-text/fireworks/error-message.ts
@@ -39,7 +39,7 @@ run(async () => {
           streamError = error;
         },
       });
-      result.consumeStream();
+      await result.consumeStream();
       if (streamError) throw streamError;
       console.log(`\n${testCase.name}  unexpectedly succeeded`);
     } catch (error) {


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md

AI SDK maintenance is becoming increasingly automated. High-quality issues, reproductions,
failing tests, docs fixes, and focused clarifications are especially valuable. You do not
need to send a complete bug fix for your contribution to be appreciated or credited.
-->

## Summary

<!-- What did you change? -->

Follow-up to https://github.com/vercel/ai/pull/18307 where we simplified an example and accidentally omitted an `await` when consuming the stream.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

<!--
List related issues here, e.g. "Fixes #1234".
If this PR adds a failing test, reproduction, or documentation fix for an issue,
please link the issue so maintainers can preserve contributor credit.
Remove the section if it's not needed.
-->