### PR TITLE
fix(open-responses): preserve reasoning in tool loops

### DIFF
--- a/.changeset/warm-bees-reason.md
+++ b/.changeset/warm-bees-reason.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/open-responses': patch
+---
+
+Preserve assistant reasoning when replaying Open Responses output in tool loops.

--- a/examples/ai-functions/src/reproduction/issue-18511-open-responses-reasoning-round-trip.ts
+++ b/examples/ai-functions/src/reproduction/issue-18511-open-responses-reasoning-round-trip.ts
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict';
+import { createOpenResponses } from '@ai-sdk/open-responses';
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+
+const reasoningText = 'REASONING THAT MUST SURVIVE THE ROUND TRIP';
+
+type AssistantContent = Extract<
+  LanguageModelV4Prompt[number],
+  { role: 'assistant' }
+>['content'];
+
+type RequestItem = {
+  type?: string;
+  role?: string;
+  call_id?: string;
+  content?: unknown;
+};
+
+type RequestBody = {
+  input: RequestItem[];
+};
+
+async function main() {
+  const requestBodies: RequestBody[] = [];
+
+  function modelReturning(output: unknown[]) {
+    return createOpenResponses({
+      name: 'reproduction',
+      apiKey: 'not-used',
+      url: 'https://example.invalid/v1/responses',
+      fetch: async (_url, init) => {
+        requestBodies.push(JSON.parse(String(init?.body)) as RequestBody);
+
+        return new Response(
+          JSON.stringify({
+            id: 'r',
+            object: 'response',
+            created_at: 0,
+            model: 'm',
+            status: 'completed',
+            output,
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        );
+      },
+    })('any-model');
+  }
+
+  const firstStep = await modelReturning([
+    {
+      type: 'reasoning',
+      id: 'rs_1',
+      content: [{ type: 'reasoning_text', text: reasoningText }],
+      summary: [],
+    },
+    {
+      type: 'function_call',
+      id: 'fc_1',
+      call_id: 'call_1',
+      name: 'get_weather',
+      arguments: '{"location":"San Francisco"}',
+    },
+  ]).doGenerate({
+    prompt: [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'What is the weather?' }],
+      },
+    ],
+    tools: [
+      {
+        type: 'function',
+        name: 'get_weather',
+        inputSchema: {
+          type: 'object',
+          properties: { location: { type: 'string' } },
+          required: ['location'],
+        },
+      },
+    ],
+  });
+
+  const reasoningRead = firstStep.content.filter(
+    part => part.type === 'reasoning',
+  );
+  assert.equal(
+    reasoningRead.length,
+    1,
+    'precondition: the provider response should produce one reasoning part',
+  );
+
+  await modelReturning([]).doGenerate({
+    prompt: [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'What is the weather?' }],
+      },
+      {
+        role: 'assistant',
+        content: firstStep.content as AssistantContent,
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_1',
+            toolName: 'get_weather',
+            output: {
+              type: 'json',
+              value: { temperature: 72, condition: 'sunny' },
+            },
+          },
+        ],
+      },
+    ],
+    tools: [
+      {
+        type: 'function',
+        name: 'get_weather',
+        inputSchema: {
+          type: 'object',
+          properties: { location: { type: 'string' } },
+          required: ['location'],
+        },
+      },
+    ],
+  });
+
+  const secondRequest = requestBodies.at(-1);
+  assert.ok(secondRequest != null, 'no second request body was captured');
+
+  assert.deepEqual(
+    secondRequest.input.map(item => item.type ?? `message:${item.role}`),
+    ['message', 'reasoning', 'function_call', 'function_call_output'],
+  );
+
+  const replayedReasoning = secondRequest.input[1];
+  assert.deepEqual(replayedReasoning, {
+    type: 'reasoning',
+    summary: [],
+    content: [{ type: 'reasoning_text', text: reasoningText }],
+  });
+
+  assert.equal(secondRequest.input[2].call_id, 'call_1');
+  assert.equal(secondRequest.input[3].call_id, 'call_1');
+
+  console.log('Reasoning survived the Open Responses tool-loop round trip.');
+  console.log(
+    secondRequest.input
+      .map(item => item.type ?? `message:${item.role}`)
+      .join(', '),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/open-responses/src/responses/convert-to-open-responses-input.test.ts
+++ b/packages/open-responses/src/responses/convert-to-open-responses-input.test.ts
@@ -362,6 +362,66 @@ describe('convertToOpenResponsesInput', () => {
   });
 
   describe('assistant messages with tool calls', () => {
+    it('should preserve reasoning before a tool call and its result', async () => {
+      const result = await convertToOpenResponsesInput({
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'reasoning',
+                text: 'I should use the weather tool.',
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'call_123',
+                toolName: 'get_weather',
+                input: { location: 'San Francisco' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_123',
+                toolName: 'get_weather',
+                output: {
+                  type: 'json',
+                  value: { temperature: 72, condition: 'sunny' },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'reasoning',
+          summary: [],
+          content: [
+            {
+              type: 'reasoning_text',
+              text: 'I should use the weather tool.',
+            },
+          ],
+        },
+        {
+          type: 'function_call',
+          call_id: 'call_123',
+          name: 'get_weather',
+          arguments: '{"location":"San Francisco"}',
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_123',
+          output: '{"temperature":72,"condition":"sunny"}',
+        },
+      ]);
+    });
+
     it('should convert assistant message with a single tool-call', async () => {
       const result = await convertToOpenResponsesInput({
         prompt: [

--- a/packages/open-responses/src/responses/convert-to-open-responses-input.ts
+++ b/packages/open-responses/src/responses/convert-to-open-responses-input.ts
@@ -16,6 +16,7 @@ import type {
   InputTextContentParam,
   OpenResponsesRequestBody,
   OutputTextContentParam,
+  ReasoningItemParam,
   RefusalContentParam,
 } from './open-responses-api';
 
@@ -105,10 +106,19 @@ export async function convertToOpenResponsesInput({
         const assistantContent: Array<
           OutputTextContentParam | RefusalContentParam
         > = [];
+        const reasoningItems: Array<ReasoningItemParam> = [];
         const toolCalls: Array<FunctionCallItemParam> = [];
 
         for (const part of content) {
           switch (part.type) {
+            case 'reasoning': {
+              reasoningItems.push({
+                type: 'reasoning',
+                summary: [],
+                content: [{ type: 'reasoning_text', text: part.text }],
+              });
+              break;
+            }
             case 'text': {
               assistantContent.push({ type: 'output_text', text: part.text });
               break;
@@ -127,6 +137,11 @@ export async function convertToOpenResponsesInput({
               break;
             }
           }
+        }
+
+        // Push reasoning as separate items
+        for (const reasoningItem of reasoningItems) {
+          input.push(reasoningItem);
         }
 
         // Push assistant message with text content if any

--- a/packages/open-responses/src/responses/open-responses-api.ts
+++ b/packages/open-responses/src/responses/open-responses-api.ts
@@ -143,7 +143,7 @@ export type ReasoningItemParam = {
   id?: string;
   type: 'reasoning';
   summary: ReasoningSummaryContentParam[];
-  content?: unknown;
+  content?: ReasoningTextContent[];
   encrypted_content?: string;
 };
 


### PR DESCRIPTION
## Background

`@ai-sdk/open-responses` parsed provider reasoning items into assistant `reasoning` parts, but silently dropped those parts when the assistant output was replayed in a subsequent tool-loop request.

The live-provider investigation in #18512 captured the missing reasoning item, but DeepSeek accepted that request when its provider-issued tool call ID was retained. The provider-free reproduction in #18514 isolated the serialization defect independently of that provider behavior.

## Summary

- Serialize assistant reasoning parts as Open Responses reasoning items with `reasoning_text` content.
- Keep replayed reasoning immediately before its function call and tool result.
- Narrow the request type for reasoning content.
- Add converter regression coverage and a provider-free end-to-end reproduction.
- Add a patch changeset for `@ai-sdk/open-responses`.

## End-to-End Verification

Ran the provider-free two-step reproduction:

```sh
pnpm -C examples/ai-functions exec tsx src/reproduction/issue-18511-open-responses-reasoning-round-trip.ts
```

It completed successfully with the expected second-request ordering:

```text
message, reasoning, function_call, function_call_output
```

## Verification

- `pnpm --filter @ai-sdk/open-responses test`
- `pnpm --filter @ai-sdk/open-responses build`
- `pnpm --filter @example/ai-functions type-check`
- `pnpm check`
- `pnpm type-check:full`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #18511
Fixes #18513

Closes #18512
Closes #18514
Closes #18515

Co-authored by Co-authored-by: Astro-Han <255364436+Astro-Han@users.noreply.github.com>
