### PR TITLE
docs: useChat request cancellation

### DIFF
--- a/content/docs/06-advanced/02-stopping-streams.mdx
+++ b/content/docs/06-advanced/02-stopping-streams.mdx
@@ -44,7 +44,7 @@ export async function POST(req: Request) {
 ## AI SDK UI
 
 The hooks, e.g. `useChat` or `useCompletion`, provide a `stop` helper function that can be used to cancel a stream.
-This will cancel the stream from the client side to the server.
+This aborts the HTTP request from the client. To also stop the model request on the server, your server runtime must propagate the client disconnect to the request's `AbortSignal`, and your route must forward that signal to the AI SDK Core call as shown above.
 
 <Note type="warning">
   Stream abort functionality is not compatible with stream resumption. If you're
@@ -77,6 +77,27 @@ export default function Chat() {
   );
 }
 ```
+
+### Vercel
+
+On Vercel, [request cancellation](https://vercel.com/docs/functions/functions-api-reference#cancel-requests) is only supported in the Node.js runtime and must be enabled for each function that needs it. Add `supportsCancellation` to the function's configuration in `vercel.json`:
+
+```json filename="vercel.json"
+{
+  "functions": {
+    "app/api/chat/route.ts": {
+      "supportsCancellation": true
+    }
+  }
+}
+```
+
+With cancellation enabled, calling `stop()` aborts the client request, Vercel aborts `req.signal`, and forwarding `req.signal` as `abortSignal` cancels the model request.
+
+<Note type="warning">
+  Without `supportsCancellation`, `stop()` still stops the client-side stream
+  but the server-side generation may continue.
+</Note>
 
 ## Handling stream abort cleanup
 

--- a/content/docs/06-advanced/10-vercel-deployment-guide.mdx
+++ b/content/docs/06-advanced/10-vercel-deployment-guide.mdx
@@ -118,15 +118,15 @@ For example, enable cancellation for your chat route:
 Then forward the request signal to the AI SDK:
 
 ```ts filename="app/api/chat/route.ts" highlight="10"
-import { streamText } from 'ai';
+import { convertToModelMessages, streamText, type UIMessage } from 'ai';
 __PROVIDER_IMPORT__;
 
 export async function POST(req: Request) {
-  const { messages } = await req.json();
+  const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
     model: __MODEL__,
-    messages,
+    messages: convertToModelMessages(messages),
     abortSignal: req.signal,
   });
 

--- a/content/docs/06-advanced/10-vercel-deployment-guide.mdx
+++ b/content/docs/06-advanced/10-vercel-deployment-guide.mdx
@@ -95,6 +95,47 @@ export const maxDuration = 30;
 
 You can increase the max duration to 60 seconds on the Hobby Tier. For other tiers, [see the documentation](https://vercel.com/docs/functions/runtimes#max-duration) for limits.
 
+### Request Cancellation
+
+AI SDK UI helpers such as `useChat` and `useCompletion` abort the client request when you call `stop()`. To propagate that cancellation to a Vercel Function and its model request, you must:
+
+1. Use the Node.js runtime, which is the default for Next.js route handlers.
+2. Enable [`supportsCancellation`](https://vercel.com/docs/functions/functions-api-reference#cancel-requests) for the route in `vercel.json`.
+3. Forward the route's `req.signal` to `streamText` or `generateText` as `abortSignal`.
+
+For example, enable cancellation for your chat route:
+
+```json filename="vercel.json"
+{
+  "functions": {
+    "app/api/chat/route.ts": {
+      "supportsCancellation": true
+    }
+  }
+}
+```
+
+Then forward the request signal to the AI SDK:
+
+```ts filename="app/api/chat/route.ts" highlight="10"
+import { streamText } from 'ai';
+__PROVIDER_IMPORT__;
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = streamText({
+    model: __MODEL__,
+    messages,
+    abortSignal: req.signal,
+  });
+
+  return result.toUIMessageStreamResponse();
+}
+```
+
+Without `supportsCancellation`, calling `stop()` closes the client-side stream but does not cancel the Vercel Function or model request. See [Stopping Streams](/docs/advanced/stopping-streams) for the complete client and server setup.
+
 ## Security Considerations
 
 Given the high cost of calling an LLM, it's important to have measures in place that can protect your application from abuse.


### PR DESCRIPTION
## Background

The `stop` function returned by `useChat()` doesn't cancel the server-side stream unless you pass the abort signal through to `streamText`. On Vercel, you also have to enable request cancellation. This wasn't well-documented.

## Summary

Documented it

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

## Related Issues

https://github.com/vercel/ai/issues/6422 (documented behavior)

Closes https://github.com/vercel/ai/pull/14588 (supersede)
