### PR TITLE
feat(harness): add `HarnessBridgeCapabilityUnsupportedError` for bridge code that needs to flag missing capability

### DIFF
--- a/.changeset/silver-cups-complain.md
+++ b/.changeset/silver-cups-complain.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness": patch
+---
+
+feat(harness): add `HarnessBridgeCapabilityUnsupportedError` for bridge code that needs to flag missing capability

--- a/packages/harness/bridge/index.ts
+++ b/packages/harness/bridge/index.ts
@@ -1,4 +1,7 @@
-export { runBridge } from '../src/bridge';
+export {
+  HarnessBridgeCapabilityUnsupportedError,
+  runBridge,
+} from '../src/bridge';
 export type {
   RunBridgeOptions,
   BridgeTurn,

--- a/packages/harness/src/bridge/harness-bridge-capability-unsupported-error.test.ts
+++ b/packages/harness/src/bridge/harness-bridge-capability-unsupported-error.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest';
+import { HarnessBridgeCapabilityUnsupportedError } from './harness-bridge-capability-unsupported-error';
+
+describe('HarnessBridgeCapabilityUnsupportedError', () => {
+  test('preserves the supplied context', () => {
+    const cause = new Error('inner');
+    const error = new HarnessBridgeCapabilityUnsupportedError({
+      message: 'The bridge does not support this capability.',
+      harnessId: 'example',
+      cause,
+    });
+
+    expect(error).toMatchObject({
+      name: 'AI_HarnessBridgeCapabilityUnsupportedError',
+      message: 'The bridge does not support this capability.',
+      harnessId: 'example',
+      cause,
+    });
+    expect(HarnessBridgeCapabilityUnsupportedError.isInstance(error)).toBe(
+      true,
+    );
+  });
+
+  test('recognizes the serialized bridge error shape', () => {
+    expect(
+      HarnessBridgeCapabilityUnsupportedError.isInstance({
+        name: 'AI_HarnessBridgeCapabilityUnsupportedError',
+        message: 'Unsupported.',
+        stack: 'stack',
+      }),
+    ).toBe(true);
+  });
+
+  test('rejects unrelated errors and malformed serialized values', () => {
+    expect(
+      HarnessBridgeCapabilityUnsupportedError.isInstance(new Error('x')),
+    ).toBe(false);
+    expect(
+      HarnessBridgeCapabilityUnsupportedError.isInstance({
+        name: 'AI_HarnessBridgeCapabilityUnsupportedError',
+      }),
+    ).toBe(false);
+    expect(HarnessBridgeCapabilityUnsupportedError.isInstance(null)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/harness/src/bridge/harness-bridge-capability-unsupported-error.ts
+++ b/packages/harness/src/bridge/harness-bridge-capability-unsupported-error.ts
@@ -1,0 +1,39 @@
+const name = 'AI_HarnessBridgeCapabilityUnsupportedError';
+
+/**
+ * Signals an unsupported capability discovered inside a sandbox bridge.
+ * `isInstance` also recognizes the serialized error shape received by the
+ * host, where it can be translated to `HarnessCapabilityUnsupportedError`.
+ */
+export class HarnessBridgeCapabilityUnsupportedError extends Error {
+  readonly harnessId?: string;
+  readonly cause?: unknown;
+
+  constructor({
+    message,
+    harnessId,
+    cause,
+  }: {
+    message: string;
+    harnessId?: string;
+    cause?: unknown;
+  }) {
+    super(message);
+    Object.defineProperty(this, 'name', { value: name });
+    this.harnessId = harnessId;
+    this.cause = cause;
+  }
+
+  static isInstance(
+    error: unknown,
+  ): error is HarnessBridgeCapabilityUnsupportedError {
+    return (
+      error != null &&
+      typeof error === 'object' &&
+      'name' in error &&
+      error.name === name &&
+      'message' in error &&
+      typeof error.message === 'string'
+    );
+  }
+}

--- a/packages/harness/src/bridge/index.ts
+++ b/packages/harness/src/bridge/index.ts
@@ -11,6 +11,8 @@ import { existsSync, readFileSync } from 'node:fs';
 import { env as procEnv, pid, stdout } from 'node:process';
 import { WebSocketServer, type WebSocket } from 'ws';
 
+export { HarnessBridgeCapabilityUnsupportedError } from './harness-bridge-capability-unsupported-error';
+
 export type BridgeState = 'init' | 'waiting' | 'running' | 'draining' | 'done';
 
 /** Outbound turn event the adapter emits. `seq` is added by the runtime. */


### PR DESCRIPTION
## Background

Sandbox bridges need a recognizable error for reporting unsupported capabilities across the serialized bridge boundary. Not all harness capability gaps can be identified from the host environment alone.

This is needed, for instance, for the in-progress ACP harness adapter.

## Summary

- Add `HarnessBridgeCapabilityUnsupportedError` with optional harness and cause context.
- Recognize both local instances and serialized bridge error shapes.
- Export the error from the harness bridge entry point and cover it with unit tests.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
