### PR TITLE
Backport: fix(provider/fireworks): parse the object error envelope

### DIFF
--- a/.changeset/fireworks-error-schema-object-envelope.md
+++ b/.changeset/fireworks-error-schema-object-envelope.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fireworks': patch
+---
+
+Parse the object error envelope Fireworks actually returns (`{"error":{"object","type","code","message"}}`) instead of a bare string. The mismatched schema failed to parse, so error messages silently degraded to the HTTP reason phrase — `Bad Request` over HTTP/1.1, and an empty string over HTTP/2, which has no reason phrase. Fireworks' own message now reaches the caller, e.g. `Model not found, inaccessible, and/or not deployed` rather than `Not Found`.

--- a/examples/ai-core/src/stream-text/fireworks-error-message.ts
+++ b/examples/ai-core/src/stream-text/fireworks-error-message.ts
@@ -39,8 +39,6 @@ run(async () => {
           streamError = error;
         },
       });
-      // Must be awaited: streamText reports failures through onError, and
-      // without this the check below runs before the stream has even started.
       await result.consumeStream();
       if (streamError) throw streamError;
       console.log(`\n${testCase.name}  unexpectedly succeeded`);

--- a/examples/ai-core/src/stream-text/fireworks-error-message.ts
+++ b/examples/ai-core/src/stream-text/fireworks-error-message.ts
@@ -1,0 +1,60 @@
+import { createFireworks } from '@ai-sdk/fireworks';
+import { APICallError } from '@ai-sdk/provider';
+import { streamText } from 'ai';
+import { run } from '../lib/run';
+
+const MODEL = 'accounts/fireworks/models/kimi-k3';
+
+const CASES = [
+  {
+    name: 'unknown field',
+    expect: '400, names the rejected field',
+    model: createFireworks({})(MODEL),
+    providerOptions: { fireworks: { notARealField: 'x' } },
+  },
+  {
+    name: 'unknown model',
+    expect: '404, names the model',
+    model: createFireworks({})('accounts/fireworks/models/not-a-real-model'),
+  },
+  {
+    name: 'invalid api key',
+    expect: '401, mentions the key',
+    model: createFireworks({ apiKey: 'not-a-real-key' })(MODEL),
+  },
+];
+
+run(async () => {
+  for (const testCase of CASES) {
+    let streamError: unknown;
+    try {
+      const result = streamText({
+        model: testCase.model,
+        prompt: 'Reply with only the word: ok',
+        maxOutputTokens: 512,
+        ...(testCase.providerOptions
+          ? { providerOptions: testCase.providerOptions }
+          : {}),
+        onError: ({ error }) => {
+          streamError = error;
+        },
+      });
+      // Must be awaited: streamText reports failures through onError, and
+      // without this the check below runs before the stream has even started.
+      await result.consumeStream();
+      if (streamError) throw streamError;
+      console.log(`\n${testCase.name}  unexpectedly succeeded`);
+    } catch (error) {
+      const apiError = APICallError.isInstance(error) ? error : undefined;
+      console.log(`\n${testCase.name}  (expect ${testCase.expect})`);
+      console.log(`  status  : ${apiError?.statusCode ?? '-'}`);
+      console.log(`  message : ${(error as Error)?.message}`);
+      console.log(`  body    : ${apiError?.responseBody ?? '-'}`);
+    }
+  }
+
+  console.log(
+    '\nA message that is only "Bad Request" / "Not Found" / "" while the body\n' +
+      'holds real text means the error schema no longer matches Fireworks.',
+  );
+});

--- a/packages/fireworks/src/fireworks-provider.test.ts
+++ b/packages/fireworks/src/fireworks-provider.test.ts
@@ -135,6 +135,80 @@ describe('FireworksProvider', () => {
       expect(config.includeUsage).toBe(true);
     });
 
