### PR TITLE
feat(svelte): support automatic chat stream resumption

### DIFF
--- a/.changeset/quiet-rivers-resume.md
+++ b/.changeset/quiet-rivers-resume.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/svelte': patch
+---
+
+feat(svelte): add automatic chat stream resumption on mount

--- a/content/docs/04-ai-sdk-ui/03-chatbot-resume-streams.mdx
+++ b/content/docs/04-ai-sdk-ui/03-chatbot-resume-streams.mdx
@@ -5,7 +5,9 @@ description: Learn how to resume chatbot streams after client disconnects.
 
 # Chatbot Resume Streams
 
-`useChat` supports resuming ongoing streams after page reloads. Use this feature to build applications with long-running generations.
+React's `useChat` hook and Svelte's `Chat` class support resuming ongoing
+streams after page reloads. Use this feature to build applications with
+long-running generations.
 
 <Note type="warning">
   In a resumable stream setup, client-side aborts are treated as disconnects.
@@ -24,7 +26,7 @@ Stream resumption requires persistence for messages and active streams in your a
 
 **The AI SDK provides:**
 
-- A `resume` option in `useChat` that automatically reconnects to active streams
+- A `resume` option in React's `useChat` hook and Svelte's `Chat` class that automatically reconnects to active streams
 - Access to the outgoing stream through the `consumeSseStream` callback
 - Automatic HTTP requests to your resume endpoints
 
@@ -47,7 +49,12 @@ To implement resumable streams in your chat application, you need:
 
 ### 1. Client-side: Enable stream resumption
 
-Use the `resume` option in the `useChat` hook to enable stream resumption. When `resume` is true, the hook automatically attempts to reconnect to any active stream for the chat on mount:
+Use the `resume` option to enable stream resumption. When `resume` is true, the
+React hook or Svelte class automatically attempts to reconnect to any active
+stream for the chat on mount:
+
+<Tabs items={['React', 'Svelte']}>
+<Tab>
 
 ```tsx filename="app/chat/[chatId]/chat.tsx"
 'use client';
@@ -83,12 +90,59 @@ export function Chat({
 }
 ```
 
+</Tab>
+<Tab>
+
+```svelte filename="src/routes/chat/[chatId]/+page.svelte"
+<script lang="ts">
+  import { Chat } from '@ai-sdk/svelte';
+  import { DefaultChatTransport, type UIMessage } from 'ai';
+
+  let {
+    chatData,
+    resume = false,
+  }: {
+    chatData: { id: string; messages: UIMessage[] };
+    resume?: boolean;
+  } = $props();
+
+  const chat = new Chat({
+    id: chatData.id,
+    messages: chatData.messages,
+    resume, // Enable automatic stream resumption
+    transport: new DefaultChatTransport({
+      // You must send the id of the chat
+      prepareSendMessagesRequest: ({ id, messages }) => {
+        return {
+          body: {
+            id,
+            message: messages[messages.length - 1],
+          },
+        };
+      },
+    }),
+  });
+</script>
+
+<!-- Your chat UI -->
+```
+
+</Tab>
+</Tabs>
+
 <Note>
   You must send the chat ID with each request (see
   `prepareSendMessagesRequest`).
 </Note>
 
-When you enable `resume`, the `useChat` hook makes a `GET` request to `/api/chat/[id]/stream` on mount to check for and resume any active streams.
+<Note>
+  The server examples below use Next.js. For SvelteKit, implement equivalent
+  POST and GET handlers that use the same UI message stream protocol and
+  persistence flow.
+</Note>
+
+When you enable `resume`, the React hook or Svelte class makes a `GET` request
+to `/api/chat/[id]/stream` on mount to check for and resume any active streams.
 
 Let's start by creating the POST handler to create the resumable stream.
 

--- a/packages/svelte/src/chat-resume.test.ts
+++ b/packages/svelte/src/chat-resume.test.ts
@@ -1,0 +1,24 @@
+import type { ChatTransport, UIMessage, UIMessageChunk } from 'ai';
+import { render } from 'svelte/server';
+import ChatResume from './tests/chat-resume.svelte';
+import { expect, it, vi } from 'vitest';
+
+it('should not resume a stream during server-side rendering', () => {
+  const reconnectToStream = vi.fn(async () => null);
+  const transport = {
+    sendMessages: async () => new ReadableStream<UIMessageChunk>(),
+    reconnectToStream,
+  } satisfies ChatTransport<UIMessage>;
+
+  render(ChatResume, {
+    props: {
+      options: {
+        id: 'chat-id',
+        resume: true,
+        transport,
+      },
+    },
+  });
+
+  expect(reconnectToStream).not.toHaveBeenCalled();
+});

--- a/packages/svelte/src/chat.svelte.test.ts
+++ b/packages/svelte/src/chat.svelte.test.ts
@@ -7,10 +7,14 @@ import {
   DefaultChatTransport,
   isStaticToolUIPart,
   TextStreamChatTransport,
+  type ChatTransport,
+  type UIMessage,
   type UIMessageChunk,
 } from 'ai';
