### PR TITLE
feat(harness-claude-code): add optional `env` property to `createClaudeCode()` for custom env vars

### DIFF
--- a/.changeset/plenty-timers-matter.md
+++ b/.changeset/plenty-timers-matter.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-claude-code": patch
+---
+
+feat(harness-claude-code): add optional `env` property to `createClaudeCode()` for custom env vars

--- a/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
+++ b/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
@@ -80,6 +80,9 @@ Use `createClaudeCode()` to configure the runtime:
 const harness = createClaudeCode({
   model: 'claude-sonnet-4-6',
   maxTurns: 10,
+  env: {
+    DEPLOYMENT_ENV: 'staging',
+  },
   thinking: {
     type: 'adaptive',
     display: 'summarized',
@@ -92,6 +95,8 @@ Settings:
 - `auth`: direct Anthropic or AI Gateway authentication settings.
 - `model`: Anthropic model id passed to the underlying Claude Code runtime.
 - `maxTurns`: maximum internal turns before yielding.
+- `env`: environment variables for the Claude Code process. Values are merged
+  over the sandbox bridge process environment and take precedence.
 - `thinking`: extended-thinking configuration. `type` can be `enabled`,
   `disabled`, or `adaptive`. For enabled or adaptive thinking, `display` can be
   `summarized` or `omitted`. Defaults to

--- a/examples/ai-functions/src/harness-agent/claude-code/runtime-configuration.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/runtime-configuration.ts
@@ -1,0 +1,39 @@
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { createClaudeCode } from '@ai-sdk/harness-claude-code';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const sandbox = createVercelSandbox({
+    runtime: 'node24',
+    ports: [4000],
+    timeout: 10 * 60 * 1000,
+  });
+  const agent = new HarnessAgent({
+    harness: createClaudeCode({
+      env: {
+        AI_SDK_EXAMPLE_ENV: 'staging',
+      },
+    }),
+    instructions:
+      'Report environment values using the format `Environment: <value>`.',
+    sandbox,
+  });
+
+  let exitCode = 0;
+  const session = await agent.createSession();
+  try {
+    const result = await agent.generate({
+      session,
+      prompt:
+        'Use Bash to read AI_SDK_EXAMPLE_ENV, then report its value as instructed.',
+    });
+    console.log('text:', result.text);
+  } catch (err) {
+    exitCode = 1;
+    console.error('[example] failed:', err);
+  } finally {
+    await session.destroy();
+    process.exit(exitCode);
+  }
+});

--- a/packages/harness-claude-code/README.md
+++ b/packages/harness-claude-code/README.md
@@ -62,3 +62,16 @@ try {
 ```
 
 The adapter requires a `HarnessV1SandboxProvider` whose handles expose at least one port — `@ai-sdk/sandbox-vercel` is the supported choice today. The agent calls `provider.createSession()` when a session starts. Use `session.detach()` to park the bridge and sandbox, `session.stop()` to save state and stop the sandbox, or `session.destroy()` to clean up without keeping resume state.
+
+## Runtime configuration
+
+Use `env` to add environment variables to the Claude Code process. Configured
+values override variables inherited from the sandbox bridge process.
+
+```ts
+const harness = createClaudeCode({
+  env: {
+    DEPLOYMENT_ENV: 'staging',
+  },
+});
+```

--- a/packages/harness-claude-code/src/bridge/index.test.ts
+++ b/packages/harness-claude-code/src/bridge/index.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+type QueryArgs = {
+  options: Record<string, unknown>;
+};
+
+const TEST_ENV_KEYS = [
+  'CLAUDE_CODE_BRIDGE_INHERITED_TEST',
+  'CLAUDE_CODE_BRIDGE_OVERRIDE_TEST',
+  'CLAUDE_CODE_BRIDGE_CONFIGURED_TEST',
+] as const;
+
+const state = vi.hoisted(() => ({
+  queryArgs: [] as QueryArgs[],
+  start: {} as Record<string, unknown>,
+  originalArgv: [] as string[],
+  originalEnv: {} as Record<string, string | undefined>,
+}));
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: (args: QueryArgs) => {
+    state.queryArgs.push(args);
+    return (async function* () {
+      yield {
+        type: 'result',
+        subtype: 'success',
+        result: 'done',
+      };
+    })();
+  },
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: class {},
+}));
+
+vi.mock('@ai-sdk/harness/bridge', () => ({
+  runBridge: async ({
+    onStart,
+  }: {
+    onStart: (start: unknown, turn: unknown) => Promise<void>;
+  }) => {
+    await onStart(state.start, {
+      abortSignal: new AbortController().signal,
+      pendingUserMessages: [],
+      firstTurn: true,
+      emit: () => {},
+      emitWarning: () => {},
+      emitError: () => {},
+      requestToolResult: async () => ({ output: {} }),
+      requestToolApproval: async () => ({ approved: true }),
+    });
+  },
+}));
+
+describe('Claude Code bridge configuration', () => {
+  beforeEach(() => {
+    state.queryArgs = [];
+    state.start = {
+      prompt: 'Inspect the project.',
+      thinking: { type: 'disabled' },
+    };
+    state.originalArgv = [...process.argv];
+    state.originalEnv = Object.fromEntries(
+      TEST_ENV_KEYS.map(key => [key, process.env[key]]),
+    );
+    for (const key of TEST_ENV_KEYS) {
+      delete process.env[key];
+    }
+    process.argv.splice(
+      0,
+      process.argv.length,
+      'node',
+      'bridge.mjs',
+      '--workdir',
+      '/tmp/harness-claude-code-test/work',
+      '--bridge-state-dir',
+      '/tmp/harness-claude-code-test/state',
+    );
+  });
+
+  afterEach(() => {
+    process.argv.splice(0, process.argv.length, ...state.originalArgv);
+    for (const key of TEST_ENV_KEYS) {
+      const value = state.originalEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    vi.resetModules();
+  });
+
+  test('merges the configured environment', async () => {
+    process.env.CLAUDE_CODE_BRIDGE_INHERITED_TEST = 'inherited';
+    process.env.CLAUDE_CODE_BRIDGE_OVERRIDE_TEST = 'inherited';
+    state.start = {
+      ...state.start,
+      env: {
+        CLAUDE_CODE_BRIDGE_OVERRIDE_TEST: 'configured',
+        CLAUDE_CODE_BRIDGE_CONFIGURED_TEST: 'configured',
+      },
+    };
+
+    await import('./index');
+
+    const options = state.queryArgs[0]?.options;
+    expect(options?.env).toMatchObject({
+      CLAUDE_CODE_BRIDGE_INHERITED_TEST: 'inherited',
+      CLAUDE_CODE_BRIDGE_OVERRIDE_TEST: 'configured',
+      CLAUDE_CODE_BRIDGE_CONFIGURED_TEST: 'configured',
+    });
+  });
+
+  test('lets the Agent SDK inherit the environment when none is configured', async () => {
+    await import('./index');
+
+    expect(state.queryArgs[0]?.options).not.toHaveProperty('env');
+  });
+});

--- a/packages/harness-claude-code/src/bridge/index.ts
+++ b/packages/harness-claude-code/src/bridge/index.ts
@@ -12,7 +12,7 @@ import {
 import { createCompactionLatch } from './compaction-latch';
 import type { StartMessage } from '../claude-code-bridge-protocol';
 import { randomUUID } from 'node:crypto';
-import { argv, stdout } from 'node:process';
+import { argv, env as procEnv, stdout } from 'node:process';
 
 /*
  * CONSTRAINT — the third-party imports below are NEVER bundled into the
@@ -391,6 +391,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     options: {
       ...(start.model ? { model: start.model } : {}),
       ...(start.maxTurns !== undefined ? { maxTurns: start.maxTurns } : {}),
+      ...(start.env !== undefined ? { env: { ...procEnv, ...start.env } } : {}),
       ...(skillsOption ? { skills: skillsOption } : {}),
       ...(nativeTools !== undefined ? { tools: nativeTools } : {}),
       ...(inactiveNativeTools.length > 0

--- a/packages/harness-claude-code/src/claude-code-bridge-protocol.test.ts
+++ b/packages/harness-claude-code/src/claude-code-bridge-protocol.test.ts
@@ -68,12 +68,24 @@ describe('inboundMessageSchema', () => {
         tools: [{ name: 'deploy' }],
         model: 'claude-sonnet-4-5',
         maxTurns: 5,
+        env: { DEPLOYMENT_ENV: 'staging' },
         thinking: { type: 'adaptive', display: 'summarized' },
         skills: ['weather-forecast', 'weather-codes'],
         permissionMode: 'allow-edits',
         builtinToolFiltering: { mode: 'deny', toolNames: ['bash'] },
       }),
     ).not.toThrow();
+  });
+
+  it('rejects non-string environment values', () => {
+    expect(() =>
+      inboundMessageSchema.parse({
+        type: 'start',
+        prompt: 'hi',
+        thinking: { type: 'disabled' },
+        env: { RETRY_COUNT: 3 },
+      }),
+    ).toThrow();
   });
 
   it('rejects legacy string thinking values', () => {

--- a/packages/harness-claude-code/src/claude-code-bridge-protocol.ts
+++ b/packages/harness-claude-code/src/claude-code-bridge-protocol.ts
@@ -33,6 +33,7 @@ const thinkingSchema = z.discriminatedUnion('type', [
 export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
   thinking: thinkingSchema,
   maxTurns: z.number().optional(),
+  env: z.record(z.string(), z.string()).optional(),
   skills: z.array(z.string()).optional(),
   // Resume signal. When true, the bridge passes `{ continue: true }` to the
   // Claude SDK so the in-workdir thread state is rehydrated. The host sets this

--- a/packages/harness-claude-code/src/claude-code-harness.test-d.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test-d.ts
@@ -32,4 +32,12 @@ describe('claudeCode ↔ HarnessAgent harness setting', () => {
 
     assertType<typeof claudeCode>(acceptsHarness(claudeCode));
   });
+
+  test('createClaudeCode accepts environment configuration', () => {
+    expectTypeOf(
+      createClaudeCode({
+        env: { DEPLOYMENT_ENV: 'staging' },
+      }),
+    ).toExtend<HarnessAgentAdapter<any>>();
+  });
 });

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -355,6 +355,57 @@ describe('createClaudeCode adapter', () => {
     await session.doDestroy();
   });
 
+  it('sends environment configuration to the bridge', async () => {
+    const env = { DEPLOYMENT_ENV: 'staging' };
+    const harness = createClaudeCode({ env });
+    const session = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        writes: [],
+        runs: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+    });
+    const control = await session.doPromptTurn({
+      prompt: 'inspect the project',
+      emit: () => {},
+    });
+    void Promise.resolve(control.done).catch(() => {});
+
+    expect(lastStart()).toMatchObject({ env });
+
+    await session.doDestroy();
+  });
+
+  it('sends environment configuration when rerunning a continued turn', async () => {
+    const env = { DEPLOYMENT_ENV: 'staging' };
+    const harness = createClaudeCode({ env });
+    const session = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        writes: [],
+        runs: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+      continueFrom: {
+        type: 'continue-turn',
+        harnessId: 'claude-code',
+        specificationVersion: 'harness-v1',
+        data: {},
+      },
+    });
+    const control = await session.doContinueTurn({
+      emit: () => {},
+    });
+    void Promise.resolve(control.done).catch(() => {});
+
+    expect(lastStart()).toMatchObject({ env, continue: true });
+
+    await session.doDestroy();
+  });
+
   it('writes standard Claude skill files and enables their names on start', async () => {
     const writes: Array<{ path: string; content: string }> = [];
     const runs: string[] = [];

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -74,6 +74,11 @@ export type ClaudeCodeHarnessSettings = {
    */
   readonly maxTurns?: number;
   /**
+   * Environment variables for the Claude Code process. These values are
+   * merged over the sandbox bridge process environment.
+   */
+  readonly env?: Readonly<Record<string, string>>;
+  /**
    * Controls extended-thinking behavior and whether reasoning is summarized or
    * omitted. Defaults to `{ type: 'adaptive', display: 'summarized' }`.
    */
@@ -549,6 +554,7 @@ export function createClaudeCode(
             proc: undefined,
             model: settings.model,
             maxTurns: settings.maxTurns,
+            env: settings.env,
             thinking,
             isResume: true,
             continueOnFirstPrompt: false,
@@ -719,6 +725,7 @@ export function createClaudeCode(
         proc,
         model: settings.model,
         maxTurns: settings.maxTurns,
+        env: settings.env,
         thinking,
         isResume: respawnStrategy !== undefined,
         continueOnFirstPrompt: respawnStrategy !== undefined,
@@ -961,6 +968,7 @@ function createSession({
   proc,
   model,
   maxTurns,
+  env,
   thinking,
   isResume,
   continueOnFirstPrompt,
@@ -979,6 +987,7 @@ function createSession({
   proc: Experimental_SandboxProcess | undefined;
   model: string | undefined;
   maxTurns: number | undefined;
+  env: Readonly<Record<string, string>> | undefined;
   thinking: ClaudeCodeThinkingConfig;
   isResume: boolean;
   continueOnFirstPrompt: boolean;
@@ -1169,6 +1178,7 @@ function createSession({
         })),
         model,
         maxTurns,
+        ...(env !== undefined ? { env } : {}),
         thinking,
         ...(skills.length > 0
           ? { skills: skills.map(skill => skill.name) }
@@ -1221,6 +1231,7 @@ function createSession({
           })),
           model,
           maxTurns,
+          ...(env !== undefined ? { env } : {}),
           thinking,
           ...(skills.length > 0
             ? { skills: skills.map(skill => skill.name) }


### PR DESCRIPTION
## Background

The Claude Code harness did not expose a way to pass custom environment variables to the underlying Agent SDK process.

## Summary

- Add an optional `env` setting to `createClaudeCode()`.
- Preserve the bridge process environment while allowing configured values to override it.
- Forward configuration for initial, resumed, and continued turns.
- Add tests, documentation, and a runnable example.

## End-to-End Verification

Ran the new `examples/ai-functions/src/harness-agent/claude-code/runtime-configuration.ts`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
