### PR TITLE
perf: remove runtime Zod 3 dependency

### DIFF
--- a/.changeset/calm-dragons-wave.md
+++ b/.changeset/calm-dragons-wave.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Reduce bundle size by removing the runtime Zod 3 dependency.

--- a/packages/ai/scripts/check-bundle-size.ts
+++ b/packages/ai/scripts/check-bundle-size.ts
@@ -3,7 +3,7 @@ import { writeFileSync, statSync } from 'fs';
 import { join } from 'path';
 
 // Bundle size limits in bytes
-const LIMIT = 650 * 1024;
+const LIMIT = 620 * 1024;
 
 interface BundleResult {
   size: number;

--- a/packages/provider-utils/src/to-json-schema/zod3-to-json-schema/parsers/array.ts
+++ b/packages/provider-utils/src/to-json-schema/zod3-to-json-schema/parsers/array.ts
@@ -1,4 +1,4 @@
-import { ZodFirstPartyTypeKind, type ZodArrayDef } from 'zod/v3';
+import type { ZodArrayDef } from 'zod/v3';
 import { parseDef } from '../parse-def';
 import type { JsonSchema7Type } from '../parse-types';
 import type { Refs } from '../refs';
@@ -14,10 +14,7 @@ export function parseArrayDef(def: ZodArrayDef, refs: Refs) {
   const res: JsonSchema7ArrayType = {
     type: 'array',
   };
-  if (
-    def.type?._def &&
-    def.type?._def?.typeName !== ZodFirstPartyTypeKind.ZodAny
-  ) {
+  if (def.type?._def && def.type?._def?.typeName !== 'ZodAny') {
     res.items = parseDef(def.type._def, {
       ...refs,
       currentPath: [...refs.currentPath, 'items'],

--- a/packages/provider-utils/src/to-json-schema/zod3-to-json-schema/parsers/record.ts
+++ b/packages/provider-utils/src/to-json-schema/zod3-to-json-schema/parsers/record.ts
@@ -1,9 +1,4 @@
-import {
-  ZodFirstPartyTypeKind,
-  type ZodMapDef,
-  type ZodRecordDef,
-  type ZodTypeAny,
-} from 'zod/v3';
+import type { ZodMapDef, ZodRecordDef, ZodTypeAny } from 'zod/v3';
 import { parseDef } from '../parse-def';
 import type { JsonSchema7Type } from '../parse-types';
 import type { Refs } from '../refs';
@@ -34,7 +29,7 @@ export function parseRecordDef(
   };
 
   if (
-    def.keyType?._def.typeName === ZodFirstPartyTypeKind.ZodString &&
+    def.keyType?._def.typeName === 'ZodString' &&
     def.keyType._def.checks?.length
   ) {
     const { type: _type, ...keyType } = parseStringDef(def.keyType._def, refs);
@@ -43,7 +38,7 @@ export function parseRecordDef(
       ...schema,
       propertyNames: keyType,
     };
-  } else if (def.keyType?._def.typeName === ZodFirstPartyTypeKind.ZodEnum) {
+  } else if (def.keyType?._def.typeName === 'ZodEnum') {
     return {
       ...schema,
       propertyNames: {
@@ -51,8 +46,8 @@ export function parseRecordDef(
       },
     };
   } else if (
-    def.keyType?._def.typeName === ZodFirstPartyTypeKind.ZodBranded &&
-    def.keyType._def.type._def.typeName === ZodFirstPartyTypeKind.ZodString &&
+    def.keyType?._def.typeName === 'ZodBranded' &&
+    def.keyType._def.type._def.typeName === 'ZodString' &&
     def.keyType._def.type._def.checks?.length
   ) {
     const { type: _type, ...keyType } = parseBrandedDef(

--- a/packages/provider-utils/src/to-json-schema/zod3-to-json-schema/select-parser.ts
+++ b/packages/provider-utils/src/to-json-schema/zod3-to-json-schema/select-parser.ts
@@ -1,4 +1,4 @@
-import { ZodFirstPartyTypeKind } from 'zod/v3';
+import type { ZodFirstPartyTypeKind } from 'zod/v3';
 import { parseAnyDef } from './parsers/any';
 import { parseArrayDef } from './parsers/array';
 import { parseBigintDef } from './parsers/bigint';
@@ -34,79 +34,81 @@ import type { JsonSchema7Type } from './parse-types';
 
 export type InnerDefGetter = () => any;
 
+type Zod3TypeName = `${ZodFirstPartyTypeKind}`;
+
 export const selectParser = (
   def: any,
-  typeName: ZodFirstPartyTypeKind,
+  typeName: Zod3TypeName,
   refs: Refs,
 ): JsonSchema7Type | undefined | InnerDefGetter => {
   switch (typeName) {
-    case ZodFirstPartyTypeKind.ZodString:
+    case 'ZodString':
       return parseStringDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodNumber:
+    case 'ZodNumber':
       return parseNumberDef(def);
-    case ZodFirstPartyTypeKind.ZodObject:
+    case 'ZodObject':
       return parseObjectDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodBigInt:
+    case 'ZodBigInt':
       return parseBigintDef(def);
-    case ZodFirstPartyTypeKind.ZodBoolean:
+    case 'ZodBoolean':
       return parseBooleanDef();
-    case ZodFirstPartyTypeKind.ZodDate:
+    case 'ZodDate':
       return parseDateDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodUndefined:
+    case 'ZodUndefined':
       return parseUndefinedDef();
-    case ZodFirstPartyTypeKind.ZodNull:
+    case 'ZodNull':
       return parseNullDef();
-    case ZodFirstPartyTypeKind.ZodArray:
+    case 'ZodArray':
       return parseArrayDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodUnion:
-    case ZodFirstPartyTypeKind.ZodDiscriminatedUnion:
+    case 'ZodUnion':
+    case 'ZodDiscriminatedUnion':
       return parseUnionDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodIntersection:
+    case 'ZodIntersection':
       return parseIntersectionDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodTuple:
+    case 'ZodTuple':
       return parseTupleDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodRecord:
+    case 'ZodRecord':
       return parseRecordDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodLiteral:
+    case 'ZodLiteral':
       return parseLiteralDef(def);
-    case ZodFirstPartyTypeKind.ZodEnum:
+    case 'ZodEnum':
       return parseEnumDef(def);
-    case ZodFirstPartyTypeKind.ZodNativeEnum:
+    case 'ZodNativeEnum':
       return parseNativeEnumDef(def);
-    case ZodFirstPartyTypeKind.ZodNullable:
+    case 'ZodNullable':
       return parseNullableDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodOptional:
+    case 'ZodOptional':
       return parseOptionalDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodMap:
+    case 'ZodMap':
       return parseMapDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodSet:
+    case 'ZodSet':
       return parseSetDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodLazy:
+    case 'ZodLazy':
       return () => (def as any).getter()._def;
-    case ZodFirstPartyTypeKind.ZodPromise:
+    case 'ZodPromise':
       return parsePromiseDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodNaN:
-    case ZodFirstPartyTypeKind.ZodNever:
+    case 'ZodNaN':
+    case 'ZodNever':
       return parseNeverDef();
-    case ZodFirstPartyTypeKind.ZodEffects:
+    case 'ZodEffects':
       return parseEffectsDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodAny:
+    case 'ZodAny':
       return parseAnyDef();
-    case ZodFirstPartyTypeKind.ZodUnknown:
+    case 'ZodUnknown':
       return parseUnknownDef();
-    case ZodFirstPartyTypeKind.ZodDefault:
+    case 'ZodDefault':
       return parseDefaultDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodBranded:
+    case 'ZodBranded':
       return parseBrandedDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodReadonly:
+    case 'ZodReadonly':
       return parseReadonlyDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodCatch:
+    case 'ZodCatch':
       return parseCatchDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodPipeline:
+    case 'ZodPipeline':
       return parsePipelineDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodFunction:
-    case ZodFirstPartyTypeKind.ZodVoid:
-    case ZodFirstPartyTypeKind.ZodSymbol:
+    case 'ZodFunction':
+    case 'ZodVoid':
+    case 'ZodSymbol':
       return undefined;
     default:
       /* c8 ignore next */


### PR DESCRIPTION
## Background

`@ai-sdk/provider-utils` imported the `ZodFirstPartyTypeKind` enum from `zod/v3` in its parser. But that file includes a bunch of Zod schemas that aren't tree shaken.

## Summary

Replaced that enum with strings that are typed checked against the original enum at compile-time, so that the import is type-only.

| Target | `main` raw | This branch raw | Raw saved | Gzip saved | Brotli saved |
|---|---:|---:|---:|---:|---:|
| Node | 665,384 B | 607,959 B | **57,425 B** | **12,875 B** | **9,958 B** |
| Browser | 653,465 B | 596,040 B | **57,425 B** | **12,803 B** | **9,862 B** |

This doesn't break anything because `ZodFirstPartyTypeKind.ZodString === 'ZodString', so we can just check the string `'ZodString'` directly rather than importing the enum.

## End-to-End Verification

Tested `examples/ai-functions/src/generate-text/mock/output-object.ts` example which uses Zod 3 and the JSON Schema parser, and it still works.

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)