### PR TITLE
feat(harness): support preinstalled bridge runtimes

### DIFF
--- a/.changeset/calm-bridges-travel.md
+++ b/.changeset/calm-bridges-travel.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/harness': patch
+'@ai-sdk/harness-codex': patch
+'@ai-sdk/sandbox-vercel': patch
+'@ai-sdk/sandbox-just-bash': patch
+---
+
+Add provider-owned guest path and directory operations, direct executable and
+argv process spawning, and an opt-in preinstalled Codex bridge mode that skips
+the adapter-owned pnpm bootstrap while preserving the existing default.

--- a/packages/harness-codex/README.md
+++ b/packages/harness-codex/README.md
@@ -10,6 +10,23 @@ npm i @ai-sdk/harness-codex @ai-sdk/harness @ai-sdk/sandbox-vercel
 
 The bridge installs `@openai/codex-sdk` (and the `codex` CLI it depends on) inside the sandbox the first time the session starts.
 
+Applications that package the bridge ahead of time can skip that install:
+
+```ts
+const harness = createCodex({
+  preinstalledBridge: {
+    identity: 'codex-bridge-v1',
+    nodeExecutable: '/opt/app/node',
+    entrypoint: '/opt/app/codex-bridge/bridge.mjs',
+  },
+});
+```
+
+Preinstalled mode requires the sandbox session to expose `homeDirectory` and
+implement `resolvePath`, `ensureDirectory`, and `spawnExecutable`. The bridge
+is launched directly with argv; the legacy adapter-owned pnpm bootstrap remains
+the default.
+
 ## Usage
 
 ```ts

--- a/packages/harness-codex/src/codex-harness.test.ts
+++ b/packages/harness-codex/src/codex-harness.test.ts
@@ -4,6 +4,7 @@ import {
 } from '@ai-sdk/harness';
 import type * as HarnessUtils from '@ai-sdk/harness/utils';
 import type * as NodeFsPromises from 'node:fs/promises';
+import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { createCodex } from './codex-harness';
 
@@ -57,15 +58,42 @@ function fakeNetworkSandboxSessionForStartupSuccess({
   runs,
   spawns,
   spawnEnvs,
+  spawnCalls,
+  directories,
   writes,
+  defaultWorkingDirectory = '/vercel/sandbox',
+  homeDirectory,
+  pathDialect = path.posix,
 }: {
   bridgePortUrl: string;
   runs: string[];
   spawns: string[];
   spawnEnvs?: Array<Record<string, string | undefined>>;
+  spawnCalls?: Array<Record<string, unknown>>;
+  directories?: string[];
   writes: Array<{ path: string; content: string }>;
+  defaultWorkingDirectory?: string;
+  homeDirectory?: string;
+  pathDialect?: typeof path.posix | typeof path.win32;
 }): HarnessV1NetworkSandboxSession {
+  const spawnProcess = async (options: Record<string, unknown>) => {
+    const command = options.command;
+    const env = options.env as Record<string, string | undefined> | undefined;
+    spawns.push(
+      typeof command === 'string' ? command : String(options.executable ?? ''),
+    );
+    spawnCalls?.push(options);
+    if (env) spawnEnvs?.push(env);
+    return {
+      stdout: textStream('{"type":"bridge-ready","port":4319}\n'),
+      stderr: textStream(''),
+      kill: async () => {},
+      wait: async () => ({ exitCode: 0 }),
+    };
+  };
   const session = {
+    homeDirectory:
+      homeDirectory ?? pathDialect.resolve(defaultWorkingDirectory, '..'),
     run: async ({ command }: { command: string }) => {
       runs.push(command);
       return { exitCode: 0, stdout: '', stderr: '' };
@@ -80,26 +108,22 @@ function fakeNetworkSandboxSessionForStartupSuccess({
     }) => {
       writes.push({ path, content });
     },
-    spawn: async ({
-      command,
-      env,
+    spawn: spawnProcess,
+    spawnExecutable: spawnProcess,
+    resolvePath: ({
+      base,
+      segments,
     }: {
-      command: string;
-      env?: Record<string, string | undefined>;
-    }) => {
-      spawns.push(command);
-      if (env) spawnEnvs?.push(env);
-      return {
-        stdout: textStream('{"type":"bridge-ready","port":4319}\n'),
-        stderr: textStream(''),
-        kill: async () => {},
-        wait: async () => ({ exitCode: 0 }),
-      };
+      base?: string;
+      segments: ReadonlyArray<string>;
+    }) => pathDialect.resolve(base ?? defaultWorkingDirectory, ...segments),
+    ensureDirectory: async ({ path }: { path: string }) => {
+      directories?.push(path);
     },
   };
   return {
     id: 'test-sandbox',
-    defaultWorkingDirectory: '/vercel/sandbox',
+    defaultWorkingDirectory,
     restricted: () => session,
     ports: [4319],
     async getPortUrl() {
@@ -237,5 +261,124 @@ describe('createCodex adapter', () => {
       const b = await harness.getBootstrap!();
       expect(a).toBe(b);
     });
+
+    it('uses immutable no-install bootstrap identity for a preinstalled bridge', async () => {
+      const harness = createCodex({
+        preinstalledBridge: {
+          identity: 'codex-bridge-v1',
+          nodeExecutable: 'C:\\Program Files\\nodejs\\node.exe',
+          entrypoint: 'C:\\AI SDK\\bridge runtime\\bridge.mjs',
+        },
+      });
+
+      const recipe = await harness.getBootstrap!();
+      expect(recipe.identity).toContain('codex-bridge-v1');
+      expect(recipe.files).toEqual([]);
+      expect(recipe.commands).toEqual([]);
+
+      const relocatedRecipe = await createCodex({
+        preinstalledBridge: {
+          identity: 'codex-bridge-v1',
+          nodeExecutable: 'D:\\Runtime\\node.exe',
+          entrypoint: 'D:\\Runtime\\bridge.mjs',
+        },
+      }).getBootstrap!();
+      const upgradedRecipe = await createCodex({
+        preinstalledBridge: {
+          identity: 'codex-bridge-v2',
+          nodeExecutable: 'D:\\Runtime\\node.exe',
+          entrypoint: 'D:\\Runtime\\bridge.mjs',
+        },
+      }).getBootstrap!();
+      expect(relocatedRecipe).toEqual(recipe);
+      expect(upgradedRecipe.identity).not.toBe(recipe.identity);
+    });
+  });
+
+  it('launches a preinstalled Windows bridge with argv and no shell setup', async () => {
+    const runs: string[] = [];
+    const spawns: string[] = [];
+    const spawnCalls: Array<Record<string, unknown>> = [];
+    const directories: string[] = [];
+    const writes: Array<{ path: string; content: string }> = [];
+    const harness = createCodex({
+      preinstalledBridge: {
+        identity: 'codex-bridge-v1',
+        nodeExecutable: 'C:\\Program Files\\nodejs\\node.exe',
+        entrypoint: 'C:\\AI SDK\\bridge runtime\\bridge.mjs',
+      },
+    });
+    const sandboxSession = fakeNetworkSandboxSessionForStartupSuccess({
+      bridgePortUrl: 'ws://127.0.0.1:1',
+      runs,
+      spawns,
+      spawnCalls,
+      directories,
+      writes,
+      defaultWorkingDirectory: 'C:\\Users\\Ada\\Work Machine',
+      homeDirectory: 'C:\\Users\\Ada',
+      pathDialect: path.win32,
+    });
+    const skills = [
+      {
+        name: 'review',
+        description: 'Review changes.',
+        content: 'Check the diff.',
+      },
+    ];
+
+    const session = await harness.doStart({
+      sessionId: 'session with spaces',
+      sandboxSession,
+      sessionWorkDir: 'C:\\Users\\Ada\\Work Machine\\repo with spaces',
+      skills,
+    });
+
+    expect(runs).toEqual([]);
+    expect(directories).toEqual([
+      'C:\\Users\\Ada\\.codex',
+      'C:\\Users\\Ada\\.agents\\skills',
+      'C:\\Users\\Ada\\Work Machine\\repo with spaces',
+      'C:\\Users\\Ada\\Work Machine\\.agent-runs\\session with spaces\\bridge',
+    ]);
+    expect(writes).toContainEqual({
+      path: 'C:\\Users\\Ada\\.agents\\skills\\review\\SKILL.md',
+      content:
+        '---\nname: review\ndescription: Review changes.\n---\n\nCheck the diff.',
+    });
+    expect(spawnCalls).toEqual([
+      expect.objectContaining({
+        executable: 'C:\\Program Files\\nodejs\\node.exe',
+        args: [
+          'C:\\AI SDK\\bridge runtime\\bridge.mjs',
+          '--workdir',
+          'C:\\Users\\Ada\\Work Machine\\repo with spaces',
+          '--bridge-state-dir',
+          'C:\\Users\\Ada\\Work Machine\\.agent-runs\\session with spaces\\bridge',
+          '--cli-shim-dir',
+          'C:\\Users\\Ada\\Work Machine\\.agent-runs\\session with spaces\\codex',
+        ],
+      }),
+    ]);
+    expect(spawns).toEqual(['C:\\Program Files\\nodejs\\node.exe']);
+    await session.doDestroy();
+    const resumed = await harness.doStart({
+      sessionId: 'session with spaces',
+      sandboxSession,
+      sessionWorkDir: 'C:\\Users\\Ada\\Work Machine\\repo with spaces',
+      skills,
+      resumeFrom: {
+        type: 'resume-session',
+        harnessId: 'codex',
+        specificationVersion: 'harness-v1',
+        data: { threadId: 'thread-abc' },
+      },
+    });
+    expect(runs).toEqual([]);
+    expect(spawns).toEqual([
+      'C:\\Program Files\\nodejs\\node.exe',
+      'C:\\Program Files\\nodejs\\node.exe',
+    ]);
+    await resumed.doDestroy();
   });
 });

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -98,6 +98,19 @@ export type CodexHarnessSettings = {
   readonly port?: number;
   /** Maximum milliseconds to wait for the bridge to advertise its port. Defaults to 120000. */
   readonly startupTimeoutMs?: number;
+  /**
+   * Immutable bridge runtime already installed in the sandbox. When set, the
+   * adapter skips its pnpm bootstrap and launches the supplied Node executable
+   * with argv directly, without a shell.
+   */
+  readonly preinstalledBridge?: {
+    /** Stable identity of the packaged bridge payload. */
+    readonly identity: string;
+    /** Guest path of the Node executable used to launch the bridge. */
+    readonly nodeExecutable: string;
+    /** Guest path of the preinstalled bridge entrypoint. */
+    readonly entrypoint: string;
+  };
 };
 
 /*
@@ -178,6 +191,16 @@ export function createCodex(
     lifecycleStateSchema: codexResumeStateSchema,
     getBootstrap: async () => {
       if (cachedBootstrap != null) return cachedBootstrap;
+      if (settings.preinstalledBridge != null) {
+        cachedBootstrap = {
+          harnessId: 'codex',
+          identity: settings.preinstalledBridge.identity,
+          bootstrapDir: '.harness-bootstrap/codex-preinstalled',
+          files: [],
+          commands: [],
+        };
+        return cachedBootstrap;
+      }
       const [pkg, lock, bridge] = await Promise.all([
         readBridgeAsset('package.json'),
         readBridgeAsset('pnpm-lock.yaml'),
@@ -219,11 +242,15 @@ export function createCodex(
       }
       const sandboxSession = startOpts.sandboxSession;
       const session = sandboxSession.restricted();
+      if (settings.preinstalledBridge != null) {
+        assertPreinstalledBridgeCapabilities(session);
+      }
       const sandboxId = sandboxSession.id;
-      const bootstrapDir = path.posix.resolve(
-        sandboxSession.defaultWorkingDirectory,
-        BOOTSTRAP_DIR,
-      );
+      const bootstrapDir = resolveGuestPath({
+        session,
+        base: sandboxSession.defaultWorkingDirectory,
+        segments: [BOOTSTRAP_DIR],
+      });
       const lifecycleState = startOpts.continueFrom ?? startOpts.resumeFrom;
       const isResume = lifecycleState != null;
       const isContinue = startOpts.continueFrom != null;
@@ -242,10 +269,26 @@ export function createCodex(
       const coords = resumeData?.bridge;
 
       const workDir = startOpts.sessionWorkDir;
-      const sessionDataDir = `${sandboxSession.defaultWorkingDirectory}/.agent-runs/${startOpts.sessionId}`;
-      const bridgeStateDir = `${sessionDataDir}/bridge`;
-      const cliShimDir = `${sessionDataDir}/codex`;
-      const cliShimPath = `${cliShimDir}/${CLI_SHIM_FILENAME}`;
+      const sessionDataDir = resolveGuestPath({
+        session,
+        base: sandboxSession.defaultWorkingDirectory,
+        segments: ['.agent-runs', startOpts.sessionId],
+      });
+      const bridgeStateDir = resolveGuestPath({
+        session,
+        base: sessionDataDir,
+        segments: ['bridge'],
+      });
+      const cliShimDir = resolveGuestPath({
+        session,
+        base: sessionDataDir,
+        segments: ['codex'],
+      });
+      const cliShimPath = resolveGuestPath({
+        session,
+        base: cliShimDir,
+        segments: [CLI_SHIM_FILENAME],
+      });
       const timeoutMs = settings.startupTimeoutMs ?? 120_000;
 
       // Normalize each forwarded bridge diagnostics frame into the general
@@ -363,10 +406,25 @@ export function createCodex(
       };
 
       if (respawnStrategy === undefined) {
-        await session.run({
-          command: `mkdir -p ${shellQuote(workDir)} ${shellQuote(bridgeStateDir)}`,
-          abortSignal: startOpts.abortSignal,
-        });
+        if (settings.preinstalledBridge != null) {
+          await Promise.all([
+            session.ensureDirectory!({
+              path: workDir,
+              recursive: true,
+              abortSignal: startOpts.abortSignal,
+            }),
+            session.ensureDirectory!({
+              path: bridgeStateDir,
+              recursive: true,
+              abortSignal: startOpts.abortSignal,
+            }),
+          ]);
+        } else {
+          await session.run({
+            command: `mkdir -p ${shellQuote(workDir)} ${shellQuote(bridgeStateDir)}`,
+            abortSignal: startOpts.abortSignal,
+          });
+        }
       }
 
       await markBridgeStarting({
@@ -376,11 +434,26 @@ export function createCodex(
         abortSignal: startOpts.abortSignal,
       });
 
-      const proc = await session.spawn({
-        command: `node ${shellQuote(`${bootstrapDir}/bridge.mjs`)} --workdir ${shellQuote(workDir)} --bridge-state-dir ${shellQuote(bridgeStateDir)} --cli-shim-dir ${shellQuote(cliShimDir)}`,
-        env,
-        abortSignal: startOpts.abortSignal,
-      });
+      const proc = await (settings.preinstalledBridge == null
+        ? session.spawn({
+            command: `node ${shellQuote(`${bootstrapDir}/bridge.mjs`)} --workdir ${shellQuote(workDir)} --bridge-state-dir ${shellQuote(bridgeStateDir)} --cli-shim-dir ${shellQuote(cliShimDir)}`,
+            env,
+            abortSignal: startOpts.abortSignal,
+          })
+        : session.spawnExecutable!({
+            executable: settings.preinstalledBridge.nodeExecutable,
+            args: [
+              settings.preinstalledBridge.entrypoint,
+              '--workdir',
+              workDir,
+              '--bridge-state-dir',
+              bridgeStateDir,
+              '--cli-shim-dir',
+              cliShimDir,
+            ],
+            env,
+            abortSignal: startOpts.abortSignal,
+          }));
       const stderrTail: string[] = [];
       const bridgeStderrDone = forwardBridgeProcessStream({
         stream: proc.stderr,
@@ -473,6 +546,43 @@ function resolveBridgePort(
   });
 }
 
+function assertPreinstalledBridgeCapabilities(
+  session: Experimental_SandboxSession,
+): asserts session is Experimental_SandboxSession &
+  Required<
+    Pick<
+      Experimental_SandboxSession,
+      'homeDirectory' | 'resolvePath' | 'ensureDirectory' | 'spawnExecutable'
+    >
+  > {
+  if (
+    session.homeDirectory == null ||
+    session.resolvePath == null ||
+    session.ensureDirectory == null ||
+    session.spawnExecutable == null
+  ) {
+    throw new HarnessCapabilityUnsupportedError({
+      harnessId: 'codex',
+      message:
+        'The preinstalled Codex bridge requires sandbox homeDirectory, resolvePath, ensureDirectory, and spawnExecutable support.',
+    });
+  }
+}
+
+function resolveGuestPath({
+  session,
+  base,
+  segments,
+}: {
+  session: Experimental_SandboxSession;
+  base?: string;
+  segments: ReadonlyArray<string>;
+}): string {
+  return session.resolvePath != null
+    ? session.resolvePath({ base, segments })
+    : path.posix.resolve(base ?? '.', ...segments);
+}
+
 async function readBridgeAsset(name: string): Promise<string> {
   const candidates = [
     new URL(`./bridge/${name}`, import.meta.url),
@@ -501,13 +611,29 @@ async function writeCodexSkills({
   abortSignal?: AbortSignal;
 }): Promise<WriteSkillsResult> {
   const homeDir = await resolveSandboxHomeDir({ sandbox, abortSignal });
-  const codexHomeDir = path.posix.join(homeDir, '.codex');
-  await sandbox.run({
-    command: `mkdir -p ${shellQuote(codexHomeDir)}`,
-    abortSignal,
+  const codexHomeDir = resolveGuestPath({
+    session: sandbox,
+    base: homeDir,
+    segments: ['.codex'],
   });
+  if (sandbox.ensureDirectory != null) {
+    await sandbox.ensureDirectory({
+      path: codexHomeDir,
+      recursive: true,
+      abortSignal,
+    });
+  } else {
+    await sandbox.run({
+      command: `mkdir -p ${shellQuote(codexHomeDir)}`,
+      abortSignal,
+    });
+  }
 
-  const rootDir = path.posix.join(homeDir, '.agents', 'skills');
+  const rootDir = resolveGuestPath({
+    session: sandbox,
+    base: homeDir,
+    segments: ['.agents', 'skills'],
+  });
   await writeHarnessSkills({
     sandbox,
     rootDir,

--- a/packages/harness/src/agent/harness-agent.ts
+++ b/packages/harness/src/agent/harness-agent.ts
@@ -294,6 +294,7 @@ export class HarnessAgent<
     const sandboxSession = leased.sandboxSession;
     const leasedBridgePort = leased.port;
     const sessionWorkDir = resolveSessionWorkDir({
+      session: sandboxSession,
       defaultWorkingDirectory: sandboxSession.defaultWorkingDirectory,
       harnessId: harness.harnessId,
       sessionId,

--- a/packages/harness/src/agent/internal/bootstrap-recipe.test.ts
+++ b/packages/harness/src/agent/internal/bootstrap-recipe.test.ts
@@ -1,4 +1,5 @@
 import type { Experimental_SandboxSession as SandboxSession } from '@ai-sdk/provider-utils';
+import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import type { HarnessV1Bootstrap } from '../../v1';
 import {
@@ -74,6 +75,14 @@ describe('hashHarnessBootstrap', () => {
     };
     expect(await hashHarnessBootstrap(altered)).not.toBe(
       await hashHarnessBootstrap(baseRecipe),
+    );
+  });
+
+  it('changes when an external bootstrap identity changes', async () => {
+    const first = { ...baseRecipe, identity: 'bridge-v1' };
+    const second = { ...baseRecipe, identity: 'bridge-v2' };
+    expect(await hashHarnessBootstrap(first)).not.toBe(
+      await hashHarnessBootstrap(second),
     );
   });
 });
@@ -165,6 +174,52 @@ describe('applyBootstrapRecipe', () => {
     });
     expect(readTextFile).toHaveBeenCalledTimes(1);
     expect(writeTextFile).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('applies an identity-only recipe with provider-owned Windows paths and no shell', async () => {
+    const ensureDirectory = vi.fn(async () => {});
+    const writeTextFile = vi.fn(async () => {});
+    const run = vi.fn();
+    const session = {
+      description: 'windows mock',
+      resolvePath: ({
+        base,
+        segments,
+      }: {
+        base?: string;
+        segments: ReadonlyArray<string>;
+      }) => path.win32.resolve(base ?? 'C:\\Work', ...segments),
+      ensureDirectory,
+      readTextFile: vi.fn(async () => null),
+      writeTextFile,
+      run,
+    } as unknown as SandboxSession;
+    const recipe: HarnessV1Bootstrap = {
+      harnessId: 'codex',
+      identity: 'bridge-v1',
+      bootstrapDir: '.harness-bootstrap/codex-preinstalled',
+      files: [],
+      commands: [],
+    };
+
+    await applyBootstrapRecipe({
+      session,
+      recipe,
+      identity: 'abc1234567890def',
+      defaultWorkingDirectory: 'C:\\Work Machine',
+    });
+
+    expect(ensureDirectory).toHaveBeenCalledWith({
+      path: 'C:\\Work Machine\\.harness-bootstrap\\codex-preinstalled',
+      recursive: true,
+      abortSignal: undefined,
+    });
+    expect(writeTextFile).toHaveBeenCalledWith({
+      path: 'C:\\Work Machine\\.harness-bootstrap\\codex-preinstalled\\.bootstrap-abc1234567890def.ok',
+      content: '',
+      abortSignal: undefined,
+    });
     expect(run).not.toHaveBeenCalled();
   });
 

--- a/packages/harness/src/agent/internal/bootstrap-recipe.ts
+++ b/packages/harness/src/agent/internal/bootstrap-recipe.ts
@@ -29,6 +29,10 @@ export async function hashHarnessBootstrap(
 
   pushString(recipe.harnessId);
   pushString(recipe.bootstrapDir);
+  if (recipe.identity != null) {
+    pushString('identity');
+    pushString(recipe.identity);
+  }
 
   const sortedFiles = [...recipe.files].sort((a, b) =>
     a.path.localeCompare(b.path),
@@ -64,21 +68,27 @@ export async function hashHarnessBootstrap(
  * with the matching `identity` has already been applied.
  */
 export function bootstrapMarkerPath({
+  session,
   recipe,
   identity,
   defaultWorkingDirectory,
 }: {
+  session?: SandboxSession;
   recipe: HarnessV1Bootstrap;
   identity: string;
   defaultWorkingDirectory: string;
 }): string {
-  return posix.join(
-    resolveBootstrapPath({
-      path: recipe.bootstrapDir,
-      defaultWorkingDirectory,
-    }),
-    `.bootstrap-${identity}.ok`,
-  );
+  const bootstrapDir = resolveBootstrapPath({
+    session,
+    path: recipe.bootstrapDir,
+    defaultWorkingDirectory,
+  });
+  return session?.resolvePath != null
+    ? session.resolvePath({
+        base: bootstrapDir,
+        segments: [`.bootstrap-${identity}.ok`],
+      })
+    : posix.join(bootstrapDir, `.bootstrap-${identity}.ok`);
 }
 
 /**
@@ -105,6 +115,7 @@ export async function applyBootstrapRecipe({
   abortSignal?: AbortSignal;
 }): Promise<void> {
   const markerPath = bootstrapMarkerPath({
+    session,
     recipe,
     identity,
     defaultWorkingDirectory,
@@ -119,24 +130,34 @@ export async function applyBootstrapRecipe({
   }
 
   const bootstrapDir = resolveBootstrapPath({
+    session,
     path: recipe.bootstrapDir,
     defaultWorkingDirectory,
   });
-  const mkdirResult = await session.run({
-    command: 'mkdir -p "$BOOTSTRAP_DIR"',
-    workingDirectory: defaultWorkingDirectory,
-    env: { BOOTSTRAP_DIR: bootstrapDir },
-    abortSignal,
-  });
-  if (mkdirResult.exitCode !== 0) {
-    throw new Error(
-      `Failed to create bootstrap directory for harness '${recipe.harnessId}' (exit ${mkdirResult.exitCode}): ${bootstrapDir}\n${mkdirResult.stderr || mkdirResult.stdout}`,
-    );
+  if (session.ensureDirectory != null) {
+    await session.ensureDirectory({
+      path: bootstrapDir,
+      recursive: true,
+      abortSignal,
+    });
+  } else {
+    const mkdirResult = await session.run({
+      command: 'mkdir -p "$BOOTSTRAP_DIR"',
+      workingDirectory: defaultWorkingDirectory,
+      env: { BOOTSTRAP_DIR: bootstrapDir },
+      abortSignal,
+    });
+    if (mkdirResult.exitCode !== 0) {
+      throw new Error(
+        `Failed to create bootstrap directory for harness '${recipe.harnessId}' (exit ${mkdirResult.exitCode}): ${bootstrapDir}\n${mkdirResult.stderr || mkdirResult.stdout}`,
+      );
+    }
   }
 
   for (const file of recipe.files) {
     await session.writeTextFile({
       path: resolveBootstrapPath({
+        session,
         path: file.path,
         defaultWorkingDirectory,
       }),
@@ -166,12 +187,20 @@ export async function applyBootstrapRecipe({
 }
 
 function resolveBootstrapPath({
+  session,
   path,
   defaultWorkingDirectory,
 }: {
+  session?: SandboxSession;
   path: string;
   defaultWorkingDirectory: string;
 }): string {
+  if (session?.resolvePath != null) {
+    return session.resolvePath({
+      base: defaultWorkingDirectory,
+      segments: [path],
+    });
+  }
   return posix.isAbsolute(path)
     ? path
     : posix.resolve(defaultWorkingDirectory, path);

--- a/packages/harness/src/agent/internal/sandbox-bootstrap.ts
+++ b/packages/harness/src/agent/internal/sandbox-bootstrap.ts
@@ -65,17 +65,20 @@ export function normalizeSandboxWorkDir(workDir: string): string {
 }
 
 export function resolveSessionWorkDir({
+  session,
   defaultWorkingDirectory,
   harnessId,
   sessionId,
   workDir,
 }: {
+  readonly session?: SandboxSession;
   readonly defaultWorkingDirectory: string;
   readonly harnessId: string;
   readonly sessionId: string;
   readonly workDir?: string;
 }): string {
   return joinSandboxPath({
+    session,
     base: defaultWorkingDirectory,
     path: workDir ?? `${harnessId}-${sessionId}`,
   });
@@ -169,6 +172,7 @@ export async function runSandboxBootstrap({
     workDir == null
       ? resolvedDefaultWorkingDirectory
       : joinSandboxPath({
+          session,
           base: resolvedDefaultWorkingDirectory,
           path: workDir,
         });
@@ -188,6 +192,16 @@ export async function resolveDefaultWorkingDirectory({
   readonly session: SandboxSession;
   readonly abortSignal?: AbortSignal;
 }): Promise<string> {
+  if (session.resolvePath != null) {
+    const cwd = session.resolvePath({ segments: [] });
+    if (cwd.length === 0 || cwd.includes('\0')) {
+      throw new Error(
+        `Failed to resolve sandbox default working directory: expected a non-empty path, got ${JSON.stringify(cwd)}.`,
+      );
+    }
+    return cwd;
+  }
+
   const result = await session.run({
     command: 'pwd',
     abortSignal,
@@ -216,6 +230,15 @@ export async function ensureSandboxDirectory({
   readonly workDir: string;
   readonly abortSignal?: AbortSignal;
 }): Promise<void> {
+  if (session.ensureDirectory != null) {
+    await session.ensureDirectory({
+      path: workDir,
+      recursive: true,
+      abortSignal,
+    });
+    return;
+  }
+
   const result = await session.run({
     command: 'mkdir -p "$WORK_DIR"',
     env: { WORK_DIR: workDir },
@@ -267,11 +290,19 @@ async function hashSandboxBootstrapIdentity({
 }
 
 function joinSandboxPath({
+  session,
   base,
   path,
 }: {
+  readonly session?: SandboxSession;
   readonly base: string;
   readonly path: string;
 }): string {
+  if (session?.resolvePath != null) {
+    return session.resolvePath({
+      base,
+      segments: path.split('/'),
+    });
+  }
   return posix.join(base, path);
 }

--- a/packages/harness/src/utils/sandbox-home-dir.ts
+++ b/packages/harness/src/utils/sandbox-home-dir.ts
@@ -8,6 +8,9 @@ export async function resolveSandboxHomeDir({
   sandbox: Experimental_SandboxSession;
   abortSignal?: AbortSignal;
 }): Promise<string> {
+  if (sandbox.homeDirectory != null) {
+    return sandbox.homeDirectory;
+  }
   const result = await sandbox.run({
     command: 'printf "%s" "$HOME"',
     abortSignal,

--- a/packages/harness/src/utils/write-skills.ts
+++ b/packages/harness/src/utils/write-skills.ts
@@ -48,10 +48,18 @@ export async function writeSkills({
     }
   }
 
-  await sandbox.run({
-    command: `mkdir -p ${shellQuote(rootDir)}`,
-    abortSignal,
-  });
+  if (sandbox.ensureDirectory != null) {
+    await sandbox.ensureDirectory({
+      path: rootDir,
+      recursive: true,
+      abortSignal,
+    });
+  } else {
+    await sandbox.run({
+      command: `mkdir -p ${shellQuote(rootDir)}`,
+      abortSignal,
+    });
+  }
 
   for (const skill of skills) {
     const name = validateSkillName({
@@ -59,9 +67,9 @@ export async function writeSkills({
       pattern: skillNamePattern,
       message: invalidSkillNameMessage,
     });
-    const skillDir = path.posix.join(rootDir, name);
+    const skillDir = resolveSkillPath(sandbox, rootDir, [name]);
     await sandbox.writeTextFile({
-      path: path.posix.join(skillDir, 'SKILL.md'),
+      path: resolveSkillPath(sandbox, skillDir, ['SKILL.md']),
       content: renderSkillFile({ skill, trailingNewline }),
       abortSignal,
     });
@@ -74,12 +82,22 @@ export async function writeSkills({
         message: invalidSkillFilePathMessage,
       });
       await sandbox.writeTextFile({
-        path: path.posix.join(skillDir, filePath),
+        path: resolveSkillPath(sandbox, skillDir, filePath.split('/')),
         content: file.content,
         abortSignal,
       });
     }
   }
+}
+
+function resolveSkillPath(
+  sandbox: Experimental_SandboxSession,
+  base: string,
+  segments: ReadonlyArray<string>,
+): string {
+  return sandbox.resolvePath != null
+    ? sandbox.resolvePath({ base, segments })
+    : path.posix.join(base, ...segments);
 }
 
 function validateSkillName({

--- a/packages/harness/src/v1/harness-v1-bootstrap.ts
+++ b/packages/harness/src/v1/harness-v1-bootstrap.ts
@@ -32,6 +32,13 @@ export interface HarnessV1Bootstrap {
   readonly harnessId: string;
 
   /**
+   * Optional immutable identity for bootstrap content that is already present
+   * in the sandbox and therefore is not represented by {@link files} or
+   * {@link commands}. Included in the recipe hash when provided.
+   */
+  readonly identity?: string;
+
+  /**
    * Path inside the sandbox where this recipe writes its state. Absolute paths
    * are used as-is. Relative paths are resolved against the sandbox's default
    * working directory. The marker file lives directly under it. Files

--- a/packages/provider-utils/src/types/sandbox.test-d.ts
+++ b/packages/provider-utils/src/types/sandbox.test-d.ts
@@ -14,6 +14,49 @@ test('SandboxSession exposes spawn returning a process handle', () => {
   >().toEqualTypeOf<SandboxProcess>();
 });
 
+test('legacy command-only spawn implementations remain structurally compatible', () => {
+  const legacySpawn = async (_options: {
+    command: string;
+    workingDirectory?: string;
+    env?: Record<string, string>;
+    abortSignal?: AbortSignal;
+  }): Promise<SandboxProcess> => ({}) as SandboxProcess;
+
+  const legacySession = { spawn: legacySpawn } satisfies Pick<
+    SandboxSession,
+    'spawn'
+  >;
+  expectTypeOf(legacySession.spawn).toMatchTypeOf<SandboxSession['spawn']>();
+});
+
+test('SandboxSession optionally exposes provider-owned path operations', () => {
+  expectTypeOf<SandboxSession['homeDirectory']>().toEqualTypeOf<
+    string | undefined
+  >();
+  expectTypeOf<SandboxSession['resolvePath']>().toEqualTypeOf<
+    | ((options: { base?: string; segments: ReadonlyArray<string> }) => string)
+    | undefined
+  >();
+  expectTypeOf<SandboxSession['ensureDirectory']>().toEqualTypeOf<
+    | ((options: {
+        path: string;
+        recursive: true;
+        abortSignal?: AbortSignal;
+      }) => PromiseLike<void>)
+    | undefined
+  >();
+  expectTypeOf<SandboxSession['spawnExecutable']>().toMatchTypeOf<
+    | ((options: {
+        executable: string;
+        args?: ReadonlyArray<string>;
+        workingDirectory?: string;
+        env?: Record<string, string>;
+        abortSignal?: AbortSignal;
+      }) => PromiseLike<SandboxProcess>)
+    | undefined
+  >();
+});
+
 test('SandboxProcess exposes the expected handle shape', () => {
   expectTypeOf<SandboxProcess['pid']>().toEqualTypeOf<number | undefined>();
   expectTypeOf<SandboxProcess['stdout']>().toEqualTypeOf<

--- a/packages/provider-utils/src/types/sandbox.ts
+++ b/packages/provider-utils/src/types/sandbox.ts
@@ -3,7 +3,7 @@
  */
 type SandboxProcessOptions = {
   /**
-   * Command to execute in the sandbox.
+   * Shell command to execute in the sandbox.
    */
   command: string;
 
@@ -25,6 +25,16 @@ type SandboxProcessOptions = {
    * process is killed; for `spawn`, `wait()` rejects with the abort reason.
    */
   abortSignal?: AbortSignal;
+};
+
+type SandboxExecutableProcessOptions = Omit<
+  SandboxProcessOptions,
+  'command'
+> & {
+  /** Executable to launch directly, without shell parsing. */
+  executable: string;
+  /** Arguments passed directly to the executable. */
+  args?: ReadonlyArray<string>;
 };
 
 /**
@@ -73,6 +83,12 @@ export type SandboxSession = {
    * ports, the public hostname, etc.
    */
   readonly description: string;
+
+  /**
+   * Provider-owned absolute home directory inside the guest environment.
+   * Optional for backwards compatibility.
+   */
+  readonly homeDirectory?: string;
 
   /**
    * Read one file from the sandbox as a stream of bytes. Resolves to `null`
@@ -155,6 +171,31 @@ export type SandboxSession = {
   ) => PromiseLike<void>;
 
   /**
+   * Resolve a path using the sandbox provider's guest path dialect. When
+   * `base` is omitted, resolution starts at the session's default working
+   * directory.
+   *
+   * Optional for backwards compatibility. Harness features that require a
+   * non-POSIX path dialect validate that the provider implements it.
+   */
+  readonly resolvePath?: (options: {
+    base?: string;
+    segments: ReadonlyArray<string>;
+  }) => string;
+
+  /**
+   * Create a directory in the sandbox without invoking a shell.
+   *
+   * Optional for backwards compatibility. Harness features that require
+   * shell-free setup validate that the provider implements it.
+   */
+  readonly ensureDirectory?: (options: {
+    path: string;
+    recursive: true;
+    abortSignal?: AbortSignal;
+  }) => PromiseLike<void>;
+
+  /**
    * Spawn a long-running process in the sandbox. Returns immediately with a
    * handle that streams stdout/stderr, can be waited on, and can be killed.
    *
@@ -163,6 +204,14 @@ export type SandboxSession = {
    */
   readonly spawn: (
     options: SandboxProcessOptions,
+  ) => PromiseLike<SandboxProcess>;
+
+  /**
+   * Spawn a long-running executable with argv directly, without a shell.
+   * Optional for backwards compatibility.
+   */
+  readonly spawnExecutable?: (
+    options: SandboxExecutableProcessOptions,
   ) => PromiseLike<SandboxProcess>;
 
   /**

--- a/packages/sandbox-just-bash/src/just-bash-sandbox-session.test.ts
+++ b/packages/sandbox-just-bash/src/just-bash-sandbox-session.test.ts
@@ -165,6 +165,18 @@ describe('JustBashSandboxSession', () => {
       expect(stdout).toBe('shared payload');
     });
 
+    it('launches an executable with argv without shell parsing', async () => {
+      const proc = await sandbox.spawnExecutable({
+        executable: 'printf',
+        args: ['%s', 'path with spaces; not a shell command'],
+      });
+
+      expect(await collect(proc.stdout)).toBe(
+        'path with spaces; not a shell command',
+      );
+      expect((await proc.wait()).exitCode).toBe(0);
+    });
+
     it('non-zero exit codes are surfaced via wait()', async () => {
       const proc = await sandbox.spawn({ command: 'exit 7' });
       await collect(proc.stdout);
@@ -190,6 +202,29 @@ describe('JustBashSandboxSession', () => {
       });
       ac.abort();
       await expect(proc.wait()).rejects.toThrow();
+    });
+  });
+
+  describe('provider-owned path operations', () => {
+    it('resolves paths and creates directories without a shell', async () => {
+      expect(
+        sandbox.resolvePath({ segments: ['folder with spaces', 'bridge'] }),
+      ).toBe('/work/folder with spaces/bridge');
+
+      await sandbox.ensureDirectory({
+        path: '/work/folder with spaces/bridge',
+        recursive: true,
+      });
+      await sandbox.writeTextFile({
+        path: '/work/folder with spaces/bridge/ready',
+        content: 'yes',
+      });
+
+      expect(
+        await sandbox.readTextFile({
+          path: '/work/folder with spaces/bridge/ready',
+        }),
+      ).toBe('yes');
     });
   });
 });

--- a/packages/sandbox-just-bash/src/just-bash-sandbox-session.ts
+++ b/packages/sandbox-just-bash/src/just-bash-sandbox-session.ts
@@ -27,7 +27,7 @@ export class JustBashSandboxSession implements Experimental_SandboxSession {
     ].join('\n');
   }
 
-  private resolvePath(path: string): string {
+  private resolveFilePath(path: string): string {
     return isAbsolute(path)
       ? path
       : posix.join(this.sandbox.bashEnvInstance.getCwd(), path);
@@ -71,12 +71,9 @@ export class JustBashSandboxSession implements Experimental_SandboxSession {
     workingDirectory,
     env,
     abortSignal,
-  }: {
-    command: string;
-    workingDirectory?: string;
-    env?: Record<string, string>;
-    abortSignal?: AbortSignal;
-  }): Promise<Experimental_SandboxProcess> {
+  }: Parameters<
+    Experimental_SandboxSession['spawn']
+  >[0]): Promise<Experimental_SandboxProcess> {
     abortSignal?.throwIfAborted();
 
     const live = await this.sandbox.runCommand({
@@ -89,6 +86,52 @@ export class JustBashSandboxSession implements Experimental_SandboxSession {
     });
 
     return createSandboxProcess(live, abortSignal);
+  }
+
+  async spawnExecutable({
+    executable,
+    args,
+    workingDirectory,
+    env,
+    abortSignal,
+  }: Parameters<
+    NonNullable<Experimental_SandboxSession['spawnExecutable']>
+  >[0]): Promise<Experimental_SandboxProcess> {
+    abortSignal?.throwIfAborted();
+    const live = await this.sandbox.runCommand({
+      cmd: executable,
+      args: [...(args ?? [])],
+      detached: true,
+      ...(workingDirectory !== undefined ? { cwd: workingDirectory } : {}),
+      ...(env !== undefined ? { env } : {}),
+      ...(abortSignal !== undefined ? { signal: abortSignal } : {}),
+    });
+    return createSandboxProcess(live, abortSignal);
+  }
+
+  resolvePath({
+    base,
+    segments,
+  }: {
+    base?: string;
+    segments: ReadonlyArray<string>;
+  }): string {
+    return posix.resolve(
+      base ?? this.sandbox.bashEnvInstance.getCwd(),
+      ...segments,
+    );
+  }
+
+  async ensureDirectory({
+    path,
+    abortSignal,
+  }: {
+    path: string;
+    recursive: true;
+    abortSignal?: AbortSignal;
+  }): Promise<void> {
+    abortSignal?.throwIfAborted();
+    await this.sandbox.bashEnvInstance.fs.mkdir(path, { recursive: true });
   }
 
   async readFile({
@@ -111,7 +154,7 @@ export class JustBashSandboxSession implements Experimental_SandboxSession {
     abortSignal?: AbortSignal;
   }): Promise<Uint8Array | null> {
     abortSignal?.throwIfAborted();
-    const resolved = this.resolvePath(path);
+    const resolved = this.resolveFilePath(path);
     try {
       const bytes =
         await this.sandbox.bashEnvInstance.fs.readFileBuffer(resolved);
@@ -164,7 +207,7 @@ export class JustBashSandboxSession implements Experimental_SandboxSession {
     abortSignal?: AbortSignal;
   }): Promise<void> {
     abortSignal?.throwIfAborted();
-    const resolved = this.resolvePath(path);
+    const resolved = this.resolveFilePath(path);
     await this.sandbox.bashEnvInstance.fs.writeFile(resolved, content);
   }
 

--- a/packages/sandbox-vercel/src/vercel-sandbox-session.test.ts
+++ b/packages/sandbox-vercel/src/vercel-sandbox-session.test.ts
@@ -260,7 +260,11 @@ describe('VercelSandboxSession', () => {
       });
 
       expect(baseSandbox.spies.runCommand).toHaveBeenCalledWith(
-        expect.objectContaining({ detached: true }),
+        expect.objectContaining({
+          cmd: 'bash',
+          args: ['-c', 'node x.js'],
+          detached: true,
+        }),
       );
 
       const [stdout, stderr, { exitCode }] = await Promise.all([
@@ -272,6 +276,22 @@ describe('VercelSandboxSession', () => {
       expect(stdout).toBe('out\n');
       expect(stderr).toBe('err\n');
       expect(exitCode).toBe(0);
+    });
+
+    it('launches an executable with argv without a shell', async () => {
+      const { handle } = makeMockCommand({ exitCode: 0 });
+      baseSandbox.spies.runCommand.mockResolvedValueOnce(handle);
+
+      await new VercelSandboxSession(baseSandbox.sandbox).spawnExecutable({
+        executable: 'C:\\Program Files\\nodejs\\node.exe',
+        args: ['C:\\AI SDK\\bridge.mjs', '--workdir', 'C:\\Work Space'],
+      });
+
+      expect(baseSandbox.spies.runCommand).toHaveBeenCalledWith({
+        cmd: 'C:\\Program Files\\nodejs\\node.exe',
+        args: ['C:\\AI SDK\\bridge.mjs', '--workdir', 'C:\\Work Space'],
+        detached: true,
+      });
     });
 
     it('surfaces non-zero exit codes via wait()', async () => {
@@ -304,6 +324,31 @@ describe('VercelSandboxSession', () => {
       });
       ac.abort(new Error('user cancelled'));
       await expect(proc.wait()).rejects.toThrow('user cancelled');
+    });
+  });
+
+  describe('provider-owned path operations', () => {
+    it('resolves paths and creates directories without a shell', async () => {
+      const { sandbox, spies } = makeMockSandbox({
+        currentSession: () => ({ cwd: '/vercel/sandbox' }),
+      } as Partial<Sandbox>);
+      spies.runCommand.mockResolvedValueOnce(
+        makeMockCommand({ exitCode: 0 }).handle,
+      );
+      const session = new VercelSandboxSession(sandbox);
+
+      expect(
+        session.resolvePath({ segments: ['folder with spaces', 'bridge'] }),
+      ).toBe('/vercel/sandbox/folder with spaces/bridge');
+      await session.ensureDirectory({
+        path: '/vercel/sandbox/folder with spaces/bridge',
+        recursive: true,
+      });
+
+      expect(spies.runCommand).toHaveBeenCalledWith({
+        cmd: 'mkdir',
+        args: ['-p', '/vercel/sandbox/folder with spaces/bridge'],
+      });
     });
   });
 });

--- a/packages/sandbox-vercel/src/vercel-sandbox-session.ts
+++ b/packages/sandbox-vercel/src/vercel-sandbox-session.ts
@@ -61,12 +61,9 @@ export class VercelSandboxSession implements Experimental_SandboxSession {
     workingDirectory,
     env,
     abortSignal,
-  }: {
-    command: string;
-    workingDirectory?: string;
-    env?: Record<string, string>;
-    abortSignal?: AbortSignal;
-  }): Promise<Experimental_SandboxProcess> {
+  }: Parameters<
+    Experimental_SandboxSession['spawn']
+  >[0]): Promise<Experimental_SandboxProcess> {
     abortSignal?.throwIfAborted();
 
     const live = await this.sandbox.runCommand({
@@ -79,6 +76,59 @@ export class VercelSandboxSession implements Experimental_SandboxSession {
     });
 
     return createSandboxProcess(live, abortSignal);
+  }
+
+  async spawnExecutable({
+    executable,
+    args,
+    workingDirectory,
+    env,
+    abortSignal,
+  }: Parameters<
+    NonNullable<Experimental_SandboxSession['spawnExecutable']>
+  >[0]): Promise<Experimental_SandboxProcess> {
+    abortSignal?.throwIfAborted();
+    const live = await this.sandbox.runCommand({
+      cmd: executable,
+      args: [...(args ?? [])],
+      detached: true,
+      ...(workingDirectory !== undefined ? { cwd: workingDirectory } : {}),
+      ...(env !== undefined ? { env } : {}),
+      ...(abortSignal !== undefined ? { signal: abortSignal } : {}),
+    });
+    return createSandboxProcess(live, abortSignal);
+  }
+
+  resolvePath({
+    base,
+    segments,
+  }: {
+    base?: string;
+    segments: ReadonlyArray<string>;
+  }): string {
+    return posix.resolve(
+      base ?? this.sandbox.currentSession().cwd,
+      ...segments,
+    );
+  }
+
+  async ensureDirectory({
+    path,
+    abortSignal,
+  }: {
+    path: string;
+    recursive: true;
+    abortSignal?: AbortSignal;
+  }): Promise<void> {
+    abortSignal?.throwIfAborted();
+    const result = await this.sandbox.runCommand({
+      cmd: 'mkdir',
+      args: ['-p', path],
+      ...(abortSignal !== undefined ? { signal: abortSignal } : {}),
+    });
+    if (result.exitCode !== 0) {
+      throw new Error(`Failed to create sandbox directory: ${path}`);
+    }
   }
 
   async readFile({


### PR DESCRIPTION
## Summary

- add backwards-compatible optional sandbox capabilities for provider-owned guest paths, home directories, recursive directory creation, and shell-free executable + argv spawning
- use those capabilities throughout Harness bootstrap/work-directory/skills setup while retaining the legacy POSIX shell fallbacks
- add an opt-in `preinstalledBridge` mode to `@ai-sdk/harness-codex` that skips pnpm/bootstrap network work and directly launches packaged Node/bridge paths
- preserve the existing adapter-owned bootstrap and `spawn({ command })` contracts

References #18609.

## Verification

Run under Node.js 22.23.2:

- type checks for `@ai-sdk/provider-utils`, `@ai-sdk/harness`, `@ai-sdk/harness-codex`, `@ai-sdk/sandbox-vercel`, and `@ai-sdk/sandbox-just-bash`
- focused Harness bootstrap/path/home/skills tests: 32 passed
- focused Codex tests, including Windows paths with spaces, one skill, zero shell commands, immutable identity relocation, and resume: 11 passed
- Vercel sandbox session tests: 17 passed
- just-bash sandbox session tests: 16 passed
- focused oxfmt and oxlint checks
- `git diff --check`

## Compatibility

All new sandbox capabilities are optional. Existing third-party command-only `spawn` implementations remain structurally compatible; preinstalled Codex mode validates the new capabilities only when explicitly selected.