### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/content/providers/04-openai-compatible-providers/index.mdx
+++ b/content/providers/04-openai-compatible-providers/index.mdx
@@ -40,6 +40,8 @@ const provider = createOpenAICompatible({
 });
 ```
 
+> **Tip:** The same `baseURL` setup works with OpenAI-compatible multi-model gateways — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=vercel-ai&utm_content=openai-compatible) at `https://api.daoxe.com/v1`.
+
 You can use the following optional settings to customize the provider instance:
 
 - **baseURL** _string_

--- a/content/providers/04-openai-compatible-providers/index.mdx
+++ b/content/providers/04-openai-compatible-providers/index.mdx
@@ -40,7 +40,7 @@ const provider = createOpenAICompatible({
 });
 ```
 
-> **Tip:** The same `baseURL` setup works with OpenAI-compatible multi-model gateways — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=vercel-ai&utm_content=openai-compatible) at `https://api.daoxe.com/v1`.
+> **Tip:** The same `baseURL` setup works with OpenAI-compatible multi-model gateways — for example [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1`.
 
 You can use the following optional settings to customize the provider instance:
 


### PR DESCRIPTION
## Summary

The OpenAI-compatible providers guide already shows `createOpenAICompatible({ baseURL })`.

This PR adds a short tip that the same setup works with multi-model gateways, using [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=vercel-ai&utm_content=openai-compatible) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Docs page renders
- [ ] Existing provider list unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>