### PR TITLE
feat(@ai-sdk/minimax): add image generation support

### DIFF
--- a/.changeset/smart-images-dream.md
+++ b/.changeset/smart-images-dream.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/minimax': patch
+---
+
+feat (ai/minimax): add image generation support for the MiniMax provider

--- a/content/providers/01-ai-sdk-providers/33-minimax.mdx
+++ b/content/providers/01-ai-sdk-providers/33-minimax.mdx
@@ -50,6 +50,12 @@ You can use the following optional settings to customize the MiniMax provider in
   the MiniMax V2 native endpoint (not the Anthropic-compatible endpoint).
   The default prefix is `https://api.minimax.io`.
 
+- **imageBaseURL** _string_
+
+  Use a different URL prefix for image generation API calls. The image API uses
+  the MiniMax V1 native endpoint (not the Anthropic-compatible endpoint).
+  The default prefix is `https://api.minimax.io`.
+
 - **apiKey** _string_
 
   API key for the MiniMax API. It defaults to the `MINIMAX_API_KEY` environment
@@ -135,7 +141,41 @@ The following optional provider options are available for MiniMax language model
     think, so `'disabled'` has no effect on them.
   </Note>
 
+## Image Models
+
+You can generate images with the `image-01` and `image-01-live` models using the
+[`experimental_generateImage`](/docs/reference/ai-sdk-core/generate-image)
+function:
+
+```ts
+import { minimax, type MiniMaxImageModelOptions } from '@ai-sdk/minimax';
+import { experimental_generateImage as generateImage } from 'ai';
+
+const { images } = await generateImage({
+  model: minimax.image('image-01'),
+  prompt: 'A cute baby sea otter',
+  n: 2,
+  aspectRatio: '16:9',
+});
+```
+
+Input images are supported for image-to-image generation via the `prompt.images`
+field. They are sent to the API as subject references.
+
+### Image Provider Options
+
+The following optional provider options are available for MiniMax image models:
+
+- **responseFormat** _'url' | 'base64'_
+
+  Format of the generated images. Defaults to `url`. URLs expire after 24 hours.
+
+- **promptOptimizer** _boolean_
+
+  Whether to enable automatic optimization of the prompt. Defaults to `false`.
+
 ## Video Models
+
 
 You can generate videos with the MiniMax-H3 model using the
 [`experimental_generateVideo`](/docs/reference/ai-sdk-core/generate-video)

--- a/packages/minimax/README.md
+++ b/packages/minimax/README.md
@@ -57,6 +57,20 @@ const { text } = await generateText({
 });
 ```
 
+## Image Generation Example
+
+```ts
+import { minimax } from '@ai-sdk/minimax';
+import { experimental_generateImage as generateImage } from 'ai';
+
+const { images } = await generateImage({
+  model: minimax.image('image-01'),
+  prompt: 'A cute baby sea otter',
+  n: 2,
+  aspectRatio: '16:9',
+});
+```
+
 ## Video Generation Example
 
 ```ts

--- a/packages/minimax/src/index.ts
+++ b/packages/minimax/src/index.ts
@@ -9,6 +9,8 @@ export type {
   /** @deprecated Use `MiniMaxLanguageModelOptions` instead. */
   MiniMaxLanguageModelOptions as MiniMaxProviderOptions,
 } from './minimax-chat-options';
+export type { MiniMaxImageModelId } from './minimax-image-settings';
+export type { MiniMaxImageModelOptions } from './minimax-image-model-options';
 export type { MiniMaxVideoModelId } from './minimax-video-settings';
 export type { MiniMaxVideoModelOptions } from './minimax-video-model-options';
 export { VERSION } from './version';

