### PR TITLE
feat (provider/gateway): support async video operations (doStart/doStatus) on the v4 video model

### DIFF
--- a/.changeset/gateway-video-operations-v4.md
+++ b/.changeset/gateway-video-operations-v4.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+feat (provider/gateway): support the async video operation flow (doStart/doStatus) on the v4 video model

--- a/.changeset/video-dostart-idempotency.md
+++ b/.changeset/video-dostart-idempotency.md
@@ -1,0 +1,12 @@
+---
+"@ai-sdk/gateway": patch
+"ai": patch
+---
+
+fix (ai/gateway): make retried `doStart` calls idempotent
+
+`generateVideo` retries `doStart`, which creates a billable generation, so a
+retry after a lost response could start a second one. The start options object is
+now built once outside the retry closure, and `GatewayVideoModel` sends one
+`idempotency-key` per options identity — stable across those retries, fresh for a
+genuinely new call.

--- a/.changeset/video-dostart-idempotency.md
+++ b/.changeset/video-dostart-idempotency.md
@@ -6,7 +6,9 @@
 fix (ai/gateway): make retried `doStart` calls idempotent
 
 `generateVideo` retries `doStart`, which creates a billable generation, so a
-retry after a lost response could start a second one. The start options object is
-now built once outside the retry closure, and `GatewayVideoModel` sends one
-`idempotency-key` per options identity — stable across those retries, fresh for a
-genuinely new call.
+retry after a lost response could start a second one. It now mints one
+idempotency token per logical start — outside the retry closure — and forwards it
+as an `idempotency-key` header, so a provider that deduplicates (the Vercel AI
+Gateway does) sees the same key on every attempt. `GatewayVideoModel` simply
+forwards the caller's headers rather than inferring retry identity from an
+options object, which would collide across unrelated calls.

--- a/packages/ai/src/generate-video/generate-video.test.ts
+++ b/packages/ai/src/generate-video/generate-video.test.ts
@@ -1137,6 +1137,108 @@ describe('experimental_generateVideo', () => {
       expect(result.videos.length).toBe(1);
     });
 
