### PR TITLE
fix(ai): surface mid-stream provider SSE errors as Error instances with statusCode

### DIFF
--- a/.changeset/midstream-error-statuscode.md
+++ b/.changeset/midstream-error-statuscode.md
@@ -1,0 +1,13 @@
+---
+'ai': patch
+---
+
+fix(ai): surface mid-stream provider SSE errors as `Error` instances with `statusCode`
+
+Mid-stream provider SSE `error` events (e.g. Anthropic `error` events emitted
+after the first chunk) were forwarded to consumers as raw plain objects, so they
+failed `instanceof Error` checks, carried no `statusCode`, and broke error
+handling in streaming consumers. `streamText` now normalizes such error values
+into `Error` instances, preserving `.message` and attaching `statusCode`, `type`,
+and `isRetryable` when the provider includes them. Existing `Error` instances and
+string error values are passed through unchanged.

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -2571,6 +2571,51 @@ describe('streamText', () => {
       );
     });
 
+    it('should surface mid-stream provider error events as Errors with statusCode', async () => {
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            {
+              type: 'response-metadata',
+              id: 'id-0',
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'Hello' },
+            {
+              type: 'error',
+              error: {
+                type: 'api_error',
+                statusCode: 500,
+                message:
+                  'Unable to complete this request right now. Please try again.',
+              },
+            },
+            {
+              type: 'finish',
+              finishReason: { unified: 'error', raw: undefined },
+              usage: testUsage,
+            },
+          ]),
+        }),
+        prompt: 'test-input',
+        onError: () => {},
+      });
+
+      const streamParts = await convertAsyncIterableToArray(result.stream);
+      const errorPart = streamParts.find(part => part.type === 'error');
+
+      expect(errorPart).toBeDefined();
+      expect(errorPart!.error).toBeInstanceOf(Error);
+      expect((errorPart!.error as Error).message).toBe(
+        'Unable to complete this request right now. Please try again.',
+      );
+      expect(
+        (errorPart!.error as Error & { statusCode?: number }).statusCode,
+      ).toBe(500);
+    });
+
     it('should invoke onError callback when error is thrown in 2nd step', async () => {
       const onError = vi.fn();
       let responseCount = 0;

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -215,6 +215,49 @@ function isOutputChunk(chunk: ExecuteToolsStreamPart): boolean {
   }
 }
 
+/**
+ * Normalizes an error value received from a model stream.
+ *
+ * Providers surface mid-stream SSE `error` events as raw plain objects
+ * (e.g. `{ type: 'api_error', message: '...', statusCode: 500 }`) rather
+ * than `Error` instances. Normalize such values into `Error` instances so
+ * that consumers receive objects that behave like errors (instanceof,
+ * `.message`, `.statusCode`, `.isRetryable`).
+ *
+ * Values that are already `Error` instances or non-object values are passed
+ * through unchanged so that existing error strings are preserved.
+ */
+function toStreamError(error: unknown): unknown {
+  if (error instanceof Error || error == null || typeof error !== 'object') {
+    return error;
+  }
+
+  const { message, statusCode, type, isRetryable } = error as {
+    message?: unknown;
+    statusCode?: unknown;
+    type?: unknown;
+    isRetryable?: unknown;
+  };
+
+  const normalized = new Error(
+    typeof message === 'string' ? message : getErrorMessage(error),
+  );
+
+  if (typeof type === 'string') {
+    (normalized as Error & { type?: string }).type = type;
+  }
+
+  if (typeof statusCode === 'number') {
+    (normalized as Error & { statusCode?: number }).statusCode = statusCode;
+  }
+
+  if (typeof isRetryable === 'boolean') {
+    (normalized as Error & { isRetryable?: boolean }).isRetryable = isRetryable;
+  }
+
+  return normalized;
+}
+
 export type StreamTextInclude = {
   /**
    * Whether to retain the request body in step results.
@@ -2305,7 +2348,10 @@ class DefaultStreamTextResult<
 
                     case 'error': {
                       hasReceivedTerminalChunk = true;
-                      controller.enqueue(chunk);
+                      controller.enqueue({
+                        type: 'error',
+                        error: toStreamError(chunk.error),
+                      });
                       stepFinishReason = 'error';
                       break;
                     }


### PR DESCRIPTION
## Problem

Mid-stream provider SSE `error` events (e.g. Anthropic `error` events emitted after the first chunk) are surfaced to `streamText` consumers as **raw plain objects** instead of `Error` instances:

- The raw object fails `error instanceof Error` checks.
- It carries no `.message` normalization, no `.statusCode`, and no `.isRetryable` flag.
- `maxRetries` only covers the initial call, so mid-stream provider errors are not retried and arrive at the consumer completely untyped.

In `packages/ai/src/generate-text/stream-text.ts`, the `case 'error'` handler enqueued the provider error chunk verbatim, so consumers received `{ type: 'error', error: { type: 'api_error', statusCode: 500, message: '...' } }` — a plain object that breaks `instanceof Error` handling in streaming consumers.

## Fix

Normalize the error value before enqueueing it to the consumer:

- **`packages/ai/src/generate-text/stream-text.ts`** — add a `toStreamError` helper that wraps plain-object error values into an `Error` instance, preserving `.message` and attaching `statusCode`, `type`, and `isRetryable` when the provider includes them. The `case 'error'` handler now enqueues the normalized error.
- Values that are already `Error` instances, and string/primitive error values, pass through unchanged — so existing error-string streams and `onError` behavior are preserved.

After the fix, consumers of `result.stream` (and the `onError` callback) receive a real `Error` with `.statusCode` set, so they can branch on status and `instanceof Error`.

## Verification (TDD)

Added a regression test to `packages/ai/src/generate-text/stream-text.test.ts` that feeds a mock provider emitting an SSE error event mid-stream (`{ type: 'error', error: { type: 'api_error', statusCode: 500, message: '...' } }`) and asserts the consumer's error stream part is an `Error` instance with the correct `.message` and `.statusCode`.

- **RED**: fails on `main` (the error part's `error` is the raw plain object, so `toBeInstanceOf(Error)` fails).
- **GREEN**: passes with the fix.

```sh
cd packages/ai && pnpm exec vitest --config vitest.node.config.js --run src/generate-text/stream-text.test.ts
```