### PR TITLE
feat(provider/google-vertex): add Chirp 3 HD voices (Cloud Text-to-Speech) speech model

### DIFF
--- a/.changeset/chirp-three-hd-speech.md
+++ b/.changeset/chirp-three-hd-speech.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+Add Chirp 3: HD voice support to the speech model via the Google Cloud Text-to-Speech API. Use `vertex.speech('chirp-3-hd')` with `voice` (e.g. `Kore`) and `language` (BCP-47 locale, e.g. `en-US`), or pass a fully-qualified voice name such as `en-US-Chirp3-HD-Kore`.

--- a/.changeset/chirp-three-hd-speech.md
+++ b/.changeset/chirp-three-hd-speech.md
@@ -2,4 +2,4 @@
 '@ai-sdk/google-vertex': patch
 ---
 
-Add Chirp 3: HD voice support to the speech model via the Google Cloud Text-to-Speech API. Use `vertex.speech('chirp-3-hd')` with `voice` (e.g. `Kore`) and `language` (BCP-47 locale, e.g. `en-US`), or pass a fully-qualified voice name such as `en-US-Chirp3-HD-Kore`.
+feat(provider/google-vertex): add Chirp 3 HD voices (Cloud Text-to-Speech) speech model

--- a/examples/ai-functions/src/generate-speech/google-vertex/chirp-3-hd.ts
+++ b/examples/ai-functions/src/generate-speech/google-vertex/chirp-3-hd.ts
@@ -1,0 +1,21 @@
+import { googleVertex } from '@ai-sdk/google-vertex';
+import { generateSpeech } from 'ai';
+import { saveAudioFile } from '../../lib/save-audio';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateSpeech({
+    model: googleVertex.speech('chirp-3-hd'),
+    text: 'Hello from the AI SDK!',
+    // Composed into the Chirp 3: HD voice name `en-US-Chirp3-HD-Kore`.
+    voice: 'Kore',
+    language: 'en-US',
+  });
+
+  console.log('Audio:', result.audio);
+  console.log('Warnings:', result.warnings);
+  console.log('Responses:', result.responses);
+  console.log('Provider Metadata:', result.providerMetadata);
+
+  await saveAudioFile(result.audio);
+});