--- a/packages/minimax/src/minimax-image-model-options.ts
+++ b/packages/minimax/src/minimax-image-model-options.ts
@@ -1,0 +1,45 @@
+import {
+  lazySchema,
+  zodSchema,
+  type InferSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+/**
+ * Aspect ratios supported by the MiniMax image generation API.
+ */
+export const minimaxImageAspectRatios = [
+  '1:1',
+  '16:9',
+  '4:3',
+  '3:2',
+  '2:3',
+  '3:4',
+  '9:16',
+  '21:9',
+] as const;
+
+/**
+ * Provider options for MiniMax image generation.
+ */
+export const minimaxImageProviderOptions = z.object({
+  /**
+   * Format of the generated images. Defaults to `url`.
+   */
+  responseFormat: z.enum(['url', 'base64']).optional(),
+
+  /**
+   * Whether to enable automatic optimization of the prompt. Defaults to `false`.
+   */
+  promptOptimizer: z.boolean().optional(),
+});
+
+export type MiniMaxImageModelOptions = z.infer<
+  typeof minimaxImageProviderOptions
+>;
+
+export const minimaxImageModelOptionsSchema = lazySchema(() =>
+  zodSchema(minimaxImageProviderOptions),
+);
+
+export type { InferSchema };

--- a/packages/minimax/src/minimax-image-model.test.ts
+++ b/packages/minimax/src/minimax-image-model.test.ts
@@ -1,0 +1,379 @@
+import type { FetchFunction } from '@ai-sdk/provider-utils';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it } from 'vitest';
+import { MiniMaxImageModel } from './minimax-image-model';
+
+const prompt = 'A cute baby sea otter';
+
+const TEST_BASE_URL = 'https://api.example.com';
+const GENERATE_URL = `${TEST_BASE_URL}/v1/image_generation`;
+
+const IMAGE_URL = 'https://api.example.com/image-001.png';
+const IMAGE_URL_2 = 'https://api.example.com/image-002.png';
+
+const defaultOptions = {
+  prompt,
+  files: undefined,
+  mask: undefined,
+  n: 1,
+  size: undefined,
+  aspectRatio: undefined,
+  seed: undefined,
+  providerOptions: {},
+} as const;
+
+function createModel({
+  currentDate,
+  fetch,
+}: {
+  currentDate?: () => Date;
+  fetch?: FetchFunction;
+} = {}) {
+  return new MiniMaxImageModel('image-01', {
+    provider: 'minimax.image',
+    baseURL: TEST_BASE_URL,
+    headers: () => ({ Authorization: 'Bearer test-key' }),
+    fetch,
+    _internal: { currentDate },
+  });
+}
+
+describe('MiniMaxImageModel', () => {
+  describe('constructor', () => {
+    it('should expose correct provider and model information', () => {
+      const model = createModel();
+
+      expect(model.provider).toBe('minimax.image');
+      expect(model.modelId).toBe('image-01');
+      expect(model.specificationVersion).toBe('v4');
+      expect(model.maxImagesPerCall).toBe(9);
+    });
+  });
+
+  describe('doGenerate (text-to-image)', () => {
+    const server = createTestServer({
+      [GENERATE_URL]: {
+        response: {
+          type: 'json-value',
+          body: {
+            data: { image_urls: [IMAGE_URL, IMAGE_URL_2] },
+            metadata: { success_count: 2, failed_count: 0 },
+            id: 'trace-001',
+            base_resp: { status_code: 0, status_msg: 'success' },
+          },
+        },
+      },
+      [IMAGE_URL]: {
+        response: { type: 'binary', body: Buffer.from('image-bytes-1') },
+      },
+      [IMAGE_URL_2]: {
+        response: { type: 'binary', body: Buffer.from('image-bytes-2') },
+      },
+    });
+
+    it('should send a text-to-image request with required fields', async () => {
+      const model = createModel();
+
+      await model.doGenerate({ ...defaultOptions });
+
+      expect(server.calls[0].requestMethod).toBe('POST');
+      expect(server.calls[0].requestUrl).toBe(GENERATE_URL);
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'image-01',
+        prompt,
+        n: 1,
+        response_format: 'url',
+      });
+    });
+
+    it('should use a bearer token for the request', async () => {
+      const model = createModel();
+
+      await model.doGenerate({ ...defaultOptions });
+
+      expect(server.calls[0].requestHeaders).toMatchObject({
+        authorization: 'Bearer test-key',
+      });
+    });
+
+    it('should download and return URL-based images', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({ ...defaultOptions });
+
+      expect(result.images).toStrictEqual([
+        new Uint8Array(Buffer.from('image-bytes-1')),
+        new Uint8Array(Buffer.from('image-bytes-2')),
+      ]);
+      expect(result.providerMetadata?.minimax).toMatchObject({
+        images: [{ url: IMAGE_URL }, { url: IMAGE_URL_2 }],
+        traceId: 'trace-001',
+        successCount: 2,
+        failedCount: 0,
+      });
+    });
+
+    it('should map size to width and height', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        size: '1024x1024',
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        width: 1024,
+        height: 1024,
+      });
+    });
+
+    it('should map a supported aspect ratio', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        aspectRatio: '16:9',
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        aspect_ratio: '16:9',
+      });
+    });
+
+    it('should warn and ignore an unsupported aspect ratio', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        aspectRatio: '2:1',
+      });
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'aspect_ratio',
+      );
+      expect(result.warnings).toContainEqual({
+        type: 'unsupported',
+        feature: 'aspectRatio',
+        details: expect.stringContaining('2:1'),
+      });
+    });
+
+    it('should pass through the seed', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        seed: 123,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        seed: 123,
+      });
+    });
+
+    it('should pass provider options promptOptimizer and responseFormat', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          minimax: { promptOptimizer: true, responseFormat: 'base64' },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        prompt_optimizer: true,
+        response_format: 'base64',
+      });
+    });
+  });
+
+  describe('doGenerate (image-to-image)', () => {
+    const server = createTestServer({
+      [GENERATE_URL]: {
+        response: {
+          type: 'json-value',
+          body: {
+            data: { image_urls: [IMAGE_URL] },
+            base_resp: { status_code: 0, status_msg: 'success' },
+          },
+        },
+      },
+      [IMAGE_URL]: {
+        response: { type: 'binary', body: Buffer.from('image-bytes-1') },
+      },
+    });
+
+    it('should map input files to subject references', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        files: [
+          {
+            type: 'url',
+            url: 'https://cdn.example.com/reference.png',
+          },
+        ],
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        subject_reference: [
+          {
+            type: 'character',
+            image_file: 'https://cdn.example.com/reference.png',
+          },
+        ],
+      });
+    });
+
+    it('should convert inline files to data URIs for subject references', async () => {
+      const model = createModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        files: [
+          {
+            type: 'file',
+            data: new Uint8Array(Buffer.from('file-bytes')),
+            mediaType: 'image/png',
+          },
+        ],
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      expect(body.subject_reference).toHaveLength(1);
+      expect(body.subject_reference[0].type).toBe('character');
+      expect(body.subject_reference[0].image_file).toMatch(
+        /^data:image\/png;base64,/,
+      );
+    });
+
+    it('should warn and ignore a mask image', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        mask: {
+          type: 'file',
+          data: new Uint8Array(Buffer.from('mask-bytes')),
+          mediaType: 'image/png',
+        },
+      });
+
+      expect(result.warnings).toContainEqual({
+        type: 'unsupported',
+        feature: 'mask',
+        details: expect.any(String),
+      });
+    });
+  });
+
+  describe('doGenerate (base64 response)', () => {
+    const server = createTestServer({
+      [GENERATE_URL]: {
+        response: {
+          type: 'json-value',
+          body: {
+            data: {
+              image_base64: ['aGVsbG8td29ybGQ=', 'c2Vjb25kLWltYWdl'],
+            },
+            base_resp: { status_code: 0, status_msg: 'success' },
+          },
+        },
+      },
+    });
+
+    it('should return base64 strings directly', async () => {
+      const model = createModel();
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: { minimax: { responseFormat: 'base64' } },
+      });
+
+      expect(result.images).toStrictEqual([
+        'aGVsbG8td29ybGQ=',
+        'c2Vjb25kLWltYWdl',
+      ]);
+      expect(result.providerMetadata?.minimax?.images).toStrictEqual([{}, {}]);
+    });
+  });
+
+  describe('doGenerate (errors)', () => {
+    const server = createTestServer({
+      [GENERATE_URL]: {
+        response: {
+          type: 'json-value',
+          body: {
+            data: { image_urls: [] },
+            base_resp: {
+              status_code: 1008,
+              status_msg: 'insufficient balance',
+            },
+          },
+        },
+      },
+    });
+
+    it('should throw when base_resp status code is non-zero', async () => {
+      const model = createModel();
+
+      await expect(model.doGenerate({ ...defaultOptions })).rejects.toThrow(
+        /insufficient balance/,
+      );
+    });
+  });
+
+  describe('doGenerate (no images)', () => {
+    const server = createTestServer({
+      [GENERATE_URL]: {
+        response: {
+          type: 'json-value',
+          body: {
+            data: {},
+            base_resp: { status_code: 0, status_msg: 'success' },
+          },
+        },
+      },
+    });
+
+    it('should throw when no images are returned', async () => {
+      const model = createModel();
+
+      await expect(model.doGenerate({ ...defaultOptions })).rejects.toThrow(
+        /returned no images/,
+      );
+    });
+  });
+
+  describe('doGenerate (response timestamp)', () => {
+    const currentDate = new Date('2026-01-01T00:00:00Z');
+
+    const server = createTestServer({
+      [GENERATE_URL]: {
+        response: {
+          type: 'json-value',
+          body: {
+            data: { image_base64: ['aGVsbG8td29ybGQ='] },
+            base_resp: { status_code: 0, status_msg: 'success' },
+          },
+        },
+      },
+    });
+
+    it('should use the injected current date for the response timestamp', async () => {
+      const model = createModel({
+        currentDate: () => currentDate,
+      });
+
+      const result = await model.doGenerate({
+        ...defaultOptions,
+        providerOptions: { minimax: { responseFormat: 'base64' } },
+      });
+
+      expect(result.response.timestamp).toBe(currentDate);
+      expect(result.response.modelId).toBe('image-01');
+    });
+  });
+});

