### PR TITLE
feat(video): allow `aspectRatio: 'adaptive'` on generateVideo

### DIFF
--- a/.changeset/tidy-pugs-hammer.md
+++ b/.changeset/tidy-pugs-hammer.md
@@ -1,0 +1,13 @@
+---
+'@ai-sdk/provider': patch
+'ai': patch
+---
+
+feat(video): allow `aspectRatio: 'adaptive'` on `generateVideo`
+
+Some video models derive the output ratio from the input and reject explicit
+`{width}:{height}` values — BytePlus Seedance 2.5 does this for first-frame,
+first-and-last-frame, editing, and extension tasks. `aspectRatio` on
+`VideoModelV3CallOptions`, `VideoModelV4CallOptions`, and
+`experimental_generateVideo` is now `` `${number}:${number}` | 'adaptive' ``, so
+those calls no longer need a type assertion. Support is provider-specific.

--- a/content/docs/03-ai-sdk-core/38-video-generation.mdx
+++ b/content/docs/03-ai-sdk-core/38-video-generation.mdx
@@ -48,6 +48,22 @@ const { video } = await generateVideo({
 });
 ```
 
+Some models also accept `'adaptive'`, which lets the provider derive the output
+ratio from the input media instead of a fixed value. This is typically required
+for image-to-video, video editing, and video extension, where the output
+inherits the ratio of the input and an explicit ratio is rejected.
+
+```tsx highlight={"7"}
+import { experimental_generateVideo as generateVideo } from 'ai';
+__PROVIDER_IMPORT__;
+
+const { video } = await generateVideo({
+  model: __VIDEO_MODEL__,
+  prompt: { image: firstFrame, text: 'A cat walking on a treadmill' },
+  aspectRatio: 'adaptive',
+});
+```
+
 ### Resolution
 
 The resolution is specified as a string in the format `{width}x{height}`.

--- a/content/docs/07-reference/01-ai-sdk-core/13-generate-video.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/13-generate-video.mdx
@@ -83,7 +83,7 @@ console.log(videos);
       type: 'string',
       isOptional: true,
       description:
-        'Aspect ratio of the videos to generate. Format: `{width}:{height}`.',
+        "Aspect ratio of the videos to generate. Format: `{width}:{height}`, or `'adaptive'` to inherit the ratio from the input media (e.g. a first-frame image or a source video). Support for `'adaptive'` is provider-specific.",
     },
     {
       name: 'resolution',

--- a/content/providers/01-ai-sdk-providers/85-bytedance.mdx
+++ b/content/providers/01-ai-sdk-providers/85-bytedance.mdx
@@ -253,6 +253,14 @@ const { video } = await generateVideo({
 });
 ```
 
+<Note>
+  When the output ratio is dictated by an input — first-frame or
+  first-and-last-frame image-to-video, video editing, and video extension — pass
+  `aspectRatio: 'adaptive'` or omit `aspectRatio` entirely. Newer Seedance
+  models reject an explicit ratio on those paths, because the output inherits
+  the ratio of the input media.
+</Note>
+
 ### Image-to-Video with Audio
 
 Seedance 1.5 Pro supports generating synchronized audio alongside the video:

--- a/packages/ai/src/generate-video/generate-video.ts
+++ b/packages/ai/src/generate-video/generate-video.ts
@@ -93,7 +93,7 @@ export type GenerateVideoWebhookFactory = () => PromiseLike<{
  * @param model - The video model to use.
  * @param prompt - The prompt that should be used to generate the video.
  * @param n - Number of videos to generate. Default: 1.
- * @param aspectRatio - Aspect ratio of the videos to generate. Must have the format `{width}:{height}`.
+ * @param aspectRatio - Aspect ratio of the videos to generate. Must have the format `{width}:{height}`, or `'adaptive'`.
  * @param resolution - Resolution of the videos to generate. Must have the format `{width}x{height}`.
  * @param duration - Duration of the video in seconds.
  * @param fps - Frames per second for the video.
@@ -155,9 +155,10 @@ export async function experimental_generateVideo({
   maxVideosPerCall?: number;
 
   /**
-   * Aspect ratio of the videos to generate. Must have the format `{width}:{height}`.
+   * Aspect ratio of the videos to generate. Must have the format
+   * `{width}:{height}`, or `'adaptive'` to inherit the ratio from the input media.
    */
-  aspectRatio?: `${number}:${number}`;
+  aspectRatio?: `${number}:${number}` | 'adaptive';
 
   /**
    * Resolution of the videos to generate. Must have the format `{width}x${height}`.

--- a/packages/bytedance/src/bytedance-video-model.test.ts
+++ b/packages/bytedance/src/bytedance-video-model.test.ts
@@ -156,6 +156,26 @@ describe('ByteDanceVideoModel', () => {
       });
     });
 
+    it('should pass an adaptive aspect ratio through unchanged', async () => {
+      const model = createBasicModel();
+
+      await model.doGenerate({
+        ...defaultOptions,
+        aspectRatio: 'adaptive',
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'seedance-1-0-pro-250528',
+        content: [
+          {
+            type: 'text',
+            text: prompt,
+          },
+        ],
+        ratio: 'adaptive',
+      });
+    });
+
     it('should pass duration when provided', async () => {
       const model = createBasicModel();
 

--- a/packages/provider/src/video-model/v3/video-model-v3-call-options.ts
+++ b/packages/provider/src/video-model/v3/video-model-v3-call-options.ts
@@ -16,11 +16,12 @@ export type VideoModelV3CallOptions = {
 
   /**
    * Aspect ratio of the videos to generate.
-   * Must have the format `{width}:{height}`.
+   * Must have the format `{width}:{height}`, or `'adaptive'` to inherit the
+   * ratio from the input media.
    * `undefined` will use the provider's default aspect ratio.
    * Common values: '16:9', '9:16', '1:1', '21:9', '4:3'
    */
-  aspectRatio: `${number}:${number}` | undefined;
+  aspectRatio: `${number}:${number}` | 'adaptive' | undefined;
 
   /**
    * Resolution of the video to generate.

--- a/packages/provider/src/video-model/v4/video-model-v4-call-options.ts
+++ b/packages/provider/src/video-model/v4/video-model-v4-call-options.ts
@@ -16,11 +16,12 @@ export type VideoModelV4CallOptions = {
 
   /**
    * Aspect ratio of the videos to generate.
-   * Must have the format `{width}:{height}`.
+   * Must have the format `{width}:{height}`, or `'adaptive'` to inherit the
+   * ratio from the input media.
    * `undefined` will use the provider's default aspect ratio.
    * Common values: '16:9', '9:16', '1:1', '21:9', '4:3'
    */
-  aspectRatio: `${number}:${number}` | undefined;
+  aspectRatio: `${number}:${number}` | 'adaptive' | undefined;
 
   /**
    * Resolution of the video to generate.


### PR DESCRIPTION
video models whose output ratio is dictated by the input reject an explicit `{width}:{height}` ratio. seedance is the concrete case: for first-frame image-to-video, first-and-last-frame, video editing, and video extension, `ratio` only accepts `adaptive` and any numeric ratio returns a 400.

widen `aspectRatio` to `${number}:${number} | 'adaptive'` on VideoModelV3CallOptions, VideoModelV4CallOptions, and experimental_generateVideo.
