### PR TITLE
fix(provider-utils): fall back when TextDecoderStream is missing

### DIFF
--- a/.changeset/fix-text-decoder-stream-rn-fallback.md
+++ b/.changeset/fix-text-decoder-stream-rn-fallback.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Fall back to TextDecoder when TextDecoderStream is unavailable (e.g. React Native / Expo), fixing streamText SSE parsing crashes.

--- a/packages/provider-utils/src/create-text-decoder-stream.test.ts
+++ b/packages/provider-utils/src/create-text-decoder-stream.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { createTextDecoderStream } from './create-text-decoder-stream';
+import { convertReadableStreamToArray } from './test/convert-readable-stream-to-array';
+
+function encodeChunks(...parts: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream({
+    start(controller) {
+      for (const part of parts) {
+        controller.enqueue(encoder.encode(part));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe('createTextDecoderStream', () => {
+  it('decodes utf-8 chunks with the native TextDecoderStream when available', async () => {
+    expect(typeof TextDecoderStream).not.toBe('undefined');
+
+    const values = await convertReadableStreamToArray(
+      encodeChunks('hel', 'lo').pipeThrough(createTextDecoderStream()),
+    );
+
+    expect(values.join('')).toBe('hello');
+  });
+
+  it('falls back to TextDecoder when TextDecoderStream is unavailable', async () => {
+    const originalTextDecoderStream = globalThis.TextDecoderStream;
+    // Simulate React Native / Expo environments that do not provide TextDecoderStream.
+    // @ts-expect-error -- intentionally remove the global for this test
+    delete globalThis.TextDecoderStream;
+
+    try {
+      expect(typeof TextDecoderStream).toBe('undefined');
+
+      const values = await convertReadableStreamToArray(
+        encodeChunks('hel', 'lo').pipeThrough(createTextDecoderStream()),
+      );
+
+      expect(values.join('')).toBe('hello');
+    } finally {
+      globalThis.TextDecoderStream = originalTextDecoderStream;
+    }
+  });
+
+  it('preserves multi-byte characters split across chunks in the fallback path', async () => {
+    const originalTextDecoderStream = globalThis.TextDecoderStream;
+    // @ts-expect-error -- intentionally remove the global for this test
+    delete globalThis.TextDecoderStream;
+
+    try {
+      const emoji = '🙂';
+      const bytes = new TextEncoder().encode(emoji);
+
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          // Split a multi-byte UTF-8 sequence across two chunks.
+          controller.enqueue(bytes.slice(0, 2));
+          controller.enqueue(bytes.slice(2));
+          controller.close();
+        },
+      });
+
+      const values = await convertReadableStreamToArray(
+        stream.pipeThrough(createTextDecoderStream()),
+      );
+
+      expect(values.join('')).toBe(emoji);
+    } finally {
+      globalThis.TextDecoderStream = originalTextDecoderStream;
+    }
+  });
+});

--- a/packages/provider-utils/src/create-text-decoder-stream.ts
+++ b/packages/provider-utils/src/create-text-decoder-stream.ts
@@ -1,0 +1,29 @@
+/**
+ * Creates a transform stream that decodes Uint8Array chunks to strings.
+ *
+ * Uses the native `TextDecoderStream` when available. In environments that
+ * lack it (notably React Native / Expo), falls back to a `TransformStream`
+ * backed by `TextDecoder`.
+ */
+export function createTextDecoderStream(): ReadableWritablePair<
+  string,
+  Uint8Array
+> {
+  if (typeof TextDecoderStream !== 'undefined') {
+    return new TextDecoderStream();
+  }
+
+  const decoder = new TextDecoder();
+
+  return new TransformStream<Uint8Array, string>({
+    transform(chunk, controller) {
+      controller.enqueue(decoder.decode(chunk, { stream: true }));
+    },
+    flush(controller) {
+      const remaining = decoder.decode();
+      if (remaining.length > 0) {
+        controller.enqueue(remaining);
+      }
+    },
+  });
+}

--- a/packages/provider-utils/src/parse-json-event-stream.test.ts
+++ b/packages/provider-utils/src/parse-json-event-stream.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { parseJsonEventStream } from './parse-json-event-stream';
+import { convertReadableStreamToArray } from './test/convert-readable-stream-to-array';
+
+function createEventStream(...payloads: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream({
+    start(controller) {
+      for (const payload of payloads) {
+        controller.enqueue(encoder.encode(`data: ${payload}\n\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+const schema = z.object({
+  content: z.string(),
+});
+
+describe('parseJsonEventStream', () => {
+  it('parses SSE JSON events', async () => {
+    const results = await convertReadableStreamToArray(
+      parseJsonEventStream({
+        stream: createEventStream(
+          JSON.stringify({ content: 'hello' }),
+          '[DONE]',
+        ),
+        schema,
+      }),
+    );
+
+    expect(results).toEqual([
+      {
+        success: true,
+        value: { content: 'hello' },
+        rawValue: { content: 'hello' },
+      },
+    ]);
+  });
+
+  it('parses SSE JSON events when TextDecoderStream is unavailable', async () => {
+    const originalTextDecoderStream = globalThis.TextDecoderStream;
+    // @ts-expect-error -- intentionally remove the global for this test
+    delete globalThis.TextDecoderStream;
+
+    try {
+      const results = await convertReadableStreamToArray(
+        parseJsonEventStream({
+          stream: createEventStream(
+            JSON.stringify({ content: 'from-fallback' }),
+            '[DONE]',
+          ),
+          schema,
+        }),
+      );
+
+      expect(results).toEqual([
+        {
+          success: true,
+          value: { content: 'from-fallback' },
+          rawValue: { content: 'from-fallback' },
+        },
+      ]);
+    } finally {
+      globalThis.TextDecoderStream = originalTextDecoderStream;
+    }
+  });
+});

--- a/packages/provider-utils/src/parse-json-event-stream.ts
+++ b/packages/provider-utils/src/parse-json-event-stream.ts
@@ -2,6 +2,7 @@ import {
   EventSourceParserStream,
   type EventSourceMessage,
 } from 'eventsource-parser/stream';
+import { createTextDecoderStream } from './create-text-decoder-stream';
 import { safeParseJSON, type ParseResult } from './parse-json';
 import type { FlexibleSchema } from './schema';
 
@@ -16,7 +17,7 @@ export function parseJsonEventStream<T>({
   schema: FlexibleSchema<T>;
 }): ReadableStream<ParseResult<T>> {
   return stream
-    .pipeThrough(new TextDecoderStream())
+    .pipeThrough(createTextDecoderStream())
     .pipeThrough(new EventSourceParserStream())
     .pipeThrough(
       new TransformStream<EventSourceMessage, ParseResult<T>>({


### PR DESCRIPTION
## Background

`streamText` crashes in Expo / React Native because SSE parsing in `@ai-sdk/provider-utils` constructs `new TextDecoderStream()`, which is unavailable in those runtimes.

Maintainer reproduction for #13588 confirmed the failure mode:
`TypeError: TextDecoderStream is not a constructor` against a successful SSE response.

## Summary

- Add `createTextDecoderStream()` that uses native `TextDecoderStream` when present and falls back to a `TextDecoder`-backed `TransformStream` otherwise
- Route `parseJsonEventStream` through that helper (used by `createEventSourceResponseHandler` / provider streaming)
- Add unit tests covering native path, fallback path, multi-byte chunk splits, and SSE parsing without `TextDecoderStream`
- Add a patch changeset

## End-to-End Verification

- Reproduced Expo-like failure mode by deleting `globalThis.TextDecoderStream` and calling `parseJsonEventStream`
- After the fix, the same Expo-like run succeeds (`expo-like ok: true`)
- `pnpm test:node` and `pnpm test:edge` in `@ai-sdk/provider-utils` (804 tests passed)

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #13588