### PR TITLE
fix(skills): match use-ai-sdk skill name to its directory

### DIFF
--- a/skills/use-ai-sdk/SKILL.md
+++ b/skills/use-ai-sdk/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ai-sdk
+name: use-ai-sdk
 description: 'Answer questions about the AI SDK and help build AI-powered features. Use when developers: (1) Ask about AI SDK functions like generateText, streamText, ToolLoopAgent, embed, or tools, (2) Want to build AI agents, chatbots, RAG systems, or text generation features, (3) Have questions about AI providers (OpenAI, Anthropic, Google, etc.), streaming, tool calling, structured output, or embeddings, (4) Use React hooks like useChat or useCompletion. Triggers on: "AI SDK", "Vercel AI SDK", "generateText", "streamText", "add AI to my app", "build an agent", "tool calling", "structured output", "useChat".'
 ---
 


### PR DESCRIPTION
## What

`skills/use-ai-sdk/SKILL.md` declares:

```yaml
name: ai-sdk
```

but its parent directory is `use-ai-sdk`.

## Why it matters

The Agent Skills specification requires the `name` field to **match the parent directory name**:

> The required `name` field: … Must match the parent directory name
> — <https://agentskills.io/specification#name-field>

`skills-ref validate skills/use-ai-sdk` fails on this today, and a spec-compliant loader can fail to resolve the skill by path.

## Why this looks like a slip, not an alias

It is the only mismatch in `skills/`. All eleven siblings already match their directory:

`add-function-examples`, `add-harness-package`, `add-provider-package`, `adr-skill`, `capture-api-response-test-fixture`, `develop-ai-functions-example`, `list-npm-package-content`, `major-version-mode`, `migrate-ai-sdk-v6-to-v7`, `update-harness-dependencies`, `update-provider-models`.

## The change

One line. Renaming the field rather than the directory keeps the path stable and breaks no links — `git grep "name: ai-sdk"` matches only this frontmatter line.

---

Found with [AgentCompass](https://github.com/YoavLax/agent-compass), an offline static analyzer for AI-agent repo readiness. Verified by hand against the spec before opening.