### PR TITLE
fix(react): backport throttled chat snapshots to v5

### DIFF
--- a/.changeset/calm-chats-throttle.md
+++ b/.changeset/calm-chats-throttle.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+Fix `useChat` throttling so unrelated React renders cannot publish message snapshots ahead of the configured throttle cadence.

--- a/examples/next-openai/app/api/use-chat-throttle/route.ts
+++ b/examples/next-openai/app/api/use-chat-throttle/route.ts
@@ -3,8 +3,8 @@ import { createUIMessageStreamResponse, simulateReadableStream } from 'ai';
 export async function POST(req: Request) {
   return createUIMessageStreamResponse({
     stream: simulateReadableStream({
-      initialDelayInMs: 0, // Delay before the first chunk
-      chunkDelayInMs: 0, // Delay between chunks
+      initialDelayInMs: 0,
+      chunkDelayInMs: 0,
       chunks: [
         {
           type: 'start',
@@ -12,7 +12,19 @@ export async function POST(req: Request) {
         {
           type: 'start-step',
         },
-        ...Array(5000).fill({ type: 'text', value: 'T\n' }),
+        {
+          type: 'text-start',
+          id: 'text-1',
+        },
+        ...Array(500).fill({
+          type: 'text-delta',
+          id: 'text-1',
+          delta: 'T\n',
+        }),
+        {
+          type: 'text-end',
+          id: 'text-1',
+        },
         {
           type: 'finish-step',
         },

--- a/examples/next-openai/app/use-chat-throttle/page.tsx
+++ b/examples/next-openai/app/use-chat-throttle/page.tsx
@@ -1,36 +1,165 @@
 'use client';
 
-import ChatInput from '@/components/chat-input';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
-import { useLayoutEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+const THROTTLE_MS = 50;
+const EXPECTED_ASSISTANT_CHARACTERS = 1000;
+
+type Result = {
+  assistantCharacterCountAtReady: number;
+  durationInMs: number;
+  maximumExpectedSnapshotChanges: number;
+  renderCount: number;
+  snapshotChangeCount: number;
+};
 
 export default function Chat() {
   const renderCount = useRef(0);
-  useLayoutEffect(() => {
-    console.log(`component rendered #${++renderCount.current}`);
+  renderCount.current += 1;
+
+  const { error, messages, status, sendMessage } = useChat({
+    transport: new DefaultChatTransport({ api: '/api/use-chat-throttle' }),
+    experimental_throttle: THROTTLE_MS,
   });
 
-  const { messages, status, sendMessage } = useChat({
-    transport: new DefaultChatTransport({ api: '/api/use-chat-throttle' }),
-    experimental_throttle: 50,
-  });
+  const previousMessages = useRef(messages);
+  const snapshotChangeCount = useRef(0);
+  if (previousMessages.current !== messages) {
+    previousMessages.current = messages;
+    snapshotChangeCount.current += 1;
+  }
+
+  const [result, setResult] = useState<Result>();
+  const [hasMounted, setHasMounted] = useState(false);
+  const [, forceUnrelatedRender] = useState(0);
+  const startedAt = useRef<number>();
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  const assistantMessages = messages.filter(
+    message => message.role === 'assistant',
+  );
+  const latestAssistantMessage =
+    assistantMessages[assistantMessages.length - 1];
+  const assistantText = (latestAssistantMessage?.parts ?? [])
+    .filter(part => part.type === 'text')
+    .map(part => part.text)
+    .join('');
+
+  useEffect(() => {
+    if (status !== 'submitted' && status !== 'streaming') {
+      return;
+    }
+
+    // Re-render independently from useChat while the response streams. Before
+    // the fix for #6166, these renders read the always-current messages array
+    // from getSnapshot and bypass the throttled subscription.
+    const interval = setInterval(() => {
+      forceUnrelatedRender(count => count + 1);
+    }, 0);
+
+    return () => clearInterval(interval);
+  }, [status]);
+
+  useEffect(() => {
+    if (startedAt.current == null || status !== 'ready') {
+      return;
+    }
+
+    const durationInMs = performance.now() - startedAt.current;
+    setResult({
+      assistantCharacterCountAtReady: assistantText.length,
+      durationInMs,
+      // Account for the leading update, trailing update, user message, and
+      // timer/commit boundary variance around the throttle window.
+      maximumExpectedSnapshotChanges: Math.ceil(durationInMs / THROTTLE_MS) + 4,
+      renderCount: renderCount.current,
+      snapshotChangeCount: snapshotChangeCount.current,
+    });
+    startedAt.current = undefined;
+  }, [assistantText.length, status]);
+
+  const runReproduction = () => {
+    previousMessages.current = messages;
+    renderCount.current = 0;
+    snapshotChangeCount.current = 0;
+    setResult(undefined);
+    startedAt.current = performance.now();
+    sendMessage({ text: 'Run the throttle snapshot reproduction' });
+  };
+
+  const passed =
+    result != null &&
+    result.snapshotChangeCount <= result.maximumExpectedSnapshotChanges &&
+    result.assistantCharacterCountAtReady === EXPECTED_ASSISTANT_CHARACTERS;
 
   return (
     <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
       <h4 className="pb-4 text-xl font-bold text-gray-900 md:text-xl">
-        useChat throttle example
+        useChat throttle snapshot reproduction
       </h4>
-      {messages.map(m => (
-        <div key={m.id} className="whitespace-pre-wrap">
-          {m.role === 'user' ? 'User: ' : 'AI: '}
-          {m.parts
-            .map(part => (part.type === 'text' ? part.text : ''))
-            .join('')}
-        </div>
-      ))}
+      <p className="pb-4 text-sm text-gray-700">
+        Streams 500 chunks with a 50ms throttle while an unrelated timer
+        re-renders the component. Message snapshots should only change within
+        the throttle cadence.
+      </p>
 
-      <ChatInput status={status} onSubmit={text => sendMessage({ text })} />
+      <dl className="grid grid-cols-2 gap-2 pb-4 text-sm">
+        <dt>Status</dt>
+        <dd data-testid="status">{status}</dd>
+        <dt>React renders</dt>
+        <dd data-testid="render-count">
+          {hasMounted ? renderCount.current : '—'}
+        </dd>
+        <dt>Message snapshot changes</dt>
+        <dd data-testid="snapshot-change-count">
+          {snapshotChangeCount.current}
+        </dd>
+        <dt>Assistant characters</dt>
+        <dd data-testid="assistant-character-count">{assistantText.length}</dd>
+      </dl>
+
+      {result != null && (
+        <div
+          className={`mb-4 rounded border p-3 ${
+            passed
+              ? 'border-green-600 bg-green-50 text-green-900'
+              : 'border-red-600 bg-red-50 text-red-900'
+          }`}
+          data-testid="result"
+        >
+          <strong>{passed ? 'PASS' : 'FAIL'}</strong>: observed{' '}
+          {result.snapshotChangeCount} message snapshot changes in{' '}
+          {Math.round(result.durationInMs)}ms; expected at most{' '}
+          {result.maximumExpectedSnapshotChanges} with a {THROTTLE_MS}ms
+          throttle. Assistant characters when status became ready:{' '}
+          {result.assistantCharacterCountAtReady}/
+          {EXPECTED_ASSISTANT_CHARACTERS}. Total renders: {result.renderCount}.
+        </div>
+      )}
+
+      {error != null && (
+        <pre
+          className="mb-4 whitespace-pre-wrap text-red-700"
+          data-testid="error"
+        >
+          {error.message}
+        </pre>
+      )}
+
+      <button
+        className="rounded bg-black px-4 py-2 text-white disabled:opacity-50"
+        data-testid="run-reproduction"
+        disabled={status !== 'ready' || startedAt.current != null}
+        onClick={runReproduction}
+        type="button"
+      >
+        Run reproduction
+      </button>
     </div>
   );
 }

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -66,24 +66,81 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     chatRef.current = 'chat' in options ? options.chat : new Chat(options);
   }
 
+  const chat = chatRef.current;
+  const messagesSnapshotRef = useRef({
+    chat,
+    messages: chat.messages,
+  });
+
+  if (messagesSnapshotRef.current.chat !== chat) {
+    messagesSnapshotRef.current = { chat, messages: chat.messages };
+  }
+
   const subscribeToMessages = useCallback(
-    (update: () => void) =>
-      chatRef.current['~registerMessagesCallback'](update, throttleWaitMs),
-    // `chatRef.current.id` is required to trigger re-subscription when the chat ID changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [throttleWaitMs, chatRef.current.id],
+    (update: () => void) => {
+      let isSubscribed = true;
+
+      const updateMessages = () => {
+        if (!isSubscribed || messagesSnapshotRef.current.chat !== chat) {
+          return;
+        }
+
+        messagesSnapshotRef.current = { chat, messages: chat.messages };
+        update();
+      };
+
+      const unsubscribe = chat['~registerMessagesCallback'](
+        updateMessages,
+        throttleWaitMs,
+      );
+
+      // Synchronize changes that may have happened between render and
+      // subscription. useSyncExternalStore checks the snapshot after
+      // subscribing and schedules a render when it changed.
+      messagesSnapshotRef.current = { chat, messages: chat.messages };
+
+      return () => {
+        isSubscribed = false;
+        unsubscribe();
+      };
+    },
+    [chat, throttleWaitMs],
+  );
+
+  const getMessagesSnapshot = useCallback(
+    () => messagesSnapshotRef.current.messages,
+    [],
   );
 
   const messages = useSyncExternalStore(
     subscribeToMessages,
-    () => chatRef.current.messages,
-    () => chatRef.current.messages,
+    getMessagesSnapshot,
+    getMessagesSnapshot,
   );
 
+  const subscribeToStatus = useCallback(
+    (update: () => void) =>
+      chat['~registerStatusCallback'](() => {
+        if (messagesSnapshotRef.current.chat !== chat) {
+          return;
+        }
+
+        if (chat.status === 'ready' || chat.status === 'error') {
+          // Publish the latest messages before the terminal status can render.
+          messagesSnapshotRef.current = { chat, messages: chat.messages };
+        }
+
+        update();
+      }),
+    [chat],
+  );
+
+  const getStatusSnapshot = useCallback(() => chat.status, [chat]);
+
   const status = useSyncExternalStore(
-    chatRef.current['~registerStatusCallback'],
-    () => chatRef.current.status,
-    () => chatRef.current.status,
+    subscribeToStatus,
+    getStatusSnapshot,
+    getStatusSnapshot,
   );
 
   const error = useSyncExternalStore(

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -5,7 +5,7 @@ import {
   mockId,
   TestResponseController,
 } from '@ai-sdk/provider-utils/test';
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   type FinishReason,
@@ -2051,15 +2051,28 @@ describe('stop', () => {
 describe('experimental_throttle', () => {
   const throttleMs = 50;
 
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   setupTestComponent(() => {
-    const { messages, sendMessage, status } = useChat({
+    const [id, setId] = useState('first-id');
+    const { error, messages, sendMessage, status, stop } = useChat({
+      id,
       experimental_throttle: throttleMs,
       generateId: mockId(),
     });
+    const [, forceUnrelatedRender] = useState(0);
 
     return (
       <div>
         <div data-testid="status">{status.toString()}</div>
+        {error != null && <div data-testid="error">{error.message}</div>}
         {messages.map((m, idx) => (
           <div data-testid={`message-${idx}`} key={m.id}>
             {m.role === 'user' ? 'User: ' : 'AI: '}
@@ -2074,6 +2087,12 @@ describe('experimental_throttle', () => {
             sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
           }}
         />
+        <button
+          data-testid="force-unrelated-render"
+          onClick={() => forceUnrelatedRender(count => count + 1)}
+        />
+        <button data-testid="change-chat" onClick={() => setId('second-id')} />
+        <button data-testid="stop" onClick={stop} />
       </div>
     );
   });
@@ -2086,10 +2105,8 @@ describe('experimental_throttle', () => {
       controller,
     };
 
-    await userEvent.click(screen.getByTestId('do-send'));
+    fireEvent.click(screen.getByTestId('do-send'));
     expect(screen.getByTestId('message-0')).toHaveTextContent('User: hi');
-
-    vi.useFakeTimers();
 
     controller.write(formatChunk({ type: 'text-start', id: '0' }));
     controller.write(
@@ -2121,8 +2138,146 @@ describe('experimental_throttle', () => {
     expect(screen.getByTestId('message-1')).toHaveTextContent(
       'AI: Hello There',
     );
+  });
 
-    vi.useRealTimers();
+  it('should not publish a new message snapshot during an unrelated render', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['/api/chat'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    fireEvent.click(screen.getByTestId('do-send'));
+
+    controller.write(formatChunk({ type: 'text-start', id: '0' }));
+    controller.write(
+      formatChunk({ type: 'text-delta', id: '0', delta: 'Hel' }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(throttleMs + 10);
+    });
+
+    expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hel');
+
+    controller.write(formatChunk({ type: 'text-delta', id: '0', delta: 'lo' }));
+    fireEvent.click(screen.getByTestId('force-unrelated-render'));
+
+    expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hel');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(throttleMs + 10);
+    });
+
+    expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
+  });
+
+  it('should publish the final message snapshot with ready status', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['/api/chat'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    fireEvent.click(screen.getByTestId('do-send'));
+    controller.write(formatChunk({ type: 'text-start', id: '0' }));
+    controller.write(
+      formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+    );
+    controller.write(formatChunk({ type: 'text-end', id: '0' }));
+    controller.close();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.getByTestId('status')).toHaveTextContent('ready');
+    expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
+  });
+
+  it('should publish the latest message snapshot with error status', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['/api/chat'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    fireEvent.click(screen.getByTestId('do-send'));
+    controller.write(formatChunk({ type: 'text-start', id: '0' }));
+    controller.write(
+      formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+    );
+    controller.write(
+      formatChunk({ type: 'error', errorText: 'stream failed' }),
+    );
+    controller.close();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.getByTestId('status')).toHaveTextContent('error');
+    expect(screen.getByTestId('error')).toHaveTextContent('stream failed');
+    expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
+  });
+
+  it('should publish the latest message snapshot when an abort becomes ready', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['/api/chat'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    fireEvent.click(screen.getByTestId('do-send'));
+    await act(async () => {
+      await controller.write(formatChunk({ type: 'text-start', id: '0' }));
+      await controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+      );
+    });
+
+    expect(screen.queryByTestId('message-1')).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('stop'));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(screen.getByTestId('status')).toHaveTextContent('ready');
+    expect(screen.getByTestId('message-1')).toHaveTextContent('AI: Hello');
+  });
+
+  it('should ignore a delayed publication after changing chats', async () => {
+    const controller = new TestResponseController();
+
+    server.urls['/api/chat'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    fireEvent.click(screen.getByTestId('do-send'));
+    await act(async () => {
+      await controller.write(formatChunk({ type: 'text-start', id: '0' }));
+      await controller.write(
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+      );
+    });
+
+    expect(screen.getByTestId('status')).toHaveTextContent('streaming');
+    expect(screen.queryByTestId('message-1')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('change-chat'));
+    expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(throttleMs + 10);
+    });
+
+    expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
+    controller.close();
   });
 });
 


### PR DESCRIPTION
## Background

`useChat` in AI SDK 5 throttles its messages subscription callback, but its `useSyncExternalStore` snapshot always reads the latest `chat.messages` array. Because streaming replaces that array for every chunk, an unrelated React render can observe a new snapshot before the throttled callback publishes it. In high-frequency streams this bypasses `experimental_throttle`, causes per-chunk renders, and can contribute to the "Maximum update depth exceeded" failures reported in #6166.

This is a branch-native backport of #18525 to `release-v5.0`.

## Summary

- Keep a published messages snapshot per `useChat` hook and advance it from that hook's throttled subscription callback.
- Publish the latest message snapshot before `ready` or `error` becomes observable, including normal completion and aborts.
- Synchronize updates that occur between render and subscription, and ignore delayed callbacks after a hook unsubscribes or changes chat instances.
- Add regression coverage for unrelated renders, terminal status/message coherence, aborts, errors, and delayed callbacks after chat replacement.
- Turn the existing Next.js throttle route into a deterministic end-to-end reproduction that streams 500 chunks while forcing unrelated renders, reports pass/fail from observed snapshot identities, and verifies the complete message is visible when status becomes `ready`.
- Update the reproduction's stale text stream-part shape to the v5 protocol and avoid a render-counter hydration mismatch.
- Add a patch changeset for `@ai-sdk/react`.

## Contributor Credit

- @brahmveda-arkin reported #6166.
- @takumiz19 isolated the snapshot/subscription mismatch and proposed #17893.
- @ben-reitz demonstrated the practical value of a conservative UI update cadence in cloudflare/agents#2058.

## Manual Verification

Ran `/use-chat-throttle` in `examples/next-openai` in a real browser. The route streamed 500 chunks (1,000 assistant characters) with `experimental_throttle: 50` while a zero-delay timer independently re-rendered the component.

The patched v5 run passed with 15 distinct message snapshots in 1,227ms (maximum expected: 29), across 654 total React renders. All 1,000 assistant characters were visible on the first render where status became `ready`, with no Next.js error overlay.

Also ran:

- `NODE_PATH=packages/rsc/node_modules pnpm --filter @ai-sdk/react test -- use-chat.ui.test.tsx` (53 tests passed; v5's React Vitest config imports the plugin already pinned by the RSC package but does not declare it itself)
- `pnpm --filter @ai-sdk/react type-check`
- `pnpm --filter @ai-sdk/react... build`
- `pnpm check`
- `git diff --check`

`pnpm type-check:full` remains red in this checkout because unchanged v5 examples resolve incompatible React type versions. It did not report any changed file; the changed React package type-check and declaration build pass, and the changed Next.js route compiled successfully during browser verification.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

This backport intentionally leaves the v5 opt-in default unchanged, so applications must continue to set `experimental_throttle` to benefit from paced React publications.

For v8, I recommend making a 50ms UI publication cadence the default when `throttle` is omitted, with `throttle: 0` as the explicit unthrottled opt-out. Stream processing, tool handling, and callbacks should remain immediate; only snapshots exposed to React should be paced. The default should guarantee an immediate leading publication and a terminal flush so final messages and `ready` status stay coherent.

This would cap the normal rendering rate at about 20 updates per second and protect applications that do not know they need to opt in today. The tradeoff is up to 50ms of additional visible text latency and an explicit opt-out for applications that intentionally need per-chunk rendering, which makes the behavior change appropriate for a major release.

## Related Issues

Backport of #18525.

Addresses the throttled snapshot bypass discussed in #6166. Reports using the default unthrottled behavior remain outside this PR.

Related to https://github.com/cloudflare/agents/pull/2058.
