### PR TITLE
feat(harness-acp): further simplify public `createACP()` API

### DIFF
--- a/.changeset/cuddly-ways-shout.md
+++ b/.changeset/cuddly-ways-shout.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-acp": patch
+---
+
+feat(harness-acp): further simplify public `createACP()` API

--- a/content/providers/02-ai-sdk-harnesses/06-acp.mdx
+++ b/content/providers/02-ai-sdk-harnesses/06-acp.mdx
@@ -62,9 +62,11 @@ try {
 - `harnessId`: stable kebab-case identity for this profile.
 - `version`: ACP protocol version. It defaults to and currently supports only
   `'v1'`.
-- `implementation`: simple or locked NPM acquisition, executable, arguments,
-  host environment variables to forward through `forwardEnv`, and persistent
-  `env`.
+- `source`: where the ACP package comes from, as a simple or locked NPM source.
+- `executable`: the package bin name to launch.
+- `args`: optional arguments passed to the executable.
+- `forwardEnv`: host environment variable names to forward into the sandbox.
+- `env`: persistent environment values written at bootstrap.
 - `builtinTools`: optional native tool definitions for static typing and exact
   name matching.
 - `authentication`: advertised ACP authentication method, metadata, and client
@@ -94,39 +96,38 @@ try {
 Runtime-specific package names, environment variables, modes, and session
 metadata belong in the inline profile, not in the generic adapter.
 
-### Implementation acquisition
+### Package source
 
-Simple NPM acquisition requires an exact package version:
+A simple NPM source installs a single package by name:
 
 ```ts
-const implementation = {
-  type: 'npm',
-  mode: 'simple',
+const source = {
+  type: 'npm-simple',
   packageName: '@agentclientprotocol/codex-acp',
-  version: '1.1.4',
-  executable: 'codex-acp',
+  packageVersion: '1.1.4',
 } as const;
 ```
 
-This pins the requested ACP package, while its transitive dependencies are
-resolved when the sandbox bootstraps. To freeze the complete installation, use
-locked acquisition and provide the contents of a `package.json` and its
-`pnpm-lock.yaml`:
+`packageVersion` is optional and must be an exact version when supplied. Omit it
+to install the package's `latest` dist-tag instead. An omitted version also
+stays out of the harness identity, so a new upstream release does not
+invalidate existing lifecycle state.
+
+A simple source pins only the requested ACP package, while its transitive
+dependencies are resolved when the sandbox bootstraps. To freeze the complete
+installation, use a locked source and provide the contents of a `package.json`
+and its `pnpm-lock.yaml`:
 
 ```ts
-const implementation = {
-  type: 'npm',
-  mode: 'locked',
+const source = {
+  type: 'npm-locked',
   packageJson: packageJsonContents,
   pnpmLockYaml: pnpmLockYamlContents,
-  executable: 'codex-acp',
 } as const;
 ```
 
-Locked acquisition installs the supplied files with
-`pnpm install --frozen-lockfile`. Both modes also accept `args`, `forwardEnv`,
-and `env`. The manifest and lockfile are bootstrap artifacts, so never put
-credentials in either string.
+A locked source installs the supplied files with
+`pnpm install --frozen-lockfile`.
 
 ## Authentication
 
@@ -142,7 +143,7 @@ With the default `auth: 'auto'`, the adapter uses AI Gateway when
 `AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN` is available and otherwise uses
 direct authentication.
 
-For direct authentication, configure `implementation.forwardEnv` with the host
+For direct authentication, configure `forwardEnv` with the host
 environment variable names that the underlying ACP implementation reads. These
 variables are allowlisted and forwarded unchanged to the ACP process. Their
 names depend on the ACP implementation. Credential values are resolved at
@@ -220,16 +221,15 @@ export const claudeCodeACPHarness = createACP({
   // Define the runtime's built-in tool names and input schemas to expose
   // provider-executed calls as typed HarnessAgent tools.
   // builtinTools: { ... },
-  implementation: {
-    type: 'npm',
-    mode: 'simple',
+  source: {
+    type: 'npm-simple',
     packageName: '@agentclientprotocol/claude-agent-acp',
-    version: '0.61.0',
-    executable: 'claude-agent-acp',
-    forwardEnv: ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'],
-    env: {
-      IS_SANDBOX: '1',
-    },
+    packageVersion: '0.61.0',
+  },
+  executable: 'claude-agent-acp',
+  forwardEnv: ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'],
+  env: {
+    IS_SANDBOX: '1',
   },
   permissionModeMapping: {
     'allow-reads': { type: 'session-mode', modeId: 'default' },
@@ -268,14 +268,13 @@ export const codexACPHarness = createACP({
   // Define the runtime's built-in tool names and input schemas to expose
   // provider-executed calls as typed HarnessAgent tools.
   // builtinTools: { ... },
-  implementation: {
-    type: 'npm',
-    mode: 'simple',
+  source: {
+    type: 'npm-simple',
     packageName: '@agentclientprotocol/codex-acp',
-    version: '1.1.4',
-    executable: 'codex-acp',
-    forwardEnv: ['CODEX_API_KEY', 'OPENAI_API_KEY'],
+    packageVersion: '1.1.4',
   },
+  executable: 'codex-acp',
+  forwardEnv: ['CODEX_API_KEY', 'OPENAI_API_KEY'],
   permissionModeMapping: {
     'allow-reads': null,
     'allow-edits': null,
@@ -342,15 +341,14 @@ export const grokBuildACPHarness = createACP({
   // Define the runtime's built-in tool names and input schemas to expose
   // provider-executed calls as typed HarnessAgent tools.
   // builtinTools: { ... },
-  implementation: {
-    type: 'npm',
-    mode: 'simple',
+  source: {
+    type: 'npm-simple',
     packageName: '@xai-official/grok',
-    version: '0.2.111',
-    executable: 'grok',
-    args: ['agent', 'stdio'],
-    forwardEnv: ['XAI_API_KEY'],
+    packageVersion: '0.2.111',
   },
+  executable: 'grok',
+  args: ['agent', 'stdio'],
+  forwardEnv: ['XAI_API_KEY'],
   providerAuthentication: {
     gateway: {
       env: {

--- a/examples/ai-functions/src/harness-agent/codex-acp/generate-text-locked.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/generate-text-locked.ts
@@ -5,15 +5,15 @@ import { createCodexACP } from '../../lib/codex-acp-harness';
 import { run } from '../../lib/run';
 
 run(async () => {
-  const acquisitionDir = new URL('./locked-acquisition/', import.meta.url);
+  const lockedSourceDir = new URL('./locked-acquisition/', import.meta.url);
   const [packageJson, pnpmLockYaml] = await Promise.all([
-    readFile(new URL('package.json', acquisitionDir), 'utf8'),
-    readFile(new URL('pnpm-lock.yaml', acquisitionDir), 'utf8'),
+    readFile(new URL('package.json', lockedSourceDir), 'utf8'),
+    readFile(new URL('pnpm-lock.yaml', lockedSourceDir), 'utf8'),
   ]);
   const agent = new HarnessAgent({
     harness: createCodexACP({
-      acquisition: {
-        mode: 'locked',
+      source: {
+        type: 'npm-locked',
         packageJson,
         pnpmLockYaml,
       },

--- a/examples/ai-functions/src/lib/codex-acp-harness.ts
+++ b/examples/ai-functions/src/lib/codex-acp-harness.ts
@@ -2,6 +2,7 @@ import {
   createACP,
   type ACPAuthOptions,
   type ACPPermissionModeMapping,
+  type ACPSource,
 } from '@ai-sdk/harness-acp';
 import { commonTool } from '@ai-sdk/harness';
 import { z } from 'zod';
@@ -24,13 +25,12 @@ const webSearchActionSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('other') }),
 ]);
 
-const CODEX_ACP_IMPLEMENTATION = {
-  type: 'npm',
-  mode: 'simple',
+const CODEX_ACP_EXECUTABLE = 'codex-acp';
+
+const CODEX_ACP_SOURCE = {
+  type: 'npm-simple',
   packageName: '@agentclientprotocol/codex-acp',
-  version: '1.1.4',
-  executable: 'codex-acp',
-} as const;
+} as const satisfies ACPSource;
 
 const CODEX_ACP_BUILTIN_TOOLS = {
   bash: commonTool('bash', {
@@ -62,43 +62,25 @@ const CODEX_ACP_PERMISSION_MODE_MAPPING = {
 export function createCodexACP({
   auth = 'auto',
   webSearch,
-  acquisition,
+  source = CODEX_ACP_SOURCE,
 }: {
   auth?: ACPAuthOptions;
   webSearch?: boolean;
-  acquisition?:
-    | { mode: 'simple' }
-    | {
-        mode: 'locked';
-        packageJson: string;
-        pnpmLockYaml: string;
-      };
+  source?: ACPSource;
 } = {}) {
-  const implementation =
-    acquisition?.mode === 'locked'
-      ? ({
-          type: 'npm',
-          mode: 'locked',
-          packageJson: acquisition.packageJson,
-          pnpmLockYaml: acquisition.pnpmLockYaml,
-          executable: CODEX_ACP_IMPLEMENTATION.executable,
-        } as const)
-      : CODEX_ACP_IMPLEMENTATION;
-
   return createACP({
     harnessId: 'codex-acp',
     auth,
-    implementation: {
-      ...implementation,
-      forwardEnv: ['CODEX_API_KEY', 'OPENAI_API_KEY'],
-      ...(webSearch
-        ? {
-            env: {
-              CODEX_CONFIG: JSON.stringify({ web_search: 'live' }),
-            },
-          }
-        : {}),
-    },
+    source,
+    executable: CODEX_ACP_EXECUTABLE,
+    forwardEnv: ['CODEX_API_KEY', 'OPENAI_API_KEY'],
+    ...(webSearch
+      ? {
+          env: {
+            CODEX_CONFIG: JSON.stringify({ web_search: 'live' }),
+          },
+        }
+      : {}),
     builtinTools: CODEX_ACP_BUILTIN_TOOLS,
     permissionModeMapping: CODEX_ACP_PERMISSION_MODE_MAPPING,
     authentication: {

--- a/examples/ai-functions/src/lib/codex-acp-harness.ts
+++ b/examples/ai-functions/src/lib/codex-acp-harness.ts
@@ -30,6 +30,7 @@ const CODEX_ACP_EXECUTABLE = 'codex-acp';
 const CODEX_ACP_SOURCE = {
   type: 'npm-simple',
   packageName: '@agentclientprotocol/codex-acp',
+  packageVersion: '1.1.4',
 } as const satisfies ACPSource;
 
 const CODEX_ACP_BUILTIN_TOOLS = {

--- a/examples/harness-e2e-next/agent/harness/acp-claude-code/harness.ts
+++ b/examples/harness-e2e-next/agent/harness/acp-claude-code/harness.ts
@@ -6,16 +6,14 @@ const harnessId = 'acp-claude-code';
 export const claudeCodeACPHarness = createACP({
   harnessId,
   builtinTools: claudeCodeACPBuiltinTools,
-  implementation: {
-    type: 'npm',
-    mode: 'simple',
+  source: {
+    type: 'npm-simple',
     packageName: '@agentclientprotocol/claude-agent-acp',
-    version: '0.61.0',
-    executable: 'claude-agent-acp',
-    forwardEnv: ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'],
-    env: {
-      IS_SANDBOX: '1',
-    },
+  },
+  executable: 'claude-agent-acp',
+  forwardEnv: ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'],
+  env: {
+    IS_SANDBOX: '1',
   },
   permissionModeMapping: {
     'allow-reads': { type: 'session-mode', modeId: 'default' },

--- a/examples/harness-e2e-next/agent/harness/acp-claude-code/harness.ts
+++ b/examples/harness-e2e-next/agent/harness/acp-claude-code/harness.ts
@@ -9,6 +9,7 @@ export const claudeCodeACPHarness = createACP({
   source: {
     type: 'npm-simple',
     packageName: '@agentclientprotocol/claude-agent-acp',
+    packageVersion: '0.61.0',
   },
   executable: 'claude-agent-acp',
   forwardEnv: ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'],

--- a/examples/harness-e2e-next/agent/harness/acp-codex/harness.ts
+++ b/examples/harness-e2e-next/agent/harness/acp-codex/harness.ts
@@ -9,6 +9,7 @@ export const codexACPHarness = createACP({
   source: {
     type: 'npm-simple',
     packageName: '@agentclientprotocol/codex-acp',
+    packageVersion: '1.1.4',
   },
   executable: 'codex-acp',
   forwardEnv: ['CODEX_API_KEY', 'OPENAI_API_KEY'],

--- a/examples/harness-e2e-next/agent/harness/acp-codex/harness.ts
+++ b/examples/harness-e2e-next/agent/harness/acp-codex/harness.ts
@@ -6,14 +6,12 @@ const harnessId = 'acp-codex';
 export const codexACPHarness = createACP({
   harnessId,
   builtinTools: codexACPBuiltinTools,
-  implementation: {
-    type: 'npm',
-    mode: 'simple',
+  source: {
+    type: 'npm-simple',
     packageName: '@agentclientprotocol/codex-acp',
-    version: '1.1.4',
-    executable: 'codex-acp',
-    forwardEnv: ['CODEX_API_KEY', 'OPENAI_API_KEY'],
   },
+  executable: 'codex-acp',
+  forwardEnv: ['CODEX_API_KEY', 'OPENAI_API_KEY'],
   permissionModeMapping: {
     'allow-reads': null,
     'allow-edits': null,

--- a/examples/harness-e2e-next/agent/harness/acp-grok-build/harness.ts
+++ b/examples/harness-e2e-next/agent/harness/acp-grok-build/harness.ts
@@ -6,15 +6,13 @@ const harnessId = 'acp-grok-build';
 export const grokBuildACPHarness = createACP({
   harnessId,
   builtinTools: grokBuildACPBuiltinTools,
-  implementation: {
-    type: 'npm',
-    mode: 'simple',
+  source: {
+    type: 'npm-simple',
     packageName: '@xai-official/grok',
-    version: '0.2.111',
-    executable: 'grok',
-    args: ['agent', 'stdio'],
-    forwardEnv: ['XAI_API_KEY'],
   },
+  executable: 'grok',
+  args: ['agent', 'stdio'],
+  forwardEnv: ['XAI_API_KEY'],
   providerAuthentication: {
     gateway: {
       env: {

--- a/examples/harness-e2e-next/agent/harness/acp-grok-build/harness.ts
+++ b/examples/harness-e2e-next/agent/harness/acp-grok-build/harness.ts
@@ -9,6 +9,7 @@ export const grokBuildACPHarness = createACP({
   source: {
     type: 'npm-simple',
     packageName: '@xai-official/grok',
+    packageVersion: '0.2.111',
   },
   executable: 'grok',
   args: ['agent', 'stdio'],

--- a/packages/harness-acp/README.md
+++ b/packages/harness-acp/README.md
@@ -27,14 +27,13 @@ import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 
 const codexACP = createACP({
   harnessId: 'acp-codex',
-  implementation: {
-    type: 'npm',
-    mode: 'simple',
+  source: {
+    type: 'npm-simple',
     packageName: '@agentclientprotocol/codex-acp',
-    version: '1.1.4',
-    executable: 'codex-acp',
-    forwardEnv: ['CODEX_API_KEY', 'OPENAI_API_KEY'],
+    packageVersion: '1.1.4',
   },
+  executable: 'codex-acp',
+  forwardEnv: ['CODEX_API_KEY', 'OPENAI_API_KEY'],
   permissionModeMapping: {
     'allow-reads': null,
     'allow-edits': null,

--- a/packages/harness-acp/src/acp-harness.test-d.ts
+++ b/packages/harness-acp/src/acp-harness.test-d.ts
@@ -51,6 +51,14 @@ describe('createACP built-in tool inference', () => {
       executable: 'acp-agent',
     });
     createACP({
+      harnessId: 'unpinned-acp',
+      source: {
+        type: 'npm-simple',
+        packageName: '@example/acp-agent',
+      },
+      executable: 'acp-agent',
+    });
+    createACP({
       harnessId: 'locked-acp',
       source: {
         type: 'npm-locked',

--- a/packages/harness-acp/src/acp-harness.test-d.ts
+++ b/packages/harness-acp/src/acp-harness.test-d.ts
@@ -27,13 +27,12 @@ describe('createACP built-in tool inference', () => {
     });
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation: {
-        type: 'npm',
-        mode: 'simple',
+      source: {
+        type: 'npm-simple',
         packageName: '@agentclientprotocol/codex-acp',
-        version: '1.1.4',
-        executable: 'codex-acp',
+        packageVersion: '1.1.4',
       },
+      executable: 'codex-acp',
       builtinTools: { bash },
       clientApp: { name: 'example-app', version: '1.2.3' },
     });
@@ -41,26 +40,24 @@ describe('createACP built-in tool inference', () => {
     expectTypeOf(harness.builtinTools).toEqualTypeOf<{ bash: typeof bash }>();
   });
 
-  test('accepts discriminated simple and locked npm acquisition', () => {
+  test('accepts discriminated simple and locked npm sources', () => {
     createACP({
       harnessId: 'simple-acp',
-      implementation: {
-        type: 'npm',
-        mode: 'simple',
+      source: {
+        type: 'npm-simple',
         packageName: '@example/acp-agent',
-        version: '1.2.3',
-        executable: 'acp-agent',
+        packageVersion: '1.2.3',
       },
+      executable: 'acp-agent',
     });
     createACP({
       harnessId: 'locked-acp',
-      implementation: {
-        type: 'npm',
-        mode: 'locked',
+      source: {
+        type: 'npm-locked',
         packageJson: '{"private":true}',
         pnpmLockYaml: "lockfileVersion: '9.0'\n",
-        executable: 'acp-agent',
       },
+      executable: 'acp-agent',
     });
   });
 });

--- a/packages/harness-acp/src/acp-harness.test.ts
+++ b/packages/harness-acp/src/acp-harness.test.ts
@@ -587,6 +587,28 @@ describe('createACP', () => {
     ).toThrow('exact semantic version');
   });
 
+  it('resolves the latest dist-tag when no package version is pinned', async () => {
+    const harness = createACP({
+      harnessId: 'codex-acp-unpinned',
+      ...agentSettings,
+      source: {
+        type: 'npm-simple',
+        packageName: '@agentclientprotocol/codex-acp',
+      },
+    });
+    const bootstrap = await harness.getBootstrap!();
+
+    expect(
+      bootstrap.files.find(file =>
+        file.path.endsWith('/implementation/package.json'),
+      )?.content,
+    ).toContain('"@agentclientprotocol/codex-acp": "latest"');
+    expect(bootstrap.commands.map(command => command.command)).toEqual([
+      'pnpm install --frozen-lockfile --store-dir .pnpm-store',
+      'pnpm --dir implementation install --prod --store-dir ../.pnpm-store',
+    ]);
+  });
+
   it('generates implementation acquisition files and caches the bootstrap', async () => {
     const harness = createACP({
       harnessId: 'codex-acp',

--- a/packages/harness-acp/src/acp-harness.test.ts
+++ b/packages/harness-acp/src/acp-harness.test.ts
@@ -141,11 +141,12 @@ vi.mock('node:fs/promises', async importOriginal => {
   };
 });
 
-const implementation = {
-  type: 'npm',
-  mode: 'simple',
-  packageName: '@agentclientprotocol/codex-acp',
-  version: '1.1.4',
+const agentSettings = {
+  source: {
+    type: 'npm-simple',
+    packageName: '@agentclientprotocol/codex-acp',
+    packageVersion: '1.1.4',
+  },
   executable: 'codex-acp',
   args: ['--example'],
   forwardEnv: ['CODEX_API_KEY'],
@@ -362,7 +363,7 @@ describe('createACP', () => {
   it('constructs the default v1 harness synchronously without reading assets', () => {
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
     });
 
     expect(harness).not.toBeInstanceOf(Promise);
@@ -379,7 +380,7 @@ describe('createACP', () => {
       createACP({
         version: 'v1',
         harnessId: 'codex-acp',
-        implementation,
+        ...agentSettings,
       }).specificationVersion,
     ).toBe('harness-v1');
   });
@@ -387,12 +388,12 @@ describe('createACP', () => {
   it('advertises approvals with and without a complete mapping', () => {
     const mapped = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
       permissionModeMapping,
     });
     const incomplete = createACP({
       harnessId: 'codex-acp-incomplete',
-      implementation,
+      ...agentSettings,
       permissionModeMapping: {
         'allow-all': permissionModeMapping['allow-all'],
       } as never,
@@ -407,7 +408,7 @@ describe('createACP', () => {
   it('supports restrictive permission modes without a mapping', async () => {
     const harness = createACP({
       harnessId: 'grok-build-acp',
-      implementation,
+      ...agentSettings,
     });
 
     const session = await harness.doStart({
@@ -451,7 +452,7 @@ describe('createACP', () => {
     } as const satisfies ACPPermissionModeMapping;
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
       permissionModeMapping: unsupportedMapping,
     });
     const session = await harness.doStart({
@@ -486,7 +487,7 @@ describe('createACP', () => {
   it('does not claim native filtering when approval mapping is complete', async () => {
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
       permissionModeMapping,
     });
 
@@ -510,7 +511,7 @@ describe('createACP', () => {
       createACP({
         version: 'v2',
         harnessId: 'codex-acp',
-        implementation,
+        ...agentSettings,
       } as never),
     ).toThrow('Unsupported ACP protocol version "v2"');
   });
@@ -518,7 +519,7 @@ describe('createACP', () => {
   it.each(['CodexACP', 'codex_acp', 'codex/acp', 'codex--acp', ''])(
     'rejects unstable harness id %j',
     harnessId => {
-      expect(() => createACP({ harnessId, implementation })).toThrow(
+      expect(() => createACP({ harnessId, ...agentSettings })).toThrow(
         'stable kebab-case identifier',
       );
     },
@@ -533,7 +534,7 @@ describe('createACP', () => {
     };
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
       builtinTools,
     });
 
@@ -580,7 +581,8 @@ describe('createACP', () => {
     expect(() =>
       createACP({
         harnessId: 'codex-acp',
-        implementation: { ...implementation, version: '^1.1.4' },
+        ...agentSettings,
+        source: { ...agentSettings.source, packageVersion: '^1.1.4' },
       }),
     ).toThrow('exact semantic version');
   });
@@ -588,7 +590,7 @@ describe('createACP', () => {
   it('generates implementation acquisition files and caches the bootstrap', async () => {
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
     });
     const first = await harness.getBootstrap!();
     const second = await harness.getBootstrap!();
@@ -634,11 +636,11 @@ describe('createACP', () => {
   it('caches bootstrap per factory without sharing configuration globally', async () => {
     const firstHarness = createACP({
       harnessId: 'first-acp',
-      implementation,
+      ...agentSettings,
     });
     const secondHarness = createACP({
       harnessId: 'second-acp',
-      implementation,
+      ...agentSettings,
     });
     const firstBootstrap = await firstHarness.getBootstrap!();
     const secondBootstrap = await secondHarness.getBootstrap!();
@@ -653,13 +655,12 @@ describe('createACP', () => {
   it('uses caller-provided artifacts for locked frozen acquisition', async () => {
     const harness = createACP({
       harnessId: 'codex-acp-locked',
-      implementation: {
-        type: 'npm',
-        mode: 'locked',
+      source: {
+        type: 'npm-locked',
         packageJson: lockedPackageJson,
         pnpmLockYaml: lockedPnpmLockYaml,
-        executable: 'codex-acp',
       },
+      executable: 'codex-acp',
     });
     const bootstrap = await harness.getBootstrap!();
 
@@ -723,7 +724,7 @@ describe('createACP', () => {
     const harness = createACP({
       harnessId: 'codex-acp',
       auth: 'direct',
-      implementation,
+      ...agentSettings,
       authentication: { methodId: 'api-key' },
       providerAuthentication: {
         gateway: {
@@ -765,7 +766,7 @@ describe('createACP', () => {
   it('rejects an already-aborted turn without sending a start frame', async () => {
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
     });
     const session = await harness.doStart({
       sessionId: 'session-1',
@@ -801,7 +802,7 @@ describe('createACP', () => {
     const writes: Array<{ path: string; content: string }> = [];
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
     });
     const session = await harness.doStart({
       sessionId: 'session-1',
@@ -938,7 +939,7 @@ describe('createACP', () => {
     ] as const;
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
       authentication: { methodId: 'api-key' },
     });
     const firstSession = await harness.doStart({
@@ -1049,10 +1050,8 @@ describe('createACP', () => {
     const harness = createACP({
       harnessId: 'cold-gateway-acp',
       auth: 'ai-gateway',
-      implementation: {
-        ...implementation,
-        forwardEnv: [],
-      },
+      ...agentSettings,
+      forwardEnv: [],
       modelId: 'gpt-5.1-codex',
       session: {
         meta: {
@@ -1289,7 +1288,7 @@ describe('createACP', () => {
     });
     const harness = createACP({
       harnessId: 'unsupported-cold-acp',
-      implementation,
+      ...agentSettings,
     });
     const firstSession = await harness.doStart({
       sessionId: 'session-1',
@@ -1358,7 +1357,7 @@ describe('createACP', () => {
     });
     const firstHarness = createACP({
       harnessId: 'model-identity-acp',
-      implementation,
+      ...agentSettings,
       modelId: 'model-before-stop',
     });
     const firstSession = await firstHarness.doStart({
@@ -1385,7 +1384,7 @@ describe('createACP', () => {
 
     const changedHarness = createACP({
       harnessId: 'model-identity-acp',
-      implementation,
+      ...agentSettings,
       modelId: 'model-after-stop',
     });
     await expect(
@@ -1412,7 +1411,7 @@ describe('createACP', () => {
     });
     const harness = createACP({
       harnessId: 'idempotent-lifecycle-acp',
-      implementation,
+      ...agentSettings,
     });
     const stoppedSession = await harness.doStart({
       sessionId: 'session-stop',
@@ -1478,7 +1477,7 @@ describe('createACP', () => {
   it('rejects standard ACP v1 manual compaction without sending a command', async () => {
     const harness = createACP({
       harnessId: 'compact-acp',
-      implementation,
+      ...agentSettings,
     });
     const session = await harness.doStart({
       sessionId: 'session-1',
@@ -1513,7 +1512,7 @@ describe('createACP', () => {
     });
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
     });
     const firstSession = await harness.doStart({
       sessionId: 'session-1',
@@ -1599,7 +1598,7 @@ describe('createACP', () => {
     });
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
     });
     const initialSession = await harness.doStart({
       sessionId: 'session-replay',
@@ -1698,7 +1697,7 @@ describe('createACP', () => {
     const harness = createACP({
       harnessId: 'codex-acp',
       auth: 'ai-gateway',
-      implementation,
+      ...agentSettings,
       providerAuthentication: {
         gateway: {
           env: {
@@ -1814,7 +1813,7 @@ describe('createACP', () => {
     });
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
     });
     const firstAgent = new HarnessAgent({
       harness,
@@ -1904,7 +1903,7 @@ describe('createACP', () => {
     });
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
       builtinTools: {
         bash: commonTool('bash', {
           nativeName: 'shell',
@@ -2021,7 +2020,7 @@ describe('createACP', () => {
     async ({ permissionMode }) => {
       const harness = createACP({
         harnessId: 'codex-acp',
-        implementation,
+        ...agentSettings,
         permissionModeMapping,
       });
       const session = await harness.doStart({
@@ -2058,7 +2057,7 @@ describe('createACP', () => {
   it('submits a host approval decision to the pending ACP turn', async () => {
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
       permissionModeMapping,
     });
     const session = await harness.doStart({
@@ -2102,7 +2101,7 @@ describe('createACP', () => {
   it('sends the exact host tool catalog and submits a continued client result', async () => {
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
     });
     const session = await harness.doStart({
       sessionId: 'session-1',
@@ -2181,7 +2180,7 @@ describe('createACP', () => {
   it('sends changed, removed, and unchanged catalogs on consecutive turns', async () => {
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
     });
     const session = await harness.doStart({
       sessionId: 'session-1',
@@ -2277,7 +2276,7 @@ describe('createACP', () => {
   it('preserves capability errors reported by the sandbox bridge', async () => {
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
     });
     const session = await harness.doStart({
       sessionId: 'session-1',
@@ -2339,7 +2338,7 @@ describe('createACP', () => {
     const agent = new HarnessAgent({
       harness: createACP({
         harnessId: 'codex-acp',
-        implementation,
+        ...agentSettings,
       }),
       sandbox: sandboxProvider({ session: sandboxSession }),
       tools: { weather },
@@ -2415,7 +2414,7 @@ describe('createACP', () => {
     const agent = new HarnessAgent({
       harness: createACP({
         harnessId: 'codex-acp',
-        implementation,
+        ...agentSettings,
       }),
       sandbox: sandboxProvider({ session: sandboxSession }),
       tools: { clientTool },
@@ -2483,7 +2482,7 @@ describe('createACP', () => {
   it('waits for the bridge terminal sequence after cancellation before rejecting the turn', async () => {
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
     });
     const session = await harness.doStart({
       sessionId: 'session-1',
@@ -2561,7 +2560,7 @@ describe('createACP', () => {
   it('rejects a cancelled turn when the bridge connection fails', async () => {
     const harness = createACP({
       harnessId: 'codex-acp',
-      implementation,
+      ...agentSettings,
     });
     const session = await harness.doStart({
       sessionId: 'session-1',
@@ -2607,10 +2606,8 @@ describe('createACP', () => {
       harnessId: 'codex-acp-gateway',
       auth: 'ai-gateway',
       clientApp: { name: 'custom-client', version: '1.2.3' },
-      implementation: {
-        ...implementation,
-        forwardEnv: [],
-      },
+      ...agentSettings,
+      forwardEnv: [],
       providerAuthentication: {
         gateway: {
           env: {},
@@ -2648,10 +2645,8 @@ describe('createACP', () => {
     }> = [];
     const harness = createACP({
       harnessId: 'late-auth-acp',
-      implementation: {
-        ...implementation,
-        forwardEnv: [],
-      },
+      ...agentSettings,
+      forwardEnv: [],
       providerAuthentication: {
         gateway: {
           env: {
@@ -2710,12 +2705,10 @@ describe('createACP', () => {
     const harness = createACP({
       harnessId: 'secret-safe-acp',
       auth: 'ai-gateway',
-      implementation: {
-        ...implementation,
-        forwardEnv: ['PROVIDER_API_KEY'],
-        env: {
-          PROVIDER_BASE_URL: 'https://provider.example',
-        },
+      ...agentSettings,
+      forwardEnv: ['PROVIDER_API_KEY'],
+      env: {
+        PROVIDER_BASE_URL: 'https://provider.example',
       },
       providerAuthentication: {
         gateway: {
@@ -2769,10 +2762,8 @@ describe('createACP', () => {
     const harness = createACP({
       harnessId: 'direct-secret-safe-acp',
       auth: 'direct',
-      implementation: {
-        ...implementation,
-        forwardEnv: ['PROVIDER_API_KEY'],
-      },
+      ...agentSettings,
+      forwardEnv: ['PROVIDER_API_KEY'],
       providerAuthentication: {
         gateway: {
           env: {
@@ -2811,14 +2802,12 @@ describe('createACP', () => {
   it('validates lifecycle state structurally and rejects incompatible identities at start', async () => {
     const first = createACP({
       harnessId: 'identity-acp',
-      implementation,
+      ...agentSettings,
     });
     const second = createACP({
       harnessId: 'identity-acp',
-      implementation: {
-        ...implementation,
-        args: ['different'],
-      },
+      ...agentSettings,
+      args: ['different'],
     });
     const sandbox = fakeSandbox({
       runs: [],

--- a/packages/harness-acp/src/acp-harness.ts
+++ b/packages/harness-acp/src/acp-harness.ts
@@ -22,7 +22,11 @@ export type ACPHarnessSettings<TBuiltinTools extends ToolSet = {}> = {
   readonly version?: ACPV1Settings['version'];
   readonly harnessId: ACPV1Settings['harnessId'];
   readonly auth?: ACPV1Settings['auth'];
-  readonly implementation: ACPV1Settings['implementation'];
+  readonly source: ACPV1Settings['source'];
+  readonly executable: ACPV1Settings['executable'];
+  readonly args?: ACPV1Settings['args'];
+  readonly forwardEnv?: ACPV1Settings['forwardEnv'];
+  readonly env?: ACPV1Settings['env'];
   readonly authentication?: ACPV1Settings['authentication'];
   readonly providerAuthentication?: ACPV1Settings['providerAuthentication'];
   readonly modelId?: ACPV1Settings['modelId'];

--- a/packages/harness-acp/src/index.ts
+++ b/packages/harness-acp/src/index.ts
@@ -3,8 +3,8 @@ export type { ACPAuthOptions, ACPClientApp } from './acp-auth';
 export type { ACPHarnessSettings } from './acp-harness';
 export type {
   ACPAuthentication,
-  ACPLockedNpmImplementation,
-  ACPNpmImplementation,
+  ACPNpmLockedSource,
+  ACPNpmSimpleSource,
   ACPPermissionModeMapping,
   ACPPermissionModeTarget,
   ACPProfileValue,
@@ -12,7 +12,7 @@ export type {
   ACPProviderAuthenticationMode,
   ACPSerializablePrimitive,
   ACPSerializableValue,
-  ACPSimpleNpmImplementation,
+  ACPSource,
   ACPV1Settings,
   ACPValueSource,
 } from './v1';

--- a/packages/harness-acp/src/v1/acp-v1-harness.ts
+++ b/packages/harness-acp/src/v1/acp-v1-harness.ts
@@ -41,6 +41,7 @@ import {
   type ACPClientApp,
 } from '../acp-auth';
 import {
+  createACPV1Implementation,
   createImplementationDescriptor,
   createImplementationIdentity,
   createImplementationInstallCommand,
@@ -130,7 +131,8 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
       `ACP harnessId must be a stable kebab-case identifier; received ${JSON.stringify(settings.harnessId)}.`,
     );
   }
-  validateACPV1Implementation(settings.implementation);
+  const implementation = createACPV1Implementation({ settings });
+  validateACPV1Implementation(implementation);
 
   const BOOTSTRAP_DIR = `.harness-bootstrap/${settings.harnessId}`;
 
@@ -158,7 +160,7 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
           readBridgeAsset({ name: 'host-tool-mcp.mjs' }),
         ]);
       const implementationLock = getImplementationLockfile({
-        implementation: settings.implementation,
+        implementation,
       });
       cachedBootstrap = {
         harnessId: settings.harnessId,
@@ -180,13 +182,13 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
           {
             path: `${BOOTSTRAP_DIR}/implementation/package.json`,
             content: createImplementationManifest({
-              implementation: settings.implementation,
+              implementation,
             }),
           },
           {
             path: `${BOOTSTRAP_DIR}/implementation/implementation.json`,
             content: createImplementationDescriptor({
-              implementation: settings.implementation,
+              implementation,
             }),
           },
           ...(implementationLock == null
@@ -206,7 +208,7 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
             command: createImplementationInstallCommand({
               implementationDir: 'implementation',
               storeDir: '../.pnpm-store',
-              implementation: settings.implementation,
+              implementation,
             }),
           },
         ],
@@ -232,7 +234,7 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
       const implementationIdentity = createImplementationIdentity({
         harnessId: settings.harnessId,
         acpVersion: 'v1',
-        implementation: settings.implementation,
+        implementation,
         clientApp,
         providerAuthentication: providerAuthenticationCompatibility,
         permissionModeMapping: settings.permissionModeMapping,
@@ -484,7 +486,7 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
           ` --bridge-type ${shellQuote(settings.harnessId)}`,
         env: {
           ...resolveImplementationEnvironment({
-            implementation: settings.implementation,
+            implementation,
             env,
           }),
           ...createACPBridgeEnvironment({

--- a/packages/harness-acp/src/v1/acp-v1-settings.ts
+++ b/packages/harness-acp/src/v1/acp-v1-settings.ts
@@ -26,33 +26,19 @@ export type ACPProfileValue =
   | ReadonlyArray<ACPProfileValue>
   | { readonly [key: string]: ACPProfileValue };
 
-type ACPNpmLaunchSettings = {
-  readonly type: 'npm';
-  readonly executable: string;
-  readonly args?: ReadonlyArray<string>;
-  readonly forwardEnv?: ReadonlyArray<string>;
-  /**
-   * Runtime environment values that are safe to persist in bootstrap and
-   * lifecycle compatibility identity.
-   */
-  readonly env?: Readonly<Record<string, string>>;
-};
-
-export type ACPSimpleNpmImplementation = ACPNpmLaunchSettings & {
-  readonly mode: 'simple';
+export type ACPNpmSimpleSource = {
+  readonly type: 'npm-simple';
   readonly packageName: string;
-  readonly version: string;
+  readonly packageVersion: string;
 };
 
-export type ACPLockedNpmImplementation = ACPNpmLaunchSettings & {
-  readonly mode: 'locked';
+export type ACPNpmLockedSource = {
+  readonly type: 'npm-locked';
   readonly packageJson: string;
   readonly pnpmLockYaml: string;
 };
 
-export type ACPNpmImplementation =
-  | ACPSimpleNpmImplementation
-  | ACPLockedNpmImplementation;
+export type ACPSource = ACPNpmSimpleSource | ACPNpmLockedSource;
 
 export type ACPAuthentication = {
   readonly methodId: string;
@@ -87,7 +73,15 @@ export type ACPV1Settings = {
   readonly version?: 'v1';
   readonly harnessId: string;
   readonly auth?: ACPProviderAuthenticationMode;
-  readonly implementation: ACPNpmImplementation;
+  readonly source: ACPSource;
+  readonly executable: string;
+  readonly args?: ReadonlyArray<string>;
+  readonly forwardEnv?: ReadonlyArray<string>;
+  /**
+   * Runtime environment values that are safe to persist in bootstrap and
+   * lifecycle compatibility identity.
+   */
+  readonly env?: Readonly<Record<string, string>>;
   readonly authentication?: ACPAuthentication;
   readonly providerAuthentication?: ACPProviderAuthentication;
   readonly modelId?: string;

--- a/packages/harness-acp/src/v1/acp-v1-settings.ts
+++ b/packages/harness-acp/src/v1/acp-v1-settings.ts
@@ -29,7 +29,12 @@ export type ACPProfileValue =
 export type ACPNpmSimpleSource = {
   readonly type: 'npm-simple';
   readonly packageName: string;
-  readonly packageVersion: string;
+  /**
+   * Exact version to install. When omitted, the package's `latest` dist-tag is
+   * installed and no version takes part in the implementation identity, so a
+   * new upstream release does not invalidate existing lifecycle state.
+   */
+  readonly packageVersion?: string;
 };
 
 export type ACPNpmLockedSource = {

--- a/packages/harness-acp/src/v1/implementation.test.ts
+++ b/packages/harness-acp/src/v1/implementation.test.ts
@@ -29,6 +29,19 @@ const simpleImplementation = {
   },
 } as const satisfies ACPNpmImplementation;
 
+const unpinnedImplementation = {
+  source: {
+    type: 'npm-simple',
+    packageName: '@example/acp-agent',
+  },
+  executable: 'acp-agent',
+  args: ['stdio'],
+  forwardEnv: ['PROVIDER_API_KEY', 'SECOND_PROVIDER_API_KEY'],
+  env: {
+    PROVIDER_BASE_URL: 'https://provider.example',
+  },
+} as const satisfies ACPNpmImplementation;
+
 const packageJson = `{
   "name": "locked-acp-agent",
   "private": true,
@@ -118,6 +131,50 @@ describe('ACP npm implementation', () => {
         implementation: simpleImplementation,
       }),
     ).toBeUndefined();
+  });
+
+  it('installs the latest dist-tag when no version is pinned', () => {
+    expect(
+      createImplementationManifest({
+        implementation: unpinnedImplementation,
+      }),
+    ).toBe(`{
+  "name": "harness-acp-implementation",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@example/acp-agent": "latest"
+  }
+}
+`);
+    expect(() =>
+      validateACPV1Implementation(unpinnedImplementation),
+    ).not.toThrow();
+  });
+
+  it('keeps the identity of an unpinned source free of any version', () => {
+    const unpinnedIdentity = identity({
+      implementation: unpinnedImplementation,
+    });
+
+    expect(identity({ implementation: unpinnedImplementation })).toBe(
+      unpinnedIdentity,
+    );
+    expect(identity({ implementation: simpleImplementation })).not.toBe(
+      unpinnedIdentity,
+    );
+    expect(
+      identity({
+        implementation: {
+          ...unpinnedImplementation,
+          source: {
+            ...unpinnedImplementation.source,
+            packageName: '@example/other-agent',
+          },
+        },
+      }),
+    ).not.toBe(unpinnedIdentity);
   });
 
   it('preserves caller-provided locked artifacts and freezes installation', () => {

--- a/packages/harness-acp/src/v1/implementation.test.ts
+++ b/packages/harness-acp/src/v1/implementation.test.ts
@@ -3,11 +3,9 @@ import type {
   ACPClientApp,
   ACPProviderAuthenticationCompatibility,
 } from '../acp-auth';
-import type {
-  ACPNpmImplementation,
-  ACPPermissionModeMapping,
-} from './acp-v1-settings';
+import type { ACPPermissionModeMapping } from './acp-v1-settings';
 import {
+  type ACPNpmImplementation,
   createImplementationDescriptor,
   createImplementationIdentity,
   createImplementationInstallCommand,
@@ -18,10 +16,11 @@ import {
 } from './implementation';
 
 const simpleImplementation = {
-  type: 'npm',
-  mode: 'simple',
-  packageName: '@example/acp-agent',
-  version: '1.2.3',
+  source: {
+    type: 'npm-simple',
+    packageName: '@example/acp-agent',
+    packageVersion: '1.2.3',
+  },
   executable: 'acp-agent',
   args: ['stdio'],
   forwardEnv: ['PROVIDER_API_KEY', 'SECOND_PROVIDER_API_KEY'],
@@ -48,10 +47,11 @@ importers:
 `;
 
 const lockedImplementation = {
-  type: 'npm',
-  mode: 'locked',
-  packageJson,
-  pnpmLockYaml,
+  source: {
+    type: 'npm-locked',
+    packageJson,
+    pnpmLockYaml,
+  },
   executable: 'acp-agent',
   args: ['stdio'],
   forwardEnv: ['PROVIDER_API_KEY', 'SECOND_PROVIDER_API_KEY'],
@@ -142,11 +142,14 @@ describe('ACP npm implementation', () => {
     );
   });
 
-  it('requires exact versions only for simple acquisition', () => {
+  it('requires exact versions only for a simple npm source', () => {
     expect(() =>
       validateACPV1Implementation({
         ...simpleImplementation,
-        version: '^1.2.3',
+        source: {
+          ...simpleImplementation.source,
+          packageVersion: '^1.2.3',
+        },
       }),
     ).toThrow('must be an exact semantic version');
     expect(() =>
@@ -260,7 +263,10 @@ describe('ACP npm implementation', () => {
       identity({
         implementation: {
           ...simpleImplementation,
-          packageName: '@example/other-agent',
+          source: {
+            ...simpleImplementation.source,
+            packageName: '@example/other-agent',
+          },
         },
       }),
     ).not.toBe(baseIdentity);
@@ -268,7 +274,10 @@ describe('ACP npm implementation', () => {
       identity({
         implementation: {
           ...simpleImplementation,
-          version: '1.2.4',
+          source: {
+            ...simpleImplementation.source,
+            packageVersion: '1.2.4',
+          },
         },
       }),
     ).not.toBe(baseIdentity);
@@ -336,7 +345,10 @@ describe('ACP npm implementation', () => {
       identity({
         implementation: {
           ...lockedImplementation,
-          packageJson: packageJson.replace('locked-acp-agent', 'other-agent'),
+          source: {
+            ...lockedImplementation.source,
+            packageJson: packageJson.replace('locked-acp-agent', 'other-agent'),
+          },
         },
       }),
     ).not.toBe(lockedIdentity);
@@ -344,7 +356,10 @@ describe('ACP npm implementation', () => {
       identity({
         implementation: {
           ...lockedImplementation,
-          pnpmLockYaml: `${pnpmLockYaml}\n# changed\n`,
+          source: {
+            ...lockedImplementation.source,
+            pnpmLockYaml: `${pnpmLockYaml}\n# changed\n`,
+          },
         },
       }),
     ).not.toBe(lockedIdentity);

--- a/packages/harness-acp/src/v1/implementation.ts
+++ b/packages/harness-acp/src/v1/implementation.ts
@@ -4,10 +4,41 @@ import type {
   ACPProviderAuthenticationCompatibility,
 } from '../acp-auth';
 import type {
-  ACPNpmImplementation,
+  ACPNpmSimpleSource,
   ACPPermissionModeMapping,
-  ACPSimpleNpmImplementation,
+  ACPSource,
+  ACPV1Settings,
 } from './acp-v1-settings';
+
+/*
+ * Launch descriptor assembled from the launch-related settings fields. The
+ * fields are declared here rather than derived from ACPV1Settings so that the
+ * settings type stays free to describe the configuration surface while this
+ * type describes what the bootstrap, install, and identity logic consume. The
+ * two shapes are required to agree, and createACPV1Implementation is the only
+ * place that maps between them.
+ */
+export type ACPNpmImplementation = {
+  readonly source: ACPSource;
+  readonly executable: string;
+  readonly args?: ReadonlyArray<string>;
+  readonly forwardEnv?: ReadonlyArray<string>;
+  readonly env?: Readonly<Record<string, string>>;
+};
+
+export function createACPV1Implementation({
+  settings,
+}: {
+  settings: ACPV1Settings;
+}): ACPNpmImplementation {
+  return {
+    source: settings.source,
+    executable: settings.executable,
+    args: settings.args,
+    forwardEnv: settings.forwardEnv,
+    env: settings.env,
+  };
+}
 
 const EXACT_SEMVER_REGEXP =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
@@ -19,19 +50,16 @@ const ENVIRONMENT_VARIABLE_NAME_REGEXP = /^[A-Za-z_][A-Za-z0-9_]*$/;
 export function validateACPV1Implementation(
   implementation: ACPNpmImplementation,
 ): void {
-  if (isLockedImplementation(implementation)) {
-    if (implementation.packageJson.length === 0) {
-      throw new Error(
-        'ACP locked npm implementation packageJson must not be empty.',
-      );
+  const { source } = implementation;
+  if (source.type === 'npm-locked') {
+    if (source.packageJson.length === 0) {
+      throw new Error('ACP source.packageJson must not be empty.');
     }
-    if (implementation.pnpmLockYaml.length === 0) {
-      throw new Error(
-        'ACP locked npm implementation pnpmLockYaml must not be empty.',
-      );
+    if (source.pnpmLockYaml.length === 0) {
+      throw new Error('ACP source.pnpmLockYaml must not be empty.');
     }
   } else {
-    validateSimpleImplementation({ implementation });
+    validateNpmSimpleSource({ source });
   }
   if (!EXECUTABLE_NAME_REGEXP.test(implementation.executable)) {
     throw new Error(
@@ -56,8 +84,9 @@ export function createImplementationManifest({
 }: {
   implementation: ACPNpmImplementation;
 }): string {
-  if (isLockedImplementation(implementation)) {
-    return implementation.packageJson;
+  const { source } = implementation;
+  if (source.type === 'npm-locked') {
+    return source.packageJson;
   }
   return (
     JSON.stringify(
@@ -67,7 +96,7 @@ export function createImplementationManifest({
         private: true,
         type: 'module',
         dependencies: {
-          [implementation.packageName]: implementation.version,
+          [source.packageName]: source.packageVersion,
         },
       },
       null,
@@ -81,9 +110,8 @@ export function getImplementationLockfile({
 }: {
   implementation: ACPNpmImplementation;
 }): string | undefined {
-  return isLockedImplementation(implementation)
-    ? implementation.pnpmLockYaml
-    : undefined;
+  const { source } = implementation;
+  return source.type === 'npm-locked' ? source.pnpmLockYaml : undefined;
 }
 
 export function createImplementationDescriptor({
@@ -119,17 +147,19 @@ export function createImplementationIdentity({
   providerAuthentication: ACPProviderAuthenticationCompatibility | undefined;
   permissionModeMapping?: ACPPermissionModeMapping;
 }): string {
-  const acquisition = isLockedImplementation(implementation)
-    ? {
-        mode: 'locked',
-        packageJson: implementation.packageJson,
-        pnpmLockYaml: implementation.pnpmLockYaml,
-      }
-    : {
-        mode: 'simple',
-        packageName: implementation.packageName,
-        version: implementation.version,
-      };
+  const { source } = implementation;
+  const sourceIdentity =
+    source.type === 'npm-locked'
+      ? {
+          type: source.type,
+          packageJson: source.packageJson,
+          pnpmLockYaml: source.pnpmLockYaml,
+        }
+      : {
+          type: source.type,
+          packageName: source.packageName,
+          packageVersion: source.packageVersion,
+        };
   const forwardedEnvironment = [
     ...new Set(implementation.forwardEnv ?? []),
   ].sort();
@@ -141,7 +171,7 @@ export function createImplementationIdentity({
   const payload = {
     harnessId,
     acpVersion,
-    acquisition,
+    source: sourceIdentity,
     executable: implementation.executable,
     args: implementation.args ?? [],
     clientApp,
@@ -168,7 +198,7 @@ export function createImplementationInstallCommand({
 }): string {
   return (
     `pnpm --dir ${implementationDir} install` +
-    (isLockedImplementation(implementation) ? ' --frozen-lockfile' : '') +
+    (implementation.source.type === 'npm-locked' ? ' --frozen-lockfile' : '') +
     ` --prod --store-dir ${storeDir}`
   );
 }
@@ -193,19 +223,19 @@ export function resolveImplementationEnvironment({
   };
 }
 
-function validateSimpleImplementation({
-  implementation,
+function validateNpmSimpleSource({
+  source,
 }: {
-  implementation: ACPSimpleNpmImplementation;
+  source: ACPNpmSimpleSource;
 }): void {
-  if (!PACKAGE_NAME_REGEXP.test(implementation.packageName)) {
+  if (!PACKAGE_NAME_REGEXP.test(source.packageName)) {
     throw new Error(
-      `ACP npm package name is invalid: ${JSON.stringify(implementation.packageName)}.`,
+      `ACP npm package name is invalid: ${JSON.stringify(source.packageName)}.`,
     );
   }
-  if (!EXACT_SEMVER_REGEXP.test(implementation.version)) {
+  if (!EXACT_SEMVER_REGEXP.test(source.packageVersion)) {
     throw new Error(
-      `ACP npm implementation version must be an exact semantic version; received ${JSON.stringify(implementation.version)}.`,
+      `ACP npm package version must be an exact semantic version; received ${JSON.stringify(source.packageVersion)}.`,
     );
   }
 }
@@ -252,12 +282,6 @@ function getImplementationEnvironmentKeys({
       ...Object.keys(implementation.env ?? {}),
     ]),
   ].sort();
-}
-
-function isLockedImplementation(
-  implementation: ACPNpmImplementation,
-): implementation is Extract<ACPNpmImplementation, { mode: 'locked' }> {
-  return implementation.mode === 'locked';
 }
 
 function stableStringify({ value }: { value: unknown }): string {

--- a/packages/harness-acp/src/v1/implementation.ts
+++ b/packages/harness-acp/src/v1/implementation.ts
@@ -96,7 +96,7 @@ export function createImplementationManifest({
         private: true,
         type: 'module',
         dependencies: {
-          [source.packageName]: source.packageVersion,
+          [source.packageName]: source.packageVersion ?? 'latest',
         },
       },
       null,
@@ -158,7 +158,9 @@ export function createImplementationIdentity({
       : {
           type: source.type,
           packageName: source.packageName,
-          packageVersion: source.packageVersion,
+          ...(source.packageVersion == null
+            ? {}
+            : { packageVersion: source.packageVersion }),
         };
   const forwardedEnvironment = [
     ...new Set(implementation.forwardEnv ?? []),
@@ -233,7 +235,10 @@ function validateNpmSimpleSource({
       `ACP npm package name is invalid: ${JSON.stringify(source.packageName)}.`,
     );
   }
-  if (!EXACT_SEMVER_REGEXP.test(source.packageVersion)) {
+  if (
+    source.packageVersion != null &&
+    !EXACT_SEMVER_REGEXP.test(source.packageVersion)
+  ) {
     throw new Error(
       `ACP npm package version must be an exact semantic version; received ${JSON.stringify(source.packageVersion)}.`,
     );

--- a/packages/harness-acp/src/v1/index.ts
+++ b/packages/harness-acp/src/v1/index.ts
@@ -1,8 +1,8 @@
 export { createACPV1 } from './acp-v1-harness';
 export type {
   ACPAuthentication,
-  ACPLockedNpmImplementation,
-  ACPNpmImplementation,
+  ACPNpmLockedSource,
+  ACPNpmSimpleSource,
   ACPPermissionModeMapping,
   ACPPermissionModeTarget,
   ACPProfileValue,
@@ -10,7 +10,7 @@ export type {
   ACPProviderAuthenticationMode,
   ACPSerializablePrimitive,
   ACPSerializableValue,
-  ACPSimpleNpmImplementation,
+  ACPSource,
   ACPV1Settings,
   ACPValueSource,
 } from './acp-v1-settings';


### PR DESCRIPTION
## Background

The `createACP()` configuration grouped package acquisition and runtime launch settings into one nested implementation object, making reusable package sources harder to compose.

## Summary

- Separate package acquisition into `npm-simple` and `npm-locked` source types while keeping executable and runtime settings at the top level.
- Make `packageVersion` optional for simple NPM sources, defaulting installation to `latest` without including an omitted version in lifecycle identity.
- Update tests, examples, and documentation for the simplified API.

### Before

```ts
import { createACP } from '@ai-sdk/harness-acp';

export function createCodexACP() {
  return createACP({
    harnessId: 'codex-acp',
    implementation: {
      type: 'npm',
      mode: 'simple',
      packageName: '@agentclientprotocol/codex-acp',
      version: '1.1.4',
      executable: 'codex-acp',
      forwardEnv: ['CODEX_API_KEY', 'OPENAI_API_KEY'],
    },
    env: {
      IS_SANDBOX: '1',
    },
  });
}
```

### After

```ts
import { createACP } from '@ai-sdk/harness-acp';

export function createCodexACP() {
  return createACP({
    harnessId: 'codex-acp',
    source: {
      type: 'npm-simple',
      packageName: '@agentclientprotocol/codex-acp',
	},
    executable: 'codex-acp',
    forwardEnv: ['CODEX_API_KEY', 'OPENAI_API_KEY'],
    env: {
      IS_SANDBOX: '1',
    },
  });
}
```

## End-to-End Verification

No functional changes.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
