### PR TITLE
feat(openai): accept serviceTier 'fast' for OpenAI's renamed priority tier

### DIFF
--- a/.changeset/openai-service-tier-fast.md
+++ b/.changeset/openai-service-tier-fast.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Accept `serviceTier: 'fast'` on OpenAI chat and responses models. OpenAI renamed priority processing to Fast mode and accepts `service_tier: 'fast'` and `'priority'` interchangeably, so `'fast'` is now passed through verbatim and gated on the same model capability as `'priority'`.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -217,10 +217,12 @@ The following provider options are available:
   `.nullable()`.
 </Note>
 
-- **serviceTier** _'auto' | 'flex' | 'priority' | 'default'_
+- **serviceTier** _'auto' | 'flex' | 'priority' | 'fast' | 'default'_
   Service tier for the request. Set to 'flex' for 50% cheaper processing
   at the cost of increased latency (available for o3, o4-mini, and gpt-5 models).
   Set to 'priority' for faster processing with Enterprise access (available for gpt-4, gpt-5, gpt-5-mini, o3, o4-mini; gpt-5-nano is not supported).
+  'fast' is OpenAI's newer name for the 'priority' tier; the two are interchangeable, and responses from
+  gpt-5.6 and earlier report `serviceTier: 'priority'` for either.
 
   Defaults to 'auto'.
 
@@ -1991,11 +1993,13 @@ The following optional provider options are available for OpenAI chat models:
 
   Parameters for prediction mode.
 
-- **serviceTier** _'auto' | 'flex' | 'priority' | 'default'_
+- **serviceTier** _'auto' | 'flex' | 'priority' | 'fast' | 'default'_
 
   Service tier for the request. Set to 'flex' for 50% cheaper processing
   at the cost of increased latency (available for o3, o4-mini, and gpt-5 models).
   Set to 'priority' for faster processing with Enterprise access (available for gpt-4, gpt-5, gpt-5-mini, o3, o4-mini; gpt-5-nano is not supported).
+  'fast' is OpenAI's newer name for the 'priority' tier; the two are interchangeable, and responses from
+  gpt-5.6 and earlier report `serviceTier: 'priority'` for either.
 
   Defaults to 'auto'.
 

