### PR TITLE
fix(ai): handle plus signs in number exponents in fixJson

### DIFF
--- a/.changeset/plus-exponent-fix-json.md
+++ b/.changeset/plus-exponent-fix-json.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): handle plus signs in number exponents in fixJson

--- a/packages/ai/src/util/fix-json.test.ts
+++ b/packages/ai/src/util/fix-json.test.ts
@@ -40,14 +40,18 @@ describe('number', () => {
   test('should handle e-notation numbers', () => {
     assert.strictEqual(fixJson('2.5e'), '2.5');
     assert.strictEqual(fixJson('2.5e-'), '2.5');
+    assert.strictEqual(fixJson('2.5e+'), '2.5');
     assert.strictEqual(fixJson('2.5e3'), '2.5e3');
+    assert.strictEqual(fixJson('2.5e+3'), '2.5e+3');
     assert.strictEqual(fixJson('-2.5e3'), '-2.5e3');
   });
 
   test('should handle uppercase e-notation numbers', () => {
     assert.strictEqual(fixJson('2.5E'), '2.5');
     assert.strictEqual(fixJson('2.5E-'), '2.5');
+    assert.strictEqual(fixJson('2.5E+'), '2.5');
     assert.strictEqual(fixJson('2.5E3'), '2.5E3');
+    assert.strictEqual(fixJson('2.5E+3'), '2.5E+3');
     assert.strictEqual(fixJson('-2.5E3'), '-2.5E3');
   });
 

--- a/packages/ai/src/util/fix-json.ts
+++ b/packages/ai/src/util/fix-json.ts
@@ -313,6 +313,7 @@ export function fixJson(input: string): string {
           case 'e':
           case 'E':
           case '-':
+          case '+':
           case '.': {
             break;
           }


### PR DESCRIPTION
## Background

`fixJson` accepts `-` and `.` inside a number but not `+`, so an explicit plus exponent cuts the number short. `fixJson('2.5e+10')` returns `'2.5'`, and a streamed `{"value":2.5e+10` is repaired to `{"value":2.5}`, silently changing the value. This happens with real payloads because `JSON.stringify` emits plus exponents for large numbers (`JSON.stringify(1e21) === "1e+21"`).

## Summary

Treat `+` like the existing `-` case in the number scanner. Added `e+`/`E+` cases to the e-notation tests; they fail without the fix.

## End-to-End Verification

Ran `fixJson('2.5e+10')` and `fixJson('{"value":2.5e+10')` against main and this branch: main returns `2.5` and `{"value":2.5}`, with the fix both are preserved.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features)
