### PR TITLE
fix: strip OpenAI-unsupported keywords from tool schemas

### DIFF
--- a/.changeset/early-server-error-strict-tools.md
+++ b/.changeset/early-server-error-strict-tools.md
@@ -1,0 +1,22 @@
+---
+'@ai-sdk/openai': patch
+'@ai-sdk/gateway': patch
+'@ai-sdk/provider-utils': patch
+---
+
+fix: strip JSON Schema keywords OpenAI's strict tool schemas reject
+
+OpenAI's Responses API defaults function tools to `strict: true` and only
+supports a subset of JSON Schema. Keywords like `minItems`/`maxItems`,
+`minLength`/`maxLength`, `pattern`, `format`, and `minimum`/`maximum` can make
+OpenAI fail with a generic in-stream `server_error` on gpt-5.x models while it
+compiles the schema into a constrained-decoding grammar. This is what the
+default Zod v4 conversion produces for common schemas (e.g.
+`z.array(z.string()).min(1).max(30000)`), so AI SDK users hit it without
+writing any problematic schema themselves.
+
+Adds a shared `sanitizeJsonSchema` util that strips the OpenAI-unsupported
+keywords (folding their values into the schema `description` as guidance) and
+applies it to function tool schemas in `@ai-sdk/openai` (Responses and chat
+completions) and to requests routed to OpenAI through `@ai-sdk/gateway`. The
+full original schema is still used for SDK-side tool input validation.

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -1,4 +1,5 @@
 import type {
+  LanguageModelV4FunctionTool,
   LanguageModelV4Prompt,
   LanguageModelV4FilePart,
 } from '@ai-sdk/provider';
