### PR TITLE
fix(google): preserve error details in APICallError.data

### DIFF
--- a/.changeset/calm-gemini-retry-info.md
+++ b/.changeset/calm-gemini-retry-info.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Preserve Google API error details, including `google.rpc.RetryInfo`, in `APICallError.data`.

--- a/packages/google/src/__fixtures__/google-429-retry-info.json
+++ b/packages/google/src/__fixtures__/google-429-retry-info.json
@@ -1,0 +1,21 @@
+{
+  "error": {
+    "code": 429,
+    "message": "You exceeded your current quota, please check your plan.",
+    "status": "RESOURCE_EXHAUSTED",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.QuotaFailure",
+        "violations": [
+          {
+            "quotaId": "GenerateRequestsPerMinutePerProjectPerModel-FreeTier"
+          }
+        ]
+      },
+      {
+        "@type": "type.googleapis.com/google.rpc.RetryInfo",
+        "retryDelay": "34.4s"
+      }
+    ]
+  }
+}

--- a/packages/google/src/google-error.test.ts
+++ b/packages/google/src/google-error.test.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { googleFailedResponseHandler } from './google-error';
+
+describe('googleFailedResponseHandler', () => {
+  it('preserves google.rpc.RetryInfo in APICallError.data', async () => {
+    const responseBody = fs.readFileSync(
+      'src/__fixtures__/google-429-retry-info.json',
+      'utf8',
+    );
+
+    const result = await googleFailedResponseHandler({
+      url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent',
+      requestBodyValues: { contents: [] },
+      response: new Response(responseBody, {
+        status: 429,
+        headers: { 'content-type': 'application/json' },
+      }),
+    });
+
+    expect(result.value.data).toMatchObject({
+      error: {
+        details: [
+          {
+            '@type': 'type.googleapis.com/google.rpc.QuotaFailure',
+          },
+          {
+            '@type': 'type.googleapis.com/google.rpc.RetryInfo',
+            retryDelay: '34.4s',
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/google/src/google-error.ts
+++ b/packages/google/src/google-error.ts
@@ -13,6 +13,7 @@ const googleErrorDataSchema = lazySchema(() =>
         code: z.number().nullable(),
         message: z.string(),
         status: z.string(),
+        details: z.array(z.unknown()).nullish(),
       }),
     }),
   ),


### PR DESCRIPTION
## Background

Gemini 429 responses can include structured Google RPC error details such as `google.rpc.RetryInfo`, but the Google provider error schema currently strips `error.details` before the parsed payload reaches `APICallError.data`.

As a result, callers cannot access Google's provider-supplied retry delay through the typed error data and must instead re-parse `responseBody`.

The issue has already been reproduced against current `main`, confirming that the provider schema drops `error.details` even though the raw response body retains the information.

## Summary

This PR keeps the change deliberately narrow:

- preserves `error.details` in the Google provider error schema
- retains arbitrary Google RPC detail payloads without over-modeling them
- preserves entries such as `google.rpc.QuotaFailure` and `google.rpc.RetryInfo`
- adds regression coverage for Gemini HTTP 429 responses
- adds a patch changeset for `@ai-sdk/google`

The change does not modify retry timing, retry policy, public retry APIs, or existing error-message behavior.

## End-to-End Verification

Added a representative Gemini 429 fixture containing:

- `google.rpc.QuotaFailure`
- `google.rpc.RetryInfo`
- `retryDelay: "34.4s"`

The regression test passes the fixture through `googleFailedResponseHandler` and verifies that both structured detail entries survive parsing into `APICallError.data`.

This directly covers the reported failure mode where `responseBody` contains the retry information but `APICallError.data` does not.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated
- [ ] Documentation has been added / updated
- [x] A patch changeset for the relevant package has been added
- [x] I have reviewed this pull request

## Related Issues

Fixes #18627.