### PR TITLE
fix(ai): collect trailing local tool approvals

### DIFF
--- a/packages/ai/src/generate-text/collect-tool-approvals.ts
+++ b/packages/ai/src/generate-text/collect-tool-approvals.ts
@@ -7,6 +7,7 @@ import type {
 } from '@ai-sdk/provider-utils';
 import { InvalidToolApprovalError } from '../error/invalid-tool-approval-error';
 import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
+import { getLatestAssistantApprovalTurn } from '../util/get-latest-assistant-approval-turn';
 import type { TypedToolCall } from './tool-call';
 
 export type CollectedToolApprovals<TOOLS extends ToolSet> = {
@@ -16,9 +17,20 @@ export type CollectedToolApprovals<TOOLS extends ToolSet> = {
   existingToolResult?: ToolResultPart;
 };
 
+function createEmptyToolApprovals<TOOLS extends ToolSet>(): {
+  approvedToolApprovals: Array<CollectedToolApprovals<TOOLS>>;
+  deniedToolApprovals: Array<CollectedToolApprovals<TOOLS>>;
+} {
+  return {
+    approvedToolApprovals: [],
+    deniedToolApprovals: [],
+  };
+}
+
 /**
- * If the last message is a tool message, this function collects all tool approvals
- * from that message.
+ * Collects unresolved tool approvals for the latest assistant turn. Approval
+ * responses may be followed by non-assistant context messages, but are not
+ * replayed once a later assistant response exists.
  */
 export function collectToolApprovals<TOOLS extends ToolSet>({
   messages,
@@ -28,14 +40,13 @@ export function collectToolApprovals<TOOLS extends ToolSet>({
   approvedToolApprovals: Array<CollectedToolApprovals<TOOLS>>;
   deniedToolApprovals: Array<CollectedToolApprovals<TOOLS>>;
 } {
-  const lastMessage = messages.at(-1);
+  const approvalTurn = getLatestAssistantApprovalTurn(messages);
 
-  if (lastMessage?.role != 'tool') {
-    return {
-      approvedToolApprovals: [],
-      deniedToolApprovals: [],
-    };
+  if (approvalTurn == null) {
+    return createEmptyToolApprovals();
   }
+
+  const { latestAssistantContent, suffixMessages } = approvalTurn;
 
   // gather tool calls and prepare lookup.
   //
@@ -50,45 +61,45 @@ export function collectToolApprovals<TOOLS extends ToolSet>({
     string,
     TypedToolCall<TOOLS>
   > = Object.create(null);
-  for (const message of messages) {
-    if (message.role === 'assistant' && typeof message.content !== 'string') {
-      const content = message.content;
-      for (const part of content) {
-        if (part.type === 'tool-call') {
-          toolCallsByToolCallId[part.toolCallId] = part as TypedToolCall<TOOLS>;
-        }
-      }
+  for (const part of latestAssistantContent) {
+    if (part.type === 'tool-call') {
+      toolCallsByToolCallId[part.toolCallId] = part as TypedToolCall<TOOLS>;
     }
   }
 
-  // gather approval responses and prepare lookup
+  // gather approval requests from the latest assistant turn only. If a later
+  // assistant message exists, older approval responses belong to already
+  // continued history and must not trigger side effects again.
   const toolApprovalRequestsByApprovalId: Record<string, ToolApprovalRequest> =
     Object.create(null);
-  for (const message of messages) {
-    if (message.role === 'assistant' && typeof message.content !== 'string') {
-      const content = message.content;
-      for (const part of content) {
-        if (part.type === 'tool-approval-request') {
-          toolApprovalRequestsByApprovalId[part.approvalId] = part;
-        }
-      }
+  for (const part of latestAssistantContent) {
+    if (part.type === 'tool-approval-request') {
+      toolApprovalRequestsByApprovalId[part.approvalId] = part;
     }
   }
 
-  // gather tool results from the last tool message
+  const approvalResponses: ToolApprovalResponse[] = [];
+
+  // gather tool results from the unresolved suffix after the latest assistant
+  // turn, allowing user/system context to trail approval responses.
   const toolResults: Record<string, ToolResultPart> = Object.create(null);
-  for (const part of lastMessage.content) {
-    if (part.type === 'tool-result') {
-      toolResults[part.toolCallId] = part;
+  for (const message of suffixMessages) {
+    if (message.role !== 'tool') {
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (part.type === 'tool-approval-response') {
+        approvalResponses.push(part);
+      } else if (part.type === 'tool-result') {
+        toolResults[part.toolCallId] = part;
+      }
     }
   }
 
   const approvedToolApprovals: Array<CollectedToolApprovals<TOOLS>> = [];
   const deniedToolApprovals: Array<CollectedToolApprovals<TOOLS>> = [];
 
-  const approvalResponses = lastMessage.content.filter(
-    part => part.type === 'tool-approval-response',
-  );
   for (const approvalResponse of approvalResponses) {
     const approvalRequest =
       toolApprovalRequestsByApprovalId[approvalResponse.approvalId];

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -29,6 +29,7 @@ import { mergeObjects } from '../util/merge-objects';
 import { convertToLanguageModelV4FilePart } from './file-part-data';
 import { logWarnings } from '../logger/log-warnings';
 import type { Warning } from '../types/warning';
+import { getLatestAssistantApprovalTurn } from '../util/get-latest-assistant-approval-turn';
 import { InvalidMessageRoleError } from './invalid-message-role-error';
 import type { StandardizedPrompt } from './standardize-prompt';
 import { MissingToolResultsError } from '../error/missing-tool-result-error';
@@ -52,37 +53,8 @@ export async function convertToLanguageModelPrompt({
     supportedUrls,
   );
 
-  const approvalIdToToolCallId = new Map<string, string>();
-  for (const message of prompt.messages) {
-    if (message.role === 'assistant' && Array.isArray(message.content)) {
-      for (const part of message.content) {
-        if (
-          part.type === 'tool-approval-request' &&
-          'approvalId' in part &&
-          'toolCallId' in part
-        ) {
-          approvalIdToToolCallId.set(
-            part.approvalId as string,
-            part.toolCallId as string,
-          );
-        }
-      }
-    }
-  }
-
-  const approvedToolCallIds = new Set<string>();
-  for (const message of prompt.messages) {
-    if (message.role === 'tool') {
-      for (const part of message.content) {
-        if (part.type === 'tool-approval-response') {
-          const toolCallId = approvalIdToToolCallId.get(part.approvalId);
-          if (toolCallId) {
-            approvedToolCallIds.add(toolCallId);
-          }
-        }
-      }
-    }
-  }
+  const approvalResolvedToolCallIds =
+    collectApprovalResolvedToolCallIdsFromLatestAssistantTurn(prompt.messages);
 
   const messages = [
     ...(prompt.instructions != null
@@ -149,8 +121,8 @@ export async function convertToLanguageModelPrompt({
       }
       case 'user':
       case 'system':
-        // remove approved tool calls from the set before checking:
-        for (const id of approvedToolCallIds) {
+        // remove approval-resolved tool calls from the set before checking:
+        for (const id of approvalResolvedToolCallIds) {
           toolCallIds.delete(id);
         }
 
@@ -163,8 +135,8 @@ export async function convertToLanguageModelPrompt({
     }
   }
 
-  // remove approved tool calls from the set before checking:
-  for (const id of approvedToolCallIds) {
+  // remove approval-resolved tool calls from the set before checking:
+  for (const id of approvalResolvedToolCallIds) {
     toolCallIds.delete(id);
   }
 
@@ -179,6 +151,49 @@ export async function convertToLanguageModelPrompt({
     // Note: provider-executed tool-approval-response parts are preserved.
     message => message.role !== 'tool' || message.content.length > 0,
   );
+}
+
+function collectApprovalResolvedToolCallIdsFromLatestAssistantTurn(
+  messages: ModelMessage[],
+): Set<string> {
+  const approvalTurn = getLatestAssistantApprovalTurn(messages);
+
+  if (approvalTurn == null) {
+    return new Set();
+  }
+
+  const { latestAssistantContent, suffixMessages } = approvalTurn;
+  const approvalIdToToolCallId = new Map<string, string>();
+  for (const part of latestAssistantContent) {
+    if (
+      part.type === 'tool-approval-request' &&
+      'approvalId' in part &&
+      'toolCallId' in part
+    ) {
+      approvalIdToToolCallId.set(
+        part.approvalId as string,
+        part.toolCallId as string,
+      );
+    }
+  }
+
+  const approvalResolvedToolCallIds = new Set<string>();
+  for (const message of suffixMessages) {
+    if (message.role !== 'tool') {
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (part.type === 'tool-approval-response') {
+        const toolCallId = approvalIdToToolCallId.get(part.approvalId);
+        if (toolCallId != null) {
+          approvalResolvedToolCallIds.add(toolCallId);
+        }
+      }
+    }
+  }
+
+  return approvalResolvedToolCallIds;
 }
 
 /**

--- a/packages/ai/src/util/get-latest-assistant-approval-turn.ts
+++ b/packages/ai/src/util/get-latest-assistant-approval-turn.ts
@@ -1,0 +1,26 @@
+import type { ModelMessage } from '@ai-sdk/provider-utils';
+
+export function getLatestAssistantApprovalTurn(messages: ModelMessage[]) {
+  let latestAssistantMessageIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index].role === 'assistant') {
+      latestAssistantMessageIndex = index;
+      break;
+    }
+  }
+
+  if (latestAssistantMessageIndex === -1) {
+    return undefined;
+  }
+
+  const latestAssistantMessage = messages[latestAssistantMessageIndex];
+  const latestAssistantContent =
+    typeof latestAssistantMessage.content === 'string'
+      ? []
+      : latestAssistantMessage.content;
+
+  return {
+    latestAssistantContent,
+    suffixMessages: messages.slice(latestAssistantMessageIndex + 1),
+  };
+}


### PR DESCRIPTION
## collect trailing local tool approvals

Collect local tool approval responses from the latest assistant approval turn even when user or system context follows the approval response.

- Skip approvals that already have tool results
- Avoid replaying approvals behind a later assistant response
- Align missing-result validation with the same latest-assistant approval boundary

Fixes #17033

Rebased onto latest main (PR #17036 was stale by 266 commits).

Tests
- pnpm --filter ai type-check ✓
- pnpm --filter ai test:node -- collect-tool-approvals.test.ts ✓ (all 3327 pass)
- pnpm --filter ai test:node -- stream-text.test.ts ✓
- pnpm --filter ai test:node -- convert-to-language-model-prompt.validation.test.ts ✓