### PR TITLE
fix(provider/amazon-bedrock): preserve provider-executed tool results in message conversion

### DIFF
--- a/.changeset/bedrock-provider-executed-tool-results.md
+++ b/.changeset/bedrock-provider-executed-tool-results.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(provider/amazon-bedrock): preserve provider-executed tool results in message conversion

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
@@ -1587,6 +1587,239 @@ describe('assistant messages', () => {
       system: [],
     });
   });
+
+  it('should convert provider-executed tool results into toolResult blocks in user messages', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Add 2+2 and 3+3.' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Running the additions.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'add',
+            input: { a: 2, b: 2 },
+            providerExecuted: true,
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'add',
+            output: { type: 'json', value: { sum: 4 } },
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-2',
+            toolName: 'add',
+            input: { a: 3, b: 3 },
+            providerExecuted: true,
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-2',
+            toolName: 'add',
+            output: { type: 'json', value: { sum: 6 } },
+          },
+          { type: 'text', text: 'The sums are 4 and 6.' },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Now add those two sums.' }],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'Add 2+2 and 3+3.' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            { text: 'Running the additions.' },
+            {
+              toolUse: {
+                toolUseId: 'call-1',
+                name: 'add',
+                input: { a: 2, b: 2 },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              toolResult: {
+                toolUseId: 'call-1',
+                content: [{ text: '{"sum":4}' }],
+              },
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              toolUse: {
+                toolUseId: 'call-2',
+                name: 'add',
+                input: { a: 3, b: 3 },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              toolResult: {
+                toolUseId: 'call-2',
+                content: [{ text: '{"sum":6}' }],
+              },
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [{ text: 'The sums are 4 and 6.' }],
+        },
+        {
+          role: 'user',
+          content: [{ text: 'Now add those two sums.' }],
+        },
+      ],
+      system: [],
+    });
+  });
+
+  it('should combine trailing provider-executed tool results with the next user message', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Search for cats.' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'webSearch',
+            input: { query: 'cats' },
+            providerExecuted: true,
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'webSearch',
+            output: { type: 'json', value: { results: ['cats are great'] } },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Summarize the results.' }],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'Search for cats.' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              toolUse: {
+                toolUseId: 'call-1',
+                name: 'webSearch',
+                input: { query: 'cats' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              toolResult: {
+                toolUseId: 'call-1',
+                content: [{ text: '{"results":["cats are great"]}' }],
+              },
+            },
+            { text: 'Summarize the results.' },
+          ],
+        },
+      ],
+      system: [],
+    });
+  });
+
+  it('should convert provider-executed tool error results', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'webSearch',
+            input: { query: 'cats' },
+            providerExecuted: true,
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'webSearch',
+            output: { type: 'error-text', value: 'search unavailable' },
+          },
+          { type: 'text', text: 'The search failed.' },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              toolUse: {
+                toolUseId: 'call-1',
+                name: 'webSearch',
+                input: { query: 'cats' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              toolResult: {
+                toolUseId: 'call-1',
+                content: [{ text: 'search unavailable' }],
+              },
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [{ text: 'The search failed.' }],
+        },
+      ],
+      system: [],
+    });
+  });
 });
 
 describe('tool messages', () => {

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -5,6 +5,7 @@ import {
   type JSONValue,
   type LanguageModelV4Message,
   type LanguageModelV4Prompt,
+  type LanguageModelV4ToolResultPart,
   type SharedV4ProviderMetadata,
 } from '@ai-sdk/provider';
 import {
@@ -28,6 +29,7 @@ import {
   type AmazonBedrockImageMimeType,
   type AmazonBedrockMessages,
   type AmazonBedrockSystemMessages,
+  type AmazonBedrockToolResultBlock,
   type AmazonBedrockUserMessage,
   type AmazonBedrockVideoBlock,
   type AmazonBedrockVideoFormat,
@@ -316,126 +318,14 @@ export async function convertToAmazonBedrockChatMessages(
                 if (part.type === 'tool-approval-response') {
                   continue;
                 }
-                let toolResultContent;
-
-                const output = part.output;
-                switch (output.type) {
-                  case 'content': {
-                    toolResultContent = await Promise.all(
-                      output.value.map(async contentPart => {
-                        switch (contentPart.type) {
-                          case 'text':
-                            return { text: contentPart.text };
-                          case 'file': {
-                            if (
-                              contentPart.data.type !== 'data' &&
-                              (contentPart.data.type !== 'url' ||
-                                contentPart.data.url.protocol !== 's3:')
-                            ) {
-                              throw new UnsupportedFunctionalityError({
-                                functionality: `tool result file data of type "${contentPart.data.type}"`,
-                              });
-                            }
-
-                            const fullMediaType = resolveFullMediaType({
-                              part: contentPart,
-                            });
-
-                            switch (getTopLevelMediaType(fullMediaType)) {
-                              case 'image': {
-                                return {
-                                  image: {
-                                    format:
-                                      getAmazonBedrockImageFormat(
-                                        fullMediaType,
-                                      ),
-                                    source: getAmazonBedrockMediaSource({
-                                      data: contentPart.data,
-                                      functionality: `tool result file data of type "${contentPart.data.type}"`,
-                                    }),
-                                  },
-                                };
-                              }
-                              case 'video': {
-                                return {
-                                  video: {
-                                    format:
-                                      getAmazonBedrockVideoFormat(
-                                        fullMediaType,
-                                      ),
-                                    source: getAmazonBedrockMediaSource({
-                                      data: contentPart.data,
-                                      functionality: `tool result file data of type "${contentPart.data.type}"`,
-                                    }),
-                                  },
-                                };
-                              }
-                              default: {
-                                if (contentPart.data.type !== 'data') {
-                                  throw new UnsupportedFunctionalityError({
-                                    functionality: `tool result file data of type "${contentPart.data.type}"`,
-                                  });
-                                }
-
-                                const enableCitations =
-                                  await shouldEnableCitations(
-                                    contentPart.providerOptions,
-                                  );
-
-                                return {
-                                  document: {
-                                    format:
-                                      getAmazonBedrockDocumentFormat(
-                                        fullMediaType,
-                                      ),
-                                    name: contentPart.filename
-                                      ? stripFileExtension(contentPart.filename)
-                                      : generateDocumentName(),
-                                    source: {
-                                      bytes: convertToBase64(
-                                        contentPart.data.data,
-                                      ),
-                                    },
-                                    ...(enableCitations && {
-                                      citations: { enabled: true },
-                                    }),
-                                  },
-                                };
-                              }
-                            }
-                          }
-                          default: {
-                            throw new UnsupportedFunctionalityError({
-                              functionality: `unsupported tool content part type: ${contentPart.type}`,
-                            });
-                          }
-                        }
-                      }),
-                    );
-                    break;
-                  }
-                  case 'text':
-                  case 'error-text':
-                    toolResultContent = [{ text: output.value }];
-                    break;
-                  case 'execution-denied':
-                    toolResultContent = [
-                      { text: output.reason ?? 'Tool call execution denied.' },
-                    ];
-                    break;
-                  case 'json':
-                  case 'error-json':
-                  default:
-                    toolResultContent = [
-                      { text: JSON.stringify(output.value) },
-                    ];
-                    break;
-                }
 
                 amazonBedrockContent.push({
                   toolResult: {
                     toolUseId: normalizeToolCallId(part.toolCallId, isMistral),
-                    content: toolResultContent,
+                    content: await convertToolResultOutput({
+                      output: part.output,
+                      generateDocumentName,
+                    }),
                   },
                 });
                 pushCachePoint(amazonBedrockContent, part.providerOptions);
@@ -452,15 +342,32 @@ export async function convertToAmazonBedrockChatMessages(
           pushCachePoint(amazonBedrockContent, providerOptions);
         }
 
-        messages.push({ role: 'user', content: amazonBedrockContent });
+        appendToUserMessage(messages, amazonBedrockContent);
 
         break;
       }
 
       case 'assistant': {
         // combines multiple assistant messages in this block into a single message:
-        const amazonBedrockContent: AmazonBedrockAssistantMessage['content'] =
-          [];
+        let assistantContent: AmazonBedrockAssistantMessage['content'] = [];
+        let toolResultContent: AmazonBedrockUserMessage['content'] = [];
+        let emittedMessageForBlock = false;
+
+        const flushAssistantContent = () => {
+          if (assistantContent.length > 0) {
+            messages.push({ role: 'assistant', content: assistantContent });
+            assistantContent = [];
+            emittedMessageForBlock = true;
+          }
+        };
+
+        const flushToolResultContent = () => {
+          if (toolResultContent.length > 0) {
+            appendToUserMessage(messages, toolResultContent);
+            toolResultContent = [];
+            emittedMessageForBlock = true;
+          }
+        };
 
         for (let j = 0; j < block.messages.length; j++) {
           const message = block.messages[j];
@@ -474,6 +381,10 @@ export async function convertToAmazonBedrockChatMessages(
             const part = content[k];
             const isLastContentPart = k === content.length - 1;
 
+            if (part.type !== 'tool-result') {
+              flushToolResultContent();
+            }
+
             switch (part.type) {
               case 'text': {
                 // Skip empty text blocks unless reasoning blocks are present
@@ -481,7 +392,7 @@ export async function convertToAmazonBedrockChatMessages(
                   break;
                 }
 
-                amazonBedrockContent.push({
+                assistantContent.push({
                   text:
                     // trim the last text part if it's the last message in the block
                     // because Bedrock does not allow trailing whitespace
@@ -512,7 +423,7 @@ export async function convertToAmazonBedrockChatMessages(
                 if (reasoningMetadata?.signature != null) {
                   // do not trim reasoning text when a signature is present:
                   // the signature validates the exact original bytes
-                  amazonBedrockContent.push({
+                  assistantContent.push({
                     reasoningContent: {
                       reasoningText: {
                         text: part.text,
@@ -521,7 +432,7 @@ export async function convertToAmazonBedrockChatMessages(
                     },
                   });
                 } else if (reasoningMetadata?.redactedData != null) {
-                  amazonBedrockContent.push({
+                  assistantContent.push({
                     reasoningContent: {
                       redactedReasoning: {
                         data: reasoningMetadata.redactedData,
@@ -537,7 +448,7 @@ export async function convertToAmazonBedrockChatMessages(
               }
 
               case 'tool-call': {
-                amazonBedrockContent.push({
+                assistantContent.push({
                   toolUse: {
                     toolUseId: normalizeToolCallId(part.toolCallId, isMistral),
                     name: sanitizeToolName(part.toolName),
@@ -546,14 +457,40 @@ export async function convertToAmazonBedrockChatMessages(
                 });
                 break;
               }
+
+              case 'tool-result': {
+                // provider-executed tool result: Bedrock only accepts toolResult
+                // blocks in the user message that follows the toolUse:
+                flushAssistantContent();
+
+                toolResultContent.push({
+                  toolResult: {
+                    toolUseId: normalizeToolCallId(part.toolCallId, isMistral),
+                    content: await convertToolResultOutput({
+                      output: part.output,
+                      generateDocumentName,
+                    }),
+                  },
+                });
+                break;
+              }
             }
 
-            pushCachePoint(amazonBedrockContent, part.providerOptions);
+            pushCachePoint(
+              part.type === 'tool-result'
+                ? toolResultContent
+                : assistantContent,
+              part.providerOptions,
+            );
           }
-          pushCachePoint(amazonBedrockContent, message.providerOptions);
+          pushCachePoint(assistantContent, message.providerOptions);
         }
 
-        messages.push({ role: 'assistant', content: amazonBedrockContent });
+        flushToolResultContent();
+
+        if (assistantContent.length > 0 || !emittedMessageForBlock) {
+          messages.push({ role: 'assistant', content: assistantContent });
+        }
 
         break;
       }
@@ -566,6 +503,122 @@ export async function convertToAmazonBedrockChatMessages(
   }
 
   return { system, messages };
+}
+
+// Bedrock requires conversation roles to alternate, so consecutive
+// user messages must be combined:
+function appendToUserMessage(
+  messages: AmazonBedrockMessages,
+  content: AmazonBedrockUserMessage['content'],
+) {
+  const lastMessage = messages[messages.length - 1];
+
+  if (lastMessage?.role === 'user') {
+    lastMessage.content.push(...content);
+  } else {
+    messages.push({ role: 'user', content });
+  }
+}
+
+async function convertToolResultOutput({
+  output,
+  generateDocumentName,
+}: {
+  output: LanguageModelV4ToolResultPart['output'];
+  generateDocumentName: () => string;
+}): Promise<AmazonBedrockToolResultBlock['toolResult']['content']> {
+  switch (output.type) {
+    case 'content': {
+      return Promise.all(
+        output.value.map(async contentPart => {
+          switch (contentPart.type) {
+            case 'text':
+              return { text: contentPart.text };
+            case 'file': {
+              if (
+                contentPart.data.type !== 'data' &&
+                (contentPart.data.type !== 'url' ||
+                  contentPart.data.url.protocol !== 's3:')
+              ) {
+                throw new UnsupportedFunctionalityError({
+                  functionality: `tool result file data of type "${contentPart.data.type}"`,
+                });
+              }
+
+              const fullMediaType = resolveFullMediaType({
+                part: contentPart,
+              });
+
+              switch (getTopLevelMediaType(fullMediaType)) {
+                case 'image': {
+                  return {
+                    image: {
+                      format: getAmazonBedrockImageFormat(fullMediaType),
+                      source: getAmazonBedrockMediaSource({
+                        data: contentPart.data,
+                        functionality: `tool result file data of type "${contentPart.data.type}"`,
+                      }),
+                    },
+                  };
+                }
+                case 'video': {
+                  return {
+                    video: {
+                      format: getAmazonBedrockVideoFormat(fullMediaType),
+                      source: getAmazonBedrockMediaSource({
+                        data: contentPart.data,
+                        functionality: `tool result file data of type "${contentPart.data.type}"`,
+                      }),
+                    },
+                  };
+                }
+                default: {
+                  if (contentPart.data.type !== 'data') {
+                    throw new UnsupportedFunctionalityError({
+                      functionality: `tool result file data of type "${contentPart.data.type}"`,
+                    });
+                  }
+
+                  const enableCitations = await shouldEnableCitations(
+                    contentPart.providerOptions,
+                  );
+
+                  return {
+                    document: {
+                      format: getAmazonBedrockDocumentFormat(fullMediaType),
+                      name: contentPart.filename
+                        ? stripFileExtension(contentPart.filename)
+                        : generateDocumentName(),
+                      source: {
+                        bytes: convertToBase64(contentPart.data.data),
+                      },
+                      ...(enableCitations && {
+                        citations: { enabled: true },
+                      }),
+                    },
+                  };
+                }
+              }
+            }
+            default: {
+              throw new UnsupportedFunctionalityError({
+                functionality: `unsupported tool content part type: ${contentPart.type}`,
+              });
+            }
+          }
+        }),
+      );
+    }
+    case 'text':
+    case 'error-text':
+      return [{ text: output.value }];
+    case 'execution-denied':
+      return [{ text: output.reason ?? 'Tool call execution denied.' }];
+    case 'json':
+    case 'error-json':
+    default:
+      return [{ text: JSON.stringify(output.value) }];
+  }
 }
 
 // wrap invalid tool call input because Bedrock requires it to be an object


### PR DESCRIPTION
## Background

Fixes #18149.

When an assistant message contains provider-executed tool calls together with their tool results (e.g. a conversation that went through `convertToModelMessages` with `providerExecuted: true` tool parts), the Bedrock converter emitted the `toolUse` blocks but silently dropped the `tool-result` parts — the assistant content switch had no `tool-result` case. Bedrock then rejects the request because every `toolUse` must be followed by a matching `toolResult` in the next user message.

## Summary

- `convert-to-amazon-bedrock-chat-messages.ts` now handles `tool-result` parts in assistant messages: the pending assistant content is flushed and the results are emitted as `toolResult` blocks in an interleaved user message, which is the only place the Converse API accepts them.
- When an assistant message ends with a provider-executed tool result, the `toolResult` block is merged into the following user message so conversation roles keep alternating.
- Extracted the tool result output conversion (previously inlined in the `tool` role branch) into `convertToolResultOutput` so both paths share it.
- Added regression tests covering the interleaved case from the issue, the trailing-result merge, and error outputs.

## Contributor Credit

Thanks @jpeters5392 for the report with the full prompt array and request payload, which made this easy to reproduce.

## End-to-End Verification

Converted the exact prompt array from the issue and checked the generated Converse payload: each `toolUse` is now followed by its `toolResult` in a user message and roles alternate, which is what Bedrock validates against. I don't have a Bedrock account to run the live repro, so verification is at the request-payload level.
