### PR TITLE
chore(xai): drop the unused @ai-sdk/openai-compatible dependency

### DIFF
--- a/.changeset/olive-pugs-tickle.md
+++ b/.changeset/olive-pugs-tickle.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/xai': patch
+---
+
+chore(xai): drop the unused `@ai-sdk/openai-compatible` dependency
+
+This provider was originally built on the shared openai-compatible model and
+has since been rewritten to implement its own, with its own tool preparation,
+finish-reason mapping and response metadata helpers. Nothing in the package
+imports `@ai-sdk/openai-compatible` any more, but the dependency and the
+TypeScript project reference to it were both left behind. No runtime change.

--- a/packages/xai/package.json
+++ b/packages/xai/package.json
@@ -42,7 +42,6 @@
     }
   },
   "dependencies": {
-    "@ai-sdk/openai-compatible": "workspace:*",
     "@ai-sdk/provider": "workspace:*",
     "@ai-sdk/provider-utils": "workspace:*"
   },

--- a/packages/xai/tsconfig.json
+++ b/packages/xai/tsconfig.json
@@ -13,9 +13,6 @@
   ],
   "references": [
     {
-      "path": "../openai-compatible"
-    },
-    {
       "path": "../provider"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2547,6 +2547,7 @@ importers:
       zod:
         specifier: 3.25.76
         version: 3.25.76
+
   packages/gateway:
     dependencies:
       '@ai-sdk/provider':
@@ -4127,9 +4128,6 @@ importers:
 
   packages/xai:
     dependencies:
-      '@ai-sdk/openai-compatible':
-        specifier: workspace:*
-        version: link:../openai-compatible
       '@ai-sdk/provider':
         specifier: workspace:*
         version: link:../provider


### PR DESCRIPTION
## Background

`@ai-sdk/xai` was originally built on the shared openai-compatible chat model — the CHANGELOG still records it: `feat (provider/xai): Add grok-2 models, use openai-compatible base impl.` It has since been rewritten to implement its own language model, with its own tool preparation, finish-reason mapping and response-metadata helpers.

Nothing in the package imports `@ai-sdk/openai-compatible` any more, in `src` or in tests, but the dependency and a TypeScript project reference to it were both left behind. `@ai-sdk/deepseek` went through the same migration and lists only `@ai-sdk/provider` and `@ai-sdk/provider-utils`; this brings xai in line.

## Summary

- Removed `@ai-sdk/openai-compatible` from `dependencies`.
- Removed the `../openai-compatible` entry from `references` in `tsconfig.json`.

No source changes, no runtime change.

## End-to-End Verification

Confirmed the dependency is genuinely unreferenced first — the only remaining mentions anywhere in the package are historical CHANGELOG entries. After removal: reinstalled and confirmed the `node_modules/@ai-sdk` symlink is gone, rebuilt, ran `type-check` and the node suite (384 tests, passing).

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)