--- a/packages/openai/src/chat/openai-chat-language-model-options.ts
+++ b/packages/openai/src/chat/openai-chat-language-model-options.ts
@@ -138,11 +138,15 @@ export const openaiLanguageModelChatOptions = lazySchema(() =>
        *           Project settings. Unless otherwise configured, the Project will use 'default'.
        * - 'flex': 50% cheaper processing at the cost of increased latency. Only available for o3 and o4-mini models.
        * - 'priority': Higher-speed processing with predictably low latency at premium cost. Available for Enterprise customers.
+       * - 'fast': The same tier as 'priority', which OpenAI renamed to Fast mode. Both values are accepted
+       *           and interchangeable; responses from gpt-5.6 and earlier echo 'priority' either way.
        * - 'default': The request will be processed with the standard pricing and performance for the selected model.
        *
        * @default 'auto'
        */
-      serviceTier: z.enum(['auto', 'flex', 'priority', 'default']).optional(),
+      serviceTier: z
+        .enum(['auto', 'flex', 'priority', 'fast', 'default'])
+        .optional(),
 
       /**
        * Whether to use strict JSON schema validation.

--- a/packages/openai/src/chat/openai-chat-language-model-options.ts
+++ b/packages/openai/src/chat/openai-chat-language-model-options.ts
@@ -138,8 +138,7 @@ export const openaiLanguageModelChatOptions = lazySchema(() =>
        *           Project settings. Unless otherwise configured, the Project will use 'default'.
        * - 'flex': 50% cheaper processing at the cost of increased latency. Only available for o3 and o4-mini models.
        * - 'priority': Higher-speed processing with predictably low latency at premium cost. Available for Enterprise customers.
-       * - 'fast': The same tier as 'priority', which OpenAI renamed to Fast mode. Both values are accepted
-       *           and interchangeable; responses from gpt-5.6 and earlier echo 'priority' either way.
+       * - 'fast': OpenAI's newer name for the 'priority' tier. Interchangeable with it.
        * - 'default': The request will be processed with the standard pricing and performance for the selected model.
        *
        * @default 'auto'

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -2231,6 +2231,81 @@ describe('doGenerate', () => {
     expect(requestBody.service_tier).toBe('priority');
     expect(result.warnings).toEqual([]);
   });
+
+  it('should send serviceTier fast processing setting', async () => {
+    prepareJsonFixtureResponse('openai-text');
+
+    const model = provider.chat('gpt-4o-mini');
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        openai: {
+          serviceTier: 'fast',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "messages": [
+          {
+            "content": "Hello",
+            "role": "user",
+          },
+        ],
+        "model": "gpt-4o-mini",
+        "service_tier": "fast",
+      }
+    `);
+  });
+
+  it('should show warning when using fast processing with unsupported model', async () => {
+    prepareJsonFixtureResponse('openai-text');
+
+    const model = provider.chat('gpt-3.5-turbo');
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        openai: {
+          serviceTier: 'fast',
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody.service_tier).toBeUndefined();
+
+    expect(result.warnings).toMatchInlineSnapshot(`
+      [
+        {
+          "details": "priority processing is only available for supported models (gpt-4, gpt-5, gpt-5-mini, o3, o4-mini) and requires Enterprise access. gpt-5-nano is not supported",
+          "feature": "serviceTier",
+          "type": "unsupported",
+        },
+      ]
+    `);
+  });
+
+  it('should allow fast processing with gpt-4o model without warnings', async () => {
+    prepareJsonFixtureResponse('openai-text');
+
+    const model = provider.chat('gpt-4o');
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        openai: {
+          serviceTier: 'fast',
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody.service_tier).toBe('fast');
+    expect(result.warnings).toEqual([]);
+  });
 });
 
 describe('doStream', () => {

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -306,9 +306,11 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
       baseArgs.service_tier = undefined;
     }
 
-    // Validate priority processing support
+    // Validate priority processing support. 'fast' is OpenAI's newer name for
+    // the same tier, so it is gated on the same capability.
     if (
-      openaiOptions.serviceTier === 'priority' &&
+      (openaiOptions.serviceTier === 'priority' ||
+        openaiOptions.serviceTier === 'fast') &&
       !modelCapabilities.supportsPriorityProcessing
     ) {
       warnings.push({

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -306,8 +306,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
       baseArgs.service_tier = undefined;
     }
 
-    // Validate priority processing support. 'fast' is OpenAI's newer name for
-    // the same tier, so it is gated on the same capability.
+    // Validate priority processing support
     if (
       (openaiOptions.serviceTier === 'priority' ||
         openaiOptions.serviceTier === 'fast') &&

--- a/packages/openai/src/responses/openai-responses-language-model-options.ts
+++ b/packages/openai/src/responses/openai-responses-language-model-options.ts
@@ -293,10 +293,14 @@ export const openaiLanguageModelResponsesOptionsSchema = lazySchema(() =>
        * Service tier for the request.
        * Set to 'flex' for 50% cheaper processing at the cost of increased latency (available for o3, o4-mini, and gpt-5 models).
        * Set to 'priority' for faster processing with Enterprise access (available for gpt-4, gpt-5, gpt-5-mini, o3, o4-mini; gpt-5-nano is not supported).
+       * Set to 'fast' for the same tier as 'priority', which OpenAI renamed to Fast mode. Both values are
+       * accepted and interchangeable; responses from gpt-5.6 and earlier echo 'priority' either way.
        *
        * Defaults to 'auto'.
        */
-      serviceTier: z.enum(['auto', 'flex', 'priority', 'default']).nullish(),
+      serviceTier: z
+        .enum(['auto', 'flex', 'priority', 'fast', 'default'])
+        .nullish(),
 
       /**
        * Whether to store the generation. Defaults to `true`.

--- a/packages/openai/src/responses/openai-responses-language-model-options.ts
+++ b/packages/openai/src/responses/openai-responses-language-model-options.ts
@@ -293,8 +293,7 @@ export const openaiLanguageModelResponsesOptionsSchema = lazySchema(() =>
        * Service tier for the request.
        * Set to 'flex' for 50% cheaper processing at the cost of increased latency (available for o3, o4-mini, and gpt-5 models).
        * Set to 'priority' for faster processing with Enterprise access (available for gpt-4, gpt-5, gpt-5-mini, o3, o4-mini; gpt-5-nano is not supported).
-       * Set to 'fast' for the same tier as 'priority', which OpenAI renamed to Fast mode. Both values are
-       * accepted and interchangeable; responses from gpt-5.6 and earlier echo 'priority' either way.
+       * Set to 'fast' for the same tier as 'priority' (OpenAI's newer name for it).
        *
        * Defaults to 'auto'.
        */

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1684,6 +1684,51 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should send serviceTier fast provider option', async () => {
+        const { warnings } = await createModel('gpt-5').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              serviceTier: 'fast',
+            } satisfies OpenAILanguageModelResponsesOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-5',
+          input: [
+            { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+          ],
+          service_tier: 'fast',
+        });
+
+        expect(warnings).toStrictEqual([]);
+      });
+
+      it('should warn and drop serviceTier fast for a model without priority processing', async () => {
+        const { warnings } = await createModel('gpt-5-nano').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              serviceTier: 'fast',
+            } satisfies OpenAILanguageModelResponsesOptions,
+          },
+        });
+
+        expect(
+          (await server.calls[0].requestBodyJson).service_tier,
+        ).toBeUndefined();
+
+        expect(warnings).toStrictEqual([
+          {
+            type: 'unsupported',
+            feature: 'serviceTier',
+            details:
+              'priority processing is only available for supported models (gpt-4, gpt-5, gpt-5-mini, o3, o4-mini) and requires Enterprise access. gpt-5-nano is not supported',
+          },
+        ]);
+      });
+
       it('should send truncation auto provider option', async () => {
         const { warnings } = await createModel('gpt-5').doGenerate({
           prompt: TEST_PROMPT,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -572,9 +572,11 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
       delete (baseArgs as any).service_tier;
     }
 
-    // Validate priority processing support
+    // Validate priority processing support. 'fast' is OpenAI's newer name for
+    // the same tier, so it is gated on the same capability.
     if (
-      openaiOptions?.serviceTier === 'priority' &&
+      (openaiOptions?.serviceTier === 'priority' ||
+        openaiOptions?.serviceTier === 'fast') &&
       !modelCapabilities.supportsPriorityProcessing
     ) {
       warnings.push({

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -572,8 +572,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
       delete (baseArgs as any).service_tier;
     }
 
-    // Validate priority processing support. 'fast' is OpenAI's newer name for
-    // the same tier, so it is gated on the same capability.
+    // Validate priority processing support
     if (
       (openaiOptions?.serviceTier === 'priority' ||
         openaiOptions?.serviceTier === 'fast') &&


### PR DESCRIPTION
references

- https://developers.openai.com/api/docs/guides/priority-processing
- https://help.openai.com/en/articles/11647665-fast-mode-faq

summary

- add `'fast'` to the `serviceTier` enum on both the chat and responses provider options. the value is forwarded verbatim as `service_tier: "fast"`
- gate `'fast'` on the existing `supportsPriorityProcessing` capability rather than a new one, since it is the same tier. Unsupported models get the same warning and the same `service_tier` removal as `'priority'`.

note on the response side: for gpt-5.6 and earlier, oai echoes `service_tier: "priority"` regardless of which value was sent, so `providerMetadata.openai.serviceTier` may read `'priority'` after a `'fast'` request. oai says future models will echo `'fast'`. this pr reports the echoed value as-is rather than normalizing it.