### PR TITLE
docs: update outdated Vercel product names

### DIFF
--- a/content/cookbook/00-guides/04-natural-language-postgres.mdx
+++ b/content/cookbook/00-guides/04-natural-language-postgres.mdx
@@ -24,7 +24,7 @@ This project uses the following stack:
 - [AI SDK](/docs)
 - [OpenAI](https://openai.com)
 - [Zod](https://zod.dev)
-- [Postgres](https://www.postgresql.org/) with [ Vercel Postgres ](https://vercel.com/postgres)
+- [Postgres](https://www.postgresql.org/) with [Neon through the Vercel Marketplace](https://vercel.com/marketplace/neon)
 - [shadcn-ui](https://ui.shadcn.com) and [TailwindCSS](https://tailwindcss.com) for styling
 - [Recharts](https://recharts.org) for data visualization
 

--- a/content/docs/06-advanced/04-caching.mdx
+++ b/content/docs/06-advanced/04-caching.mdx
@@ -120,9 +120,7 @@ You can see a full example of caching with Redis in a Next.js application in our
 
 Alternatively, each AI SDK Core function has special lifecycle callbacks you can use. The one of interest is likely `onEnd`, which is called when the generation is complete. This is where you can cache the full response.
 
-Here's an example of how you can implement caching using Vercel KV and Next.js to cache the OpenAI response for 1 hour:
-
-This example uses [Upstash Redis](https://upstash.com/docs/redis/overall/getstarted) and Next.js to cache the response for 1 hour.
+Here's an example of how you can use [Upstash Redis](https://upstash.com/redis) and Next.js to cache the OpenAI response for 1 hour:
 
 ```tsx filename="app/api/chat/route.ts"
 import {

--- a/content/docs/06-advanced/06-rate-limiting.mdx
+++ b/content/docs/06-advanced/06-rate-limiting.mdx
@@ -11,13 +11,11 @@ specified timeframe. This simple technique acts as a gatekeeper,
 preventing excessive usage that can degrade service performance and incur
 unnecessary costs.
 
-## Rate Limiting with Vercel KV and Upstash Ratelimit
+## Rate Limiting with Upstash Redis and Upstash Ratelimit
 
-In this example, you will protect an API endpoint using [Vercel KV](https://vercel.com/storage/kv)
-and [Upstash Ratelimit](https://github.com/upstash/ratelimit).
+In this example, you will protect an API endpoint using [Upstash Redis](https://upstash.com/redis) and [Upstash Ratelimit](https://github.com/upstash/ratelimit).
 
 ```tsx filename='app/api/generate/route.ts'
-import kv from '@vercel/kv';
 import {
   createUIMessageStreamResponse,
   streamText,
@@ -25,6 +23,7 @@ import {
 } from 'ai';
 __PROVIDER_IMPORT__;
 import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
 import { NextRequest } from 'next/server';
 
 // Allow streaming responses up to 30 seconds
@@ -32,7 +31,7 @@ export const maxDuration = 30;
 
 // Create Rate limit
 const ratelimit = new Ratelimit({
-  redis: kv,
+  redis: Redis.fromEnv(),
   limiter: Ratelimit.fixedWindow(5, '30s'),
 });
 
@@ -61,6 +60,6 @@ export async function POST(req: NextRequest) {
 
 ## Simplify API Protection
 
-With Vercel KV and Upstash Ratelimit, it is possible to protect your APIs
+With Upstash Redis and Upstash Ratelimit, it is possible to protect your APIs
 from such attacks with ease. To learn more about how Ratelimit works and
 how it can be configured to your needs, see [Ratelimit Documentation](https://upstash.com/docs/oss/sdks/ts/ratelimit/overview).

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -138,8 +138,7 @@ You can use the following optional settings to customize the provider instance:
 <a id="google-vertex-edge-runtime"></a>
 #### Edge Runtime
 
-Edge runtimes (like Vercel Edge Functions and Cloudflare Workers) are lightweight JavaScript environments that run closer to users at the network edge.
-They only provide a subset of the standard Node.js APIs.
+Edge runtimes (like Cloudflare Workers) are lightweight JavaScript environments that run closer to users at the network edge. They only provide a subset of the standard Node.js APIs.
 For example, direct file system access is not available, and many Node.js-specific libraries
 (including the standard Google Auth library) are not compatible.
 
@@ -1627,8 +1626,7 @@ You can use the following optional settings to customize the Google Vertex Anthr
 <a id="google-vertex-anthropic-edge-runtime"></a>
 #### Edge Runtime
 
-Edge runtimes (like Vercel Edge Functions and Cloudflare Workers) are lightweight JavaScript environments that run closer to users at the network edge.
-They only provide a subset of the standard Node.js APIs.
+Edge runtimes (like Cloudflare Workers) are lightweight JavaScript environments that run closer to users at the network edge. They only provide a subset of the standard Node.js APIs.
 For example, direct file system access is not available, and many Node.js-specific libraries
 (including the standard Google Auth library) are not compatible.
 

--- a/content/providers/06-adapters/02-llamaindex.mdx
+++ b/content/providers/06-adapters/02-llamaindex.mdx
@@ -5,7 +5,7 @@ description: Learn how to use LlamaIndex with the AI SDK.
 
 # LlamaIndex
 
-[LlamaIndex](https://ts.llamaindex.ai/) is a framework for building LLM-powered applications. LlamaIndex helps you ingest, structure, and access private or domain-specific data. LlamaIndex.TS offers the core features of LlamaIndex for Python for popular runtimes like Node.js (official support), Vercel Edge Functions (experimental), and Deno (experimental).
+[LlamaIndex](https://ts.llamaindex.ai/) is a framework for building LLM-powered applications. LlamaIndex helps you ingest, structure, and access private or domain-specific data. LlamaIndex.TS supports modern JavaScript runtimes such as Node.js, Deno, and Bun.
 
 ## Example: Completion
 


### PR DESCRIPTION
## Background

Some docs pages made references to outdated Vercel product names (Vercel Postgres, Edge Functions)

## Summary

Changed to the updated product names for those instances, or removed when no longer necessary to mention.

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)
