### PR TITLE
fix(@ai-sdk/amazon-bedrock): normalize Anthropic exception frames

### DIFF
--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.test.ts
@@ -148,7 +148,10 @@ describe('createAmazonBedrockAnthropicFetch', () => {
     const text = new TextDecoder().decode(value);
 
     expect(text).toBe(
-      `data: ${JSON.stringify({ type: 'error', error: errorData })}\n\n`,
+      `data: ${JSON.stringify({
+        type: 'error',
+        error: { type: 'error', message: 'Rate limit exceeded' },
+      })}\n\n`,
     );
   });
 

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
@@ -93,9 +93,20 @@ function transformAmazonBedrockEventStreamToSSE(
           controller.enqueue(textEncoder.encode('data: [DONE]\n\n'));
         }
       } else if (event.messageType === 'exception') {
+        const parsed = await safeParseJSON({
+          text: event.data,
+          schema: amazonBedrockErrorSchema,
+        });
+        const message =
+          parsed.success && parsed.value.message
+            ? parsed.value.message
+            : event.data;
         controller.enqueue(
           textEncoder.encode(
-            `data: ${JSON.stringify({ type: 'error', error: event.data })}\n\n`,
+            `data: ${JSON.stringify({
+              type: 'error',
+              error: { type: 'error', message },
+            })}\n\n`,
           ),
         );
       }


### PR DESCRIPTION
Fixes #17124

### Summary

- Normalize Bedrock event-stream exception bodies into the Anthropic error object shape.
- Preserve the raw exception body as a fallback when it is not a JSON object with a message.
- Add focused coverage for structured exception messages.

### Verification

local verification not run; relying on upstream CI

The fresh worktree has no `node_modules` installed, so the package test runner cannot execute locally.
