### PR TITLE
fix(ai): distinguish undefined array elements in canonical hashes

### DIFF
--- a/.changeset/kind-bats-hash.md
+++ b/.changeset/kind-bats-hash.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Prevent canonical hash collisions between empty arrays and arrays containing undefined values.

--- a/packages/ai/src/util/canonical-hash.test.ts
+++ b/packages/ai/src/util/canonical-hash.test.ts
@@ -18,6 +18,11 @@ describe('canonicalJSON', () => {
     expect(canonicalJSON('x')).toBe('"x"');
     expect(canonicalJSON(42)).toBe('42');
   });
+
+  it('serializes undefined array elements as null', () => {
+    expect(canonicalJSON([undefined])).toBe('[null]');
+    expect(canonicalJSON([1, undefined, 2])).toBe('[1,null,2]');
+  });
 });
 
 describe('hashCanonical', () => {
@@ -37,5 +42,9 @@ describe('hashCanonical', () => {
     expect(await hashCanonical({ a: 1 })).not.toBe(
       await hashCanonical({ a: 2 }),
     );
+  });
+
+  it('distinguishes empty arrays from arrays containing undefined', async () => {
+    expect(await hashCanonical([])).not.toBe(await hashCanonical([undefined]));
   });
 });

--- a/packages/ai/src/util/canonical-hash.ts
+++ b/packages/ai/src/util/canonical-hash.ts
@@ -15,7 +15,9 @@ export function canonicalJSON(value: unknown): string {
     return JSON.stringify(value);
   }
   if (Array.isArray(value)) {
-    return `[${value.map(canonicalJSON).join(',')}]`;
+    return `[${value
+      .map(element => (element === undefined ? 'null' : canonicalJSON(element)))
+      .join(',')}]`;
   }
   const keys = Object.keys(value as Record<string, unknown>).sort();
   const entries = keys.map(


### PR DESCRIPTION
## Summary

- serialize `undefined` array elements as `null` during canonicalization, matching JSON array semantics
- prevent empty arrays and arrays containing `undefined` from producing the same SHA-256 input
- add focused serialization and digest regression coverage plus a patch changeset

This addresses the canonical-hash collision reported as finding 2 in #18187. It intentionally preserves the existing top-level `undefined` behavior and changes only array-element handling.

## Validation

- `pnpm --filter ai exec vitest run --config vitest.node.config.js src/util/canonical-hash.test.ts` (8 passed, no type errors)
- `pnpm --filter ai type-check`
- `pnpm exec oxfmt --check packages/ai/src/util/canonical-hash.ts packages/ai/src/util/canonical-hash.test.ts .changeset/kind-bats-hash.md`
- `pnpm exec oxlint packages/ai/src/util/canonical-hash.ts packages/ai/src/util/canonical-hash.test.ts`
- `pnpm changeset status --since origin/main`
- `git diff --cached --check`