--- a/packages/minimax/src/minimax-image-model.ts
+++ b/packages/minimax/src/minimax-image-model.ts
@@ -1,0 +1,254 @@
+import {
+  AISDKError,
+  type ImageModelV4,
+  type SharedV4Warning,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertImageModelFileToDataUri,
+  createBinaryResponseHandler,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  createStatusCodeErrorResponseHandler,
+  getFromApi,
+  parseProviderOptions,
+  postJsonToApi,
+  resolve,
+  type FetchFunction,
+  type Resolvable,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import {
+  minimaxImageAspectRatios,
+  minimaxImageModelOptionsSchema,
+  type MiniMaxImageModelOptions,
+} from './minimax-image-model-options';
+import type { MiniMaxImageModelId } from './minimax-image-settings';
+
+interface MiniMaxImageModelConfig {
+  provider: string;
+  // API root without a version suffix, e.g. `https://api.minimax.io`.
+  baseURL: string;
+  headers: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+const MAX_IMAGES_PER_CALL = 9;
+const allowedAspectRatios = new Set<string>(minimaxImageAspectRatios);
+
+export class MiniMaxImageModel implements ImageModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly maxImagesPerCall = MAX_IMAGES_PER_CALL;
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: MiniMaxImageModelId,
+    private readonly config: MiniMaxImageModelConfig,
+  ) {}
+
+  async doGenerate({
+    prompt,
+    files,
+    mask,
+    n,
+    size,
+    aspectRatio,
+    seed,
+    providerOptions,
+    headers,
+    abortSignal,
+  }: Parameters<ImageModelV4['doGenerate']>[0]): Promise<
+    Awaited<ReturnType<ImageModelV4['doGenerate']>>
+  > {
+    const warnings: SharedV4Warning[] = [];
+
+    const minimaxOptions = (await parseProviderOptions({
+      provider: 'minimax',
+      providerOptions,
+      schema: minimaxImageModelOptionsSchema,
+    })) as MiniMaxImageModelOptions | undefined;
+
+    if (mask != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'mask',
+        details:
+          'MiniMax image generation does not support a mask image. The mask was ignored.',
+      });
+    }
+
+    // Size is passed as `{width}x{height}`; the API takes width and height as
+    // separate integers.
+    const [widthStr, heightStr] = size?.split('x') ?? [];
+    const width = size != null ? Number(widthStr) : undefined;
+    const height = size != null ? Number(heightStr) : undefined;
+
+    // The API takes aspect ratios as `{width}:{height}` strings, matching the
+    // top-level option. Unsupported ratios are ignored with a warning.
+    let resolvedAspectRatio: string | undefined;
+    if (aspectRatio != null) {
+      if (allowedAspectRatios.has(aspectRatio)) {
+        resolvedAspectRatio = aspectRatio;
+      } else {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'aspectRatio',
+          details:
+            `MiniMax image generation does not support the aspect ratio "${aspectRatio}". ` +
+            'Using the provider default (1:1).',
+        });
+      }
+    }
+
+    // Image-to-image generation: input images are sent as subject references.
+    // The API currently only supports the `character` subject type.
+    const subjectReference =
+      files != null && files.length > 0
+        ? files.map(file => ({
+            type: 'character',
+            image_file: convertImageModelFileToDataUri(file),
+          }))
+        : undefined;
+
+    const body: Record<string, unknown> = {
+      model: this.modelId,
+      prompt: prompt ?? '',
+      ...(subjectReference != null
+        ? { subject_reference: subjectReference }
+        : {}),
+      ...(resolvedAspectRatio != null
+        ? { aspect_ratio: resolvedAspectRatio }
+        : {}),
+      ...(width != null ? { width } : {}),
+      ...(height != null ? { height } : {}),
+      ...(seed != null ? { seed } : {}),
+      n,
+      response_format: minimaxOptions?.responseFormat ?? 'url',
+      ...(minimaxOptions?.promptOptimizer != null
+        ? { prompt_optimizer: minimaxOptions.promptOptimizer }
+        : {}),
+    };
+
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const { value: response, responseHeaders } = await postJsonToApi({
+      url: `${this.config.baseURL}/v1/image_generation`,
+      headers: combineHeaders(await resolve(this.config.headers), headers),
+      body,
+      failedResponseHandler: minimaxImageFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        minimaxImageResponseSchema,
+      ),
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const statusCode = response.base_resp?.status_code;
+    if (statusCode != null && statusCode !== 0) {
+      throw new AISDKError({
+        name: 'MINIMAX_IMAGE_GENERATION_ERROR',
+        message:
+          `MiniMax image generation failed: ${response.base_resp?.status_msg ?? 'unknown error'} ` +
+          `(status code ${statusCode}).`,
+      });
+    }
+
+    const imageUrls = response.data?.image_urls ?? [];
+    const imageBase64 = response.data?.image_base64 ?? [];
+
+    if (imageUrls.length === 0 && imageBase64.length === 0) {
+      throw new AISDKError({
+        name: 'MINIMAX_IMAGE_GENERATION_ERROR',
+        message: 'MiniMax image generation returned no images.',
+      });
+    }
+
+    // `response_format: "base64"` returns base64 strings directly; otherwise the
+    // API returns URLs that must be downloaded.
+    const images: Array<string> | Array<Uint8Array> =
+      imageBase64.length > 0
+        ? imageBase64
+        : await Promise.all(
+            imageUrls.map(url =>
+              getFromApi({
+                url,
+                // URLs come from the provider response body; validate them.
+                validateUrl: true,
+                trustedOrigin: this.config.baseURL,
+                // Image URLs are delivered from a CDN without credentials.
+                abortSignal,
+                failedResponseHandler: createStatusCodeErrorResponseHandler(),
+                successfulResponseHandler: createBinaryResponseHandler(),
+                fetch: this.config.fetch,
+              }).then(({ value }) => value),
+            ),
+          );
+
+    return {
+      images,
+      warnings,
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+      },
+      providerMetadata: {
+        minimax: {
+          images:
+            imageUrls.length > 0
+              ? imageUrls.map(url => ({ url }))
+              : imageBase64.map(() => ({})),
+          ...(response.id != null ? { traceId: response.id } : {}),
+          ...(response.metadata?.success_count != null
+            ? { successCount: response.metadata.success_count }
+            : {}),
+          ...(response.metadata?.failed_count != null
+            ? { failedCount: response.metadata.failed_count }
+            : {}),
+        },
+      },
+    };
+  }
+}
+
+const minimaxImageResponseSchema = z.object({
+  data: z
+    .object({
+      image_urls: z.array(z.string()).nullish(),
+      image_base64: z.array(z.string()).nullish(),
+    })
+    .nullish(),
+  metadata: z
+    .object({
+      success_count: z.coerce.number().nullish(),
+      failed_count: z.coerce.number().nullish(),
+    })
+    .nullish(),
+  id: z.string().nullish(),
+  base_resp: z
+    .object({
+      status_code: z.coerce.number().nullish(),
+      status_msg: z.string().nullish(),
+    })
+    .nullish(),
+});
+
+const minimaxImageErrorSchema = z.object({
+  base_resp: z
+    .object({
+      status_code: z.coerce.number().nullish(),
+      status_msg: z.string().nullish(),
+    })
+    .nullish(),
+});
+
+const minimaxImageFailedResponseHandler = createJsonErrorResponseHandler({
+  errorSchema: minimaxImageErrorSchema,
+  errorToMessage: data =>
+    data.base_resp?.status_msg ?? 'MiniMax image generation error',
+});