--- a/packages/google-vertex/src/google-vertex-cloud-tts-speech-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-cloud-tts-speech-model.test.ts
@@ -85,6 +85,20 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should default the language for a Chirp 3: HD voice name without a locale prefix', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      text: 'Hello!',
+      voice: 'Chirp3-HD-Kore',
+    });
+
+    expect((await server.calls[0].requestBodyJson).voice).toStrictEqual({
+      languageCode: 'en-US',
+      name: 'Chirp3-HD-Kore',
+    });
+  });
+
   it('should prefer an explicit language over the voice-name locale', async () => {
     prepareJsonResponse();
 
@@ -106,6 +120,9 @@ describe('doGenerate', () => {
     const result = await model.doGenerate({ text: 'Hello!' });
 
     expect(result.audio).toStrictEqual(audioBytes);
+    expect(result.providerMetadata).toStrictEqual({
+      google: { mimeType: 'audio/wav' },
+    });
   });
 
   it('should map speed to speakingRate', async () => {

--- a/packages/google-vertex/src/google-vertex-cloud-tts-speech-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-cloud-tts-speech-model.test.ts
@@ -1,0 +1,241 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { GoogleVertexCloudTTSSpeechModel } from './google-vertex-cloud-tts-speech-model';
+import { createGoogleVertex } from './google-vertex-provider-base';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const provider = createGoogleVertex({
+  project: 'test-project',
+  location: 'us-central1',
+});
+const model = provider.speech('chirp-3-hd');
+
+// 8 bytes of audio; base64 -> 'AQIDBAUGBwg='.
+const audioBytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+const AUDIO_BASE64 = 'AQIDBAUGBwg=';
+
+const url = 'https://texttospeech.googleapis.com/v1/text:synthesize';
+
+const server = createTestServer({
+  [url]: {},
+});
+
+function prepareJsonResponse({
+  headers,
+}: {
+  headers?: Record<string, string>;
+} = {}) {
+  server.urls[url].response = {
+    type: 'json-value',
+    headers,
+    body: { audioContent: AUDIO_BASE64 },
+  };
+}
+
+describe('doGenerate', () => {
+  it('should target the Cloud Text-to-Speech synthesize endpoint', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({ text: 'Hello from the AI SDK!' });
+
+    expect(server.calls[0].requestUrl).toBe(url);
+  });
+
+  it('should send text, a default voice and LINEAR16 audio config', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({ text: 'Hello from the AI SDK!' });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      input: { text: 'Hello from the AI SDK!' },
+      voice: { languageCode: 'en-US', name: 'en-US-Chirp3-HD-Kore' },
+      audioConfig: { audioEncoding: 'LINEAR16' },
+    });
+  });
+
+  it('should compose the voice name from language and voice', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      text: 'Hallo!',
+      voice: 'Aoede',
+      language: 'de-DE',
+    });
+
+    expect((await server.calls[0].requestBodyJson).voice).toStrictEqual({
+      languageCode: 'de-DE',
+      name: 'de-DE-Chirp3-HD-Aoede',
+    });
+  });
+
+  it('should pass a fully-qualified Chirp 3: HD voice name through verbatim', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      text: 'Bonjour !',
+      voice: 'fr-FR-Chirp3-HD-Charon',
+    });
+
+    expect((await server.calls[0].requestBodyJson).voice).toStrictEqual({
+      languageCode: 'fr-FR',
+      name: 'fr-FR-Chirp3-HD-Charon',
+    });
+  });
+
+  it('should prefer an explicit language over the voice-name locale', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({
+      text: 'Hello!',
+      voice: 'en-AU-Chirp3-HD-Kore',
+      language: 'en-GB',
+    });
+
+    expect((await server.calls[0].requestBodyJson).voice).toStrictEqual({
+      languageCode: 'en-GB',
+      name: 'en-AU-Chirp3-HD-Kore',
+    });
+  });
+
+  it('should decode the base64 audio content', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({ text: 'Hello!' });
+
+    expect(result.audio).toStrictEqual(audioBytes);
+  });
+
+  it('should map speed to speakingRate', async () => {
+    prepareJsonResponse();
+
+    await model.doGenerate({ text: 'Hello!', speed: 1.5 });
+
+    expect((await server.calls[0].requestBodyJson).audioConfig).toStrictEqual({
+      audioEncoding: 'LINEAR16',
+      speakingRate: 1.5,
+    });
+  });
+
+  it('should warn about unsupported instructions', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello!',
+      instructions: 'Speak slowly.',
+    });
+
+    expect(result.warnings).toEqual([
+      expect.objectContaining({ type: 'unsupported', feature: 'instructions' }),
+    ]);
+  });
+
+  it('should warn about unsupported output formats', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello!',
+      outputFormat: 'mp3',
+    });
+
+    expect(result.warnings).toEqual([
+      expect.objectContaining({ type: 'unsupported', feature: 'outputFormat' }),
+    ]);
+  });
+
+  it('should not warn for the wav output format', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({
+      text: 'Hello!',
+      outputFormat: 'wav',
+    });
+
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('should return empty audio when the response has no audio content', async () => {
+    server.urls[url].response = { type: 'json-value', body: {} };
+
+    const result = await model.doGenerate({ text: 'Hello!' });
+
+    expect(result.audio).toStrictEqual(new Uint8Array(0));
+  });
+
+  it('should pass headers and user agent', async () => {
+    prepareJsonResponse();
+
+    const providerWithHeaders = createGoogleVertex({
+      project: 'test-project',
+      location: 'us-central1',
+      headers: { 'Custom-Provider-Header': 'provider-header-value' },
+    });
+
+    await providerWithHeaders.speech('chirp-3-hd').doGenerate({
+      text: 'Hello!',
+      headers: { 'Custom-Request-Header': 'request-header-value' },
+    });
+
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      'custom-provider-header': 'provider-header-value',
+      'custom-request-header': 'request-header-value',
+    });
+    expect(server.calls[0].requestUserAgent).toContain(
+      'ai-sdk/google-vertex/0.0.0-test',
+    );
+  });
+
+  it('should include response data with timestamp, modelId, headers and raw body', async () => {
+    prepareJsonResponse({ headers: { 'x-request-id': 'test-request-id' } });
+
+    const testDate = new Date(0);
+    const customModel = new GoogleVertexCloudTTSSpeechModel('chirp-3-hd', {
+      provider: 'google.vertex.speech',
+      headers: () => ({}),
+      _internal: { currentDate: () => testDate },
+    });
+
+    const result = await customModel.doGenerate({ text: 'Hello!' });
+
+    expect(result.response.timestamp.getTime()).toBe(testDate.getTime());
+    expect(result.response.modelId).toBe('chirp-3-hd');
+    expect(result.response.headers?.['x-request-id']).toBe('test-request-id');
+    expect(result.response.body).toStrictEqual({
+      audioContent: AUDIO_BASE64,
+    });
+  });
+
+  it('should include the request body', async () => {
+    prepareJsonResponse();
+
+    const result = await model.doGenerate({ text: 'Hello!' });
+
+    expect(result.request?.body).toBe(
+      JSON.stringify({
+        input: { text: 'Hello!' },
+        voice: { languageCode: 'en-US', name: 'en-US-Chirp3-HD-Kore' },
+        audioConfig: { audioEncoding: 'LINEAR16' },
+      }),
+    );
+  });
+
+  it('should throw an API call error for error responses', async () => {
+    server.urls[url].response = {
+      type: 'error',
+      status: 400,
+      body: JSON.stringify({
+        error: {
+          code: 400,
+          message: 'Voice not found.',
+          status: 'INVALID_ARGUMENT',
+        },
+      }),
+    };
+
+    await expect(model.doGenerate({ text: 'Hello!' })).rejects.toThrow(
+      'Voice not found.',
+    );
+  });
+});

