### PR TITLE
fix(provider-utils): preserve streamed size-limit errors during cleanup

### DIFF
--- a/.changeset/tidy-readers-preserve-errors.md
+++ b/.changeset/tidy-readers-preserve-errors.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Preserve streamed download size errors when reader cancellation fails during cleanup.

--- a/packages/provider-utils/src/read-response-with-size-limit.test.ts
+++ b/packages/provider-utils/src/read-response-with-size-limit.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { readResponseWithSizeLimit } from './read-response-with-size-limit';
+import { describe, expect, it, vi } from 'vitest';
 import { DownloadError } from './download-error';
+import { readResponseWithSizeLimit } from './read-response-with-size-limit';
 
 function createMockResponse({
   body,
@@ -119,6 +119,36 @@ describe('readResponseWithSizeLimit', () => {
       );
       return true;
     });
+  });
+
+  it('should preserve the size error when stream cancellation rejects', async () => {
+    const cancelError = new Error('cancel failed');
+    const cancel = vi.fn(() => Promise.reject(cancelError));
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]));
+      },
+      cancel,
+    });
+    const response = {
+      headers: new Headers(),
+      body,
+    } as unknown as Response;
+
+    await expect(
+      readResponseWithSizeLimit({
+        response,
+        url: 'http://example.com/streaming',
+        maxBytes: 1,
+      }),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(DownloadError.isInstance(error)).toBe(true);
+      expect(error).not.toBe(cancelError);
+      return true;
+    });
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(body.locked).toBe(false);
   });
 
   it('should handle lying Content-Length (says small, sends large)', async () => {

--- a/packages/provider-utils/src/read-response-with-size-limit.ts
+++ b/packages/provider-utils/src/read-response-with-size-limit.ts
@@ -84,6 +84,8 @@ export async function readResponseWithSizeLimit({
   } finally {
     try {
       await reader.cancel();
+    } catch {
+      // Ignore cancel errors so the original rejection is preserved.
     } finally {
       reader.releaseLock();
     }


### PR DESCRIPTION
## Background

`readResponseWithSizeLimit()` cancels its reader in `finally`.

When streamed bytes exceed `maxBytes`, the function has already selected a `DownloadError`. If the underlying stream's cancellation algorithm then rejects, the cancellation error currently replaces that size-limit error.

The adjacent `cancelResponseBody()` helper already follows the opposite cleanup policy: cancellation failures are contained so they don't mask the operation's original rejection.

## Summary

* contain rejection from terminal `reader.cancel()` cleanup;
* always release the reader lock;
* add a native `ReadableStream` regression where streamed overflow is followed by rejecting cancellation;
* add a patch changeset for `@ai-sdk/provider-utils`.

The read loop, byte accounting, Content-Length behavior, returned bytes, and public API aren't changed.

## End-to-End Verification

A native Web Streams reproduction against the unfixed current-main implementation sends two bytes with a one-byte size limit and makes the underlying stream cancellation reject.

Before the change, the observed rejection is:

```text
Error: cancel failed
```

With this change, the same reproduction preserves the intended size-limit `DownloadError`, cancellation is still attempted, and the stream is unlocked afterward.

## Checklist

* [x] All commits are signed
* [x] Tests have been added / updated
* [ ] Documentation has been added / updated
* [x] A patch changeset for the relevant package has been added
* [x] I've reviewed this pull request

## Related Issues

* Closes #18571
