### PR TITLE
fix(openai): handle missing reasoning state in streamed responses

### DIFF
--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -5562,7 +5562,6 @@ describe('OpenAIResponsesLanguageModel', () => {
         user: null,
         metadata: {},
       };
-
       it('should use "azure" as providerMetadata key when provider includes "azure"', async () => {
         server.urls['https://api.openai.com/v1/responses'].response = {
           type: 'json-value',
@@ -6062,6 +6061,58 @@ describe('OpenAIResponsesLanguageModel', () => {
           });
         }
       });
+    });
+
+    it('should not crash when reasoning summary events arrive without response.output_item.added', async () => {
+      server.urls['https://api.openai.com/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data:{"type":"response.created","response":{"id":"resp_reasoning","object":"response","created_at":1741269019,"status":"in_progress","error":null,"incomplete_details":null,"input":[],"instructions":null,"max_output_tokens":null,"model":"o3-mini-2025-01-31","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":"low","summary":"auto"},"store":true,"temperature":null,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":null,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}\n\n`,
+          `data:{"type":"response.reasoning_summary_part.added","item_id":"rs_reasoning_item","summary_index":0}\n\n`,
+          `data:{"type":"response.reasoning_summary_text.delta","item_id":"rs_reasoning_item","summary_index":0,"delta":"thinking through the steps"}\n\n`,
+          `data:{"type":"response.reasoning_summary_part.done","item_id":"rs_reasoning_item","summary_index":0}\n\n`,
+          `data:{"type":"response.output_item.done","output_index":0,"item":{"id":"rs_reasoning_item","type":"reasoning","summary":[{"type":"summary_text","text":"thinking through the steps"}]}}\n\n`,
+          `data:{"type":"response.completed","response":{"id":"resp_reasoning","object":"response","created_at":1741269019,"status":"completed","error":null,"incomplete_details":null,"input":[],"instructions":null,"max_output_tokens":null,"model":"o3-mini-2025-01-31","output":[{"id":"rs_reasoning_item","type":"reasoning","summary":[{"type":"summary_text","text":"thinking through the steps"}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":"low","summary":"auto"},"store":true,"temperature":null,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":null,"truncation":"disabled","usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":20,"output_tokens_details":{"reasoning_tokens":20},"total_tokens":30},"user":null,"metadata":{}}}\n\n`,
+        ],
+      };
+
+      const model = new OpenAIResponsesLanguageModel('o3-mini', {
+        provider: 'azure.responses',
+        url: ({ path }) => `https://api.openai.com/v1${path}`,
+        headers: () => ({ Authorization: `Bearer APIKEY` }),
+      });
+
+      const { stream } = await model.doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const events = await convertReadableStreamToArray(stream);
+
+      const reasoningStart = events.find(
+        event => event.type === 'reasoning-start',
+      );
+      expect(reasoningStart?.type === 'reasoning-start').toBe(true);
+      if (reasoningStart?.type === 'reasoning-start') {
+        expect(reasoningStart.providerMetadata).toHaveProperty('azure');
+        expect(reasoningStart.providerMetadata).not.toHaveProperty('openai');
+        expect(reasoningStart.providerMetadata?.azure).toMatchObject({
+          itemId: 'rs_reasoning_item',
+          reasoningEncryptedContent: null,
+        });
+      }
+
+      const reasoningDelta = events.find(
+        event => event.type === 'reasoning-delta',
+      );
+      expect(reasoningDelta?.type === 'reasoning-delta').toBe(true);
+      if (reasoningDelta?.type === 'reasoning-delta') {
+        expect(reasoningDelta.providerMetadata).toHaveProperty('azure');
+        expect(reasoningDelta.providerMetadata).not.toHaveProperty('openai');
+        expect(reasoningDelta.providerMetadata?.azure).toMatchObject({
+          itemId: 'rs_reasoning_item',
+        });
+      }
     });
 
     it('should send finish reason for incomplete response', async () => {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -2128,7 +2128,14 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
                   } satisfies InferSchema<typeof shellOutputSchema>,
                 });
               } else if (value.item.type === 'reasoning') {
-                const activeReasoningPart = activeReasoning[value.item.id];
+                // lazily initialize the reasoning part state in case the provider
+                // did not emit a matching response.output_item.added event first:
+                const activeReasoningPart =
+                  activeReasoning[value.item.id] ??
+                  (activeReasoning[value.item.id] = {
+                    encryptedContent: undefined,
+                    summaryParts: {},
+                  });
 
                 // get all active or can-conclude summary parts' ids
                 // to conclude ongoing reasoning parts:
@@ -2298,20 +2305,37 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
                 logprobs.push(value.logprobs);
               }
             } else if (value.type === 'response.reasoning_summary_part.added') {
-              // the first reasoning start is pushed in isResponseOutputItemAddedReasoningChunk
-              if (value.summary_index > 0) {
-                const activeReasoningPart = activeReasoning[value.item_id]!;
+              // lazily initialize the reasoning part state in case the provider
+              // did not emit a response.output_item.added event first:
+              const activeReasoningPart =
+                activeReasoning[value.item_id] ??
+                (activeReasoning[value.item_id] = {
+                  encryptedContent: undefined,
+                  summaryParts: {},
+                });
 
+              const isNewSummaryPart = !(
+                value.summary_index in activeReasoningPart.summaryParts
+              );
+
+              // the first reasoning-start is normally pushed from the
+              // response.output_item.added (type: 'reasoning') handler above. if that
+              // event was never received (e.g. providers that emit summary parts
+              // without a preceding item-added event), emit a reasoning-start here
+              // for whatever summary part is being added.
+              if (isNewSummaryPart) {
                 activeReasoningPart.summaryParts[value.summary_index] =
                   'active';
 
-                // since there is a new active summary part, we can conclude all can-conclude summary parts
+                // since there is a new active summary part, we can conclude all
+                // can-conclude summary parts
                 for (const summaryIndex of Object.keys(
                   activeReasoningPart.summaryParts,
                 )) {
                   if (
+                    summaryIndex !== String(value.summary_index) &&
                     activeReasoningPart.summaryParts[summaryIndex] ===
-                    'can-conclude'
+                      'can-conclude'
                   ) {
                     controller.enqueue({
                       type: 'reasoning-end',
@@ -2322,6 +2346,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
                         } satisfies ResponsesReasoningProviderMetadata,
                       },
                     });
+
                     activeReasoningPart.summaryParts[summaryIndex] =
                       'concluded';
                   }
@@ -2334,8 +2359,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
                     [providerOptionsName]: {
                       itemId: value.item_id,
                       reasoningEncryptedContent:
-                        activeReasoning[value.item_id]?.encryptedContent ??
-                        null,
+                        activeReasoningPart.encryptedContent ?? null,
                     } satisfies ResponsesReasoningProviderMetadata,
                   },
                 });
