### PR TITLE
feat(harness): improve harness sandbox auth error handling and expose `getHarnessErrorMessage()` helper

### DIFF
--- a/.changeset/ninety-poems-jog.md
+++ b/.changeset/ninety-poems-jog.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk/sandbox-vercel": patch
+"@ai-sdk/harness": patch
+---
+
+feat(harness): improve harness sandbox auth error handling and expose `getHarnessErrorMessage()` helper

--- a/content/docs/03-ai-sdk-harnesses/07-ui.mdx
+++ b/content/docs/03-ai-sdk-harnesses/07-ui.mdx
@@ -24,7 +24,7 @@ import { useState } from 'react';
 
 export default function Page() {
   const [input, setInput] = useState('');
-  const { messages, sendMessage, status } = useChat({
+  const { error, messages, sendMessage, status } = useChat({
     id: 'example-chat',
     transport: new DefaultChatTransport({
       api: '/api/chat',
@@ -49,6 +49,8 @@ export default function Page() {
           })}
         </div>
       ))}
+
+      {error && <div>{error.message}</div>}
 
       <form
         onSubmit={event => {
@@ -150,8 +152,10 @@ result stream back to a UI message stream:
 ```ts filename='app/api/chat/route.ts'
 import { agent } from './agent';
 import { detachAndPersist, resumeOrCreateSession } from './session-store';
+import { getHarnessErrorMessage } from '@ai-sdk/harness/agent';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -169,19 +173,33 @@ export async function POST(request: Request) {
 
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
-  const session = await resumeOrCreateSession({ agent, chatId });
-  const result = await agent.stream({ session, messages });
 
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onEnd: async () => {
-        await detachAndPersist({ chatId, session });
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession({ agent, chatId });
+        const result = await agent.stream({ session, messages });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessErrorMessage,
+            onEnd: async () => {
+              await detachAndPersist({ chatId, session });
+            },
+          }),
+        );
       },
+      onError: getHarnessErrorMessage,
     }),
   });
 }
 ```
+
+Creating the UI message stream before acquiring the session ensures sandbox,
+bootstrap, and harness startup failures are sent as UI error parts instead of
+becoming generic HTTP errors. `getHarnessErrorMessage` preserves reviewed,
+client-safe harness messages and masks unknown server errors.
 
 Do not use `createAgentUIStreamResponse` directly with `HarnessAgent` unless you
 wrap the agent to inject the required session. `HarnessAgent.stream()` requires

--- a/examples/harness-e2e-next/app/api/harness/claude-code/ai-sdk-coding/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/claude-code/ai-sdk-coding/route.ts
@@ -1,10 +1,12 @@
 import { aiSdkCodingHarnessAgent } from '@/agent/harness/claude-code/ai-sdk-coding-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,14 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(aiSdkCodingHarnessAgent, chatId);
-
-  const result = await aiSdkCodingHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          aiSdkCodingHarnessAgent,
+          chatId,
+        );
+
+        const result = await aiSdkCodingHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/claude-code/basic-with-stop/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/claude-code/basic-with-stop/route.ts
@@ -1,10 +1,12 @@
 import { claudeCodeHarnessAgent } from '@/agent/harness/claude-code/basic-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   resumeOrCreateSession,
   stopAndPersist,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,16 +24,30 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(claudeCodeHarnessAgent, chatId);
-
-  const result = await claudeCodeHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      // Stop the session at the end of the turn so the next request resumes
-      // from the persisted snapshot rather than attaching to a parked bridge.
-      onFinish: () => stopAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          claudeCodeHarnessAgent,
+          chatId,
+        );
+
+        const result = await claudeCodeHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            // Stop the session at the end of the turn so the next request resumes
+            // from the persisted snapshot rather than attaching to a parked bridge.
+            onFinish: () => stopAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/claude-code/basic/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/claude-code/basic/route.ts
@@ -1,10 +1,12 @@
 import { claudeCodeHarnessAgent } from '@/agent/harness/claude-code/basic-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,15 +24,29 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(claudeCodeHarnessAgent, chatId);
-
-  const result = await claudeCodeHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      originalMessages: body.messages,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          claudeCodeHarnessAgent,
+          chatId,
+        );
+
+        const result = await claudeCodeHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            originalMessages: body.messages,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/claude-code/weather-approval/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/claude-code/weather-approval/route.ts
@@ -1,10 +1,12 @@
 import { weatherApprovalClaudeCodeHarnessAgent } from '@/agent/harness/claude-code/weather-approval-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,21 +24,29 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    weatherApprovalClaudeCodeHarnessAgent,
-    chatId,
-  );
-
-  const result = await weatherApprovalClaudeCodeHarnessAgent.stream({
-    session,
-    messages,
-  });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      originalMessages: body.messages,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          weatherApprovalClaudeCodeHarnessAgent,
+          chatId,
+        );
+
+        const result = await weatherApprovalClaudeCodeHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            originalMessages: body.messages,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/claude-code/weather-only/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/claude-code/weather-only/route.ts
@@ -1,10 +1,12 @@
 import { weatherClaudeCodeHarnessAgent } from '@/agent/harness/claude-code/weather-only-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,20 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    weatherClaudeCodeHarnessAgent,
-    chatId,
-  );
-
-  const result = await weatherClaudeCodeHarnessAgent.stream({
-    session,
-    messages,
-  });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          weatherClaudeCodeHarnessAgent,
+          chatId,
+        );
+
+        const result = await weatherClaudeCodeHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/claude-code/weather/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/claude-code/weather/route.ts
@@ -1,10 +1,12 @@
 import { weatherClaudeCodeHarnessAgent } from '@/agent/harness/claude-code/weather-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,20 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    weatherClaudeCodeHarnessAgent,
-    chatId,
-  );
-
-  const result = await weatherClaudeCodeHarnessAgent.stream({
-    session,
-    messages,
-  });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          weatherClaudeCodeHarnessAgent,
+          chatId,
+        );
+
+        const result = await weatherClaudeCodeHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/claude-code/workflow-stepped/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/claude-code/workflow-stepped/route.ts
@@ -1,9 +1,11 @@
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   type UIMessage,
   type UIMessageChunk,
 } from 'ai';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import { start } from 'workflow/api';
 import { agentWorkflow } from './workflow';
 
@@ -13,9 +15,17 @@ export async function POST(request: Request) {
     return new Response('Missing chat id', { status: 400 });
   }
 
