### PR TITLE
Add eve starter links

### DIFF
--- a/apps/docs/components/docs/marketing-cards.tsx
+++ b/apps/docs/components/docs/marketing-cards.tsx
@@ -12,6 +12,13 @@ const templates = [
     href: 'https://vercel.com/templates/next.js/nextjs-ai-chatbot',
   },
   {
+    title: 'eve Chat',
+    description:
+      'A persisted AI SDK chat app powered by eve with durable agent sessions, tools, and integrations.',
+    type: 'starter-kits',
+    href: 'https://vercel.com/templates/eve/eve-chat-template',
+  },
+  {
     title: 'Internal Knowledge Base',
     description: 'A retrieval-augmented generation starter with guardrails.',
     type: 'starter-kits',

--- a/content/cookbook/00-guides/03-slackbot.mdx
+++ b/content/cookbook/00-guides/03-slackbot.mdx
@@ -500,3 +500,5 @@ You've built a Slack chatbot powered by the AI SDK! Here are some ways you could
   In a production environment, it is recommended to implement a robust queueing
   system to ensure messages are properly handled.
 </Note>
+
+For a framework-managed alternative with durable threaded sessions, typing indicators, approval buttons, and multichannel support, see [eve's Slack channel](https://eve.dev/docs/channels/slack).


### PR DESCRIPTION
- Add eve Chat to Starter Kits through its deployable Vercel template.
- Present eve’s Slack channel as a durable, framework-managed alternative after the tutorial’s production note.