### PR TITLE
docs(contributing): correct example path in add-new-provider guide

### DIFF
--- a/contributing/add-new-provider.md
+++ b/contributing/add-new-provider.md
@@ -16,7 +16,7 @@ https://github.com/vercel/ai/pull/8136/files
 2. Set version in `packages/<provider>/package.json` to exactly `0.0.0` — no pre-release suffix (do **not** use `0.0.0-canary.0`), even when `main` is in pre-release mode. See [When in pre-release mode](#when-in-pre-release-mode).
 3. Create changeset for new package with `major`
 4. Add workflow serialization support to all model classes (see [providers.md#workflow-serialization](providers.md#workflow-serialization))
-5. Add examples to `examples/ai-functions/src/*/<provider>.ts` depending on what model types the provider supports
+5. Add examples to `examples/ai-functions/src/<function>/<provider>/` depending on what model types the provider supports. Name the entry example `basic.ts` and use descriptive `kebab-case` names for the rest. Do not create flat files like `examples/ai-functions/src/generate-speech/<provider>.ts`.
 6. Add documentation in `content/providers/01-ai-sdk-providers/<last number + 10>-<provider>.mdx`
 7. Bootstrap the npm package and Trusted Publisher (Vercel IT team) — see [Bootstrapping a new `@ai-sdk/*` package](./releases.md#bootstrapping-a-new-ai-sdk-package). This is required before the first automated release can publish the package with provenance.
 


### PR DESCRIPTION
## Background

Step 5 of `contributing/add-new-provider.md` tells new provider authors to add examples at:

```
examples/ai-functions/src/*/<provider>.ts
```

That is the flat layout `CLAUDE.md` explicitly forbids:

> - Place examples under `examples/ai-functions/src/<function>/<provider>/`
> - Use `basic.ts` for the provider entry example file
> - Place all other examples in the same provider folder using descriptive `kebab-case` file names
> - Do not create flat top-level provider files like `src/stream-text/openai.ts`

The repo has standardized on the directory layout: **166** provider directories exist under `examples/ai-functions/src`, versus a **single** remaining flat provider file (`stream-text-custom-loop/openai.ts`).

## Change

Update step 5 to describe the directory layout, name `basic.ts` as the entry example, and call out the flat pattern as something to avoid — mirroring the `CLAUDE.md` wording so the two don't drift again.

Docs-only; no changeset (contributor guide, not published code).

Found while adding a new provider, where following the guide as written would have produced a layout that needed correcting in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)