+  const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
-  const run = await start(agentWorkflow, [{ messages, sessionId: body.id }]);
   return createUIMessageStreamResponse({
-    stream: run.readable as ReadableStream<UIMessageChunk>,
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const run = await start(agentWorkflow, [
+          { messages, sessionId: chatId },
+        ]);
+        writer.merge(run.readable as ReadableStream<UIMessageChunk>);
+      },
+      onError: getHarnessE2EErrorMessage,
+    }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/claude-code/workflow-timed/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/claude-code/workflow-timed/route.ts
@@ -1,9 +1,11 @@
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   type UIMessage,
   type UIMessageChunk,
 } from 'ai';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import { start } from 'workflow/api';
 import { timeSliceWorkflow } from './workflow';
 
@@ -23,17 +25,22 @@ export async function POST(request: Request) {
     return new Response('Missing chat id', { status: 400 });
   }
 
+  const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
   /*
    * The chat id is the stable harness session id across turns; the workflow
    * loads and persists its resume handle by that id. Passing the complete
    * message list also preserves tool approval and tool result continuations.
    */
-  const run = await start(timeSliceWorkflow, [
-    { messages, sessionId: body.id },
-  ]);
-
   return createUIMessageStreamResponse({
-    stream: run.readable as ReadableStream<UIMessageChunk>,
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const run = await start(timeSliceWorkflow, [
+          { messages, sessionId: chatId },
+        ]);
+        writer.merge(run.readable as ReadableStream<UIMessageChunk>);
+      },
+      onError: getHarnessE2EErrorMessage,
+    }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/codex/ai-sdk-coding/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/codex/ai-sdk-coding/route.ts
@@ -1,10 +1,12 @@
 import { aiSdkCodingCodexHarnessAgent } from '@/agent/harness/codex/ai-sdk-coding-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,20 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    aiSdkCodingCodexHarnessAgent,
-    chatId,
-  );
-
-  const result = await aiSdkCodingCodexHarnessAgent.stream({
-    session,
-    messages,
-  });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          aiSdkCodingCodexHarnessAgent,
+          chatId,
+        );
+
+        const result = await aiSdkCodingCodexHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/codex/basic-with-stop/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/codex/basic-with-stop/route.ts
@@ -1,10 +1,12 @@
 import { codexHarnessAgent } from '@/agent/harness/codex/basic-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   resumeOrCreateSession,
   stopAndPersist,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,16 +24,24 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(codexHarnessAgent, chatId);
-
-  const result = await codexHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      // Stop the session at the end of the turn so the next request resumes
-      // from the persisted snapshot rather than attaching to a parked bridge.
-      onFinish: () => stopAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(codexHarnessAgent, chatId);
+
+        const result = await codexHarnessAgent.stream({ session, messages });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            // Stop the session at the end of the turn so the next request resumes
+            // from the persisted snapshot rather than attaching to a parked bridge.
+            onFinish: () => stopAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/codex/basic/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/codex/basic/route.ts
@@ -1,10 +1,12 @@
 import { codexHarnessAgent } from '@/agent/harness/codex/basic-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,15 +24,23 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(codexHarnessAgent, chatId);
-
-  const result = await codexHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      originalMessages: body.messages,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(codexHarnessAgent, chatId);
+
+        const result = await codexHarnessAgent.stream({ session, messages });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            originalMessages: body.messages,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/codex/weather-approval/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/codex/weather-approval/route.ts
@@ -1,10 +1,12 @@
 import { weatherApprovalCodexHarnessAgent } from '@/agent/harness/codex/weather-approval-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,21 +24,29 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    weatherApprovalCodexHarnessAgent,
-    chatId,
-  );
-
-  const result = await weatherApprovalCodexHarnessAgent.stream({
-    session,
-    messages,
-  });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      originalMessages: body.messages,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          weatherApprovalCodexHarnessAgent,
+          chatId,
+        );
+
+        const result = await weatherApprovalCodexHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            originalMessages: body.messages,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/codex/weather/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/codex/weather/route.ts
@@ -1,10 +1,12 @@
 import { weatherCodexHarnessAgent } from '@/agent/harness/codex/weather-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,14 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(weatherCodexHarnessAgent, chatId);
-
-  const result = await weatherCodexHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          weatherCodexHarnessAgent,
+          chatId,
+        );
+
+        const result = await weatherCodexHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/codex/workflow-stepped/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/codex/workflow-stepped/route.ts
@@ -1,9 +1,11 @@
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   type UIMessage,
   type UIMessageChunk,
 } from 'ai';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import { start } from 'workflow/api';
 import { agentWorkflow } from './workflow';
 
@@ -13,9 +15,17 @@ export async function POST(request: Request) {
     return new Response('Missing chat id', { status: 400 });
   }
 
+  const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
-  const run = await start(agentWorkflow, [{ messages, sessionId: body.id }]);
   return createUIMessageStreamResponse({
-    stream: run.readable as ReadableStream<UIMessageChunk>,
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const run = await start(agentWorkflow, [
+          { messages, sessionId: chatId },
+        ]);
+        writer.merge(run.readable as ReadableStream<UIMessageChunk>);
+      },
+      onError: getHarnessE2EErrorMessage,
+    }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/codex/workflow-timed/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/codex/workflow-timed/route.ts
@@ -1,9 +1,11 @@
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   type UIMessage,
   type UIMessageChunk,
 } from 'ai';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import { start } from 'workflow/api';
 import { timeSliceWorkflow } from './workflow';
 
@@ -23,12 +25,17 @@ export async function POST(request: Request) {
     return new Response('Missing chat id', { status: 400 });
   }
 
+  const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
-  const run = await start(timeSliceWorkflow, [
-    { messages, sessionId: body.id },
-  ]);
-
   return createUIMessageStreamResponse({
-    stream: run.readable as ReadableStream<UIMessageChunk>,
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const run = await start(timeSliceWorkflow, [
+          { messages, sessionId: chatId },
+        ]);
+        writer.merge(run.readable as ReadableStream<UIMessageChunk>);
+      },
+      onError: getHarnessE2EErrorMessage,
+    }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/deepagents/ai-sdk-coding/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/deepagents/ai-sdk-coding/route.ts
@@ -1,10 +1,12 @@
 import { aiSdkCodingDeepAgentsHarnessAgent } from '@/agent/harness/deepagents/ai-sdk-coding-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,20 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    aiSdkCodingDeepAgentsHarnessAgent,
-    chatId,
-  );
-
-  const result = await aiSdkCodingDeepAgentsHarnessAgent.stream({
-    session,
-    messages,
-  });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          aiSdkCodingDeepAgentsHarnessAgent,
+          chatId,
+        );
+
+        const result = await aiSdkCodingDeepAgentsHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/deepagents/basic-with-stop/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/deepagents/basic-with-stop/route.ts
@@ -1,10 +1,12 @@
 import { deepAgentsHarnessAgent } from '@/agent/harness/deepagents/basic-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   resumeOrCreateSession,
   stopAndPersist,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,14 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(deepAgentsHarnessAgent, chatId);