+import { render } from '@testing-library/svelte';
 import { flushSync } from 'svelte';
 import { Chat } from './chat.svelte.js';
+import ChatResume from './tests/chat-resume.svelte';
 import { promiseWithResolvers } from './utils.svelte.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -34,6 +38,64 @@ function createFileList(...files: File[]): FileList {
 
 const server = createTestServer({
   '/api/chat': {},
+});
+
+describe('resume', () => {
+  it('should resume an ongoing stream when the component mounts', async () => {
+    const reconnectToStream = vi.fn(
+      async () =>
+        new ReadableStream<UIMessageChunk>({
+          start(controller) {
+            controller.enqueue({ type: 'text-start', id: '0' });
+            controller.enqueue({ type: 'text-delta', id: '0', delta: 'Hello' });
+            controller.enqueue({ type: 'text-end', id: '0' });
+            controller.close();
+          },
+        }),
+    );
+    const transport = {
+      sendMessages: async () => new ReadableStream<UIMessageChunk>(),
+      reconnectToStream,
+    } satisfies ChatTransport<UIMessage>;
+
+    const {
+      component: { chat },
+    } = render(ChatResume, {
+      options: {
+        id: 'chat-id',
+        resume: true,
+        transport,
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(reconnectToStream).toHaveBeenCalledOnce();
+      expect(chat.messages.at(0)?.parts).toEqual([
+        { type: 'text', text: 'Hello', state: 'done' },
+      ]);
+    });
+    expect(reconnectToStream).toHaveBeenCalledWith(
+      expect.objectContaining({ chatId: 'chat-id' }),
+    );
+  });
+
+  it('should not resume a stream by default', async () => {
+    const reconnectToStream = vi.fn(async () => null);
+    const transport = {
+      sendMessages: async () => new ReadableStream<UIMessageChunk>(),
+      reconnectToStream,
+    } satisfies ChatTransport<UIMessage>;
+
+    render(ChatResume, {
+      options: {
+        id: 'chat-id',
+        transport,
+      },
+    });
+
+    await Promise.resolve();
+    expect(reconnectToStream).not.toHaveBeenCalled();
+  });
 });
 
 describe('data protocol stream', () => {

--- a/packages/svelte/src/chat.svelte.ts
+++ b/packages/svelte/src/chat.svelte.ts
@@ -6,16 +6,32 @@ import {
   type CreateUIMessage,
   type UIMessage,
 } from 'ai';
+import { onMount } from 'svelte';
 export type { CreateUIMessage, UIMessage };
+
+export type ChatOptions<UI_MESSAGE extends UIMessage = UIMessage> = Readonly<
+  ChatInit<UI_MESSAGE> & {
+    /**
+     * Whether to resume an ongoing chat generation stream when the component mounts.
+     */
+    resume?: boolean;
+  }
+>;
 
 export class Chat<
   UI_MESSAGE extends UIMessage = UIMessage,
 > extends AbstractChat<UI_MESSAGE> {
-  constructor(init: ChatInit<UI_MESSAGE>) {
+  constructor({ resume = false, ...init }: ChatOptions<UI_MESSAGE>) {
     super({
       ...init,
       state: new SvelteChatState(init.messages),
     });
+
+    if (resume) {
+      onMount(() => {
+        void this.resumeStream();
+      });
+    }
   }
 }
 

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -4,7 +4,12 @@ import {
   type StructuredObjectOptions,
 } from './structured-object.svelte.js';
 
-export { Chat, type CreateUIMessage, type UIMessage } from './chat.svelte.js';
+export {
+  Chat,
+  type ChatOptions,
+  type CreateUIMessage,
+  type UIMessage,
+} from './chat.svelte.js';
 export { Completion, type CompletionOptions } from './completion.svelte.js';
 export { createAIContext } from './context-provider.js';
 export {

--- a/packages/svelte/src/tests/chat-resume.svelte
+++ b/packages/svelte/src/tests/chat-resume.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { Chat, type ChatOptions } from '../chat.svelte.js';
+
+  let { options }: { options: ChatOptions } = $props();
+
+  function createChat() {
+    return new Chat(options);
+  }
+
+  const chat = createChat();
+
+  export { chat };
+</script>


### PR DESCRIPTION
## Background

`@ai-sdk/svelte` exposes `resumeStream()` for manual reconnection, but unlike React `useChat`, its `Chat` constructor had no `resume` option. Applications therefore needed custom mount-time wiring to resume an active stream after a reload.

## Summary

- add a public `ChatOptions` type with `resume?: boolean`
- resume an active stream once when the owning Svelte component mounts, while avoiding reconnection during SSR
- cover enabled, default-disabled, streamed-message, and SSR behavior
- document Svelte stream resumption and add a patch changeset

## Contributor Credit

Thanks @dkozma for reporting the missing Svelte API parity and providing the original context in #9504.

## End-to-End Verification

Rendered the Svelte chat fixture with a reconnect-capable transport and confirmed that `resume: true` triggers one reconnect after client mount, consumes the resumed stream into reactive messages, and remains inactive during server rendering. Also confirmed that omitting `resume` does not reconnect.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #9504
