### PR TITLE
fix(openai): serialize tool text outputs when an output schema is configured

### DIFF
--- a/.changeset/curvy-tools-serialize.md
+++ b/.changeset/curvy-tools-serialize.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+fix(openai): serialize tool text outputs when an output schema is configured

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -2772,6 +2772,82 @@ describe('convertToOpenAIResponsesInput', () => {
       `);
     });
 
+    it('should JSON-encode text outputs only for tools with an output schema', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_text',
+                toolName: 'search',
+                output: {
+                  type: 'text',
+                  value: 'The weather is sunny',
+                },
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call_error',
+                toolName: 'search',
+                output: {
+                  type: 'error-text',
+                  value: 'Error: boom',
+                },
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call_denied',
+                toolName: 'search',
+                output: {
+                  type: 'execution-denied',
+                  reason: 'User denied the tool execution',
+                },
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call_without_schema',
+                toolName: 'lookup',
+                output: {
+                  type: 'error-text',
+                  value: 'Error: unchanged',
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+        outputSchemaToolNames: new Set(['search']),
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call_output',
+          call_id: 'call_text',
+          output: '"The weather is sunny"',
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_error',
+          output: '"Error: boom"',
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_denied',
+          output: '"User denied the tool execution"',
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_without_schema',
+          output: 'Error: unchanged',
+        },
+      ]);
+    });
+
     it('should convert execution-denied tool result to function_call_output', async () => {
       const result = await convertToOpenAIResponsesInput({
         toolNameMapping: testToolNameMapping,

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -98,6 +98,7 @@ export async function convertToOpenAIResponsesInput({
   hasApplyPatchTool = false,
   hasComputerTool = false,
   customProviderToolNames,
+  outputSchemaToolNames,
 }: {
   prompt: LanguageModelV4Prompt;
   toolNameMapping: ToolNameMapping;
@@ -114,6 +115,7 @@ export async function convertToOpenAIResponsesInput({
   hasApplyPatchTool?: boolean;
   hasComputerTool?: boolean;
   customProviderToolNames?: Set<string>;
+  outputSchemaToolNames?: Set<string>;
 }): Promise<{
   input: OpenAIResponsesInput;
   warnings: Array<SharedV4Warning>;
@@ -1141,14 +1143,22 @@ export async function convertToOpenAIResponsesInput({
           }
 
           let contentValue: OpenAIResponsesFunctionCallOutput['output'];
+          // `output` is always a string, but for functions with output_schema
+          // OpenAI parses the contents of that string as JSON. Text-like results
+          // therefore need JSON.stringify to become valid JSON string literals.
+          const hasOutputSchema = outputSchemaToolNames?.has(part.toolName);
           switch (output.type) {
             case 'text':
             case 'error-text':
-              contentValue = output.value;
+              contentValue = hasOutputSchema
+                ? JSON.stringify(output.value)
+                : output.value;
               break;
-            case 'execution-denied':
-              contentValue = output.reason ?? 'Tool call execution denied.';
+            case 'execution-denied': {
+              const reason = output.reason ?? 'Tool call execution denied.';
+              contentValue = hasOutputSchema ? JSON.stringify(reason) : reason;
               break;
+            }
             case 'json':
             case 'error-json':
               contentValue = JSON.stringify(output.value);

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2885,6 +2885,75 @@ describe('OpenAIResponsesLanguageModel', () => {
         `);
       });
 