@@ -2354,6 +2378,12 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
             } else if (value.type === 'response.reasoning_summary_part.done') {
               // when OpenAI stores the message data, we can immediately conclude the reasoning part
               // since we do not need to send the encrypted content.
+              const reasoning =
+                activeReasoning[value.item_id] ??
+                (activeReasoning[value.item_id] = {
+                  encryptedContent: undefined,
+                  summaryParts: {},
+                });
               if (store) {
                 controller.enqueue({
                   type: 'reasoning-end',
@@ -2366,15 +2396,11 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
                 });
 
                 // mark the summary part as concluded
-                activeReasoning[value.item_id]!.summaryParts[
-                  value.summary_index
-                ] = 'concluded';
+                reasoning.summaryParts[value.summary_index] = 'concluded';
               } else {
                 // mark the summary part as can-conclude only
                 // because we need to have a final summary part with the encrypted content
-                activeReasoning[value.item_id]!.summaryParts[
-                  value.summary_index
-                ] = 'can-conclude';
+                reasoning.summaryParts[value.summary_index] = 'can-conclude';
               }
             } else if (isResponseFinishedChunk(value)) {
               finishReason = {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -2333,9 +2333,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
                   activeReasoningPart.summaryParts,
                 )) {
                   if (
-                    summaryIndex !== String(value.summary_index) &&
                     activeReasoningPart.summaryParts[summaryIndex] ===
-                      'can-conclude'
+                    'can-conclude'
                   ) {
                     controller.enqueue({
                       type: 'reasoning-end',


### PR DESCRIPTION

## Summary

Fixes a crash when streaming reasoning summaries from Responses-API-compatible providers that emit reasoning summary events before `response.output_item.added`.

The current implementation assumes `activeReasoning[item_id]` has already been initialized. Providers such as GitHub Copilot can emit `response.reasoning_summary_part.*` events without first sending the corresponding `response.output_item.added` event, causing:

```text
TypeError: Cannot read properties of undefined (reading 'summaryParts')
```

This PR makes the reasoning state initialization defensive by lazily creating the missing state whenever it is first accessed. It also emits the initial `reasoning-start` event when the first summary part arrives without a preceding `response.output_item.added`, preserving the expected stream behavior while maintaining compatibility with the existing OpenAI event flow.

## Changes

- Lazily initialize missing reasoning state in all reasoning event handlers.
- Handle reasoning summary events that arrive before `response.output_item.added`.
- Emit the initial `reasoning-start` event when necessary.
- Preserve existing behavior for providers that follow OpenAI's event ordering.
- Add a regression test covering the missing `response.output_item.added` scenario.

## Testing

- ✅ Added a regression test reproducing the reported issue.
- ✅ Targeted regression test passes.
- ✅ Full `@ai-sdk/openai` test suite passes (867 tests).
- ✅ Type checking passes.

Fixes #18270