### PR TITLE
fix(provider-utils): guard fetch type check to prevent import crash in fetch-less environments

### DIFF
--- a/packages/provider-utils/src/safe-node-fetch.ts
+++ b/packages/provider-utils/src/safe-node-fetch.ts
@@ -132,6 +132,7 @@ export async function getDefaultDownloadFetch(): Promise<FetchFunction> {
 }
 
 function isNodeDefaultFetch(fetch: FetchFunction): boolean {
+  if (typeof fetch !== 'function') return false;
   const source = Function.prototype.toString.call(fetch);
   return (
     source.includes('internal/deps/undici') ||


### PR DESCRIPTION
Fixes #18528

### Description
In restricted JavaScript environments where `globalThis.fetch` is undefined (such as Temporal workflow sandboxes or Node instances with `--no-experimental-fetch`), importing the AI SDK currently causes a fatal `TypeError` at module load time. 

This happens because `isNodeDefaultFetch` is evaluated at module scope and blindly calls `Function.prototype.toString.call(fetch)` without verifying that `fetch` is a function.

This PR adds a defensive type guard (`if (typeof fetch !== 'function') return false;`) to immediately bypass the check in fetch-less environments.

### Testing
- Verified 799 `@ai-sdk/provider-utils` tests pass successfully.
- Manually verified via `node -e "delete globalThis.fetch; require('./dist/index.js')"` that the package now imports cleanly without throwing a `TypeError`.