+    // A schema that does not match what Fireworks actually returns fails the
+    // parse, and the message silently degrades to the HTTP reason phrase —
+    // "Bad Request" over HTTP/1.1, and "" over HTTP/2, which has none.
+    describe('errorStructure', () => {
+      const getErrorStructure = () => {
+        const provider = createFireworks();
+        provider.chatModel('test-model');
+        return OpenAICompatibleChatLanguageModelMock.mock.calls[0][1]
+          .errorStructure;
+      };
+
+      it('should parse the object error envelope Fireworks returns', () => {
+        const { errorSchema, errorToMessage } = getErrorStructure();
+
+        const parsed = errorSchema.parse({
+          error: {
+            object: 'error',
+            type: 'invalid_request_error',
+            code: 'invalid_request_error',
+            message:
+              "Extra inputs are not permitted, field: 'promptCacheKey', value: 'x'",
+          },
+        });
+
+        expect(errorToMessage(parsed)).toBe(
+          "Extra inputs are not permitted, field: 'promptCacheKey', value: 'x'",
+        );
+      });
+
+      it('should parse an error envelope with a null param and numeric code', () => {
+        const { errorSchema, errorToMessage } = getErrorStructure();
+
+        const parsed = errorSchema.parse({
+          error: {
+            message: 'The API key you provided is invalid.',
+            param: null,
+            code: 401,
+            type: 'error',
+          },
+        });
+
+        expect(errorToMessage(parsed)).toBe(
+          'The API key you provided is invalid.',
+        );
+      });
+
+      it('should ignore unknown keys alongside the error object', () => {
+        const { errorSchema, errorToMessage } = getErrorStructure();
+
+        const parsed = errorSchema.parse({
+          error: { message: 'Model not found', code: 'NOT_FOUND' },
+          request_id: 'chatcmpl-abc123',
+        });
+
+        expect(errorToMessage(parsed)).toBe('Model not found');
+      });
+
+      it('should still accept a bare string error', () => {
+        const { errorSchema, errorToMessage } = getErrorStructure();
+
+        const parsed = errorSchema.parse({ error: 'something went wrong' });
+
+        expect(errorToMessage(parsed)).toBe('something went wrong');
+      });
+
+      it('should reject an error object without a message', () => {
+        const { errorSchema } = getErrorStructure();
+
+        expect(() =>
+          errorSchema.parse({ error: { code: 'NOT_FOUND' } }),
+        ).toThrow();
+      });
+    });
+
     // Fireworks rejects unknown fields outright ("Extra inputs are not
     // permitted, field: 'promptCacheKey'") rather than ignoring them, so any
     // option left in camelCase fails the whole request.

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -27,12 +27,22 @@ import { VERSION } from './version';
 export type FireworksErrorData = z.infer<typeof fireworksErrorSchema>;
 
 const fireworksErrorSchema = z.object({
-  error: z.string(),
+  error: z.union([
+    z.string(),
+    z.object({
+      message: z.string(),
+      object: z.string().nullish(),
+      type: z.string().nullish(),
+      param: z.any().nullish(),
+      code: z.union([z.string(), z.number()]).nullish(),
+    }),
+  ]),
 });
 
 const fireworksErrorStructure: ProviderErrorStructure<FireworksErrorData> = {
   errorSchema: fireworksErrorSchema,
-  errorToMessage: data => data.error,
+  errorToMessage: data =>
+    typeof data.error === 'string' ? data.error : data.error.message,
 };
 
 export interface FireworksProviderSettings {


### PR DESCRIPTION
Backport of #18307 (v6: #18310) to `release-v5.0`.

Fireworks returns errors as an **object**, but the schema expected `error` to be a bare string:

```ts
const fireworksErrorSchema = z.object({ error: z.string() });
```

```json
{"error":{"object":"error","type":"invalid_request_error","code":"invalid_request_error","message":"Extra inputs are not permitted, field: 'promptCacheKey'"},"request_id":"chatcmpl-…"}
```

So the parse always failed and the message fell back to the HTTP reason phrase. That is the quiet part: over HTTP/1.1 it produces `"Bad Request"` / `"Not Found"`, which read like genuine provider messages, and over **HTTP/2 there is no reason phrase at all**, so the message is `""`. Either way Fireworks' actual text is discarded.

## Shape

`error` becomes a union of the object envelope and the original bare string. Keeping the string means an envelope we have not seen degrades to the previous behavior rather than failing the parse outright — a too-narrow schema is exactly what caused this. Secondary fields (`object`, `type`, `param`, `code`) are handled loosely, matching `openaiCompatibleErrorDataSchema`; `code` allows string or number since Fireworks sends both.

## Deviations from the v6 change

Two, both forced by v5:

- **Example path.** v6 puts it at `examples/ai-functions/src/stream-text/fireworks/error-message.ts`. v5's `examples/ai-core/src/stream-text/` is flat — no per-provider subdirectories — so it lands at `fireworks-error-message.ts`, alongside `fireworks-reasoning.ts` and friends.
- **`await result.consumeStream()`.** Upstream does not await it. Run as-is on v5, all three cases print `unexpectedly succeeded`: the `streamError` check runs before the stream has started, so the example exercises nothing. Worth checking whether the v6 example carries the same latent race.

## Verified against Fireworks

`examples/ai-core/src/stream-text/fireworks-error-message.ts` (added here) provokes three real errors and prints `message` next to the raw body:

| case | before | after |
|---|---|---|
| unknown field (400) | `Bad Request` | `Extra inputs are not permitted, field: 'notARealField', value: 'x'` |
| unknown model (404) | `Not Found` | `Model not found, inaccessible, and/or not deployed` |
| invalid api key (401) | `Unauthorized` | `The API key you provided is invalid.` |

Live bodies confirm the envelope shape, including `param: null` and a string `code` (`NOT_FOUND`, `UNAUTHORIZED`).

The example is the regression check: a `message` that is only a status phrase while `body` holds real text means the schema has drifted again.

## Tests

5 cases over `errorStructure` (19 → 24): the object envelope, an envelope with `param: null` and a numeric `code`, unknown sibling keys like `request_id`, the bare-string fallback, and an object missing `message` still rejecting.

Reverting the schema fails 3 of the 5. The other two — bare-string and missing-`message` — pass either way by construction, since the old schema accepted strings and rejected every object; they are guards against future drift rather than proof of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