--- a/packages/minimax/src/minimax-image-settings.ts
+++ b/packages/minimax/src/minimax-image-settings.ts
@@ -1,0 +1,2 @@
+// https://platform.minimax.io/docs/api-reference/image-generation-t2i
+export type MiniMaxImageModelId = 'image-01' | 'image-01-live' | (string & {});

--- a/packages/minimax/src/minimax-provider.test.ts
+++ b/packages/minimax/src/minimax-provider.test.ts
@@ -3,10 +3,12 @@ import { loadApiKey } from '@ai-sdk/provider-utils';
 import { NoSuchModelError } from '@ai-sdk/provider';
 import { AnthropicLanguageModel } from '@ai-sdk/anthropic/internal';
 import { createMiniMax } from './minimax-provider';
+import { MiniMaxImageModel } from './minimax-image-model';
 import { MiniMaxVideoModel } from './minimax-video-model';
 
 const AnthropicLanguageModelMock = AnthropicLanguageModel as unknown as Mock;
 const MiniMaxVideoModelMock = MiniMaxVideoModel as unknown as Mock;
+const MiniMaxImageModelMock = MiniMaxImageModel as unknown as Mock;
 
 vi.mock('@ai-sdk/anthropic/internal', () => {
   const mockConstructor = vi.fn().mockImplementation(function (
@@ -35,6 +37,21 @@ vi.mock('./minimax-video-model', () => {
   });
   return {
     MiniMaxVideoModel: mockConstructor,
+  };
+});
+
+vi.mock('./minimax-image-model', () => {
+  const mockConstructor = vi.fn().mockImplementation(function (
+    this: any,
+    modelId: string,
+    config: any,
+  ) {
+    this.provider = config.provider;
+    this.modelId = modelId;
+    this.config = config;
+  });
+  return {
+    MiniMaxImageModel: mockConstructor,
   };
 });
 
@@ -126,6 +143,115 @@ describe('MiniMaxProvider', () => {
       const provider = createMiniMax();
       const model = provider.chat('minimax-m2.1');
       expect(model).toBeInstanceOf(AnthropicLanguageModel);
+    });
+  });
+
+  describe('image', () => {
+    it('should construct an image model with the image provider id', () => {
+      const provider = createMiniMax();
+      const model = provider.image('image-01');
+
+      expect(model).toBeInstanceOf(MiniMaxImageModel);
+
+      const constructorCall = MiniMaxImageModelMock.mock.calls[0];
+      expect(constructorCall[0]).toBe('image-01');
+      expect(constructorCall[1].provider).toBe('minimax.image');
+    });
+
+    it('should use the default native base URL', () => {
+      const provider = createMiniMax();
+      provider.image('image-01');
+
+      const constructorCall = MiniMaxImageModelMock.mock.calls[0];
+      expect(constructorCall[1].baseURL).toBe('https://api.minimax.io');
+    });
+
+    it('should use a custom imageBaseURL', () => {
+      const provider = createMiniMax({
+        imageBaseURL: 'https://api.minimaxi.com',
+      });
+      provider.image('image-01');
+
+      const constructorCall = MiniMaxImageModelMock.mock.calls[0];
+      expect(constructorCall[1].baseURL).toBe('https://api.minimaxi.com');
+    });
+
+    it('should not derive the image base URL from the chat baseURL', () => {
+      const provider = createMiniMax({
+        baseURL: 'https://custom.url/anthropic/v1',
+      });
+      provider.image('image-01');
+
+      const constructorCall = MiniMaxImageModelMock.mock.calls[0];
+      expect(constructorCall[1].baseURL).toBe('https://api.minimax.io');
+    });
+
+    it('should send a bearer token rather than the Anthropic x-api-key header', () => {
+      const provider = createMiniMax({ apiKey: 'test-key' });
+      provider.image('image-01');
+
+      const constructorCall = MiniMaxImageModelMock.mock.calls[0];
+      const headers = constructorCall[1].headers();
+
+      expect(headers).toMatchObject({
+        authorization: 'Bearer mock-api-key',
+        'user-agent': expect.stringMatching(/^ai-sdk\/minimax\//),
+      });
+      expect(headers).not.toHaveProperty('x-api-key');
+      expect(headers).not.toHaveProperty('anthropic-version');
+      expect(loadApiKey).toHaveBeenCalledWith({
+        apiKey: 'test-key',
+        environmentVariableName: 'MINIMAX_API_KEY',
+        description: 'MiniMax API key',
+      });
+    });
+
+    it('should merge custom headers into the image headers', () => {
+      const provider = createMiniMax({
+        headers: { 'Custom-Header': 'value' },
+      });
+      provider.image('image-01');
+
+      const constructorCall = MiniMaxImageModelMock.mock.calls[0];
+      expect(constructorCall[1].headers()).toMatchObject({
+        authorization: 'Bearer mock-api-key',
+        'custom-header': 'value',
+      });
+    });
+
+    it('should pass a custom fetch to the image model', () => {
+      const customFetch = vi.fn();
+      const provider = createMiniMax({ fetch: customFetch });
+      provider.image('image-01');
+
+      const constructorCall = MiniMaxImageModelMock.mock.calls[0];
+      expect(constructorCall[1].fetch).toBe(customFetch);
+    });
+  });
+
+  describe('imageModel', () => {
+    it('should construct the same image model as image()', () => {
+      const provider = createMiniMax();
+      const model = provider.imageModel('image-01');
+
+      expect(model).toBeInstanceOf(MiniMaxImageModel);
+
+      const constructorCall = MiniMaxImageModelMock.mock.calls[0];
+      expect(constructorCall[0]).toBe('image-01');
+      expect(constructorCall[1].provider).toBe('minimax.image');
+      expect(constructorCall[1].baseURL).toBe('https://api.minimax.io');
+    });
+
+    it('should use the same custom imageBaseURL as image()', () => {
+      const provider = createMiniMax({
+        imageBaseURL: 'https://custom-image.example.com',
+      });
+      provider.imageModel('image-01');
+
+      const constructorCall = MiniMaxImageModelMock.mock.calls[0];
+      expect(constructorCall[1].baseURL).toBe(
+        'https://custom-image.example.com',
+      );
     });
   });
 
@@ -249,11 +375,6 @@ describe('MiniMaxProvider', () => {
       expect(() => provider.textEmbeddingModel('foo')).toThrow(
         NoSuchModelError,
       );
-    });
-
-    it('should throw NoSuchModelError for imageModel', () => {
-      const provider = createMiniMax();
-      expect(() => provider.imageModel('foo')).toThrow(NoSuchModelError);
     });
   });
 });

