### PR TITLE
fix(ai): fix stop() on resumed streams by passing abortSignal

### DIFF
--- a/.changeset/fix-resume-stream-stop.md
+++ b/.changeset/fix-resume-stream-stop.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Fix stop() on resumed streams by passing abort signal to reconnectToStream

--- a/packages/ai/src/ui/chat-transport.ts
+++ b/packages/ai/src/ui/chat-transport.ts
@@ -78,6 +78,8 @@ export interface ChatTransport<UI_MESSAGE extends UIMessage> {
     options: {
       /** Unique identifier for the chat session to reconnect to */
       chatId: string;
+      /** Abort signal to cancel the request */
+      abortSignal?: AbortSignal;
     } & ChatRequestOptions,
   ) => Promise<ReadableStream<UIMessageChunk> | null>;
 }

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -1546,6 +1546,55 @@ describe('Chat', () => {
     }
   });
 
+  it('should abort resume-stream when stop is called', async () => {
+    let isAborted = false;
+    let resumeController!: ReadableStreamDefaultController<UIMessageChunk>;
+    const resumeStream = new ReadableStream<UIMessageChunk>({
+      start(controller) {
+        resumeController = controller;
+        controller.enqueue({ type: 'start' });
+        controller.enqueue({ type: 'start-step' });
+        controller.enqueue({ type: 'text-start', id: 'text-1' });
+        controller.enqueue({
+          type: 'text-delta',
+          id: 'text-1',
+          delta: 'resumed',
+        });
+      },
+    });
+
+    const chat = new TestChat({
+      id: '123',
+      generateId: mockId(),
+      transport: {
+        sendMessages: async () => {
+          throw new Error('should not be called');
+        },
+        reconnectToStream: async options => {
+          options.abortSignal?.addEventListener('abort', () => {
+            isAborted = true;
+            resumeController.error(new DOMException('Aborted', 'AbortError'));
+          });
+          return resumeStream;
+        },
+      },
+      onFinish: () => {},
+    });
+
+    const resumePromise = chat.resumeStream();
+
+    while ((chat.messages[0]?.parts[1] as any)?.text !== 'resumed') {
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    await chat.stop();
+
+    await resumePromise;
+
+    expect(isAborted).toBe(true);
+    expect(chat.status).toBe('ready');
+  });
+
   describe('sendAutomaticallyWhen', () => {
     it('should delay tool output submission until the stream is finished', async () => {
       const controller1 = new TestResponseController();

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -616,41 +616,12 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
     trigger: 'submit-message' | 'resume-stream' | 'regenerate-message';
     messageId?: string;
   } & ChatRequestOptions) {
-    // For resume-stream, check if there's an active stream before
-    // changing status. This avoids a brief flash of 'submitted' status
-    // when there is no stream to resume (e.g. on page load).
-    let resumeStream: ReadableStream<UIMessageChunk> | undefined;
-    if (trigger === 'resume-stream') {
-      try {
-        const reconnect = await this.transport.reconnectToStream({
-          chatId: this.id,
-          metadata,
-          headers,
-          body,
-        });
-
-        if (reconnect == null) {
-          return; // no active stream found, so we do not resume
-        }
-
-        resumeStream = reconnect;
-      } catch (err) {
-        if (this.onError && err instanceof Error) {
-          this.onError(err);
-        }
-        this.setStatus({ status: 'error', error: err as Error });
-        return;
-      }
-    }
-
-    this.setStatus({ status: 'submitted', error: undefined });
-
-    const lastMessage = this.lastMessage;
-
     let isAbort = false;
     let isDisconnect = false;
     let isError = false;
     let activeResponse: ActiveResponse<UI_MESSAGE> | undefined;
+
+    const lastMessage = this.lastMessage;
 
     try {
       const response = {
@@ -668,6 +639,46 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       });
 
       this.activeResponse = response;
+
+      // For resume-stream, check if there's an active stream before
+      // changing status. This avoids a brief flash of 'submitted' status
+      // when there is no stream to resume (e.g. on page load).
+      let resumeStream: ReadableStream<UIMessageChunk> | undefined;
+      if (trigger === 'resume-stream') {
+        let reconnect: ReadableStream<UIMessageChunk> | null = null;
+        try {
+          reconnect = await this.transport.reconnectToStream({
+            chatId: this.id,
+            abortSignal: response.abortController.signal,
+            metadata,
+            headers,
+            body,
+          });
+        } catch (err) {
+          activeResponse = undefined;
+          this.activeResponse = undefined;
+          if (isAbort || (err as any).name === 'AbortError') {
+            isAbort = true;
+            this.setStatus({ status: 'ready' });
+            return null;
+          }
+          if (this.onError && err instanceof Error) {
+            this.onError(err);
+          }
+          this.setStatus({ status: 'error', error: err as Error });
+          return;
+        }
+
+        if (reconnect == null) {
+          activeResponse = undefined;
+          this.activeResponse = undefined;
+          return; // no active stream found, so we do not resume
+        }
+
+        resumeStream = reconnect;
+      }
+
+      this.setStatus({ status: 'submitted', error: undefined });
 
       let stream: ReadableStream<UIMessageChunk>;
 

--- a/packages/ai/src/ui/http-chat-transport.ts
+++ b/packages/ai/src/ui/http-chat-transport.ts
@@ -247,6 +247,7 @@ export abstract class HttpChatTransport<
       method: 'GET',
       headers,
       credentials,
+      signal: options.abortSignal,
     });
 
     // no active stream found, so we do not resume


### PR DESCRIPTION
Fixes #18458

When a stream is resumed, `reconnectToStream` fetches the remaining stream. However, it was not accepting an `AbortSignal`, meaning that if the user called `stop()` during a resumed stream, the underlying fetch request was never aborted and generation continued.

This PR:
- Adds `abortSignal?: AbortSignal` to `ChatTransport`'s `reconnectToStream` options.
- Updates `http-chat-transport` to pass this `abortSignal` to `fetch`.
- Refactors `makeRequest` in `ui/chat.ts` to instantiate the `AbortController` and populate `this.activeResponse` *before* the network request is triggered (for both stream resuming and normal submits).
- Wires the `abortController.signal` into `reconnectToStream`.
- Adds an automated test to `chat.test.ts` to ensure `stop()` successfully aborts a resumed stream.
