### PR TITLE
feat(harness): add optional `mintBridgeToken(sandboxId)` to harness settings to control the bridge token value

### DIFF
--- a/.changeset/poor-ducks-destroy.md
+++ b/.changeset/poor-ducks-destroy.md
@@ -1,0 +1,10 @@
+---
+"@ai-sdk/harness-claude-code": patch
+"@ai-sdk/harness-deepagents": patch
+"@ai-sdk/harness-grok-build": patch
+"@ai-sdk/harness-opencode": patch
+"@ai-sdk/harness-codex": patch
+"@ai-sdk/harness-acp": patch
+---
+
+feat(harness): add optional `mintBridgeToken(sandboxId)` to harness settings to control the bridge token value

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -252,6 +252,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "mintBridgeToken": {},
                     "port": { "type": "number" },
                     "startupTimeoutMs": { "type": "number" }
                   }
@@ -278,6 +279,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "mintBridgeToken": {},
                     "port": { "type": "number" },
                     "startupTimeoutMs": { "type": "number" }
                   }

--- a/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
+++ b/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
@@ -98,6 +98,10 @@ Settings:
   `{ type: 'adaptive', display: 'summarized' }`.
 - `port`: bridge port override.
 - `startupTimeoutMs`: maximum time to wait for the bridge to start.
+- `mintBridgeToken`: synchronous function that receives the sandbox id and
+  returns the bridge authentication token. By default, the adapter generates a
+  random 32-byte token. Custom implementations must return a suitably secret
+  token.
 
 ## Authentication
 

--- a/content/providers/02-ai-sdk-harnesses/02-codex.mdx
+++ b/content/providers/02-ai-sdk-harnesses/02-codex.mdx
@@ -91,6 +91,10 @@ Settings:
 - `webSearch`: allow live web search.
 - `port`: bridge port override.
 - `startupTimeoutMs`: maximum time to wait for the bridge to start.
+- `mintBridgeToken`: synchronous function that receives the sandbox id and
+  returns the bridge authentication token. By default, the adapter generates a
+  random 32-byte token. Custom implementations must return a suitably secret
+  token.
 
 ## Authentication
 

--- a/content/providers/02-ai-sdk-harnesses/04-opencode.mdx
+++ b/content/providers/02-ai-sdk-harnesses/04-opencode.mdx
@@ -95,6 +95,10 @@ Settings:
   such as `low`, `medium`, or `high`.
 - `port`: bridge port override.
 - `startupTimeoutMs`: maximum time to wait for the bridge to start.
+- `mintBridgeToken`: synchronous function that receives the sandbox id and
+  returns the bridge authentication token. By default, the adapter generates a
+  random 32-byte token. Custom implementations must return a suitably secret
+  token.
 
 ## Authentication
 

--- a/content/providers/02-ai-sdk-harnesses/05-deepagents.mdx
+++ b/content/providers/02-ai-sdk-harnesses/05-deepagents.mdx
@@ -94,6 +94,10 @@ Settings:
 - `recursionLimit`: maximum LangGraph super-steps per turn. When omitted, the
   Deep Agents default applies.
 - `startupTimeoutMs`: maximum time to wait for the bridge to start.
+- `mintBridgeToken`: synchronous function that receives the sandbox id and
+  returns the bridge authentication token. By default, the adapter generates a
+  random 32-byte token. Custom implementations must return a suitably secret
+  token.
 
 ## Authentication
 

