### PR TITLE
[v6.0] fix(provider-utils): drop Function-constructor Node 18 import shim rejected by Next.js Edge Runtime

### DIFF
--- a/.changeset/eager-donuts-shout.md
+++ b/.changeset/eager-donuts-shout.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+fix(provider-utils): drop Function-constructor dynamic import shim rejected by Next.js Edge Runtime builds

--- a/packages/provider-utils/src/safe-node-fetch.test.ts
+++ b/packages/provider-utils/src/safe-node-fetch.test.ts
@@ -103,37 +103,26 @@ describe('createSafeLookup', () => {
 });
 
 describe('getDefaultDownloadFetch', () => {
-  it('loads Node modules without process.getBuiltinModule', async () => {
+  it('rejects when Node modules are unavailable without process.getBuiltinModule', async () => {
     if (!isNodeRuntime()) {
       return;
     }
 
-    const nodeModules = new Map<string, unknown>([
-      ['node:dns', await import('node:dns')],
-      ['node:module', await import('node:module')],
-    ]);
-    const dynamicImport = vi.fn(async (id: string) => nodeModules.get(id));
-    const functionConstructor = vi.fn(() => dynamicImport);
+    // No dynamic-import fallback exists: Metro rejects non-static import()
+    // expressions while parsing, and Next.js Edge Runtime rejects the
+    // Function-constructor shim. See #18545, #18559.
     const runtimeProcess = globalThis.process as unknown as {
       getBuiltinModule: ((id: string) => unknown) | undefined;
     };
     const originalGetBuiltinModule = runtimeProcess.getBuiltinModule;
-    vi.stubGlobal('Function', functionConstructor);
     runtimeProcess.getBuiltinModule = undefined;
 
     try {
-      await expect(getDefaultDownloadFetch()).resolves.not.toBe(
-        globalThis.fetch,
+      await expect(getDefaultDownloadFetch()).rejects.toThrow(
+        'Node.js built-in module node:module is unavailable',
       );
-      expect(functionConstructor).toHaveBeenCalledWith(
-        'specifier',
-        'return import(specifier)',
-      );
-      expect(dynamicImport).toHaveBeenCalledWith('node:module');
-      expect(dynamicImport).toHaveBeenCalledWith('node:dns');
     } finally {
       runtimeProcess.getBuiltinModule = originalGetBuiltinModule;
-      vi.unstubAllGlobals();
     }
   });
 });

--- a/packages/provider-utils/src/safe-node-fetch.ts
+++ b/packages/provider-utils/src/safe-node-fetch.ts
@@ -140,8 +140,8 @@ function isNodeDefaultFetch(fetch: FetchFunction): boolean {
 }
 
 async function createSafeNodeFetch(): Promise<FetchFunction> {
-  // Node 20.16+ exposes getBuiltinModule; older supported Node versions use an
-  // indirect dynamic import that is hidden from browser bundle parsers.
+  // Load Node-only modules indirectly so browser bundlers do not pull undici
+  // and Node built-ins into the browser-facing provider-utils entry point.
   const [{ createRequire }, { lookup }] = await Promise.all([
     loadNodeModule<NodeModule>('node:module'),
     loadNodeModule<NodeDns>('node:dns'),
@@ -174,23 +174,16 @@ async function loadNodeModule<T>(id: string): Promise<T> {
     | undefined;
   const builtinModule = processWithBuiltins?.getBuiltinModule?.(id);
 
-  return builtinModule == null
-    ? ((await importNodeModule(id)) as T)
-    : (builtinModule as T);
-}
+  if (builtinModule == null) {
+    // There is no bundle-safe way to load Node built-ins without
+    // process.getBuiltinModule (Node <20.16): Metro rejects non-static
+    // import() expressions while parsing, and Next.js Edge Runtime rejects
+    // the Function-constructor shim during static analysis. Throw rather
+    // than ship either, matching the v7 implementation. See #18545, #18559.
+    throw new Error(`Node.js built-in module ${id} is unavailable`);
+  }
 
-let dynamicImport: ((specifier: string) => Promise<unknown>) | undefined;
-
-function importNodeModule(id: string): Promise<unknown> {
-  // Metro rejects non-static dynamic imports while parsing, even though this
-  // Node-only fallback is never executed in React Native. Construct the import
-  // function lazily so the distributed module contains no import expression for
-  // Metro to analyze and runtimes with process.getBuiltinModule avoid it.
-  dynamicImport ??= Function('specifier', 'return import(specifier)') as (
-    specifier: string,
-  ) => Promise<unknown>;
-
-  return dynamicImport(id);
+  return builtinModule as T;
 }
 
 function getCurrentModulePath(): string {


### PR DESCRIPTION
## Problem

Since #18559 landed on `release-v6.0`, the `Build Examples (next-telemetry)` CI job fails on every run (e.g. the `Version Packages` runs on Aug 7, and every open PR against the branch):

```
../../packages/provider-utils/dist/index.mjs
Dynamic Code Evaluation (e. g. 'eval', 'new Function', 'WebAssembly.compile') not allowed in Edge Runtime
Used by fetchWithValidatedRedirects, downloadBlob
  Import trace: provider-utils/dist/index.mjs → ai/dist/index.mjs → ./pages/api/chat-edge.ts
```

## Root cause

#18559 fixed a Metro (React Native) bundling failure (#18545) by replacing the non-static `import(id)` fallback with a lazily-constructed shim:

```ts
dynamicImport ??= Function('specifier', 'return import(specifier)');
```

That satisfies Metro, but Next.js statically rejects `eval`/`Function(...)`/`new Function(...)` in Edge Runtime bundles (webpack parser hooks in `middleware-plugin`), so every Next.js app using the AI SDK in an edge route fails to build. The three constraints are mutually exclusive in a single flat bundle:

- **Metro** rejects non-static `import(id)` at parse time (and a literal `import('node:dns')` at resolve time — the module doesn't exist in RN).
- **Next.js Edge** rejects the `Function`-constructor shim during static analysis.
- **Node 18 ESM** offers no third way to load a built-in (`createRequire` itself needs `node:module`; `process.getBuiltinModule` was added in Node 20.16/22.3).

## Fix

Align v6 with the v7 implementation (#18072): use `process.getBuiltinModule` and throw when it is unavailable, dropping the dynamic-import fallback entirely. This matches main's `loadBuiltinModule` behavior.

**Impact:** only Node runtimes **<20.16** (i.e. Node 18.x, EOL since April 2025, and Node 20.0–20.15) lose the SSRF-guarded download fetch path; they now get a clear error instead of a working fallback. CI on this branch already only tests Node 20/22/24. All other runtimes are unaffected: Node ≥20.16 uses `getBuiltinModule`, and non-Node runtimes (Edge, browsers, React Native) never reach this code (`isNodeRuntime()` guard).

**Alternative considered:** shipping an `edge-light` conditional build variant of provider-utils without the shim (Next's edge compiler resolves the `edge-light` export condition first). That preserves the Node 18 fallback but adds packaging surface on a maintenance branch — happy to do that instead if we want to keep Node 18 support for this path.

## Testing

- Reproduced the CI failure locally (`examples/next-openai-pages` `next build`) — same `Dynamic Code Evaluation` error pointing at `provider-utils/dist/index.mjs`.
- After the fix: the example builds end-to-end (webpack compiles, type check passes).
- `pnpm --filter @ai-sdk/provider-utils test` — 57 files, 505 tests passed (node + edge), including an updated regression test asserting the rejection when `getBuiltinModule` is unavailable.
- `pnpm type-check:full` and `ultracite check` pass.

Refs #18545, #18559