### PR TITLE
policy-opa: add composed-judgment example

### DIFF
--- a/.changeset/silly-rivers-attend.md
+++ b/.changeset/silly-rivers-attend.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/policy-opa': patch
+---
+
+Add a runnable example composing `@ai-sdk/policy-opa` with an independent judgment call for cases the deterministic policy can't resolve on its own (`examples/mock/composed-judgment.ts`).

--- a/.changeset/silly-rivers-attend.md
+++ b/.changeset/silly-rivers-attend.md
@@ -2,4 +2,4 @@
 '@ai-sdk/policy-opa': patch
 ---
 
-Add a runnable example composing `@ai-sdk/policy-opa` with an independent judgment call for cases the deterministic policy can't resolve on its own (`examples/mock/composed-judgment.ts`).
+Add a runnable example composing `@ai-sdk/policy-opa` with contextual judgment and human-approval fallbacks, and document the package examples.

--- a/packages/policy-opa/README.md
+++ b/packages/policy-opa/README.md
@@ -70,6 +70,17 @@ const result = await generateText({
 });
 ```
 
+## Examples
+
+- [`examples/mock/basic.ts`](./examples/mock/basic.ts) demonstrates direct
+  allow and deny decisions plus transitive enforcement through a composite
+  shell tool.
+- [`examples/mock/composed-judgment.ts`](./examples/mock/composed-judgment.ts)
+  composes deterministic OPA decisions with a contextual judgment service and
+  human-approval fallback.
+- [`examples/git-in-bash`](./examples/git-in-bash) contains a complete Rego
+  policy, parser, tests, and `generateText` demo for transitive git enforcement.
+
 ## Writing the Rego policy
 
 The adapter expects the policy to emit a decision object with one of three `decision` values. `reason` is optional and gets surfaced back to the model (for `deny`) or to the human approver (for `requires-approval`).

--- a/packages/policy-opa/examples/mock/composed-judgment.ts
+++ b/packages/policy-opa/examples/mock/composed-judgment.ts
@@ -1,0 +1,297 @@
+/**
+ * Runnable demo composing `@ai-sdk/policy-opa` with a judgment-based second
+ * opinion, for the cases a deterministic policy can't resolve on its own.
+ *
+ * Run from the package directory:
+ *   pnpm tsx examples/mock/composed-judgment.ts
+ *
+ * WHY THIS COMPOSITION
+ *
+ * OPA is the right tool for a hard, deterministic rule ("never let a
+ * non-admin call `sendPayment`") -- a boolean expression over known fields.
+ * It's the wrong tool for "is *this specific* payment, in *this* context,
+ * actually sound" -- a question with no fixed rule to write. This example
+ * shows OPA handling the deterministic layer first, and only escalating to a
+ * judgment call for the case OPA itself flags as `requires-approval` (mapped
+ * by the SDK to `user-approval`) -- instead of routing that case straight to
+ * a human, ask an independent judgment service first and only fall through
+ * to a human when the judgment call is itself uncertain.
+ *
+ *   tool call
+ *     -> OPA evaluates      --+--> allow / deny (clear-cut)  -> resolved, no judgment call
+ *                              |
+ *                              +--> requires-approval          -> ask a judgment service
+ *                                                                    +--> confident verdict -> resolved
+ *                                                                    +--> still uncertain    -> SDK's
+ *                                                                                                human-in-the-loop UI
+ *
+ * `judgmentCall` below is a minimal interface (one async function, one
+ * verdict shape) so ANY judgment provider can be plugged in -- an in-house
+ * LLM-as-judge, a compliance review service, or a hosted verdict API. This
+ * example stubs it (deterministic, no network call, no API key) so it runs
+ * the same way `examples/mock/basic.ts` does. A concrete, live-verified
+ * implementation against a real judgment API (invinoveritas's `/review`,
+ * <https://github.com/babyblueviper1/invinoveritas/tree/main/integrations/vercel-ai-sdk>)
+ * is linked in the README for anyone who wants the non-stubbed version --
+ * swapping it in is a one-line change to `judgmentCall` below, same as
+ * swapping `MockLanguageModelV3` for a real provider.
+ *
+ * To swap the mock model for a real provider, replace the
+ * `MockLanguageModelV3` construction with one line, e.g.
+ * `model: anthropic('claude-sonnet-4-5')`. Everything else (tools,
+ * toolApproval, policy, judgmentCall) is provider-agnostic.
+ */
+import { jsonSchema, type InferToolSetContext } from '@ai-sdk/provider-utils';
+import {
+  generateText,
+  isStepCount,
+  tool,
+  type GenericToolApprovalFunction,
+  type ToolApprovalStatus,
+  type ToolSet,
+} from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import type { PolicyClient } from '../../src/policy-client';
+import { opaPolicy } from '../../src/opa/opa-policy';
+
+type ToolsContext = InferToolSetContext<ToolSet>;
+
+const dummyUsage = {
+  inputTokens: {
+    total: 3,
+    noCache: 3,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: { total: 10, text: 10, reasoning: undefined },
+} as const;
+
+function mockModel(toolName: string, input: string): MockLanguageModelV3 {
+  let step = 0;
+  return new MockLanguageModelV3({
+    doGenerate: async () => {
+      switch (step++) {
+        case 0:
+          return {
+            warnings: [],
+            usage: dummyUsage,
+            finishReason: { unified: 'tool-calls', raw: undefined },
+            content: [
+              {
+                type: 'tool-call',
+                toolCallType: 'function',
+                toolCallId: 'call-1',
+                toolName,
+                input,
+              },
+            ],
+          };
+        default:
+          return {
+            warnings: [],
+            usage: dummyUsage,
+            finishReason: { unified: 'stop', raw: 'stop' },
+            content: [{ type: 'text', text: 'understood, stopping.' }],
+          };
+      }
+    },
+  });
+}
+
+/**
+ * A tiny OPA stand-in: a real, hard ceiling (deny anything over $1M outright)
+ * plus explicit `requires-approval` for everything else, so this example
+ * demonstrates OPA actually owning the deterministic rule rather than just
+ * asserting it in a comment.
+ */
+const opaClient: PolicyClient = {
+  async evaluate(_path, input) {
+    const amount = (input as { args?: { amount?: number } }).args?.amount ?? 0;
+    if (amount > 1_000_000) {
+      return { decision: 'deny', reason: 'payments over $1M are never auto-approved' } as never;
+    }
+    return { decision: 'requires-approval' } as never;
+  },
+};
+
+/**
+ * Minimal judgment-provider interface: given the tool call, return a verdict
+ * with a confidence score. Any provider (in-house LLM judge, a hosted
+ * verdict API, a compliance service) implements this same shape.
+ */
+interface JudgmentVerdict {
+  verdict: 'approve' | 'reject' | 'uncertain';
+  confidence: number;
+  reason: string;
+}
+
+type JudgmentCall = (toolCall: {
+  toolName: string;
+  input: unknown;
+}) => Promise<JudgmentVerdict>;
+
+/**
+ * Stub judgment call -- deterministic, no network, so this example runs the
+ * same way examples/mock/basic.ts does. A real implementation calls out to
+ * a judgment service and returns its verdict in this same shape; see the
+ * module docstring above for a live-verified example.
+ */
+const stubJudgmentCall: JudgmentCall = async ({ input }) => {
+  const amount = (input as { amount?: number }).amount ?? 0;
+  if (amount > 100_000) {
+    return {
+      verdict: 'reject',
+      confidence: 0.95,
+      reason: 'Payment amount far exceeds any precedent for this account; needs a human.',
+    };
+  }
+  return {
+    verdict: 'approve',
+    confidence: 0.92,
+    reason: 'Amount, recipient, and context match prior approved payments for this account.',
+  };
+};
+
+/**
+ * Compose an OPA policy with a judgment call: OPA resolves clear-cut cases;
+ * a `requires-approval` (or unmatched / not-applicable) result escalates to
+ * the judgment call instead of going straight to a human. The judgment call
+ * only resolves automatically above a confidence threshold -- anything less
+ * still falls through to the SDK's own human-in-the-loop UI.
+ */
+function composedToolApproval(opts: {
+  opaClient: PolicyClient;
+  opaPath: string;
+  judgmentCall: JudgmentCall;
+  approveConfidence?: number;
+}): GenericToolApprovalFunction<ToolSet, ToolsContext, unknown> {
+  // opaPolicy's return type is a union (a single generic function, OR a
+  // per-tool-keyed object) so that it can be used either way as the SDK's
+  // `toolApproval` option -- opaPolicy itself always returns the function
+  // arm (see its implementation), the union is only there to satisfy the
+  // wider ToolApprovalConfiguration contract, so the cast here is safe.
+  const policy = opaPolicy({ client: opts.opaClient, path: opts.opaPath }) as GenericToolApprovalFunction<
+    ToolSet,
+    ToolsContext,
+    unknown
+  >;
+  const threshold = opts.approveConfidence ?? 0.9;
+
+  return async (args): Promise<ToolApprovalStatus> => {
+    // `undefined` is documented as equivalent to 'not-applicable'.
+    const opaResult = (await policy(args)) ?? 'not-applicable';
+    const opaType = typeof opaResult === 'string' ? opaResult : opaResult.type;
+
+    if (opaType !== 'user-approval' && opaType !== 'not-applicable') {
+      // OPA resolved this on its own (a clear allow or deny) -- done.
+      return opaResult;
+    }
+
+    // OPA has no fixed rule for this case (or explicitly flagged it as
+    // needing review) -- get an independent judgment call before falling
+    // through to a human.
+    const verdict = await opts.judgmentCall(args.toolCall);
+
+    if (verdict.verdict === 'approve' && verdict.confidence >= threshold) {
+      return { type: 'approved', reason: `judgment: ${verdict.reason} (confidence ${verdict.confidence})` };
+    }
+    if (verdict.verdict === 'reject' && verdict.confidence >= threshold) {
+      return { type: 'denied', reason: `judgment: ${verdict.reason} (confidence ${verdict.confidence})` };
+    }
+    // Uncertain, or below the confidence bar -- escalate to a human, same
+    // as OPA's own `requires-approval` would have.
+    return 'user-approval';
+  };
+}
+
+const sendPaymentTool = tool({
+  description: 'Send a payment to a recipient',
+  inputSchema: jsonSchema<{ recipient: string; amount: number }>({
+    type: 'object',
+    properties: {
+      recipient: { type: 'string' },
+      amount: { type: 'number' },
+    },
+    required: ['recipient', 'amount'],
+  }),
+  execute: async ({ recipient, amount }) => `sent $${amount} to ${recipient}`,
+});
+
+function printResult(label: string, result: { responseMessages: unknown }) {
+  const messages = result.responseMessages as Array<{
+    role: string;
+    content: Array<Record<string, unknown>>;
+  }>;
+  // biome-ignore lint/suspicious/noConsole: example output is the whole point
+  console.log(`\n=== ${label} ===`);
+  for (const m of messages) {
+    for (const c of m.content) {
+      // biome-ignore lint/suspicious/noConsole: example output is the whole point
+      console.log(`[${m.role}] ${c.type}`, summarize(c));
+    }
+  }
+}
+
+function summarize(c: Record<string, unknown>): string {
+  if (c.type === 'tool-call') {
+    return `${c.toolName as string}(${JSON.stringify(c.input)})`;
+  }
+  if (c.type === 'tool-result') {
+    const out = c.output as { type: string; reason?: string } | string;
+    return typeof out === 'string' ? out : `${out.type}: ${out.reason ?? ''}`;
+  }
+  if (c.type === 'tool-approval-response') {
+    return `approved=${c.approved as boolean} reason=${c.reason as string | undefined}`;
+  }
+  if (c.type === 'text') return JSON.stringify(c.text);
+  return '';
+}
+
+async function main() {
+  const toolApproval = composedToolApproval({
+    opaClient,
+    opaPath: 'agent/call/decision',
+    judgmentCall: stubJudgmentCall,
+  });
+
+  // 1. OPA has no fixed rule for a $500 payment (below its $1M ceiling) --
+  //    falls through to the judgment call, which approves it with high
+  //    confidence.
+  const approved = await generateText({
+    model: mockModel('sendPayment', `{ "recipient": "vendor-a", "amount": 500 }`),
+    prompt: 'pay our vendor $500',
+    stopWhen: isStepCount(3),
+    tools: { sendPayment: sendPaymentTool },
+    toolApproval,
+  });
+  printResult('1. judgment approves: routine $500 payment', approved);
+
+  // 2. A $250,000 payment is still under OPA's hard $1M ceiling, so it also
+  //    falls through -- the judgment call rejects it with high confidence,
+  //    no human needed to see it denied.
+  const denied = await generateText({
+    model: mockModel('sendPayment', `{ "recipient": "unknown-account", "amount": 250000 }`),
+    prompt: 'send $250,000 to this new account',
+    stopWhen: isStepCount(3),
+    tools: { sendPayment: sendPaymentTool },
+    toolApproval,
+  });
+  printResult('2. judgment denies: anomalous $250,000 payment', denied);
+
+  // 3. $5,000,000 is over OPA's hard ceiling -- denied outright, the
+  //    judgment call is never even consulted.
+  const opaOnlyDenied = await generateText({
+    model: mockModel('sendPayment', `{ "recipient": "unknown-account", "amount": 5000000 }`),
+    prompt: 'send $5,000,000 to this new account',
+    stopWhen: isStepCount(3),
+    tools: { sendPayment: sendPaymentTool },
+    toolApproval,
+  });
+  printResult('3. OPA denies outright: $5,000,000 payment (over the hard ceiling)', opaOnlyDenied);
+}
+
+main().catch(err => {
+  // biome-ignore lint/suspicious/noConsole: example output is the whole point
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/policy-opa/examples/mock/composed-judgment.ts
+++ b/packages/policy-opa/examples/mock/composed-judgment.ts
@@ -108,7 +108,10 @@ const opaClient: PolicyClient = {
   async evaluate(_path, input) {
     const amount = (input as { args?: { amount?: number } }).args?.amount ?? 0;
     if (amount > 1_000_000) {
-      return { decision: 'deny', reason: 'payments over $1M are never auto-approved' } as never;
+      return {
+        decision: 'deny',
+        reason: 'payments over $1M are never auto-approved',
+      } as never;
     }
     return { decision: 'requires-approval' } as never;
   },
@@ -142,13 +145,15 @@ const stubJudgmentCall: JudgmentCall = async ({ input }) => {
     return {
       verdict: 'reject',
       confidence: 0.95,
-      reason: 'Payment amount far exceeds any precedent for this account; needs a human.',
+      reason:
+        'Payment amount far exceeds any precedent for this account; needs a human.',
     };
   }
   return {
     verdict: 'approve',
     confidence: 0.92,
-    reason: 'Amount, recipient, and context match prior approved payments for this account.',
+    reason:
+      'Amount, recipient, and context match prior approved payments for this account.',
   };
 };
 
@@ -170,11 +175,10 @@ function composedToolApproval(opts: {
   // `toolApproval` option -- opaPolicy itself always returns the function
   // arm (see its implementation), the union is only there to satisfy the
   // wider ToolApprovalConfiguration contract, so the cast here is safe.
-  const policy = opaPolicy({ client: opts.opaClient, path: opts.opaPath }) as GenericToolApprovalFunction<
-    ToolSet,
-    ToolsContext,
-    unknown
-  >;
+  const policy = opaPolicy({
+    client: opts.opaClient,
+    path: opts.opaPath,
+  }) as GenericToolApprovalFunction<ToolSet, ToolsContext, unknown>;
   const threshold = opts.approveConfidence ?? 0.9;
 
   return async (args): Promise<ToolApprovalStatus> => {
@@ -193,10 +197,16 @@ function composedToolApproval(opts: {
     const verdict = await opts.judgmentCall(args.toolCall);
 
     if (verdict.verdict === 'approve' && verdict.confidence >= threshold) {
-      return { type: 'approved', reason: `judgment: ${verdict.reason} (confidence ${verdict.confidence})` };
+      return {
+        type: 'approved',
+        reason: `judgment: ${verdict.reason} (confidence ${verdict.confidence})`,
+      };
     }
     if (verdict.verdict === 'reject' && verdict.confidence >= threshold) {
-      return { type: 'denied', reason: `judgment: ${verdict.reason} (confidence ${verdict.confidence})` };
+      return {
+        type: 'denied',
+        reason: `judgment: ${verdict.reason} (confidence ${verdict.confidence})`,
+      };
     }
     // Uncertain, or below the confidence bar -- escalate to a human, same
     // as OPA's own `requires-approval` would have.
@@ -258,7 +268,10 @@ async function main() {
   //    falls through to the judgment call, which approves it with high
   //    confidence.
   const approved = await generateText({
-    model: mockModel('sendPayment', `{ "recipient": "vendor-a", "amount": 500 }`),
+    model: mockModel(
+      'sendPayment',
+      `{ "recipient": "vendor-a", "amount": 500 }`,
+    ),
     prompt: 'pay our vendor $500',
     stopWhen: isStepCount(3),
     tools: { sendPayment: sendPaymentTool },
@@ -270,7 +283,10 @@ async function main() {
   //    falls through -- the judgment call rejects it with high confidence,
   //    no human needed to see it denied.
   const denied = await generateText({
-    model: mockModel('sendPayment', `{ "recipient": "unknown-account", "amount": 250000 }`),
+    model: mockModel(
+      'sendPayment',
+      `{ "recipient": "unknown-account", "amount": 250000 }`,
+    ),
     prompt: 'send $250,000 to this new account',
     stopWhen: isStepCount(3),
     tools: { sendPayment: sendPaymentTool },
@@ -281,13 +297,19 @@ async function main() {
   // 3. $5,000,000 is over OPA's hard ceiling -- denied outright, the
   //    judgment call is never even consulted.
   const opaOnlyDenied = await generateText({
-    model: mockModel('sendPayment', `{ "recipient": "unknown-account", "amount": 5000000 }`),
+    model: mockModel(
+      'sendPayment',
+      `{ "recipient": "unknown-account", "amount": 5000000 }`,
+    ),
     prompt: 'send $5,000,000 to this new account',
     stopWhen: isStepCount(3),
     tools: { sendPayment: sendPaymentTool },
     toolApproval,
   });
-  printResult('3. OPA denies outright: $5,000,000 payment (over the hard ceiling)', opaOnlyDenied);
+  printResult(
+    '3. OPA denies outright: $5,000,000 payment (over the hard ceiling)',
+    opaOnlyDenied,
+  );
 }
 
 main().catch(err => {

--- a/packages/policy-opa/examples/mock/composed-judgment.ts
+++ b/packages/policy-opa/examples/mock/composed-judgment.ts
@@ -1,21 +1,14 @@
 /**
- * Runnable demo composing `@ai-sdk/policy-opa` with a judgment-based second
- * opinion, for the cases a deterministic policy can't resolve on its own.
+ * Runnable demo composing `@ai-sdk/policy-opa` with a contextual judgment
+ * service for cases a deterministic policy cannot resolve on its own.
  *
  * Run from the package directory:
  *   pnpm tsx examples/mock/composed-judgment.ts
  *
- * WHY THIS COMPOSITION
- *
- * OPA is the right tool for a hard, deterministic rule ("never let a
- * non-admin call `sendPayment`") -- a boolean expression over known fields.
- * It's the wrong tool for "is *this specific* payment, in *this* context,
- * actually sound" -- a question with no fixed rule to write. This example
- * shows OPA handling the deterministic layer first, and only escalating to a
- * judgment call for the case OPA itself flags as `requires-approval` (mapped
- * by the SDK to `user-approval`) -- instead of routing that case straight to
- * a human, ask an independent judgment service first and only fall through
- * to a human when the judgment call is itself uncertain.
+ * OPA handles the hard limit first. Calls that need more review go to an
+ * independent judgment service, which can use the tool call, runtime context,
+ * and conversation messages. Only confident verdicts are applied
+ * automatically; uncertain or unavailable judgments fall back to a human.
  *
  *   tool call
  *     -> OPA evaluates      --+--> allow / deny (clear-cut)  -> resolved, no judgment call
@@ -25,23 +18,22 @@
  *                                                                    +--> still uncertain    -> SDK's
  *                                                                                                human-in-the-loop UI
  *
- * `judgmentCall` below is a minimal interface (one async function, one
- * verdict shape) so ANY judgment provider can be plugged in -- an in-house
- * LLM-as-judge, a compliance review service, or a hosted verdict API. This
- * example stubs it (deterministic, no network call, no API key) so it runs
- * the same way `examples/mock/basic.ts` does. A concrete, live-verified
- * implementation against a real judgment API (invinoveritas's `/review`,
- * <https://github.com/babyblueviper1/invinoveritas/tree/main/integrations/vercel-ai-sdk>)
- * is linked in the README for anyone who wants the non-stubbed version --
- * swapping it in is a one-line change to `judgmentCall` below, same as
- * swapping `MockLanguageModelV3` for a real provider.
+ * `judgmentCall` is a provider-neutral async function. This example stubs it
+ * so the script is deterministic and needs no API key. A production
+ * implementation can call an in-house model, compliance service, or hosted
+ * verdict API using the same request and response shapes.
  *
  * To swap the mock model for a real provider, replace the
  * `MockLanguageModelV3` construction with one line, e.g.
  * `model: anthropic('claude-sonnet-4-5')`. Everything else (tools,
  * toolApproval, policy, judgmentCall) is provider-agnostic.
  */
-import { jsonSchema, type InferToolSetContext } from '@ai-sdk/provider-utils';
+import {
+  jsonSchema,
+  type Context,
+  type InferToolSetContext,
+  type ModelMessage,
+} from '@ai-sdk/provider-utils';
 import {
   generateText,
   isStepCount,
@@ -55,6 +47,12 @@ import type { PolicyClient } from '../../src/policy-client';
 import { opaPolicy } from '../../src/opa/opa-policy';
 
 type ToolsContext = InferToolSetContext<ToolSet>;
+
+type PaymentRuntimeContext = Context & {
+  accountId: string;
+  approvedRecipients: string[];
+  largestApprovedPayment: number;
+};
 
 const dummyUsage = {
   inputTokens: {
@@ -128,32 +126,46 @@ interface JudgmentVerdict {
   reason: string;
 }
 
-type JudgmentCall = (toolCall: {
-  toolName: string;
-  input: unknown;
-}) => Promise<JudgmentVerdict>;
+interface JudgmentRequest {
+  toolCall: { toolName: string; input: unknown };
+  messages: ReadonlyArray<ModelMessage>;
+  runtimeContext: PaymentRuntimeContext;
+}
+
+type JudgmentCall = (request: JudgmentRequest) => Promise<JudgmentVerdict>;
 
 /**
- * Stub judgment call -- deterministic, no network, so this example runs the
- * same way examples/mock/basic.ts does. A real implementation calls out to
- * a judgment service and returns its verdict in this same shape; see the
- * module docstring above for a live-verified example.
+ * Stub judgment call -- deterministic and context-aware, but with no network
+ * call. A real implementation can send this request to a judgment service and
+ * return its verdict in the same shape.
  */
-const stubJudgmentCall: JudgmentCall = async ({ input }) => {
-  const amount = (input as { amount?: number }).amount ?? 0;
-  if (amount > 100_000) {
+const stubJudgmentCall: JudgmentCall = async ({ toolCall, runtimeContext }) => {
+  const { amount, recipient } = toolCall.input as {
+    amount: number;
+    recipient: string;
+  };
+  const knownRecipient = runtimeContext.approvedRecipients.includes(recipient);
+
+  if (knownRecipient && amount <= runtimeContext.largestApprovedPayment) {
+    return {
+      verdict: 'approve',
+      confidence: 0.96,
+      reason: `Recipient and amount match prior payments for ${runtimeContext.accountId}.`,
+    };
+  }
+
+  if (!knownRecipient && amount > 100_000) {
     return {
       verdict: 'reject',
       confidence: 0.95,
-      reason:
-        'Payment amount far exceeds any precedent for this account; needs a human.',
+      reason: `Large payment to an unknown recipient for ${runtimeContext.accountId}.`,
     };
   }
+
   return {
-    verdict: 'approve',
-    confidence: 0.92,
-    reason:
-      'Amount, recipient, and context match prior approved payments for this account.',
+    verdict: 'uncertain',
+    confidence: 0.55,
+    reason: `No sufficient payment precedent for ${runtimeContext.accountId}.`,
   };
 };
 
@@ -168,18 +180,19 @@ function composedToolApproval(opts: {
   opaClient: PolicyClient;
   opaPath: string;
   judgmentCall: JudgmentCall;
-  approveConfidence?: number;
-}): GenericToolApprovalFunction<ToolSet, ToolsContext, unknown> {
-  // opaPolicy's return type is a union (a single generic function, OR a
-  // per-tool-keyed object) so that it can be used either way as the SDK's
-  // `toolApproval` option -- opaPolicy itself always returns the function
-  // arm (see its implementation), the union is only there to satisfy the
-  // wider ToolApprovalConfiguration contract, so the cast here is safe.
-  const policy = opaPolicy({
+  confidenceThreshold?: number;
+}): GenericToolApprovalFunction<ToolSet, ToolsContext, PaymentRuntimeContext> {
+  // opaPolicy is implemented as a generic function, but its public return
+  // type also permits a per-tool map. Narrow that union before composing it.
+  const policy = opaPolicy<ToolSet, PaymentRuntimeContext>({
     client: opts.opaClient,
     path: opts.opaPath,
-  }) as GenericToolApprovalFunction<ToolSet, ToolsContext, unknown>;
-  const threshold = opts.approveConfidence ?? 0.9;
+  });
+  if (typeof policy !== 'function') {
+    throw new Error('opaPolicy must return a generic approval function');
+  }
+
+  const threshold = opts.confidenceThreshold ?? 0.9;
 
   return async (args): Promise<ToolApprovalStatus> => {
     // `undefined` is documented as equivalent to 'not-applicable'.
@@ -194,7 +207,18 @@ function composedToolApproval(opts: {
     // OPA has no fixed rule for this case (or explicitly flagged it as
     // needing review) -- get an independent judgment call before falling
     // through to a human.
-    const verdict = await opts.judgmentCall(args.toolCall);
+    let verdict: JudgmentVerdict;
+    try {
+      verdict = await opts.judgmentCall({
+        toolCall: args.toolCall,
+        messages: args.messages,
+        runtimeContext: args.runtimeContext,
+      });
+    } catch {
+      // A production judgment provider should enforce its own timeout and
+      // reject on transport failures. Without a verdict, require a human.
+      return 'user-approval';
+    }
 
     if (verdict.verdict === 'approve' && verdict.confidence >= threshold) {
       return {
@@ -253,11 +277,19 @@ function summarize(c: Record<string, unknown>): string {
   if (c.type === 'tool-approval-response') {
     return `approved=${c.approved as boolean} reason=${c.reason as string | undefined}`;
   }
+  if (c.type === 'tool-approval-request') {
+    return `automatic=${c.isAutomatic === true}`;
+  }
   if (c.type === 'text') return JSON.stringify(c.text);
   return '';
 }
 
 async function main() {
+  const runtimeContext: PaymentRuntimeContext = {
+    accountId: 'acct-123',
+    approvedRecipients: ['vendor-a'],
+    largestApprovedPayment: 1_000,
+  };
   const toolApproval = composedToolApproval({
     opaClient,
     opaPath: 'agent/call/decision',
@@ -276,6 +308,7 @@ async function main() {
     stopWhen: isStepCount(3),
     tools: { sendPayment: sendPaymentTool },
     toolApproval,
+    runtimeContext,
   });
   printResult('1. judgment approves: routine $500 payment', approved);
 
@@ -291,6 +324,7 @@ async function main() {
     stopWhen: isStepCount(3),
     tools: { sendPayment: sendPaymentTool },
     toolApproval,
+    runtimeContext,
   });
   printResult('2. judgment denies: anomalous $250,000 payment', denied);
 
@@ -305,11 +339,28 @@ async function main() {
     stopWhen: isStepCount(3),
     tools: { sendPayment: sendPaymentTool },
     toolApproval,
+    runtimeContext,
   });
   printResult(
     '3. OPA denies outright: $5,000,000 payment (over the hard ceiling)',
     opaOnlyDenied,
   );
+
+  // 4. A small payment to an unfamiliar recipient has no clear precedent.
+  //    The judgment service is not confident enough to decide, so the SDK
+  //    emits a tool-approval-request for a human.
+  const needsHuman = await generateText({
+    model: mockModel(
+      'sendPayment',
+      `{ "recipient": "new-vendor", "amount": 500 }`,
+    ),
+    prompt: 'pay a new vendor $500',
+    stopWhen: isStepCount(3),
+    tools: { sendPayment: sendPaymentTool },
+    toolApproval,
+    runtimeContext,
+  });
+  printResult('4. judgment uncertain: request human approval', needsHuman);
 }
 
 main().catch(err => {

--- a/packages/policy-opa/package.json
+++ b/packages/policy-opa/package.json
@@ -43,6 +43,7 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "ai": "workspace:*",
     "tsup": "^8.5.1",
+    "tsx": "^4.22.0",
     "typescript": "5.8.3"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3390,6 +3390,9 @@ importers:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.25)(tsx@4.22.0)(typescript@5.8.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.22.0
+        version: 4.22.0
       typescript:
         specifier: 5.8.3
         version: 5.8.3


### PR DESCRIPTION
## Summary

Per #18376 -- @gr2m asked for a PR adding the worked example. This adds `examples/mock/composed-judgment.ts` to `@ai-sdk/policy-opa`, next to the existing `examples/mock/basic.ts`.

Shows `@ai-sdk/policy-opa` composed with an independent judgment call for the cases a deterministic OPA rule can't resolve on its own:

```
tool call
  -> OPA evaluates  --+--> allow / deny (clear-cut)  -> resolved, no judgment call
                       +--> requires-approval          -> ask a judgment service
                                                            +--> confident verdict -> resolved
                                                            +--> still uncertain    -> SDK's human-in-the-loop UI
