### PR TITLE
feat (provider/xai): add reference audio for reference-to-video

### DIFF
--- a/.changeset/xai-r2v-reference-voices.md
+++ b/.changeset/xai-r2v-reference-voices.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat (provider/xai): add `referenceVoiceIds` for reference-to-video reference audio. Pass up to 3 xAI preset voice ids (e.g. `['eve']`) and reference them from the prompt with `<AUDIO_0>`–`<AUDIO_2>`; they are sent as `reference_audios: [{ voice_id }]` on `POST /v1/videos/generations`.

--- a/content/docs/03-ai-sdk-core/38-video-generation.mdx
+++ b/content/docs/03-ai-sdk-core/38-video-generation.mdx
@@ -466,21 +466,21 @@ try {
 
 ## Video Models
 
-| Provider                                                                | Model                       | Features                                               |
-| ----------------------------------------------------------------------- | --------------------------- | ------------------------------------------------------ |
-| [FAL](/providers/ai-sdk-providers/fal#video-models)                     | `luma-dream-machine/ray-2`  | Text-to-video, image-to-video                          |
-| [FAL](/providers/ai-sdk-providers/fal#video-models)                     | `minimax-video`             | Text-to-video                                          |
-| [Google](/providers/ai-sdk-providers/google#video-models)               | `veo-2.0-generate-001`      | Text-to-video, up to 4 videos per call                 |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#video-models) | `veo-3.1-generate-001`      | Text-to-video, audio generation                        |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#video-models) | `veo-3.1-fast-generate-001` | Text-to-video, audio generation                        |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#video-models) | `veo-3.0-generate-001`      | Text-to-video, audio generation                        |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#video-models) | `veo-3.0-fast-generate-001` | Text-to-video, audio generation                        |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#video-models) | `veo-2.0-generate-001`      | Text-to-video, up to 4 videos per call                 |
-| [Kling AI](/providers/ai-sdk-providers/klingai#video-models)            | `kling-v2.6-t2v`            | Text-to-video                                          |
-| [Kling AI](/providers/ai-sdk-providers/klingai#video-models)            | `kling-v2.6-i2v`            | Image-to-video                                         |
-| [Kling AI](/providers/ai-sdk-providers/klingai#video-models)            | `kling-v2.6-motion-control` | Motion control                                         |
-| [Replicate](/providers/ai-sdk-providers/replicate#video-models)         | `minimax/video-01`          | Text-to-video                                          |
-| [xAI](/providers/ai-sdk-providers/xai#video-models)                     | `grok-imagine-video`        | Text-to-video, image-to-video, editing, extension, R2V |
-| [xAI](/providers/ai-sdk-providers/xai#video-models)                     | `grok-imagine-video-1.5`    | Text-to-video, image-to-video, editing, extension, R2V |
+| Provider                                                                | Model                       | Features                                                                      |
+| ----------------------------------------------------------------------- | --------------------------- | ----------------------------------------------------------------------------- |
+| [FAL](/providers/ai-sdk-providers/fal#video-models)                     | `luma-dream-machine/ray-2`  | Text-to-video, image-to-video                                                 |
+| [FAL](/providers/ai-sdk-providers/fal#video-models)                     | `minimax-video`             | Text-to-video                                                                 |
+| [Google](/providers/ai-sdk-providers/google#video-models)               | `veo-2.0-generate-001`      | Text-to-video, up to 4 videos per call                                        |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#video-models) | `veo-3.1-generate-001`      | Text-to-video, audio generation                                               |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#video-models) | `veo-3.1-fast-generate-001` | Text-to-video, audio generation                                               |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#video-models) | `veo-3.0-generate-001`      | Text-to-video, audio generation                                               |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#video-models) | `veo-3.0-fast-generate-001` | Text-to-video, audio generation                                               |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#video-models) | `veo-2.0-generate-001`      | Text-to-video, up to 4 videos per call                                        |
+| [Kling AI](/providers/ai-sdk-providers/klingai#video-models)            | `kling-v2.6-t2v`            | Text-to-video                                                                 |
+| [Kling AI](/providers/ai-sdk-providers/klingai#video-models)            | `kling-v2.6-i2v`            | Image-to-video                                                                |
+| [Kling AI](/providers/ai-sdk-providers/klingai#video-models)            | `kling-v2.6-motion-control` | Motion control                                                                |
+| [Replicate](/providers/ai-sdk-providers/replicate#video-models)         | `minimax/video-01`          | Text-to-video                                                                 |
+| [xAI](/providers/ai-sdk-providers/xai#video-models)                     | `grok-imagine-video`        | Text-to-video, image-to-video, editing, extension, R2V                        |
+| [xAI](/providers/ai-sdk-providers/xai#video-models)                     | `grok-imagine-video-1.5`    | Text-to-video, image-to-video, editing, extension, R2V (with reference audio) |
 
 Above are a small subset of the video models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -1235,6 +1235,51 @@ media type (for example a video or audio clip) is ignored with a warning, and a
 reference with no media type is treated as an image. If no image reference
 remains, reference-to-video is not selected and no reference images are sent.
 
+#### Reference Audio
+
+Reference-to-video can also give the subject a voice. `referenceVoiceIds` takes
+up to 3 xAI **preset** voice ids — you cannot upload your own audio clips.
+Reference the voices from the prompt with `<AUDIO_0>`, `<AUDIO_1>`, and
+`<AUDIO_2>`, in the order the voices are passed.
+
+```ts
+import { xai, type XaiVideoModelOptions } from '@ai-sdk/xai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { video } = await generateVideo({
+  model: xai.video('grok-imagine-video-1.5'),
+  prompt:
+    'The person from <IMAGE_0> stands in the room from <IMAGE_1> and speaks ' +
+    'to the camera with the voice from <AUDIO_0>.',
+  aspectRatio: '9:16',
+  duration: 10,
+  providerOptions: {
+    xai: {
+      mode: 'reference-to-video',
+      referenceImageUrls: [
+        'https://example.com/person.png',
+        'https://example.com/room.png',
+      ],
+      referenceVoiceIds: ['eve'],
+      resolution: '720p',
+      pollTimeoutMs: 600000,
+    } satisfies XaiVideoModelOptions,
+  },
+});
+```
+
+Valid voice ids come from the xAI
+[text-to-speech voice roster](https://docs.x.ai/developers/model-capabilities/audio/text-to-speech#voices).
+Ids are case-insensitive, and an unknown id returns a `400` response listing the
+available voices. `referenceVoiceIds` is ignored with a warning when the
+resolved operation is not reference-to-video.
+
+<Note>
+  xAI documents reference audio as available in the United States only, for
+  trusted partners. Requests from accounts without access are rejected by the
+  xAI API.
+</Note>
+
 <Note>
   Reference-to-video supports `duration`, `aspectRatio`, and `resolution`. Use
   `mode` to select the operation — each mode is mutually exclusive. When both
@@ -1297,6 +1342,17 @@ You can validate the provider options using the `XaiVideoModelOptions` type.
   `<IMAGE_N>` tags in the prompt to reference specific images — see the
   reference-to-video section above for per-model tag numbering. Used with
   `mode: 'reference-to-video'`.
+
+- **referenceVoiceIds** _string[]_
+
+  Up to 3 xAI preset voice ids that give the subject a voice in
+  reference-to-video (R2V) generation. Preset voices only — audio clips
+  cannot be uploaded. Ids are case-insensitive and come from the
+  [text-to-speech voice roster](https://docs.x.ai/developers/model-capabilities/audio/text-to-speech#voices);
+  an unknown id returns a `400` listing the available voices. Use `<AUDIO_0>`,
+  `<AUDIO_1>`, and `<AUDIO_2>` tags in the prompt to reference the voices.
+  Ignored with a warning outside reference-to-video. Reference audio is
+  documented as US-only and limited to trusted partners.
 
 <Note>
   Video generation is an asynchronous process that can take several minutes.

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -1195,14 +1195,7 @@ const { video } = await generateVideo({
 });
 ```
 
-Use `<IMAGE_1>`, `<IMAGE_2>`, etc. in your prompt to reference specific images, in the order the images are passed. Up to 7 reference images are supported per request.
-
-<Note>
-  Tag numbering differs by model. xAI's `grok-imagine-video` reference-to-video
-  examples tag images starting at `<IMAGE_1>`, while `grok-imagine-video-1.5`
-  documents zero-indexed tags (`<IMAGE_0>` … `<IMAGE_N>`). Follow the
-  convention for the model you are calling.
-</Note>
+Use `<IMAGE_1>`, `<IMAGE_2>`, etc. in your prompt to reference specific images. Up to 7 reference images are supported per request.
 
 Alternatively, use the provider-agnostic top-level `inputReferences` option. Providing it automatically selects reference-to-video mode, and it accepts file data (e.g. a `Buffer`) or `{ type: 'url', url }` objects:
 
@@ -1339,9 +1332,8 @@ You can validate the provider options using the `XaiVideoModelOptions` type.
   Array of reference image URLs (1–7 images) or base64 data URIs for
   reference-to-video (R2V) generation. The model incorporates visual
   elements from these images without using them as the first frame. Use
-  `<IMAGE_N>` tags in the prompt to reference specific images — see the
-  reference-to-video section above for per-model tag numbering. Used with
-  `mode: 'reference-to-video'`.
+  `<IMAGE_1>`, `<IMAGE_2>`, etc. in the prompt to reference specific
+  images. Used with `mode: 'reference-to-video'`.
 
 - **referenceVoiceIds** _string[]_
 

--- a/examples/ai-functions/src/generate-video/xai/r2v-reference-voice.ts
+++ b/examples/ai-functions/src/generate-video/xai/r2v-reference-voice.ts
@@ -1,0 +1,37 @@
+import { xai, type XaiVideoModelOptions } from '@ai-sdk/xai';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video, warnings } = await withSpinner(
+    'Generating xAI reference-to-video with a preset reference voice...',
+    () =>
+      generateVideo({
+        model: xai.video('grok-imagine-video-1.5'),
+        prompt:
+          'The comic cat from <IMAGE_0> sits beside the comic dog from ' +
+          '<IMAGE_1>. The cat speaks with the voice from <AUDIO_0> and the dog talks to the camera with the voice from <AUDIO_1>. ' +
+          'Handheld vertical shot, warm afternoon light.',
+        aspectRatio: '9:16',
+        duration: 10,
+        providerOptions: {
+          xai: {
+            mode: 'reference-to-video',
+            referenceImageUrls: [
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-dog.png',
+            ],
+            referenceVoiceIds: ['luna', 'zagan'],
+            resolution: '720p',
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies XaiVideoModelOptions,
+        },
+      }),
+  );
+
+  console.log('Warnings:', warnings);
+
+  await presentVideos([video]);
+});

--- a/packages/xai/src/xai-video-model-options.ts
+++ b/packages/xai/src/xai-video-model-options.ts
@@ -48,6 +48,10 @@ interface XaiVideoReferenceToVideoOptions
   mode: 'reference-to-video';
   /** Reference image URLs (1-7) for R2V generation. */
   referenceImageUrls: string[];
+  /**
+   * Preset voice ids (up to 3) that give the subject a voice.
+   */
+  referenceVoiceIds?: string[];
 }
 
 interface XaiVideoGenerationOptions
@@ -75,6 +79,10 @@ interface XaiLegacyReferenceToVideoOptions
    */
   mode?: undefined;
   referenceImageUrls: string[];
+  /**
+   * Preset voice ids (up to 3) that give the subject a voice.
+   */
+  referenceVoiceIds?: string[];
 }
 
 /**
@@ -113,6 +121,7 @@ const runtimeSchema = z.looseObject({
   mode: modeSchema.optional(),
   videoUrl: nonEmptyStringSchema.optional(),
   referenceImageUrls: z.array(nonEmptyStringSchema).min(1).max(7).optional(),
+  referenceVoiceIds: z.array(nonEmptyStringSchema).max(3).optional(),
   user: z.string().optional(),
   ...baseFields,
 });

--- a/packages/xai/src/xai-video-model-options.ts
+++ b/packages/xai/src/xai-video-model-options.ts
@@ -95,9 +95,6 @@ interface XaiLegacyReferenceToVideoOptions
  * - `'reference-to-video'` + `referenceImageUrls` -- R2V generation  (`POST /v1/videos/generations`)
  * - no `mode`                                     -- standard generation from text prompts or image input
  *
- * Reference images may also come from the top-level `inputReferences` option
- * instead of `referenceImageUrls`.
- *
  * Runtime remains backward compatible with legacy auto-detected provider
  * options, but the public TypeScript type is intentionally explicit so editors
  * can suggest valid modes and flag invalid field combinations.

--- a/packages/xai/src/xai-video-model.test.ts
+++ b/packages/xai/src/xai-video-model.test.ts
@@ -1,3 +1,4 @@
+import { InvalidArgumentError } from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { describe, expect, it } from 'vitest';
 import { XaiVideoModel } from './xai-video-model';
@@ -1076,6 +1077,149 @@ describe('XaiVideoModel', () => {
       expect(result.warnings).not.toContainEqual(
         expect.objectContaining({ feature: 'aspectRatio' }),
       );
+    });
+
+    it('should send reference_audios for preset reference voices', async () => {
+      const model = createModel({ modelId: 'grok-imagine-video-1.5' });
+
+      await model.doStart({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            mode: 'reference-to-video',
+            referenceImageUrls: ['https://example.com/ref1.jpg'],
+            referenceVoiceIds: ['eve'],
+          },
+        },
+      });
+
+      expect(server.calls[0].requestUrl).toBe(
+        `${TEST_BASE_URL}/videos/generations`,
+      );
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        reference_images: [{ url: 'https://example.com/ref1.jpg' }],
+        reference_audios: [{ voice_id: 'eve' }],
+      });
+    });
+
+    it('should send up to 3 preset reference voices in order', async () => {
+      const model = createModel({ modelId: 'grok-imagine-video-1.5' });
+
+      await model.doStart({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            mode: 'reference-to-video',
+            referenceImageUrls: ['https://example.com/ref1.jpg'],
+            referenceVoiceIds: ['eve', 'leo', 'rex'],
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).toMatchObject({
+        reference_audios: [
+          { voice_id: 'eve' },
+          { voice_id: 'leo' },
+          { voice_id: 'rex' },
+        ],
+      });
+    });
+
+    it('should reject more than 3 preset reference voices', async () => {
+      const model = createModel({ modelId: 'grok-imagine-video-1.5' });
+
+      await expect(
+        model.doStart({
+          ...defaultOptions,
+          providerOptions: {
+            xai: {
+              mode: 'reference-to-video',
+              referenceImageUrls: ['https://example.com/ref1.jpg'],
+              referenceVoiceIds: ['ara', 'eve', 'leo', 'rex'],
+            },
+          },
+        }),
+      ).rejects.toThrow(InvalidArgumentError);
+    });
+
+    it('should reject empty-string preset reference voice ids', async () => {
+      const model = createModel({ modelId: 'grok-imagine-video-1.5' });
+
+      await expect(
+        model.doStart({
+          ...defaultOptions,
+          providerOptions: {
+            xai: {
+              mode: 'reference-to-video',
+              referenceImageUrls: ['https://example.com/ref1.jpg'],
+              referenceVoiceIds: [''],
+            },
+          },
+        }),
+      ).rejects.toThrow(InvalidArgumentError);
+    });
+
+    it('should omit reference_audios for an empty referenceVoiceIds array', async () => {
+      const model = createModel({ modelId: 'grok-imagine-video-1.5' });
+
+      const result = await model.doStart({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            mode: 'reference-to-video',
+            referenceImageUrls: ['https://example.com/ref1.jpg'],
+            referenceVoiceIds: [],
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).not.toHaveProperty('reference_audios');
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ feature: 'referenceVoiceIds' }),
+      );
+    });
+
+    it('should warn and omit referenceVoiceIds outside reference-to-video', async () => {
+      const model = createModel({ modelId: 'grok-imagine-video-1.5' });
+
+      const result = await model.doStart({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            referenceVoiceIds: ['eve'],
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).not.toHaveProperty('reference_audios');
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({
+          type: 'unsupported',
+          feature: 'referenceVoiceIds',
+        }),
+      );
+    });
+
+    it('should never forward referenceVoiceIds as a raw body key', async () => {
+      const model = createModel({ modelId: 'grok-imagine-video-1.5' });
+
+      await model.doStart({
+        ...defaultOptions,
+        providerOptions: {
+          xai: {
+            mode: 'reference-to-video',
+            referenceImageUrls: ['https://example.com/ref1.jpg'],
+            referenceVoiceIds: ['eve'],
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body).not.toHaveProperty('referenceVoiceIds');
     });
   });
 

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -383,6 +383,13 @@ export class XaiVideoModel implements VideoModelV4 {
         });
       }
 
+      const referenceVoiceIds = xaiOptions?.referenceVoiceIds;
+      if (referenceVoiceIds != null && referenceVoiceIds.length > 0) {
+        body.reference_audios = referenceVoiceIds.map(voiceId => ({
+          voice_id: voiceId,
+        }));
+      }
+
       // Reference-to-video is capped at 720p; downgrade a 1080p request.
       if (body.resolution === '1080p') {
         warnings.push({
@@ -428,6 +435,21 @@ export class XaiVideoModel implements VideoModelV4 {
       });
     }
 
+    // Preset reference voices only apply to reference-to-video generation.
+    if (
+      xaiOptions?.referenceVoiceIds != null &&
+      xaiOptions.referenceVoiceIds.length > 0 &&
+      !hasReferenceImages
+    ) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'referenceVoiceIds',
+        details:
+          'xAI only supports reference voices for reference-to-video ' +
+          'generation. The reference voices were ignored.',
+      });
+    }
+
     if (!isExtension && xaiOptions?.user !== undefined) {
       body.user = xaiOptions.user;
     }
@@ -442,6 +464,7 @@ export class XaiVideoModel implements VideoModelV4 {
             'resolution',
             'videoUrl',
             'referenceImageUrls',
+            'referenceVoiceIds',
             'user',
           ].includes(key)
         ) {

--- a/packages/xai/src/xai-video-model.ts
+++ b/packages/xai/src/xai-video-model.ts
@@ -118,9 +118,6 @@ function resolveReferences(
       imageFiles.push(reference);
     }
 
-    // Every reference may have been filtered out (audio- or video-only input),
-    // so collapse an empty list to undefined rather than sending an empty
-    // `reference_images` array.
     return imageFiles.length > 0
       ? imageFiles.map(reference => ({ url: fileToXaiUrl(reference) }))
       : undefined;
@@ -136,8 +133,7 @@ function resolveReferences(
   return undefined;
 }
 
-// True when at least one reference would survive as an image. Audio-only or
-// video-only references cannot drive reference-to-video on their own.
+// True when at least one reference would survive as an image.
 function hasImageInputReference(options: XaiVideoCallOptions): boolean {
   return options.inputReferences?.some(isImageReference) ?? false;
 }

--- a/packages/xai/src/xai-video-options.test-d.ts
+++ b/packages/xai/src/xai-video-options.test-d.ts
@@ -48,6 +48,25 @@ describe('XaiVideoModelOptions type', () => {
     expectTypeOf(options).toMatchTypeOf<XaiVideoModelOptions>();
   });
 
+  it('should allow reference-to-video mode with referenceVoiceIds', () => {
+    const options = {
+      mode: 'reference-to-video',
+      referenceImageUrls: ['https://example.com/ref.png'],
+      referenceVoiceIds: ['eve'],
+    } satisfies XaiVideoModelOptions;
+
+    expectTypeOf(options).toMatchTypeOf<XaiVideoModelOptions>();
+  });
+
+  it('should allow referenceVoiceIds without mode for backward compatibility', () => {
+    const options = {
+      referenceImageUrls: ['https://example.com/ref.png'],
+      referenceVoiceIds: ['eve', 'leo', 'rex'],
+    } satisfies XaiVideoModelOptions;
+
+    expectTypeOf(options).toMatchTypeOf<XaiVideoModelOptions>();
+  });
+
   // ── Plain generation + legacy no-mode compatibility ────────────────
 
   it('should allow generic video options without mode', () => {
@@ -167,6 +186,39 @@ describe('XaiVideoModelOptions type', () => {
       videoUrl: 'https://example.com/video.mp4',
       // @ts-expect-error - extend-video does not accept referenceImageUrls
       referenceImageUrls: ['https://example.com/ref.png'],
+    };
+
+    options;
+  });
+
+  it('should not allow referenceVoiceIds with edit-video mode', () => {
+    const options: XaiVideoModelOptions = {
+      mode: 'edit-video',
+      videoUrl: 'https://example.com/video.mp4',
+      // @ts-expect-error - edit-video does not accept referenceVoiceIds
+      referenceVoiceIds: ['eve'],
+    };
+
+    options;
+  });
+
+  it('should not allow referenceVoiceIds with extend-video mode', () => {
+    const options: XaiVideoModelOptions = {
+      mode: 'extend-video',
+      videoUrl: 'https://example.com/video.mp4',
+      // @ts-expect-error - extend-video does not accept referenceVoiceIds
+      referenceVoiceIds: ['eve'],
+    };
+
+    options;
+  });
+
+  it('should require referenceVoiceIds to be a string array', () => {
+    const options: XaiVideoModelOptions = {
+      mode: 'reference-to-video',
+      referenceImageUrls: ['https://example.com/ref.png'],
+      // @ts-expect-error - referenceVoiceIds must be a string array
+      referenceVoiceIds: 'eve',
     };
 
     options;


### PR DESCRIPTION
### Background

Grok Imagine Video 1.5 can give a reference-to-video subject a voice. The API takes **preset voices by id** — `reference_audios: [{ "voice_id": "eve" }]`, up to 3 — and explicitly does not accept uploaded audio clips.

### Summary

- Adds the `referenceVoiceIds` provider option: up to 3 xAI preset voice ids, sent as `reference_audios: [{ voice_id }]`.
- Only applies to reference-to-video. Supplied in any other mode, it is omitted with an `unsupported` warning naming `referenceVoiceIds`.
- Ids pass through unmodified — the API treats them case-insensitively and returns `400` with the valid roster for an unknown id, so no allowlist is encoded in the schema.
- Nothing is routed through the top-level `inputReferences` option, which stays image-only. Reference audio is not a file input.
