### PR TITLE
[v6.0] fix(provider-utils): preserve Metro compatibility

### DIFF
--- a/.changeset/tidy-pandas-bundle.md
+++ b/.changeset/tidy-pandas-bundle.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+fix(provider-utils): prevent Metro from parsing the Node 18 dynamic import fallback

--- a/packages/provider-utils/src/safe-node-fetch.test.ts
+++ b/packages/provider-utils/src/safe-node-fetch.test.ts
@@ -108,18 +108,32 @@ describe('getDefaultDownloadFetch', () => {
       return;
     }
 
+    const nodeModules = new Map<string, unknown>([
+      ['node:dns', await import('node:dns')],
+      ['node:module', await import('node:module')],
+    ]);
+    const dynamicImport = vi.fn(async (id: string) => nodeModules.get(id));
+    const functionConstructor = vi.fn(() => dynamicImport);
     const runtimeProcess = globalThis.process as unknown as {
       getBuiltinModule: ((id: string) => unknown) | undefined;
     };
     const originalGetBuiltinModule = runtimeProcess.getBuiltinModule;
+    vi.stubGlobal('Function', functionConstructor);
     runtimeProcess.getBuiltinModule = undefined;
 
     try {
       await expect(getDefaultDownloadFetch()).resolves.not.toBe(
         globalThis.fetch,
       );
+      expect(functionConstructor).toHaveBeenCalledWith(
+        'specifier',
+        'return import(specifier)',
+      );
+      expect(dynamicImport).toHaveBeenCalledWith('node:module');
+      expect(dynamicImport).toHaveBeenCalledWith('node:dns');
     } finally {
       runtimeProcess.getBuiltinModule = originalGetBuiltinModule;
+      vi.unstubAllGlobals();
     }
   });
 });

--- a/packages/provider-utils/src/safe-node-fetch.ts
+++ b/packages/provider-utils/src/safe-node-fetch.ts
@@ -141,8 +141,7 @@ function isNodeDefaultFetch(fetch: FetchFunction): boolean {
 
 async function createSafeNodeFetch(): Promise<FetchFunction> {
   // Node 20.16+ exposes getBuiltinModule; older supported Node versions use an
-  // indirect dynamic import. Keeping the specifier non-literal prevents browser
-  // bundlers from pulling Node built-ins into the provider-utils entry point.
+  // indirect dynamic import that is hidden from browser bundle parsers.
   const [{ createRequire }, { lookup }] = await Promise.all([
     loadNodeModule<NodeModule>('node:module'),
     loadNodeModule<NodeDns>('node:dns'),
@@ -180,8 +179,18 @@ async function loadNodeModule<T>(id: string): Promise<T> {
     : (builtinModule as T);
 }
 
+let dynamicImport: ((specifier: string) => Promise<unknown>) | undefined;
+
 function importNodeModule(id: string): Promise<unknown> {
-  return import(id);
+  // Metro rejects non-static dynamic imports while parsing, even though this
+  // Node-only fallback is never executed in React Native. Construct the import
+  // function lazily so the distributed module contains no import expression for
+  // Metro to analyze and runtimes with process.getBuiltinModule avoid it.
+  dynamicImport ??= Function('specifier', 'return import(specifier)') as (
+    specifier: string,
+  ) => Promise<unknown>;
+
+  return dynamicImport(id);
 }
 
 function getCurrentModulePath(): string {


### PR DESCRIPTION
## Background

The v7 implementation from #18072 uses `process.getBuiltinModule`, which Metro can parse because it contains no dynamic import expression. The v6 backport in #18095 added a non-static `import(id)` fallback to preserve Node 18 support, but Metro rejects that syntax before React Native or Hermes can execute the runtime guard.

## Summary

- construct the Node 18 dynamic importer lazily from a string so Metro has no dynamic import expression to analyze
- continue using `process.getBuiltinModule` on Node versions that provide it
- preserve the Node 18-compatible fallback and its internal, fixed module specifiers
- strengthen the fallback regression test and add a provider-utils patch changeset

## Verification

- `pnpm --filter @ai-sdk/provider-utils test:node` — 57 files, 505 tests passed
- `pnpm --filter @ai-sdk/provider-utils test:edge` — 57 files, 505 tests passed
- `pnpm --filter @ai-sdk/provider-utils type-check`
- `pnpm --filter @ai-sdk/provider-utils build`
- `pnpm check`
- `pnpm type-check:full`
- React Native 0.86.2 / Metro 0.84.3 bundle importing `useChat` from `@ai-sdk/react@3.0.245`:
  - published `@ai-sdk/provider-utils@4.0.41`: fails at `dist/index.mjs:481` with `Invalid call: import(id)`
  - patched 4.0.41 package tarball: bundle completes successfully
- disabling `process.getBuiltinModule` in a standalone Node process still loads `node:module`, `node:dns`, and Undici successfully

Fixes #18545
