### PR TITLE
feat(provider/google): support JSON Schema for structured outputs via `useResponseJsonSchema`

### DIFF
--- a/.changeset/brown-hoops-shout.md
+++ b/.changeset/brown-hoops-shout.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat (provider/google): add `useResponseJsonSchema` provider option to send structured output schemas as JSON Schema

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -1079,7 +1079,13 @@ const { output } = await generateText({
 });
 ```
 
-JSON Schema also only supports a subset of the specification. See the
+JSON Schema also only supports a subset of the specification, and it is a
+different subset, so switching is a trade-off rather than an upgrade. There is
+no `pattern`, `minLength` or `maxLength` in it, and unsupported keywords are
+ignored instead of rejected, so a `z.string().min(3)` constraint silently stops
+being enforced. In the other direction, the conversion to the OpenAPI subset
+drops `minimum`, `maximum`, `minItems` and `maxItems`, which
+`responseJsonSchema` keeps. See the
 [Gemini structured output documentation](https://ai.google.dev/gemini-api/docs/structured-output)
 for the supported schema features.
 

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -142,6 +142,17 @@ The following optional provider options are available for Google models:
 
   See [Troubleshooting: Schema Limitations](#schema-limitations) for more details.
 
+- **useResponseJsonSchema** _boolean_
+
+  Optional. Send the response schema as JSON Schema instead of the OpenAPI 3.0
+  subset that Google uses by default. Default is false.
+
+  JSON Schema supports features that the OpenAPI subset does not, e.g. unions
+  (`z.union`), records (`z.record`) and recursive schemas. Requires Gemini 2.5
+  or later.
+
+  See [Troubleshooting: Schema Limitations](#schema-limitations) for more details.
+
 - **safetySettings** _Array\<\{ category: string; threshold: string \}\>_
 
   Optional. Safety settings for the model.
@@ -1036,6 +1047,41 @@ The following Zod features are known to not work with Google:
 
 - `z.union`
 - `z.record`
+
+Alternatively, you can keep structured outputs enabled and send the schema as
+JSON Schema, which Gemini 2.5 and later models support:
+
+```ts highlight="5"
+const { output } = await generateText({
+  model: google('gemini-2.5-flash'),
+  providerOptions: {
+    google: {
+      useResponseJsonSchema: true,
+    } satisfies GoogleLanguageModelOptions,
+  },
+  output: Output.object({
+    schema: z.object({
+      name: z.string(),
+      age: z.number(),
+      contact: z.union([
+        z.object({
+          type: z.literal('email'),
+          value: z.string(),
+        }),
+        z.object({
+          type: z.literal('phone'),
+          value: z.string(),
+        }),
+      ]),
+    }),
+  }),
+  prompt: 'Generate an example person for testing.',
+});
+```
+
+JSON Schema also only supports a subset of the specification. See the
+[Gemini structured output documentation](https://ai.google.dev/gemini-api/docs/structured-output)
+for the supported schema features.
 
 ### Model Capabilities
 

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -294,6 +294,17 @@ The following optional provider options are available for Google Vertex models:
 
   See [Troubleshooting: Schema Limitations](#schema-limitations) for more details.
 
+- **useResponseJsonSchema** _boolean_
+
+  Optional. Send the response schema as JSON Schema instead of the OpenAPI 3.0
+  subset that Google Vertex uses by default. Default is false.
+
+  JSON Schema supports features that the OpenAPI subset does not, e.g. unions
+  (`z.union`), records (`z.record`) and recursive schemas. Requires Gemini 2.5
+  or later.
+
+  See [Troubleshooting: Schema Limitations](#schema-limitations) for more details.
+
 - **safetySettings** _Array\<\{ category: string; threshold: string \}\>_
 
   Optional. Safety settings for the model.
@@ -903,6 +914,41 @@ The following Zod features are known to not work with Google Vertex:
 
 - `z.union`
 - `z.record`
+
+Alternatively, you can keep structured outputs enabled and send the schema as
+JSON Schema, which Gemini 2.5 and later models support:
+
+```ts highlight="4"
+const result = await generateText({
+  model: googleVertex('gemini-2.5-pro'),
+  providerOptions: {
+    vertex: {
+      useResponseJsonSchema: true,
+    } satisfies GoogleLanguageModelOptions,
+  },
+  output: Output.object({
+    schema: z.object({
+      name: z.string(),
+      age: z.number(),
+      contact: z.union([
+        z.object({
+          type: z.literal('email'),
+          value: z.string(),
+        }),
+        z.object({
+          type: z.literal('phone'),
+          value: z.string(),
+        }),
+      ]),
+    }),
+  }),
+  prompt: 'Generate an example person for testing.',
+});
+```
+
+JSON Schema also only supports a subset of the specification. See the
+[Gemini structured output documentation](https://ai.google.dev/gemini-api/docs/structured-output)
+for the supported schema features.
 
 ### Model Capabilities
 

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -946,7 +946,13 @@ const result = await generateText({
 });
 ```
 