+      it('should JSON-encode error outputs for tools with an output schema', async () => {
+        const outputSchema = {
+          type: 'object' as const,
+          properties: {
+            temperature: { type: 'number' as const },
+          },
+          required: ['temperature'],
+          additionalProperties: false,
+        };
+
+        await createModel('gpt-4o').doGenerate({
+          prompt: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call_123',
+                  toolName: 'weather',
+                  input: { location: 'San Francisco' },
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call_123',
+                  toolName: 'weather',
+                  output: { type: 'error-text', value: 'Error: boom' },
+                },
+              ],
+            },
+          ],
+          tools: [
+            {
+              ...TEST_TOOLS[0],
+              providerOptions: {
+                openai: { outputSchema },
+              },
+            },
+          ],
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          input: [
+            {
+              type: 'function_call',
+              call_id: 'call_123',
+              name: 'weather',
+              arguments: '{"location":"San Francisco"}',
+            },
+            {
+              type: 'function_call_output',
+              call_id: 'call_123',
+              output: '"Error: boom"',
+            },
+          ],
+          tools: [
+            {
+              type: 'function',
+              name: 'weather',
+              output_schema: outputSchema,
+            },
+          ],
+        });
+      });
+
       it('should have tool-calls finish reason', async () => {
         const result = await createModel('gpt-4o').doGenerate({
           prompt: TEST_PROMPT,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -322,6 +322,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
     });
 
     const customProviderToolNames = new Set<string>();
+    // OpenAI requires function_call_output.output to contain valid JSON when the
+    // function declares output_schema. Preserve the affected SDK tool names so
+    // prompt conversion can apply that encoding only to their results.
+    const outputSchemaToolNames = new Set<string>();
     const {
       tools: openaiTools,
       toolChoice: openaiToolChoice,
@@ -332,6 +336,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
       allowedTools: openaiOptions?.allowedTools ?? undefined,
       toolNameMapping,
       customProviderToolNames,
+      outputSchemaToolNames,
     });
 
     const { input, warnings: inputWarnings } =
@@ -358,6 +363,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
           customProviderToolNames.size > 0
             ? customProviderToolNames
             : undefined,
+        outputSchemaToolNames:
+          outputSchemaToolNames.size > 0 ? outputSchemaToolNames : undefined,
       });
 
     warnings.push(...inputWarnings);

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -42,6 +42,7 @@ export async function prepareResponsesTools({
   allowedTools,
   toolNameMapping,
   customProviderToolNames,
+  outputSchemaToolNames,
 }: {
   tools: LanguageModelV4CallOptions['tools'];
   toolChoice: LanguageModelV4CallOptions['toolChoice'] | undefined;
@@ -51,6 +52,7 @@ export async function prepareResponsesTools({
   };
   toolNameMapping?: ToolNameMapping;
   customProviderToolNames?: Set<string>;
+  outputSchemaToolNames?: Set<string>;
 }): Promise<{
   tools?: Array<OpenAIResponsesTool>;
   toolChoice?:
@@ -98,6 +100,9 @@ export async function prepareResponsesTools({
         const openaiOptions = tool.providerOptions?.openai as
           | OpenAIToolOptions
           | undefined;
+        if (openaiOptions?.outputSchema != null) {
+          outputSchemaToolNames?.add(tool.name);
+        }
         const openaiFunctionTool = prepareFunctionTool({
           tool,
           options: openaiOptions,


### PR DESCRIPTION
## Background

OpenAI Responses function tools can declare an `output_schema`, requiring `function_call_output.output` to contain valid JSON. AI SDK serialized thrown tool errors as raw text, causing OpenAI to reject the continuation request; see OpenAI’s [function calling guide](https://platform.openai.com/docs/guides/function-calling) and [Responses API reference](https://platform.openai.com/docs/api-reference/responses/create).

## Summary

Track which tools declare `providerOptions.openai.outputSchema` and JSON-encode their text, error, and execution-denied outputs before sending them to OpenAI. Tools without an output schema retain their existing serialization behavior.

## End-to-End Verification

This code threw an error before, but works now:

```ts
  const result = await generateText({
    model: openai.responses('gpt-4.1'),
    prompt: "What's the weather in London? Use the tool.",
    stopWhen: isStepCount(3),
    tools: {
      getWeather: tool({
        description: 'Get the current weather for a city.',
        inputSchema: z.object({ city: z.string() }),
        execute: async (): Promise<{
          temperatureC: number;
          conditions: string;
        }> => {
          throw new Error(errorMessage);
        },
        providerOptions: {
          openai: {
            outputSchema: {
              type: 'object',
              properties: {
                temperatureC: { type: 'number' },
                conditions: { type: 'string' },
              },
              required: ['temperatureC', 'conditions'],
              additionalProperties: false,
            },
          } satisfies OpenAIToolOptions,
        },
      }),
    },
  });
```

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

Fixes https://github.com/vercel/ai/issues/18590