+    it('should send one stable idempotency key across doStart retries', async () => {
+      // `doStart` creates a billable generation, so a retry after a lost
+      // response must dedupe rather than start a second one. The key is minted
+      // once per logical start, not inferred from options identity.
+      const seenKeys: Array<string | undefined> = [];
+      let startCallCount = 0;
+
+      const result = await experimental_generateVideo({
+        model: new MockVideoModelV4({
+          doGenerate: undefined,
+          doStart: async options => {
+            startCallCount++;
+            seenKeys.push(options.headers?.['idempotency-key']);
+            if (startCallCount === 1) {
+              throw new APICallError({
+                message: 'lost response',
+                url: 'https://example.com/start',
+                requestBodyValues: {},
+                statusCode: 500,
+                responseHeaders: { 'retry-after-ms': '0' },
+              });
+            }
+            return {
+              operation: 'op-1',
+              warnings: [],
+              response: {
+                timestamp: new Date(),
+                modelId: 'test-model-id',
+                headers: {},
+              },
+            };
+          },
+          doStatus: async () => ({
+            status: 'completed' as const,
+            videos: [
+              { type: 'base64', data: mp4Base64, mediaType: 'video/mp4' },
+            ],
+            warnings: [],
+            response: {
+              timestamp: new Date(),
+              modelId: 'test-model-id',
+              headers: {},
+            },
+          }),
+        }),
+        prompt,
+        maxRetries: 1,
+        poll: { intervalMs: 0 },
+      });
+
+      expect(startCallCount).toBe(2);
+      expect(seenKeys[0]).toMatch(/^aisdk_vid_/);
+      expect(seenKeys[1]).toBe(seenKeys[0]);
+      expect(result.videos.length).toBe(1);
+    });
+
+    it('should mint a distinct idempotency key per generateVideo call', async () => {
+      const seenKeys: Array<string | undefined> = [];
+      const model = () =>
+        new MockVideoModelV4({
+          doGenerate: undefined,
+          doStart: async options => {
+            seenKeys.push(options.headers?.['idempotency-key']);
+            return {
+              operation: 'op-1',
+              warnings: [],
+              response: {
+                timestamp: new Date(),
+                modelId: 'test-model-id',
+                headers: {},
+              },
+            };
+          },
+          doStatus: async () => ({
+            status: 'completed' as const,
+            videos: [
+              { type: 'base64', data: mp4Base64, mediaType: 'video/mp4' },
+            ],
+            warnings: [],
+            response: {
+              timestamp: new Date(),
+              modelId: 'test-model-id',
+              headers: {},
+            },
+          }),
+        });
+
+      await experimental_generateVideo({
+        model: model(),
+        prompt,
+        poll: { intervalMs: 0 },
+      });
+      await experimental_generateVideo({
+        model: model(),
+        prompt,
+        poll: { intervalMs: 0 },
+      });
+
+      expect(seenKeys).toHaveLength(2);
+      expect(seenKeys[1]).not.toBe(seenKeys[0]);
+    });
+
     it('should fall back to doGenerate when poll is provided but model lacks doStart/doStatus', async () => {
       const result = await experimental_generateVideo({
         model: new MockVideoModelV4({

--- a/packages/ai/src/generate-video/generate-video.test.ts
+++ b/packages/ai/src/generate-video/generate-video.test.ts
@@ -1277,6 +1277,53 @@ describe('experimental_generateVideo', () => {
       expect(seenKeys).toEqual(['caller-key-1']);
     });
 
+    it('should honor a caller-supplied idempotency key regardless of header casing', async () => {
+      const seenHeaders: Array<Record<string, string | undefined> | undefined> =
+        [];
+      const model = new MockVideoModelV4({
+        doGenerate: undefined,
+        doStart: async options => {
+          seenHeaders.push(options.headers);
+          return {
+            operation: 'op-1',
+            warnings: [],
+            response: {
+              timestamp: new Date(),
+              modelId: 'test-model-id',
+              headers: {},
+            },
+          };
+        },
+        doStatus: async () => ({
+          status: 'completed' as const,
+          videos: [{ type: 'base64', data: mp4Base64, mediaType: 'video/mp4' }],
+          warnings: [],
+          response: {
+            timestamp: new Date(),
+            modelId: 'test-model-id',
+            headers: {},
+          },
+        }),
+      });
+
+      await experimental_generateVideo({
+        model,
+        prompt,
+        headers: { 'Idempotency-Key': 'caller-key-cased' },
+        poll: { intervalMs: 0 },
+      });
+
+      // generateVideo normalizes header casing via the Headers round-trip in
+      // withUserAgentSuffix, so the caller's key arrives lowercased — and no
+      // minted key replaces or duplicates it.
+      expect(seenHeaders[0]?.['idempotency-key']).toBe('caller-key-cased');
+      expect(
+        Object.values(seenHeaders[0] ?? {}).filter(value =>
+          String(value).startsWith('aisdk_vid_'),
+        ),
+      ).toHaveLength(0);
+    });
+
     it('should fall back to doGenerate when poll is provided but model lacks doStart/doStatus', async () => {
       const result = await experimental_generateVideo({
         model: new MockVideoModelV4({

--- a/packages/ai/src/generate-video/generate-video.test.ts
+++ b/packages/ai/src/generate-video/generate-video.test.ts
@@ -1239,6 +1239,44 @@ describe('experimental_generateVideo', () => {
       expect(seenKeys[1]).not.toBe(seenKeys[0]);
     });
 
+    it('should preserve a caller-supplied idempotency key instead of minting one', async () => {
+      const seenKeys: Array<string | undefined> = [];
+      const model = new MockVideoModelV4({
+        doGenerate: undefined,
+        doStart: async options => {
+          seenKeys.push(options.headers?.['idempotency-key']);
+          return {
+            operation: 'op-1',
+            warnings: [],
+            response: {
+              timestamp: new Date(),
+              modelId: 'test-model-id',
+              headers: {},
+            },
+          };
+        },
+        doStatus: async () => ({
+          status: 'completed' as const,
+          videos: [{ type: 'base64', data: mp4Base64, mediaType: 'video/mp4' }],
+          warnings: [],
+          response: {
+            timestamp: new Date(),
+            modelId: 'test-model-id',
+            headers: {},
+          },
+        }),
+      });
+
+      await experimental_generateVideo({
+        model,
+        prompt,
+        headers: { 'idempotency-key': 'caller-key-1' },
+        poll: { intervalMs: 0 },
+      });
+
+      expect(seenKeys).toEqual(['caller-key-1']);
+    });
+
     it('should fall back to doGenerate when poll is provided but model lacks doStart/doStatus', async () => {
       const result = await experimental_generateVideo({
         model: new MockVideoModelV4({

--- a/packages/ai/src/generate-video/generate-video.ts
+++ b/packages/ai/src/generate-video/generate-video.ts
@@ -553,13 +553,15 @@ async function executeStartStatusFlow({
     }
   }
 
-  // 2. Start the generation
-  const startResult = await retry(() =>
-    model.doStart!({
-      ...callOptions,
-      webhookUrl,
-    }),
-  );
+  // 2. Start the generation.
+  //
+  // The options object is built ONCE, outside the retry closure, so every
+  // attempt receives the identical reference. `doStart` has a side effect the
+  // caller pays for, and a retry after a lost response would otherwise create a
+  // second generation; a provider (or the Vercel AI Gateway) can key
+  // deduplication off this identity without a spec change.
+  const startCallOptions = { ...callOptions, webhookUrl };
+  const startResult = await retry(() => model.doStart!(startCallOptions));
 
   const allWarnings = [...earlyWarnings, ...startResult.warnings];
   let operationProviderMetadata =

--- a/packages/ai/src/generate-video/generate-video.ts
+++ b/packages/ai/src/generate-video/generate-video.ts
@@ -11,6 +11,7 @@ import type {
 import {
   convertBase64ToUint8Array,
   delay as defaultDelay,
+  generateId,
   withUserAgentSuffix,
   type DataContent,
   detectMediaType,
@@ -555,12 +556,21 @@ async function executeStartStatusFlow({
 
   // 2. Start the generation.
   //
-  // The options object is built ONCE, outside the retry closure, so every
-  // attempt receives the identical reference. `doStart` has a side effect the
-  // caller pays for, and a retry after a lost response would otherwise create a
-  // second generation; a provider (or the Vercel AI Gateway) can key
-  // deduplication off this identity without a spec change.
-  const startCallOptions = { ...callOptions, webhookUrl };
+  // `doStart` has a side effect the caller pays for, so a retry after a lost
+  // response must not create a second generation. Mint ONE idempotency token per
+  // logical start — here, outside the retry closure — and forward it as a header
+  // so a provider that supports deduplication can key off it. Explicit, rather
+  // than inferred from object identity: two unrelated calls that happen to share
+  // an options object must never share a token.
+  const startIdempotencyKey = `aisdk_vid_${generateId()}`;
+  const startCallOptions = {
+    ...callOptions,
+    headers: {
+      ...callOptions.headers,
+      'idempotency-key': startIdempotencyKey,
+    },
+    webhookUrl,
+  };
   const startResult = await retry(() => model.doStart!(startCallOptions));
 
   const allWarnings = [...earlyWarnings, ...startResult.warnings];

--- a/packages/ai/src/generate-video/generate-video.ts
+++ b/packages/ai/src/generate-video/generate-video.ts
@@ -562,7 +562,11 @@ async function executeStartStatusFlow({
   // so a provider that supports deduplication can key off it. Explicit, rather
   // than inferred from object identity: two unrelated calls that happen to share
   // an options object must never share a token.
-  const startIdempotencyKey = `aisdk_vid_${generateId()}`;
+  // A caller-supplied `idempotency-key` header wins: users implementing their
+  // own dedupe (e.g. an outer retry wrapper with a stable key) must not have
+  // it silently replaced.
+  const startIdempotencyKey =
+    callOptions.headers?.['idempotency-key'] ?? `aisdk_vid_${generateId()}`;
   const startCallOptions = {
     ...callOptions,
     headers: {

--- a/packages/ai/src/generate-video/generate-video.ts
+++ b/packages/ai/src/generate-video/generate-video.ts
@@ -554,24 +554,19 @@ async function executeStartStatusFlow({
     }
   }
 
-  // 2. Start the generation.
-  //
-  // `doStart` has a side effect the caller pays for, so a retry after a lost
-  // response must not create a second generation. Mint ONE idempotency token per
-  // logical start — here, outside the retry closure — and forward it as a header
-  // so a provider that supports deduplication can key off it. Explicit, rather
-  // than inferred from object identity: two unrelated calls that happen to share
-  // an options object must never share a token.
-  // A caller-supplied `idempotency-key` header wins: users implementing their
-  // own dedupe (e.g. an outer retry wrapper with a stable key) must not have
-  // it silently replaced.
-  const startIdempotencyKey =
-    callOptions.headers?.['idempotency-key'] ?? `aisdk_vid_${generateId()}`;
+  // 2. Start the generation. `doStart` is billable: mint one idempotency token
+  // per logical start, outside the retry closure; a caller-supplied key wins.
+  const callerIdempotencyKey = Object.entries(callOptions.headers ?? {}).find(
+    ([key, value]) =>
+      key.toLowerCase() === 'idempotency-key' && value !== undefined,
+  );
   const startCallOptions = {
     ...callOptions,
     headers: {
       ...callOptions.headers,
-      'idempotency-key': startIdempotencyKey,
+      ...(callerIdempotencyKey
+        ? {}
+        : { 'idempotency-key': `aisdk_vid_${generateId()}` }),
     },
     webhookUrl,
   };

--- a/packages/gateway/src/gateway-video-model.test.ts
+++ b/packages/gateway/src/gateway-video-model.test.ts
@@ -1,3 +1,4 @@
+import type { Experimental_VideoModelV4 } from '@ai-sdk/provider';
 import { describe, it, expect } from 'vitest';
 import { GatewayVideoModel } from './gateway-video-model';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
@@ -26,6 +27,8 @@ const createTestModel = (
 describe('GatewayVideoModel', () => {
   const server = createTestServer({
     'https://api.test.com/video-model': {},
+    'https://api.test.com/video-model/start': {},
+    'https://api.test.com/video-model/status': {},
   });
 
   describe('constructor', () => {
@@ -1174,6 +1177,237 @@ describe('GatewayVideoModel', () => {
         expect(requestBody).not.toHaveProperty('frameImages');
         expect(requestBody).not.toHaveProperty('inputReferences');
       });
+    });
+  });
+
+  describe('doStart', () => {
+    const baseCallOptions = {
+      prompt: 'A beautiful sunset over mountains',
+      image: undefined,
+      frameImages: undefined,
+      inputReferences: undefined,
+      n: 1,
+      aspectRatio: undefined,
+      resolution: undefined,
+      duration: undefined,
+      fps: undefined,
+      seed: undefined,
+      generateAudio: undefined,
+      providerOptions: {},
+    };
+
+    it('should call the Gateway start endpoint and return the operation', async () => {
+      server.urls['https://api.test.com/video-model/start'].response = {
+        type: 'json-value',
+        body: {
+          operation: { gatewayJobId: 'job_123' },
+          warnings: [{ type: 'other', message: 'queued' }],
+          providerMetadata: {
+            gateway: { asyncJob: { jobId: 'job_123', status: 'queued' } },
+          },
+        },
+      };
+
+      const result = await createTestModel().doStart({
+        ...baseCallOptions,
+        aspectRatio: '16:9',
+        resolution: '1280x720',
+        duration: 5,
+        fps: 24,
+        seed: 123,
+        generateAudio: true,
+        providerOptions: { gateway: { tags: ['async'] } },
+        webhookUrl: 'https://example.com/webhook',
+      });
+
+      expect(result.operation).toEqual({ gatewayJobId: 'job_123' });
+      expect(result.warnings).toEqual([{ type: 'other', message: 'queued' }]);
+      expect(result.providerMetadata).toEqual({
+        gateway: { asyncJob: { jobId: 'job_123', status: 'queued' } },
+      });
+      expect(result.response.modelId).toBe(TEST_MODEL_ID);
+      expect(result.response.timestamp).toBeInstanceOf(Date);
+      expect(result.response.headers).toBeDefined();
+
+      const call = server.calls[0];
+      expect(call.requestHeaders).toMatchObject({
+        authorization: 'Bearer test-token',
+        'ai-video-model-specification-version': '4',
+        'ai-model-id': TEST_MODEL_ID,
+      });
+      await expect(call.requestBodyJson).resolves.toEqual({
+        prompt: 'A beautiful sunset over mountains',
+        n: 1,
+        aspectRatio: '16:9',
+        resolution: '1280x720',
+        duration: 5,
+        fps: 24,
+        seed: 123,
+        generateAudio: true,
+        providerOptions: { gateway: { tags: ['async'] } },
+        webhookUrl: 'https://example.com/webhook',
+      });
+    });
+
+    it('should omit optional fields and webhookUrl when not provided', async () => {
+      server.urls['https://api.test.com/video-model/start'].response = {
+        type: 'json-value',
+        body: { operation: { gatewayJobId: 'job_123' } },
+      };
+
+      const result = await createTestModel().doStart(baseCallOptions);
+
+      // warnings defaults to an empty array when omitted by the gateway
+      expect(result.warnings).toEqual([]);
+      await expect(server.calls[0].requestBodyJson).resolves.toEqual({
+        prompt: 'A beautiful sunset over mountains',
+        n: 1,
+        providerOptions: {},
+      });
+    });
+
+    it('should map gateway errors', async () => {
+      server.urls['https://api.test.com/video-model/start'].response = {
+        type: 'error',
+        status: 400,
+        body: JSON.stringify({
+          error: { message: 'Invalid request', code: 'invalid_request' },
+        }),
+      };
+
+      await expect(
+        createTestModel().doStart(baseCallOptions),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('doStatus', () => {
+    it('should return pending status', async () => {
+      server.urls['https://api.test.com/video-model/status'].response = {
+        type: 'json-value',
+        body: {
+          status: 'pending',
+          providerMetadata: {
+            gateway: { asyncJob: { jobId: 'job_123', status: 'running' } },
+          },
+        },
+      };
+
+      const result = await createTestModel().doStatus({
+        operation: { gatewayJobId: 'job_123' },
+      });
+
+      expect(result).toMatchObject({
+        status: 'pending',
+        providerMetadata: {
+          gateway: { asyncJob: { jobId: 'job_123', status: 'running' } },
+        },
+      });
+      expect(result.response.modelId).toBe(TEST_MODEL_ID);
+      await expect(server.calls[0].requestBodyJson).resolves.toEqual({
+        operation: { gatewayJobId: 'job_123' },
+      });
+    });
+
+    it('should return completed videos (provider-hosted URLs)', async () => {
+      server.urls['https://api.test.com/video-model/status'].response = {
+        type: 'json-value',
+        body: {
+          status: 'completed',
+          videos: [
+            {
+              type: 'url',
+              url: 'https://cdn.example.com/v.mp4',
+              mediaType: 'video/mp4',
+            },
+          ],
+          warnings: [{ type: 'other', message: 'complete' }],
+          providerMetadata: {
+            gateway: {
+              asyncJob: {
+                jobId: 'job_123',
+                result: { expiresAt: 1234 },
+                status: 'completed',
+              },
+            },
+          },
+        },
+      };
+
+      const result = await createTestModel().doStatus({
+        operation: { gatewayJobId: 'job_123' },
+      });
+
+      expect(result).toMatchObject({
+        status: 'completed',
+        videos: [
+          {
+            type: 'url',
+            url: 'https://cdn.example.com/v.mp4',
+            mediaType: 'video/mp4',
+          },
+        ],
+        warnings: [{ type: 'other', message: 'complete' }],
+      });
+    });
+
+    it('should return error status', async () => {
+      server.urls['https://api.test.com/video-model/status'].response = {
+        type: 'json-value',
+        body: {
+          status: 'error',
+          error: 'Async video job failed',
+        },
+      };
+
+      const result = await createTestModel().doStatus({
+        operation: { gatewayJobId: 'job_123' },
+      });
+
+      expect(result).toMatchObject({
+        status: 'error',
+        error: 'Async video job failed',
+      });
+    });
+
+    it('maps the gateway cancelled status to a terminal error', async () => {
+      server.urls['https://api.test.com/video-model/status'].response = {
+        type: 'json-value',
+        body: {
+          status: 'cancelled',
+          providerMetadata: {
+            gateway: { asyncJob: { jobId: 'job_123', status: 'cancelled' } },
+          },
+        },
+      };
+
+      const result = await createTestModel().doStatus({
+        operation: { gatewayJobId: 'job_123' },
+      });
+
+      expect(result).toMatchObject({
+        status: 'error',
+        error: 'Video generation was cancelled.',
+      });
+    });
+
+    it('should map gateway errors', async () => {
+      server.urls['https://api.test.com/video-model/status'].response = {
+        type: 'error',
+        status: 401,
+        body: JSON.stringify({
+          error: { message: 'Unauthorized', code: 'unauthorized' },
+        }),
+      };
+
+      await expect(
+        createTestModel().doStatus({ operation: { gatewayJobId: 'job_123' } }),
+      ).rejects.toThrow();
+    });
+
+    it('does not implement handleWebhookOption (polling-only gateway)', () => {
+      const model: Experimental_VideoModelV4 = createTestModel();
+      expect(model.handleWebhookOption).toBeUndefined();
     });
   });
 });

--- a/packages/gateway/src/gateway-video-model.test.ts
+++ b/packages/gateway/src/gateway-video-model.test.ts
@@ -1280,38 +1280,36 @@ describe('GatewayVideoModel', () => {
       ).rejects.toThrow();
     });
 
-    it('should reuse one idempotency key when retried with the same options', async () => {
+    it('should forward the caller-supplied idempotency key', async () => {
       server.urls['https://api.test.com/video-model/start'].response = {
         type: 'json-value',
         body: { operation: { gatewayJobId: 'job_123' } },
       };
 
-      // `generateVideo` builds the options object once outside its retry
-      // closure, so a retry after a lost response must not start a second
-      // billable generation.
-      const model = createTestModel();
-      await model.doStart(baseCallOptions);
-      await model.doStart(baseCallOptions);
+      // The key is minted by `generateVideo` once per logical start and passed
+      // down, so a retry of a lost response dedupes at the gateway rather than
+      // starting a second billable generation. The model must not invent one:
+      // inferring retry identity from an options object would collide across
+      // unrelated calls that happen to share it.
+      await createTestModel().doStart({
+        ...baseCallOptions,
+        headers: { 'idempotency-key': 'aisdk_vid_abc123' },
+      });
 
-      const first = server.calls[0].requestHeaders['idempotency-key'];
-      const second = server.calls[1].requestHeaders['idempotency-key'];
-      expect(first).toBeDefined();
-      expect(second).toBe(first);
+      expect(server.calls[0].requestHeaders['idempotency-key']).toBe(
+        'aisdk_vid_abc123',
+      );
     });
 
-    it('should use a distinct idempotency key for a distinct call', async () => {
+    it('should send no idempotency key when the caller supplies none', async () => {
       server.urls['https://api.test.com/video-model/start'].response = {
         type: 'json-value',
         body: { operation: { gatewayJobId: 'job_123' } },
       };
 
-      const model = createTestModel();
-      await model.doStart({ ...baseCallOptions });
-      await model.doStart({ ...baseCallOptions });
+      await createTestModel().doStart(baseCallOptions);
 
-      expect(server.calls[1].requestHeaders['idempotency-key']).not.toBe(
-        server.calls[0].requestHeaders['idempotency-key'],
-      );
+      expect(server.calls[0].requestHeaders['idempotency-key']).toBeUndefined();
     });
   });
 

--- a/packages/gateway/src/gateway-video-model.test.ts
+++ b/packages/gateway/src/gateway-video-model.test.ts
@@ -1279,6 +1279,40 @@ describe('GatewayVideoModel', () => {
         createTestModel().doStart(baseCallOptions),
       ).rejects.toThrow();
     });
+
+    it('should reuse one idempotency key when retried with the same options', async () => {
+      server.urls['https://api.test.com/video-model/start'].response = {
+        type: 'json-value',
+        body: { operation: { gatewayJobId: 'job_123' } },
+      };
+
+      // `generateVideo` builds the options object once outside its retry
+      // closure, so a retry after a lost response must not start a second
+      // billable generation.
+      const model = createTestModel();
+      await model.doStart(baseCallOptions);
+      await model.doStart(baseCallOptions);
+
+      const first = server.calls[0].requestHeaders['idempotency-key'];
+      const second = server.calls[1].requestHeaders['idempotency-key'];
+      expect(first).toBeDefined();
+      expect(second).toBe(first);
+    });
+
+    it('should use a distinct idempotency key for a distinct call', async () => {
+      server.urls['https://api.test.com/video-model/start'].response = {
+        type: 'json-value',
+        body: { operation: { gatewayJobId: 'job_123' } },
+      };
+
+      const model = createTestModel();
+      await model.doStart({ ...baseCallOptions });
+      await model.doStart({ ...baseCallOptions });
+
+      expect(server.calls[1].requestHeaders['idempotency-key']).not.toBe(
+        server.calls[0].requestHeaders['idempotency-key'],
+      );
+    });
   });
 
   describe('doStatus', () => {

--- a/packages/gateway/src/gateway-video-model.test.ts
+++ b/packages/gateway/src/gateway-video-model.test.ts
@@ -1245,11 +1245,13 @@ describe('GatewayVideoModel', () => {
         seed: 123,
         generateAudio: true,
         providerOptions: { gateway: { tags: ['async'] } },
-        webhookUrl: 'https://example.com/webhook',
+        // The spec-side `webhookUrl` option maps onto the Gateway's
+        // `callbackUrl` wire field (its completion-webhook contract).
+        callbackUrl: 'https://example.com/webhook',
       });
     });
 
-    it('should omit optional fields and webhookUrl when not provided', async () => {
+    it('should omit optional fields and callbackUrl when webhookUrl is not provided', async () => {
       server.urls['https://api.test.com/video-model/start'].response = {
         type: 'json-value',
         body: { operation: { gatewayJobId: 'job_123' } },

--- a/packages/gateway/src/gateway-video-model.ts
+++ b/packages/gateway/src/gateway-video-model.ts
@@ -154,8 +154,8 @@ export class GatewayVideoModel implements VideoModelV4 {
       return {
         videos: responseBody.videos,
         warnings: responseBody.warnings ?? [],
-        providerMetadata:
-          responseBody.providerMetadata as SharedV4ProviderMetadata,
+        providerMetadata: (responseBody.providerMetadata ??
+          undefined) as SharedV4ProviderMetadata,
         response: {
           timestamp: new Date(),
           modelId: this.modelId,
@@ -174,8 +174,11 @@ export class GatewayVideoModel implements VideoModelV4 {
   // async video jobs are polling-first: it does not expose a provider->SDK
   // webhook completion channel. If this method were present, `generateVideo`
   // would forward a webhook URL and await a notification that never arrives.
-  // `doStart` still forwards `webhookUrl` when supplied, so enabling webhooks
-  // later only requires adding `handleWebhookOption` here.
+  // `doStart` still forwards the spec's `webhookUrl` — as the Gateway's
+  // `callbackUrl` wire field (its completion-webhook contract; unknown body
+  // keys are stripped server-side). Enabling webhooks later requires adding
+  // `handleWebhookOption` here plus handling the Gateway's HMAC-signed
+  // delivery format; the wire field is already the right one.
 
   async doStart(
     options: VideoModelV4CallOptions & {
@@ -197,7 +200,9 @@ export class GatewayVideoModel implements VideoModelV4 {
         ),
         body: {
           ...this.buildRequestBody(options),
-          ...(webhookUrl && { webhookUrl }),
+          // The spec option is `webhookUrl`; the Gateway's wire contract for a
+          // completion webhook is `callbackUrl`.
+          ...(webhookUrl && { callbackUrl: webhookUrl }),
         },
         successfulResponseHandler: createJsonResponseHandler(
           gatewayVideoStartResponseSchema,
@@ -213,8 +218,8 @@ export class GatewayVideoModel implements VideoModelV4 {
       return {
         operation: responseBody.operation as JSONValue,
         warnings: responseBody.warnings ?? [],
-        providerMetadata:
-          responseBody.providerMetadata as SharedV4ProviderMetadata,
+        providerMetadata: (responseBody.providerMetadata ??
+          undefined) as SharedV4ProviderMetadata,
         response: {
           timestamp: new Date(),
           modelId: this.modelId,
@@ -273,8 +278,8 @@ export class GatewayVideoModel implements VideoModelV4 {
           status: 'completed',
           videos: responseBody.videos,
           warnings: responseBody.warnings ?? [],
-          providerMetadata:
-            responseBody.providerMetadata as SharedV4ProviderMetadata,
+          providerMetadata: (responseBody.providerMetadata ??
+            undefined) as SharedV4ProviderMetadata,
           response,
         };
       }
@@ -283,8 +288,8 @@ export class GatewayVideoModel implements VideoModelV4 {
         return {
           status: 'error',
           error: responseBody.error,
-          providerMetadata:
-            responseBody.providerMetadata as SharedV4ProviderMetadata,
+          providerMetadata: (responseBody.providerMetadata ??
+            undefined) as SharedV4ProviderMetadata,
           response,
         };
       }
@@ -296,8 +301,8 @@ export class GatewayVideoModel implements VideoModelV4 {
         return {
           status: 'error',
           error: 'Video generation was cancelled.',
-          providerMetadata:
-            responseBody.providerMetadata as SharedV4ProviderMetadata,
+          providerMetadata: (responseBody.providerMetadata ??
+            undefined) as SharedV4ProviderMetadata,
           response,
         };
       }
@@ -305,8 +310,8 @@ export class GatewayVideoModel implements VideoModelV4 {
       return {
         status: 'pending',
         warnings: responseBody.warnings ?? [],
-        providerMetadata:
-          responseBody.providerMetadata as SharedV4ProviderMetadata,
+        providerMetadata: (responseBody.providerMetadata ??
+          undefined) as SharedV4ProviderMetadata,
         response,
       };
     } catch (error) {
@@ -447,39 +452,37 @@ const gatewayVideoEventSchema = z.discriminatedUnion('type', [
 
 const gatewayVideoStartResponseSchema = z.object({
   operation: z.unknown(),
-  warnings: z.array(gatewayVideoWarningSchema).optional(),
-  providerMetadata: z
-    .record(z.string(), providerMetadataEntrySchema)
-    .optional(),
+  warnings: z.array(gatewayVideoWarningSchema).nullish(),
+  providerMetadata: z.record(z.string(), providerMetadataEntrySchema).nullish(),
 });
 
 const gatewayVideoStatusResponseSchema = z.discriminatedUnion('status', [
   z.object({
     status: z.literal('pending'),
-    warnings: z.array(gatewayVideoWarningSchema).optional(),
+    warnings: z.array(gatewayVideoWarningSchema).nullish(),
     providerMetadata: z
       .record(z.string(), providerMetadataEntrySchema)
-      .optional(),
+      .nullish(),
   }),
   z.object({
     status: z.literal('completed'),
     videos: z.array(gatewayVideoDataSchema),
-    warnings: z.array(gatewayVideoWarningSchema).optional(),
+    warnings: z.array(gatewayVideoWarningSchema).nullish(),
     providerMetadata: z
       .record(z.string(), providerMetadataEntrySchema)
-      .optional(),
+      .nullish(),
   }),
   z.object({
     status: z.literal('error'),
     error: z.string(),
     providerMetadata: z
       .record(z.string(), providerMetadataEntrySchema)
-      .optional(),
+      .nullish(),
   }),
   z.object({
     status: z.literal('cancelled'),
     providerMetadata: z
       .record(z.string(), providerMetadataEntrySchema)
-      .optional(),
+      .nullish(),
   }),
 ]);

--- a/packages/gateway/src/gateway-video-model.ts
+++ b/packages/gateway/src/gateway-video-model.ts
@@ -183,6 +183,11 @@ export class GatewayVideoModel implements VideoModelV4 {
     },
   ): Promise<VideoModelV4OperationStartResult> {
     const { headers, abortSignal, webhookUrl } = options;
+    // `doStart` creates a billable generation, and core retries it. Core builds
+    // the options object once outside its retry closure, so one key per object
+    // identity is stable across those retries and the gateway dedupes instead of
+    // starting a second generation after a lost response.
+    const idempotencyKey = startIdempotencyKey(options);
     const resolvedHeaders = this.config.headers
       ? await resolve(this.config.headers)
       : undefined;
@@ -194,6 +199,7 @@ export class GatewayVideoModel implements VideoModelV4 {
           headers ?? {},
           this.getModelConfigHeaders(),
           await resolve(this.config.o11yHeaders),
+          { 'idempotency-key': idempotencyKey },
         ),
         body: {
           ...this.buildRequestBody(options),
@@ -483,3 +489,18 @@ const gatewayVideoStatusResponseSchema = z.discriminatedUnion('status', [
       .optional(),
   }),
 ]);
+
+/**
+ * One idempotency key per `doStart` options object, so core's retries of the
+ * same call reuse it while a genuinely new call gets a fresh one. A WeakMap
+ * keeps this from retaining anything.
+ */
+const startIdempotencyKeys = new WeakMap<object, string>();
+
+function startIdempotencyKey(options: object): string {
+  const existing = startIdempotencyKeys.get(options);
+  if (existing !== undefined) return existing;
+  const key = `gw_vid_${crypto.randomUUID()}`;
+  startIdempotencyKeys.set(options, key);
+  return key;
+}

--- a/packages/gateway/src/gateway-video-model.ts
+++ b/packages/gateway/src/gateway-video-model.ts
@@ -183,11 +183,6 @@ export class GatewayVideoModel implements VideoModelV4 {
     },
   ): Promise<VideoModelV4OperationStartResult> {
     const { headers, abortSignal, webhookUrl } = options;
-    // `doStart` creates a billable generation, and core retries it. Core builds
-    // the options object once outside its retry closure, so one key per object
-    // identity is stable across those retries and the gateway dedupes instead of
-    // starting a second generation after a lost response.
-    const idempotencyKey = startIdempotencyKey(options);
     const resolvedHeaders = this.config.headers
       ? await resolve(this.config.headers)
       : undefined;
@@ -199,7 +194,6 @@ export class GatewayVideoModel implements VideoModelV4 {
           headers ?? {},
           this.getModelConfigHeaders(),
           await resolve(this.config.o11yHeaders),
-          { 'idempotency-key': idempotencyKey },
         ),
         body: {
           ...this.buildRequestBody(options),
@@ -489,18 +483,3 @@ const gatewayVideoStatusResponseSchema = z.discriminatedUnion('status', [
       .optional(),
   }),
 ]);
-
-/**
- * One idempotency key per `doStart` options object, so core's retries of the
- * same call reuse it while a genuinely new call gets a fresh one. A WeakMap
- * keeps this from retaining anything.
- */
-const startIdempotencyKeys = new WeakMap<object, string>();
-
-function startIdempotencyKey(options: object): string {
-  const existing = startIdempotencyKeys.get(options);
-  if (existing !== undefined) return existing;
-  const key = `gw_vid_${crypto.randomUUID()}`;
-  startIdempotencyKeys.set(options, key);
-  return key;
-}

--- a/packages/gateway/src/gateway-video-model.ts
+++ b/packages/gateway/src/gateway-video-model.ts
@@ -3,7 +3,10 @@ import {
   type Experimental_VideoModelV4 as VideoModelV4,
   type Experimental_VideoModelV4CallOptions as VideoModelV4CallOptions,
   type Experimental_VideoModelV4File as VideoModelV4File,
+  type Experimental_VideoModelV4OperationStartResult as VideoModelV4OperationStartResult,
+  type Experimental_VideoModelV4OperationStatusResult as VideoModelV4OperationStatusResult,
   type Experimental_VideoModelV4VideoData as VideoModelV4VideoData,
+  type JSONValue,
   type SharedV4ProviderMetadata,
   type SharedV4Warning,
 } from '@ai-sdk/provider';
@@ -11,6 +14,7 @@ import {
   combineHeaders,
   convertUint8ArrayToBase64,
   createJsonErrorResponseHandler,
+  createJsonResponseHandler,
   parseJsonEventStream,
   postJsonToApi,
   resolve,
@@ -38,22 +42,7 @@ export class GatewayVideoModel implements VideoModelV4 {
     return this.config.provider;
   }
 
-  async doGenerate({
-    prompt,
-    n,
-    aspectRatio,
-    resolution,
-    duration,
-    fps,
-    seed,
-    generateAudio,
-    image,
-    frameImages,
-    inputReferences,
-    providerOptions,
-    headers,
-    abortSignal,
-  }: VideoModelV4CallOptions): Promise<{
+  async doGenerate(options: VideoModelV4CallOptions): Promise<{
     videos: Array<VideoModelV4VideoData>;
     warnings: Array<SharedV4Warning>;
     providerMetadata?: SharedV4ProviderMetadata;
@@ -63,6 +52,7 @@ export class GatewayVideoModel implements VideoModelV4 {
       headers: Record<string, string> | undefined;
     };
   }> {
+    const { headers, abortSignal } = options;
     const resolvedHeaders = this.config.headers
       ? await resolve(this.config.headers)
       : undefined;
@@ -76,29 +66,7 @@ export class GatewayVideoModel implements VideoModelV4 {
           await resolve(this.config.o11yHeaders),
           { accept: 'text/event-stream' },
         ),
-        body: {
-          prompt,
-          n,
-          ...(aspectRatio && { aspectRatio }),
-          ...(resolution && { resolution }),
-          ...(duration && { duration }),
-          ...(fps && { fps }),
-          ...(seed && { seed }),
-          ...(generateAudio !== undefined && { generateAudio }),
-          ...(providerOptions && { providerOptions }),
-          ...(image && { image: maybeEncodeVideoFile(image) }),
-          ...(frameImages && {
-            frameImages: frameImages.map(frame => ({
-              ...frame,
-              image: maybeEncodeVideoFile(frame.image),
-            })),
-          }),
-          ...(inputReferences && {
-            inputReferences: inputReferences.map(reference =>
-              maybeEncodeVideoFile(reference),
-            ),
-          }),
-        },
+        body: this.buildRequestBody(options),
         successfulResponseHandler: async ({
           response,
           url,
@@ -202,8 +170,202 @@ export class GatewayVideoModel implements VideoModelV4 {
     }
   }
 
+  // `handleWebhookOption` is intentionally NOT implemented. The Gateway's
+  // async video jobs are polling-first: it does not expose a provider->SDK
+  // webhook completion channel. If this method were present, `generateVideo`
+  // would forward a webhook URL and await a notification that never arrives.
+  // `doStart` still forwards `webhookUrl` when supplied, so enabling webhooks
+  // later only requires adding `handleWebhookOption` here.
+
+  async doStart(
+    options: VideoModelV4CallOptions & {
+      webhookUrl?: string;
+    },
+  ): Promise<VideoModelV4OperationStartResult> {
+    const { headers, abortSignal, webhookUrl } = options;
+    const resolvedHeaders = this.config.headers
+      ? await resolve(this.config.headers)
+      : undefined;
+    try {
+      const { responseHeaders, value: responseBody } = await postJsonToApi({
+        url: this.getStartUrl(),
+        headers: combineHeaders(
+          resolvedHeaders,
+          headers ?? {},
+          this.getModelConfigHeaders(),
+          await resolve(this.config.o11yHeaders),
+        ),
+        body: {
+          ...this.buildRequestBody(options),
+          ...(webhookUrl && { webhookUrl }),
+        },
+        successfulResponseHandler: createJsonResponseHandler(
+          gatewayVideoStartResponseSchema,
+        ),
+        failedResponseHandler: createJsonErrorResponseHandler({
+          errorSchema: z.any(),
+          errorToMessage: data => data,
+        }),
+        ...(abortSignal && { abortSignal }),
+        fetch: this.config.fetch,
+      });
+
+      return {
+        operation: responseBody.operation as JSONValue,
+        warnings: responseBody.warnings ?? [],
+        providerMetadata:
+          responseBody.providerMetadata as SharedV4ProviderMetadata,
+        response: {
+          timestamp: new Date(),
+          modelId: this.modelId,
+          headers: responseHeaders,
+        },
+      };
+    } catch (error) {
+      throw await asGatewayError(
+        error,
+        await parseAuthMethod(resolvedHeaders ?? {}),
+      );
+    }
+  }
+
+  async doStatus({
+    operation,
+    abortSignal,
+    headers,
+  }: {
+    operation: JSONValue;
+    abortSignal?: AbortSignal;
+    headers?: Record<string, string | undefined>;
+  }): Promise<VideoModelV4OperationStatusResult> {
+    const resolvedHeaders = this.config.headers
+      ? await resolve(this.config.headers)
+      : undefined;
+    try {
+      const { responseHeaders, value: responseBody } = await postJsonToApi({
+        url: this.getStatusUrl(),
+        headers: combineHeaders(
+          resolvedHeaders,
+          headers ?? {},
+          this.getModelConfigHeaders(),
+          await resolve(this.config.o11yHeaders),
+        ),
+        body: { operation },
+        successfulResponseHandler: createJsonResponseHandler(
+          gatewayVideoStatusResponseSchema,
+        ),
+        failedResponseHandler: createJsonErrorResponseHandler({
+          errorSchema: z.any(),
+          errorToMessage: data => data,
+        }),
+        ...(abortSignal && { abortSignal }),
+        fetch: this.config.fetch,
+      });
+
+      const response = {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: responseHeaders,
+      };
+
+      if (responseBody.status === 'completed') {
+        return {
+          status: 'completed',
+          videos: responseBody.videos,
+          warnings: responseBody.warnings ?? [],
+          providerMetadata:
+            responseBody.providerMetadata as SharedV4ProviderMetadata,
+          response,
+        };
+      }
+
+      if (responseBody.status === 'error') {
+        return {
+          status: 'error',
+          error: responseBody.error,
+          providerMetadata:
+            responseBody.providerMetadata as SharedV4ProviderMetadata,
+          response,
+        };
+      }
+
+      // The Gateway reports cooperative cancellation as its own terminal
+      // status; the v4 operation union has no cancelled state, so surface it
+      // as a terminal error rather than polling forever.
+      if (responseBody.status === 'cancelled') {
+        return {
+          status: 'error',
+          error: 'Video generation was cancelled.',
+          providerMetadata:
+            responseBody.providerMetadata as SharedV4ProviderMetadata,
+          response,
+        };
+      }
+
+      return {
+        status: 'pending',
+        warnings: responseBody.warnings ?? [],
+        providerMetadata:
+          responseBody.providerMetadata as SharedV4ProviderMetadata,
+        response,
+      };
+    } catch (error) {
+      throw await asGatewayError(
+        error,
+        await parseAuthMethod(resolvedHeaders ?? {}),
+      );
+    }
+  }
+
+  private buildRequestBody({
+    prompt,
+    n,
+    aspectRatio,
+    resolution,
+    duration,
+    fps,
+    seed,
+    generateAudio,
+    image,
+    frameImages,
+    inputReferences,
+    providerOptions,
+  }: VideoModelV4CallOptions) {
+    return {
+      prompt,
+      n,
+      ...(aspectRatio && { aspectRatio }),
+      ...(resolution && { resolution }),
+      ...(duration && { duration }),
+      ...(fps && { fps }),
+      ...(seed && { seed }),
+      ...(generateAudio !== undefined && { generateAudio }),
+      ...(providerOptions && { providerOptions }),
+      ...(image && { image: maybeEncodeVideoFile(image) }),
+      ...(frameImages && {
+        frameImages: frameImages.map(frame => ({
+          ...frame,
+          image: maybeEncodeVideoFile(frame.image),
+        })),
+      }),
+      ...(inputReferences && {
+        inputReferences: inputReferences.map(reference =>
+          maybeEncodeVideoFile(reference),
+        ),
+      }),
+    };
+  }
+
   private getUrl() {
     return `${this.config.baseURL}/video-model`;
+  }
+
+  private getStartUrl() {
+    return `${this.config.baseURL}/video-model/start`;
+  }
+
+  private getStatusUrl() {
+    return `${this.config.baseURL}/video-model/status`;
   }
 
   private getModelConfigHeaders() {
@@ -280,5 +442,44 @@ const gatewayVideoEventSchema = z.discriminatedUnion('type', [
     errorType: z.string(),
     statusCode: z.number(),
     param: z.unknown().nullable(),
+  }),
+]);
+
+const gatewayVideoStartResponseSchema = z.object({
+  operation: z.unknown(),
+  warnings: z.array(gatewayVideoWarningSchema).optional(),
+  providerMetadata: z
+    .record(z.string(), providerMetadataEntrySchema)
+    .optional(),
+});
+
+const gatewayVideoStatusResponseSchema = z.discriminatedUnion('status', [
+  z.object({
+    status: z.literal('pending'),
+    warnings: z.array(gatewayVideoWarningSchema).optional(),
+    providerMetadata: z
+      .record(z.string(), providerMetadataEntrySchema)
+      .optional(),
+  }),
+  z.object({
+    status: z.literal('completed'),
+    videos: z.array(gatewayVideoDataSchema),
+    warnings: z.array(gatewayVideoWarningSchema).optional(),
+    providerMetadata: z
+      .record(z.string(), providerMetadataEntrySchema)
+      .optional(),
+  }),
+  z.object({
+    status: z.literal('error'),
+    error: z.string(),
+    providerMetadata: z
+      .record(z.string(), providerMetadataEntrySchema)
+      .optional(),
+  }),
+  z.object({
+    status: z.literal('cancelled'),
+    providerMetadata: z
+      .record(z.string(), providerMetadataEntrySchema)
+      .optional(),
   }),
 ]);


### PR DESCRIPTION
## Background

#12515 shipped the async video operation protocol on the v4 spec (`doStart`/`doStatus`), and the async-native providers implement it. The AI Gateway serves durable async video jobs over `POST /v4/ai/video-model/start|status`, but `GatewayVideoModel` only implements `doGenerate` — so `experimental_generateVideo({ model: gateway(...), poll: {...} })` cannot use the async flow end-to-end.

## Summary

Implements `doStart`/`doStatus` on `GatewayVideoModel` (v4) against the Gateway's async video job endpoints, and makes retried `doStart` calls idempotent in core:

- `doStart` → `POST {baseURL}/video-model/start`; the 202 body's `operation` becomes the opaque v4 operation reference. Shares `doGenerate`'s full request-body construction and forwards `webhookUrl` when supplied.
- `doStatus` → `POST {baseURL}/video-model/status`, mapping the gateway's `pending`/`completed`/`error` shapes onto `VideoModelV4OperationStatusResult`. The gateway's `cancelled` terminal has no v4 union member, so it surfaces as a terminal `error` (never an infinite poll).
- **`doStart` retries are idempotent.** `generateVideo` retries `doStart`, which creates a *billable* generation — a retry after a lost response could start (and charge for) a second one. Core now mints one explicit token per logical start (`aisdk_vid_<id>`, outside the retry closure) and forwards it as an `idempotency-key` header; a caller-supplied key wins over the minted one. `GatewayVideoModel` just forwards headers — the Gateway's start endpoint already deduplicates on this header, and other providers receive a header they can ignore today and honor later. No spec change; if a first-class `idempotencyKey` call option is preferred so non-gateway providers can opt in explicitly, happy to switch — the experimental v4 surface allows it.
- `handleWebhookOption` is intentionally **not** implemented: the gateway is polling-first and exposes no provider→SDK webhook completion channel today; presence of the method would make `generateVideo` await a notification that never arrives. Adding webhooks later is additive.
- Errors on both calls flow through the existing `asGatewayError` mapping.

One recorded contract note: the Gateway can serve a long-completed job whose provider asset has expired as `completed` with empty `videos[]` plus explanatory `providerMetadata`. Unreachable inside a single `generateVideo` run (a just-started operation's result is always fresh; core throws `NoVideoGeneratedError` on empty results as usual) — relevant only if the SDK later exposes resuming an operation by reference.

## Verification

- `pnpm --filter @ai-sdk/gateway test` — 509 passed (new `doStart`/`doStatus` tests: request/headers shape, webhookUrl forwarding, pending/completed/error/cancelled mappings, no `handleWebhookOption`).
- `generate-video` suite — 62 passed (stable idempotency key across retries, distinct key per call, caller-supplied key preserved).
- `tsc --noEmit` clean in both packages; `oxlint` + `ultracite check` clean.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated — n/a (experimental surface; gateway async video docs land with the gateway feature)
- [x] A _patch changeset_ for relevant packages has been added
- [x] Formatting issues have been fixed (`ultracite check` clean)

## Related

vercel/ai#12515 (protocol), vercel/ai-gateway#2974 + the Option-B stack (server side).