-
-  const result = await deepAgentsHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => stopAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          deepAgentsHarnessAgent,
+          chatId,
+        );
+
+        const result = await deepAgentsHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => stopAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/deepagents/basic/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/deepagents/basic/route.ts
@@ -1,10 +1,12 @@
 import { deepAgentsHarnessAgent } from '@/agent/harness/deepagents/basic-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,15 +24,29 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(deepAgentsHarnessAgent, chatId);
-
-  const result = await deepAgentsHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      originalMessages: body.messages,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          deepAgentsHarnessAgent,
+          chatId,
+        );
+
+        const result = await deepAgentsHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            originalMessages: body.messages,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/deepagents/weather-approval/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/deepagents/weather-approval/route.ts
@@ -1,10 +1,12 @@
 import { weatherApprovalDeepAgentsHarnessAgent } from '@/agent/harness/deepagents/weather-approval-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,21 +24,29 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    weatherApprovalDeepAgentsHarnessAgent,
-    chatId,
-  );
-
-  const result = await weatherApprovalDeepAgentsHarnessAgent.stream({
-    session,
-    messages,
-  });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      originalMessages: body.messages,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          weatherApprovalDeepAgentsHarnessAgent,
+          chatId,
+        );
+
+        const result = await weatherApprovalDeepAgentsHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            originalMessages: body.messages,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/deepagents/weather-only/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/deepagents/weather-only/route.ts
@@ -1,10 +1,12 @@
 import { weatherDeepAgentsHarnessAgent } from '@/agent/harness/deepagents/weather-only-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,20 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    weatherDeepAgentsHarnessAgent,
-    chatId,
-  );
-
-  const result = await weatherDeepAgentsHarnessAgent.stream({
-    session,
-    messages,
-  });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          weatherDeepAgentsHarnessAgent,
+          chatId,
+        );
+
+        const result = await weatherDeepAgentsHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/deepagents/weather/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/deepagents/weather/route.ts
@@ -1,10 +1,12 @@
 import { weatherDeepAgentsHarnessAgent } from '@/agent/harness/deepagents/weather-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,20 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    weatherDeepAgentsHarnessAgent,
-    chatId,
-  );
-
-  const result = await weatherDeepAgentsHarnessAgent.stream({
-    session,
-    messages,
-  });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          weatherDeepAgentsHarnessAgent,
+          chatId,
+        );
+
+        const result = await weatherDeepAgentsHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/deepagents/workflow-stepped/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/deepagents/workflow-stepped/route.ts
@@ -1,9 +1,11 @@
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   type UIMessage,
   type UIMessageChunk,
 } from 'ai';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import { start } from 'workflow/api';
 import { agentWorkflow } from './workflow';
 
@@ -13,9 +15,17 @@ export async function POST(request: Request) {
     return new Response('Missing chat id', { status: 400 });
   }
 
+  const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
-  const run = await start(agentWorkflow, [{ messages, sessionId: body.id }]);
   return createUIMessageStreamResponse({
-    stream: run.readable as ReadableStream<UIMessageChunk>,
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const run = await start(agentWorkflow, [
+          { messages, sessionId: chatId },
+        ]);
+        writer.merge(run.readable as ReadableStream<UIMessageChunk>);
+      },
+      onError: getHarnessE2EErrorMessage,
+    }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/deepagents/workflow-timed/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/deepagents/workflow-timed/route.ts
@@ -1,9 +1,11 @@
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   type UIMessage,
   type UIMessageChunk,
 } from 'ai';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import { start } from 'workflow/api';
 import { timeSliceWorkflow } from './workflow';
 
@@ -18,16 +20,21 @@ export async function POST(request: Request) {
     return new Response('Missing chat id', { status: 400 });
   }
 
+  const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
   /*
    * The chat id is the stable harness session id. The complete message list
    * lets HarnessAgent identify new turns and tool continuations.
    */
-  const run = await start(timeSliceWorkflow, [
-    { messages, sessionId: body.id },
-  ]);
-
   return createUIMessageStreamResponse({
-    stream: run.readable as ReadableStream<UIMessageChunk>,
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const run = await start(timeSliceWorkflow, [
+          { messages, sessionId: chatId },
+        ]);
+        writer.merge(run.readable as ReadableStream<UIMessageChunk>);
+      },
+      onError: getHarnessE2EErrorMessage,
+    }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/opencode/ai-sdk-coding/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/opencode/ai-sdk-coding/route.ts
@@ -1,10 +1,12 @@
 import { aiSdkCodingOpenCodeHarnessAgent } from '@/agent/harness/opencode/ai-sdk-coding-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,20 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    aiSdkCodingOpenCodeHarnessAgent,
-    chatId,
-  );
-
-  const result = await aiSdkCodingOpenCodeHarnessAgent.stream({
-    session,
-    messages,
-  });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          aiSdkCodingOpenCodeHarnessAgent,
+          chatId,
+        );
+
+        const result = await aiSdkCodingOpenCodeHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/opencode/basic-with-stop/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/opencode/basic-with-stop/route.ts
@@ -1,10 +1,12 @@
 import { openCodeHarnessAgent } from '@/agent/harness/opencode/basic-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   resumeOrCreateSession,
   stopAndPersist,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,16 +24,27 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(openCodeHarnessAgent, chatId);
-
-  const result = await openCodeHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      // Stop the session at the end of the turn so the next request resumes
-      // from the persisted snapshot rather than attaching to a parked bridge.
-      onFinish: () => stopAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          openCodeHarnessAgent,
+          chatId,
+        );
+
+        const result = await openCodeHarnessAgent.stream({ session, messages });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            // Stop the session at the end of the turn so the next request resumes
+            // from the persisted snapshot rather than attaching to a parked bridge.
+            onFinish: () => stopAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/opencode/basic/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/opencode/basic/route.ts
@@ -1,10 +1,12 @@
 import { openCodeHarnessAgent } from '@/agent/harness/opencode/basic-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,15 +24,26 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(openCodeHarnessAgent, chatId);
-
-  const result = await openCodeHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      originalMessages: body.messages,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          openCodeHarnessAgent,
+          chatId,
+        );
+
+        const result = await openCodeHarnessAgent.stream({ session, messages });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            originalMessages: body.messages,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/opencode/weather-approval/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/opencode/weather-approval/route.ts
@@ -1,10 +1,12 @@
 import { weatherApprovalOpenCodeHarnessAgent } from '@/agent/harness/opencode/weather-approval-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,21 +24,29 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    weatherApprovalOpenCodeHarnessAgent,
