### PR TITLE
fix(WorkflowAgent): apply maxRetries and abortSignal from prepareCall

### DIFF
--- a/.changeset/workflow-agent-preparecall-retries.md
+++ b/.changeset/workflow-agent-preparecall-retries.md
@@ -2,4 +2,4 @@
 "@ai-sdk/workflow": patch
 ---
 
-fix(WorkflowAgent): apply `maxRetries` and `abortSignal` returned from `prepareCall`
+Fixed `WorkflowAgent.prepareCall` dropping `maxRetries` and `abortSignal`, and `prepareStep` silently dropping `abortSignal`. Per-stream and prepareCall abort signals are now merged instead of one replacing the other.

--- a/.changeset/workflow-agent-preparecall-retries.md
+++ b/.changeset/workflow-agent-preparecall-retries.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/workflow": patch
+---
+
+fix(WorkflowAgent): apply `maxRetries` and `abortSignal` returned from `prepareCall`

--- a/packages/workflow/src/stream-text-iterator.test.ts
+++ b/packages/workflow/src/stream-text-iterator.test.ts
@@ -135,6 +135,30 @@ describe('streamTextIterator', () => {
         maxOutputTokens: 256,
       });
     });
+
+    it('applies abortSignal from prepareStep', async () => {
+      vi.mocked(doStreamStep).mockResolvedValue(createMockDoStreamStepResult());
+      const stepAbort = new AbortController();
+
+      const iterator = streamTextIterator({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+        tools: {},
+        model: vi.fn() as any,
+        generationSettings: {
+          temperature: 0.2,
+        },
+        prepareStep: () => ({
+          abortSignal: stepAbort.signal,
+        }),
+      });
+
+      await iterator.next();
+
+      expect(vi.mocked(doStreamStep).mock.calls[0]?.[4]).toMatchObject({
+        temperature: 0.2,
+        abortSignal: stepAbort.signal,
+      });
+    });
   });
 
   describe('telemetry', () => {

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -51,6 +51,7 @@ const prepareStepGenerationSettingKeys = [
   'stopSequences',
   'seed',
   'maxRetries',
+  'abortSignal',
   'headers',
   'reasoning',
   'providerOptions',

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -163,6 +163,34 @@ describe('WorkflowAgent', () => {
         }),
       );
     });
+
+    it('applies maxRetries and abortSignal from prepareCall', async () => {
+      const abortController = new AbortController();
+      const prepareCall = vi.fn(() => ({
+        maxRetries: 0,
+        abortSignal: abortController.signal,
+      }));
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockReturnValue({
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      } as unknown as MockIterator);
+
+      const agent = new WorkflowAgent({
+        model: createMockModel(),
+        prepareCall,
+      });
+
+      await agent.stream({ prompt: 'test' });
+
+      expect(streamTextIterator).toHaveBeenCalledWith(
+        expect.objectContaining({
+          generationSettings: expect.objectContaining({
+            maxRetries: 0,
+            abortSignal: abortController.signal,
+          }),
+        }),
+      );
+    });
   });
 
   describe('tool execution error handling', () => {

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -191,6 +191,40 @@ describe('WorkflowAgent', () => {
         }),
       );
     });
+
+    it('merges prepareCall and per-stream abortSignal', async () => {
+      const prepareAbort = new AbortController();
+      const streamAbort = new AbortController();
+      const prepareCall = vi.fn(() => ({
+        abortSignal: prepareAbort.signal,
+      }));
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockClear();
+      vi.mocked(streamTextIterator).mockReturnValue({
+        next: vi.fn().mockResolvedValueOnce({ done: true, value: [] }),
+      } as unknown as MockIterator);
+
+      const agent = new WorkflowAgent({
+        model: createMockModel(),
+        prepareCall,
+      });
+
+      await agent.stream({
+        prompt: 'test',
+        abortSignal: streamAbort.signal,
+      });
+
+      expect(streamTextIterator).toHaveBeenCalledTimes(1);
+      const generationSettings = vi.mocked(streamTextIterator).mock
+        .calls[0]?.[0]?.generationSettings;
+      expect(generationSettings?.abortSignal).toBeDefined();
+      expect(generationSettings?.abortSignal).not.toBe(prepareAbort.signal);
+      expect(generationSettings?.abortSignal).not.toBe(streamAbort.signal);
+
+      streamAbort.abort('stream-cancel');
+      expect(generationSettings?.abortSignal?.aborted).toBe(true);
+      expect(generationSettings?.abortSignal?.reason).toBe('stream-cancel');
+    });
   });
 
   describe('tool execution error handling', () => {

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1434,6 +1434,10 @@ export class WorkflowAgent<
         effectiveGenerationSettings.stopSequences = prepared.stopSequences;
       if (prepared.seed !== undefined)
         effectiveGenerationSettings.seed = prepared.seed;
+      if (prepared.maxRetries !== undefined)
+        effectiveGenerationSettings.maxRetries = prepared.maxRetries;
+      if (prepared.abortSignal !== undefined)
+        effectiveGenerationSettings.abortSignal = prepared.abortSignal;
       if (prepared.headers !== undefined)
         effectiveGenerationSettings.headers = prepared.headers;
       if (prepared.reasoning !== undefined)

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1788,8 +1788,11 @@ export class WorkflowAgent<
       download,
     });
 
+    // Merge per-stream + prepareCall/constructor abort sources so neither is
+    // discarded when both are present (timeout still races whichever wins).
     const effectiveAbortSignal = mergeAbortSignals(
-      options.abortSignal ?? effectiveGenerationSettings.abortSignal,
+      options.abortSignal,
+      effectiveGenerationSettings.abortSignal,
       options.timeout,
     );
 


### PR DESCRIPTION
## Summary
- `WorkflowAgent.prepareCall` can return `maxRetries` and `abortSignal` (they are on `GenerationSettings` / `PrepareCallResult`), but the field-by-field merge skipped both so they were silently dropped.
- Copy those two fields into `effectiveGenerationSettings` the same way as `seed` / `headers`.
- `prepareStep` also dropped `abortSignal` via `prepareStepGenerationSettingKeys` — now included.
- Per-stream and prepareCall `abortSignal`s are merged with `mergeAbortSignals` instead of one replacing the other.
- Note: `maxRetries` still does not reach a model-retry implementation in `packages/workflow` (step mechanism owns retries); the copy keeps the typed merge honest / consistent with telemetry.

Fixes #18576

## Test plan
- [x] `pnpm test:node -- src/workflow-agent.test.ts src/stream-text-iterator.test.ts` in `packages/workflow`
- [x] prepareCall maxRetries/abortSignal land on `streamTextIterator`
- [x] prepareStep abortSignal applied
- [x] prepareCall + per-stream abortSignal merge