@@ -49,6 +50,97 @@ describe('GatewayLanguageModel', () => {
       expect(model.modelId).toBe('test-model');
       expect(model.provider).toBe('test-provider');
       expect(model.specificationVersion).toBe('v4');
+    });
+  });
+
+  describe('tool schema sanitization', () => {
+    function prepareJsonResponse() {
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'json-value',
+        body: {
+          id: 'test-id',
+          created: 1711115037,
+          model: 'openai/gpt-5.6-terra',
+          content: { type: 'text', text: '' },
+          finish_reason: 'stop',
+          usage: { prompt_tokens: 4, completion_tokens: 30 },
+        },
+      };
+    }
+
+    const tool: LanguageModelV4FunctionTool = {
+      type: 'function',
+      name: 'testTool',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          values: {
+            type: 'array',
+            items: { type: 'string' },
+            minItems: 1,
+            maxItems: 30000,
+          },
+        },
+        required: ['values'],
+        additionalProperties: false,
+      },
+    };
+
+    const createOpenAIModel = () =>
+      new GatewayLanguageModel('openai/gpt-5.6-terra', {
+        provider: 'gateway',
+        baseURL: 'https://api.test.com',
+        headers: () => ({ Authorization: 'Bearer test-token' }),
+        fetch: globalThis.fetch,
+        o11yHeaders: {},
+      });
+
+    it('should strip OpenAI-unsupported keywords from tool schemas for openai models', async () => {
+      prepareJsonResponse();
+
+      await createOpenAIModel().doGenerate({
+        prompt: TEST_PROMPT,
+        tools: [tool],
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.tools[0].inputSchema).toEqual({
+        type: 'object',
+        properties: {
+          values: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'min items: 1; max items: 30000.',
+          },
+        },
+        required: ['values'],
+        additionalProperties: false,
+      });
+    });
+
+    it('should not sanitize tool schemas for non-openai models', async () => {
+      prepareJsonResponse();
+
+      const model = new GatewayLanguageModel('anthropic/claude-opus-4', {
+        provider: 'gateway',
+        baseURL: 'https://api.test.com',
+        headers: () => ({ Authorization: 'Bearer test-token' }),
+        fetch: globalThis.fetch,
+        o11yHeaders: {},
+      });
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        tools: [tool],
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.tools[0].inputSchema.properties.values).toHaveProperty(
+        'minItems',
+      );
+      expect(requestBody.tools[0].inputSchema.properties.values).toHaveProperty(
+        'maxItems',
+      );
     });
   });
 

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -12,6 +12,7 @@ import {
   createJsonResponseHandler,
   postJsonToApi,
   resolve,
+  sanitizeJsonSchema,
   serializeModelOptions,
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
@@ -60,8 +61,37 @@ export class GatewayLanguageModel implements LanguageModelV4 {
     const { abortSignal: _abortSignal, ...optionsWithoutSignal } = options;
 
     return {
-      args: this.maybeEncodeFileParts(optionsWithoutSignal),
+      args: this.maybeEncodeFileParts(
+        this.maybeSanitizeToolSchemas(optionsWithoutSignal),
+      ),
       warnings: [],
+    };
+  }
+
+  /**
+   * Strips JSON Schema keywords that OpenAI's strict function-tool schemas
+   * reject (`minItems`/`maxItems`, `minLength`/`maxLength`, `pattern`,
+   * `format`, `minimum`/`maximum`, ...) for requests routed to OpenAI. OpenAI
+   * defaults function tools to `strict: true` and can fail with a generic
+   * in-stream `server_error` on gpt-5.x models while compiling such schemas
+   * into a constrained-decoding grammar. Only OpenAI models are sanitized,
+   * because the upstream provider is encoded in the model id prefix and other
+   * providers may support these keywords.
+   */
+  private maybeSanitizeToolSchemas(
+    options: LanguageModelV4CallOptions,
+  ): LanguageModelV4CallOptions {
+    if (!this.modelId.startsWith('openai/') || options.tools == null) {
+      return options;
+    }
+
+    return {
+      ...options,
+      tools: options.tools.map(tool =>
+        tool.type === 'function'
+          ? { ...tool, inputSchema: sanitizeJsonSchema(tool.inputSchema) }
+          : tool,
+      ),
     };
   }
 

--- a/packages/openai/src/chat/openai-chat-prepare-tools.test.ts
+++ b/packages/openai/src/chat/openai-chat-prepare-tools.test.ts
@@ -83,6 +83,63 @@ describe('prepareChatTools', () => {
   `);
   });
 
+  it('should strip JSON Schema keywords OpenAI strict mode rejects from function tool parameters', () => {
+    const result = prepareChatTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          description: 'A test function',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              values: {
+                type: 'array',
+                items: { type: 'string' },
+                minItems: 1,
+                maxItems: 30000,
+              },
+            },
+            required: ['values'],
+            additionalProperties: false,
+          },
+        },
+      ],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+    {
+      "toolChoice": undefined,
+      "toolWarnings": [],
+      "tools": [
+        {
+          "function": {
+            "description": "A test function",
+            "name": "testFunction",
+            "parameters": {
+              "additionalProperties": false,
+              "properties": {
+                "values": {
+                  "description": "min items: 1; max items: 30000.",
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              },
+              "required": [
+                "values",
+              ],
+              "type": "object",
+            },
+          },
+          "type": "function",
+        },
+      ],
+    }
+  `);
+  });
+
   it('should handle tool choice "auto"', () => {
     const result = prepareChatTools({
       tools: [

--- a/packages/openai/src/chat/openai-chat-prepare-tools.ts
+++ b/packages/openai/src/chat/openai-chat-prepare-tools.ts
@@ -3,6 +3,7 @@ import {
   type LanguageModelV4CallOptions,
   type SharedV4Warning,
 } from '@ai-sdk/provider';
+import { sanitizeJsonSchema } from '@ai-sdk/provider-utils';
 import type {
   OpenAIChatToolChoice,
   OpenAIChatFunctionTool,
@@ -38,7 +39,7 @@ export function prepareChatTools({
           function: {
             name: tool.name,
             description: tool.description,
-            parameters: tool.inputSchema,
+            parameters: sanitizeJsonSchema(tool.inputSchema),
             ...(tool.strict != null ? { strict: tool.strict } : {}),
           },
         });

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -171,6 +171,130 @@ describe('prepareResponsesTools', () => {
     });
   });
 
+  describe('function tool schema sanitization', () => {
+    it('should strip JSON Schema keywords OpenAI strict mode rejects from function tool parameters', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                values: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  minItems: 1,
+                  maxItems: 30000,
+                },
+                email: {
+                  type: 'string',
+                  format: 'email',
+                  pattern: '^[^@]+@[^@]+$',
+                },
+              },
+              required: ['values', 'email'],
+              additionalProperties: false,
+            },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "description": "A test function",
+              "name": "testFunction",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "email": {
+                    "description": "pattern: ^[^@]+@[^@]+$.",
+                    "format": "email",
+                    "type": "string",
+                  },
+                  "values": {
+                    "description": "min items: 1; max items: 30000.",
+                    "items": {
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                },
+                "required": [
+                  "values",
+                  "email",
+                ],
+                "type": "object",
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
+
+    it('should sanitize output schema when provided', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            providerOptions: {
+              openai: {
+                outputSchema: {
+                  type: 'object',
+                  properties: {
+                    values: {
+                      type: 'array',
+                      minItems: 1,
+                      maxItems: 30000,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "toolChoice": undefined,
+          "toolWarnings": [],
+          "tools": [
+            {
+              "description": "A test function",
+              "name": "testFunction",
+              "output_schema": {
+                "properties": {
+                  "values": {
+                    "description": "min items: 1; max items: 30000.",
+                    "type": "array",
+                  },
+                },
+                "type": "object",
+              },
+              "parameters": {
+                "properties": {},
+                "type": "object",
+              },
+              "type": "function",
+            },
+          ],
+        }
+      `);
+    });
+  });
+
   describe('code interpreter', () => {
     it('should prepare code interpreter tool with no container (auto mode)', async () => {
       const result = await prepareResponsesTools({

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -9,6 +9,7 @@ import {
 } from '@ai-sdk/provider';
 import {
   resolveProviderReference,
+  sanitizeJsonSchema,
   validateTypes,
   type ToolNameMapping,
 } from '@ai-sdk/provider-utils';
@@ -427,14 +428,18 @@ function prepareFunctionTool({
     type: 'function',
     name: tool.name,
     description: tool.description,
-    parameters: tool.inputSchema,
+    parameters: sanitizeJsonSchema(tool.inputSchema),
     ...(tool.strict != null ? { strict: tool.strict } : {}),
     ...(deferLoading != null ? { defer_loading: deferLoading } : {}),
     ...(options?.allowedCallers != null
       ? { allowed_callers: options.allowedCallers }
       : {}),
     ...(options?.outputSchema != null
-      ? { output_schema: options.outputSchema as JSONSchema7 }
+      ? {
+          output_schema: sanitizeJsonSchema(
+            options.outputSchema as JSONSchema7,
+          ),
+        }
       : {}),
   };
 }

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -73,6 +73,7 @@ export {
   DEFAULT_MAX_DOWNLOAD_SIZE,
   readResponseWithSizeLimit,
 } from './read-response-with-size-limit';
+export { sanitizeJsonSchema } from './sanitize-json-schema';
 export * from './remove-undefined-entries';
 export * from './resolve';
 export { resolveFullMediaType } from './resolve-full-media-type';

--- a/packages/provider-utils/src/sanitize-json-schema.test.ts
+++ b/packages/provider-utils/src/sanitize-json-schema.test.ts
@@ -1,0 +1,237 @@
+import type { JSONSchema7 } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { sanitizeJsonSchema } from './sanitize-json-schema';
+
+describe('sanitizeJsonSchema', () => {
+  it('strips unsupported number constraints and adds readable descriptions', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        recurringIntervalMinutes: {
+          type: 'number',
+          exclusiveMinimum: 0,
+          minimum: 1,
+          maximum: 60,
+          exclusiveMaximum: 120,
+        },
+      },
+      required: ['recurringIntervalMinutes'],
+      additionalProperties: false,
+    };
+
+    expect(sanitizeJsonSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "additionalProperties": false,
+        "properties": {
+          "recurringIntervalMinutes": {
+            "description": "minimum: 1; maximum: 60; exclusive minimum: 0; exclusive maximum: 120.",
+            "type": "number",
+          },
+        },
+        "required": [
+          "recurringIntervalMinutes",
+        ],
+        "type": "object",
+      }
+    `);
+  });
+
+  it('strips unsupported string constraints and unsupported formats', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        slug: {
+          type: 'string',
+          description: 'A URL slug',
+          minLength: 1,
+          maxLength: 20,
+          pattern: '^[a-z0-9-]+$',
+          format: 'regex',
+        },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "properties": {
+          "slug": {
+            "description": "A URL slug
+      min length: 1; max length: 20; pattern: ^[a-z0-9-]+$; format: regex.",
+            "type": "string",
+          },
+        },
+        "type": "object",
+      }
+    `);
+  });
+
+  it('strips minItems/maxItems from arrays (repro for gpt-5.6 server_error)', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        values: {
+          type: 'array',
+          items: { type: 'string' },
+          minItems: 1,
+          maxItems: 30000,
+        },
+      },
+      required: ['values'],
+      additionalProperties: false,
+    };
+
+    expect(sanitizeJsonSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "additionalProperties": false,
+        "properties": {
+          "values": {
+            "description": "min items: 1; max items: 30000.",
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "values",
+        ],
+        "type": "object",
+      }
+    `);
+  });
+
+  it('recursively sanitizes arrays, definitions, and composition schemas', () => {
+    const schema = {
+      type: 'object',
+      $defs: {
+        PositiveInteger: {
+          type: 'integer',
+          minimum: 1,
+        },
+      },
+      properties: {
+        count: { $ref: '#/$defs/PositiveInteger' },
+        tags: {
+          type: 'array',
+          minItems: 2,
+          maxItems: 4,
+          uniqueItems: true,
+          items: {
+            anyOf: [
+              { type: 'string', minLength: 1 },
+              { type: 'number', maximum: 10 },
+            ],
+          },
+        },
+      },
+    } as JSONSchema7 & {
+      $defs: Record<string, JSONSchema7>;
+    };
+
+    expect(sanitizeJsonSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "$defs": {
+          "PositiveInteger": {
+            "description": "minimum: 1.",
+            "type": "integer",
+          },
+        },
+        "properties": {
+          "count": {
+            "$ref": "#/$defs/PositiveInteger",
+          },
+          "tags": {
+            "description": "min items: 2; max items: 4; unique items: true.",
+            "items": {
+              "anyOf": [
+                {
+                  "description": "min length: 1.",
+                  "type": "string",
+                },
+                {
+                  "description": "maximum: 10.",
+                  "type": "number",
+                },
+              ],
+            },
+            "type": "array",
+          },
+        },
+        "type": "object",
+      }
+    `);
+  });
+
+  it('keeps supported formats and strips unsupported ones', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        email: { type: 'string', format: 'email' },
+        slug: { type: 'string', format: 'slug' },
+      },
+    };
+
+    expect(sanitizeJsonSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "properties": {
+          "email": {
+            "format": "email",
+            "type": "string",
+          },
+          "slug": {
+            "description": "format: slug.",
+            "type": "string",
+          },
+        },
+        "type": "object",
+      }
+    `);
+  });
+
+  it('converts oneOf to anyOf', () => {
+    const schema: JSONSchema7 = {
+      oneOf: [
+        { type: 'string', minLength: 1 },
+        { type: 'number', minimum: 0 },
+      ],
+    };
+
+    expect(sanitizeJsonSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "anyOf": [
+          {
+            "description": "min length: 1.",
+            "type": "string",
+          },
+          {
+            "description": "minimum: 0.",
+            "type": "number",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        value: { type: 'number', exclusiveMinimum: 0 },
+      },
+    };
+
+    sanitizeJsonSchema(schema);
+
+    expect(schema).toMatchInlineSnapshot(`
+      {
+        "properties": {
+          "value": {
+            "exclusiveMinimum": 0,
+            "type": "number",
+          },
+        },
+        "type": "object",
+      }
+    `);
+  });
+});

--- a/packages/provider-utils/src/sanitize-json-schema.ts
+++ b/packages/provider-utils/src/sanitize-json-schema.ts
@@ -1,0 +1,205 @@
+import type { JSONSchema7, JSONSchema7Definition } from '@ai-sdk/provider';
+import { isRecord } from './is-record';
+
+const SUPPORTED_STRING_FORMATS = new Set([
+  'date-time',
+  'time',
+  'date',
+  'duration',
+  'email',
+  'hostname',
+  'uri',
+  'ipv4',
+  'ipv6',
+  'uuid',
+]);
+
+const DESCRIPTION_CONSTRAINT_KEYS = [
+  'minimum',
+  'maximum',
+  'exclusiveMinimum',
+  'exclusiveMaximum',
+  'multipleOf',
+  'minLength',
+  'maxLength',
+  'pattern',
+  'minItems',
+  'maxItems',
+  'uniqueItems',
+  'minProperties',
+  'maxProperties',
+  'not',
+] satisfies Array<keyof JSONSchema7>;
+
+/**
+ * Removes JSON Schema keywords that OpenAI's strict function-tool schemas
+ * reject (the Responses API defaults function tools to `strict: true`), and
+ * that can otherwise make OpenAI fail with a generic in-stream `server_error`
+ * on gpt-5.x models while it compiles the schema into a constrained-decoding
+ * grammar. The documented strict-mode subset excludes value-constraint
+ * keywords such as `minItems`/`maxItems`, `minLength`/`maxLength`, `pattern`,
+ * `format`, `minimum`/`maximum`, `uniqueItems`, and `minProperties`/
+ * `maxProperties`.
+ *
+ * The full original schema is still used by AI SDK result validation. This
+ * only relaxes the schema sent to OpenAI, folding the removed constraints into
+ * the `description` so the model still receives them as guidance.
+ */
+export function sanitizeJsonSchema(schema: JSONSchema7): JSONSchema7 {
+  return sanitizeSchema(schema) as JSONSchema7;
+}
+
+function sanitizeDefinition(
+  definition: JSONSchema7Definition,
+): JSONSchema7Definition {
+  if (typeof definition === 'boolean' || !isRecord(definition)) {
+    return definition;
+  }
+
+  return sanitizeSchema(definition as JSONSchema7);
+}
+
+function sanitizeSchema(schema: JSONSchema7): JSONSchema7 {
+  const result: JSONSchema7 = {};
+  const schemaWithDefs = schema as JSONSchema7 & {
+    $defs?: Record<string, JSONSchema7Definition>;
+  };
+
+  if (schema.$ref != null) {
+    return { $ref: schema.$ref };
+  }
+
+  if (schema.$schema != null) {
+    result.$schema = schema.$schema;
+  }
+
+  if (schema.$id != null) {
+    result.$id = schema.$id;
+  }
+
+  if (schema.title != null) {
+    result.title = schema.title;
+  }
+
+  if (schema.description != null) {
+    result.description = schema.description;
+  }
+
+  if (schema.default !== undefined) {
+    result.default = schema.default;
+  }
+
+  if (schema.const !== undefined) {
+    result.const = schema.const;
+  }
+
+  if (schema.enum != null) {
+    result.enum = schema.enum;
+  }
+
+  if (schema.type != null) {
+    result.type = schema.type;
+  }
+
+  if (schema.anyOf != null) {
+    result.anyOf = schema.anyOf.map(sanitizeDefinition);
+  } else if (schema.oneOf != null) {
+    result.anyOf = schema.oneOf.map(sanitizeDefinition);
+  }
+
+  if (schema.definitions != null) {
+    result.definitions = Object.fromEntries(
+      Object.entries(schema.definitions).map(([name, definition]) => [
+        name,
+        sanitizeDefinition(definition),
+      ]),
+    );
+  }
+
+  if (schemaWithDefs.$defs != null) {
+    const resultWithDefs = result as JSONSchema7 & {
+      $defs?: Record<string, JSONSchema7Definition>;
+    };
+    resultWithDefs.$defs = Object.fromEntries(
+      Object.entries(schemaWithDefs.$defs).map(([name, definition]) => [
+        name,
+        sanitizeDefinition(definition),
+      ]),
+    );
+  }
+
+  if (schema.type === 'object' || schema.properties != null) {
+    if (schema.properties != null) {
+      result.properties = Object.fromEntries(
+        Object.entries(schema.properties).map(([name, definition]) => [
+          name,
+          sanitizeDefinition(definition),
+        ]),
+      );
+    }
+
+    if (schema.additionalProperties !== undefined) {
+      result.additionalProperties = schema.additionalProperties;
+    }
+
+    if (schema.required != null) {
+      result.required = schema.required;
+    }
+  }
+
+  if (schema.items != null) {
+    result.items = Array.isArray(schema.items)
+      ? schema.items.map(sanitizeDefinition)
+      : sanitizeDefinition(schema.items);
+  }
+
+  if (
+    typeof schema.format === 'string' &&
+    SUPPORTED_STRING_FORMATS.has(schema.format)
+  ) {
+    result.format = schema.format;
+  }
+
+  const constraintDescription = getConstraintDescription(schema);
+  if (constraintDescription != null) {
+    result.description =
+      result.description == null
+        ? constraintDescription
+        : `${result.description}\n${constraintDescription}`;
+  }
+
+  return result;
+}
+
+function getConstraintDescription(schema: JSONSchema7): string | undefined {
+  const descriptions = DESCRIPTION_CONSTRAINT_KEYS.flatMap(key => {
+    const value = schema[key];
+
+    if (value == null || value === false) {
+      return [];
+    }
+
+    return `${formatConstraintName(key)}: ${formatConstraintValue(value)}`;
+  });
+
+  if (
+    typeof schema.format === 'string' &&
+    !SUPPORTED_STRING_FORMATS.has(schema.format)
+  ) {
+    descriptions.push(`format: ${schema.format}`);
+  }
+
+  return descriptions.length === 0 ? undefined : `${descriptions.join('; ')}.`;
+}
+
+function formatConstraintName(key: string): string {
+  return key.replace(/[A-Z]/g, match => ` ${match.toLowerCase()}`);
+}
+
+function formatConstraintValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return JSON.stringify(value);
+}


### PR DESCRIPTION
Fixes #18510.

`streamText` with tools dies right after the first chunk with a generic OpenAI `server_error` on `gpt-5.6-*`. OpenAI compiles function tool schemas into a strict grammar and rejects a chunk of JSON Schema keywords — `minItems`/`maxItems`, `minLength`/`maxLength`, `pattern`, `format`, etc. Zod v4 emits these for common expressions like `z.array(z.string()).min(1).max(30000)`, so users hit it without doing anything unusual.

This mirrors how Anthropic already handles it (same keyword stripping, folded into the description), and applies it:

- `@ai-sdk/openai`: function tool `parameters` and `output_schema` in both Responses and chat paths.
- `@ai-sdk/gateway`: tool schemas for `openai/`-routed requests.

The original schema still validates tool inputs on the SDK side. Gateway + OpenAI credentials weren't available here, so the repro above wasn't run against the hosted gateway end-to-end — worth a quick confirmation after release.