### PR TITLE
fix(anthropic): handle out-of-spec message_start events in response streams

### DIFF
--- a/.changeset/fail-spliced-anthropic-streams.md
+++ b/.changeset/fail-spliced-anthropic-streams.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+Handle out-of-spec message_start events in the response stream instead of silently corrupting the recorded generation. A duplicated message_start frame for the message that is already open (emitted by some Anthropic-compatible gateways) is now ignored instead of producing a spurious response-metadata part and overwriting usage counters. A message_start for a different message while the previous message is still open (two generations spliced into one stream, e.g. by an intermediary retrying its upstream connection mid-response) now fails the stream with an explicit error; previously both generations' thinking blocks were merged into one recorded step, and Anthropic rejected every subsequent request in the tool loop with "`thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified". Legitimate message_start/message_stop sequences (programmatic tool calling) are unaffected.

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -7386,6 +7386,186 @@ describe('AnthropicLanguageModel', () => {
       `);
     });
 
+    it('should ignore a duplicated message_start frame for the same message', async () => {
+      // some gateways duplicate the message_start frame of a single
+      // response (same message id) on their Anthropic passthrough.
+      server.urls['https://api.anthropic.com/v1/messages'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"message_start","message":{"id":"msg_dup","type":"message","role":"assistant","content":[],"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"output_tokens":1}}}\n\n`,
+          `data: {"type":"message_start","message":{"id":"msg_dup","type":"message","role":"assistant","content":[],"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"output_tokens":1}}}\n\n`,
+          `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello, World!"}}\n\n`,
+          `data: {"type":"content_block_stop","index":0}\n\n`,
+          `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":227}}\n\n`,
+          `data: {"type":"message_stop"}\n\n`,
+        ],
+      };
+
+      const { stream } = await model.doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
+          },
+          {
+            "id": "msg_dup",
+            "modelId": "claude-3-haiku-20240307",
+            "type": "response-metadata",
+          },
+          {
+            "id": "0",
+            "type": "text-start",
+          },
+          {
+            "delta": "Hello, World!",
+            "id": "0",
+            "type": "text-delta",
+          },
+          {
+            "id": "0",
+            "type": "text-end",
+          },
+          {
+            "finishReason": {
+              "raw": "end_turn",
+              "unified": "stop",
+            },
+            "providerMetadata": {
+              "anthropic": {
+                "container": null,
+                "contextManagement": null,
+                "iterations": null,
+                "stopSequence": null,
+                "usage": {
+                  "input_tokens": 17,
+                  "output_tokens": 227,
+                },
+              },
+            },
+            "type": "finish",
+            "usage": {
+              "inputTokens": {
+                "cacheRead": 0,
+                "cacheWrite": 0,
+                "noCache": 17,
+                "total": 17,
+              },
+              "outputTokens": {
+                "reasoning": undefined,
+                "text": undefined,
+                "total": 227,
+              },
+              "raw": {
+                "input_tokens": 17,
+                "output_tokens": 227,
+              },
+            },
+          },
+        ]
+      `);
+    });
+
+    it('should fail the stream when a message_start for a different message arrives while the previous message is open', async () => {
+      // two generations spliced into one stream: the first generation is
+      // cut mid tool input, then an intermediary retried upstream and the
+      // second generation's events continue on the same response.
+      server.urls['https://api.anthropic.com/v1/messages'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"message_start","message":{"id":"msg_first","type":"message","role":"assistant","content":[],"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"output_tokens":1}}}\n\n`,
+          `data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"I will call the tool."}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-first"}}\n\n`,
+          `data: {"type":"content_block_stop","index":0}\n\n`,
+          `data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_first","name":"test-tool","input":{}}}\n\n`,
+          `data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"value\\":\\"Spark"}}\n\n`,
+          `data: {"type":"message_start","message":{"id":"msg_second","type":"message","role":"assistant","content":[],"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"output_tokens":1}}}\n\n`,
+          `data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me call the tool."}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-second"}}\n\n`,
+          `data: {"type":"content_block_stop","index":0}\n\n`,
+          `data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_second","name":"test-tool","input":{}}}\n\n`,
+          `data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"value\\":\\"Sparkle Day\\"}"}}\n\n`,
+          `data: {"type":"content_block_stop","index":1}\n\n`,
+          `data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":65}}\n\n`,
+          `data: {"type":"message_stop"}\n\n`,
+        ],
+      };
+
+      const { stream } = await model.doStream({
+        tools: [
+          {
+            type: 'function',
+            name: 'test-tool',
+            inputSchema: {
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              required: ['value'],
+              additionalProperties: false,
+              $schema: 'http://json-schema.org/draft-07/schema#',
+            },
+          },
+        ],
+        prompt: TEST_PROMPT,
+      });
+
+      expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "stream-start",
+            "warnings": [],
+          },
+          {
+            "id": "msg_first",
+            "modelId": "claude-3-haiku-20240307",
+            "type": "response-metadata",
+          },
+          {
+            "id": "0",
+            "type": "reasoning-start",
+          },
+          {
+            "delta": "I will call the tool.",
+            "id": "0",
+            "type": "reasoning-delta",
+          },
+          {
+            "delta": "",
+            "id": "0",
+            "providerMetadata": {
+              "anthropic": {
+                "signature": "sig-first",
+              },
+            },
+            "type": "reasoning-delta",
+          },
+          {
+            "id": "0",
+            "type": "reasoning-end",
+          },
+          {
+            "id": "toolu_first",
+            "toolName": "test-tool",
+            "type": "tool-input-start",
+          },
+          {
+            "delta": "{"value":"Spark",
+            "id": "toolu_first",
+            "type": "tool-input-delta",
+          },
+          {
+            "error": [AI_InvalidResponseDataError: Received a message_start event for a different message while the previous message was still open. The stream contains spliced generations (e.g. an intermediary retried its upstream connection mid-response) and cannot be processed safely.],
+            "type": "error",
+          },
+        ]
+      `);
+    });
+
     it('should stream redacted reasoning', async () => {
       server.urls['https://api.anthropic.com/v1/messages'].response = {
         type: 'stream-chunks',

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -1,5 +1,6 @@
 import {
   APICallError,
+  InvalidResponseDataError,
   type JSONObject,
   type LanguageModelV4,
   type LanguageModelV4CallOptions,
@@ -1609,6 +1610,17 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
 
     const generateId = this.generateId;
 
+    // Multiple message_start/message_stop sequences are valid in one
+    // stream (e.g. programmatic tool calling), and some gateways send a
+    // duplicated message_start frame for the same message, which is
+    // ignored. A message_start with a different id while the previous
+    // message is still open means an intermediary spliced two generations
+    // into the same stream. Earlier blocks may already have been emitted
+    // downstream, so the stream is failed explicitly instead of merging
+    // the generations.
+    let openMessageId: string | null = null;
+    let isStreamCorrupted = false;
+
     const transformedStream = response.pipeThrough(
       new TransformStream<
         ParseResult<InferSchema<typeof anthropicChunkSchema>>,
@@ -1621,6 +1633,11 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
         transform(chunk, controller) {
           if (options.includeRawChunks) {
             controller.enqueue({ type: 'raw', rawValue: chunk.rawValue });
+          }
+
+          // drop all events after the stream was marked corrupted:
+          if (isStreamCorrupted) {
+            return;
           }
 
           if (!chunk.success) {
@@ -2405,6 +2422,28 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
             }
 
             case 'message_start': {
+              if (openMessageId != null) {
+                // duplicated frame for the message that is already open:
+                if ((value.message.id ?? '') === openMessageId) {
+                  return;
+                }
+                isStreamCorrupted = true;
+                controller.enqueue({
+                  type: 'error',
+                  error: new InvalidResponseDataError({
+                    data: value,
+                    message:
+                      'Received a message_start event for a different ' +
+                      'message while the previous message was still open. ' +
+                      'The stream contains spliced generations (e.g. an ' +
+                      'intermediary retried its upstream connection ' +
+                      'mid-response) and cannot be processed safely.',
+                  }),
+                });
+                return;
+              }
+              openMessageId = value.message.id ?? '';
+
               usage.input_tokens = value.message.usage.input_tokens;
               usage.cache_read_input_tokens =
                 value.message.usage.cache_read_input_tokens ?? 0;
@@ -2559,6 +2598,8 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
             }
 
             case 'message_stop': {
+              openMessageId = null;
+
               const anthropicMetadata = {
                 usage: (rawUsage as JSONObject) ?? null,
                 stopSequence,


### PR DESCRIPTION
## Background

Fixes #18331.

A valid Anthropic response stream contains exactly one `message_start` per message, but intermediaries violate this in two documented ways:

1. An intermediary that loses its upstream connection mid-generation and retries can splice a second generation into the same HTTP response body: a `message_start` with a new message id arrives while the previous message is still open (observed in production behind Google Vertex; the first generation's `tool_use` was cut mid `input_json_delta`).
2. Some Anthropic-compatible gateways duplicate the `message_start` frame of a single response, same message id (maximhq/bifrost#4556, BerriAI/litellm#32479).

The parser currently accepts both silently. For shape 1, both generations' signed thinking blocks are merged into one recorded step; the step cannot be replayed, and every subsequent request in the tool loop fails with Anthropic's non-retryable 400 "`thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified". For shape 2, the duplicate frame emits a spurious second `response-metadata` part and overwrites usage counters.

## Summary

`doStream` now tracks the open message id (set on `message_start`, cleared on `message_stop`):

- A `message_start` for the **same** message id while it is open is ignored (shape 2, benign duplicate).
- A `message_start` for a **different** message id while the previous message is still open fails the stream with an explicit `InvalidResponseDataError` part and drops all subsequent events (shape 1). Earlier blocks may already have been consumed downstream, so the stream cannot be repaired at this layer; failing explicitly prevents the corrupted history from being recorded.

Legitimate `message_start`/`message_stop` sequences (programmatic tool calling) are unaffected: the existing multi-message fixtures pass unchanged.

## Verification

- Two new tests in `anthropic-language-model.test.ts` using raw SSE stream chunks: the spliced-generation stream and the same-id duplicate. Both fail on current `main` (the first shows the silent merge, the second shows the spurious `response-metadata`).
- Full package suite passes: 474/474 in both node and edge configs.
- `ultracite check` and `tsc --build` clean.

## Checklist

- [x] Patch changeset added (`.changeset/fail-spliced-anthropic-streams.md`)
- [x] Tests added, failing on `main`, passing with the fix
- [x] All commits are signed

## Related Issues

Fixes #18331
