### PR TITLE
fix(ai): release async iterator reader after read errors

### DIFF
--- a/.changeset/quiet-stream-errors-release.md
+++ b/.changeset/quiet-stream-errors-release.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Release async-iterator reader locks when upstream stream reads fail.

--- a/packages/ai/src/util/async-iterable-stream-read-error.test.ts
+++ b/packages/ai/src/util/async-iterable-stream-read-error.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import {
+  asAsyncIterableStream,
+  createAsyncIterableStream,
+  type AsyncIterableStream,
+} from './async-iterable-stream';
+
+type StreamFactory = <T>(stream: ReadableStream<T>) => AsyncIterableStream<T>;
+
+const implementations: Array<{
+  name: string;
+  create: StreamFactory;
+}> = [
+  {
+    name: 'createAsyncIterableStream',
+    create: createAsyncIterableStream,
+  },
+  {
+    name: 'asAsyncIterableStream',
+    create: asAsyncIterableStream,
+  },
+];
+
+describe.each(implementations)('$name read-error cleanup', ({ create }) => {
+  it('releases the reader and preserves the exact source error', async () => {
+    const sourceError = { type: 'source-error' };
+    let controller!: ReadableStreamDefaultController<string>;
+    let cancelCalls = 0;
+
+    const source = new ReadableStream<string>({
+      start(controllerParam) {
+        controller = controllerParam;
+        controller.enqueue('chunk1');
+      },
+      cancel() {
+        cancelCalls++;
+      },
+    });
+
+    const stream = create(source);
+    const iterator = stream[Symbol.asyncIterator]();
+
+    expect(await iterator.next()).toEqual({
+      done: false,
+      value: 'chunk1',
+    });
+
+    const failedRead = iterator.next();
+    controller.error(sourceError);
+
+    await expect(failedRead).rejects.toBe(sourceError);
+    expect(stream.locked).toBe(false);
+    expect(cancelCalls).toBe(0);
+
+    expect(await iterator.next()).toEqual({
+      done: true,
+      value: undefined,
+    });
+    expect(await iterator.return?.()).toEqual({
+      done: true,
+      value: undefined,
+    });
+
+    const reader = stream.getReader();
+    await expect(reader.read()).rejects.toBe(sourceError);
+    reader.releaseLock();
+  });
+
+  it('releases the reader when the source error reason is undefined', async () => {
+    let controller!: ReadableStreamDefaultController<string>;
+
+    const stream = create(
+      new ReadableStream<string>({
+        start(controllerParam) {
+          controller = controllerParam;
+        },
+      }),
+    );
+    const iterator = stream[Symbol.asyncIterator]();
+    const failedRead = iterator.next();
+
+    controller.error(undefined);
+
+    await expect(failedRead).rejects.toBeUndefined();
+    expect(stream.locked).toBe(false);
+    expect(await iterator.next()).toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('settles concurrent pending reads with the original error and cleans up once', async () => {
+    const sourceError = new Error('source failed');
+    let controller!: ReadableStreamDefaultController<string>;
+    let cancelCalls = 0;
+
+    const source = new ReadableStream<string>({
+      start(controllerParam) {
+        controller = controllerParam;
+      },
+      cancel() {
+        cancelCalls++;
+      },
+    });
+
+    const stream = create(source);
+    const iterator = stream[Symbol.asyncIterator]();
+    const firstRead = iterator.next();
+    const secondRead = iterator.next();
+
+    controller.error(sourceError);
+
+    const outcomes = await Promise.allSettled([firstRead, secondRead]);
+    expect(outcomes).toEqual([
+      { status: 'rejected', reason: sourceError },
+      { status: 'rejected', reason: sourceError },
+    ]);
+    expect(stream.locked).toBe(false);
+    expect(cancelCalls).toBe(0);
+    expect(await iterator.next()).toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+});

--- a/packages/ai/src/util/async-iterable-stream.ts
+++ b/packages/ai/src/util/async-iterable-stream.ts
@@ -78,14 +78,19 @@ export function asAsyncIterableStream<T>(
           return { done: true, value: undefined };
         }
 
-        const { done, value } = await reader.read();
+        try {
+          const { done, value } = await reader.read();
 
-        if (done) {
-          await cleanup(true);
-          return { done: true, value: undefined };
+          if (done) {
+            await cleanup(true);
+            return { done: true, value: undefined };
+          }
+
+          return { done: false, value };
+        } catch (error) {
+          await cleanup(false);
+          throw error;
         }
-
-        return { done: false, value };
       },
 
       /**


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md

AI SDK maintenance is becoming increasingly automated. High-quality issues, reproductions,
failing tests, docs fixes, and focused clarifications are especially valuable. You do not
need to send a complete bug fix for your contribution to be appreciated or credited.
-->

## Background

Closes #18370.

<!--
Why was this change necessary?
If this PR clarifies or reproduces an issue, please explain that context here.
-->

Current behavior:

```text
source stream errors
        ↓
reader.read() rejects
        ↓
next() exits before cleanup
        ↓
caller receives the original error
        ↓
stream stays locked
```

This change makes the rejected read follow the existing cleanup path:

```text
reader.read() rejects
        ↓
cleanup(false)
        ↓
release the reader without cancellation
        ↓
throw the original error
        ↓
later iterator calls return done: true
```

The stream remains errored, and a newly acquired reader still receives the stored source error.

## Summary

<!-- What did you change? -->

- handle rejected reads with `cleanup(false)`;
- add regression coverage for both async-iterable stream helpers;
- add a patch changeset for `ai`.

## End-to-End Verification

<!--
For features & bugfixes.
Remove the section if it's not needed (e.g. for docs).
Please explain how you verified that the change works end-to-end as expected.
Do not include integration/unit tests or linting
-->

The regression test was run locally against the unfixed upstream baseline at `861d42334474f5e411a4b58b741f6ab3c7fb86f3`.

All six cases failed across both helper implementations. The saved terminal output shows that the caller received the source error but the stream stayed locked.

With this change, the same cases pass.

The rebased signed candidate head is `fd6335acd351b4c00824d8b2e68d1fab40053c86`.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

<!--
List related issues here, e.g. "Fixes #1234".
If this PR adds a failing test, reproduction, or documentation fix for an issue,
please link the issue so maintainers can preserve contributor credit.
Remove the section if it's not needed.
-->
- Closes #18370
- Related cleanup precedent: https://redirect.github.com/vercel/ai/issues/11715