### PR TITLE
fix(react): throttle published useChat snapshots

### DIFF
--- a/.changeset/calm-chats-throttle.md
+++ b/.changeset/calm-chats-throttle.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+Fix `useChat` throttling so unrelated React renders cannot publish message snapshots ahead of the configured throttle cadence.

--- a/examples/ai-e2e-next/app/api/chat/throttle/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/throttle/route.ts
@@ -3,8 +3,8 @@ import { createUIMessageStreamResponse, simulateReadableStream } from 'ai';
 export async function POST(req: Request) {
   return createUIMessageStreamResponse({
     stream: simulateReadableStream({
-      initialDelayInMs: 0, // Delay before the first chunk
-      chunkDelayInMs: 0, // Delay between chunks
+      initialDelayInMs: 0,
+      chunkDelayInMs: 0,
       chunks: [
         {
           type: 'start',
@@ -16,7 +16,7 @@ export async function POST(req: Request) {
           type: 'text-start',
           id: 'text-1',
         },
-        ...Array(5000).fill({ type: 'text-delta', id: 'text-1', delta: 'T\n' }),
+        ...Array(500).fill({ type: 'text-delta', id: 'text-1', delta: 'T\n' }),
         {
           type: 'text-end',
           id: 'text-1',

--- a/examples/ai-e2e-next/app/chat/throttle/page.tsx
+++ b/examples/ai-e2e-next/app/chat/throttle/page.tsx
@@ -1,36 +1,157 @@
 'use client';
 
-import ChatInput from '@/components/chat-input';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
-import { useLayoutEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+const THROTTLE_MS = 50;
+const EXPECTED_ASSISTANT_CHARACTERS = 1000;
+
+type Result = {
+  durationInMs: number;
+  maximumExpectedSnapshotChanges: number;
+  renderCount: number;
+  snapshotChangeCount: number;
+};
 
 export default function Chat() {
   const renderCount = useRef(0);
-  useLayoutEffect(() => {
-    console.log(`component rendered #${++renderCount.current}`);
+  renderCount.current += 1;
+
+  const { error, messages, status, sendMessage } = useChat({
+    transport: new DefaultChatTransport({ api: '/api/chat/throttle' }),
+    throttle: THROTTLE_MS,
   });
 
-  const { messages, status, sendMessage } = useChat({
-    transport: new DefaultChatTransport({ api: '/api/chat/throttle' }),
-    throttle: 50,
-  });
+  const previousMessages = useRef(messages);
+  const snapshotChangeCount = useRef(0);
+  if (previousMessages.current !== messages) {
+    previousMessages.current = messages;
+    snapshotChangeCount.current += 1;
+  }
+
+  const [result, setResult] = useState<Result>();
+  const [, forceUnrelatedRender] = useState(0);
+  const startedAt = useRef<number>();
+
+  const assistantMessages = messages.filter(
+    message => message.role === 'assistant',
+  );
+  const latestAssistantMessage =
+    assistantMessages[assistantMessages.length - 1];
+  const assistantText = (latestAssistantMessage?.parts ?? [])
+    .filter(part => part.type === 'text')
+    .map(part => part.text)
+    .join('');
+
+  useEffect(() => {
+    if (status !== 'submitted' && status !== 'streaming') {
+      return;
+    }
+
+    // Re-render independently from useChat while the response streams. Before
+    // the fix for #6166, these renders read the always-current messages array
+    // from getSnapshot and bypass the throttled subscription.
+    const interval = setInterval(() => {
+      forceUnrelatedRender(count => count + 1);
+    }, 0);
+
+    return () => clearInterval(interval);
+  }, [status]);
+
+  useEffect(() => {
+    if (
+      startedAt.current == null ||
+      status !== 'ready' ||
+      assistantText.length !== EXPECTED_ASSISTANT_CHARACTERS
+    ) {
+      return;
+    }
+
+    const durationInMs = performance.now() - startedAt.current;
+    setResult({
+      durationInMs,
+      // Account for the leading update, trailing update, user message, and
+      // timer/commit boundary variance around the throttle window.
+      maximumExpectedSnapshotChanges: Math.ceil(durationInMs / THROTTLE_MS) + 4,
+      renderCount: renderCount.current,
+      snapshotChangeCount: snapshotChangeCount.current,
+    });
+    startedAt.current = undefined;
+  }, [assistantText.length, status]);
+
+  const runReproduction = () => {
+    previousMessages.current = messages;
+    renderCount.current = 0;
+    snapshotChangeCount.current = 0;
+    setResult(undefined);
+    startedAt.current = performance.now();
+    sendMessage({ text: 'Run the throttle snapshot reproduction' });
+  };
+
+  const passed =
+    result != null &&
+    result.snapshotChangeCount <= result.maximumExpectedSnapshotChanges;
 
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
       <h4 className="pb-4 text-xl font-bold text-gray-900 md:text-xl">
-        useChat throttle example
+        useChat throttle snapshot reproduction
       </h4>
-      {messages.map(m => (
-        <div key={m.id} className="whitespace-pre-wrap">
-          {m.role === 'user' ? 'User: ' : 'AI: '}
-          {m.parts
-            .map(part => (part.type === 'text' ? part.text : ''))
-            .join('')}
-        </div>
-      ))}
+      <p className="pb-4 text-sm text-gray-700">
+        Streams 500 chunks with a 50ms throttle while an unrelated timer
+        re-renders the component. Message snapshots should only change within
+        the throttle cadence.
+      </p>
 
-      <ChatInput status={status} onSubmit={text => sendMessage({ text })} />
+      <dl className="grid grid-cols-2 gap-2 pb-4 text-sm">
+        <dt>Status</dt>
+        <dd data-testid="status">{status}</dd>
+        <dt>React renders</dt>
+        <dd data-testid="render-count">{renderCount.current}</dd>
+        <dt>Message snapshot changes</dt>
+        <dd data-testid="snapshot-change-count">
+          {snapshotChangeCount.current}
+        </dd>
+        <dt>Assistant characters</dt>
+        <dd data-testid="assistant-character-count">{assistantText.length}</dd>
+      </dl>
+
+      {result != null && (
+        <div
+          className={`mb-4 rounded border p-3 ${
+            passed
+              ? 'border-green-600 bg-green-50 text-green-900'
+              : 'border-red-600 bg-red-50 text-red-900'
+          }`}
+          data-testid="result"
+        >
+          <strong>{passed ? 'PASS' : 'FAIL'}</strong>: observed{' '}
+          {result.snapshotChangeCount} message snapshot changes in{' '}
+          {Math.round(result.durationInMs)}ms; expected at most{' '}
+          {result.maximumExpectedSnapshotChanges} with a {THROTTLE_MS}ms
+          throttle. Total renders: {result.renderCount}.
+        </div>
+      )}
+
+      {error != null && (
+        <pre
+          className="mb-4 whitespace-pre-wrap text-red-700"
+          data-testid="error"
+        >
+          {error.message}
+        </pre>
+      )}
+
+      <button
+        className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
+        data-testid="run-reproduction"
+        disabled={status !== 'ready' || startedAt.current != null}
+        onClick={runReproduction}
+        type="button"
+      >
+        Run reproduction
+      </button>
     </div>
   );
 }

--- a/examples/ai-e2e-next/app/chat/throttle/page.tsx
+++ b/examples/ai-e2e-next/app/chat/throttle/page.tsx
@@ -8,6 +8,7 @@ const THROTTLE_MS = 50;
 const EXPECTED_ASSISTANT_CHARACTERS = 1000;
 
 type Result = {
+  assistantCharacterCountAtReady: number;
   durationInMs: number;
   maximumExpectedSnapshotChanges: number;
   renderCount: number;
@@ -60,16 +61,13 @@ export default function Chat() {
   }, [status]);
 
   useEffect(() => {
-    if (
-      startedAt.current == null ||
-      status !== 'ready' ||
-      assistantText.length !== EXPECTED_ASSISTANT_CHARACTERS
-    ) {
+    if (startedAt.current == null || status !== 'ready') {
       return;
     }
 
     const durationInMs = performance.now() - startedAt.current;
     setResult({
+      assistantCharacterCountAtReady: assistantText.length,
       durationInMs,
       // Account for the leading update, trailing update, user message, and
       // timer/commit boundary variance around the throttle window.
@@ -91,7 +89,8 @@ export default function Chat() {
 
   const passed =
     result != null &&
-    result.snapshotChangeCount <= result.maximumExpectedSnapshotChanges;
+    result.snapshotChangeCount <= result.maximumExpectedSnapshotChanges &&
+    result.assistantCharacterCountAtReady === EXPECTED_ASSISTANT_CHARACTERS;
 
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
@@ -130,7 +129,9 @@ export default function Chat() {
           {result.snapshotChangeCount} message snapshot changes in{' '}
           {Math.round(result.durationInMs)}ms; expected at most{' '}
           {result.maximumExpectedSnapshotChanges} with a {THROTTLE_MS}ms
-          throttle. Total renders: {result.renderCount}.
+          throttle. Assistant characters when status became ready:{' '}
+          {result.assistantCharacterCountAtReady}/
+          {EXPECTED_ASSISTANT_CHARACTERS}. Total renders: {result.renderCount}.
         </div>
       )}
 

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -135,18 +135,56 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     chatRef.current = 'chat' in options ? options.chat : new Chat(chatOptions);
   }
 
+  const chat = chatRef.current;
+  const messagesSnapshotRef = useRef({
+    chat,
+    messages: chat.messages,
+  });
+
+  if (messagesSnapshotRef.current.chat !== chat) {
+    messagesSnapshotRef.current = { chat, messages: chat.messages };
+  }
+
   const subscribeToMessages = useCallback(
-    (update: () => void) =>
-      chatRef.current['~registerMessagesCallback'](update, throttleWaitMs),
-    // `chatRef.current.id` is required to trigger re-subscription when the chat ID changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [throttleWaitMs, chatRef.current.id],
+    (update: () => void) => {
+      let isSubscribed = true;
+
+      const updateMessages = () => {
+        if (!isSubscribed || messagesSnapshotRef.current.chat !== chat) {
+          return;
+        }
+
+        messagesSnapshotRef.current = { chat, messages: chat.messages };
+        update();
+      };
+
+      const unsubscribe = chat['~registerMessagesCallback'](
+        updateMessages,
+        throttleWaitMs,
+      );
+
+      // Synchronize changes that may have happened between render and
+      // subscription. useSyncExternalStore checks the snapshot after
+      // subscribing and schedules a render when it changed.
+      messagesSnapshotRef.current = { chat, messages: chat.messages };
+
+      return () => {
+        isSubscribed = false;
+        unsubscribe();
+      };
+    },
+    [chat, throttleWaitMs],
+  );
+
+  const getMessagesSnapshot = useCallback(
+    () => messagesSnapshotRef.current.messages,
+    [],
   );
 
   const messages = useSyncExternalStore(
     subscribeToMessages,
-    () => chatRef.current.messages,
-    () => chatRef.current.messages,
+    getMessagesSnapshot,
+    getMessagesSnapshot,
   );
 
   const status = useSyncExternalStore(

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -187,10 +187,29 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     getMessagesSnapshot,
   );
 
+  const subscribeToStatus = useCallback(
+    (update: () => void) =>
+      chat['~registerStatusCallback'](() => {
+        if (messagesSnapshotRef.current.chat !== chat) {
+          return;
+        }
+
+        if (chat.status === 'ready' || chat.status === 'error') {
+          // Publish the latest messages before the terminal status can render.
+          messagesSnapshotRef.current = { chat, messages: chat.messages };
+        }
+
+        update();
+      }),
+    [chat],
+  );
+
+  const getStatusSnapshot = useCallback(() => chat.status, [chat]);
+
   const status = useSyncExternalStore(
-    chatRef.current['~registerStatusCallback'],
-    () => chatRef.current.status,
-    () => chatRef.current.status,
+    subscribeToStatus,
+    getStatusSnapshot,
+    getStatusSnapshot,
   );
 
   const error = useSyncExternalStore(

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -2320,6 +2320,7 @@ describe('use-chat', () => {
         throttle: throttleMs,
         generateId: mockId(),
       });
+      const [, forceUnrelatedRender] = useState(0);
 
       return (
         <div>
@@ -2337,6 +2338,10 @@ describe('use-chat', () => {
             onClick={() => {
               sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
             }}
+          />
+          <button
+            data-testid="force-unrelated-render"
+            onClick={() => forceUnrelatedRender(count => count + 1)}
           />
         </div>
       );
@@ -2385,6 +2390,40 @@ describe('use-chat', () => {
       expect(screen.getByTestId('message-1')).toHaveTextContent(
         'AI: Hello There',
       );
+    });
+
+    it('should not publish a new message snapshot during an unrelated render', async () => {
+      const controller = new TestResponseController();
+
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      fireEvent.click(screen.getByTestId('do-send'));
+
+      controller.write(formatChunk({ type: 'text-start', id: '0' }));
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hel' }),
+      );
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(throttleMs + 10);
+      });
+
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hel');
+
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'lo' }),
+      );
+      fireEvent.click(screen.getByTestId('force-unrelated-render'));
+
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hel');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(throttleMs + 10);
+      });
+
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
     });
   });
 

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -2316,7 +2316,9 @@ describe('use-chat', () => {
     });
 
     setupTestComponent(() => {
-      const { messages, sendMessage, status } = useChat({
+      const [id, setId] = useState('first-id');
+      const { error, messages, sendMessage, status, stop } = useChat({
+        id,
         throttle: throttleMs,
         generateId: mockId(),
       });
@@ -2325,6 +2327,7 @@ describe('use-chat', () => {
       return (
         <div>
           <div data-testid="status">{status.toString()}</div>
+          {error != null && <div data-testid="error">{error.message}</div>}
           {messages.map((m, idx) => (
             <div data-testid={`message-${idx}`} key={m.id}>
               {m.role === 'user' ? 'User: ' : 'AI: '}
@@ -2343,6 +2346,11 @@ describe('use-chat', () => {
             data-testid="force-unrelated-render"
             onClick={() => forceUnrelatedRender(count => count + 1)}
           />
+          <button
+            data-testid="change-chat"
+            onClick={() => setId('second-id')}
+          />
+          <button data-testid="stop" onClick={stop} />
         </div>
       );
     });
@@ -2424,6 +2432,114 @@ describe('use-chat', () => {
       });
 
       expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
+    });
+
+    it('should publish the final message snapshot with ready status', async () => {
+      const controller = new TestResponseController();
+
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      fireEvent.click(screen.getByTestId('do-send'));
+      controller.write(formatChunk({ type: 'text-start', id: '0' }));
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+      );
+      controller.write(formatChunk({ type: 'text-end', id: '0' }));
+      controller.close();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(screen.getByTestId('status')).toHaveTextContent('ready');
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
+    });
+
+    it('should publish the latest message snapshot with error status', async () => {
+      const controller = new TestResponseController();
+
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      fireEvent.click(screen.getByTestId('do-send'));
+      controller.write(formatChunk({ type: 'text-start', id: '0' }));
+      controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+      );
+      controller.write(
+        formatChunk({ type: 'error', errorText: 'stream failed' }),
+      );
+      controller.close();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(screen.getByTestId('status')).toHaveTextContent('error');
+      expect(screen.getByTestId('error')).toHaveTextContent('stream failed');
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
+    });
+
+    it('should publish the latest message snapshot when an abort becomes ready', async () => {
+      const controller = new TestResponseController();
+
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      fireEvent.click(screen.getByTestId('do-send'));
+      await act(async () => {
+        await controller.write(formatChunk({ type: 'text-start', id: '0' }));
+        await controller.write(
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        );
+      });
+
+      expect(screen.queryByTestId('message-1')).not.toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('stop'));
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(screen.getByTestId('status')).toHaveTextContent('ready');
+      expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
+    });
+
+    it('should ignore a delayed publication after changing chats', async () => {
+      const controller = new TestResponseController();
+
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      fireEvent.click(screen.getByTestId('do-send'));
+      await act(async () => {
+        await controller.write(formatChunk({ type: 'text-start', id: '0' }));
+        await controller.write(
+          formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        );
+      });
+
+      expect(screen.getByTestId('status')).toHaveTextContent('streaming');
+      expect(screen.queryByTestId('message-1')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('change-chat'));
+      expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(throttleMs + 10);
+      });
+
+      expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
+      controller.close();
     });
   });
 


### PR DESCRIPTION
## Background

`useChat` currently throttles its messages subscription callback, but its `useSyncExternalStore` snapshot always reads the latest `chat.messages` array. Because streaming replaces that array for every chunk, any unrelated React render can observe a new snapshot before the throttled callback publishes it. In high-frequency streams this bypasses `throttle`, causes per-chunk renders, and can contribute to the "Maximum update depth exceeded" failures reported in #6166.

## Summary

- Keep a published messages snapshot per `useChat` hook and advance it from that hook's throttled subscription callback.
- Publish the latest message snapshot before `ready` or `error` becomes observable, including normal completion and aborts.
- Synchronize updates that occur between render and subscription, and ignore delayed callbacks after a hook unsubscribes or changes chat instances.
- Add regression coverage for unrelated renders, terminal status/message coherence, aborts, errors, and delayed callbacks after chat replacement.
- Turn the existing Next.js throttle route into a deterministic end-to-end reproduction that streams 500 chunks while forcing unrelated renders, reports pass/fail from observed snapshot identities, and verifies the complete message is visible when status becomes `ready`.
- Add a patch changeset for `@ai-sdk/react`.

## Contributor Credit

- @brahmveda-arkin reported #6166.
- @takumiz19 isolated the snapshot/subscription mismatch and proposed #17893.
- @ben-reitz demonstrated the practical value of a conservative UI update cadence in cloudflare/agents#2058.

## End-to-End Verification

Ran `/chat/throttle` in `examples/ai-e2e-next` in a real browser. The route streams 500 chunks (1,000 assistant characters) with `throttle: 50` while a zero-delay timer independently re-renders the component.

- Before: **FAIL**, 255 distinct message snapshots in 1,475ms (maximum expected: 34), across 946 total React renders.
- After: **PASS**, 15 distinct message snapshots in 1,144ms (maximum expected: 27), across 602 total React renders.

The patched run rendered all 1,000 assistant characters on the same render where status became `ready`, and had no Next.js error overlay or browser error.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

This PR intentionally leaves the current opt-in default unchanged, so it does not protect applications that omit `throttle` from high-frequency unthrottled rendering.

For v8, I recommend making a 50ms UI publication cadence the default when `throttle` is omitted, with `throttle: 0` as the explicit unthrottled opt-out. Stream processing, tool handling, and callbacks should remain immediate; only snapshots exposed to React should be paced. The default should also guarantee an immediate leading publication and a terminal flush so the final messages and `ready` status stay coherent.

This would cap the normal rendering rate at about 20 updates per second and protect applications that do not know they need to opt in today. The tradeoff is up to 50ms of additional visible text latency and an explicit opt-out for applications that intentionally need per-chunk rendering, which makes the behavior change appropriate for a major release.

## Related Issues

Addresses the throttled snapshot bypass discussed in #6166. Reports using the default unthrottled behavior remain outside this PR.

Closes #17893.

Related to https://github.com/cloudflare/agents/pull/2058.
