### PR TITLE
feat(harness): add configurable Pi native file-tool paths

### DIFF
--- a/.changeset/bright-roots-open.md
+++ b/.changeset/bright-roots-open.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-pi': patch
+---
+
+Add configurable readable, writable, and denied sandbox roots for Pi's native file tools.

--- a/content/providers/02-ai-sdk-harnesses/03-pi.mdx
+++ b/content/providers/02-ai-sdk-harnesses/03-pi.mdx
@@ -84,6 +84,34 @@ Settings:
 - `auth`: AI Gateway or custom provider environment configuration.
 - `model`: Pi model id or model name.
 - `thinkingLevel`: Pi thinking budget level.
+- `fileToolPathPolicy`: Additional readable, writable, and denied sandbox roots
+  for Pi's native file tools.
+
+### File Tool Paths
+
+By default, Pi's native file tools can read and write the session workspace,
+while harness-provided skills are read-only. Use `fileToolPathPolicy` to expose
+additional sandbox paths:
+
+```ts
+const harness = createPi({
+  fileToolPathPolicy: {
+    readableRoots: ['/mnt/reference'],
+    writableRoots: ['/tmp', '/mnt/artifacts'],
+    deniedRoots: ['/tmp/private'],
+  },
+});
+```
+
+Each root must be an absolute path inside the sandbox. Writable roots are also
+readable. Denied roots take precedence over the session workspace,
+harness-provided skills, and configured readable or writable roots.
+
+The policy applies only to Pi's native file tools (`read`, `write`, `edit`,
+`grep`, `glob`, and `ls`). It does not restrict commands executed by `bash`.
+Shell filesystem access is defined by the sandbox. The harness `permissionMode`
+can require approval for the tool call, but it does not create a filesystem
+boundary.
 
 ## Authentication
 

--- a/examples/ai-functions/src/harness-agent/pi/file-tool-path-policy.ts
+++ b/examples/ai-functions/src/harness-agent/pi/file-tool-path-policy.ts
@@ -1,0 +1,41 @@
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { createPi } from '@ai-sdk/harness-pi';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+import { printFullStream } from '../../lib/print-full-stream';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const sandbox = createVercelSandbox({
+    runtime: 'node24',
+    timeout: 10 * 60 * 1000,
+  });
+  const agent = new HarnessAgent({
+    harness: createPi({
+      fileToolPathPolicy: {
+        readableRoots: ['/mnt/reference'],
+        writableRoots: ['/tmp'],
+        deniedRoots: ['/tmp/private'],
+      },
+    }),
+    activeTools: ['write', 'read'],
+    sandbox,
+  });
+
+  let exitCode = 0;
+  const session = await agent.createSession();
+  try {
+    const result = await agent.stream({
+      session,
+      prompt:
+        'Write a short project summary to `/tmp/project-summary.txt`, then read it back and include it in your reply.',
+    });
+
+    await printFullStream({ result });
+  } catch (err) {
+    exitCode = 1;
+    console.error('[example] failed:', err);
+  } finally {
+    await session.destroy();
+    process.exit(exitCode);
+  }
+});