-JSON Schema also only supports a subset of the specification. See the
+JSON Schema also only supports a subset of the specification, and it is a
+different subset, so switching is a trade-off rather than an upgrade. There is
+no `pattern`, `minLength` or `maxLength` in it, and unsupported keywords are
+ignored instead of rejected, so a `z.string().min(3)` constraint silently stops
+being enforced. In the other direction, the conversion to the OpenAPI subset
+drops `minimum`, `maximum`, `minItems` and `maxItems`, which
+`responseJsonSchema` keeps. See the
 [Gemini structured output documentation](https://ai.google.dev/gemini-api/docs/structured-output)
 for the supported schema features.
 

--- a/packages/google/src/google-language-model-options.ts
+++ b/packages/google/src/google-language-model-options.ts
@@ -88,6 +88,19 @@ export const googleLanguageModelOptions = lazySchema(() =>
       structuredOutputs: z.boolean().optional(),
 
       /**
+       * Optional. Send the response schema as JSON Schema
+       * (`generationConfig.responseJsonSchema`) instead of the OpenAPI 3.0
+       * subset (`generationConfig.responseSchema`). Default is false.
+       *
+       * JSON Schema supports features that the OpenAPI subset does not,
+       * e.g. unions (`anyOf`), records (`additionalProperties`) and
+       * recursive schemas (`$ref` / `$defs`). Requires Gemini 2.5 or later.
+       *
+       * https://ai.google.dev/gemini-api/docs/structured-output
+       */
+      useResponseJsonSchema: z.boolean().optional(),
+
+      /**
        * Optional. A list of unique safety settings for blocking unsafe content.
        */
       safetySettings: z

--- a/packages/google/src/google-language-model-options.ts
+++ b/packages/google/src/google-language-model-options.ts
@@ -96,6 +96,9 @@ export const googleLanguageModelOptions = lazySchema(() =>
        * e.g. unions (`anyOf`), records (`additionalProperties`) and
        * recursive schemas (`$ref` / `$defs`). Requires Gemini 2.5 or later.
        *
+       * It is a different subset rather than a superset: `pattern`,
+       * `minLength` and `maxLength` are ignored on this path.
+       *
        * https://ai.google.dev/gemini-api/docs/structured-output
        */
       useResponseJsonSchema: z.boolean().optional(),

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -1,5 +1,6 @@
 import {
   LanguageModelV4ProviderTool,
+  type JSONSchema7,
   type LanguageModelV4Prompt,
 } from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
@@ -25,6 +26,15 @@ vi.mock('./version', () => ({
 const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 ];
+
+const CONSTRAINED_TEST_SCHEMA: JSONSchema7 = {
+  type: 'object',
+  properties: {
+    slug: { type: 'string', pattern: '^[a-z-]+$', minLength: 3, maxLength: 50 },
+    count: { type: 'integer', minimum: 1, maximum: 9 },
+  },
+  required: ['slug'],
+};
 
 const SAFETY_RATINGS = [
   {
@@ -1690,6 +1700,79 @@ describe('doGenerate', () => {
             "type": "object",
           },
           "responseMimeType": "application/json",
+        },
+      }
+    `);
+  });
+
+  it('should keep string and number constraints with useResponseJsonSchema = true', async () => {
+    prepareJsonFixtureResponse('google-text');
+
+    await provider.languageModel('gemini-pro').doGenerate({
+      providerOptions: {
+        google: {
+          useResponseJsonSchema: true,
+        },
+      },
+      responseFormat: { type: 'json', schema: CONSTRAINED_TEST_SCHEMA },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(
+      (await server.calls[0].requestBodyJson).generationConfig,
+    ).toMatchInlineSnapshot(`
+      {
+        "responseJsonSchema": {
+          "properties": {
+            "count": {
+              "maximum": 9,
+              "minimum": 1,
+              "type": "integer",
+            },
+            "slug": {
+              "maxLength": 50,
+              "minLength": 3,
+              "pattern": "^[a-z-]+$",
+              "type": "string",
+            },
+          },
+          "required": [
+            "slug",
+          ],
+          "type": "object",
+        },
+        "responseMimeType": "application/json",
+      }
+    `);
+  });
+
+  it('should drop most constraints when converting to the OpenAPI subset', async () => {
+    prepareJsonFixtureResponse('google-text');
+
+    await provider.languageModel('gemini-pro').doGenerate({
+      responseFormat: { type: 'json', schema: CONSTRAINED_TEST_SCHEMA },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(
+      (await server.calls[0].requestBodyJson).generationConfig,
+    ).toMatchInlineSnapshot(`
+      {
+        "responseMimeType": "application/json",
+        "responseSchema": {
+          "properties": {
+            "count": {
+              "type": "integer",
+            },
+            "slug": {
+              "minLength": 3,
+              "type": "string",
+            },
+          },
+          "required": [
+            "slug",
+          ],
+          "type": "object",
         },
       }
     `);

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -1619,6 +1619,121 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should pass json schema with responseFormat and useResponseJsonSchema = true', async () => {
+    prepareJsonFixtureResponse('google-text');
+
+    await provider.languageModel('gemini-pro').doGenerate({
+      providerOptions: {
+        google: {
+          useResponseJsonSchema: true,
+        },
+      },
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            contact: {
+              anyOf: [
+                { type: 'object', properties: { email: { type: 'string' } } },
+                { type: 'object', properties: { phone: { type: 'string' } } },
+              ],
+            },
+          },
+          required: ['contact'],
+          additionalProperties: false,
+        },
+      },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Hello",
+              },
+            ],
+            "role": "user",
+          },
+        ],
+        "generationConfig": {
+          "responseJsonSchema": {
+            "additionalProperties": false,
+            "properties": {
+              "contact": {
+                "anyOf": [
+                  {
+                    "properties": {
+                      "email": {
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  {
+                    "properties": {
+                      "phone": {
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                ],
+              },
+            },
+            "required": [
+              "contact",
+            ],
+            "type": "object",
+          },
+          "responseMimeType": "application/json",
+        },
+      }
+    `);
+  });
+
+  it('should not pass any schema with useResponseJsonSchema = true and structuredOutputs = false', async () => {
+    prepareJsonFixtureResponse('google-text');
+
+    await provider.languageModel('gemini-pro').doGenerate({
+      providerOptions: {
+        google: {
+          useResponseJsonSchema: true,
+          structuredOutputs: false,
+        },
+      },
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { property1: { type: 'string' } },
+        },
+      },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "contents": [
+          {
+            "parts": [
+              {
+                "text": "Hello",
+              },
+            ],
+            "role": "user",
+          },
+        ],
+        "generationConfig": {
+          "responseMimeType": "application/json",
+        },
+      }
+    `);
+  });
+
   it('should pass tools and toolChoice', async () => {
     prepareJsonFixtureResponse('google-text');
 

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -305,6 +305,17 @@ export class GoogleLanguageModel implements LanguageModelV4 {
           }))
         : undefined);
 
+    const structuredOutputSchema =
+      responseFormat?.type === 'json' &&
+      responseFormat.schema != null &&
+      // Google GenAI does not support all OpenAPI Schema features,
+      // so this is needed as an escape hatch:
+      // TODO convert into provider option
+      (googleOptions?.structuredOutputs ?? true)
+        ? responseFormat.schema
+        : undefined;
+    const useResponseJsonSchema = googleOptions?.useResponseJsonSchema ?? false;
+
     const toolConfig =
       googleToolConfig ||
       streamFunctionCallArguments ||
@@ -340,14 +351,14 @@ export class GoogleLanguageModel implements LanguageModelV4 {
           responseMimeType:
             responseFormat?.type === 'json' ? 'application/json' : undefined,
           responseSchema:
-            responseFormat?.type === 'json' &&
-            responseFormat.schema != null &&
-            // Google GenAI does not support all OpenAPI Schema features,
-            // so this is needed as an escape hatch:
-            // TODO convert into provider option
-            (googleOptions?.structuredOutputs ?? true)
-              ? convertJSONSchemaToOpenAPISchema(responseFormat.schema)
+            structuredOutputSchema != null && !useResponseJsonSchema
+              ? convertJSONSchemaToOpenAPISchema(structuredOutputSchema)
               : undefined,
+          // mutually exclusive with `responseSchema`:
+          ...(structuredOutputSchema != null &&
+            useResponseJsonSchema && {
+              responseJsonSchema: structuredOutputSchema,
+            }),
           ...(googleOptions?.audioTimestamp && {
             audioTimestamp: googleOptions.audioTimestamp,
           }),


### PR DESCRIPTION
## Background

Fixes #6494.

Gemini structured outputs currently go out as `generationConfig.responseSchema`, which is a subset of the OpenAPI 3.0 spec rather than JSON Schema. That subset trips on unions and records: `anyOf` itself is accepted by the API, but the schema this provider builds for a `z.union` carries no `type` on the union node, and the API requires one. So `z.union` / `z.record` schemas either fail with errors like `response_schema.properties[occupation].type: must be specified` or force users to disable structured outputs entirely (`structuredOutputs: false`), losing constrained decoding.

Gemini 2.5 and later support submitting JSON Schema through `generationConfig.responseJsonSchema`, which is mutually exclusive with `responseSchema` and requires `responseMimeType` ([API reference](https://ai.google.dev/api/generate-content#GenerationConfig), [guide](https://ai.google.dev/gemini-api/docs/structured-output)).

## Summary

Adds a `useResponseJsonSchema` provider option to `@ai-sdk/google`:

- when `true`, the response format schema is sent unchanged as `generationConfig.responseJsonSchema` instead of being converted to the OpenAPI subset for `generationConfig.responseSchema`
- the two fields are never sent together, and `responseMimeType` keeps being set as before
- defaults to `false`, so existing requests are unchanged
- `structuredOutputs: false` still wins and suppresses both fields

This unblocks unions, records and recursive schemas for object generation on Gemini 2.5+ without giving up structured outputs.

```ts
const { output } = await generateText({
  model: google('gemini-2.5-flash'),
  providerOptions: {
    google: {
      useResponseJsonSchema: true,
    } satisfies GoogleLanguageModelOptions,
  },
  output: Output.object({
    schema: z.object({
      name: z.string(),
      contact: z.union([
        z.object({ type: z.literal('email'), value: z.string() }),
        z.object({ type: z.literal('phone'), value: z.string() }),
      ]),
    }),
  }),
  prompt: 'Generate an example person for testing.',
});
```

The schema is forwarded as-is (including `$schema`), matching how the official [`js-genai`](https://github.com/googleapis/js-genai) SDK routes JSON Schema payloads to this field.

## What the flag costs

The two fields support different subsets, so this is a trade-off rather than an upgrade, and the docs now say so. Gemini's supported keyword list for `responseJsonSchema` has no `pattern`, `minLength` or `maxLength`, and unsupported keywords there are ignored rather than rejected. Of those, `minLength` is the only one the OpenAPI conversion forwards today, so it is the one that goes from enforced to silently ignored. In the other direction the conversion drops `minimum`, `maximum`, `minItems` and `maxItems`, which `responseJsonSchema` keeps.

## Contributor Credit

- @namuorg for reporting #6494
- @percymcn for pointing out that the two schema fields are complementary rather than nested

## End-to-End Verification

Verified through the provider request-body tests, which assert the exact JSON sent to `:generateContent`:

- `useResponseJsonSchema: true` produces `generationConfig.responseJsonSchema` with the untouched `anyOf` union schema and no `responseSchema`
- `useResponseJsonSchema: true` combined with `structuredOutputs: false` sends neither schema field
- a constraint-bearing schema is snapshotted on both paths, so the trade-off documented above is pinned rather than asserted
- all pre-existing structured-output snapshots are unchanged, confirming the default path is untouched

`pnpm --filter @ai-sdk/google exec vitest --config vitest.node.config.js --run` → 739 passed. `tsc --build` and `oxlint` on the touched files are clean.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

The Gemini API exposes the same escape hatch for tool inputs via `FunctionDeclaration.parametersJsonSchema`. Wiring that up would let tool input schemas use unions and records too; it was left out here to keep this change focused on structured outputs.
