### PR TITLE
test(provider-utils): capture #18333 crash on non-zero tool-call index

### DIFF
--- a/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
+++ b/packages/provider-utils/src/streaming-tool-call-tracker.test.ts
@@ -392,6 +392,42 @@ describe('StreamingToolCallTracker', () => {
       // No events should be emitted since tool call was already finished
       expect(parts).toEqual([]);
     });
+
+    // Failing regression test for #18333: a provider/gateway whose
+    // tool_calls[].index does not start at 0 leaves earlier slots as array
+    // holes. flush() iterates with for...of, which yields `undefined` for holes
+    // (unlike forEach), so it throws
+    // `Cannot read properties of undefined (reading 'hasFinished')` instead of
+    // finalizing the tracked call.
+    //
+    // Marked `it.fails` so it captures the bug without breaking CI: it passes
+    // while the crash exists and turns red once the tracker handles the gap,
+    // prompting whoever fixes it to drop `.fails` and assert the emitted call.
+    it.fails('should finalize a tool call whose index does not start at zero (#18333)', () => {
+      const { parts, controller } = createCollector();
+      const tracker = new StreamingToolCallTracker(controller);
+
+      tracker.processDelta({
+        index: 2,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'fn', arguments: '{}' },
+      });
+
+      parts.length = 0;
+
+      tracker.flush();
+
+      expect(parts).toEqual([
+        { type: 'tool-input-end', id: 'call_1' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName: 'fn',
+          input: '{}',
+        },
+      ]);
+    });
   });
 
   describe('metadata', () => {


### PR DESCRIPTION
## What

Adds a failing regression test in `packages/provider-utils/src/streaming-tool-call-tracker.test.ts` that captures the crash reported in #18333.

## Why

When a provider/gateway streams `tool_calls[].index` values that don't start at 0, `StreamingToolCallTracker` stores the call at that index and leaves the earlier slots as array holes:

```ts
const index = toolCallDelta.index ?? this.toolCalls.length;
if (this.toolCalls[index] == null) this.processNewToolCall(index, toolCallDelta);
```

`flush()` then iterates with `for...of`, which yields `undefined` for holes (unlike `forEach`), and throws on the first empty slot:

```
TypeError: Cannot read properties of undefined (reading 'hasFinished')
    at StreamingToolCallTracker.flush (streaming-tool-call-tracker.ts:123)
```

## The test

It processes a single delta with `index: 2` and calls `flush()`, asserting the tracked call is finalized. Against `main` it currently throws, so it's marked `it.fails` — this captures the bug without turning CI red, and it flips to failing once the tracker handles the gap, prompting whoever fixes it to drop `.fails` and confirm the emitted `tool-call`.

Scoped deliberately to the reported crash (non-zero starting index). The related shapes @Astro-Han documented on the issue — a reused index silently merging two calls, and index-less continuation deltas throwing — point at re-keying the tracker on the tool-call `id` rather than the index. I've left those out so this test stays neutral on that larger fix and doesn't pre-judge it. Credit to @Astro-Han for the deeper analysis.

No changeset: test-only change, nothing published is affected.

Refs #18333