--- a/packages/harness-pi/README.md
+++ b/packages/harness-pi/README.md
@@ -50,3 +50,29 @@ try {
 ```
 
 The adapter requires a `HarnessV1SandboxProvider`. Pi has no in-sandbox bridge, so the sandbox doesn't need to expose any ports — `@ai-sdk/sandbox-vercel` or `@ai-sdk/sandbox-just-bash` both work.
+
+## File Tool Path Policy
+
+By default, Pi's native file tools can read and write the session workspace,
+while harness-provided skills are read-only. Use `fileToolPathPolicy` to expose
+additional sandbox paths:
+
+```ts
+const harness = createPi({
+  fileToolPathPolicy: {
+    readableRoots: ['/mnt/reference'],
+    writableRoots: ['/tmp', '/mnt/artifacts'],
+    deniedRoots: ['/tmp/private'],
+  },
+});
+```
+
+Every configured root must be an absolute path inside the sandbox. Writable
+roots are also readable, and denied roots take precedence over the workspace,
+harness-provided skills, and configured readable or writable roots.
+
+This policy applies only to Pi's native file tools (`read`, `write`, `edit`,
+`grep`, `glob`, and `ls`). It does not restrict commands executed by `bash`,
+whose filesystem access is defined by the sandbox. The harness
+`permissionMode` can require approval for the tool call, but it does not create
+a filesystem boundary.

--- a/packages/harness-pi/package.json
+++ b/packages/harness-pi/package.json
@@ -44,6 +44,7 @@
     "zod": "^3.25.76 || ^4.1.8"
   },
   "devDependencies": {
+    "@ai-sdk/sandbox-just-bash": "workspace:*",
     "@types/node": "22.19.19",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8.5.1",

--- a/packages/harness-pi/src/index.ts
+++ b/packages/harness-pi/src/index.ts
@@ -10,3 +10,4 @@ export { createPi } from './pi-harness';
 export { VERSION } from './version';
 export type { PiHarnessSettings } from './pi-harness';
 export type { PiAuthOptions } from './pi-auth';
+export type { PiFileToolPathPolicy } from './pi-paths';

--- a/packages/harness-pi/src/pi-file-tool-path-policy.integration.test.ts
+++ b/packages/harness-pi/src/pi-file-tool-path-policy.integration.test.ts
@@ -1,0 +1,161 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createJustBashSandbox } from '@ai-sdk/sandbox-just-bash';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPiPathMapper } from './pi-paths';
+import { createPiRemoteOps } from './pi-remote-ops';
+
+const sandboxWorkDir = '/sandbox/workspace';
+const artifactRoot = '/tmp/pi-artifacts';
+
+let hostWorkDir: string;
+
+beforeEach(() => {
+  hostWorkDir = mkdtempSync(path.join(tmpdir(), 'pi-path-policy-'));
+});
+
+afterEach(() => {
+  rmSync(hostWorkDir, { recursive: true, force: true });
+});
+
+describe('Pi file-tool path policy with JustBash', () => {
+  it('enforces external allow and deny roots through the real sandbox provider', async () => {
+    const provider = createJustBashSandbox();
+    const session = await provider.createSession();
+    const sandbox = session.restricted();
+    const onFileChange = vi.fn();
+
+    try {
+      await sandbox.run({
+        command: `mkdir -p ${sandboxWorkDir} ${artifactRoot}/private /etc`,
+      });
+      await sandbox.run({
+        command: `ln -s /etc ${sandboxWorkDir}/outside-link`,
+      });
+      await sandbox.writeTextFile({
+        path: `${artifactRoot}/private/secret.txt`,
+        content: 'credential-secret',
+      });
+      await sandbox.writeTextFile({
+        path: `${artifactRoot}/public.txt`,
+        content: 'public-value',
+      });
+      await sandbox.writeTextFile({
+        path: '/etc/secret.txt',
+        content: 'outside-secret',
+      });
+
+      const paths = createPiPathMapper({
+        hostWorkDir,
+        sandboxWorkDir,
+        fileToolPathPolicy: {
+          writableRoots: [artifactRoot],
+          deniedRoots: [`${artifactRoot}/private`],
+        },
+      });
+      const operations = createPiRemoteOps({
+        sandbox,
+        paths,
+        onFileChange,
+      });
+
+      await operations.writeFile(`${artifactRoot}/result.txt`, 'before');
+      await expect(
+        operations.editFile(`${artifactRoot}/result.txt`, 'before', 'after'),
+      ).resolves.toBe('after');
+      await expect(
+        operations.readBuffer(`${artifactRoot}/result.txt`),
+      ).resolves.toEqual(Buffer.from('after'));
+      expect(onFileChange).not.toHaveBeenCalled();
+
+      await expect(operations.listDirectory(artifactRoot)).resolves.toEqual([
+        'public.txt',
+        'result.txt',
+      ]);
+      await expect(operations.findFiles('**', artifactRoot)).resolves.toEqual([
+        'public.txt',
+        'result.txt',
+      ]);
+      await expect(
+        operations.grepFiles('credential-secret', { path: artifactRoot }),
+      ).resolves.toBe('No matches found');
+      await expect(
+        operations.grepFiles('public-value', { path: artifactRoot }),
+      ).resolves.toContain(`${artifactRoot}/public.txt:1:public-value`);
+
+      await expect(
+        operations.readBuffer(`${artifactRoot}/private/secret.txt`),
+      ).rejects.toThrow(/denied/);
+      await expect(
+        operations.readBuffer('./outside-link/secret.txt'),
+      ).rejects.toThrow(/escapes the readable roots/);
+
+      await operations.writeFile('./inside.txt', 'workspace-value');
+      expect(onFileChange).toHaveBeenCalledOnce();
+      expect(onFileChange).toHaveBeenCalledWith(
+        'create',
+        'inside.txt',
+        Buffer.from('workspace-value'),
+      );
+    } finally {
+      await session.destroy?.();
+    }
+  });
+
+  it('canonicalizes configured symlink roots and prunes literal metacharacter paths', async () => {
+    const provider = createJustBashSandbox();
+    const session = await provider.createSession();
+    const sandbox = session.restricted();
+    const allowedAlias = '/tmp/pi-allowed-link';
+    const allowedTarget = '/mnt/pi-allowed-target';
+    const deniedAlias = '/tmp/pi-denied-link';
+    const deniedTarget = '/mnt/pi-denied-target';
+
+    try {
+      await sandbox.run({
+        command: `mkdir -p ${sandboxWorkDir} '${allowedTarget}/[private]' ${deniedTarget} && ln -s ${allowedTarget} ${allowedAlias} && ln -s ${deniedTarget} ${deniedAlias}`,
+      });
+      await sandbox.writeTextFile({
+        path: `${allowedTarget}/[private]/secret.txt`,
+        content: 'metacharacter-secret',
+      });
+      await sandbox.writeTextFile({
+        path: `${deniedTarget}/secret.txt`,
+        content: 'alias-secret',
+      });
+
+      const paths = createPiPathMapper({
+        hostWorkDir,
+        sandboxWorkDir,
+        fileToolPathPolicy: {
+          readableRoots: [deniedTarget],
+          writableRoots: [allowedAlias],
+          deniedRoots: [deniedAlias, `${allowedAlias}/[private]`],
+        },
+      });
+      const operations = createPiRemoteOps({ sandbox, paths });
+
+      await operations.writeFile(`${allowedAlias}/result.txt`, 'result');
+      await expect(
+        operations.readBuffer(`${allowedAlias}/result.txt`),
+      ).resolves.toEqual(Buffer.from('result'));
+
+      await expect(operations.listDirectory(allowedAlias)).resolves.toEqual([
+        'result.txt',
+      ]);
+      await expect(operations.findFiles('**', allowedAlias)).resolves.toEqual([
+        'result.txt',
+      ]);
+      await expect(
+        operations.grepFiles('metacharacter-secret', { path: allowedAlias }),
+      ).resolves.toBe('No matches found');
+
+      await expect(
+        operations.readBuffer(`${deniedTarget}/secret.txt`),
+      ).rejects.toThrow(/denied by the file-tool policy/);
+    } finally {
+      await session.destroy?.();
+    }
+  });
+});

--- a/packages/harness-pi/src/pi-harness.test.ts
+++ b/packages/harness-pi/src/pi-harness.test.ts
@@ -1,7 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import type { HarnessV1NetworkSandboxSession } from '@ai-sdk/harness';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createPi } from './pi-harness';
 
+const piSessionMock = vi.hoisted(() => ({
+  createPiSession: vi.fn(),
+}));
+
+vi.mock('./pi-session', () => ({
+  createPiSession: piSessionMock.createPiSession,
+}));
+
 describe('createPi adapter', () => {
+  beforeEach(() => {
+    piSessionMock.createPiSession.mockReset();
+    piSessionMock.createPiSession.mockResolvedValue({});
+  });
+
   it('declares the harness id and builtin tools', () => {
     const harness = createPi();
     expect(harness.harnessId).toBe('pi');
@@ -38,5 +52,24 @@ describe('createPi adapter', () => {
   it('omits getBootstrap (no in-sandbox install needed)', () => {
     const harness = createPi();
     expect(harness.getBootstrap).toBeUndefined();
+  });
+
+  it('forwards the native file-tool path policy to the Pi session', async () => {
+    const fileToolPathPolicy = {
+      readableRoots: ['/mnt/reference'],
+      writableRoots: ['/tmp', '/mnt/artifacts'],
+      deniedRoots: ['/tmp/private'],
+    };
+    const harness = createPi({ fileToolPathPolicy });
+
+    await harness.doStart({
+      sessionId: 'session-with-file-tool-policy',
+      sandboxSession: {} as HarnessV1NetworkSandboxSession,
+      sessionWorkDir: '/sandbox/work',
+    });
+
+    expect(piSessionMock.createPiSession).toHaveBeenCalledWith(
+      expect.objectContaining({ fileToolPathPolicy }),
+    );
   });
 });

--- a/packages/harness-pi/src/pi-harness.ts
+++ b/packages/harness-pi/src/pi-harness.ts
@@ -6,6 +6,7 @@ import {
 import { tool } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import type { PiAuthOptions } from './pi-auth';
+import type { PiFileToolPathPolicy } from './pi-paths';
 import { piResumeStateSchema } from './pi-resume-state';
 import { createPiSession, type PiThinkingLevel } from './pi-session';
 import { VERSION } from './version';
@@ -40,6 +41,11 @@ export type PiHarnessSettings = {
    * model settings.
    */
   readonly agentDir?: string;
+  /**
+   * Additional allow and deny roots for Pi's native file tools. This does not
+   * constrain shell commands executed by the `bash` tool.
+   */
+  readonly fileToolPathPolicy?: PiFileToolPathPolicy;
 };
 
 const PI_BUILTIN_TOOLS = {
@@ -156,6 +162,9 @@ export function createPi(
           ? { abortSignal: startOpts.abortSignal }
           : {}),
         ...(settings.agentDir ? { agentDir: settings.agentDir } : {}),
+        ...(settings.fileToolPathPolicy
+          ? { fileToolPathPolicy: settings.fileToolPathPolicy }
+          : {}),
       });
     },
   };

--- a/packages/harness-pi/src/pi-paths.test.ts
+++ b/packages/harness-pi/src/pi-paths.test.ts
@@ -1,8 +1,8 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { createPiPathMapper } from './pi-paths';
+import { createPiPathMapper, type PiFileToolPathPolicy } from './pi-paths';
 
 let hostWorkDir: string;
 const sandboxWorkDir = '/sandbox/work/session';
@@ -14,6 +14,14 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(hostWorkDir, { recursive: true, force: true });
 });
+
+function createPolicyMapper(fileToolPathPolicy: PiFileToolPathPolicy) {
+  return createPiPathMapper({
+    hostWorkDir,
+    sandboxWorkDir,
+    fileToolPathPolicy,
+  });
+}
 
 describe('createPiPathMapper', () => {
   it('translates relative paths to sandbox POSIX paths', () => {
@@ -58,6 +66,159 @@ describe('createPiPathMapper', () => {
         '/home/vercel-sandbox/.agents/skills/weather-codes/SKILL.md',
       ),
     ).toThrow(/escapes the workspace/);
+  });
+
+  it('allows additional read-only roots without making them writable', () => {
+    const mapper = createPolicyMapper({
+      readableRoots: ['/mnt/reference/../reference'],
+    });
+    const referencePath = '/mnt/reference/catalog.json';
+
+    expect(mapper.toReadableSandboxPath(referencePath)).toBe(referencePath);
+    expect(mapper.assertReadableSandboxPath(referencePath)).toBe(referencePath);
+    expect(() => mapper.toSandboxPath(referencePath)).toThrow(
+      /escapes the workspace/,
+    );
+    expect(() => mapper.assertSandboxPath(referencePath)).toThrow(
+      /escapes the workspace/,
+    );
+  });
+
+  it('makes writable roots readable and keeps path-prefix boundaries', () => {
+    const mapper = createPolicyMapper({ writableRoots: ['/tmp/'] });
+
+    expect(mapper.toSandboxPath('/tmp/output.json')).toBe('/tmp/output.json');
+    expect(mapper.toReadableSandboxPath('/tmp/output.json')).toBe(
+      '/tmp/output.json',
+    );
+    expect(mapper.assertSandboxPath('/tmp/output.json')).toBe(
+      '/tmp/output.json',
+    );
+    expect(() => mapper.toSandboxPath('/tmp-evil/output.json')).toThrow(
+      /escapes the workspace/,
+    );
+    expect(() => mapper.toReadableSandboxPath('/tmp-evil/output.json')).toThrow(
+      /escapes the readable roots/,
+    );
+  });
+
+  it('requires every public policy root to be an absolute sandbox path', () => {
+    expect(() => createPolicyMapper({ readableRoots: ['reference'] })).toThrow(
+      'Pi readable root must be an absolute sandbox path: reference',
+    );
+    expect(() => createPolicyMapper({ writableRoots: ['scratch'] })).toThrow(
+      'Pi writable root must be an absolute sandbox path: scratch',
+    );
+    expect(() => createPolicyMapper({ deniedRoots: ['private'] })).toThrow(
+      'Pi denied root must be an absolute sandbox path: private',
+    );
+  });
+
+  it('gives denied roots precedence over every readable and writable root', () => {
+    const skillRoot = '/home/vercel-sandbox/.agents/skills';
+    const mapper = createPiPathMapper({
+      hostWorkDir,
+      sandboxWorkDir,
+      readableRoots: [{ sandboxDir: skillRoot }],
+      fileToolPathPolicy: {
+        readableRoots: ['/mnt/reference'],
+        writableRoots: ['/tmp'],
+        deniedRoots: [
+          `${sandboxWorkDir}/private`,
+          `${skillRoot}/private`,
+          '/mnt/reference/private',
+          '/tmp/private',
+        ],
+      },
+    });
+
+    expect(() => mapper.toSandboxPath('private/token')).toThrow(
+      /denied by the file-tool policy/,
+    );
+    expect(() =>
+      mapper.toReadableSandboxPath(`${skillRoot}/private/SKILL.md`),
+    ).toThrow(/denied by the file-tool policy/);
+    expect(() =>
+      mapper.toReadableSandboxPath('/mnt/reference/private/data.json'),
+    ).toThrow(/denied by the file-tool policy/);
+    expect(() => mapper.toSandboxPath('/tmp/private/result.json')).toThrow(
+      /denied by the file-tool policy/,
+    );
+
+    expect(mapper.toSandboxPath(`${sandboxWorkDir}/public.txt`)).toBe(
+      `${sandboxWorkDir}/public.txt`,
+    );
+    expect(mapper.toReadableSandboxPath(`${skillRoot}/public/SKILL.md`)).toBe(
+      `${skillRoot}/public/SKILL.md`,
+    );
+    expect(mapper.toReadableSandboxPath('/mnt/reference/public.json')).toBe(
+      '/mnt/reference/public.json',
+    );
+    expect(mapper.toSandboxPath('/tmp/public.json')).toBe('/tmp/public.json');
+  });
+
+  it('maps absolute host mirror paths before matching writable sandbox roots', () => {
+    const mapper = createPolicyMapper({
+      writableRoots: [path.posix.dirname(hostWorkDir)],
+    });
+    const hostFilePath = path.join(hostWorkDir, 'result.json');
+
+    expect(mapper.toSandboxPath(hostFilePath)).toBe(
+      `${sandboxWorkDir}/result.json`,
+    );
+    expect(mapper.toReadableSandboxPath(hostFilePath)).toBe(
+      `${sandboxWorkDir}/result.json`,
+    );
+  });
+
+  it('does not reinterpret a host mirror symlink escape as an allowed sandbox path', () => {
+    const hostLink = path.join(hostWorkDir, 'outside-link');
+    symlinkSync(tmpdir(), hostLink, 'dir');
+    const mapper = createPolicyMapper({
+      writableRoots: [path.posix.normalize(tmpdir())],
+    });
+
+    expect(() =>
+      mapper.toSandboxPath(path.join(hostLink, 'secret.txt')),
+    ).toThrow(/escapes the workspace/);
+    expect(() =>
+      mapper.toReadableSandboxPath(path.join(hostLink, 'secret.txt')),
+    ).toThrow(/escapes the workspace/);
+  });
+
+  it('reports workspace membership with normalized boundary-safe checks', () => {
+    const mapper = createPolicyMapper({ writableRoots: ['/tmp'] });
+
+    expect(mapper.isWorkspacePath(sandboxWorkDir)).toBe(true);
+    expect(
+      mapper.isWorkspacePath(`${sandboxWorkDir}/src/../package.json`),
+    ).toBe(true);
+    expect(mapper.isWorkspacePath(`${sandboxWorkDir}-other/file.txt`)).toBe(
+      false,
+    );
+    expect(mapper.isWorkspacePath('/tmp/output.json')).toBe(false);
+  });
+
+  it('returns normalized denied descendants within a recursive root', () => {
+    const mapper = createPolicyMapper({
+      deniedRoots: [
+        `${sandboxWorkDir}/private`,
+        `${sandboxWorkDir}/nested/../credentials`,
+        '/tmp/private',
+        '/tmp-other/not-a-descendant',
+      ],
+    });
+
+    expect(mapper.getDeniedSandboxRootsWithin(sandboxWorkDir)).toEqual([
+      `${sandboxWorkDir}/private`,
+      `${sandboxWorkDir}/credentials`,
+    ]);
+    expect(mapper.getDeniedSandboxRootsWithin('/tmp')).toEqual([
+      '/tmp/private',
+    ]);
+    expect(mapper.getDeniedSandboxRootsWithin('/tmp/private')).toEqual([
+      '/tmp/private',
+    ]);
   });
 
   it('toRelativePath returns "." for the sandbox root', () => {

--- a/packages/harness-pi/src/pi-paths.ts
+++ b/packages/harness-pi/src/pi-paths.ts
@@ -6,10 +6,16 @@ export interface PiPathMapper {
   readonly hostWorkDir: string;
   /** The sandbox-side working directory where tools actually operate. */
   readonly sandboxWorkDir: string;
+  /** Additional sandbox roots accepted by read-only tools. */
+  readonly readableSandboxRoots: ReadonlyArray<string>;
+  /** Additional sandbox roots accepted by mutating tools. */
+  readonly writableSandboxRoots: ReadonlyArray<string>;
+  /** Sandbox roots rejected by every native file tool. */
+  readonly deniedSandboxRoots: ReadonlyArray<string>;
   /**
    * Translate a path the host sees (relative to `hostWorkDir`, or absolute
    * inside it, or already a sandbox path) to the canonical sandbox path. Throws
-   * if the path would escape the workspace.
+   * if the path would escape the workspace and configured writable roots.
    */
   toSandboxPath(inputPath: string): string;
   /**
@@ -17,13 +23,17 @@ export interface PiPathMapper {
    * allows explicitly configured sandbox roots such as `$HOME/.agents/skills`.
    */
   toReadableSandboxPath(inputPath: string): string;
-  /** Verify that a sandbox-side path is still inside `sandboxWorkDir`. */
+  /** Verify that a sandbox-side path is writable under the configured policy. */
   assertSandboxPath(inputPath: string): string;
   /**
    * Verify that a sandbox-side path is inside `sandboxWorkDir` or an
    * explicitly configured readable root.
    */
   assertReadableSandboxPath(inputPath: string): string;
+  /** Whether a sandbox-side path is inside `sandboxWorkDir`. */
+  isWorkspacePath(inputPath: string): boolean;
+  /** Denied roots nested within a sandbox-side path. */
+  getDeniedSandboxRootsWithin(inputPath: string): ReadonlyArray<string>;
   /** Translate any path to its POSIX-relative form under `sandboxWorkDir`. */
   toRelativePath(inputPath: string): string;
 }
@@ -32,10 +42,26 @@ export interface PiReadablePathRoot {
   readonly sandboxDir: string;
 }
 
+/**
+ * Additional sandbox paths exposed to Pi's native file tools. The session
+ * workspace remains read-write and harness-provided skills remain read-only.
+ * Writable roots are also readable, and denied roots take precedence over
+ * every allowed root.
+ *
+ * This policy does not restrict Pi's `bash` tool. Shell filesystem access is
+ * defined by the sandbox; the harness permission mode only controls approval.
+ */
+export interface PiFileToolPathPolicy {
+  readonly readableRoots?: ReadonlyArray<string>;
+  readonly writableRoots?: ReadonlyArray<string>;
+  readonly deniedRoots?: ReadonlyArray<string>;
+}
+
 export interface CreatePiPathMapperOptions {
   readonly hostWorkDir: string;
   readonly sandboxWorkDir: string;
   readonly readableRoots?: ReadonlyArray<PiReadablePathRoot>;
+  readonly fileToolPathPolicy?: PiFileToolPathPolicy;
 }
 
 function isInsidePath(parent: string, candidate: string): boolean {
@@ -69,6 +95,20 @@ function canonicalizeForContainment(inputPath: string): string {
   }
 }
 
+function normalizeSandboxRoots(
+  roots: ReadonlyArray<string> | undefined,
+  kind: string,
+): string[] {
+  return (roots ?? []).map(root => {
+    if (!path.posix.isAbsolute(root)) {
+      throw new Error(
+        `Pi ${kind} root must be an absolute sandbox path: ${root}`,
+      );
+    }
+    return path.posix.normalize(root);
+  });
+}
+
 export function createPiPathMapper(
   options: CreatePiPathMapperOptions,
 ): PiPathMapper {
@@ -79,10 +119,37 @@ export function createPiPathMapper(
     options.readableRoots?.map(root => ({
       sandboxDir: path.posix.normalize(root.sandboxDir),
     })) ?? [];
+  const policyReadableRoots = normalizeSandboxRoots(
+    options.fileToolPathPolicy?.readableRoots,
+    'readable',
+  );
+  const writableRoots = normalizeSandboxRoots(
+    options.fileToolPathPolicy?.writableRoots,
+    'writable',
+  );
+  const deniedRoots = normalizeSandboxRoots(
+    options.fileToolPathPolicy?.deniedRoots,
+    'denied',
+  );
 
-  const assertWorkspaceSandboxPath = (inputPath: string): string => {
+  const isDeniedSandboxPath = (inputPath: string): boolean =>
+    deniedRoots.some(root => isInsidePosixPath(root, inputPath));
+
+  const assertNotDenied = (inputPath: string): void => {
+    if (isDeniedSandboxPath(inputPath)) {
+      throw new Error(
+        `Pi path is denied by the file-tool policy: ${inputPath}`,
+      );
+    }
+  };
+
+  const assertWritableSandboxPath = (inputPath: string): string => {
     const normalizedInput = path.posix.normalize(inputPath);
-    if (!isInsidePosixPath(normalizedSandbox, normalizedInput)) {
+    assertNotDenied(normalizedInput);
+    if (
+      !isInsidePosixPath(normalizedSandbox, normalizedInput) &&
+      !writableRoots.some(root => isInsidePosixPath(root, normalizedInput))
+    ) {
       throw new Error(`Pi path escapes the workspace: ${inputPath}`);
     }
     return normalizedInput;
@@ -90,35 +157,31 @@ export function createPiPathMapper(
 
   const assertReadableSandboxPath = (inputPath: string): string => {
     const normalizedInput = path.posix.normalize(inputPath);
+    assertNotDenied(normalizedInput);
     if (
       !isInsidePosixPath(normalizedSandbox, normalizedInput) &&
       !readableRoots.some(root =>
         isInsidePosixPath(root.sandboxDir, normalizedInput),
-      )
+      ) &&
+      !policyReadableRoots.some(root =>
+        isInsidePosixPath(root, normalizedInput),
+      ) &&
+      !writableRoots.some(root => isInsidePosixPath(root, normalizedInput))
     ) {
       throw new Error(`Pi path escapes the readable roots: ${inputPath}`);
     }
     return normalizedInput;
   };
 
-  const toWorkspaceSandboxPath = (inputPath: string): string => {
-    if (path.posix.isAbsolute(inputPath)) {
-      const normalizedInput = path.posix.normalize(inputPath);
-      try {
-        return assertWorkspaceSandboxPath(normalizedInput);
-      } catch {
-        // Absolute host paths are handled below.
-      }
-    }
-
+  const mapHostWorkspacePath = (inputPath: string): string | undefined => {
     const resolvedHost = path.isAbsolute(inputPath)
       ? path.resolve(inputPath)
       : path.resolve(normalizedHost, inputPath);
     const canonicalResolvedHost = canonicalizeForContainment(resolvedHost);
-    if (
-      !isInsidePath(normalizedHost, resolvedHost) ||
-      !isInsidePath(canonicalHost, canonicalResolvedHost)
-    ) {
+    if (!isInsidePath(normalizedHost, resolvedHost)) {
+      return undefined;
+    }
+    if (!isInsidePath(canonicalHost, canonicalResolvedHost)) {
       throw new Error(`Pi path escapes the workspace: ${inputPath}`);
     }
 
@@ -131,29 +194,93 @@ export function createPiPathMapper(
       : normalizedSandbox;
   };
 
+  const toWritableSandboxPath = (inputPath: string): string => {
+    if (path.posix.isAbsolute(inputPath)) {
+      const normalizedInput = path.posix.normalize(inputPath);
+      if (isInsidePosixPath(normalizedSandbox, normalizedInput)) {
+        return assertWritableSandboxPath(normalizedInput);
+      }
+
+      const mappedHostPath = mapHostWorkspacePath(inputPath);
+      if (mappedHostPath) {
+        return assertWritableSandboxPath(mappedHostPath);
+      }
+
+      if (
+        writableRoots.some(root => isInsidePosixPath(root, normalizedInput))
+      ) {
+        return assertWritableSandboxPath(normalizedInput);
+      }
+    } else {
+      const mappedHostPath = mapHostWorkspacePath(inputPath);
+      if (mappedHostPath) {
+        return assertWritableSandboxPath(mappedHostPath);
+      }
+    }
+
+    throw new Error(`Pi path escapes the workspace: ${inputPath}`);
+  };
+
   return {
     hostWorkDir: normalizedHost,
     sandboxWorkDir: normalizedSandbox,
+    readableSandboxRoots: [
+      ...readableRoots.map(root => root.sandboxDir),
+      ...policyReadableRoots,
+    ],
+    writableSandboxRoots: writableRoots,
+    deniedSandboxRoots: deniedRoots,
     toSandboxPath(inputPath: string) {
-      return toWorkspaceSandboxPath(inputPath);
+      return toWritableSandboxPath(inputPath);
     },
     toReadableSandboxPath(inputPath: string) {
       if (path.posix.isAbsolute(inputPath)) {
         const normalizedInput = path.posix.normalize(inputPath);
-        try {
+        if (isInsidePosixPath(normalizedSandbox, normalizedInput)) {
           return assertReadableSandboxPath(normalizedInput);
-        } catch {
-          // Absolute host paths are handled by workspace mapping below.
+        }
+
+        const mappedHostPath = mapHostWorkspacePath(inputPath);
+        if (mappedHostPath) {
+          return assertReadableSandboxPath(mappedHostPath);
+        }
+
+        if (
+          readableRoots.some(root =>
+            isInsidePosixPath(root.sandboxDir, normalizedInput),
+          ) ||
+          policyReadableRoots.some(root =>
+            isInsidePosixPath(root, normalizedInput),
+          ) ||
+          writableRoots.some(root => isInsidePosixPath(root, normalizedInput))
+        ) {
+          return assertReadableSandboxPath(normalizedInput);
+        }
+      } else {
+        const mappedHostPath = mapHostWorkspacePath(inputPath);
+        if (mappedHostPath) {
+          return assertReadableSandboxPath(mappedHostPath);
         }
       }
-
-      return toWorkspaceSandboxPath(inputPath);
+      throw new Error(`Pi path escapes the readable roots: ${inputPath}`);
     },
     assertSandboxPath(inputPath: string) {
-      return assertWorkspaceSandboxPath(inputPath);
+      return assertWritableSandboxPath(inputPath);
     },
     assertReadableSandboxPath(inputPath: string) {
       return assertReadableSandboxPath(inputPath);
+    },
+    isWorkspacePath(inputPath: string) {
+      return isInsidePosixPath(
+        normalizedSandbox,
+        path.posix.normalize(inputPath),
+      );
+    },
+    getDeniedSandboxRootsWithin(inputPath: string) {
+      const normalizedInput = path.posix.normalize(inputPath);
+      return deniedRoots.filter(root =>
+        isInsidePosixPath(normalizedInput, root),
+      );
     },
     toRelativePath(inputPath: string) {
       const sandboxPath = path.posix.isAbsolute(inputPath)

--- a/packages/harness-pi/src/pi-remote-ops.test.ts
+++ b/packages/harness-pi/src/pi-remote-ops.test.ts
@@ -16,7 +16,7 @@ function makeMockSandbox(behaviors: {
     stderr?: string;
     exitCode?: number;
   };
-  realpath?: (path: string) => string | null;
+  canonicalize?: (path: string) => string | null;
   readBinary?: (path: string) => Uint8Array | null;
 }): {
   sandbox: Experimental_SandboxSession;
@@ -40,7 +40,7 @@ function makeMockSandbox(behaviors: {
       }) => {
         runCalls.push({ command, workingDirectory });
         const result =
-          mockRealpathCommand(command, behaviors.realpath) ??
+          mockCanonicalizeCommand(command, behaviors.canonicalize) ??
           behaviors.run?.(command) ??
           {};
         return {
@@ -69,12 +69,41 @@ function makeMockSandbox(behaviors: {
   return { sandbox, runCalls, readCalls, writeCalls };
 }
 
-function mockRealpathCommand(
+function mockCanonicalizeCommand(
   command: string,
   resolvePath: ((path: string) => string | null) | undefined,
 ): { stdout?: string; stderr?: string; exitCode?: number } | undefined {
-  if (!command.includes('realpath')) {
+  if (!command.includes('pi_resolve_path')) {
     return undefined;
+  }
+
+  if (command.includes('__PI_RESOLVED_TARGET__')) {
+    const targets = [...command.matchAll(/target='([^']+)'/g)].map(
+      match => match[1],
+    );
+    const [requestedTarget, ...policyRoots] = targets;
+    if (!requestedTarget) {
+      return { stdout: '__PI_REALPATH_FAILED__\n', exitCode: 3 };
+    }
+    const resolvedTarget = resolvePath?.(requestedTarget) ?? requestedTarget;
+    if (resolvedTarget === null) {
+      return command.includes('__PI_REALPATH_NOT_FOUND__')
+        ? { stdout: '__PI_REALPATH_NOT_FOUND__\n', exitCode: 2 }
+        : { stdout: '__PI_REALPATH_FAILED__\n', exitCode: 3 };
+    }
+
+    const lines = [`__PI_RESOLVED_TARGET__${resolvedTarget}`];
+    for (const [index, target] of policyRoots.entries()) {
+      const resolvedPath = resolvePath?.(target) ?? target;
+      if (resolvedPath === null) {
+        return {
+          stdout: `__PI_POLICY_ROOT_FAILED__${index}\n`,
+          exitCode: 3,
+        };
+      }
+      lines.push(`__PI_POLICY_ROOT_${index}__${resolvedPath}`);
+    }
+    return { stdout: `${lines.join('\n')}\n` };
   }
 
   const target = command.match(/target='([^']+)'/)?.[1];
@@ -92,14 +121,31 @@ function mockRealpathCommand(
 const hostWorkDir = '/tmp/pi-test-host';
 const sandboxWorkDir = '/sandbox/workspace';
 
-function makeOps(behaviors: Parameters<typeof makeMockSandbox>[0]) {
+function makeOps(
+  behaviors: Parameters<typeof makeMockSandbox>[0],
+  options: {
+    fileToolPathPolicy?: {
+      readableRoots?: ReadonlyArray<string>;
+      writableRoots?: ReadonlyArray<string>;
+      deniedRoots?: ReadonlyArray<string>;
+    };
+    onFileChange?: Parameters<typeof createPiRemoteOps>[0]['onFileChange'];
+  } = {},
+) {
   const env = makeMockSandbox(behaviors);
   const paths = createPiPathMapper({
     hostWorkDir,
     sandboxWorkDir,
     readableRoots: [{ sandboxDir: '/home/vercel-sandbox/.agents/skills' }],
+    ...(options.fileToolPathPolicy
+      ? { fileToolPathPolicy: options.fileToolPathPolicy }
+      : {}),
   });
-  const ops = createPiRemoteOps({ sandbox: env.sandbox, paths });
+  const ops = createPiRemoteOps({
+    sandbox: env.sandbox,
+    paths,
+    ...(options.onFileChange ? { onFileChange: options.onFileChange } : {}),
+  });
   return { ...env, paths, ops };
 }
 
@@ -113,6 +159,9 @@ describe('createPiRemoteOps.readBuffer', () => {
     });
     const buf = await env.ops.readBuffer('hello.txt');
     expect(buf.toString('utf8')).toBe('hi');
+    expect(env.runCalls[0]?.command).toContain('cd -P "$dir"');
+    expect(env.runCalls[0]?.command).toContain('readlink "$candidate"');
+    expect(env.runCalls[0]?.command).not.toContain('realpath');
   });
 
   it('throws when file does not exist', async () => {
@@ -136,7 +185,7 @@ describe('createPiRemoteOps.readBuffer', () => {
   it('rejects workspace symlinks that resolve outside readable roots', async () => {
     const outsideSecretPath = '/home/vercel-sandbox/CODEX_API_KEY';
     const env = makeOps({
-      realpath: p =>
+      canonicalize: p =>
         p === `${sandboxWorkDir}/repo-controlled-secret-link`
           ? outsideSecretPath
           : p,
@@ -157,8 +206,11 @@ describe('createPiRemoteOps.writeFile', () => {
   it('mkdir -p the parent and writes via writeTextFile', async () => {
     const env = makeOps({ readBinary: () => null });
     await env.ops.writeFile('src/new.ts', 'export {};');
-    expect(env.runCalls[1]?.command).toContain('mkdir -p');
-    expect(env.runCalls[1]?.command).toContain(`'${sandboxWorkDir}/src'`);
+    const mkdirCommand = env.runCalls.find(call =>
+      call.command.includes('mkdir -p'),
+    )?.command;
+    expect(mkdirCommand).toContain('mkdir -p');
+    expect(mkdirCommand).toContain(`'${sandboxWorkDir}/src'`);
     expect(env.writeCalls).toEqual([
       { path: `${sandboxWorkDir}/src/new.ts`, content: 'export {};' },
     ]);
@@ -201,7 +253,7 @@ describe('createPiRemoteOps.writeFile', () => {
   it('rejects workspace symlinks that resolve outside the workspace', async () => {
     const outsideConfigPath = '/home/vercel-sandbox/victim-config.json';
     const env = makeOps({
-      realpath: p =>
+      canonicalize: p =>
         p === `${sandboxWorkDir}/repo-controlled-write-link`
           ? outsideConfigPath
           : p,
@@ -248,16 +300,17 @@ describe('createPiRemoteOps.editFile', () => {
 });
 
 describe('createPiRemoteOps.listDirectory', () => {
-  it('uses ls -1Ap inside the sandbox and parses output (preserves trailing / for dirs)', async () => {
+  it('uses portable ls output inside the sandbox and preserves trailing / for dirs', async () => {
     const env = makeOps({
       run: () => ({ stdout: 'src/\nREADME.md\nnode_modules/\n' }),
     });
     const names = await env.ops.listDirectory('.');
     expect(names).toEqual(['node_modules/', 'README.md', 'src/']);
     const cmd =
-      env.runCalls.find(call => call.command.includes('ls -1Ap'))?.command ??
-      '';
-    expect(cmd).toContain('ls -1Ap');
+      env.runCalls.find(call => call.command.includes('ls -1A'))?.command ?? '';
+    expect(cmd).toContain('ls -1A');
+    expect(cmd).not.toContain('ls -1Ap');
+    expect(cmd).toContain(`if [ -d "$entry" ]`);
   });
 
   it('throws on __PI_LS_NOT_FOUND__ sentinel', async () => {
@@ -283,18 +336,18 @@ describe('createPiRemoteOps.grepFiles', () => {
       limit: 50,
     });
     expect(out).toContain('foo.ts:1:hit');
-    // The inner command is wrapped in `bash -lc '...'`, so its single quotes
-    // get escaped to `'\''` in the outer string. We just look for the
-    // signature substrings without quoting.
     const cmd =
-      env.runCalls.find(call => call.command.includes('grep '))?.command ?? '';
-    expect(cmd).toContain('grep');
-    expect(cmd).toContain('-R');
+      env.runCalls.find(call => call.command.includes('-exec grep'))?.command ??
+      '';
+    expect(cmd).toContain(`find '${sandboxWorkDir}'`);
+    expect(cmd).toContain('-exec grep');
+    expect(cmd).not.toContain('grep -R');
     expect(cmd).toContain('-i');
     expect(cmd).toContain('-F');
     expect(cmd).toContain('-C');
-    expect(cmd).toContain('--include');
+    expect(cmd).toContain('-name');
     expect(cmd).toContain('*.ts');
+    expect(cmd).toContain('binary_flag');
     expect(cmd).toContain('head -n 50');
   });
 
@@ -307,7 +360,7 @@ describe('createPiRemoteOps.grepFiles', () => {
   it('rejects workspace symlinks before running grep outside readable roots', async () => {
     const outsideSecretPath = '/home/vercel-sandbox/CODEX_API_KEY';
     const env = makeOps({
-      realpath: p =>
+      canonicalize: p =>
         p === `${sandboxWorkDir}/repo-controlled-secret-link`
           ? outsideSecretPath
           : p,
@@ -320,9 +373,180 @@ describe('createPiRemoteOps.grepFiles', () => {
         literal: true,
       }),
     ).rejects.toThrow(/escapes the readable roots/);
-    expect(env.runCalls.some(call => call.command.includes('grep '))).toBe(
+    expect(env.runCalls.some(call => call.command.includes('-exec grep'))).toBe(
       false,
     );
+  });
+});
+
+describe('createPiRemoteOps configured file-tool paths', () => {
+  it('batches policy-root canonicalization into one sandbox run per operation', async () => {
+    const env = makeOps(
+      {
+        readBinary: filePath =>
+          filePath === '/mnt/reference/info.txt'
+            ? new TextEncoder().encode('reference')
+            : null,
+      },
+      {
+        fileToolPathPolicy: {
+          readableRoots: ['/mnt/reference', '/mnt/other-reference'],
+          writableRoots: ['/tmp'],
+          deniedRoots: ['/tmp/private'],
+        },
+      },
+    );
+
+    await env.ops.readBuffer('/mnt/reference/info.txt');
+
+    const policyRootCommands = env.runCalls.filter(call =>
+      call.command.includes('__PI_POLICY_ROOT_'),
+    );
+    expect(env.runCalls).toHaveLength(1);
+    expect(policyRootCommands).toHaveLength(1);
+    expect(policyRootCommands[0]?.command).toContain("target='/mnt/reference'");
+    expect(policyRootCommands[0]?.command).toContain("target='/tmp/private'");
+  });
+
+  it('allows external read/write/edit roots while preserving read-only and denied roots', async () => {
+    const onFileChange = vi.fn();
+    const env = makeOps(
+      {
+        readBinary: filePath => {
+          if (filePath === '/mnt/reference/info.txt') {
+            return new TextEncoder().encode('reference');
+          }
+          if (filePath === '/tmp/existing.txt') {
+            return new TextEncoder().encode('old value');
+          }
+          return null;
+        },
+      },
+      {
+        fileToolPathPolicy: {
+          readableRoots: ['/mnt/reference'],
+          writableRoots: ['/tmp'],
+          deniedRoots: ['/tmp/private'],
+        },
+        onFileChange,
+      },
+    );
+
+    await expect(
+      env.ops.readBuffer('/mnt/reference/info.txt'),
+    ).resolves.toEqual(Buffer.from('reference'));
+    await env.ops.writeFile('/tmp/new.txt', 'new value');
+    await expect(
+      env.ops.editFile('/tmp/existing.txt', 'old', 'updated'),
+    ).resolves.toBe('updated value');
+
+    expect(env.writeCalls).toEqual([
+      { path: '/tmp/new.txt', content: 'new value' },
+      { path: '/tmp/existing.txt', content: 'updated value' },
+    ]);
+    expect(onFileChange).not.toHaveBeenCalled();
+    await expect(
+      env.ops.writeFile('/mnt/reference/no-write.txt', 'no'),
+    ).rejects.toThrow(/escapes the workspace/);
+    await expect(env.ops.readBuffer('/tmp/private/token')).rejects.toThrow(
+      /denied by the file-tool policy/,
+    );
+  });
+
+  it('rechecks a missing write path through its nearest existing symlinked parent', async () => {
+    const env = makeOps(
+      {
+        canonicalize: filePath =>
+          filePath === '/tmp/link/missing/output.json'
+            ? '/etc/missing/output.json'
+            : filePath,
+        readBinary: () => null,
+      },
+      {
+        fileToolPathPolicy: { writableRoots: ['/tmp'] },
+      },
+    );
+
+    await expect(
+      env.ops.writeFile('/tmp/link/missing/output.json', '{}'),
+    ).rejects.toThrow(/escapes the workspace/);
+    expect(env.writeCalls).toEqual([]);
+    expect(env.runCalls[0]?.command).toContain(
+      'while [ ! -e "$dir" ] && [ ! -L "$dir" ]',
+    );
+    expect(env.runCalls[0]?.command).toContain(
+      'resolved_dir=$(pi_resolve_path "$dir")',
+    );
+    expect(env.runCalls[0]?.command).not.toContain('realpath');
+  });
+
+  it('filters denied entries, prunes recursive tools, and formats grep paths by root', async () => {
+    const env = makeOps(
+      {
+        run: command => {
+          if (command.includes('ls -1A')) {
+            return { stdout: 'private/\nvisible.txt\n' };
+          }
+          if (command.includes('-exec grep')) {
+            return command.includes(`find '${sandboxWorkDir}'`)
+              ? { stdout: `${sandboxWorkDir}/src/visible.ts:1:public\n` }
+              : { stdout: '/tmp/visible.txt:1:public\n' };
+          }
+          if (command.includes(`find '/tmp'`)) {
+            return { stdout: '/tmp/visible.txt\n' };
+          }
+          return {};
+        },
+      },
+      {
+        fileToolPathPolicy: {
+          readableRoots: ['/tmp'],
+          deniedRoots: ['/tmp/private', `${sandboxWorkDir}/secret`],
+        },
+      },
+    );
+
+    await expect(env.ops.listDirectory('/tmp')).resolves.toEqual([
+      'visible.txt',
+    ]);
+    await expect(env.ops.findFiles('*', '/tmp')).resolves.toEqual([
+      'visible.txt',
+    ]);
+    await expect(env.ops.grepFiles('public', { path: '/tmp' })).resolves.toBe(
+      '/tmp/visible.txt:1:public',
+    );
+    await expect(env.ops.grepFiles('public', { path: '.' })).resolves.toBe(
+      'src/visible.ts:1:public',
+    );
+
+    const recursiveCommands = env.runCalls
+      .map(call => call.command)
+      .filter(command => command.includes('find '));
+    expect(recursiveCommands).toHaveLength(3);
+    for (const command of recursiveCommands) {
+      expect(command).not.toContain(' -L ');
+    }
+
+    const tmpCommands = recursiveCommands.filter(command =>
+      command.includes("find '/tmp'"),
+    );
+    expect(tmpCommands).toHaveLength(2);
+    for (const command of tmpCommands) {
+      expect(command).toContain("\\( -path '/tmp/private' \\) -prune -o");
+    }
+
+    const grepCommands = recursiveCommands.filter(command =>
+      command.includes('-exec grep'),
+    );
+    expect(grepCommands).toHaveLength(2);
+    for (const command of grepCommands) {
+      expect(command).not.toContain('grep -R');
+    }
+    expect(
+      grepCommands.find(command =>
+        command.includes(`find '${sandboxWorkDir}'`),
+      ),
+    ).toContain(`\\( -path '${sandboxWorkDir}/secret' \\) -prune -o`);
   });
 });
 

--- a/packages/harness-pi/src/pi-remote-ops.ts
+++ b/packages/harness-pi/src/pi-remote-ops.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { shellQuote } from '@ai-sdk/harness/utils';
 import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
-import type { PiPathMapper } from './pi-paths';
+import { createPiPathMapper, type PiPathMapper } from './pi-paths';
 
 export type PiRemoteFileChangeKind = 'create' | 'modify';
 
@@ -65,9 +65,83 @@ interface RunShellResult {
   output: Buffer;
 }
 
-function lastOutputLine(output: Buffer): string | undefined {
-  return output.toString('utf8').trim().split('\n').filter(Boolean).at(-1);
+function escapeFindPathPattern(input: string): string {
+  return [...input]
+    .map(character => {
+      switch (character) {
+        case '\\':
+          return '[\\\\]';
+        case '*':
+          return '[*]';
+        case '?':
+          return '[?]';
+        case '[':
+          return '[[]';
+        case ']':
+          return '[]]';
+        default:
+          return character;
+      }
+    })
+    .join('');
 }
+
+function buildFindPruneExpression(deniedRoots: readonly string[]): string {
+  if (deniedRoots.length === 0) return '';
+  return `\\( ${deniedRoots
+    .map(root => `-path ${shellQuote(escapeFindPathPattern(root))}`)
+    .join(' -o ')} \\) -prune -o `;
+}
+
+interface ResolvedSandboxPath {
+  readonly path: string;
+  readonly paths: PiPathMapper;
+}
+
+// `realpath` is not available in every supported sandbox (notably just-bash),
+// so resolve physical parents and final symlink chains using portable commands.
+const canonicalizeSandboxPathScript = `pi_resolve_path() {
+  candidate=$1
+  count=0
+  while :; do
+    if [ "$candidate" = "/" ]; then printf '/\\n'; return 0; fi
+    dir=$(dirname "$candidate") || return 1
+    base=$(basename "$candidate") || return 1
+    resolved_dir=$(cd -P "$dir" 2>/dev/null && pwd -P) || return 1
+    candidate="$resolved_dir/$base"
+    if [ ! -L "$candidate" ]; then printf '%s\\n' "$candidate"; return 0; fi
+    count=$((count + 1))
+    if [ "$count" -gt 40 ]; then return 1; fi
+    link=$(readlink "$candidate") || return 1
+    case "$link" in
+      /*) candidate="$link" ;;
+      *) candidate="$resolved_dir/$link" ;;
+    esac
+  done
+}`;
+
+const resolvePotentialSandboxPathScript = `pi_resolve_potential_path() {
+  target=$1
+  if [ -e "$target" ] || [ -L "$target" ]; then
+    pi_resolve_path "$target"
+    return
+  fi
+  dir=$(dirname "$target") || return 1
+  base=$(basename "$target") || return 1
+  missing="$base"
+  while [ ! -e "$dir" ] && [ ! -L "$dir" ]; do
+    parent=$(dirname "$dir") || return 1
+    if [ "$parent" = "$dir" ]; then return 1; fi
+    missing="$(basename "$dir")/$missing"
+    dir="$parent"
+  done
+  resolved_dir=$(pi_resolve_path "$dir") || return 1
+  if [ "$resolved_dir" = "/" ]; then
+    printf '/%s\\n' "$missing"
+  else
+    printf '%s/%s\\n' "$resolved_dir" "$missing"
+  fi
+}`;
 
 export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
   const runShell = async (
@@ -98,83 +172,138 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
     };
   };
 
-  const resolveExistingSandboxPath = async (
+  const resolveSandboxPath = async (
     remotePath: string,
     inputPath: string,
-  ): Promise<string> => {
+    mustExist: boolean,
+  ): Promise<ResolvedSandboxPath> => {
+    const roots = [
+      ...new Set([
+        options.paths.sandboxWorkDir,
+        ...options.paths.readableSandboxRoots,
+        ...options.paths.writableSandboxRoots,
+        ...options.paths.deniedSandboxRoots,
+      ]),
+    ];
     const result = await runShell(
       [
+        canonicalizeSandboxPathScript,
+        resolvePotentialSandboxPathScript,
         `target=${shellQuote(remotePath)}`,
-        `if [ ! -e "$target" ]; then echo "__PI_REALPATH_NOT_FOUND__"; exit 2; fi`,
-        `resolved=$(realpath "$target" 2>/dev/null) || { echo "__PI_REALPATH_FAILED__"; exit 3; }`,
-        `printf '%s\\n' "$resolved"`,
-      ].join('; '),
+        ...(mustExist
+          ? [
+              `if [ ! -e "$target" ]; then echo "__PI_REALPATH_NOT_FOUND__"; exit 2; fi`,
+              `resolved=$(pi_resolve_path "$target") || { echo "__PI_REALPATH_FAILED__"; exit 3; }`,
+            ]
+          : [
+              `resolved=$(pi_resolve_potential_path "$target") || { echo "__PI_REALPATH_FAILED__"; exit 3; }`,
+            ]),
+        `printf '__PI_RESOLVED_TARGET__%s\\n' "$resolved"`,
+        ...roots.flatMap((root, index) => [
+          `target=${shellQuote(root)}`,
+          `resolved=$(pi_resolve_potential_path "$target") || { printf '__PI_POLICY_ROOT_FAILED__${index}\\n'; exit 3; }`,
+          `printf '__PI_POLICY_ROOT_${index}__%s\\n' "$resolved"`,
+        ]),
+      ].join('\n'),
     );
-
     const output = result.output.toString('utf8');
-    if (output.includes('__PI_REALPATH_NOT_FOUND__')) {
+    const outputLines = output.split('\n');
+    if (outputLines.includes('__PI_REALPATH_NOT_FOUND__')) {
       throw new Error(`Path not found: ${inputPath}`);
     }
-    if (output.includes('__PI_REALPATH_FAILED__') || result.exitCode !== 0) {
+    if (outputLines.includes('__PI_REALPATH_FAILED__')) {
       throw new Error(`Unable to resolve path: ${inputPath}`);
+    }
+    const failedIndex = outputLines
+      .find(line => line.startsWith('__PI_POLICY_ROOT_FAILED__'))
+      ?.slice('__PI_POLICY_ROOT_FAILED__'.length);
+    if (result.exitCode !== 0) {
+      const failedRoot =
+        failedIndex === undefined ? undefined : roots[Number(failedIndex)];
+      throw new Error(
+        failedRoot
+          ? `Unable to resolve configured root: ${failedRoot}`
+          : 'Unable to resolve configured file-tool roots',
+      );
     }
 
-    const resolvedPath = lastOutputLine(result.output);
-    if (!resolvedPath) {
+    const targetMarker = '__PI_RESOLVED_TARGET__';
+    const resolvedTargetLine = outputLines.find(line =>
+      line.startsWith(targetMarker),
+    );
+    if (!resolvedTargetLine) {
       throw new Error(`Unable to resolve path: ${inputPath}`);
     }
-    return resolvedPath;
+    const resolvedTarget = resolvedTargetLine.slice(targetMarker.length);
+
+    const resolvedRoots = new Map<string, string>();
+    for (const [index, root] of roots.entries()) {
+      const marker = `__PI_POLICY_ROOT_${index}__`;
+      const line = outputLines.find(line => line.startsWith(marker));
+      if (!line) {
+        throw new Error(`Unable to resolve configured root: ${root}`);
+      }
+      resolvedRoots.set(root, line.slice(marker.length));
+    }
+
+    const resolvedRoot = (root: string): string => {
+      const resolved = resolvedRoots.get(root);
+      if (!resolved) {
+        throw new Error(`Unable to resolve configured root: ${root}`);
+      }
+      return resolved;
+    };
+
+    const resolvedPaths = createPiPathMapper({
+      hostWorkDir: options.paths.hostWorkDir,
+      sandboxWorkDir: resolvedRoot(options.paths.sandboxWorkDir),
+      readableRoots: options.paths.readableSandboxRoots.map(sandboxDir => ({
+        sandboxDir: resolvedRoot(sandboxDir),
+      })),
+      fileToolPathPolicy: {
+        writableRoots: options.paths.writableSandboxRoots.map(resolvedRoot),
+        deniedRoots: options.paths.deniedSandboxRoots.map(resolvedRoot),
+      },
+    });
+    return {
+      path: mustExist
+        ? resolvedPaths.assertReadableSandboxPath(resolvedTarget)
+        : resolvedPaths.assertSandboxPath(resolvedTarget),
+      paths: resolvedPaths,
+    };
   };
 
-  const resolveReadableSandboxPath = async (
+  const resolveReadableSandboxPath = (
     remotePath: string,
     inputPath: string,
-  ): Promise<string> =>
-    options.paths.assertReadableSandboxPath(
-      await resolveExistingSandboxPath(remotePath, inputPath),
-    );
+  ): Promise<ResolvedSandboxPath> =>
+    resolveSandboxPath(remotePath, inputPath, true);
 
-  const resolveWritableSandboxPath = async (
+  const resolveWritableSandboxPath = (
     remotePath: string,
     inputPath: string,
-  ): Promise<string> => {
-    const result = await runShell(
-      [
-        `target=${shellQuote(remotePath)}`,
-        `if [ -e "$target" ] || [ -L "$target" ]; then resolved=$(realpath "$target" 2>/dev/null) || { echo "__PI_REALPATH_FAILED__"; exit 3; }; printf '%s\\n' "$resolved"; exit 0; fi`,
-        `dir=$(dirname "$target")`,
-        `base=$(basename "$target")`,
-        `missing="$base"`,
-        `while [ ! -e "$dir" ] && [ ! -L "$dir" ]; do parent=$(dirname "$dir"); if [ "$parent" = "$dir" ]; then echo "__PI_REALPATH_NOT_FOUND__"; exit 2; fi; missing="$(basename "$dir")/$missing"; dir="$parent"; done`,
-        `resolved_dir=$(realpath "$dir" 2>/dev/null) || { echo "__PI_REALPATH_FAILED__"; exit 3; }`,
-        `printf '%s/%s\\n' "$resolved_dir" "$missing"`,
-      ].join('; '),
-    );
+  ): Promise<ResolvedSandboxPath> =>
+    resolveSandboxPath(remotePath, inputPath, false);
 
-    const output = result.output.toString('utf8');
-    if (
-      output.includes('__PI_REALPATH_NOT_FOUND__') ||
-      output.includes('__PI_REALPATH_FAILED__') ||
-      result.exitCode !== 0
-    ) {
-      throw new Error(`Unable to resolve path: ${inputPath}`);
-    }
-
-    const resolvedPath = lastOutputLine(result.output);
-    if (!resolvedPath) {
-      throw new Error(`Unable to resolve path: ${inputPath}`);
-    }
-    return options.paths.assertSandboxPath(resolvedPath);
-  };
+  const getDeniedRootsWithin = (
+    remotePath: string,
+    resolved: ResolvedSandboxPath,
+  ): string[] => [
+    ...new Set([
+      ...options.paths
+        .getDeniedSandboxRootsWithin(remotePath)
+        .map(root =>
+          path.posix.join(resolved.path, path.posix.relative(remotePath, root)),
+        ),
+      ...resolved.paths.getDeniedSandboxRootsWithin(resolved.path),
+    ]),
+  ];
 
   const readBuffer = async (inputPath: string): Promise<Buffer> => {
     const remotePath = options.paths.toReadableSandboxPath(inputPath);
-    const resolvedPath = await resolveReadableSandboxPath(
-      remotePath,
-      inputPath,
-    );
+    const resolved = await resolveReadableSandboxPath(remotePath, inputPath);
     const bytes = await options.sandbox.readBinaryFile({
-      path: resolvedPath,
+      path: resolved.path,
     });
     if (!bytes) {
       throw new Error(`Path not found: ${inputPath}`);
@@ -187,20 +316,19 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
     content: string,
   ): Promise<void> => {
     const remotePath = options.paths.toSandboxPath(inputPath);
-    const resolvedPath = await resolveWritableSandboxPath(
-      remotePath,
-      inputPath,
-    );
+    const resolved = await resolveWritableSandboxPath(remotePath, inputPath);
     const previous = await options.sandbox.readBinaryFile({
-      path: resolvedPath,
+      path: resolved.path,
     });
-    await runShell(`mkdir -p ${shellQuote(path.posix.dirname(resolvedPath))}`);
-    await options.sandbox.writeTextFile({ path: resolvedPath, content });
-    options.onFileChange?.(
-      previous ? 'modify' : 'create',
-      options.paths.toRelativePath(resolvedPath),
-      Buffer.from(content, 'utf8'),
-    );
+    await runShell(`mkdir -p ${shellQuote(path.posix.dirname(resolved.path))}`);
+    await options.sandbox.writeTextFile({ path: resolved.path, content });
+    if (resolved.paths.isWorkspacePath(resolved.path)) {
+      options.onFileChange?.(
+        previous ? 'modify' : 'create',
+        resolved.paths.toRelativePath(resolved.path),
+        Buffer.from(content, 'utf8'),
+      );
+    }
   };
 
   const editFile = async (
@@ -225,16 +353,18 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
     limit: number = 500,
   ): Promise<string[]> => {
     const remotePath = options.paths.toReadableSandboxPath(inputPath);
-    const resolvedPath = await resolveReadableSandboxPath(
-      remotePath,
-      inputPath,
+    const resolved = await resolveReadableSandboxPath(remotePath, inputPath);
+    const deniedDirectEntries = new Set(
+      getDeniedRootsWithin(remotePath, resolved)
+        .map(root => path.posix.relative(resolved.path, root))
+        .filter(relative => relative.length > 0 && !relative.includes('/')),
     );
     const result = await runShell(
       [
-        `if [ ! -e ${shellQuote(resolvedPath)} ]; then echo "__PI_LS_NOT_FOUND__"; exit 2; fi`,
-        `if [ ! -d ${shellQuote(resolvedPath)} ]; then echo "__PI_LS_NOT_DIR__"; exit 3; fi`,
-        `cd ${shellQuote(resolvedPath)}`,
-        'ls -1Ap',
+        `if [ ! -e ${shellQuote(resolved.path)} ]; then echo "__PI_LS_NOT_FOUND__"; exit 2; fi`,
+        `if [ ! -d ${shellQuote(resolved.path)} ]; then echo "__PI_LS_NOT_DIR__"; exit 3; fi`,
+        `cd ${shellQuote(resolved.path)}`,
+        `ls -1A | while IFS= read -r entry; do if [ -d "$entry" ]; then printf '%s/\\n' "$entry"; else printf '%s\\n' "$entry"; fi; done`,
       ].join('; '),
     );
 
@@ -249,6 +379,12 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
     return output
       .split('\n')
       .filter(Boolean)
+      .filter(line => {
+        const entryName = line.endsWith('/')
+          ? line.slice(0, -1)
+          : line.replace(/[*=@|]$/, '');
+        return !deniedDirectEntries.has(entryName);
+      })
       .map(line => line.replace(/[*=@|]$/, ''))
       .sort((left, right) =>
         left.toLowerCase().localeCompare(right.toLowerCase()),
@@ -262,14 +398,14 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
     limit: number = 1_000,
   ): Promise<string[]> => {
     const remotePath = options.paths.toReadableSandboxPath(inputPath);
-    const resolvedPath = await resolveReadableSandboxPath(
-      remotePath,
-      inputPath,
+    const resolved = await resolveReadableSandboxPath(remotePath, inputPath);
+    const pruneExpression = buildFindPruneExpression(
+      getDeniedRootsWithin(remotePath, resolved),
     );
     const result = await runShell(
       [
-        `if [ ! -e ${shellQuote(resolvedPath)} ]; then echo "__PI_FIND_NOT_FOUND__"; exit 2; fi`,
-        `if [ -d ${shellQuote(resolvedPath)} ]; then find ${shellQuote(resolvedPath)} -type f -print; else printf '%s\\n' ${shellQuote(resolvedPath)}; fi`,
+        `if [ ! -e ${shellQuote(resolved.path)} ]; then echo "__PI_FIND_NOT_FOUND__"; exit 2; fi`,
+        `if [ -d ${shellQuote(resolved.path)} ]; then find ${shellQuote(resolved.path)} ${pruneExpression}-type f -print; else printf '%s\\n' ${shellQuote(resolved.path)}; fi`,
       ].join('; '),
     );
 
@@ -278,7 +414,7 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
       throw new Error(`Path not found: ${inputPath}`);
     }
 
-    const searchRoot = resolvedPath;
+    const searchRoot = resolved.path;
     return output
       .split('\n')
       .filter(Boolean)
@@ -310,32 +446,29 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
     },
   ): Promise<string> => {
     const remotePath = options.paths.toReadableSandboxPath(input.path ?? '.');
-    const resolvedPath = await resolveReadableSandboxPath(
+    const resolved = await resolveReadableSandboxPath(
       remotePath,
       input.path ?? '.',
     );
-    const relativeTarget = options.paths.toRelativePath(resolvedPath);
-    const targetPath =
-      relativeTarget.startsWith('../') || path.posix.isAbsolute(relativeTarget)
-        ? resolvedPath
-        : relativeTarget;
+    const pruneExpression = buildFindPruneExpression(
+      getDeniedRootsWithin(remotePath, resolved),
+    );
     const flags = [
-      '-R',
       '-n',
-      '--binary-files=without-match',
       ...(input.ignoreCase ? ['-i'] : []),
       ...(input.literal ? ['-F'] : []),
       ...(typeof input.context === 'number' && input.context > 0
         ? ['-C', String(input.context)]
         : []),
-      ...(input.glob ? ['--include', input.glob] : []),
     ];
+    const nameExpression = input.glob ? ` -name ${shellQuote(input.glob)}` : '';
     const limit = Math.max(1, input.limit ?? 100);
     const result = await runShell(
       [
-        `if [ ! -e ${shellQuote(resolvedPath)} ]; then echo "__PI_GREP_NOT_FOUND__"; exit 2; fi`,
-        `cd ${shellQuote(options.paths.sandboxWorkDir)}`,
-        `grep ${flags.map(shellQuote).join(' ')} -- ${shellQuote(pattern)} ${shellQuote(targetPath)} 2>/dev/null | head -n ${limit}`,
+        `if [ ! -e ${shellQuote(resolved.path)} ]; then echo "__PI_GREP_NOT_FOUND__"; exit 2; fi`,
+        `cd ${shellQuote(resolved.paths.sandboxWorkDir)}`,
+        `binary_flag=''; if grep --help 2>&1 | grep -q -e 'binary-files'; then binary_flag='--binary-files=without-match'; fi`,
+        `find ${shellQuote(resolved.path)} ${pruneExpression}-type f${nameExpression} -exec grep ${flags.map(shellQuote).join(' ')} $binary_flag -e ${shellQuote(pattern)} /dev/null {} + 2>/dev/null | head -n ${limit}`,
       ].join('; '),
     );
 
@@ -344,7 +477,18 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
       throw new Error(`Path not found: ${input.path ?? '.'}`);
     }
 
-    return output || 'No matches found';
+    if (!output) return 'No matches found';
+    if (!resolved.paths.isWorkspacePath(resolved.path)) return output;
+
+    const workspacePrefix = `${resolved.paths.sandboxWorkDir}/`;
+    return output
+      .split('\n')
+      .map(line =>
+        line.startsWith(workspacePrefix)
+          ? line.slice(workspacePrefix.length)
+          : line,
+      )
+      .join('\n');
   };
 
   return {

--- a/packages/harness-pi/src/pi-session.ts
+++ b/packages/harness-pi/src/pi-session.ts
@@ -37,7 +37,7 @@ import {
 } from './pi-auth';
 import { getPiTerminalError, parseNativeEvent } from './pi-events';
 import { createPiModelResolver } from './pi-model-resolver';
-import { createPiPathMapper } from './pi-paths';
+import { createPiPathMapper, type PiFileToolPathPolicy } from './pi-paths';
 import { createPiRemoteOps, type PiRemoteOps } from './pi-remote-ops';
 import { writePiSkills } from './pi-skills';
 import {
@@ -213,6 +213,7 @@ export interface CreatePiSessionInput {
    * (e.g. `~/.pi/agent/`) to reuse their CLI auth and model settings.
    */
   readonly agentDir?: string;
+  readonly fileToolPathPolicy?: PiFileToolPathPolicy;
 }
 
 interface PendingToolResult {
@@ -328,6 +329,9 @@ export async function createPiSession(
     readableRoots: sandboxSkillRootDir
       ? [{ sandboxDir: sandboxSkillRootDir }]
       : [],
+    ...(input.fileToolPathPolicy
+      ? { fileToolPathPolicy: input.fileToolPathPolicy }
+      : {}),
   });
 
   // Pi auth + model registry are global to this Pi session. These live on the

--- a/packages/harness-pi/tsconfig.json
+++ b/packages/harness-pi/tsconfig.json
@@ -13,6 +13,7 @@
   ],
   "references": [
     { "path": "../harness" },
-    { "path": "../provider-utils" }
+    { "path": "../provider-utils" },
+    { "path": "../sandbox-just-bash" }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2967,6 +2967,9 @@ importers:
         specifier: ^1.1.38
         version: 1.2.2
     devDependencies:
+      '@ai-sdk/sandbox-just-bash':
+        specifier: workspace:*
+        version: link:../sandbox-just-bash
       '@types/node':
         specifier: 22.19.19
         version: 22.19.19


### PR DESCRIPTION
## Background

Pi's native file tools currently limit writes to the session workspace and
reads to the workspace plus harness-provided skills. Adapter users therefore
cannot expose additional sandbox locations such as artifact or reference
directories, even when the sandbox itself permits access.

The restriction comes from the Pi adapter's path mapper rather than
`permissionMode`. Shell access remains a separate boundary: this policy applies
only to native file tools, while `bash` filesystem access is defined by the
sandbox and `permissionMode` only controls approval.

## Summary

- add a public `PiFileToolPathPolicy` with readable, writable, and denied
  absolute sandbox roots
- preserve workspace read-write and harness-skill read-only defaults, make
  writable roots readable, and give denied roots precedence
- canonicalize requested paths and configured roots in one sandbox call,
  including nearest-existing-ancestor checks for new writes and symlink-alias
  denial
- apply the policy to `read`, `write`, `edit`, `ls`, `glob`, and `grep`, pruning
  denied descendants without following recursive symlinks
- keep `file-change` events scoped to actual workspace mutations
- replace `realpath` and `grep -R` assumptions with JustBash-compatible
  `cd -P`/`readlink` canonicalization and `find ... -prune ... -exec grep`
- document the setting and bash limitation, add an AI-functions example and a
  patch changeset, and add real JustBash provider coverage

## End-to-End Verification

No hosted-sandbox or model-call smoke test was run. The adapter's complete file
operation path was exercised through the real JustBash sandbox provider,
including external reads/writes/edits, denied subtree pruning, canonical
symlink handling, and workspace-only file-change events.

## Validation

- `pnpm --filter @ai-sdk/harness-pi test` (14 files, 132 tests)
- `pnpm --filter @ai-sdk/harness-pi type-check`
- `pnpm --filter @ai-sdk/harness-pi build`
- `pnpm --filter @example/ai-functions type-check`
- `pnpm type-check:full`
- `pnpm check`
- `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts`
- `git diff HEAD^ --check`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)
