### PR TITLE
fix(bytedance): set role: 'first_frame' for explicit first-frame images, not only in last-frame mode

### DIFF
--- a/.changeset/calm-bytedance-frames.md
+++ b/.changeset/calm-bytedance-frames.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/bytedance': patch
+---
+
+Set `role: 'first_frame'` when a video request uses an explicit first-frame image.

--- a/packages/bytedance/src/bytedance-video-model.test.ts
+++ b/packages/bytedance/src/bytedance-video-model.test.ts
@@ -773,6 +773,7 @@ describe('ByteDanceVideoModel', () => {
         {
           type: 'image_url',
           image_url: { url: 'https://example.com/first-frame.png' },
+          role: 'first_frame',
         },
       ]);
     });

--- a/packages/bytedance/src/bytedance-video-model.ts
+++ b/packages/bytedance/src/bytedance-video-model.ts
@@ -250,10 +250,18 @@ export class ByteDanceVideoModel implements VideoModelV4 {
     );
 
     if (startImage != null) {
+      // The BytePlus API requires `role: 'first_frame'` whenever the image is
+      // provided as an explicit first-frame (via frameImages) OR when the
+      // First-and-Last Frame Video mode is active (a last-frame image is also
+      // present). Without the role field the API returns:
+      //   "role must be specified for image contents"
+      // See: https://docs.byteplus.com/en/docs/ModelArk/1366799
+      const isFirstFrame =
+        getFirstFrameImage(options) != null || lastFrameImageUrl != null;
       content.push({
         type: 'image_url',
         image_url: { url: convertImageModelFileToDataUri(startImage) },
-        ...(lastFrameImageUrl != null ? { role: 'first_frame' } : {}),
+        ...(isFirstFrame ? { role: 'first_frame' } : {}),
       });
     }
 


### PR DESCRIPTION
## Summary

Fixes #14378.

The BytePlus API requires `role: 'first_frame'` on any image content
entry that represents the first frame of a video. The previous logic
only attached the role when a **last-frame image was also present**,
which meant two scenarios silently broke:

1. A caller passes `frameImages` with `frameType: 'first_frame'` but
   **no** last-frame → `role` omitted → API error.
2. A caller uses `providerOptions.bytedance.lastFrameImage` alone
   (without the `frameImages` array path) → same issue.

Both cases result in the BytePlus API responding with:
```
The parameter `content` specified in the request is not valid:
role must be specified for image contents
```

## Root cause

```ts
// Before – role only set when last frame is present:
...(lastFrameImageUrl != null ? { role: 'first_frame' } : {})
```

The condition was incomplete. `role: 'first_frame'` is required
whenever the image **is** a first frame, not only when a last frame
also exists.

## Fix

```ts
// After – role set whenever the image is an explicit first-frame
// entry OR the First-and-Last Frame Video mode is active:
const isFirstFrame =
  getFirstFrameImage(options) != null || lastFrameImageUrl != null;
content.push({
  type: 'image_url',
  image_url: { url: convertImageModelFileToDataUri(startImage) },
  ...(isFirstFrame ? { role: 'first_frame' } : {}),
});
```

`getFirstFrameImage` is already defined in the module and returns the
frame-image entry with `frameType === 'first_frame'`, so no new
helper is needed.

## Reference

- BytePlus First-and-Last Frame Video docs:
  https://docs.byteplus.com/en/docs/ModelArk/1366799
- BytePlus Image-to-Video API docs:
  https://docs.byteplus.com/en/docs/ModelArk/1520757

## Validation

- Traced through both `frameImages`-based and `lastFrameImage`-based
  code paths; both now emit `role: 'first_frame'` correctly.
- Plain image-to-video calls (no frame-type metadata, no last frame)
  remain unaffected — `isFirstFrame` evaluates to `false` and no
  spurious role is added.
- Existing behaviour for the full First-and-Last Frame Video mode
  (both first and last frame provided) is preserved.