### PR TITLE
feat(tools-registry): update tako-search entry

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -355,7 +355,7 @@ console.log(text);`,
     slug: 'tako-search',
     name: 'Tako Search',
     description:
-      "Search Tako's knowledge base for data visualizations, insights, and well-sourced information with charts and analytics.",
+      'Ground your agent in proprietary structured data from trusted providers plus full web search. Three tools: takoSearch for knowledge cards and web results, takoAnswer for a synthesized source-attributed answer, and takoContents for the underlying rows or page text.',
     packageName: '@takoviz/ai-sdk',
     installCommand: {
       pnpm: 'pnpm install @takoviz/ai-sdk',
@@ -376,11 +376,11 @@ const { text } = await generateText({
 });
 
 console.log(text);`,
-    docsUrl: 'https://github.com/TakoData/ai-sdk#readme',
+    docsUrl: 'https://docs.tako.com/documentation/integrations/vercel-ai-sdk',
     npmUrl: 'https://www.npmjs.com/package/@takoviz/ai-sdk',
     websiteUrl: 'https://tako.com',
     apiKeyEnvName: 'TAKO_API_KEY',
-    apiKeyUrl: 'https://tako.com',
+    apiKeyUrl: 'https://tako.com/console/api-keys',
     tags: ['search', 'data', 'visualization', 'analytics'],
   },
   {


### PR DESCRIPTION
Corrects three fields on the existing `tako-search` entry in `content/tools-registry/registry.ts`. No new entry, no new page — the listing already exists and renders at [/resources/tools/tako-search](https://ai-sdk.dev/resources/tools/tako-search).

## Changes

| Field | Before | After |
| --- | --- | --- |
| `description` | Covers `takoSearch` only | Covers all three tools the package exports |
| `docsUrl` | `github.com/TakoData/ai-sdk#readme` | `docs.tako.com/documentation/integrations/vercel-ai-sdk` |
| `apiKeyUrl` | `https://tako.com` | `https://tako.com/console/api-keys` |

**`description`** — `@takoviz/ai-sdk` exports `takoSearch`, `takoAnswer`, and `takoContents`. The current text describes only the first, so the card understates the package.

**`docsUrl`** — this is the card's "Learn More" link, and it currently lands on a GitHub README. Repointed at our AI SDK integration guide, matching how neighbouring entries link to a vendor-hosted integration page (`exa` → `docs.exa.ai/reference/vercel`, `tavily` → `docs.tavily.com/documentation/integrations/vercel`, `firecrawl` → `docs.firecrawl.dev/integrations/ai-sdk`, `valyu` → `docs.valyu.ai/integrations/vercel-ai-sdk`).

**`apiKeyUrl`** — this is the "Get API Key" button. The site root leaves the reader to find the key page themselves; this links directly to it.

## Deliberately unchanged

- **`slug`** stays `tako-search`, so the existing `/resources/tools/tako-search` URL keeps working.
- **`codeExample`** is already correct — it imports `isStepCount` and typechecks against `ai@7.0.0`. Left alone.
- **`model: 'openai/gpt-5.2'`** is current and used by other entries in the file.

## Verification

- [x] Both new URLs return 200
- [x] `registry.ts` typechecks after the edit
- [x] Quoting follows `.oxfmtrc.jsonc` (`singleQuote: true`; the old value needed double quotes only for an apostrophe, which the new text doesn't contain)
- [x] Content-only change, so no changeset (per CONTRIBUTING, changesets aren't needed for docs)
- [x] Branched from `main`, independent of #18355

## Related

#18355 proposed a full community-provider page for Tako. I've parked that as a draft — the tools registry looks like the right home for a tool-only package, and this PR makes the existing entry point at the documentation instead of duplicating it.