-    chatId,
-  );
-
-  const result = await weatherApprovalOpenCodeHarnessAgent.stream({
-    session,
-    messages,
-  });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      originalMessages: body.messages,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          weatherApprovalOpenCodeHarnessAgent,
+          chatId,
+        );
+
+        const result = await weatherApprovalOpenCodeHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            originalMessages: body.messages,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/opencode/weather-only/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/opencode/weather-only/route.ts
@@ -1,10 +1,12 @@
 import { weatherOpenCodeHarnessAgent } from '@/agent/harness/opencode/weather-only-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,20 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    weatherOpenCodeHarnessAgent,
-    chatId,
-  );
-
-  const result = await weatherOpenCodeHarnessAgent.stream({
-    session,
-    messages,
-  });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          weatherOpenCodeHarnessAgent,
+          chatId,
+        );
+
+        const result = await weatherOpenCodeHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/opencode/weather/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/opencode/weather/route.ts
@@ -1,10 +1,12 @@
 import { weatherOpenCodeHarnessAgent } from '@/agent/harness/opencode/weather-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,20 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    weatherOpenCodeHarnessAgent,
-    chatId,
-  );
-
-  const result = await weatherOpenCodeHarnessAgent.stream({
-    session,
-    messages,
-  });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          weatherOpenCodeHarnessAgent,
+          chatId,
+        );
+
+        const result = await weatherOpenCodeHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/opencode/workflow-stepped/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/opencode/workflow-stepped/route.ts
@@ -1,9 +1,11 @@
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   type UIMessage,
   type UIMessageChunk,
 } from 'ai';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import { start } from 'workflow/api';
 import { agentWorkflow } from './workflow';
 
@@ -13,9 +15,17 @@ export async function POST(request: Request) {
     return new Response('Missing chat id', { status: 400 });
   }
 
+  const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
-  const run = await start(agentWorkflow, [{ messages, sessionId: body.id }]);
   return createUIMessageStreamResponse({
-    stream: run.readable as ReadableStream<UIMessageChunk>,
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const run = await start(agentWorkflow, [
+          { messages, sessionId: chatId },
+        ]);
+        writer.merge(run.readable as ReadableStream<UIMessageChunk>);
+      },
+      onError: getHarnessE2EErrorMessage,
+    }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/opencode/workflow-timed/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/opencode/workflow-timed/route.ts
@@ -1,9 +1,11 @@
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   type UIMessage,
   type UIMessageChunk,
 } from 'ai';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import { start } from 'workflow/api';
 import { timeSliceWorkflow } from './workflow';
 
@@ -23,12 +25,17 @@ export async function POST(request: Request) {
     return new Response('Missing chat id', { status: 400 });
   }
 
+  const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
-  const run = await start(timeSliceWorkflow, [
-    { messages, sessionId: body.id },
-  ]);
-
   return createUIMessageStreamResponse({
-    stream: run.readable as ReadableStream<UIMessageChunk>,
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const run = await start(timeSliceWorkflow, [
+          { messages, sessionId: chatId },
+        ]);
+        writer.merge(run.readable as ReadableStream<UIMessageChunk>);
+      },
+      onError: getHarnessE2EErrorMessage,
+    }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/pi/ai-sdk-coding/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/pi/ai-sdk-coding/route.ts
@@ -1,10 +1,12 @@
 import { aiSdkCodingPiHarnessAgent } from '@/agent/harness/pi/ai-sdk-coding-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,17 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    aiSdkCodingPiHarnessAgent,
-    chatId,
-  );
-
-  const result = await aiSdkCodingPiHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          aiSdkCodingPiHarnessAgent,
+          chatId,
+        );
+
+        const result = await aiSdkCodingPiHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/pi/basic-with-stop/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/pi/basic-with-stop/route.ts
@@ -1,10 +1,12 @@
 import { piHarnessAgent } from '@/agent/harness/pi/basic-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   resumeOrCreateSession,
   stopAndPersist,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,16 +24,24 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(piHarnessAgent, chatId);
-
-  const result = await piHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      // Stop the session at the end of the turn so the next request resumes
-      // from the persisted snapshot rather than attaching to a parked bridge.
-      onFinish: () => stopAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(piHarnessAgent, chatId);
+
+        const result = await piHarnessAgent.stream({ session, messages });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            // Stop the session at the end of the turn so the next request resumes
+            // from the persisted snapshot rather than attaching to a parked bridge.
+            onFinish: () => stopAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/pi/basic/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/pi/basic/route.ts
@@ -1,10 +1,12 @@
 import { piHarnessAgent } from '@/agent/harness/pi/basic-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,15 +24,23 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(piHarnessAgent, chatId);
-
-  const result = await piHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      originalMessages: body.messages,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(piHarnessAgent, chatId);
+
+        const result = await piHarnessAgent.stream({ session, messages });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            originalMessages: body.messages,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/pi/weather-approval/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/pi/weather-approval/route.ts
@@ -1,10 +1,12 @@
 import { weatherApprovalPiHarnessAgent } from '@/agent/harness/pi/weather-approval-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,21 +24,29 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(
-    weatherApprovalPiHarnessAgent,
-    chatId,
-  );
-
-  const result = await weatherApprovalPiHarnessAgent.stream({
-    session,
-    messages,
-  });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      originalMessages: body.messages,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          weatherApprovalPiHarnessAgent,
+          chatId,
+        );
+
+        const result = await weatherApprovalPiHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            originalMessages: body.messages,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/pi/weather-only/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/pi/weather-only/route.ts
@@ -1,10 +1,12 @@
 import { weatherPiHarnessAgent } from '@/agent/harness/pi/weather-only-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,14 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(weatherPiHarnessAgent, chatId);
-
-  const result = await weatherPiHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          weatherPiHarnessAgent,
+          chatId,
+        );
+
+        const result = await weatherPiHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/pi/weather/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/pi/weather/route.ts
@@ -1,10 +1,12 @@
 import { weatherPiHarnessAgent } from '@/agent/harness/pi/weather-agent';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import {
   detachAndPersist,
   resumeOrCreateSession,
 } from '@/util/harness-resume-store';
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   toUIMessageStream,
   type UIMessage,
