### PR TITLE
fix(ai): regenerate assistant messages separately

### DIFF
--- a/.changeset/fair-students-regenerate.md
+++ b/.changeset/fair-students-regenerate.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Fix `regenerate` so regenerating an assistant message after another assistant message creates a replacement response instead of appending to the preceding assistant message.

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -448,6 +448,73 @@ describe('Chat', () => {
     });
   });
 
+  describe('regenerate', () => {
+    it('preserves an assistant parent when regenerating the following assistant message', async () => {
+      server.urls['http://localhost:3000/api/chat'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          formatChunk({ type: 'start' }),
+          formatChunk({ type: 'text-start', id: 'text-1' }),
+          formatChunk({
+            type: 'text-delta',
+            id: 'text-1',
+            delta: 'regenerated target',
+          }),
+          formatChunk({ type: 'text-end', id: 'text-1' }),
+          formatChunk({ type: 'finish', finishReason: 'stop' }),
+        ],
+      };
+
+      const initialMessages = [
+        {
+          id: 'user',
+          role: 'user',
+          parts: [{ type: 'text', text: 'prompt' }],
+        },
+        {
+          id: 'assistant-parent',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'parent' }],
+        },
+        {
+          id: 'assistant-target',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'target' }],
+        },
+      ] satisfies UIMessage[];
+      const expectedRequestMessages = structuredClone(
+        initialMessages.slice(0, 2),
+      );
+      const expectedAssistantParent = structuredClone(initialMessages[1]);
+
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        messages: initialMessages,
+        transport: new DefaultChatTransport({
+          api: 'http://localhost:3000/api/chat',
+        }),
+      });
+
+      await chat.regenerate({ messageId: 'assistant-target' });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        trigger: 'regenerate-message',
+        messageId: 'assistant-target',
+        messages: expectedRequestMessages,
+      });
+      expect(chat.messages).toMatchObject([
+        initialMessages[0],
+        expectedAssistantParent,
+        {
+          id: 'id-0',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'regenerated target' }],
+        },
+      ]);
+    });
+  });
+
   describe('send handle a disconnected response stream', () => {
     let chat: TestChat;
     let letOnFinishArgs: any[] = [];

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -646,6 +646,8 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     this.setStatus({ status: 'submitted', error: undefined });
 
     const lastMessage = this.lastMessage;
+    const lastMessageForResponse =
+      trigger === 'regenerate-message' ? undefined : lastMessage;
 
     let isAbort = false;
     let isDisconnect = false;
@@ -655,7 +657,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     try {
       const response = {
         state: createStreamingUIMessageState({
-          lastMessage: this.state.snapshot(lastMessage),
+          lastMessage: this.state.snapshot(lastMessageForResponse),
           messageId: this.generateId(),
         }),
         abortController: new AbortController(),


### PR DESCRIPTION
## Background

Fixes #18318. The issue reports that `regenerate({ messageId })` can append regenerated content to the preceding assistant message when the target assistant message follows another assistant message.

AI assistance disclosure: this pull request was prepared with AI coding assistance and verified locally before submission.

## Summary

- Avoid seeding regenerated responses from the last retained assistant message so the stream creates a replacement assistant response.
- Add a regression test covering consecutive assistant messages during `regenerate`.
- Add a patch changeset for `ai`.

## Contributor Credit

Thanks to @FranciscoMoretti for the detailed bug report and reproduction in #18318.

## End-to-End Verification

This is an in-memory `AbstractChat` stream-state bug, so I verified the affected request/stream application path with the focused regression test rather than a browser E2E scenario.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

None.

## Related Issues

Fixes #18318

## Local Verification

- `pnpm --filter ai type-check`
- `pnpm test:node src/ui/chat.test.ts`
- `pnpm exec oxfmt --check packages/ai/src/ui/chat.ts packages/ai/src/ui/chat.test.ts .changeset/fair-students-regenerate.md`
- `git diff --check`
