### PR TITLE
fix(harness-claude-code): avoid sending custom user-agent for non-AI Gateway requests

### DIFF
--- a/.changeset/thick-pens-cheer.md
+++ b/.changeset/thick-pens-cheer.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-claude-code": patch
+---
+
+fix(harness-claude-code): avoid sending custom user-agent for non-AI Gateway requests

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -263,9 +263,48 @@ describe('createClaudeCode adapter', () => {
     expect(spawns).toEqual([
       "node '/vercel/sandbox/.harness-bootstrap/claude-code/bridge.mjs' --workdir '/vercel/sandbox/claude-code-s1; env > /tmp/workdir-leak #' --bridge-state-dir '/vercel/sandbox/.agent-runs/s1; env > /tmp/leak #/bridge'",
     ]);
+    await session.doDestroy();
+  });
+
+  it('sets the client app for AI Gateway auth', async () => {
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const harness = createClaudeCode({
+      auth: { gateway: { apiKey: 'gateway-key' } },
+    });
+    const session = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        spawnEnvs,
+        writes: [],
+        runs: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+    });
+
     expect(spawnEnvs.at(0)?.CLAUDE_AGENT_SDK_CLIENT_APP).toBe(
       'ai-sdk/harness-claude-code/0.0.0-test',
     );
+    await session.doDestroy();
+  });
+
+  it('does not set the client app for direct Anthropic auth', async () => {
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const harness = createClaudeCode({
+      auth: { anthropic: { apiKey: 'anthropic-key' } },
+    });
+    const session = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        spawnEnvs,
+        writes: [],
+        runs: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+    });
+
+    expect(spawnEnvs.at(0)).not.toHaveProperty('CLAUDE_AGENT_SDK_CLIENT_APP');
     await session.doDestroy();
   });
 

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -599,15 +599,18 @@ export function createClaudeCode(
           : undefined;
       const port = resolveBridgePort(sandboxSession, settings.port);
       const token = randomBytes(32).toString('hex');
+      const authEnv = resolveClaudeCodeEnv(settings.auth);
       const env = {
-        ...resolveClaudeCodeEnv(settings.auth),
+        ...authEnv,
         /*
          * The Claude Agent SDK does not expose arbitrary model-request
          * headers. It reads this environment variable and sends the value as
          * `x-client-app`, while also appending `client-app/<value>` to
          * `User-Agent`, so this is the attribution path for AI Gateway.
          */
-        CLAUDE_AGENT_SDK_CLIENT_APP: CLAUDE_CODE_CLIENT_APP,
+        ...(authEnv.AI_GATEWAY_BASE_URL
+          ? { CLAUDE_AGENT_SDK_CLIENT_APP: CLAUDE_CODE_CLIENT_APP }
+          : {}),
         BRIDGE_CHANNEL_TOKEN: token,
         BRIDGE_WS_PORT: String(port),
         ...(sandboxHomeDir ? { HOME: sandboxHomeDir } : {}),


### PR DESCRIPTION
## Background

Follow-up fix for #16879: The Claude Code harness unconditionally set its custom client-app environment variable, causing direct Anthropic requests to receive AI Gateway-specific attribution headers.

## Summary

- Set `CLAUDE_AGENT_SDK_CLIENT_APP` only when auth resolves to AI Gateway.
- Add regression coverage for both AI Gateway and direct Anthropic auth.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