--- a/packages/google-vertex/src/google-vertex-cloud-tts-speech-model.ts
+++ b/packages/google-vertex/src/google-vertex-cloud-tts-speech-model.ts
@@ -1,0 +1,183 @@
+import type { SharedV4Warning, SpeechModelV4 } from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertBase64ToUint8Array,
+  createJsonResponseHandler,
+  postJsonToApi,
+  resolve,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+  type FetchFunction,
+  type Resolvable,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { googleVertexFailedResponseHandler } from './google-vertex-error';
+import type { GoogleVertexSpeechModelId } from './google-vertex-speech-model-options';
+
+interface GoogleVertexCloudTTSSpeechModelConfig {
+  provider: string;
+  headers?: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+const DEFAULT_VOICE = 'Kore';
+const DEFAULT_LANGUAGE = 'en-US';
+
+// Chirp 3: HD voice names are `<locale>-Chirp3-HD-<voice>`,
+// e.g. `en-US-Chirp3-HD-Kore`.
+// https://cloud.google.com/text-to-speech/docs/chirp3-hd
+const CHIRP3_HD_VOICE_INFIX = 'Chirp3-HD';
+
+// Cloud Text-to-Speech uses a single non-regional host for standard
+// synthesis (unlike Speech-to-Text and Vertex AI, which are regional).
+// https://cloud.google.com/text-to-speech/docs/reference/rest/v1/text/synthesize
+const CLOUD_TTS_SYNTHESIZE_URL =
+  'https://texttospeech.googleapis.com/v1/text:synthesize';
+
+/**
+ * Speech model for Chirp 3: HD voices on the Google Cloud Text-to-Speech API.
+ *
+ * Unlike the Gemini TTS models (which go through the Vertex
+ * `generateContent` endpoint via `GoogleSpeechModel`), Chirp 3: HD voices are
+ * served by the dedicated Cloud Text-to-Speech `text:synthesize` endpoint,
+ * reusing the provider's Google Cloud credentials.
+ */
+export class GoogleVertexCloudTTSSpeechModel implements SpeechModelV4 {
+  readonly specificationVersion = 'v4';
+
+  static [WORKFLOW_SERIALIZE](model: GoogleVertexCloudTTSSpeechModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: GoogleVertexSpeechModelId;
+    config: GoogleVertexCloudTTSSpeechModelConfig;
+  }) {
+    return new GoogleVertexCloudTTSSpeechModel(options.modelId, options.config);
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: GoogleVertexSpeechModelId,
+    private readonly config: GoogleVertexCloudTTSSpeechModelConfig,
+  ) {}
+
+  async doGenerate(
+    options: Parameters<SpeechModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<SpeechModelV4['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const warnings: SharedV4Warning[] = [];
+
+    const {
+      text,
+      voice = DEFAULT_VOICE,
+      outputFormat,
+      instructions,
+      speed,
+      language,
+    } = options;
+
+    // Compose the voice name. A fully-qualified Chirp 3: HD voice name
+    // (e.g. `en-US-Chirp3-HD-Kore`) is passed through verbatim, with its
+    // locale prefix as the language code; otherwise the name is composed
+    // from the language (BCP-47 locale, e.g. `en-US`) and the plain voice
+    // name (e.g. `Kore`).
+    let voiceName: string;
+    let languageCode: string;
+    if (voice.includes(CHIRP3_HD_VOICE_INFIX)) {
+      voiceName = voice;
+      languageCode =
+        language ??
+        voice.split(`-${CHIRP3_HD_VOICE_INFIX}`)[0] ??
+        DEFAULT_LANGUAGE;
+    } else {
+      languageCode = language ?? DEFAULT_LANGUAGE;
+      voiceName = `${languageCode}-${CHIRP3_HD_VOICE_INFIX}-${voice}`;
+    }
+
+    if (instructions != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'instructions',
+        details:
+          'Google Cloud Text-to-Speech Chirp 3: HD voices do not support the `instructions` option. It was ignored.',
+      });
+    }
+
+    // LINEAR16 responses are WAV (RIFF) files, so only `wav` is supported.
+    if (outputFormat != null && outputFormat !== 'wav') {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'outputFormat',
+        details: `Unsupported output format: ${outputFormat}. Using wav instead.`,
+      });
+    }
+
+    const requestBody = {
+      input: { text },
+      voice: { languageCode, name: voiceName },
+      audioConfig: {
+        // LINEAR16 audio is returned as a WAV (RIFF) file, which is directly
+        // playable and detectable as `audio/wav`.
+        audioEncoding: 'LINEAR16',
+        ...(speed != null ? { speakingRate: speed } : {}),
+      },
+    };
+
+    const {
+      value: response,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url: CLOUD_TTS_SYNTHESIZE_URL,
+      headers: combineHeaders(
+        this.config.headers ? await resolve(this.config.headers) : undefined,
+        options.headers,
+      ),
+      body: requestBody,
+      failedResponseHandler: googleVertexFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        googleVertexCloudTTSResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    // Empty audio is returned as-is so the core layer throws
+    // NoSpeechGeneratedError.
+    const audio =
+      response.audioContent != null
+        ? convertBase64ToUint8Array(response.audioContent)
+        : new Uint8Array(0);
+
+    return {
+      audio,
+      warnings,
+      request: {
+        body: JSON.stringify(requestBody),
+      },
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+    };
+  }
+}
+
+// Minimal schema: only the fields the implementation reads, with `.nullish()`
+// so provider API changes don't break parsing.
+const googleVertexCloudTTSResponseSchema = z.object({
+  audioContent: z.string().nullish(),
+});

