### PR TITLE
fix(harness-codex): close pending step on terminal events

### DIFF
--- a/.changeset/quiet-codex-steps.md
+++ b/.changeset/quiet-codex-steps.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-codex': patch
+---
+
+Close the inferred Codex step when a turn completes with stale pending tool items.

--- a/packages/harness-codex/src/bridge/codex-step-tracker.test.ts
+++ b/packages/harness-codex/src/bridge/codex-step-tracker.test.ts
@@ -26,7 +26,7 @@ describe('createCodexStepTracker', () => {
 
     expect(events).toEqual([]);
 
-    tracker.finishStep();
+    tracker.finishTurn();
 
     expect(events.map(event => event.type)).toEqual(['finish-step']);
   });
@@ -83,6 +83,22 @@ describe('createCodexStepTracker', () => {
     expect(events.map(event => event.type)).toEqual(['finish-step']);
   });
 
+  it('closes a pending tool step at turn end', () => {
+    const { events, tracker } = createTracker();
+
+    tracker.observeEvent({
+      event: {
+        type: 'item.started',
+        item: { type: 'command_execution' },
+      },
+      itemId: 'item_2',
+    });
+
+    tracker.finishTurn();
+
+    expect(events.map(event => event.type)).toEqual(['finish-step']);
+  });
+
   it('closes a final model text step at turn end after a tool step', () => {
     const { events, tracker } = createTracker();
 
@@ -110,7 +126,7 @@ describe('createCodexStepTracker', () => {
 
     expect(events.map(event => event.type)).toEqual(['finish-step']);
 
-    tracker.finishStep();
+    tracker.finishTurn();
 
     expect(events.map(event => event.type)).toEqual([
       'finish-step',

--- a/packages/harness-codex/src/bridge/codex-step-tracker.ts
+++ b/packages/harness-codex/src/bridge/codex-step-tracker.ts
@@ -16,7 +16,7 @@ export type CodexStepTracker = {
     event: CodexStepTrackerEvent;
     itemId: string | undefined;
   }): void;
-  finishStep(): void;
+  finishTurn(): void;
 };
 
 export function createCodexStepTracker(input: {
@@ -53,7 +53,10 @@ export function createCodexStepTracker(input: {
         return;
       }
     },
-    finishStep,
+    finishTurn() {
+      pendingToolItemIds.clear();
+      finishStep();
+    },
   };
 }
 

--- a/packages/harness-codex/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-codex/src/bridge/create-emit-stream-event.test.ts
@@ -10,7 +10,7 @@ describe('createEmitStreamEvent', () => {
     const threadIds: string[] = [];
     const stepTracker = {
       observeEvent: input => observed.push(input),
-      finishStep: () => observed.push('finish'),
+      finishTurn: () => observed.push('finish'),
     } as CodexStepTracker;
     const emitStreamEvent = createEmitStreamEvent({
       send: event => emitted.push(event),
@@ -119,7 +119,7 @@ describe('createEmitStreamEvent', () => {
     const emitted: Record<string, unknown>[] = [];
     const stepTracker = {
       observeEvent: () => {},
-      finishStep: () => {},
+      finishTurn: () => {},
     } as CodexStepTracker;
     const emitStreamEvent = createEmitStreamEvent({
       send: event => emitted.push(event),
@@ -175,7 +175,7 @@ describe('createEmitStreamEvent', () => {
     const emitted: Record<string, unknown>[] = [];
     const stepTracker = {
       observeEvent: () => {},
-      finishStep: () => {},
+      finishTurn: () => {},
     } as CodexStepTracker;
     const emitStreamEvent = createEmitStreamEvent({
       send: event => emitted.push(event),

--- a/packages/harness-codex/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-codex/src/bridge/create-emit-stream-event.ts
@@ -85,7 +85,7 @@ export function createEmitStreamEvent({
     }
     if (event.type === 'turn.completed') {
       if (event.usage) setTurnUsage(mapUsage(event.usage));
-      stepTracker.finishStep();
+      stepTracker.finishTurn();
       return;
     }
     if (event.type === 'turn.failed') {


### PR DESCRIPTION
## Background

Harness Codex infers step boundaries from Codex item events. Its terminal `turn.completed` handler currently uses the same guarded close as ordinary item processing, so a stale pending tool item ID can leave step content open and make the following Harness `finish` invalid.

[Codex SDK 0.144.5](https://github.com/openai/codex/blob/rust-v0.144.5/codex-rs/exec/src/event_processor_with_jsonl_output.rs#L500-L552) reconciles unfinished started items before emitting `turn.completed`, then initiates shutdown. That makes the terminal event authoritative: any pending tracker IDs left at that boundary are stale, and no valid tool completion can arrive afterward.

## Summary

- Add an explicit `finishTurn()` tracker operation that clears stale pending tool IDs before closing the inferred step.
- Preserve the ordinary guard that keeps a step open while tool items are pending.
- Add focused regression coverage and a patch changeset for `@ai-sdk/harness-codex`.

## End-to-End Verification

Ran both live Codex paths against `7d74a8c` with the repository examples and a real Vercel Sandbox:

- `bash-shell.ts` created a sandbox, streamed a Codex `bash` tool call and matching result for `uname -a`, produced final text, and exited 0 without a Harness stream error.
- `generate-text.ts` returned the expected answer, `finishReason: stop`, valid usage, and exited 0.

These runs cover sandbox bootstrap, the installed Codex bridge, event translation, Harness terminal validation, and session cleanup. The live producer reconciles tool items before `turn.completed`, so the intentionally stale pending-ID branch remains covered by the focused regression test.

## Verification

- `pnpm test` in `packages/harness-codex` (83 tests)
- `pnpm type-check` in `packages/harness-codex`
- `pnpm build` in `packages/harness-codex`
- focused `ultracite check` for the four changed TypeScript files
- `pnpm exec changeset status --since origin/main`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