```

OPA owns a real, hard ceiling in the example (deny payments over $1M outright) and everything else falls through `requires-approval` to a judgment call instead of going straight to a human. The judgment call only resolves automatically above a confidence threshold; anything less still escalates to the SDK's own human-in-the-loop UI, same as OPA's own `requires-approval` would have.

`judgmentCall` is a minimal one-function interface (`(toolCall) => Promise<{verdict, confidence, reason}>`) so any judgment provider can be plugged in -- an in-house LLM-as-judge, a compliance review service, a hosted verdict API. This example stubs it deterministically (no network call, no API key) so it runs the same way `examples/mock/basic.ts` does. A concrete, live-verified implementation against a real judgment API is linked in the module docstring for anyone who wants the non-stubbed version (swapping it in is a one-line change, same as swapping `MockLanguageModelV3` for a real provider).

## Verified

- `pnpm tsx examples/mock/composed-judgment.ts` runs clean, all 3 scenarios produce the expected output (judgment-approved, judgment-denied, OPA-denied-outright-before-judgment-is-consulted).
- `tsc --noEmit` clean against the package's own tsconfig.
- `oxlint` clean (0 warnings, 0 errors).

## Test plan

- [x] Runs standalone via `pnpm tsx examples/mock/composed-judgment.ts`
- [x] Type-checks against the package's tsconfig
- [x] Lints clean

Closes #18376.