### PR TITLE
fix(openai): avoid duplicate MCP approval references

### DIFF
--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -4595,6 +4595,69 @@ describe('convertToOpenAIResponsesInput', () => {
       `);
     });
 
+    it('should omit stored mcpr item_reference when a previous response chain is linked', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'mcpr_stored_123',
+                approved: true,
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+        hasPreviousResponseId: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'mcp_approval_response',
+          approval_request_id: 'mcpr_stored_123',
+          approve: true,
+        },
+      ]);
+    });
+
+    it('should keep stored mcpr item_reference without a previous response.chain or conversation', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-approval-response',
+                approvalId: 'mcpr_stored_123',
+                approved: true,
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'item_reference',
+          id: 'mcpr_stored_123',
+        },
+        {
+          type: 'mcp_approval_response',
+          approval_request_id: 'mcpr_stored_123',
+          approve: true,
+        },
+      ]);
+    });
+
     it('should skip execution-denied output when it has approvalId in providerOptions', async () => {
       const result = await convertToOpenAIResponsesInput({
         toolNameMapping: testToolNameMapping,

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -893,7 +893,12 @@ export async function convertToOpenAIResponsesInput({
             }
             processedApprovalIds.add(approvalResponse.approvalId);
 
-            if (store) {
+            const isStoredMcpApproval =
+              (hasConversation || hasPreviousResponseId) &&
+              approvalResponse.approvalId.startsWith('mcpr_');
+
+            // OpenAI stores `mcpr_` approval requests on conversation/response chains.
+            if (store && !isStoredMcpApproval) {
               input.push({
                 type: 'item_reference',
                 id: approvalResponse.approvalId,


### PR DESCRIPTION
## Summary

- Avoid emitting a redundant `item_reference` for stored `mcpr_` approvals when the request is linked to a previous response or conversation chain.
- Preserve existing `item_reference` behavior for ordinary approvals and for stored MCP approvals without a linked chain.
- Add focused regression coverage for both paths.

## Issue

Fixes #18605.

## Verification

local verification not run; relying on upstream CI
