### PR TITLE
fix(black-forest-labs): report the settled cost for FLUX 3 video

### DIFF
--- a/.changeset/black-forest-labs-video-settled-cost.md
+++ b/.changeset/black-forest-labs-video-settled-cost.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/black-forest-labs': patch
+---
+
+Report the settled cost for FLUX 3 video generations. The submit response can only estimate, and returns no cost when the price depends on the finished video; the result endpoint answers with `SettledCostResultResponse`, whose cost was being dropped.

--- a/packages/black-forest-labs/src/black-forest-labs-video-model.test.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-video-model.test.ts
@@ -182,6 +182,72 @@ describe('BlackForestLabsVideoModel', () => {
       ]);
     });
 
+    // The submit response can only estimate, and returns null whenever the
+    // price depends on the finished video. `get_result` then answers with the
+    // `SettledCostResultResponse` variant, which carries the real charge.
+    it('should prefer the settled cost from the result over the submit estimate', async () => {
+      server.urls[POLL_URL].response = {
+        type: 'json-value',
+        body: { ...readyResponse, cost: 0.85 },
+      };
+
+      const result = await createModel().doGenerate({ ...defaultOptions });
+
+      expect(result.providerMetadata?.blackForestLabs?.videos).toStrictEqual([
+        {
+          id: REQUEST_ID,
+          videoUrl: VIDEO_URL,
+          seed: 7,
+          duration: 8,
+          cost: 0.85,
+          inputMegapixels: 1.23,
+          outputMegapixels: 4.56,
+        },
+      ]);
+    });
+
+    it('should report the settled cost when the submit response omits one', async () => {
+      server.urls[SUBMIT_URL].response = {
+        type: 'json-value',
+        body: { id: REQUEST_ID, polling_url: POLL_URL },
+      };
+      server.urls[POLL_URL].response = {
+        type: 'json-value',
+        body: { ...readyResponse, cost: 0.85 },
+      };
+
+      const result = await createModel().doGenerate({ ...defaultOptions });
+
+      expect(result.providerMetadata?.blackForestLabs?.videos).toStrictEqual([
+        {
+          id: REQUEST_ID,
+          videoUrl: VIDEO_URL,
+          seed: 7,
+          duration: 8,
+          cost: 0.85,
+        },
+      ]);
+    });
+
+    // The plain `ResultResponse` variant has no cost at all.
+    it('should omit cost entirely when neither response reports one', async () => {
+      server.urls[SUBMIT_URL].response = {
+        type: 'json-value',
+        body: { id: REQUEST_ID, polling_url: POLL_URL },
+      };
+
+      const result = await createModel().doGenerate({ ...defaultOptions });
+
+      expect(result.providerMetadata?.blackForestLabs?.videos).toStrictEqual([
+        {
+          id: REQUEST_ID,
+          videoUrl: VIDEO_URL,
+          seed: 7,
+          duration: 8,
+        },
+      ]);
+    });
+
     it('should send an empty prompt when none is provided', async () => {
       await createModel().doGenerate({ ...defaultOptions, prompt: undefined });
 
@@ -1095,6 +1161,30 @@ describe('BlackForestLabsVideoModel', () => {
         },
       });
       expect(server.calls).toHaveLength(1);
+    });
+
+    // A resumed operation carries whatever the submit response estimated,
+    // which may be stale or absent by the time the video is ready.
+    it('should prefer the settled cost over the cost carried on the operation', async () => {
+      server.urls[POLL_URL].response = {
+        type: 'json-value',
+        body: { ...readyResponse, cost: 0.85 },
+      };
+
+      const result = await createModel().doStatus({
+        operation: {
+          requestId: REQUEST_ID,
+          pollingUrl: POLL_URL,
+          cost: 0.42,
+        },
+      });
+
+      expect(result).toMatchObject({
+        status: 'completed',
+        providerMetadata: {
+          blackForestLabs: { videos: [{ cost: 0.85 }] },
+        },
+      });
     });
 
     it('should return an error from doStatus for terminal failures', async () => {

--- a/packages/black-forest-labs/src/black-forest-labs-video-model.ts
+++ b/packages/black-forest-labs/src/black-forest-labs-video-model.ts
@@ -625,6 +625,8 @@ export class BlackForestLabsVideoModel implements VideoModelV4 {
     };
     const { status, result } = value;
 
+    const cost = value.cost ?? operation.cost;
+
     if (status === 'Ready') {
       const parsed = bflVideoResultSchema.safeParse(result);
       if (!parsed.success) {
@@ -665,7 +667,7 @@ export class BlackForestLabsVideoModel implements VideoModelV4 {
                 ...(parsed.data.draft_cache != null && {
                   draftCache: parsed.data.draft_cache,
                 }),
-                ...(operation.cost != null && { cost: operation.cost }),
+                ...(cost != null && { cost }),
                 ...(operation.inputMegapixels != null && {
                   inputMegapixels: operation.inputMegapixels,
                 }),
@@ -767,6 +769,10 @@ const bflVideoPollSchema = z
     state: z.string().optional(),
     details: z.unknown().optional(),
     result: z.unknown().optional(),
+    // `SettledCostResultResponse.cost` — the price actually charged, which the
+    // API can only know once generation finishes. Absent on the plain
+    // `ResultResponse` variant.
+    cost: z.number().nullish(),
   })
   .refine(v => v.status != null || v.state != null, {
     message: 'Missing status in Black Forest Labs poll response',
@@ -775,4 +781,5 @@ const bflVideoPollSchema = z
     status: (v.status ?? v.state)!,
     details: v.details,
     result: v.result,
+    cost: v.cost,
   }));


### PR DESCRIPTION
## Background

BFL returns the cost of a FLUX 3 video generation in two different places, and the provider only read one of them.

The submit response (`POST /v1/flux-3-video` → `AsyncResponse.cost`) is an *estimate*, and it is optional and nullable in BFL's OpenAPI spec. It is null whenever the price cannot be known at submit time — a model-chosen duration, or an `fhd` request that goes through the upsampler. For those requests the real number arrives from `GET /v1/get_result`, whose 200 is `anyOf[SettledCostResultResponse, ResultResponse]`, where `SettledCostResultResponse.cost` is documented as *"Settled cost in credits for this request."*

## Summary

- Added `cost: z.number().nullish()` to `bflVideoPollSchema` and carried it through the `.transform`.
- `doStatus` now resolves `value.cost ?? operation.cost` — the settled cost wins, with the submit estimate kept as the fallback. `doGenerate` picks this up for free, since it returns `statusResult.providerMetadata`.

`inputMegapixels` / `outputMegapixels` continue to come from the operation alone: BFL's spec puts them on the submit response only, so there is nothing to prefer.