--- a/packages/minimax/src/minimax-provider.ts
+++ b/packages/minimax/src/minimax-provider.ts
@@ -1,6 +1,7 @@
 import {
   NoSuchModelError,
   type Experimental_VideoModelV4,
+  type ImageModelV4,
   type LanguageModelV4,
   type ProviderV4,
 } from '@ai-sdk/provider';
@@ -13,6 +14,8 @@ import {
 } from '@ai-sdk/provider-utils';
 import { AnthropicLanguageModel } from '@ai-sdk/anthropic/internal';
 import type { MiniMaxChatModelId } from './minimax-chat-options';
+import { MiniMaxImageModel } from './minimax-image-model';
+import type { MiniMaxImageModelId } from './minimax-image-settings';
 import { MiniMaxVideoModel } from './minimax-video-model';
 import type { MiniMaxVideoModelId } from './minimax-video-settings';
 import { VERSION } from './version';
@@ -33,6 +36,11 @@ export interface MiniMaxProviderSettings {
    * The default prefix is `https://api.minimax.io`.
    */
   videoBaseURL?: string;
+  /**
+   * Use a different URL prefix for image generation API calls.
+   * The default prefix is `https://api.minimax.io`.
+   */
+  imageBaseURL?: string;
   /**
    * Custom headers to include in the requests.
    */
@@ -61,6 +69,16 @@ export interface MiniMaxProvider extends ProviderV4 {
   chat(modelId: MiniMaxChatModelId): LanguageModelV4;
 
   /**
+   * Creates a MiniMax image model for image generation.
+   */
+  image(modelId: MiniMaxImageModelId): ImageModelV4;
+
+  /**
+   * Creates a MiniMax image model for image generation.
+   */
+  imageModel(modelId: MiniMaxImageModelId): ImageModelV4;
+
+  /**
    * Creates a MiniMax video model for video generation.
    */
   video(modelId: MiniMaxVideoModelId): Experimental_VideoModelV4;
@@ -77,7 +95,7 @@ export interface MiniMaxProvider extends ProviderV4 {
 }
 
 const defaultBaseURL = 'https://api.minimax.io/anthropic/v1';
-const defaultVideoBaseURL = 'https://api.minimax.io';
+const defaultNativeBaseURL = 'https://api.minimax.io';
 
 export function createMiniMax(
   options: MiniMaxProviderSettings = {},
@@ -86,8 +104,12 @@ export function createMiniMax(
     withoutTrailingSlash(options.baseURL ?? defaultBaseURL) ?? defaultBaseURL;
 
   const videoBaseURL =
-    withoutTrailingSlash(options.videoBaseURL ?? defaultVideoBaseURL) ??
-    defaultVideoBaseURL;
+    withoutTrailingSlash(options.videoBaseURL ?? defaultNativeBaseURL) ??
+    defaultNativeBaseURL;
+
+  const imageBaseURL =
+    withoutTrailingSlash(options.imageBaseURL ?? defaultNativeBaseURL) ??
+    defaultNativeBaseURL;
 
   const getHeaders = () =>
     withUserAgentSuffix(
@@ -113,7 +135,7 @@ export function createMiniMax(
       supportedUrls: () => ({}),
     });
 
-  const getVideoHeaders = () =>
+  const getBearerTokenHeaders = () =>
     withUserAgentSuffix(
       {
         Authorization: `Bearer ${loadApiKey({
@@ -126,11 +148,19 @@ export function createMiniMax(
       `ai-sdk/minimax/${VERSION}`,
     );
 
+  const createImageModel = (modelId: MiniMaxImageModelId) =>
+    new MiniMaxImageModel(modelId, {
+      provider: 'minimax.image',
+      baseURL: imageBaseURL,
+      headers: getBearerTokenHeaders,
+      fetch: options.fetch,
+    });
+
   const createVideoModel = (modelId: MiniMaxVideoModelId) =>
     new MiniMaxVideoModel(modelId, {
       provider: 'minimax.video',
       baseURL: videoBaseURL,
-      headers: getVideoHeaders,
+      headers: getBearerTokenHeaders,
       fetch: options.fetch,
     });
 
@@ -139,6 +169,8 @@ export function createMiniMax(
   provider.specificationVersion = 'v4' as const;
   provider.languageModel = createChatModel;
   provider.chat = createChatModel;
+  provider.image = createImageModel;
+  provider.imageModel = createImageModel;
   provider.video = createVideoModel;
   provider.videoModel = createVideoModel;
 
@@ -146,9 +178,6 @@ export function createMiniMax(
     throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
   };
   provider.textEmbeddingModel = provider.embeddingModel;
-  provider.imageModel = (modelId: string) => {
-    throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
-  };
 
   return provider;
 }


### PR DESCRIPTION
Reason: MiniMax registers chat and video models but `imageModel` throws `NoSuchModelError`; this adds image generation support for the MiniMax image API.

## Summary

Adds a `MiniMaxImageModel` to `@ai-sdk/minimax` and wires it into the provider via `minimax.image()` / `minimax.imageModel()`.

The image model calls `POST /v1/image_generation` (configurable via the new `imageBaseURL` setting) and maps the AI SDK image model options onto the MiniMax API:

- `prompt`, `n`, `seed` pass through directly.
- `size` (`{width}x{height}`) is split into `width`/`height`.
- `aspectRatio` is mapped to `aspect_ratio` when the ratio is supported, otherwise it is ignored with a warning.
- Input `files` (image-to-image) are sent as `subject_reference` entries.
- A `mask` is not supported and is ignored with a warning.
- Provider options `responseFormat` (`url` | `base64`) and `promptOptimizer` map to `response_format` and `prompt_optimizer`.

`response_format: "base64"` results are returned as base64 strings; the default `url` results are downloaded and returned as binary. Non-zero `base_resp.status_code` responses throw, and the response exposes provider metadata (`traceId`, `successCount`, `failedCount`, image URLs).

## Changes

- `packages/minimax/src/minimax-image-settings.ts` — `MiniMaxImageModelId` type.
- `packages/minimax/src/minimax-image-model-options.ts` — image provider options schema.
- `packages/minimax/src/minimax-image-model.ts` — the image model implementation.
- `packages/minimax/src/minimax-image-model.test.ts` — tests for text-to-image, image-to-image, base64 and URL responses, and error handling.
- `packages/minimax/src/minimax-provider.ts` — adds `image`/`imageModel`, `imageBaseURL` setting.
- `packages/minimax/src/minimax-provider.test.ts` — provider tests for the image model.
- `packages/minimax/src/index.ts` — exports the new types.
- `packages/minimax/README.md` + provider docs — image generation example and provider options.
- `.changeset/smart-images-dream.md` — patch changeset.

## Checks

- `pnpm --filter @ai-sdk/minimax type-check` — passed.
- `pnpm --filter @ai-sdk/minimax test:node` — 132 tests passed.
- `pnpm --filter @ai-sdk/minimax test:edge` — 132 tests passed.
- `oxlint src/` — 0 warnings, 0 errors.
- `oxfmt --check src/` — all files formatted.