--- a/packages/google-vertex/src/google-vertex-cloud-tts-speech-model.ts
+++ b/packages/google-vertex/src/google-vertex-cloud-tts-speech-model.ts
@@ -96,10 +96,12 @@ export class GoogleVertexCloudTTSSpeechModel implements SpeechModelV4 {
     let languageCode: string;
     if (voice.includes(CHIRP3_HD_VOICE_INFIX)) {
       voiceName = voice;
-      languageCode =
-        language ??
-        voice.split(`-${CHIRP3_HD_VOICE_INFIX}`)[0] ??
-        DEFAULT_LANGUAGE;
+      // The locale prefix may be missing (e.g. `Chirp3-HD-Kore`), in which
+      // case the extracted prefix is empty and the default language is used.
+      const localePrefix = voice
+        .split(CHIRP3_HD_VOICE_INFIX)[0]
+        .replace(/-$/, '');
+      languageCode = language ?? (localePrefix || DEFAULT_LANGUAGE);
     } else {
       languageCode = language ?? DEFAULT_LANGUAGE;
       voiceName = `${languageCode}-${CHIRP3_HD_VOICE_INFIX}-${voice}`;
@@ -171,6 +173,12 @@ export class GoogleVertexCloudTTSSpeechModel implements SpeechModelV4 {
         modelId: this.modelId,
         headers: responseHeaders,
         body: rawResponse,
+      },
+      providerMetadata: {
+        google: {
+          // LINEAR16 audio is returned as a WAV (RIFF) file.
+          mimeType: 'audio/wav',
+        },
       },
     };
   }

