### PR TITLE
feat(anthropic): forward streaming ping events by introducing new stream part

### DIFF
--- a/.changeset/tricky-waves-greet.md
+++ b/.changeset/tricky-waves-greet.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/anthropic": patch
+"@ai-sdk/provider": patch
+"ai": patch
+---
+
+feat(anthropic): forward streaming ping events by introducing new stream part

--- a/packages/ai/src/generate-text/stream-text-result.ts
+++ b/packages/ai/src/generate-text/stream-text-result.ts
@@ -573,6 +573,10 @@ export type TextStreamRawPart = {
   rawValue: unknown;
 };
 
+export type TextStreamPingPart = {
+  type: 'ping';
+};
+
 export type TextStreamPart<TOOLS extends ToolSet> =
   | TextStreamTextStartPart
   | TextStreamTextEndPart
@@ -599,4 +603,5 @@ export type TextStreamPart<TOOLS extends ToolSet> =
   | TextStreamFinishPart
   | TextStreamAbortPart
   | TextStreamErrorPart
+  | TextStreamPingPart
   | TextStreamRawPart;

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -21336,6 +21336,33 @@ describe('streamText', () => {
     });
   });
 
+  describe('ping forwarding', () => {
+    it('should forward ping chunks without enabling raw chunks', async () => {
+      const model = createTestModel({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'ping' },
+          {
+            type: 'finish',
+            finishReason: { unified: 'stop', raw: 'stop' },
+            usage: testUsage,
+          },
+        ]),
+      });
+
+      const result = streamText({
+        model,
+        prompt: 'test prompt',
+      });
+
+      const chunks = await convertAsyncIterableToArray(result.stream);
+
+      expect(chunks.filter(chunk => chunk.type === 'ping')).toEqual([
+        { type: 'ping' },
+      ]);
+    });
+  });
+
   describe('raw chunks forwarding', () => {
     it('should forward raw chunks when include.rawChunks is enabled', async () => {
       const modelWithRawChunks = createTestModel({

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -192,6 +192,7 @@ const isOutputChunkType = {
   'model-call-response-metadata': false,
   'model-call-end': false,
   error: false,
+  ping: false,
   raw: false,
 } as const satisfies Record<ExecuteToolsStreamPart['type'], boolean>;
 
@@ -2231,7 +2232,8 @@ class DefaultStreamTextResult<
                     case 'tool-input-start':
                     case 'tool-input-end':
                     case 'tool-input-delta':
-                    case 'tool-approval-request': {
+                    case 'tool-approval-request':
+                    case 'ping': {
                       controller.enqueue(chunk);
                       break;
                     }

--- a/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
@@ -375,6 +375,7 @@ export function toUIMessageChunk<
     }
 
     case 'tool-input-end':
+    case 'ping':
     case 'raw': {
       return undefined;
     }

--- a/packages/anthropic/src/__snapshots__/anthropic-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-language-model.test.ts.snap
@@ -1616,6 +1616,9 @@ exports[`AnthropicLanguageModel > doStream > agent skills > should stream code e
     "type": "text-delta",
   },
   {
+    "type": "ping",
+  },
+  {
     "delta": " energy sources. Let me first read the",
     "id": "0",
     "type": "text-delta",
@@ -2174,6 +2177,9 @@ Now let me create the HTML slides and convert them to Power",
     "delta": "tml"",
     "id": "srvtoolu_01HmzCUHHBGvJF25VA1Zv4p8",
     "type": "tool-input-delta",
+  },
+  {
+    "type": "ping",
   },
   {
     "delta": ", "fil",
@@ -3100,6 +3106,9 @@ Now let me create the HTML slides and convert them to Power",
     "providerExecuted": true,
     "toolName": "code_execution",
     "type": "tool-input-start",
+  },
+  {
+    "type": "ping",
   },
   {
     "delta": "{"type": "text_editor_code_execution","comma",
@@ -4113,6 +4122,9 @@ Now let me create the HTML slides and convert them to Power",
     "type": "tool-call",
   },
   {
+    "type": "ping",
+  },
+  {
     "result": {
       "content": [],
       "return_code": 0,
@@ -4990,6 +5002,9 @@ Error: PDF conversion failed
     "type": "tool-call",
   },
   {
+    "type": "ping",
+  },
+  {
     "result": {
       "content": [
         {
@@ -5348,6 +5363,9 @@ exports[`AnthropicLanguageModel > doStream > code execution 20250825 tool > shou
     "delta": " you create a Python script to calculate Fibonacci numbers,",
     "id": "0",
     "type": "text-delta",
+  },
+  {
+    "type": "ping",
   },
   {
     "delta": " execute it to find the 10th Fibonacci number",
@@ -9838,6 +9856,9 @@ Let's",
     "type": "tool-call",
   },
   {
+    "type": "ping",
+  },
+  {
     "result": {
       "is_file_update": false,
       "type": "text_editor_code_execution_create_result",
@@ -10422,6 +10443,9 @@ exports[`AnthropicLanguageModel > doStream > code execution 20250825 tool > shou
     "delta": " Fibonacci numbers and then execute it to fin",
     "id": "0",
     "type": "text-delta",
+  },
+  {
+    "type": "ping",
   },
   {
     "delta": "d the 10th Fibonacci number.",
@@ -11742,6 +11766,9 @@ exports[`AnthropicLanguageModel > doStream > code execution 20260120 tool > shou
     "type": "text-delta",
   },
   {
+    "type": "ping",
+  },
+  {
     "delta": "d the 10th Fibonacci number.",
     "id": "0",
     "type": "text-delta",
@@ -13060,6 +13087,9 @@ exports[`AnthropicLanguageModel > doStream > json schema response format with ou
     "type": "text-delta",
   },
   {
+    "type": "ping",
+  },
+  {
     "delta": ":[{"name":"Th",
     "id": "0",
     "type": "text-delta",
@@ -13830,6 +13860,9 @@ exports[`AnthropicLanguageModel > doStream > programmatic tool calling > with fi
     "delta": " this",
     "id": "0",
     "type": "text-delta",
+  },
+  {
+    "type": "ping",
   },
   {
     "delta": " game between",
@@ -15816,6 +15849,9 @@ Player 2 had better results - likely using the loaded die! 🎲
     "type": "text-delta",
   },
   {
+    "type": "ping",
+  },
+  {
     "delta": " Results",
     "id": "1",
     "type": "text-delta",
@@ -16290,6 +16326,9 @@ exports[`AnthropicLanguageModel > doStream > tool search tool > bm25 variant > s
     "type": "text-delta",
   },
   {
+    "type": "ping",
+  },
+  {
     "delta": "-",
     "id": "0",
     "type": "text-delta",
@@ -16502,6 +16541,9 @@ exports[`AnthropicLanguageModel > doStream > tool search tool > bm25 variant > s
     "delta": " current",
     "id": "0",
     "type": "text-delta",
+  },
+  {
+    "type": "ping",
   },
   {
     "delta": " weather in San Francisco,",
@@ -16835,6 +16877,9 @@ exports[`AnthropicLanguageModel > doStream > tool search tool > regex variant > 
     "type": "text-delta",
   },
   {
+    "type": "ping",
+  },
+  {
     "delta": " weather data for San Francisco:
 
 -",
@@ -16969,6 +17014,9 @@ exports[`AnthropicLanguageModel > doStream > web fetch 20260209 tool > input pro
     "providerExecuted": true,
     "toolName": "code_execution",
     "type": "tool-input-start",
+  },
+  {
+    "type": "ping",
   },
   {
     "delta": "{"type": "programmatic-tool-call","code": "\\nimport json",
@@ -17313,14 +17361,23 @@ exports[`AnthropicLanguageModel > doStream > web fetch tool > txt response > sho
     "type": "text-delta",
   },
   {
+    "type": "ping",
+  },
+  {
     "id": "0",
     "type": "text-end",
+  },
+  {
+    "type": "ping",
   },
   {
     "id": "srvtoolu_01VNMRfQny2LCrLKEdYaVcCe",
     "providerExecuted": true,
     "toolName": "web_fetch",
     "type": "tool-input-start",
+  },
+  {
+    "type": "ping",
   },
   {
     "delta": "{"url": ",

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -6602,6 +6602,9 @@ describe('AnthropicLanguageModel', () => {
               "type": "text-start",
             },
             {
+              "type": "ping",
+            },
+            {
               "delta": "{"elements": [{"location": "San Francisco", "temperature": 58, "condition": "sunny"}]",
               "id": "0",
               "type": "text-delta",
@@ -6753,8 +6756,14 @@ describe('AnthropicLanguageModel', () => {
               "type": "response-metadata",
             },
             {
+              "type": "ping",
+            },
+            {
               "id": "1",
               "type": "text-start",
+            },
+            {
+              "type": "ping",
             },
             {
               "delta": "{"elements": [{"location": "San Francisco", "temperature": 58, "condition": "sunny"}]",
@@ -6951,14 +6960,23 @@ describe('AnthropicLanguageModel', () => {
                 "type": "tool-input-start",
               },
               {
+                "type": "ping",
+              },
+              {
                 "delta": "{"location": "San Francisco",
                 "id": "toolu_019Zvehfe1XQWweT1pm7okyt",
                 "type": "tool-input-delta",
               },
               {
+                "type": "ping",
+              },
+              {
                 "delta": ""}",
                 "id": "toolu_019Zvehfe1XQWweT1pm7okyt",
                 "type": "tool-input-delta",
+              },
+              {
+                "type": "ping",
               },
               {
                 "id": "toolu_019Zvehfe1XQWweT1pm7okyt",
@@ -6970,6 +6988,12 @@ describe('AnthropicLanguageModel', () => {
                 "toolCallId": "toolu_019Zvehfe1XQWweT1pm7okyt",
                 "toolName": "weather",
                 "type": "tool-call",
+              },
+              {
+                "type": "ping",
+              },
+              {
+                "type": "ping",
               },
               {
                 "finishReason": {
@@ -8011,6 +8035,9 @@ describe('AnthropicLanguageModel', () => {
             "type": "text-start",
           },
           {
+            "type": "ping",
+          },
+          {
             "delta": "Okay",
             "id": "0",
             "type": "text-delta",
@@ -8134,6 +8161,9 @@ describe('AnthropicLanguageModel', () => {
           {
             "id": "0",
             "type": "text-start",
+          },
+          {
+            "type": "ping",
           },
           {
             "error": {
@@ -8431,6 +8461,9 @@ describe('AnthropicLanguageModel', () => {
             "type": "text-start",
           },
           {
+            "type": "ping",
+          },
+          {
             "delta": "Hello",
             "id": "0",
             "type": "text-delta",
@@ -8520,6 +8553,9 @@ describe('AnthropicLanguageModel', () => {
           {
             "id": "0",
             "type": "text-start",
+          },
+          {
+            "type": "ping",
           },
           {
             "delta": "Hello",
@@ -8617,6 +8653,9 @@ describe('AnthropicLanguageModel', () => {
           {
             "id": "0",
             "type": "text-start",
+          },
+          {
+            "type": "ping",
           },
           {
             "delta": "Hello",
@@ -8845,6 +8884,32 @@ describe('AnthropicLanguageModel', () => {
             },
           ]
         `);
+    });
+
+    it('should forward ping events without raw chunks enabled', async () => {
+      server.urls['https://api.anthropic.com/v1/messages'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"message_start","message":{"id":"msg_01KfpJoAEabmH2iHRRFjQMAG","type":"message","role":"assistant","content":[],"model":"claude-3-haiku-20240307","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"output_tokens":1}}}\n\n`,
+          `data: {"type":"ping"}\n\n`,
+          `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n`,
+          `data: {"type":"content_block_stop","index":0}\n\n`,
+          `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":2}}\n\n`,
+          `data: {"type":"message_stop"}\n\n`,
+        ],
+      };
+
+      const { stream } = await model.doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+
+      expect(chunks.filter(chunk => chunk.type === 'ping')).toEqual([
+        { type: 'ping' },
+      ]);
+      expect(chunks.filter(chunk => chunk.type === 'raw')).toHaveLength(0);
     });
 
     describe('raw chunks', () => {
@@ -9382,6 +9447,9 @@ describe('AnthropicLanguageModel', () => {
                 "type": "text-start",
               },
               {
+                "type": "ping",
+              },
+              {
                 "delta": "Okay",
                 "id": "0",
                 "type": "text-delta",
@@ -9523,13 +9591,22 @@ describe('AnthropicLanguageModel', () => {
                 "type": "text-delta",
               },
               {
+                "type": "ping",
+              },
+              {
                 "id": "0",
                 "type": "text-end",
+              },
+              {
+                "type": "ping",
               },
               {
                 "id": "toolu_01QE1WLsSVp5hy5Q3GmGTmjP",
                 "toolName": "updateIssueList",
                 "type": "tool-input-start",
+              },
+              {
+                "type": "ping",
               },
               {
                 "id": "toolu_01QE1WLsSVp5hy5Q3GmGTmjP",

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -1646,7 +1646,8 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
 
           switch (value.type) {
             case 'ping': {
-              return; // ignored
+              controller.enqueue({ type: 'ping' });
+              return;
             }
 
             case 'content_block_start': {

--- a/packages/provider/src/language-model/v4/language-model-v4-stream-part.ts
+++ b/packages/provider/src/language-model/v4/language-model-v4-stream-part.ts
@@ -97,6 +97,11 @@ export type LanguageModelV4StreamPart =
       providerMetadata?: SharedV4ProviderMetadata;
     }
 
+  // ping events that keep the stream connection alive
+  | {
+      type: 'ping';
+    }
+
   // raw chunks if enabled
   | {
       type: 'raw';


### PR DESCRIPTION
## Background

Before, Anthropic ping SSE events were parsed but discarded:

- They were only observable through opt-in raw chunks
- Normal streamText consumers, including Gateway, saw no event during long thinking periods
- This could leave downstream connections idle long enough for Claude Code to abort

## Summary

-  added `{ type: 'ping' }` to `LanguageModelV4StreamPart` (breaking change)
- `@ai-sdk/anthropic` emits it for every anthropic `ping`
- `streamText` forwards it without requiring raw chunks

## End-to-End Verification

na (need to test with gateway)

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)