### PR TITLE
fix(provider-utils): make URL regex checks stateless

### DIFF
--- a/.changeset/pure-url-patterns.md
+++ b/.changeset/pure-url-patterns.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Make URL support checks independent of state retained by global or sticky regular expressions.

--- a/.changeset/pure-url-patterns.md
+++ b/.changeset/pure-url-patterns.md
@@ -2,4 +2,4 @@
 '@ai-sdk/provider-utils': patch
 ---
 
-Make URL support checks independent of state retained by global or sticky regular expressions.
+fix(provider-utils) make URL support checks independent of state retained by global or sticky regular expressions

--- a/.changeset/pure-url-patterns.md
+++ b/.changeset/pure-url-patterns.md
@@ -2,4 +2,4 @@
 '@ai-sdk/provider-utils': patch
 ---
 
-fix(provider-utils) make URL support checks independent of state retained by global or sticky regular expressions
+fix(provider-utils): make URL regex checks stateless

--- a/packages/provider-utils/src/is-url-supported.test.ts
+++ b/packages/provider-utils/src/is-url-supported.test.ts
@@ -321,4 +321,106 @@ describe('isUrlSupported', () => {
       ).toBe(false);
     });
   });
+
+  describe('stateful regular expressions', () => {
+    const url = 'https://example.com/asset';
+
+    it('returns the same result for repeated global-regexp checks', () => {
+      const pattern = /https:\/\/example\.com\/asset/g;
+      const supportedUrls = { 'image/*': [pattern] };
+
+      expect(
+        Array.from({ length: 4 }, () =>
+          isUrlSupported({ mediaType: 'image/png', url, supportedUrls }),
+        ),
+      ).toEqual([true, true, true, true]);
+      expect(pattern.lastIndex).toBe(0);
+    });
+
+    it('returns the same result for repeated sticky-regexp checks', () => {
+      const pattern = /https:\/\/example\.com\/asset/y;
+      const supportedUrls = { 'image/*': [pattern] };
+
+      expect(
+        Array.from({ length: 4 }, () =>
+          isUrlSupported({ mediaType: 'image/png', url, supportedUrls }),
+        ),
+      ).toEqual([true, true, true, true]);
+      expect(pattern.lastIndex).toBe(0);
+    });
+
+    it('does not depend on or mutate caller-owned lastIndex', () => {
+      const globalPattern = /https:\/\/example\.com\/asset/g;
+      const stickyPattern = /https:\/\/example\.com\/asset/y;
+      globalPattern.lastIndex = 7;
+      stickyPattern.lastIndex = 11;
+
+      expect(
+        isUrlSupported({
+          mediaType: 'image/png',
+          url,
+          supportedUrls: { 'image/*': [globalPattern, stickyPattern] },
+        }),
+      ).toBe(true);
+      expect(globalPattern.lastIndex).toBe(7);
+      expect(stickyPattern.lastIndex).toBe(11);
+
+      expect(
+        isUrlSupported({
+          mediaType: 'image/png',
+          url,
+          supportedUrls: { 'image/*': [stickyPattern] },
+        }),
+      ).toBe(true);
+      expect(globalPattern.lastIndex).toBe(7);
+      expect(stickyPattern.lastIndex).toBe(11);
+    });
+
+    it('preserves state for non-matching patterns', () => {
+      const pattern = /https:\/\/other\.example\/asset/g;
+      pattern.lastIndex = 5;
+
+      expect(
+        isUrlSupported({
+          mediaType: 'image/png',
+          url,
+          supportedUrls: { 'image/*': [pattern] },
+        }),
+      ).toBe(false);
+      expect(pattern.lastIndex).toBe(5);
+    });
+
+    it('restores caller-owned state when evaluation throws', () => {
+      const pattern = /https:\/\/example\.com\/asset/g;
+      pattern.lastIndex = 5;
+      pattern.exec = () => {
+        pattern.lastIndex = 12;
+        throw new Error('test error');
+      };
+
+      expect(() =>
+        isUrlSupported({
+          mediaType: 'image/png',
+          url,
+          supportedUrls: { 'image/*': [pattern] },
+        }),
+      ).toThrow('test error');
+      expect(pattern.lastIndex).toBe(5);
+    });
+
+    it('preserves frozen non-stateful regexp behavior', () => {
+      const pattern = /https:\/\/example\.com\/asset/;
+      pattern.lastIndex = 5;
+      Object.freeze(pattern);
+
+      expect(
+        isUrlSupported({
+          mediaType: 'image/png',
+          url,
+          supportedUrls: { 'image/*': [pattern] },
+        }),
+      ).toBe(true);
+      expect(pattern.lastIndex).toBe(5);
+    });
+  });
 });

--- a/packages/provider-utils/src/is-url-supported.ts
+++ b/packages/provider-utils/src/is-url-supported.ts
@@ -50,6 +50,23 @@ export function isUrlSupported({
       })
       .flatMap(({ regexes }) => regexes)
       // check if any pattern matches the url:
-      .some(pattern => pattern.test(url))
+      .some(pattern => testRegExpFromStart(pattern, url))
   );
+}
+
+function testRegExpFromStart(pattern: RegExp, value: string): boolean {
+  if (!pattern.global && !pattern.sticky) {
+    return pattern.test(value);
+  }
+
+  // Global and sticky regexes retain match state in lastIndex.
+  // Evaluate from the start without changing caller-owned state.
+  const lastIndex = pattern.lastIndex;
+  pattern.lastIndex = 0;
+
+  try {
+    return pattern.test(value);
+  } finally {
+    pattern.lastIndex = lastIndex;
+  }
 }


### PR DESCRIPTION
## Background

`isUrlSupported()` evaluates configured URL patterns with `RegExp.test()`. Global and sticky regular expressions retain match state in `lastIndex`, so a shared pattern can make identical URL-support checks depend on previous evaluations and can mutate caller-owned state.

## Summary

* Keep the existing direct `.test()` path for ordinary regexes.
* Evaluate global and sticky regexes from index zero.
* Restore the caller's original `lastIndex` in `finally`.
* Add regression coverage to the existing `is-url-supported.test.ts` suite for repeated checks, caller-owned state, mismatch and throw paths, and frozen ordinary regexes.
* Add a patch changeset for `@ai-sdk/provider-utils`.

The helper uses `finally` so caller-owned state is restored even if custom RegExp execution mutates `lastIndex` and then throws.

This does not change URL normalization, media-type matching, wildcard behavior, or the public API.

## End-to-End Verification

* `pnpm -C packages/provider build`
* `pnpm -C packages/provider-utils test`
* `pnpm -C packages/provider-utils type-check`

## Checklist

* [x] All commits are signed
* [x] Tests have been added / updated
* [ ] Documentation has been added / updated
* [x] A *patch* changeset for the relevant package has been added
* [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #18569