### PR TITLE
chore: fix flakey OpenCode harness test

### DIFF
--- a/packages/harness-opencode/src/bridge/tool-relay-auth.test.ts
+++ b/packages/harness-opencode/src/bridge/tool-relay-auth.test.ts
@@ -14,7 +14,7 @@ describe('ToolRelayAuthorizer', () => {
   });
 
   test('consumes matching authorization exactly once', async () => {
-    const authorizer = new ToolRelayAuthorizer({ ttlMs: 10 });
+    const authorizer = new ToolRelayAuthorizer({ ttlMs: 10, now: () => 1_000 });
     const call = { toolName: 'get_weather', input: { city: 'Paris' } };
 
     authorizer.authorizeToolCall(call);
@@ -28,7 +28,10 @@ describe('ToolRelayAuthorizer', () => {
   });
 
   test('authorizes a request that arrives before the runtime event', async () => {
-    const authorizer = new ToolRelayAuthorizer({ ttlMs: 100 });
+    const authorizer = new ToolRelayAuthorizer({
+      ttlMs: 100,
+      now: () => 1_000,
+    });
     const call = { toolName: 'get_weather', input: { city: 'Paris' } };
     const authorization = authorizer.waitForToolCallAuthorization(call);
 
@@ -38,7 +41,10 @@ describe('ToolRelayAuthorizer', () => {
   });
 
   test('authorizes identical pending requests in FIFO order', async () => {
-    const authorizer = new ToolRelayAuthorizer({ ttlMs: 100 });
+    const authorizer = new ToolRelayAuthorizer({
+      ttlMs: 100,
+      now: () => 1_000,
+    });
     const call = { toolName: 'get_weather', input: { city: 'Austin' } };
     const first = authorizer.waitForToolCallAuthorization(call);
     const second = authorizer.waitForToolCallAuthorization(call);
@@ -51,7 +57,10 @@ describe('ToolRelayAuthorizer', () => {
   });
 
   test('does not use an authorization for a different call', async () => {
-    const authorizer = new ToolRelayAuthorizer({ ttlMs: 100 });
+    const authorizer = new ToolRelayAuthorizer({
+      ttlMs: 100,
+      now: () => 1_000,
+    });
     const parisCall = {
       toolName: 'get_weather',
       input: { city: 'Paris' },


### PR DESCRIPTION
## Background

See https://github.com/vercel/ai/actions/runs/31205931037/job/92958151151?pr=18588: That CI failure is unrelated to that PR - it's an OpenCode harness test race condition, a test-only problem.

## Summary

Inject a frozen `now` value into the four tests that assume an authorization does not expire mid-test.

No changeset needed - this is a test-only fix.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
