### PR TITLE
fix(gateway): normalize denied tool results

### DIFF
--- a/.changeset/clean-gateway-denials.md
+++ b/.changeset/clean-gateway-denials.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+Fix rejected tool approvals when using AI Gateway.

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -1751,6 +1751,59 @@ describe('GatewayLanguageModel', () => {
       });
     });
 
+    it('should convert execution-denied tool results to text', async () => {
+      prepareResponse();
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_1',
+              toolName: 'weather',
+              output: {
+                type: 'execution-denied',
+                reason: 'User denied the request.',
+              },
+            },
+          ],
+        },
+      ];
+
+      await createTestModel().doGenerate({ prompt });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.prompt[0].content[0].output).toEqual({
+        type: 'text',
+        value: 'User denied the request.',
+      });
+    });
+
+    it('should provide a default message for execution-denied tool results', async () => {
+      prepareResponse();
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_1',
+              toolName: 'weather',
+              output: { type: 'execution-denied' },
+            },
+          ],
+        },
+      ];
+
+      await createTestModel().doGenerate({ prompt });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.prompt[0].content[0].output).toEqual({
+        type: 'text',
+        value: 'Tool call execution denied.',
+      });
+    });
+
     it('should not modify reasoning-file data that is a URL', async () => {
       prepareResponse();
       const prompt: LanguageModelV4Prompt = [

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -203,13 +203,17 @@ export class GatewayLanguageModel implements LanguageModelV4 {
       for (const part of message.content) {
         if (part.type === 'file' || part.type === 'reasoning-file') {
           part.data = maybeBase64EncodeFileData(part.data);
-        } else if (
-          part.type === 'tool-result' &&
-          part.output.type === 'content'
-        ) {
-          for (const contentPart of part.output.value) {
-            if (contentPart.type === 'file') {
-              contentPart.data = maybeBase64EncodeFileData(contentPart.data);
+        } else if (part.type === 'tool-result') {
+          if (part.output.type === 'execution-denied') {
+            part.output = {
+              type: 'text',
+              value: part.output.reason ?? 'Tool call execution denied.',
+            };
+          } else if (part.output.type === 'content') {
+            for (const contentPart of part.output.value) {
+              if (contentPart.type === 'file') {
+                contentPart.data = maybeBase64EncodeFileData(contentPart.data);
+              }
             }
           }
         }


### PR DESCRIPTION
## Problem

When a tool execution approval is denied, the AI SDK sends an internal execution-denied output through the Gateway adapter. Gateway rejects that prompt output as invalid, so the next model request fails.

Fixes #10663

## Root cause

The Gateway adapter forwarded the v4 execution-denied output unchanged instead of converting it to a wire-compatible tool result.

## Solution

- Convert execution-denied outputs to text using the denial reason.
- Use Tool call execution denied. when no reason is provided.
- Add request-body regression tests for both cases.
- Add a patch changeset for @ai-sdk/gateway.

## Validation

- git diff --cached --check passed.
- The Gateway Vitest suite could not be started because pnpm install repeatedly stalled while linking local dependencies in this environment; GitHub CI should provide the full test result.

## Notes for Reviewer

The generic Core execution-denied contract is unchanged. Only the Gateway adapter wire normalization is changed, matching the existing provider conversion behavior.