### PR TITLE
fix(harness-claude-code): fix built-in tool filtering by using actual denylist when passing `inactiveTools`

### DIFF
--- a/.changeset/long-queens-rule.md
+++ b/.changeset/long-queens-rule.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-claude-code": patch
+---
+
+fix(harness-claude-code): fix built-in tool filtering by using actual denylist when passing `inactiveTools`

--- a/packages/harness-claude-code/src/bridge/index.ts
+++ b/packages/harness-claude-code/src/bridge/index.ts
@@ -44,6 +44,10 @@ import {
   type ClaudeMessage,
 } from './create-emit-stream-event';
 import { jsonSchemaToZodShape } from './json-schema-to-zod';
+import {
+  resolveInactiveNativeTools,
+  resolveNativeTools,
+} from './tool-filtering';
 
 /*
  * Native Claude Code tool name → cross-harness common name. Tools outside this
@@ -68,37 +72,6 @@ const NATIVE_TO_COMMON: Readonly<Record<string, CommonBuiltinToolName>> = {
   Grep: 'grep',
   WebSearch: 'webSearch',
 };
-
-const PUBLIC_TO_NATIVE: Readonly<Record<string, string>> = {
-  read: 'Read',
-  write: 'Write',
-  edit: 'Edit',
-  bash: 'Bash',
-  glob: 'Glob',
-  grep: 'Grep',
-  webSearch: 'WebSearch',
-  WebFetch: 'WebFetch',
-  NotebookEdit: 'NotebookEdit',
-  TodoWrite: 'TodoWrite',
-  Agent: 'Agent',
-  TaskCreate: 'TaskCreate',
-  TaskGet: 'TaskGet',
-  TaskUpdate: 'TaskUpdate',
-  TaskList: 'TaskList',
-  TaskStop: 'TaskStop',
-  TaskOutput: 'TaskOutput',
-  Monitor: 'Monitor',
-  ListMcpResources: 'ListMcpResources',
-  ReadMcpResource: 'ReadMcpResource',
-  ExitPlanMode: 'ExitPlanMode',
-  EnterWorktree: 'EnterWorktree',
-  ExitWorktree: 'ExitWorktree',
-  AskUserQuestion: 'AskUserQuestion',
-  Skill: 'Skill',
-  ToolSearch: 'ToolSearch',
-};
-
-const PUBLIC_TOOL_NAMES = Object.keys(PUBLIC_TO_NATIVE);
 
 const NATIVE_TOOL_KINDS: Readonly<
   Record<string, 'readonly' | 'edit' | 'bash'>
@@ -132,34 +105,6 @@ const NATIVE_TOOL_KINDS: Readonly<
 
 function toCommonName(nativeName: string): CommonBuiltinToolName | string {
   return NATIVE_TO_COMMON[nativeName] ?? nativeName;
-}
-
-function toNativeName(toolName: string): string {
-  return PUBLIC_TO_NATIVE[toolName] ?? toolName;
-}
-
-function resolveNativeTools(start: StartMessage): string[] | undefined {
-  const toolFiltering = start.builtinToolFiltering;
-  if (toolFiltering == null) return undefined;
-  const activeToolNames =
-    toolFiltering.mode === 'allow'
-      ? toolFiltering.toolNames
-      : PUBLIC_TOOL_NAMES.filter(
-          name => !toolFiltering.toolNames.includes(name),
-        );
-  return activeToolNames.map(name => toNativeName(name));
-}
-
-function resolveInactiveNativeTools(start: StartMessage): string[] {
-  const toolFiltering = start.builtinToolFiltering;
-  if (toolFiltering == null) return [];
-  const inactiveToolNames =
-    toolFiltering.mode === 'allow'
-      ? PUBLIC_TOOL_NAMES.filter(
-          name => !toolFiltering.toolNames.includes(name),
-        )
-      : toolFiltering.toolNames;
-  return inactiveToolNames.map(name => toNativeName(name));
 }
 
 const args = parseArgs(argv.slice(2));
@@ -372,8 +317,10 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     abortSignal: abortCtl.signal,
   });
   const skillsOption = toClaudeSkillsOption(start.skills);
-  const nativeTools = resolveNativeTools(start);
-  const inactiveNativeTools = resolveInactiveNativeTools(start);
+  const nativeTools = resolveNativeTools(start.builtinToolFiltering);
+  const inactiveNativeTools = resolveInactiveNativeTools(
+    start.builtinToolFiltering,
+  );
   const permissionOptions = createPermissionOptions({
     start,
     inactiveNativeTools,

--- a/packages/harness-claude-code/src/bridge/tool-filtering.test.ts
+++ b/packages/harness-claude-code/src/bridge/tool-filtering.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveInactiveNativeTools,
+  resolveNativeTools,
+} from './tool-filtering';
+
+describe('resolveNativeTools', () => {
+  it('returns undefined without filtering', () => {
+    expect(resolveNativeTools(undefined)).toBeUndefined();
+  });
+
+  it('maps allowlisted common tool names to native names', () => {
+    expect(
+      resolveNativeTools({ mode: 'allow', toolNames: ['read', 'Workflow'] }),
+    ).toEqual(['Read', 'Workflow']);
+  });
+
+  it('preserves an empty allowlist', () => {
+    expect(resolveNativeTools({ mode: 'allow', toolNames: [] })).toEqual([]);
+  });
+
+  it('returns undefined for deny filtering', () => {
+    expect(
+      resolveNativeTools({ mode: 'deny', toolNames: ['bash', 'Workflow'] }),
+    ).toBeUndefined();
+  });
+});
+
+describe('resolveInactiveNativeTools', () => {
+  it('returns an empty list without filtering', () => {
+    expect(resolveInactiveNativeTools(undefined)).toEqual([]);
+  });
+
+  it('maps denied common names and preserves native names', () => {
+    expect(
+      resolveInactiveNativeTools({
+        mode: 'deny',
+        toolNames: ['bash', 'Workflow'],
+      }),
+    ).toEqual(['Bash', 'Workflow']);
+  });
+});

--- a/packages/harness-claude-code/src/bridge/tool-filtering.ts
+++ b/packages/harness-claude-code/src/bridge/tool-filtering.ts
@@ -1,0 +1,58 @@
+import type { StartMessage } from '../claude-code-bridge-protocol';
+
+type BuiltinToolFiltering = StartMessage['builtinToolFiltering'];
+
+const PUBLIC_TO_NATIVE: Readonly<Record<string, string>> = {
+  read: 'Read',
+  write: 'Write',
+  edit: 'Edit',
+  bash: 'Bash',
+  glob: 'Glob',
+  grep: 'Grep',
+  webSearch: 'WebSearch',
+  WebFetch: 'WebFetch',
+  NotebookEdit: 'NotebookEdit',
+  TodoWrite: 'TodoWrite',
+  Agent: 'Agent',
+  TaskCreate: 'TaskCreate',
+  TaskGet: 'TaskGet',
+  TaskUpdate: 'TaskUpdate',
+  TaskList: 'TaskList',
+  TaskStop: 'TaskStop',
+  TaskOutput: 'TaskOutput',
+  Monitor: 'Monitor',
+  ListMcpResources: 'ListMcpResources',
+  ReadMcpResource: 'ReadMcpResource',
+  ExitPlanMode: 'ExitPlanMode',
+  EnterWorktree: 'EnterWorktree',
+  ExitWorktree: 'ExitWorktree',
+  AskUserQuestion: 'AskUserQuestion',
+  Skill: 'Skill',
+  ToolSearch: 'ToolSearch',
+};
+
+const PUBLIC_TOOL_NAMES = Object.keys(PUBLIC_TO_NATIVE);
+
+function toNativeName(toolName: string): string {
+  return PUBLIC_TO_NATIVE[toolName] ?? toolName;
+}
+
+export function resolveNativeTools(
+  toolFiltering: BuiltinToolFiltering,
+): string[] | undefined {
+  if (toolFiltering == null || toolFiltering.mode === 'deny') return undefined;
+  return toolFiltering.toolNames.map(name => toNativeName(name));
+}
+
+export function resolveInactiveNativeTools(
+  toolFiltering: BuiltinToolFiltering,
+): string[] {
+  if (toolFiltering == null) return [];
+  const inactiveToolNames =
+    toolFiltering.mode === 'allow'
+      ? PUBLIC_TOOL_NAMES.filter(
+          name => !toolFiltering.toolNames.includes(name),
+        )
+      : toolFiltering.toolNames;
+  return inactiveToolNames.map(name => toNativeName(name));
+}


### PR DESCRIPTION
## Background

Claude Code's deny-mode built-in tool filtering converted `inactiveTools` into an allowlist. Because the harness's declared tool list may not include every native Claude Code tool, disabling selected tools could also disable unrelated native tools.

## Summary

- Omit the Claude Agent SDK `tools` allowlist for deny-mode filtering.
- Continue passing explicitly inactive tools through `disallowedTools`.
- Preserve existing allow-mode behavior and common-to-native tool name mapping.
- Add focused regression tests for allow- and deny-mode resolution.

## End-to-End Verification

Ran `aif examples/ai-functions/src/harness-agent/claude-code/inactive-tools.ts`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