--- a/packages/google-vertex/src/google-vertex-cloud-tts-speech-model.ts
+++ b/packages/google-vertex/src/google-vertex-cloud-tts-speech-model.ts
@@ -129,8 +129,6 @@ export class GoogleVertexCloudTTSSpeechModel implements SpeechModelV4 {
       input: { text },
       voice: { languageCode, name: voiceName },
       audioConfig: {
-        // LINEAR16 audio is returned as a WAV (RIFF) file, which is directly
-        // playable and detectable as `audio/wav`.
         audioEncoding: 'LINEAR16',
         ...(speed != null ? { speakingRate: speed } : {}),
       },
@@ -176,7 +174,6 @@ export class GoogleVertexCloudTTSSpeechModel implements SpeechModelV4 {
       },
       providerMetadata: {
         google: {
-          // LINEAR16 audio is returned as a WAV (RIFF) file.
           mimeType: 'audio/wav',
         },
       },

--- a/packages/google-vertex/src/google-vertex-provider-base.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.test.ts
@@ -208,6 +208,18 @@ describe('google-vertex-provider-base', () => {
     expect(GoogleSpeechModel).not.toHaveBeenCalled();
   });
 
+  it('should throw for chirp speech models when an Express Mode API key is set', () => {
+    process.env.GOOGLE_VERTEX_API_KEY = 'test-api-key';
+    const provider = createGoogleVertex({
+      project: 'test-project',
+      location: 'test-location',
+    });
+
+    expect(() => provider.speech('chirp-3-hd')).toThrow(
+      'Google Vertex Chirp speech models do not support Express Mode API keys. Use standard Google Cloud credentials instead.',
+    );
+  });
+
   it('should keep routing gemini speech models to the Gemini speech model', () => {
     const provider = createGoogleVertex({
       project: 'test-project',

--- a/packages/google-vertex/src/google-vertex-provider-base.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.test.ts
@@ -10,6 +10,7 @@ import { GoogleVertexEmbeddingModel } from './google-vertex-embedding-model';
 import { GoogleVertexImageModel } from './google-vertex-image-model';
 import { GoogleVertexVideoModel } from './google-vertex-video-model';
 import { GoogleVertexTranscriptionModel } from './google-vertex-transcription-model';
+import { GoogleVertexCloudTTSSpeechModel } from './google-vertex-cloud-tts-speech-model';
 
 // Mock the imported modules
 vi.mock('@ai-sdk/provider-utils', async importOriginal => {
@@ -65,6 +66,10 @@ vi.mock('./google-vertex-video-model', () => ({
 
 vi.mock('./google-vertex-transcription-model', () => ({
   GoogleVertexTranscriptionModel: vi.fn(),
+}));
+
+vi.mock('./google-vertex-cloud-tts-speech-model', () => ({
+  GoogleVertexCloudTTSSpeechModel: vi.fn(),
 }));
 
 describe('google-vertex-provider-base', () => {
@@ -184,6 +189,37 @@ describe('google-vertex-provider-base', () => {
       'gemini-2.5-pro-tts',
       expect.objectContaining({ provider: 'google.vertex.speech' }),
     );
+  });
+
+  it('should route chirp speech models to the Cloud Text-to-Speech model', () => {
+    const provider = createGoogleVertex({
+      project: 'test-project',
+      location: 'test-location',
+    });
+    provider.speech('chirp-3-hd');
+
+    expect(GoogleVertexCloudTTSSpeechModel).toHaveBeenCalledWith(
+      'chirp-3-hd',
+      expect.objectContaining({
+        provider: 'google.vertex.speech',
+        headers: expect.any(Function),
+      }),
+    );
+    expect(GoogleSpeechModel).not.toHaveBeenCalled();
+  });
+
+  it('should keep routing gemini speech models to the Gemini speech model', () => {
+    const provider = createGoogleVertex({
+      project: 'test-project',
+      location: 'test-location',
+    });
+    provider.speechModel('gemini-2.5-flash-tts');
+
+    expect(GoogleSpeechModel).toHaveBeenCalledWith(
+      'gemini-2.5-flash-tts',
+      expect.objectContaining({ provider: 'google.vertex.speech' }),
+    );
+    expect(GoogleVertexCloudTTSSpeechModel).not.toHaveBeenCalled();
   });
 
   it('should create a transcription model with correct settings', () => {

--- a/packages/google-vertex/src/google-vertex-provider-base.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.ts
@@ -32,6 +32,7 @@ import type { GoogleVertexEmbeddingModelId } from './google-vertex-embedding-mod
 import { GoogleVertexImageModel } from './google-vertex-image-model';
 import type { GoogleVertexImageModelId } from './google-vertex-image-settings';
 import type { GoogleVertexModelId } from './google-vertex-options';
+import { GoogleVertexCloudTTSSpeechModel } from './google-vertex-cloud-tts-speech-model';
 import { googleVertexTools } from './google-vertex-tools';
 import { GoogleVertexTranscriptionModel } from './google-vertex-transcription-model';
 import type { GoogleVertexTranscriptionModelId } from './google-vertex-transcription-model-options';
@@ -327,8 +328,21 @@ export function createGoogleVertex(
       generateId: options.generateId ?? generateId,
     });
 
-  const createSpeechModel = (modelId: GoogleVertexSpeechModelId) =>
-    new GoogleSpeechModel(modelId, createConfig('speech'));
+  // Chirp 3: HD voices are served by the Cloud Text-to-Speech API
+  // (`text:synthesize`) instead of the Vertex Gemini `generateContent`
+  // endpoint, reusing the Vertex auth headers from createConfig.
+  const createSpeechModel = (modelId: GoogleVertexSpeechModelId) => {
+    if (modelId.startsWith('chirp')) {
+      const config = createConfig('speech');
+      return new GoogleVertexCloudTTSSpeechModel(modelId, {
+        provider: config.provider,
+        headers: config.headers,
+        fetch: config.fetch,
+      });
+    }
+
+    return new GoogleSpeechModel(modelId, createConfig('speech'));
+  };
 
   // Cloud Speech-to-Text reuses the Vertex auth headers from createConfig, but
   // targets the Speech-to-Text API.

--- a/packages/google-vertex/src/google-vertex-provider-base.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.ts
@@ -328,9 +328,6 @@ export function createGoogleVertex(
       generateId: options.generateId ?? generateId,
     });
 
-  // Chirp 3: HD voices are served by the Cloud Text-to-Speech API
-  // (`text:synthesize`) instead of the Vertex Gemini `generateContent`
-  // endpoint, reusing the Vertex auth headers from createConfig.
   const createSpeechModel = (modelId: GoogleVertexSpeechModelId) => {
     if (modelId.startsWith('chirp')) {
       if (apiKey) {

--- a/packages/google-vertex/src/google-vertex-provider-base.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.ts
@@ -333,6 +333,12 @@ export function createGoogleVertex(
   // endpoint, reusing the Vertex auth headers from createConfig.
   const createSpeechModel = (modelId: GoogleVertexSpeechModelId) => {
     if (modelId.startsWith('chirp')) {
+      if (apiKey) {
+        throw new Error(
+          'Google Vertex Chirp speech models do not support Express Mode API keys. Use standard Google Cloud credentials instead.',
+        );
+      }
+
       const config = createConfig('speech');
       return new GoogleVertexCloudTTSSpeechModel(modelId, {
         provider: config.provider,

--- a/packages/google-vertex/src/google-vertex-speech-model-options.ts
+++ b/packages/google-vertex/src/google-vertex-speech-model-options.ts
@@ -1,11 +1,15 @@
 import type { GoogleSpeechModelOptions } from '@ai-sdk/google';
 
+// Gemini TTS models (Vertex `generateContent` endpoint):
 // https://docs.cloud.google.com/text-to-speech/docs/gemini-tts
+// Chirp 3: HD voices (Cloud Text-to-Speech `text:synthesize` endpoint):
+// https://docs.cloud.google.com/text-to-speech/docs/chirp3-hd
 export type GoogleVertexSpeechModelId =
   | 'gemini-2.5-flash-tts'
   | 'gemini-2.5-pro-tts'
   | 'gemini-2.5-flash-lite-preview-tts'
   | 'gemini-3.1-flash-tts-preview'
+  | 'chirp-3-hd'
   | (string & {});
 
 export type GoogleVertexSpeechModelOptions = GoogleSpeechModelOptions;


### PR DESCRIPTION
## Motivation

Google's Chirp 3: HD voices are served by the **Google Cloud Text-to-Speech API** (`text:synthesize`), not the Vertex Gemini `generateContent` endpoint that the existing `@ai-sdk/google-vertex` speech path uses — so they need a dedicated model implementation.

## Design

- New `GoogleVertexCloudTTSSpeechModel` (`packages/google-vertex/src/google-vertex-cloud-tts-speech-model.ts`) implementing `SpeechModelV4` against `POST https://texttospeech.googleapis.com/v1/text:synthesize` (single non-regional host), reusing the provider's Google Cloud auth headers / fetch — the same config plumbing as the Vertex transcription (Speech-to-Text) model.
- **Routing**: `createSpeechModel` in `google-vertex-provider-base.ts` routes model ids starting with `chirp` (e.g. the new `chirp-3-hd` id) to the Cloud TTS model; all `gemini-*` ids keep the existing Gemini TTS path unchanged.
- **Voice composition**: Chirp 3: HD voices are named `<locale>-Chirp3-HD-<voice>`. The model composes the name from the standard call options — `language` (BCP-47 locale, default `en-US`) + `voice` (default `Kore`) → `en-US-Chirp3-HD-Kore`. A fully-qualified voice name containing `Chirp3-HD` is passed through verbatim (its locale prefix is used as `languageCode` unless `language` is set).
- **Audio**: requested as `LINEAR16`, which Cloud TTS returns as a WAV (RIFF) file — directly playable; base64 `audioContent` is decoded to bytes. `speed` maps to `audioConfig.speakingRate`. `instructions` and non-`wav` output formats produce `unsupported` warnings.
- **Usage**: Cloud TTS bills per input character. No token usage is fabricated; the raw API response is preserved on `response.body` and the request text is available via `request.body`, so callers can derive character usage from the input text.

## Out of scope (intentionally)

- `streamingSynthesize` (bidi streaming synthesis)
- Instant Custom Voice / voice cloning
- Non-Chirp Cloud TTS voice families (Standard/WaveNet/Neural2/Studio) — the routing is `chirp*`-prefix based, so these can be layered on later if wanted

## Tests

`google-vertex-cloud-tts-speech-model.test.ts` (mirrors the transcription model test style):
- endpoint URL + provider/request header + user-agent assertions
- request body shape (input/voice/audioConfig with LINEAR16)
- voice-name composition (`language` + `voice` → `en-US-Chirp3-HD-Kore`; verbatim pass-through of fully-qualified names; explicit `language` precedence)
- base64 → bytes audio decode, empty-audio fallback
- `speed` → `speakingRate` mapping
- warnings for `instructions` and unsupported output formats
- response metadata (timestamp, modelId, headers, raw body) and API error handling

Plus provider-base routing tests: `chirp-3-hd` → Cloud TTS model, `gemini-*` → existing Gemini speech model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)