@@ -22,14 +24,28 @@ export async function POST(request: Request) {
   const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
 
-  const session = await resumeOrCreateSession(weatherPiHarnessAgent, chatId);
-
-  const result = await weatherPiHarnessAgent.stream({ session, messages });
-
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream({
-      stream: result.stream,
-      onFinish: () => detachAndPersist(chatId, session),
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const session = await resumeOrCreateSession(
+          weatherPiHarnessAgent,
+          chatId,
+        );
+
+        const result = await weatherPiHarnessAgent.stream({
+          session,
+          messages,
+        });
+
+        writer.merge(
+          toUIMessageStream({
+            stream: result.stream,
+            onError: getHarnessE2EErrorMessage,
+            onFinish: () => detachAndPersist(chatId, session),
+          }),
+        );
+      },
+      onError: getHarnessE2EErrorMessage,
     }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/pi/workflow-stepped/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/pi/workflow-stepped/route.ts
@@ -1,9 +1,11 @@
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   type UIMessage,
   type UIMessageChunk,
 } from 'ai';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import { start } from 'workflow/api';
 import { agentWorkflow } from './workflow';
 
@@ -13,9 +15,17 @@ export async function POST(request: Request) {
     return new Response('Missing chat id', { status: 400 });
   }
 
+  const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
-  const run = await start(agentWorkflow, [{ messages, sessionId: body.id }]);
   return createUIMessageStreamResponse({
-    stream: run.readable as ReadableStream<UIMessageChunk>,
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const run = await start(agentWorkflow, [
+          { messages, sessionId: chatId },
+        ]);
+        writer.merge(run.readable as ReadableStream<UIMessageChunk>);
+      },
+      onError: getHarnessE2EErrorMessage,
+    }),
   });
 }

--- a/examples/harness-e2e-next/app/api/harness/pi/workflow-timed/route.ts
+++ b/examples/harness-e2e-next/app/api/harness/pi/workflow-timed/route.ts
@@ -1,9 +1,11 @@
 import {
   convertToModelMessages,
+  createUIMessageStream,
   createUIMessageStreamResponse,
   type UIMessage,
   type UIMessageChunk,
 } from 'ai';
+import { getHarnessE2EErrorMessage } from '@/util/harness-ui-stream';
 import { start } from 'workflow/api';
 import { timeSliceWorkflow } from './workflow';
 
@@ -23,12 +25,17 @@ export async function POST(request: Request) {
     return new Response('Missing chat id', { status: 400 });
   }
 
+  const chatId = body.id;
   const messages = await convertToModelMessages(body.messages);
-  const run = await start(timeSliceWorkflow, [
-    { messages, sessionId: body.id },
-  ]);
-
   return createUIMessageStreamResponse({
-    stream: run.readable as ReadableStream<UIMessageChunk>,
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        const run = await start(timeSliceWorkflow, [
+          { messages, sessionId: chatId },
+        ]);
+        writer.merge(run.readable as ReadableStream<UIMessageChunk>);
+      },
+      onError: getHarnessE2EErrorMessage,
+    }),
   });
 }

--- a/examples/harness-e2e-next/util/harness-ui-stream.ts
+++ b/examples/harness-e2e-next/util/harness-ui-stream.ts
@@ -1,0 +1,17 @@
+import { getHarnessErrorMessage } from '@ai-sdk/harness/agent';
+import { getErrorMessage } from '@ai-sdk/provider-utils';
+
+const genericHarnessErrorMessage = getHarnessErrorMessage(undefined);
+
+export function getHarnessE2EErrorMessage(error: unknown): string {
+  console.error(error);
+
+  const safeMessage = getHarnessErrorMessage(error);
+  if (safeMessage !== genericHarnessErrorMessage) {
+    return safeMessage;
+  }
+
+  const transparentMessage =
+    error instanceof Error ? error.message : getErrorMessage(error);
+  return transparentMessage || genericHarnessErrorMessage;
+}

--- a/packages/harness/agent/index.ts
+++ b/packages/harness/agent/index.ts
@@ -52,6 +52,8 @@ export type {
 } from '../src/agent/observability/types';
 export { HarnessError } from '../src/errors/harness-error';
 export { HarnessCapabilityUnsupportedError } from '../src/errors/harness-capability-unsupported-error';
