### PR TITLE
docs: add CoralBricks community provider

### DIFF
--- a/content/providers/05-community-providers/14-coralbricks.mdx
+++ b/content/providers/05-community-providers/14-coralbricks.mdx
@@ -1,0 +1,86 @@
+---
+title: CoralBricks
+description: Learn how to use the CoralBricks provider for the AI SDK.
+---
+
+# CoralBricks Provider
+
+[@coralbricks/ai-sdk-provider](https://github.com/Coral-Bricks-AI/www/tree/main/integrations/ai-sdk-provider)
+provides access to [CoralBricks](https://www.coralbricks.ai) inference — open
+models (GLM 5.2, Kimi K3, GPT-OSS 120B) with up to 1M-token context and free
+cached input, over an OpenAI-compatible API.
+
+API keys can be obtained from the [CoralBricks API keys page](https://www.coralbricks.ai/api-keys).
+
+## Setup
+
+The CoralBricks provider is available via the `@coralbricks/ai-sdk-provider` module. You can install it with:
+
+<InstallPackages packages="@coralbricks/ai-sdk-provider" />
+
+### Environment variables
+
+Create a `.env` file with a `CORALBRICKS_API_KEY` variable.
+
+## Provider Instance
+
+You can import the default provider instance `coralbricks` from `@coralbricks/ai-sdk-provider`:
+
+```ts
+import { coralbricks } from '@coralbricks/ai-sdk-provider';
+```
+
+If you need a customized setup, you can import `createCoralBricks` and create a provider instance with your settings:
+
+```ts
+import { createCoralBricks } from '@coralbricks/ai-sdk-provider';
+
+const coralbricks = createCoralBricks({
+  // Optional settings
+});
+```
+
+You can use the following optional settings to customize the CoralBricks provider instance:
+
+- **baseURL** _string_
+
+  Use a different URL prefix for API calls.
+  The default prefix is `https://inference.coralbricks.ai/v1`.
+
+- **apiKey** _string_
+
+  API key that is sent using the `Authorization` header.
+  It defaults to the `CORALBRICKS_API_KEY` environment variable.
+
+- **headers** _Record&lt;string,string&gt;_
+
+  Custom headers to include in the requests.
+
+## Language Models
+
+Create a model with the provider instance and a model id:
+
+```ts
+const model = coralbricks('glm-5.2-fp4');
+```
+
+Available model ids: `glm-5.2-fp4` (GLM 5.2), `kimi-k3` (Kimi K3), and
+`gpt-oss-120b`. The id type is open, so a newly launched model works before
+the package updates. See [coralbricks.ai/pricing](https://www.coralbricks.ai/pricing)
+for the current catalog.
+
+### Example
+
+```ts
+import { generateText } from 'ai';
+import { coralbricks } from '@coralbricks/ai-sdk-provider';
+
+const { text } = await generateText({
+  model: coralbricks('glm-5.2-fp4'),
+  prompt: 'Explain prompt caching in one sentence.',
+});
+```
+
+Streaming (`streamText`), tool calls, and structured output (`generateObject`)
+work through the standard AI SDK functions — CoralBricks speaks the OpenAI wire
+format, including streaming tool calls. Cached input tokens are billed at zero.

--- a/content/providers/05-community-providers/14-coralbricks.mdx
+++ b/content/providers/05-community-providers/14-coralbricks.mdx
@@ -7,7 +7,7 @@ description: Learn how to use the CoralBricks provider for the AI SDK.
 
 [@coralbricks/ai-sdk-provider](https://github.com/Coral-Bricks-AI/www/tree/main/integrations/ai-sdk-provider)
 provides access to [CoralBricks](https://www.coralbricks.ai) inference — open
-models (GLM 5.2, Kimi K3, GPT-OSS 120B) with up to 1M-token context and free
+models (GLM 5.3, GLM 5.2, Kimi K3, GPT-OSS 120B) with up to 1M-token context and free
 cached input, over an OpenAI-compatible API.
 
 API keys can be obtained from the [CoralBricks API keys page](https://www.coralbricks.ai/api-keys).
@@ -61,11 +61,11 @@ You can use the following optional settings to customize the CoralBricks provide
 Create a model with the provider instance and a model id:
 
 ```ts
-const model = coralbricks('glm-5.2-fp4');
+const model = coralbricks('glm-5.3-fp4');
 ```
 
-Available model ids: `glm-5.2-fp4` (GLM 5.2), `kimi-k3` (Kimi K3), and
-`gpt-oss-120b`. The id type is open, so a newly launched model works before
+Available model ids: `glm-5.3-fp4` (GLM 5.3), `glm-5.2-fp4` (GLM 5.2),
+`kimi-k3` (Kimi K3), and `gpt-oss-120b`. The id type is open, so a newly launched model works before
 the package updates. See [coralbricks.ai/pricing](https://www.coralbricks.ai/pricing)
 for the current catalog.
 
@@ -76,7 +76,7 @@ import { generateText } from 'ai';
 import { coralbricks } from '@coralbricks/ai-sdk-provider';
 
 const { text } = await generateText({
-  model: coralbricks('glm-5.2-fp4'),
+  model: coralbricks('glm-5.3-fp4'),
   prompt: 'Explain prompt caching in one sentence.',
 });
 ```

--- a/content/providers/05-community-providers/14-coralbricks.mdx
+++ b/content/providers/05-community-providers/14-coralbricks.mdx
@@ -7,7 +7,7 @@ description: Learn how to use the CoralBricks provider for the AI SDK.
 
 [@coralbricks/ai-sdk-provider](https://github.com/Coral-Bricks-AI/www/tree/main/integrations/ai-sdk-provider)
 provides access to [CoralBricks](https://www.coralbricks.ai) inference — open
-models (GLM 5.3, GLM 5.2, Kimi K3, GPT-OSS 120B) with up to 1M-token context and free
+models (GLM 5.3, Kimi K3, GPT-OSS 120B) with up to 1M-token context and free
 cached input, over an OpenAI-compatible API.
 
 API keys can be obtained from the [CoralBricks API keys page](https://www.coralbricks.ai/api-keys).
@@ -64,8 +64,8 @@ Create a model with the provider instance and a model id:
 const model = coralbricks('glm-5.3-fp4');
 ```
 
-Available model ids: `glm-5.3-fp4` (GLM 5.3), `glm-5.2-fp4` (GLM 5.2),
-`kimi-k3` (Kimi K3), and `gpt-oss-120b`. The id type is open, so a newly launched model works before
+Available model ids: `glm-5.3-fp4` (GLM 5.3), `kimi-k3` (Kimi K3), and
+`gpt-oss-120b`. The id type is open, so a newly launched model works before
 the package updates. See [coralbricks.ai/pricing](https://www.coralbricks.ai/pricing)
 for the current catalog.
 

--- a/content/providers/05-community-providers/14-coralbricks.mdx
+++ b/content/providers/05-community-providers/14-coralbricks.mdx
@@ -7,7 +7,7 @@ description: Learn how to use the CoralBricks provider for the AI SDK.
 
 [@coralbricks/ai-sdk-provider](https://github.com/Coral-Bricks-AI/www/tree/main/integrations/ai-sdk-provider)
 provides access to [CoralBricks](https://www.coralbricks.ai) inference — open
-models (GLM 5.3, Kimi K3, GPT-OSS 120B) with up to 1M-token context and free
+models (GLM 5.3, GLM 5.3 Flash, Kimi K3, GPT-OSS 120B) with up to 1M-token context and free
 cached input, over an OpenAI-compatible API.
 
 API keys can be obtained from the [CoralBricks API keys page](https://www.coralbricks.ai/api-keys).
@@ -64,8 +64,9 @@ Create a model with the provider instance and a model id:
 const model = coralbricks('glm-5.3-fp4');
 ```
 
-Available model ids: `glm-5.3-fp4` (GLM 5.3), `kimi-k3` (Kimi K3), and
-`gpt-oss-120b`. The id type is open, so a newly launched model works before
+Available model ids: `glm-5.3-fp4` (GLM 5.3), `glm-5.3-flash-fp4` (GLM 5.3
+Flash), `kimi-k3` (Kimi K3), and `gpt-oss-120b`. The id type is open, so a
+newly launched model works before
 the package updates. See [coralbricks.ai/pricing](https://www.coralbricks.ai/pricing)
 for the current catalog.
 


### PR DESCRIPTION
Adds a community-providers doc page for **CoralBricks** — open-model inference (GLM 5.2, Kimi K3, GPT-OSS 120B) with up to 1M context and free cached input, over an OpenAI-compatible API.

The provider package [`@coralbricks/ai-sdk-provider`](https://www.npmjs.com/package/@coralbricks/ai-sdk-provider) is published on npm (a thin typed wrapper over `@ai-sdk/openai-compatible`, dual ESM/CJS, tested). This PR is the docs page only, mirroring the structure of the other OpenAI-compatible community providers (e.g. SambaNova, Requesty).

I placed the file at `14-coralbricks.mdx` for rough alphabetical order (after `codex-cli`); happy to renumber wherever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)