--- a/content/providers/02-ai-sdk-harnesses/06-acp.mdx
+++ b/content/providers/02-ai-sdk-harnesses/06-acp.mdx
@@ -89,6 +89,10 @@ try {
   creation and restoration.
 - `port`: exposed bridge port override.
 - `startupTimeoutMs`: bridge startup timeout. The default is 120 seconds.
+- `mintBridgeToken`: synchronous function that receives the sandbox id and
+  returns the bridge authentication token. By default, the adapter generates a
+  random 32-byte token. Custom implementations must return a suitably secret
+  token.
 - `clientApp`: optional client attribution with `name` and `version`. It
   defaults to the installed `ai-sdk/harness-acp/<version>` identity and is
   available to Gateway environment placeholders.

--- a/content/providers/02-ai-sdk-harnesses/07-grok-build.mdx
+++ b/content/providers/02-ai-sdk-harnesses/07-grok-build.mdx
@@ -95,6 +95,10 @@ Settings:
   its own default model.
 - `port`: ACP bridge port override.
 - `startupTimeoutMs`: maximum time to wait for the ACP bridge to start.
+- `mintBridgeToken`: synchronous function that receives the sandbox id and
+  returns the ACP bridge authentication token. By default, the adapter generates
+  a random 32-byte token. Custom implementations must return a suitably secret
+  token.
 
 The adapter pins the Grok Build CLI and ACP launch command. These implementation
 details cannot be overridden through `createGrokBuild()`.

--- a/examples/ai-functions/src/harness-agent/claude-code/attach.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/attach.ts
@@ -10,12 +10,14 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from '@ai-sdk/harness-claude-code';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+import { mintBridgeToken } from '../../lib/mint-bridge-token';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
 run(async () => {
+  const harness = createClaudeCode({ mintBridgeToken });
   const sandbox = createVercelSandbox({
     runtime: 'node24',
     ports: [4000],
@@ -26,7 +28,7 @@ run(async () => {
   let sessionId: string;
   let resumeState: HarnessAgentResumeSessionState;
   {
-    const agent = new HarnessAgent({ harness: claudeCode, sandbox });
+    const agent = new HarnessAgent({ harness, sandbox });
     const session = await agent.createSession();
     sessionId = session.sessionId;
     console.log('--- turn 1 ---');
@@ -41,7 +43,7 @@ run(async () => {
 
   // Turn 2: brand-new agent instance attaches to the live bridge.
   {
-    const agent = new HarnessAgent({ harness: claudeCode, sandbox });
+    const agent = new HarnessAgent({ harness, sandbox });
     const session = await agent.createSession({
       sessionId,
       resumeFrom: resumeState,

--- a/examples/ai-functions/src/harness-agent/codex-acp/attach.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/attach.ts
@@ -12,11 +12,12 @@ import {
 } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { createCodexACP } from '../../lib/codex-acp-harness';
+import { mintBridgeToken } from '../../lib/mint-bridge-token';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
 run(async () => {
-  const harness = createCodexACP();
+  const harness = createCodexACP({ mintBridgeToken });
   const sandbox = createVercelSandbox({
     runtime: 'node24',
     ports: [4000],

--- a/examples/ai-functions/src/harness-agent/codex/attach.ts
+++ b/examples/ai-functions/src/harness-agent/codex/attach.ts
@@ -10,12 +10,14 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from '@ai-sdk/harness-codex';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+import { mintBridgeToken } from '../../lib/mint-bridge-token';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
 run(async () => {
+  const harness = createCodex({ mintBridgeToken });
   const sandbox = createVercelSandbox({
     runtime: 'node24',
     ports: [4000],
@@ -26,7 +28,7 @@ run(async () => {
   let sessionId: string;
   let resumeState: HarnessAgentResumeSessionState;
   {
-    const agent = new HarnessAgent({ harness: codex, sandbox });
+    const agent = new HarnessAgent({ harness, sandbox });
     const session = await agent.createSession();
     sessionId = session.sessionId;
     console.log('--- turn 1 ---');
@@ -41,7 +43,7 @@ run(async () => {
 
   // Turn 2: brand-new agent instance attaches to the live bridge.
   {
-    const agent = new HarnessAgent({ harness: codex, sandbox });
+    const agent = new HarnessAgent({ harness, sandbox });
     const session = await agent.createSession({
       sessionId,
       resumeFrom: resumeState,

--- a/examples/ai-functions/src/harness-agent/deepagents/attach.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/attach.ts
@@ -2,8 +2,9 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from '@ai-sdk/harness-deepagents';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+import { mintBridgeToken } from '../../lib/mint-bridge-token';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
@@ -11,6 +12,7 @@ import { run } from '../../lib/run';
 // coordinates; a fresh HarnessAgent reattaches and continues mid-conversation
 // (the in-memory conversation survives because the bridge stays alive).
 run(async () => {
+  const harness = createDeepAgents({ mintBridgeToken });
   const sandbox = createVercelSandbox({
     runtime: 'node24',
     ports: [4000],
@@ -20,7 +22,7 @@ run(async () => {
   let sessionId: string;
   let resumeState: HarnessAgentResumeSessionState;
   {
-    const agent = new HarnessAgent({ harness: deepAgents, sandbox });
+    const agent = new HarnessAgent({ harness, sandbox });
     const session = await agent.createSession();
     sessionId = session.sessionId;
     console.log('--- turn 1 ---');
@@ -34,7 +36,7 @@ run(async () => {
   }
 
   {
-    const agent = new HarnessAgent({ harness: deepAgents, sandbox });
+    const agent = new HarnessAgent({ harness, sandbox });
     const session = await agent.createSession({
       sessionId,
       resumeFrom: resumeState,

--- a/examples/ai-functions/src/harness-agent/grok-build/attach.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/attach.ts
@@ -10,12 +10,14 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from '@ai-sdk/harness-grok-build';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+import { mintBridgeToken } from '../../lib/mint-bridge-token';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
 run(async () => {
+  const harness = createGrokBuild({ mintBridgeToken });
   const sandbox = createVercelSandbox({
     runtime: 'node24',
     ports: [4000],
@@ -26,7 +28,7 @@ run(async () => {
   let sessionId: string;
   let resumeState: HarnessAgentResumeSessionState;
   {
-    const agent = new HarnessAgent({ harness: grokBuild, sandbox });
+    const agent = new HarnessAgent({ harness, sandbox });
     const session = await agent.createSession();
     sessionId = session.sessionId;
     console.log('--- turn 1 ---');
@@ -41,7 +43,7 @@ run(async () => {
 
   // Turn 2: brand-new agent instance attaches to the live bridge.
   {
-    const agent = new HarnessAgent({ harness: grokBuild, sandbox });
+    const agent = new HarnessAgent({ harness, sandbox });
     const session = await agent.createSession({
       sessionId,
       resumeFrom: resumeState,

--- a/examples/ai-functions/src/harness-agent/opencode/attach.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/attach.ts
@@ -10,12 +10,14 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from '@ai-sdk/harness-opencode';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+import { mintBridgeToken } from '../../lib/mint-bridge-token';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
 run(async () => {
+  const harness = createOpenCode({ mintBridgeToken });
   const sandbox = createVercelSandbox({
     runtime: 'node24',
     ports: [4000],
@@ -26,7 +28,7 @@ run(async () => {
   let sessionId: string;
   let resumeState: HarnessAgentResumeSessionState;
   {
-    const agent = new HarnessAgent({ harness: openCode, sandbox });
+    const agent = new HarnessAgent({ harness, sandbox });
     const session = await agent.createSession();
     sessionId = session.sessionId;
     console.log('--- turn 1 ---');
@@ -41,7 +43,7 @@ run(async () => {
 
   // Turn 2: brand-new agent instance attaches to the live bridge.
   {
-    const agent = new HarnessAgent({ harness: openCode, sandbox });
+    const agent = new HarnessAgent({ harness, sandbox });
     const session = await agent.createSession({
       sessionId,
       resumeFrom: resumeState,

--- a/examples/ai-functions/src/lib/codex-acp-harness.ts
+++ b/examples/ai-functions/src/lib/codex-acp-harness.ts
@@ -62,16 +62,19 @@ const CODEX_ACP_PERMISSION_MODE_MAPPING = {
 
 export function createCodexACP({
   auth = 'auto',
+  mintBridgeToken,
   webSearch,
   source = CODEX_ACP_SOURCE,
 }: {
   auth?: ACPAuthOptions;
+  mintBridgeToken?: (sandboxId: string) => string;
   webSearch?: boolean;
   source?: ACPSource;
 } = {}) {
   return createACP({
     harnessId: 'codex-acp',
     auth,
+    mintBridgeToken,
     source,
     executable: CODEX_ACP_EXECUTABLE,
     forwardEnv: ['CODEX_API_KEY', 'OPENAI_API_KEY'],

--- a/examples/ai-functions/src/lib/mint-bridge-token.ts
+++ b/examples/ai-functions/src/lib/mint-bridge-token.ts
@@ -1,0 +1,9 @@
+import { createHmac } from 'node:crypto';
+
+export function mintBridgeToken(sandboxId: string): string {
+  const secret = process.env.HARNESS_BRIDGE_TOKEN_SECRET;
+  if (secret == null || secret.length === 0) {
+    throw new Error('HARNESS_BRIDGE_TOKEN_SECRET is required.');
+  }
+  return createHmac('sha256', secret).update(sandboxId).digest('hex');
+}

--- a/packages/harness-acp/src/acp-harness.test.ts
+++ b/packages/harness-acp/src/acp-harness.test.ts
@@ -785,6 +785,48 @@ describe('createACP', () => {
     expect(stop).not.toHaveBeenCalled();
   });
 
+  it('uses a caller-minted bridge token and reuses it when attaching', async () => {
+    const spawns: Array<{
+      command: string;
+      env: Record<string, string | undefined>;
+    }> = [];
+    const mintBridgeToken = vi.fn(
+      (sandboxId: string) => `token-for-${sandboxId}`,
+    );
+    const harness = createACP({
+      harnessId: 'codex-acp',
+      ...agentSettings,
+      mintBridgeToken,
+    });
+    const sandboxSession = fakeSandbox({
+      runs: [],
+      spawns,
+      stop: async () => {},
+    });
+    const session = await harness.doStart({
+      sessionId: 'session-1',
+      sandboxSession,
+      sessionWorkDir: '/workspace/user-project',
+    });
+
+    expect(mintBridgeToken).toHaveBeenCalledExactlyOnceWith('sandbox-1');
+    expect(spawns[0].env.BRIDGE_CHANNEL_TOKEN).toBe('token-for-sandbox-1');
+
+    const resumeFrom = await session.doDetach();
+    expect(resumeFrom.data).toMatchObject({
+      bridge: { token: 'token-for-sandbox-1' },
+    });
+
+    const attachedSession = await harness.doStart({
+      sessionId: 'session-1',
+      sandboxSession,
+      sessionWorkDir: '/workspace/user-project',
+      resumeFrom,
+    });
+    expect(mintBridgeToken).toHaveBeenCalledTimes(1);
+    await attachedSession.doDetach();
+  });
+
   it('rejects an already-aborted turn without sending a start frame', async () => {
     const harness = createACP({
       harnessId: 'codex-acp',

--- a/packages/harness-acp/src/acp-harness.ts
+++ b/packages/harness-acp/src/acp-harness.ts
@@ -32,6 +32,7 @@ export type ACPHarnessSettings<TBuiltinTools extends ToolSet = {}> = {
   readonly modelId?: ACPV1Settings['modelId'];
   readonly permissionModeMapping?: ACPV1Settings['permissionModeMapping'];
   readonly session?: ACPV1Settings['session'];
+  readonly mintBridgeToken?: ACPV1Settings['mintBridgeToken'];
 };
 
 const ACP_BUILTIN_TOOLS = {} as const satisfies ToolSet;

--- a/packages/harness-acp/src/v1/acp-v1-harness.ts
+++ b/packages/harness-acp/src/v1/acp-v1-harness.ts
@@ -465,7 +465,10 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
         override: portOverride,
         harnessId: settings.harnessId,
       });
-      const token = randomBytes(32).toString('hex');
+      const token =
+        settings.mintBridgeToken == null
+          ? randomBytes(32).toString('hex')
+          : settings.mintBridgeToken(sandboxSession.id);
       await sandbox.run({
         command: `mkdir -p ${shellQuote(workDir)} ${shellQuote(bridgeStateDir)}`,
         abortSignal: startOptions.abortSignal,

--- a/packages/harness-acp/src/v1/acp-v1-settings.ts
+++ b/packages/harness-acp/src/v1/acp-v1-settings.ts
@@ -94,4 +94,9 @@ export type ACPV1Settings = {
   readonly session?: {
     readonly meta?: Readonly<Record<string, ACPSerializableValue>>;
   };
+  /**
+   * Creates the authentication token used by the sandbox bridge. Defaults to
+   * a random 32-byte hexadecimal token.
+   */
+  readonly mintBridgeToken?: (sandboxId: string) => string;
 };

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -26,6 +26,9 @@ vi.mock('@ai-sdk/harness/utils', async importOriginal => {
     isClosed(): boolean {
       return false;
     }
+    suspend(): Promise<number> {
+      return Promise.resolve(0);
+    }
     close(): void {}
   }
   return { ...actual, SandboxChannel: FakeSandboxChannel };
@@ -285,7 +288,46 @@ describe('createClaudeCode adapter', () => {
     expect(spawnEnvs.at(0)?.CLAUDE_AGENT_SDK_CLIENT_APP).toBe(
       'ai-sdk/harness-claude-code/0.0.0-test',
     );
+    expect(spawnEnvs.at(0)?.BRIDGE_CHANNEL_TOKEN).toMatch(/^[a-f0-9]{64}$/);
     await session.doDestroy();
+  });
+
+  it('uses a caller-minted bridge token and reuses it when attaching', async () => {
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const mintBridgeToken = vi.fn(
+      (sandboxId: string) => `token-for-${sandboxId}`,
+    );
+    const harness = createClaudeCode({ mintBridgeToken });
+    const sandboxSession = fakeNetworkSandboxSessionForStartupSuccess({
+      bridgePortUrl: 'ws://127.0.0.1:1',
+      spawnEnvs,
+      writes: [],
+      runs: [],
+    });
+    const session = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession,
+      sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+    });
+
+    expect(mintBridgeToken).toHaveBeenCalledExactlyOnceWith('test-sandbox');
+    expect(spawnEnvs.at(0)?.BRIDGE_CHANNEL_TOKEN).toBe(
+      'token-for-test-sandbox',
+    );
+
+    const resumeFrom = await session.doDetach();
+    expect(resumeFrom.data).toMatchObject({
+      bridge: { token: 'token-for-test-sandbox' },
+    });
+
+    const attachedSession = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession,
+      sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+      resumeFrom,
+    });
+    expect(mintBridgeToken).toHaveBeenCalledTimes(1);
+    await attachedSession.doDetach();
   });
 
   it('does not set the client app for direct Anthropic auth', async () => {

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -87,6 +87,11 @@ export type ClaudeCodeHarnessSettings = {
   readonly port?: number;
   /** Maximum milliseconds to wait for the bridge to advertise its port. Defaults to 120000. */
   readonly startupTimeoutMs?: number;
+  /**
+   * Creates the authentication token used by the sandbox bridge. Defaults to
+   * a random 32-byte hexadecimal token.
+   */
+  readonly mintBridgeToken?: (sandboxId: string) => string;
 };
 
 /*
@@ -598,7 +603,10 @@ export function createClaudeCode(
             })
           : undefined;
       const port = resolveBridgePort(sandboxSession, settings.port);
-      const token = randomBytes(32).toString('hex');
+      const token =
+        settings.mintBridgeToken == null
+          ? randomBytes(32).toString('hex')
+          : settings.mintBridgeToken(sandboxId);
       const authEnv = resolveClaudeCodeEnv(settings.auth);
       const env = {
         ...authEnv,

--- a/packages/harness-codex/src/codex-harness.test.ts
+++ b/packages/harness-codex/src/codex-harness.test.ts
@@ -20,6 +20,9 @@ vi.mock('@ai-sdk/harness/utils', async importOriginal => {
     isClosed(): boolean {
       return false;
     }
+    suspend(): Promise<number> {
+      return Promise.resolve(0);
+    }
     close(): void {}
   }
   return { ...actual, SandboxChannel: FakeSandboxChannel };
@@ -195,8 +198,50 @@ describe('createCodex adapter', () => {
     expect(spawnEnvs.at(0)?.AI_SDK_HARNESS_CLIENT_APP).toBe(
       'ai-sdk/harness-codex/0.0.0-test',
     );
+    expect(spawnEnvs.at(0)?.BRIDGE_CHANNEL_TOKEN).toMatch(/^[a-f0-9]{64}$/);
     expect(session.modelId).toBe('gpt-5.5');
     await session.doDestroy();
+  });
+
+  it('uses a caller-minted bridge token and reuses it when attaching', async () => {
+    const runs: string[] = [];
+    const spawns: string[] = [];
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const mintBridgeToken = vi.fn(
+      (sandboxId: string) => `token-for-${sandboxId}`,
+    );
+    const harness = createCodex({ mintBridgeToken });
+    const sandboxSession = fakeNetworkSandboxSessionForStartupSuccess({
+      bridgePortUrl: 'ws://127.0.0.1:1',
+      runs,
+      spawns,
+      spawnEnvs,
+      writes: [],
+    });
+    const session = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession,
+      sessionWorkDir: '/vercel/sandbox/codex-s1',
+    });
+
+    expect(mintBridgeToken).toHaveBeenCalledExactlyOnceWith('test-sandbox');
+    expect(spawnEnvs.at(0)?.BRIDGE_CHANNEL_TOKEN).toBe(
+      'token-for-test-sandbox',
+    );
+
+    const resumeFrom = await session.doDetach();
+    expect(resumeFrom.data).toMatchObject({
+      bridge: { token: 'token-for-test-sandbox' },
+    });
+
+    const attachedSession = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession,
+      sessionWorkDir: '/vercel/sandbox/codex-s1',
+      resumeFrom,
+    });
+    expect(mintBridgeToken).toHaveBeenCalledTimes(1);
+    await attachedSession.doDetach();
   });
 
   describe('getBootstrap', () => {

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -98,6 +98,11 @@ export type CodexHarnessSettings = {
   readonly port?: number;
   /** Maximum milliseconds to wait for the bridge to advertise its port. Defaults to 120000. */
   readonly startupTimeoutMs?: number;
+  /**
+   * Creates the authentication token used by the sandbox bridge. Defaults to
+   * a random 32-byte hexadecimal token.
+   */
+  readonly mintBridgeToken?: (sandboxId: string) => string;
 };
 
 /*
@@ -337,7 +342,10 @@ export function createCodex(
       }
 
       const port = resolveBridgePort(sandboxSession, settings.port);
-      const token = randomBytes(32).toString('hex');
+      const token =
+        settings.mintBridgeToken == null
+          ? randomBytes(32).toString('hex')
+          : settings.mintBridgeToken(sandboxId);
       const codexSkillSetup =
         startOpts.skills && startOpts.skills.length > 0
           ? await writeCodexSkills({

--- a/packages/harness-deepagents/src/deepagents-harness.test.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.test.ts
@@ -163,6 +163,7 @@ describe('createDeepAgents', () => {
     expect(spawnEnvs.at(0)?.AI_SDK_HARNESS_CLIENT_APP).toBe(
       'ai-sdk/harness-deepagents/0.0.0-test',
     );
+    expect(spawnEnvs.at(0)?.BRIDGE_CHANNEL_TOKEN).toMatch(/^[a-f0-9]{64}$/);
     expect(spawns.at(0)).toContain(
       "node '/vercel/sandbox/.harness-bootstrap/deepagents/bridge.mjs'",
     );
@@ -171,6 +172,39 @@ describe('createDeepAgents', () => {
     );
 
     await session.doDestroy();
+  });
+
+  it('uses a caller-minted bridge token and reuses it when attaching', async () => {
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const mintBridgeToken = vi.fn(
+      (sandboxId: string) => `token-for-${sandboxId}`,
+    );
+    const harness = createDeepAgents({ mintBridgeToken });
+    const sandboxSession = fakeSandboxSession({ spawnEnvs });
+    const session = await harness.doStart({
+      sessionId: 'test-session',
+      sessionWorkDir: '/vercel/sandbox/deepagents-test-session',
+      sandboxSession,
+    });
+
+    expect(mintBridgeToken).toHaveBeenCalledExactlyOnceWith('test-sandbox');
+    expect(spawnEnvs.at(0)?.BRIDGE_CHANNEL_TOKEN).toBe(
+      'token-for-test-sandbox',
+    );
+
+    const resumeFrom = await session.doDetach();
+    expect(resumeFrom.data).toMatchObject({
+      bridge: { token: 'token-for-test-sandbox' },
+    });
+
+    const attachedSession = await harness.doStart({
+      sessionId: 'test-session',
+      sessionWorkDir: '/vercel/sandbox/deepagents-test-session',
+      sandboxSession,
+      resumeFrom,
+    });
+    expect(mintBridgeToken).toHaveBeenCalledTimes(1);
+    await attachedSession.doDetach();
   });
 
   it('resolves the turn when the channel closes with reason "suspended"', async () => {

--- a/packages/harness-deepagents/src/deepagents-harness.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.ts
@@ -97,6 +97,11 @@ export type DeepAgentsHarnessSettings = {
   /** Maximum milliseconds to wait for the bridge to advertise its port. Defaults to 120000. */
   readonly startupTimeoutMs?: number;
   /**
+   * Creates the authentication token used by the sandbox bridge. Defaults to
+   * a random 32-byte hexadecimal token.
+   */
+  readonly mintBridgeToken?: (sandboxId: string) => string;
+  /**
    * Maximum LangGraph super-steps per turn before it errors.
    * When omitted, the Deep Agents default applies.
    */
@@ -285,7 +290,10 @@ export function createDeepAgents(
       }
 
       const port = resolveBridgePort(sandboxSession, settings.port);
-      const token = randomBytes(32).toString('hex');
+      const token =
+        settings.mintBridgeToken == null
+          ? randomBytes(32).toString('hex')
+          : settings.mintBridgeToken(sandboxId);
 
       // Always discover repo-provided skills under <workDir>/.agents/skills (e.g. a cloned repo); a missing dir is tolerated by deepagents.
       // Absolute paths: LocalShellBackend (non-virtual) treats a leading-slash path as a real fs path.

--- a/packages/harness-grok-build/src/grok-build-harness.test-d.ts
+++ b/packages/harness-grok-build/src/grok-build-harness.test-d.ts
@@ -2,7 +2,9 @@ import { expectTypeOf, test } from 'vitest';
 import { createGrokBuild } from './grok-build-harness';
 
 test('preserves Grok Build built-in tool types', () => {
-  const harness = createGrokBuild();
+  const harness = createGrokBuild({
+    mintBridgeToken: sandboxId => sandboxId,
+  });
 
   expectTypeOf<keyof typeof harness.builtinTools>().toEqualTypeOf<
     | 'bash'

--- a/packages/harness-grok-build/src/grok-build-harness.test.ts
+++ b/packages/harness-grok-build/src/grok-build-harness.test.ts
@@ -130,11 +130,13 @@ describe('createGrokBuild', () => {
   });
 
   it('forwards user-configurable settings', () => {
+    const mintBridgeToken = (sandboxId: string) => `token-for-${sandboxId}`;
     createGrokBuild({
       auth: 'direct',
       model: 'grok-code-fast-1',
       port: 4319,
       startupTimeoutMs: 45_000,
+      mintBridgeToken,
     });
 
     const settings = mocks.createACP.mock.calls[0]?.[0] as ACPHarnessSettings;
@@ -144,11 +146,13 @@ describe('createGrokBuild', () => {
       modelId: settings.modelId,
       port: settings.port,
       startupTimeoutMs: settings.startupTimeoutMs,
+      mintBridgeToken: settings.mintBridgeToken,
     }).toEqual({
       auth: 'direct',
       modelId: 'grok-code-fast-1',
       port: 4319,
       startupTimeoutMs: 45_000,
+      mintBridgeToken,
     });
   });
 

--- a/packages/harness-grok-build/src/grok-build-harness.ts
+++ b/packages/harness-grok-build/src/grok-build-harness.ts
@@ -40,6 +40,11 @@ export type GrokBuildHarnessSettings = {
    * Maximum milliseconds to wait for the ACP bridge to start.
    */
   readonly startupTimeoutMs?: number;
+  /**
+   * Creates the authentication token used by the sandbox bridge. Defaults to
+   * a random 32-byte hexadecimal token.
+   */
+  readonly mintBridgeToken?: (sandboxId: string) => string;
 };
 
 /*
@@ -278,6 +283,7 @@ export function createGrokBuild(
     modelId: settings.model,
     port: settings.port,
     startupTimeoutMs: settings.startupTimeoutMs,
+    mintBridgeToken: settings.mintBridgeToken,
     version: 'v1',
     harnessId: 'grok-build',
     builtinTools: GROK_BUILD_BUILTIN_TOOLS,

--- a/packages/harness-opencode/src/opencode-harness.test.ts
+++ b/packages/harness-opencode/src/opencode-harness.test.ts
@@ -142,6 +142,74 @@ describe('createOpenCode adapter', () => {
     ).rejects.toBeInstanceOf(HarnessCapabilityUnsupportedError);
   });
 
+  it('uses a caller-minted bridge token and reuses it when attaching', async () => {
+    harnessUtilsMocks.waitForBridgeReady.mockResolvedValueOnce({ port: 4000 });
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const mintBridgeToken = vi.fn(
+      (sandboxId: string) => `token-for-${sandboxId}`,
+    );
+    const emptyStream = () =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      });
+    const sandbox = {
+      async run({ command }: { command: string }) {
+        return command === 'printf "%s" "$HOME"'
+          ? { exitCode: 0, stdout: '/home/vercel-sandbox', stderr: '' }
+          : { exitCode: 0, stdout: '', stderr: '' };
+      },
+      async readTextFile() {
+        return null;
+      },
+      async spawn({ env }: { env: Record<string, string | undefined> }) {
+        spawnEnvs.push(env);
+        return {
+          stdout: emptyStream(),
+          stderr: emptyStream(),
+          async wait() {},
+          async kill() {},
+        };
+      },
+    };
+    const sandboxSession = {
+      id: 'test-sandbox',
+      defaultWorkingDirectory: '/workspace',
+      restricted: () => sandbox,
+      ports: [4000] as ReadonlyArray<number>,
+      async getPortUrl() {
+        return 'ws://sandbox.example';
+      },
+      async stop() {},
+    } as unknown as HarnessV1NetworkSandboxSession;
+    const harness = createOpenCode({ mintBridgeToken });
+    const session = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession,
+      sessionWorkDir: '/workspace/project',
+    });
+
+    expect(mintBridgeToken).toHaveBeenCalledExactlyOnceWith('test-sandbox');
+    expect(spawnEnvs.at(0)?.BRIDGE_CHANNEL_TOKEN).toBe(
+      'token-for-test-sandbox',
+    );
+
+    const resumeFrom = await session.doDetach();
+    expect(resumeFrom.data).toMatchObject({
+      bridge: { token: 'token-for-test-sandbox' },
+    });
+
+    const attachedSession = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession,
+      sessionWorkDir: '/workspace/project',
+      resumeFrom,
+    });
+    expect(mintBridgeToken).toHaveBeenCalledTimes(1);
+    await attachedSession.doDetach();
+  });
+
   it('writes skills under sandbox HOME and starts OpenCode with that HOME', async () => {
     const runCommands: string[] = [];
     const writes: Array<{ path: string; content: string }> = [];
@@ -240,6 +308,7 @@ describe('createOpenCode adapter', () => {
     expect(spawns.at(-1)?.env.AI_SDK_HARNESS_CLIENT_APP).toBe(
       'ai-sdk/harness-opencode/0.0.0-test',
     );
+    expect(spawns.at(-1)?.env.BRIDGE_CHANNEL_TOKEN).toMatch(/^[a-f0-9]{64}$/);
     expect(spawns.at(-1)?.command).toContain(
       "node '/workspace/.harness-bootstrap/opencode/bridge.mjs'",
     );

--- a/packages/harness-opencode/src/opencode-harness.ts
+++ b/packages/harness-opencode/src/opencode-harness.ts
@@ -77,6 +77,11 @@ export type OpenCodeHarnessSettings = {
   readonly reasoningVariant?: string;
   readonly port?: number;
   readonly startupTimeoutMs?: number;
+  /**
+   * Creates the authentication token used by the sandbox bridge. Defaults to
+   * a random 32-byte hexadecimal token.
+   */
+  readonly mintBridgeToken?: (sandboxId: string) => string;
 };
 
 const optionalStringRecord = z.record(z.string(), z.unknown()).optional();
@@ -339,7 +344,10 @@ export function createOpenCode(
       }
 
       const port = resolveBridgePort(sandboxSession, settings.port);
-      const token = randomBytes(32).toString('hex');
+      const token =
+        settings.mintBridgeToken == null
+          ? randomBytes(32).toString('hex')
+          : settings.mintBridgeToken(sandboxId);
       const sandboxHomeDir = await resolveSandboxHomeDir({
         sandbox: session,
         abortSignal: startOpts.abortSignal,


### PR DESCRIPTION
## Background

Bridge-backed harnesses currently generate a random authentication token that must be persisted with resume state. Callers that can deterministically derive the token from a sandbox id need a way to reconstruct resume state without storing that secret.

## Summary

- Add an optional synchronous `mintBridgeToken(sandboxId)` setting to every bridge-backed harness while preserving random token generation by default.
- Enforce it for all bridge-based harnesses via `konsistent`
- Forward the setting through ACP and Grok Build, and reuse persisted tokens when attaching to an existing bridge.
- Add tests, documentation, and HMAC-based attach examples for the new setting.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