+export { HarnessSandboxAuthenticationError } from '../src/errors/harness-sandbox-authentication-error';
+export { getHarnessErrorMessage } from '../src/agent/get-harness-error-message';
 export {
   createFileReporter,
   createTraceTreeReporter,

--- a/packages/harness/src/agent/get-harness-error-message.test.ts
+++ b/packages/harness/src/agent/get-harness-error-message.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { HarnessCapabilityUnsupportedError } from '../errors/harness-capability-unsupported-error';
+import { HarnessError } from '../errors/harness-error';
+import { HarnessSandboxAuthenticationError } from '../errors/harness-sandbox-authentication-error';
+import { getHarnessErrorMessage } from './get-harness-error-message';
+
+describe('getHarnessErrorMessage', () => {
+  it.each([
+    new HarnessError({ message: 'Invalid harness state.' }),
+    new HarnessCapabilityUnsupportedError({
+      message: 'This capability is unavailable.',
+    }),
+    new HarnessSandboxAuthenticationError({
+      message: 'Configure sandbox credentials.',
+      sandboxProviderId: 'test',
+    }),
+  ])('preserves reviewed harness error messages', error => {
+    expect(getHarnessErrorMessage(error)).toBe(error.message);
+  });
+
+  it('masks unknown errors', () => {
+    expect(getHarnessErrorMessage(new Error('secret details'))).toBe(
+      'An error occurred.',
+    );
+  });
+
+  it('masks unreviewed HarnessError subclasses', () => {
+    class UnknownHarnessError extends HarnessError {
+      constructor() {
+        super({ message: 'unreviewed details' });
+        Object.defineProperty(this, 'name', {
+          value: 'AI_UnknownHarnessError',
+        });
+      }
+    }
+
+    expect(getHarnessErrorMessage(new UnknownHarnessError())).toBe(
+      'An error occurred.',
+    );
+  });
+});

--- a/packages/harness/src/agent/get-harness-error-message.ts
+++ b/packages/harness/src/agent/get-harness-error-message.ts
@@ -1,0 +1,23 @@
+import { HarnessCapabilityUnsupportedError } from '../errors/harness-capability-unsupported-error';
+import { HarnessError } from '../errors/harness-error';
+import { HarnessSandboxAuthenticationError } from '../errors/harness-sandbox-authentication-error';
+
+const defaultErrorMessage = 'An error occurred.';
+
+/**
+ * Returns a client-safe message for errors produced by the harness runtime.
+ * Messages from explicitly reviewed harness error types are preserved. All
+ * other errors are masked so provider, sandbox, and server details are not
+ * exposed to clients by default.
+ */
+export function getHarnessErrorMessage(error: unknown): string {
+  if (
+    HarnessCapabilityUnsupportedError.isInstance(error) ||
+    HarnessSandboxAuthenticationError.isInstance(error) ||
+    (HarnessError.isInstance(error) && error.name === 'AI_HarnessError')
+  ) {
+    return error.message;
+  }
+
+  return defaultErrorMessage;
+}

--- a/packages/harness/src/errors/harness-sandbox-authentication-error.test.ts
+++ b/packages/harness/src/errors/harness-sandbox-authentication-error.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+import { HarnessError } from './harness-error';
+import { HarnessSandboxAuthenticationError } from './harness-sandbox-authentication-error';
+
+describe('HarnessSandboxAuthenticationError', () => {
+  test('is a HarnessError', () => {
+    const err = new HarnessSandboxAuthenticationError({
+      message: 'Sandbox authentication failed',
+      sandboxProviderId: 'test-sandbox',
+    });
+
+    expect(HarnessError.isInstance(err)).toBe(true);
+    expect(HarnessSandboxAuthenticationError.isInstance(err)).toBe(true);
+  });
+
+  test('preserves the supplied message and sandboxProviderId', () => {
+    const err = new HarnessSandboxAuthenticationError({
+      message: 'Set a sandbox API key',
+      sandboxProviderId: 'test-sandbox',
+    });
+
+    expect(err.message).toBe('Set a sandbox API key');
+    expect(err.sandboxProviderId).toBe('test-sandbox');
+  });
+
+  test('preserves cause', () => {
+    const cause = new Error('inner');
+    const err = new HarnessSandboxAuthenticationError({
+      message: 'Sandbox authentication failed',
+      sandboxProviderId: 'test-sandbox',
+      cause,
+    });
+
+    expect(err.cause).toBe(cause);
+  });
+
+  test('isInstance returns false for unrelated errors', () => {
+    expect(HarnessSandboxAuthenticationError.isInstance(new Error('x'))).toBe(
+      false,
+    );
+    expect(HarnessSandboxAuthenticationError.isInstance(null)).toBe(false);
+  });
+});

--- a/packages/harness/src/errors/harness-sandbox-authentication-error.ts
+++ b/packages/harness/src/errors/harness-sandbox-authentication-error.ts
@@ -1,0 +1,38 @@
+import { AISDKError } from '@ai-sdk/provider';
+import { HarnessError } from './harness-error';
+
+const name = 'AI_HarnessSandboxAuthenticationError';
+const marker = `vercel.ai.error.${name}`;
+const symbol = Symbol.for(marker);
+
+/**
+ * Thrown when a sandbox provider cannot authenticate or authorize the
+ * operation needed to create or resume a harness sandbox. Providers should
+ * preserve the underlying SDK failure as `cause` and supply a message that
+ * explains how the consumer can configure credentials.
+ */
+export class HarnessSandboxAuthenticationError extends HarnessError {
+  private readonly [symbol] = true;
+
+  readonly sandboxProviderId: string;
+
+  constructor({
+    message,
+    sandboxProviderId,
+    cause,
+  }: {
+    message: string;
+    sandboxProviderId: string;
+    cause?: unknown;
+  }) {
+    super({ message, cause });
+    Object.defineProperty(this, 'name', { value: name });
+    this.sandboxProviderId = sandboxProviderId;
+  }
+
+  static isInstance(
+    error: unknown,
+  ): error is HarnessSandboxAuthenticationError {
+    return AISDKError.hasMarker(error, marker);
+  }
+}

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,3 +1,4 @@
 export * from './v1';
 export * from './errors/harness-error';
 export * from './errors/harness-capability-unsupported-error';
+export * from './errors/harness-sandbox-authentication-error';

--- a/packages/harness/src/v1/harness-v1-sandbox-provider.ts
+++ b/packages/harness/src/v1/harness-v1-sandbox-provider.ts
@@ -23,6 +23,12 @@ export interface HarnessV1SandboxProvider {
    */
   readonly bridgePorts?: ReadonlyArray<number>;
 
+  /**
+   * Providers should throw `HarnessSandboxAuthenticationError` when sandbox
+   * acquisition fails because credentials are missing, invalid, or not
+   * authorized. This lets framework integrations distinguish configuration
+   * failures from general sandbox infrastructure errors.
+   */
   readonly createSession: (options?: {
     /**
      * Stable per-session identifier. When supplied, the provider names the

--- a/packages/sandbox-vercel/README.md
+++ b/packages/sandbox-vercel/README.md
@@ -34,6 +34,17 @@ console.log(stdout); // "hi"
 await networkSandboxSession.stop();
 ```
 
+## Authentication
+
+Vercel Sandbox accepts `VERCEL_OIDC_TOKEN`, or explicit `token`, `teamId`, and
+`projectId` settings. For local OIDC authentication, link the application with
+`vercel link`, run `vercel env pull`, and load the generated `.env.local` before
+starting it.
+
+Credential resolution failures throw
+`HarnessSandboxAuthenticationError` from `@ai-sdk/harness` and preserve the
+underlying Vercel SDK error as `cause`.
+
 `networkSandboxSession.restricted()` is typed as `Experimental_SandboxSession`, so it's safe to pass to AI SDK tools that accept `experimental_sandbox`. The network sandbox session itself carries the infra surface (`ports`, `getPortUrl`, `setNetworkPolicy`, `stop`) that only the harness should reach for.
 
 The flat-field settings are aliased directly from `@vercel/sandbox`'s `Sandbox.create` parameters, so every option Vercel supports — including its native `NetworkPolicy` — is available without re-declaration:

--- a/packages/sandbox-vercel/src/vercel-sandbox.test.ts
+++ b/packages/sandbox-vercel/src/vercel-sandbox.test.ts
@@ -1,5 +1,6 @@
 import type { Sandbox } from '@vercel/sandbox';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HarnessSandboxAuthenticationError } from '@ai-sdk/harness';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createVercelSandbox } from './vercel-sandbox';
 
 const { createMock, getMock, getOrCreateMock } = vi.hoisted(() => ({
@@ -46,6 +47,15 @@ function makeMockSandbox(overrides: Partial<MockSpies> = {}) {
     sandbox,
     spies: { domain, update, runCommand, stop, delete: deleteSandbox, routes },
   };
+}
+
+async function captureError(promise: PromiseLike<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected promise to reject');
 }
 
 describe('createVercelSandbox (wrap existing)', () => {
@@ -237,6 +247,83 @@ describe('createVercelSandbox (create from scratch)', () => {
         [key: symbol]: Map<string, string> | undefined;
       }
     )[Symbol.for('ai-sdk.harness.vercel-template-snapshots')]?.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('reports the opaque missing-auth path failure as sandbox authentication', async () => {
+    vi.stubEnv('VERCEL_OIDC_TOKEN', '');
+    const cause = Object.assign(
+      new TypeError(
+        'The "path" argument must be of type string. Received undefined',
+      ),
+      { code: 'ERR_INVALID_ARG_TYPE' },
+    );
+    createMock.mockRejectedValueOnce(cause);
+
+    const error = await captureError(createVercelSandbox({}).createSession());
+
+    expect(HarnessSandboxAuthenticationError.isInstance(error)).toBe(true);
+    if (!HarnessSandboxAuthenticationError.isInstance(error)) {
+      throw new Error('Expected sandbox authentication error');
+    }
+    expect(error.message).toMatchInlineSnapshot(
+      `"Vercel Sandbox authentication failed. Set VERCEL_OIDC_TOKEN, or pass token, teamId, and projectId to createVercelSandbox(), then verify that they can access Vercel Sandbox."`,
+    );
+    expect(error.sandboxProviderId).toBe('vercel-sandbox');
+    expect(error.cause).toBe(cause);
+  });
+
+  it('reports nested OIDC credential failures as sandbox authentication', async () => {
+    const cause = Object.assign(new Error('Could not resolve local OIDC'), {
+      name: 'LocalOidcContextError',
+    });
+    getMock.mockRejectedValueOnce(
+      Object.assign(new Error('Sandbox lookup failed'), { cause }),
+    );
+
+    const error = await captureError(
+      createVercelSandbox({}).resumeSession!({
+        sessionId: 'session-123',
+      }),
+    );
+
+    expect(HarnessSandboxAuthenticationError.isInstance(error)).toBe(true);
+    if (!HarnessSandboxAuthenticationError.isInstance(error)) {
+      throw new Error('Expected sandbox authentication error');
+    }
+    expect(error.cause).toMatchInlineSnapshot(`[Error: Sandbox lookup failed]`);
+  });
+
+  it('preserves unrelated Vercel Sandbox failures', async () => {
+    const cause = new Error('Sandbox service unavailable');
+    createMock.mockRejectedValueOnce(cause);
+
+    const error = await captureError(createVercelSandbox({}).createSession());
+
+    expect(error).toBe(cause);
+  });
+
+  it('does not treat an opaque path error as missing auth when explicit credentials are configured', async () => {
+    const cause = Object.assign(
+      new TypeError(
+        'The "path" argument must be of type string. Received undefined',
+      ),
+      { code: 'ERR_INVALID_ARG_TYPE' },
+    );
+    createMock.mockRejectedValueOnce(cause);
+
+    const error = await captureError(
+      createVercelSandbox({
+        token: 'token_test',
+        teamId: 'team_test',
+        projectId: 'prj_test',
+      }).createSession(),
+    );
+
+    expect(error).toBe(cause);
   });
 
   it('applies a 30 minute default timeout when none is provided', async () => {

--- a/packages/sandbox-vercel/src/vercel-sandbox.ts
+++ b/packages/sandbox-vercel/src/vercel-sandbox.ts
@@ -1,6 +1,7 @@
-import type {
-  HarnessV1NetworkSandboxSession,
-  HarnessV1SandboxProvider,
+import {
+  HarnessSandboxAuthenticationError,
+  type HarnessV1NetworkSandboxSession,
+  type HarnessV1SandboxProvider,
 } from '@ai-sdk/harness';
 import type { Experimental_SandboxSession as SandboxSession } from '@ai-sdk/provider-utils';
 import { Sandbox } from '@vercel/sandbox';
@@ -150,10 +151,14 @@ export class VercelSandboxProvider implements HarnessV1SandboxProvider {
       : {};
 
     if (identity == null || onFirstCreate == null) {
-      const sandbox = await Sandbox.create({
-        ...baseParams,
-        ...sessionNameOverride,
-        ...(options?.abortSignal ? { signal: options.abortSignal } : {}),
+      const sandbox = await withVercelSandboxAuthenticationError({
+        settings: this.settings,
+        operation: () =>
+          Sandbox.create({
+            ...baseParams,
+            ...sessionNameOverride,
+            ...(options?.abortSignal ? { signal: options.abortSignal } : {}),
+          }),
       });
       return new VercelNetworkSandboxSession({ sandbox, ownsLifecycle: true });
     }
@@ -163,30 +168,44 @@ export class VercelSandboxProvider implements HarnessV1SandboxProvider {
     let snapshotId = cache.get(templateName);
 
     if (snapshotId == null) {
-      const template = await Sandbox.getOrCreate({
-        ...baseParams,
-        name: templateName,
-        persistent: true,
-        snapshotExpiration: baseParams.snapshotExpiration ?? 0,
-        onCreate: async sbx => {
-          await onFirstCreate(new VercelSandboxSession(sbx), {
-            abortSignal: options?.abortSignal,
-          });
-        },
-        ...(options?.abortSignal ? { signal: options.abortSignal } : {}),
+      const template = await withVercelSandboxAuthenticationError({
+        settings: this.settings,
+        operation: () =>
+          Sandbox.getOrCreate({
+            ...baseParams,
+            name: templateName,
+            persistent: true,
+            snapshotExpiration: baseParams.snapshotExpiration ?? 0,
+            onCreate: async sbx => {
+              await onFirstCreate(new VercelSandboxSession(sbx), {
+                abortSignal: options?.abortSignal,
+              });
+            },
+            ...(options?.abortSignal ? { signal: options.abortSignal } : {}),
+          }),
       });
 
       let resolvedId: string | undefined = template.currentSnapshotId;
       if (resolvedId == null) {
-        const stopResult = await template.stop(
-          options?.abortSignal ? { signal: options.abortSignal } : undefined,
-        );
+        const stopResult = await withVercelSandboxAuthenticationError({
+          settings: this.settings,
+          operation: () =>
+            template.stop(
+              options?.abortSignal
+                ? { signal: options.abortSignal }
+                : undefined,
+            ),
+        });
         resolvedId = stopResult.snapshot?.id;
         if (resolvedId == null) {
-          resolvedId = await pollForTemplateSnapshot({
-            name: templateName,
-            lookupParams: getSandboxLookupParams(baseParams),
-            abortSignal: options?.abortSignal,
+          resolvedId = await withVercelSandboxAuthenticationError({
+            settings: this.settings,
+            operation: () =>
+              pollForTemplateSnapshot({
+                name: templateName,
+                lookupParams: getSandboxLookupParams(baseParams),
+                abortSignal: options?.abortSignal,
+              }),
           });
         }
       }
@@ -202,11 +221,15 @@ export class VercelSandboxProvider implements HarnessV1SandboxProvider {
       ...forkParams
     } = baseParams;
 
-    const fork = await Sandbox.create({
-      ...forkParams,
-      source: { type: 'snapshot', snapshotId },
-      ...sessionNameOverride,
-      ...(options?.abortSignal ? { signal: options.abortSignal } : {}),
+    const fork = await withVercelSandboxAuthenticationError({
+      settings: this.settings,
+      operation: () =>
+        Sandbox.create({
+          ...forkParams,
+          source: { type: 'snapshot', snapshotId },
+          ...sessionNameOverride,
+          ...(options?.abortSignal ? { signal: options.abortSignal } : {}),
+        }),
     });
     return new VercelNetworkSandboxSession({
       sandbox: fork,
@@ -228,10 +251,14 @@ export class VercelSandboxProvider implements HarnessV1SandboxProvider {
       });
     }
 
-    const sandbox = await Sandbox.get({
-      ...getSandboxLookupParams(this.settings),
-      name: sessionSandboxName(options.sessionId),
-      ...(options.abortSignal ? { signal: options.abortSignal } : {}),
+    const sandbox = await withVercelSandboxAuthenticationError({
+      settings: this.settings,
+      operation: () =>
+        Sandbox.get({
+          ...getSandboxLookupParams(this.settings),
+          name: sessionSandboxName(options.sessionId),
+          ...(options.abortSignal ? { signal: options.abortSignal } : {}),
+        }),
     });
     return new VercelNetworkSandboxSession({ sandbox, ownsLifecycle: true });
   };
@@ -286,6 +313,110 @@ function getSnapshotCache(): SnapshotCache {
   }
   return cache;
 }
+
+const VERCEL_SANDBOX_AUTHENTICATION_MESSAGE =
+  'Vercel Sandbox authentication failed. Set VERCEL_OIDC_TOKEN, or pass token, teamId, and projectId to createVercelSandbox(), then verify that they can access Vercel Sandbox.';
+
+async function withVercelSandboxAuthenticationError<T>({
+  settings,
+  operation,
+}: {
+  settings: VercelSandboxSettings;
+  operation: () => Promise<T>;
+}): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (
+      !isVercelSandboxAuthenticationFailure({
+        error,
+        hasConfiguredCredentials: hasConfiguredCredentials(settings),
+      })
+    ) {
+      throw error;
+    }
+    throw new HarnessSandboxAuthenticationError({
+      message: VERCEL_SANDBOX_AUTHENTICATION_MESSAGE,
+      sandboxProviderId: VERCEL_PROVIDER_ID,
+      cause: error,
+    });
+  }
+}
+
+function hasConfiguredCredentials(settings: VercelSandboxSettings): boolean {
+  if (process.env.VERCEL_OIDC_TOKEN) return true;
+  if ('sandbox' in settings && settings.sandbox != null) return true;
+  const { token, teamId, projectId } = getSandboxLookupParams(settings);
+  return Boolean(token && teamId && projectId);
+}
+
+function isVercelSandboxAuthenticationFailure({
+  error,
+  hasConfiguredCredentials,
+}: {
+  error: unknown;
+  hasConfiguredCredentials: boolean;
+}): boolean {
+  const seen = new Set<unknown>();
+  let current = error;
+  while (current != null && !seen.has(current)) {
+    seen.add(current);
+    if (typeof current === 'object') {
+      const candidate = current as {
+        name?: unknown;
+        message?: unknown;
+        code?: unknown;
+        cause?: unknown;
+        response?: { status?: unknown; statusCode?: unknown };
+      };
+      if (
+        candidate.response?.status === 401 ||
+        candidate.response?.status === 403 ||
+        candidate.response?.statusCode === 401 ||
+        candidate.response?.statusCode === 403
+      ) {
+        return true;
+      }
+      if (
+        typeof candidate.name === 'string' &&
+        VERCEL_AUTHENTICATION_ERROR_NAMES.has(candidate.name)
+      ) {
+        return true;
+      }
+      if (
+        typeof candidate.message === 'string' &&
+        VERCEL_AUTHENTICATION_ERROR_MESSAGE.test(candidate.message)
+      ) {
+        return true;
+      }
+      if (
+        !hasConfiguredCredentials &&
+        candidate.code === 'ERR_INVALID_ARG_TYPE' &&
+        typeof candidate.message === 'string' &&
+        candidate.message.includes('"path" argument') &&
+        candidate.message.includes('Received undefined')
+      ) {
+        return true;
+      }
+      current = candidate.cause;
+      continue;
+    }
+    break;
+  }
+  return false;
+}
+
+const VERCEL_AUTHENTICATION_ERROR_NAMES = new Set([
+  'AccessTokenMissingError',
+  'LocalOidcContextError',
+  'OAuthError',
+  'RefreshAccessTokenFailedError',
+  'VercelOidcContextError',
+  'VercelOidcTokenError',
+]);
+
+const VERCEL_AUTHENTICATION_ERROR_MESSAGE =
+  /Could not get credentials from OIDC context|No authentication found|Failed to (?:retrieve|refresh) authentication token|Missing credentials parameters to access the Vercel API|Authentication failed/i;
 
 async function pollForTemplateSnapshot({
   name,


### PR DESCRIPTION
## Background

Vercel Sandbox authentication failures could surface as an unrelated Node.js `path` argument error. Additionally, failures like that, which occurred before a harness stream was created, were reduced to a generic `Error` message in the AI SDK UI, making the underlying authentication problem difficult to diagnose.

## Summary

- Add a typed `HarnessSandboxAuthenticationError` class
- Normalize recognized Vercel Sandbox authentication failures while preserving their cause
- Add a production-safe `getHarnessErrorMessage()` helper that exposes reviewed harness errors and masks unknown server error details
- Start harness setup inside UI message streams so pre-stream failures reach `useChat`, with transparent diagnostics in the harness E2E app
- Document the stream-first error-handling pattern

## Contributor Credit

N/A

## End-to-End Verification

Manual verification flow:

1. Remove or rename `examples/harness-e2e-next/.vercel`.
2. Start `harness-e2e-next` and open `/harness/opencode/basic`.
3. Submit a prompt and confirm the UI shows the actionable Vercel Sandbox authentication error.

The changed packages and `harness-e2e-next` example build successfully.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
