### PR TITLE
docs: use top-level reasoning in agent call options and document ToolLoopAgent call settings

### DIFF
--- a/content/docs/03-agents/05-configuring-call-options.mdx
+++ b/content/docs/03-agents/05-configuring-call-options.mdx
@@ -14,7 +14,7 @@ When you need agent behavior to change based on runtime inputs:
 - **Add dynamic context** - Inject retrieved documents, user preferences, or session data into prompts
 - **Select models dynamically** - Choose faster or more capable models based on request complexity
 - **Configure tools per request** - Pass user location to search tools or adjust tool behavior
-- **Customize provider options** - Set reasoning effort, temperature, or other provider-specific settings
+- **Adjust generation settings** - Set reasoning effort, temperature, or other call settings
 
 Without call options, you'd need to create multiple agents or handle configuration logic outside the agent.
 
@@ -148,27 +148,23 @@ await newsAgent.generate({
 });
 ```
 
-### Provider-Specific Options
+### Dynamic Reasoning Effort
 
-Configure provider settings dynamically:
+Control how much reasoning the model performs based on runtime inputs, using the top-level [`reasoning` setting](/docs/ai-sdk-core/settings#reasoning):
 
 ```ts
-import { OpenAILanguageModelResponsesOptions } from '@ai-sdk/openai';
 import { ToolLoopAgent } from 'ai';
+__PROVIDER_IMPORT__;
 import { z } from 'zod';
 
 const agent = new ToolLoopAgent({
-  model: 'openai/o3',
+  model: __MODEL__,
   callOptionsSchema: z.object({
     taskDifficulty: z.enum(['low', 'medium', 'high']),
   }),
   prepareCall: ({ options, ...settings }) => ({
     ...settings,
-    providerOptions: {
-      openai: {
-        reasoningEffort: options.taskDifficulty,
-      } satisfies OpenAILanguageModelResponsesOptions,
-    },
+    reasoning: options.taskDifficulty,
   }),
 });
 
@@ -177,6 +173,8 @@ await agent.generate({
   options: { taskDifficulty: 'high' },
 });
 ```
+
+The `reasoning` setting is provider-agnostic, so it composes with dynamic model selection. For options that are genuinely provider-specific, return `providerOptions` from `prepareCall` in the same way; see the [reasoning guide](/docs/ai-sdk-core/reasoning) for per-provider mapping.
 
 ## Advanced Patterns
 

--- a/content/docs/03-agents/05-configuring-call-options.mdx
+++ b/content/docs/03-agents/05-configuring-call-options.mdx
@@ -174,7 +174,7 @@ await agent.generate({
 });
 ```
 
-The `reasoning` setting is provider-agnostic, so it composes with dynamic model selection. For options that are genuinely provider-specific, return `providerOptions` from `prepareCall` in the same way; see the [reasoning guide](/docs/ai-sdk-core/reasoning) for per-provider mapping.
+The `reasoning` setting is provider-agnostic, so it keeps working when you combine it with dynamic model selection. See the [reasoning guide](/docs/ai-sdk-core/reasoning) for how the values map to each provider. For options that are genuinely provider-specific, return `providerOptions` from `prepareCall` in the same way.
 
 ## Advanced Patterns
 

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -46,11 +46,12 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
 
 ### Parameters
 
-In addition to the parameters below, the constructor accepts all
+In addition to the parameters below, the constructor accepts the
 [call settings](/docs/ai-sdk-core/settings): the language model call options
 (`maxOutputTokens`, `temperature`, `topP`, `topK`, `presencePenalty`,
 `frequencyPenalty`, `stopSequences`, `seed`, and `reasoning`), the request
 options (`maxRetries`, `timeout`, and `headers`), and `providerOptions`.
+`abortSignal` is the exception: pass it to `generate()` or `stream()` per call.
 
 <PropertiesTable
   content={[

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -46,6 +46,12 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
 
 ### Parameters
 
+In addition to the parameters below, the constructor accepts all
+[call settings](/docs/ai-sdk-core/settings): the language model call options
+(`maxOutputTokens`, `temperature`, `topP`, `topK`, `presencePenalty`,
+`frequencyPenalty`, `stopSequences`, `seed`, and `reasoning`), the request
+options (`maxRetries`, `timeout`, and `headers`), and `providerOptions`.
+
 <PropertiesTable
   content={[
     {


### PR DESCRIPTION
## Background

The agents guide "Configuring Call Options" demonstrates dynamic reasoning effort through `providerOptions.openai.reasoningEffort`. Since the top-level `reasoning` call setting exists (and is typed in `prepareCall` as of #18482), the example teaches the per-provider pattern that setting replaces, and it is provider-locked while every other example on the page uses the provider-agnostic placeholders. The settings page also notes that reasoning-related provider options take precedence over top-level `reasoning`, so the documented pattern silently bypasses the modern setting.

Separately, the `ToolLoopAgent` reference lists the constructor parameters but omits the whole call-settings surface (`reasoning`, `temperature`, `maxOutputTokens`, `maxRetries`, `timeout`, `headers`, `providerOptions`, ...), so readers of that page cannot discover that the constructor accepts them.

## Summary

- `docs/03-agents/05-configuring-call-options.mdx`: replaced the "Provider-Specific Options" example with a "Dynamic Reasoning Effort" example built on the top-level `reasoning` setting, with a closing note pointing to `providerOptions` for genuinely provider-specific options and to the reasoning guide for per-provider mapping. Reworded the intro bullet that labeled reasoning effort and temperature as "provider-specific settings".
- `docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx`: added a note under the constructor parameters listing the accepted call settings, linking to the settings page. (The `timeout` mention aligns with #18521, which makes the settings-level timeout take effect.)

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Related: #18482, #18518, #18521
