### PR TITLE
fix(harness-acp): defer auth resolution until session start to correctly recognize available credentials

### DIFF
--- a/.changeset/itchy-ravens-study.md
+++ b/.changeset/itchy-ravens-study.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-acp": patch
+---
+
+fix(harness-acp): defer auth resolution until session start to correctly recognize available credentials

--- a/packages/harness-acp/src/acp-harness.test.ts
+++ b/packages/harness-acp/src/acp-harness.test.ts
@@ -10,7 +10,6 @@ import { safeParseJSON, safeValidateTypes, tool } from '@ai-sdk/provider-utils';
 import * as fsPromises from 'node:fs/promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
-import { createACPAuthenticationProfileIdentity } from './acp-auth';
 import { createACP } from './acp-harness';
 import {
   resolveBridgeAssetCandidates,
@@ -2640,6 +2639,65 @@ describe('createACP', () => {
     await session.doDestroy();
   });
 
+  it('resolves automatic provider authentication from the session-start environment', async () => {
+    vi.stubEnv('AI_GATEWAY_API_KEY', '');
+    vi.stubEnv('VERCEL_OIDC_TOKEN', '');
+    const spawns: Array<{
+      command: string;
+      env: Record<string, string | undefined>;
+    }> = [];
+    const harness = createACP({
+      harnessId: 'late-auth-acp',
+      implementation: {
+        ...implementation,
+        forwardEnv: [],
+      },
+      providerAuthentication: {
+        gateway: {
+          env: {
+            PROVIDER_API_KEY: { $source: 'gateway-api-key' },
+          },
+        },
+      },
+    });
+
+    vi.stubEnv('AI_GATEWAY_API_KEY', 'late-gateway-key');
+    vi.stubEnv('AI_GATEWAY_BASE_URL', 'https://gateway.example/late');
+    const session = await harness.doStart({
+      sessionId: 'session-1',
+      sandboxSession: fakeSandbox({
+        runs: [],
+        spawns,
+        stop: async () => {},
+      }),
+      sessionWorkDir: '/workspace/user-project',
+    });
+
+    expect(spawns[0]!.env.AI_SDK_ACP_GATEWAY_API_KEY).toBe('late-gateway-key');
+    expect(spawns[0]!.env.AI_SDK_ACP_GATEWAY_BASE_URL).toBe(
+      'https://gateway.example/late',
+    );
+    expect(
+      await safeParseJSON({
+        text: spawns[0]!.env[ACP_BRIDGE_CONFIGURATION_ENV]!,
+      }),
+    ).toMatchObject({
+      success: true,
+      value: {
+        providerAuthentication: {
+          type: 'ai-gateway',
+        },
+      },
+    });
+    expect((await session.doStop()).data).toMatchObject({
+      authenticationProfile: {
+        providerKind: 'ai-gateway',
+        providerMode: 'auto',
+        gatewayCredentialSource: 'AI_GATEWAY_API_KEY',
+      },
+    });
+  });
+
   it('excludes resolved credentials from bootstrap and lifecycle state', async () => {
     vi.stubEnv('PROVIDER_API_KEY', 'direct-secret');
     vi.stubEnv('AI_GATEWAY_API_KEY', 'gateway-secret');
@@ -2750,7 +2808,7 @@ describe('createACP', () => {
     });
   });
 
-  it('rejects lifecycle state from an incompatible implementation identity', async () => {
+  it('validates lifecycle state structurally and rejects incompatible identities at start', async () => {
     const first = createACP({
       harnessId: 'identity-acp',
       implementation,
@@ -2762,33 +2820,30 @@ describe('createACP', () => {
         args: ['different'],
       },
     });
-    const firstBootstrap = await first.getBootstrap!();
-    const descriptorText = firstBootstrap.files.find(file =>
-      file.path.endsWith('/implementation.json'),
-    )?.content;
-    expect(descriptorText).toBeDefined();
-    const descriptor = await safeParseJSON({ text: descriptorText! });
-    expect(descriptor.success).toBe(true);
-    if (!descriptor.success) return;
-    const implementationIdentity = (
-      descriptor.value as { implementationIdentity: string }
-    ).implementationIdentity;
-    const authenticationProfile = createACPAuthenticationProfileIdentity({
-      authentication: undefined,
-      providerAuthenticationCompatibility: undefined,
+    const sandbox = fakeSandbox({
+      runs: [],
+      spawns: [],
+      stop: async () => {},
     });
+    const firstSession = await first.doStart({
+      sessionId: 'session-1',
+      sandboxSession: sandbox,
+      sessionWorkDir: '/workspace/user-project',
+    });
+    const resumeFrom = await firstSession.doStop();
+    const lifecycleData = resumeFrom.data as Record<string, unknown>;
+    const authenticationProfile = lifecycleData.authenticationProfile as Record<
+      string,
+      unknown
+    >;
 
-    const compatible = await safeValidateTypes({
-      value: { implementationIdentity, authenticationProfile },
-      schema: first.lifecycleStateSchema!,
-    });
-    const incompatible = await safeValidateTypes({
-      value: { implementationIdentity, authenticationProfile },
+    const structurallyCompatible = await safeValidateTypes({
+      value: lifecycleData,
       schema: second.lifecycleStateSchema!,
     });
     const legacyCompatible = await safeValidateTypes({
       value: {
-        implementationIdentity,
+        ...lifecycleData,
         authenticationProfile: {
           ...authenticationProfile,
           providerKind: 'implementation-default',
@@ -2796,8 +2851,7 @@ describe('createACP', () => {
       },
       schema: first.lifecycleStateSchema!,
     });
-    expect(compatible.success).toBe(true);
-    expect(incompatible.success).toBe(false);
+    expect(structurallyCompatible.success).toBe(true);
     expect(legacyCompatible).toMatchObject({
       success: true,
       value: {
@@ -2806,5 +2860,15 @@ describe('createACP', () => {
         },
       },
     });
+    await expect(
+      second.doStart({
+        sessionId: 'session-1',
+        sandboxSession: sandbox,
+        sessionWorkDir: '/workspace/user-project',
+        resumeFrom,
+      }),
+    ).rejects.toThrow(
+      'ACP lifecycle state is incompatible with the configured implementation.',
+    );
   });
 });

--- a/packages/harness-acp/src/acp-harness.ts
+++ b/packages/harness-acp/src/acp-harness.ts
@@ -1,19 +1,11 @@
 import type { HarnessV1 } from '@ai-sdk/harness';
 import type { ToolSet } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
-import {
-  createACPAuthenticationProfileIdentity,
-  resolveACPProviderAuthenticationCompatibility,
-  type ACPAuthenticationProfileIdentity,
-  type ACPClientApp,
-} from './acp-auth';
+import type { ACPClientApp } from './acp-auth';
 import { createACPV1, type ACPV1Settings } from './v1';
-import { createImplementationIdentity } from './v1/implementation';
 import {
   acpColdSessionStateSchema,
   acpTurnStartConfigSchema,
-  type ACPColdSessionState,
-  type ACPTurnStartConfig,
 } from './v1/acp-v1-bridge-protocol';
 import { VERSION } from './version';
 
@@ -86,8 +78,6 @@ const acpResumeStateSchema = z.object({
   skillsFingerprint: z.string().optional(),
 });
 
-type ACPBridgeCoords = z.infer<typeof acpBridgeCoordsSchema>;
-
 export function createACP<TBuiltinTools extends ToolSet = {}>(
   settings: ACPHarnessSettings<TBuiltinTools>,
 ): HarnessV1<TBuiltinTools> {
@@ -95,50 +85,6 @@ export function createACP<TBuiltinTools extends ToolSet = {}>(
   switch (version) {
     case 'v1': {
       const clientApp = settings.clientApp ?? ACP_CLIENT_APP;
-      const providerAuthenticationCompatibility =
-        resolveACPProviderAuthenticationCompatibility({
-          auth: settings.auth,
-          providerAuthentication: settings.providerAuthentication,
-          env: process.env,
-        });
-      const implementationIdentity = createImplementationIdentity({
-        harnessId: settings.harnessId,
-        acpVersion: version,
-        implementation: settings.implementation,
-        clientApp,
-        providerAuthentication: providerAuthenticationCompatibility,
-        permissionModeMapping: settings.permissionModeMapping,
-      });
-      const authenticationProfile = createACPAuthenticationProfileIdentity({
-        authentication: settings.authentication,
-        providerAuthenticationCompatibility,
-      });
-      const lifecycleStateSchema: z.ZodType<{
-        readonly implementationIdentity: string;
-        readonly authenticationProfile?: ACPAuthenticationProfileIdentity;
-        readonly acpSessionId?: string;
-        readonly bridge?: ACPBridgeCoords;
-        readonly coldSession?: ACPColdSessionState;
-        readonly turnStartConfig?: ACPTurnStartConfig;
-        readonly recovery?: {
-          readonly mode: 'disk-replay' | 'lossy-rerun';
-          readonly reason: string;
-        };
-        readonly restoration?: {
-          readonly method: 'resume' | 'load';
-        };
-        readonly initialGuidanceApplied?: boolean;
-        readonly skillsMaterialized?: boolean;
-        readonly skillsFingerprint?: string;
-      }> = acpResumeStateSchema.extend({
-        implementationIdentity: z.literal(implementationIdentity),
-        authenticationProfile: acpResumeStateSchema.shape.authenticationProfile
-          .unwrap()
-          .extend({
-            digest: z.literal(authenticationProfile.digest),
-          })
-          .optional(),
-      });
       return createACPV1({
         settings,
         builtinTools:
@@ -146,10 +92,7 @@ export function createACP<TBuiltinTools extends ToolSet = {}>(
         port: settings.port,
         startupTimeoutMs: settings.startupTimeoutMs,
         clientApp,
-        implementationIdentity,
-        authenticationProfile,
-        providerAuthenticationCompatibility,
-        lifecycleStateSchema,
+        lifecycleStateSchema: acpResumeStateSchema,
       });
     }
     default:

--- a/packages/harness-acp/src/v1/acp-v1-harness.ts
+++ b/packages/harness-acp/src/v1/acp-v1-harness.ts
@@ -34,13 +34,15 @@ import {
 } from '@ai-sdk/provider-utils';
 import { WebSocket } from 'ws';
 import {
+  createACPAuthenticationProfileIdentity,
   resolveACPProviderAuthentication,
+  resolveACPProviderAuthenticationCompatibility,
   type ACPAuthenticationProfileIdentity,
   type ACPClientApp,
-  type ACPProviderAuthenticationCompatibility,
 } from '../acp-auth';
 import {
   createImplementationDescriptor,
+  createImplementationIdentity,
   createImplementationInstallCommand,
   createImplementationManifest,
   getImplementationLockfile,
@@ -112,9 +114,6 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
   port: portOverride,
   startupTimeoutMs,
   clientApp,
-  implementationIdentity,
-  authenticationProfile,
-  providerAuthenticationCompatibility,
   lifecycleStateSchema,
 }: {
   settings: ACPV1Settings;
@@ -122,11 +121,6 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
   port?: number;
   startupTimeoutMs?: number;
   clientApp: ACPClientApp;
-  implementationIdentity: string;
-  authenticationProfile: ACPAuthenticationProfileIdentity;
-  providerAuthenticationCompatibility:
-    | ACPProviderAuthenticationCompatibility
-    | undefined;
   lifecycleStateSchema: NonNullable<
     HarnessV1<TBuiltinTools>['lifecycleStateSchema']
   >;
@@ -193,7 +187,6 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
             path: `${BOOTSTRAP_DIR}/implementation/implementation.json`,
             content: createImplementationDescriptor({
               implementation: settings.implementation,
-              implementationIdentity,
             }),
           },
           ...(implementationLock == null
@@ -229,6 +222,25 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
         });
       }
       const permissionMode = startOptions.permissionMode ?? 'allow-all';
+      const env = { ...process.env };
+      const providerAuthenticationCompatibility =
+        resolveACPProviderAuthenticationCompatibility({
+          auth: settings.auth,
+          providerAuthentication: settings.providerAuthentication,
+          env,
+        });
+      const implementationIdentity = createImplementationIdentity({
+        harnessId: settings.harnessId,
+        acpVersion: 'v1',
+        implementation: settings.implementation,
+        clientApp,
+        providerAuthentication: providerAuthenticationCompatibility,
+        permissionModeMapping: settings.permissionModeMapping,
+      });
+      const authenticationProfile = createACPAuthenticationProfileIdentity({
+        authentication: settings.authentication,
+        providerAuthenticationCompatibility,
+      });
 
       const resolvedProviderAuthentication = resolveACPProviderAuthentication({
         auth: {
@@ -236,7 +248,7 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
           providerAuthentication: settings.providerAuthentication,
           clientApp,
         },
-        env: process.env,
+        env,
         compatibility: providerAuthenticationCompatibility,
       });
       const sandboxSession = startOptions.sandboxSession;
@@ -473,7 +485,7 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
         env: {
           ...resolveImplementationEnvironment({
             implementation: settings.implementation,
-            env: process.env,
+            env,
           }),
           ...createACPBridgeEnvironment({
             authentication: settings.authentication,

--- a/packages/harness-acp/src/v1/implementation.test.ts
+++ b/packages/harness-acp/src/v1/implementation.test.ts
@@ -224,13 +224,12 @@ describe('ACP npm implementation', () => {
   it('keeps sensitive values out of immutable descriptors', () => {
     const descriptor = createImplementationDescriptor({
       implementation: simpleImplementation,
-      implementationIdentity: identity(),
     });
 
     expect(descriptor).toContain('"PROVIDER_API_KEY"');
     expect(descriptor).toContain('"SECOND_PROVIDER_API_KEY"');
     expect(descriptor).toContain('"PROVIDER_BASE_URL"');
-    expect(descriptor).toContain('"implementationIdentity"');
+    expect(descriptor).not.toContain('"implementationIdentity"');
     expect(descriptor).not.toContain('https://provider.example');
   });
 

--- a/packages/harness-acp/src/v1/implementation.ts
+++ b/packages/harness-acp/src/v1/implementation.ts
@@ -88,10 +88,8 @@ export function getImplementationLockfile({
 
 export function createImplementationDescriptor({
   implementation,
-  implementationIdentity,
 }: {
   implementation: ACPNpmImplementation;
-  implementationIdentity: string;
 }): string {
   return (
     JSON.stringify(
@@ -99,7 +97,6 @@ export function createImplementationDescriptor({
         executable: implementation.executable,
         args: implementation.args ?? [],
         envKeys: getImplementationEnvironmentKeys({ implementation }),
-        implementationIdentity,
       },
       null,
       2,


### PR DESCRIPTION
## Background

ACP provider authentication was resolved when the harness was created, so credentials added later, e.g. just before session start were not recognized.

## Summary

- Resolve provider authentication and the derived implementation identity from a stable session-start environment snapshot.
- Keep lifecycle-state validation structural, while enforcing implementation compatibility when starting or resuming a session.
- Remove the session-derived identity from immutable bootstrap metadata and add regression coverage.

## End-to-End Verification

End-to-end examples with different auth credentials (provider-direct vs AI Gateway) were run to verify.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
