### PR TITLE
chore: harden harness bridge code import requirements in konsistent

### DIFF
--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -437,18 +437,15 @@
         "importValuesFrom": [
           "ai",
           "ai/*",
-          "@ai-sdk/provider",
-          "@ai-sdk/provider/*",
-          "@ai-sdk/provider-utils",
-          "@ai-sdk/provider-utils/*"
+          "@ai-sdk/*",
+          "!@ai-sdk/harness/bridge"
         ],
         "importTypesFrom": [
           "ai",
           "ai/*",
-          "@ai-sdk/provider",
-          "@ai-sdk/provider/*",
-          "@ai-sdk/provider-utils",
-          "@ai-sdk/provider-utils/*"
+          "@ai-sdk/*",
+          "!@ai-sdk/harness",
+          "!@ai-sdk/harness/bridge"
         ]
       }
     }


### PR DESCRIPTION
## Background

Follow-up to #18287.

Harness bridge code is special in that it runs in a sandbox, i.e. separate environment from the regular AI SDK host process. It therefore has special constraints in what it can import:
- from its own local code
- from third-party packages it directly depends on in its own `package.json` file (separate from the harness adapter's own `package.json` file)
- from `@ai-sdk/harness/bridge`
- for _types only_, from `@ai-sdk/harness`

So far we could not properly enforce it because the konsistent CLI didn't support wildcard package exclusions and the ability to negate these exclusions. This was recently added though, so now with konsistent 1.0.0-beta.5 we can properly handle it.

## Summary

Change `konsistent.json` config so that:
- no AI SDK imports are allowed at all
- except imports from `@ai-sdk/harness/bridge`
- and except type-only imports from `@ai-sdk/harness`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
