### PR TITLE
fix(ai): encode chat ids in reconnect URLs

### DIFF
--- a/.changeset/warm-pens-connect.md
+++ b/.changeset/warm-pens-connect.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Encode chat IDs when constructing default stream reconnection URLs.

--- a/packages/ai/src/ui/http-chat-transport.test.ts
+++ b/packages/ai/src/ui/http-chat-transport.test.ts
@@ -180,4 +180,23 @@ describe('HttpChatTransport', () => {
       );
     });
   });
+
+  describe('reconnectToStream', () => {
+    it('should encode the chat id in the default request URL', async () => {
+      const requestedUrls: Array<RequestInfo | URL> = [];
+      const transport = new MockHttpChatTransport({
+        api: 'http://localhost/api/chat',
+        fetch: async input => {
+          requestedUrls.push(input);
+          return new Response('');
+        },
+      });
+
+      await transport.reconnectToStream({ chatId: 'chat/../?value=1' });
+
+      expect(requestedUrls).toEqual([
+        'http://localhost/api/chat/chat%2F..%2F%3Fvalue%3D1/stream',
+      ]);
+    });
+  });
 });

--- a/packages/ai/src/ui/http-chat-transport.ts
+++ b/packages/ai/src/ui/http-chat-transport.ts
@@ -233,7 +233,9 @@ export abstract class HttpChatTransport<
       requestMetadata: options.metadata,
     });
 
-    const api = preparedRequest?.api ?? `${this.api}/${options.chatId}/stream`;
+    const api =
+      preparedRequest?.api ??
+      `${this.api}/${encodeURIComponent(options.chatId)}/stream`;
     const headers =
       preparedRequest?.headers !== undefined
         ? normalizeHeaders(preparedRequest.headers)


### PR DESCRIPTION
## Summary

- encode chat IDs before inserting them into default stream reconnection URLs
- keep custom URLs returned by `prepareReconnectToStreamRequest` unchanged
- add a regression test covering path separators, traversal segments, and query delimiters

This addresses the reconnect URL construction reported as finding 3 in #18187.

## Validation

- `NODE_OPTIONS=--localstorage-file=<temp> pnpm --filter ai exec vitest run --config vitest.node.config.js src/ui/http-chat-transport.test.ts` (5 passed, no type errors)
- `pnpm --filter ai type-check`
- `pnpm exec oxfmt --check packages/ai/src/ui/http-chat-transport.ts packages/ai/src/ui/http-chat-transport.test.ts .changeset/warm-pens-connect.md`
- `pnpm exec oxlint packages/ai/src/ui/http-chat-transport.ts packages/ai/src/ui/http-chat-transport.test.ts`
- `pnpm changeset status --since origin/main`
- `git diff --cached --check`

The temporary local-storage option is required only because the local runtime is Node 25, which is outside the repository's supported Node 22/24/26 engine range and otherwise prevents MSW from initializing before test collection.