### PR TITLE
feat(tools-registry): update tako-search entry

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -355,7 +355,7 @@ console.log(text);`,
     slug: 'tako-search',
     name: 'Tako Search',
     description:
-      'Ground answers in real data. Search Tako for charts and metrics plus web results, ask for one citation-backed answer, or download the rows behind any result. Covers finance, economics, company KPIs, sports, demographics, weather and elections.',
+      'Tako grounds your agent in two kinds of knowledge at once: curated structured data from trusted providers, and live web search. Search returns typed knowledge cards, values with named sources and methodology, plus web results. Answer synthesizes one citation-backed response. Contents returns the rows behind a card or the full text of a page, so your agent never crawls one. Covers finance, macroeconomics, geopolitics, sports and weather.',
     packageName: '@takoviz/ai-sdk',
     installCommand: {
       pnpm: 'pnpm install @takoviz/ai-sdk',

--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -355,7 +355,7 @@ console.log(text);`,
     slug: 'tako-search',
     name: 'Tako Search',
     description:
-      "Search Tako's knowledge base for data visualizations, insights, and well-sourced information with charts and analytics.",
+      'Ground answers in real data. Search Tako for charts and metrics plus web results, ask for one citation-backed answer, or download the rows behind any result. Covers finance, economics, company KPIs, sports, demographics, weather and elections.',
     packageName: '@takoviz/ai-sdk',
     installCommand: {
       pnpm: 'pnpm install @takoviz/ai-sdk',
@@ -363,25 +363,27 @@ console.log(text);`,
       yarn: 'yarn add @takoviz/ai-sdk',
       bun: 'bun add @takoviz/ai-sdk',
     },
-    codeExample: `import { takoSearch } from '@takoviz/ai-sdk';
+    codeExample: `import { takoAnswer, takoContents, takoSearch } from '@takoviz/ai-sdk';
 import { generateText, isStepCount } from 'ai';
 
 const { text } = await generateText({
   model: 'openai/gpt-5.2',
-  prompt: 'What is the stock price of Nvidia?',
+  prompt: 'Chart Nvidia vs AMD revenue since 2015',
   tools: {
     takoSearch: takoSearch(),
+    takoAnswer: takoAnswer(),
+    takoContents: takoContents({ mode: 'inline' }),
   },
   stopWhen: isStepCount(5),
 });
 
 console.log(text);`,
-    docsUrl: 'https://github.com/TakoData/ai-sdk#readme',
+    docsUrl: 'https://docs.tako.com/documentation/integrations/vercel-ai-sdk',
     npmUrl: 'https://www.npmjs.com/package/@takoviz/ai-sdk',
     websiteUrl: 'https://tako.com',
     apiKeyEnvName: 'TAKO_API_KEY',
-    apiKeyUrl: 'https://tako.com',
-    tags: ['search', 'data', 'visualization', 'analytics'],
+    apiKeyUrl: 'https://tako.com/console/api-keys',
+    tags: ['search', 'data', 'visualization', 'analytics', 'extraction'],
   },
   {
     slug: 'valyu',

--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -368,7 +368,7 @@ import { generateText, isStepCount } from 'ai';
 
 const { text } = await generateText({
   model: 'openai/gpt-5.2',
-  prompt: 'Chart Nvidia vs AMD revenue since 2015',
+  prompt: "What are today's top performing stocks?",
   tools: {
     takoSearch: takoSearch(),
     takoAnswer: takoAnswer(),


### PR DESCRIPTION
Updates the existing `tako-search` entry in `content/tools-registry/registry.ts` for `@takoviz/ai-sdk` 3.0.0. One file, +8/-6. No new entry and no new page — the listing already renders at [/resources/tools/tako-search](https://ai-sdk.dev/resources/tools/tako-search).

## The code example demonstrated the routing the tool argues against

This was the substantive problem, and it is why the example changed rather than just the metadata.

The entry prompted `'What is the stock price of Nvidia?'` against `takoSearch`. The package's own `takoSearch` description — shipped in 3.0.0, read out of the published tarball — says:

> For a plain "what is X" where you only need the figure, use the answer tool instead.

So the card showed a single-figure lookup routed to the one tool the package tells the model not to use for it. It compiled and ran, which is why it survived; it just taught the wrong thing.

The new prompt asks the kind of question somebody evaluating the package would actually ask, and it is a breadth question rather than a single figure — which is what `takoSearch` is for. The example also passes the full toolset, the way the package's own README does, consistent with `superagent`, `you-search`, `bedrock-agentcore` and `nitrosend`, which already show more than one tool.

Note the prompt string uses double quotes, because it contains an apostrophe. Every other prompt in this file is single-quoted and none contain one, so this is the first exception. `node --check` on the extracted example confirms it parses exactly as a reader would copy it; oxfmt does not reach inside a template literal, so it has no opinion here.

## Field changes

| Field | Before | After |
| --- | --- | --- |
| `description` | Describes `takoSearch` only | Leads with the two-knowledge-sources pitch and maps all three tools |
| `codeExample` | Single-figure prompt, one tool | Chart request, full toolset |
| `docsUrl` | `github.com/TakoData/ai-sdk#readme` | `docs.tako.com/documentation/integrations/vercel-ai-sdk` |
| `apiKeyUrl` | `https://tako.com` | `https://tako.com/console/api-keys` |
| `tags` | 4 tags | adds `extraction` |

**`description`** — the previous text described `takoSearch` alone, so the card understated a package that exports three tools. Rewritten against Tako's own positioning, which leads with the part that was missing entirely: Tako returns curated structured data **and** live web search from one API, so an agent need not choose between a data API that misses most questions and a search API that makes the agent read the pages itself. The new text also maps each tool to what it returns.

440 characters, against a median of 232 and a maximum of 505 in this file. Leads with the product name, matching `exa`, `valyu` and `firecrawl`. Deliberately contains no apostrophe, so single quotes remain correct under `singleQuote: true` — the previous value needed double quotes for one.

**`docsUrl`** is the card's "Learn More" link and landed on a GitHub README. Repointed at the integration guide, matching how neighbouring entries link to vendor-hosted pages (`exa` → `docs.exa.ai/reference/vercel`, `tavily` → `docs.tavily.com/documentation/integrations/vercel`, `firecrawl` → `docs.firecrawl.dev/integrations/ai-sdk`, `valyu` → `docs.valyu.ai/integrations/vercel-ai-sdk`).

**`apiKeyUrl`** is the "Get API Key" button and pointed at the site root. It now points at the key page.

**`extraction`** is already used by five entries in this file, and `takoContents` extracts web page text, so the tag applies.

## Verification

The contributing guide asks for an example that is tested, so it was executed rather than only typechecked:

```
tools called: ["takoSearch","takoContents"]
tool errors:  0
answer chars: 515
```

`takoSearch` returns a "Top Performing Stocks" card plus five web results; the model then calls `takoContents` to read the rows behind the card, and the answer names real tickers with their percent change.

- [x] **Example executed end to end** against `ai@7` and `@takoviz/ai-sdk@3.0.0` — the model reaches for `takoSearch`, then `takoContents` to read the rows behind a card. Zero tool errors.
- [x] The extracted example passes `node --check`
- [x] `registry.ts` typechecks under `--strict`
- [x] `oxfmt` 0.62.0 with this repo's `.oxfmtrc.jsonc` reports no changes
- [x] Both new URLs return 200
- [x] Content-only, so no changeset (per `CONTRIBUTING.md`: changesets are not needed for docs)
- [x] Branched from current `main`

Two deviations were needed to run it locally, neither affecting the published example: `openai('gpt-5.2')` instead of the plain `'openai/gpt-5.2'` string, because that string routes through AI Gateway and only a direct OpenAI key was available; and an explicit Tako `baseUrl`, because the key on hand was not a production one. The example in the entry keeps the plain model string used by other entries in this file.

Also worth stating: the prompt was chosen from measurement, not taste. A first attempt — `'Compare Nvidia and AMD revenue growth over the last decade'` — produced a good answer but routed to `takoAnswer` twice and never called `takoSearch`, which is odd for an entry named "Tako Search". Several candidates were run before settling on one that exercises the named tool.

One caveat a maintainer should have rather than discover: `today's` makes this prompt time-sensitive. It was run on a weekday; over a weekend or a market holiday the card reports the last trading session, which is still a correct answer but not literally today. That is a property of the question, not of the tool.

## Deliberately unchanged

- **`slug`** stays `tako-search`, so the existing URL keeps working.
- **`name`** stays "Tako Search". "Tako" would fit the package better now that it is three tools, but renaming the card is gratuitous churn and the slug would no longer match.
- **`model: 'openai/gpt-5.2'`** is current and used by other entries here.
- **`installCommand`**, `npmUrl`, `websiteUrl`, `apiKeyEnvName` are all correct.

## Supersedes

This replaces #18380 and #18355, both of which will be closed. #18380 changed three metadata fields and explicitly left `codeExample` alone; #18355 proposed a community-*provider* page, which is the wrong home — `@takoviz/ai-sdk` exports tools rather than implementing a provider interface, so the tools registry is the right listing.


