### PR TITLE
fix(mcp): add redirect:'error' to OAuth fetch calls as hardening

### DIFF
--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -329,7 +329,7 @@ async function fetchWithCorsRetry(
   fetchFn: FetchFunction = fetch,
 ): Promise<Response | undefined> {
   try {
-    return await fetchFn(url, { headers });
+    return await fetchFn(url, { headers, redirect: 'error' });
   } catch (error) {
     if (error instanceof TypeError) {
       if (headers) {
@@ -890,6 +890,7 @@ export async function exchangeAuthorization(
     method: 'POST',
     headers,
     body: params,
+    redirect: 'error',
   });
 
   if (!response.ok) {
@@ -982,6 +983,7 @@ export async function refreshAuthorization(
     method: 'POST',
     headers,
     body: params,
+    redirect: 'error',
   });
   if (!response.ok) {
     throw await parseErrorResponse(response);
@@ -1028,6 +1030,7 @@ export async function registerClient(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(clientMetadata),
+    redirect: 'error',
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary

Adds `redirect: 'error'` to all `fetch` calls in the MCP OAuth client layer (`packages/mcp/src/tool/oauth.ts`).

The OAuth layer currently relies on the Fetch API default redirect mode (`follow`). OAuth token and client registration requests carry sensitive credentials in the request body and must never be transparently forwarded to a different origin via a redirect. Per RFC 9700 / OAuth 2.1 BCP (§5.4, §5.5), clients should treat redirects on token endpoint requests as errors.

The transport layer in the same codebase already fails closed on redirects: `mcp-http-transport.ts` (L76) and `mcp-sse-transport.ts` (L45) both pass `redirect: 'error'` by default and are covered by tests. This change brings the OAuth layer to the same hardening standard.

## Changes

- `fetchWithCorsRetry` (metadata discovery): pass `redirect: 'error'`
- `exchangeAuthorization` (token exchange POST): pass `redirect: 'error'`
- `refreshAuthorization` (token refresh POST): pass `redirect: 'error'`
- `registerClient` (dynamic client registration POST): pass `redirect: 'error'`

## Testing

No change in the non-redirect path (all call sites otherwise keep their existing options). Redirected responses now raise a fetch error instead of being silently followed. Existing test suites should pass unchanged; consider adding redirect-handling tests for the OAuth layer mirroring the transport-layer coverage.
