### PR TITLE
fix(harness-codex): ensure reasoning summaries are emitted including when using AI Gateway

### DIFF
--- a/.changeset/angry-bikes-greet.md
+++ b/.changeset/angry-bikes-greet.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-codex": patch
+---
+
+fix(harness-codex): ensure reasoning summaries are emitted including when using AI Gateway

--- a/examples/ai-functions/src/harness-agent/codex/with-reasoning.ts
+++ b/examples/ai-functions/src/harness-agent/codex/with-reasoning.ts
@@ -21,8 +21,7 @@ run(async () => {
     const result = await agent.stream({
       session,
       prompt:
-        'Plan a multi-step path from A to B where A=(0,0) and B=(3,4) on a grid, moving only N/S/E/W. ' +
-        'Explain your reasoning, then give the final path.',
+        'Solve this step by step: if f(x) = x^3 - 6x^2 + 11x - 6, find all roots and prove they are correct.',
     });
     await printFullStream({ result });
   } catch (err) {

--- a/examples/ai-functions/src/harness-agent/pi/with-reasoning.ts
+++ b/examples/ai-functions/src/harness-agent/pi/with-reasoning.ts
@@ -20,8 +20,7 @@ run(async () => {
     const result = await agent.stream({
       session,
       prompt:
-        'Plan how to convert miles to kilometres, then give the answer for 26.2 miles. ' +
-        'Show your reasoning briefly.',
+        'Solve this step by step: if f(x) = x^3 - 6x^2 + 11x - 6, find all roots and prove they are correct.',
     });
 
     await printFullStream({ result });

--- a/packages/harness-codex/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-codex/src/bridge/create-emit-stream-event.test.ts
@@ -115,6 +115,62 @@ describe('createEmitStreamEvent', () => {
     `);
   });
 
+  it('emits accumulated reasoning summary events', () => {
+    const emitted: Record<string, unknown>[] = [];
+    const stepTracker = {
+      observeEvent: () => {},
+      finishStep: () => {},
+    } as CodexStepTracker;
+    const emitStreamEvent = createEmitStreamEvent({
+      send: event => emitted.push(event),
+      stepTracker,
+      setTurnUsage: () => {},
+      setThreadId: () => {},
+      emitWarning: () => {},
+      emitError: () => {},
+    });
+
+    emitStreamEvent({
+      type: 'item.updated',
+      item: {
+        type: 'reasoning',
+        id: 'reasoning-1',
+        text: 'Planning',
+      },
+    });
+    emitStreamEvent({
+      type: 'item.completed',
+      item: {
+        type: 'reasoning',
+        id: 'reasoning-1',
+        text: 'Planning the solution',
+      },
+    });
+
+    expect(emitted).toMatchInlineSnapshot(`
+      [
+        {
+          "id": "reasoning-1",
+          "type": "reasoning-start",
+        },
+        {
+          "delta": "Planning",
+          "id": "reasoning-1",
+          "type": "reasoning-delta",
+        },
+        {
+          "delta": " the solution",
+          "id": "reasoning-1",
+          "type": "reasoning-delta",
+        },
+        {
+          "id": "reasoning-1",
+          "type": "reasoning-end",
+        },
+      ]
+    `);
+  });
+
   it('preserves command and MCP result translation', () => {
     const emitted: Record<string, unknown>[] = [];
     const stepTracker = {

--- a/packages/harness-codex/src/bridge/index.test.ts
+++ b/packages/harness-codex/src/bridge/index.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-type CodexOptions = { config?: { mcp_servers?: unknown } };
+type CodexOptions = {
+  config?: {
+    mcp_servers?: unknown;
+    model_reasoning_summary?: unknown;
+    model_supports_reasoning_summaries?: unknown;
+  };
+};
+type ThreadOptions = { model?: string };
 const CODEX_ENV_KEYS = [
   'AI_GATEWAY_API_KEY',
   'AI_GATEWAY_BASE_URL',
@@ -10,6 +17,8 @@ const CODEX_ENV_KEYS = [
 
 const state = vi.hoisted(() => ({
   codexOptions: [] as CodexOptions[],
+  threadOptions: [] as ThreadOptions[],
+  startModel: 'gpt-5.5',
   originalArgv: [] as string[],
   originalEnv: {} as Record<
     (typeof CODEX_ENV_KEYS)[number],
@@ -23,7 +32,8 @@ vi.mock('@openai/codex-sdk', () => ({
       state.codexOptions.push(options);
     }
 
-    startThread() {
+    startThread(options: ThreadOptions = {}) {
+      state.threadOptions.push(options);
       return {
         runStreamed: async () => ({
           events: (async function* () {
@@ -48,6 +58,7 @@ vi.mock('@ai-sdk/harness/bridge', () => ({
     await onStart(
       {
         prompt: 'Use the weather tool.',
+        model: state.startModel,
         tools: [
           {
             name: 'get_weather',
@@ -69,6 +80,8 @@ vi.mock('@ai-sdk/harness/bridge', () => ({
 describe('Codex bridge config', () => {
   beforeEach(() => {
     state.codexOptions = [];
+    state.threadOptions = [];
+    state.startModel = 'gpt-5.5';
     state.originalArgv = [...process.argv];
     state.originalEnv = Object.fromEntries(
       CODEX_ENV_KEYS.map(key => [key, process.env[key]]),
@@ -108,5 +121,46 @@ describe('Codex bridge config', () => {
 
     expect(state.codexOptions).toHaveLength(1);
     expect(state.codexOptions[0]?.config?.mcp_servers).toBeUndefined();
+  });
+
+  test('requests detailed reasoning summaries by default', async () => {
+    await import('./index');
+
+    expect(state.codexOptions).toHaveLength(1);
+    expect(state.codexOptions[0]?.config).toMatchInlineSnapshot(`
+      {
+        "model_reasoning_summary": "detailed",
+      }
+    `);
+  });
+
+  test('uses the creator-qualified model and forces summaries for AI Gateway', async () => {
+    process.env.AI_GATEWAY_API_KEY = 'gateway-key';
+    process.env.AI_GATEWAY_BASE_URL = 'https://ai-gateway.test/v1';
+
+    await import('./index');
+
+    expect({
+      model: state.threadOptions[0]?.model,
+      reasoningSummary: state.codexOptions[0]?.config?.model_reasoning_summary,
+      supportsReasoningSummaries:
+        state.codexOptions[0]?.config?.model_supports_reasoning_summaries,
+    }).toMatchInlineSnapshot(`
+      {
+        "model": "openai/gpt-5.5",
+        "reasoningSummary": "detailed",
+        "supportsReasoningSummaries": true,
+      }
+    `);
+  });
+
+  test('preserves creator-qualified AI Gateway model ids', async () => {
+    state.startModel = 'openai/gpt-5.5';
+    process.env.AI_GATEWAY_API_KEY = 'gateway-key';
+    process.env.AI_GATEWAY_BASE_URL = 'https://ai-gateway.test/v1';
+
+    await import('./index');
+
+    expect(state.threadOptions[0]?.model).toBe('openai/gpt-5.5');
   });
 });

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -120,7 +120,9 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     );
   }
 
-  const codexConfig: Record<string, unknown> = {};
+  const codexConfig: Record<string, unknown> = {
+    model_reasoning_summary: 'detailed',
+  };
 
   const gatewayBaseUrl = procEnv.AI_GATEWAY_BASE_URL;
   const hasGatewayAuth = Boolean(procEnv.AI_GATEWAY_API_KEY || gatewayBaseUrl);
@@ -130,6 +132,19 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     );
   }
   const apiBaseUrl = hasGatewayAuth ? gatewayBaseUrl : procEnv.OPENAI_BASE_URL;
+  const codexModel =
+    start.model && hasGatewayAuth && !start.model.includes('/')
+      ? `openai/${start.model}`
+      : start.model;
+  /*
+   * AI Gateway only returns populated reasoning summaries for its
+   * creator-qualified model IDs. Codex treats qualified IDs as custom model
+   * metadata, so its reasoning-summary capability must also be forced on for
+   * the OpenAI Gateway route.
+   */
+  if (hasGatewayAuth && codexModel?.startsWith('openai/')) {
+    codexConfig.model_supports_reasoning_summaries = true;
+  }
   if (apiBaseUrl) {
     codexConfig.preferred_auth_method = 'apikey';
     codexConfig.model_provider = 'agent_bridge_openai';
@@ -168,7 +183,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   });
 
   const threadOptions = {
-    ...(start.model ? { model: start.model } : {}),
+    ...(codexModel ? { model: codexModel } : {}),
     sandboxMode: 'danger-full-access',
     approvalPolicy: 'never',
     workingDirectory: workdir,


### PR DESCRIPTION
## Background

The Codex harness did not request reasoning summaries by default. When using AI Gateway, bare OpenAI model IDs also produced empty summaries because Codex used fallback model metadata without reasoning-summary support.

## Summary

- Request detailed Codex reasoning summaries by default.
- Use creator-qualified OpenAI model IDs through AI Gateway and enable reasoning-summary support for them.
- Add regression coverage for Gateway configuration and accumulated reasoning events.
- Update harness `with-reasoning.ts` examples to all use the same prompt - no point in using different ones

## End-to-End Verification

Ran:

```bash
aif examples/ai-functions/src/harness-agent/codex/with-reasoning.ts
```

Verified that the Codex reasoning example emits a non-empty reasoning block.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

AI Gateway currently appears to close reasoning stream parts after the final text stream part, leading Codex to emit the reasoning part after the text response part - i.e. the output becomes confusing when `model_reasoning_summary: 'detailed'`. This is an AI Gateway bug and therefore cannot be addressed in AI SDK.
