### PR TITLE
feat(ui): add typed custom bodies to Completion APIs

### DIFF
--- a/.changeset/typed-completion-bodies.md
+++ b/.changeset/typed-completion-bodies.md
@@ -1,0 +1,9 @@
+---
+'ai': patch
+'@ai-sdk/angular': patch
+'@ai-sdk/react': patch
+'@ai-sdk/svelte': patch
+'@ai-sdk/vue': patch
+---
+
+feat(ui): add typed custom bodies to Completion APIs

--- a/content/docs/04-ai-sdk-ui/05-completion.mdx
+++ b/content/docs/04-ai-sdk-ui/05-completion.mdx
@@ -185,3 +185,24 @@ const { messages, input, handleInputChange, handleSubmit } = useCompletion({
 ```
 
 In this example, the `useCompletion` hook sends a POST request to the `/api/completion` endpoint with the specified headers, additional body fields, and credentials for that fetch request. On your server side, you can handle the request with these additional information.
+
+You can provide a type for the additional body fields. The type applies to
+both the body configured on the hook and the body passed to `complete`:
+
+```tsx
+type CompletionBody = {
+  model: 'fast' | 'smart';
+};
+
+const { complete } = useCompletion<CompletionBody>({
+  body: {
+    model: 'fast',
+  },
+});
+
+await complete('What is a completion?', {
+  body: {
+    model: 'smart',
+  },
+});
+```

--- a/content/docs/07-reference/02-ai-sdk-ui/02-use-completion.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/02-use-completion.mdx
@@ -42,6 +42,19 @@ Allows you to create text completion based capabilities for your application. It
 
 ## API Signature
 
+### Type Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'BODY',
+      type: 'object',
+      description:
+        'The type of the additional request body passed through the hook options or the complete function. Defaults to object.',
+    },
+  ]}
+/>
+
 ### Parameters
 
 <PropertiesTable
@@ -88,7 +101,7 @@ Allows you to create text completion based capabilities for your application. It
     },
     {
       name: 'body',
-      type: 'object',
+      type: 'BODY',
       description:
         'An optional, additional body object to be passed to the API endpoint.',
     },
@@ -134,7 +147,7 @@ Allows you to create text completion based capabilities for your application. It
     },
     {
       name: 'complete',
-      type: '(prompt: string, options?: { headers?: Record<string, string> | Headers, body?: object }) => Promise<string | null | undefined>',
+      type: '(prompt: string, options?: { headers?: Record<string, string> | Headers, body?: BODY }) => Promise<string | null | undefined>',
       description:
         'Function to execute text completion based on the provided prompt. Returns the completion result when finished.',
     },

--- a/packages/ai/src/ui/use-completion.ts
+++ b/packages/ai/src/ui/use-completion.ts
@@ -1,6 +1,6 @@
 import type { FetchFunction } from '@ai-sdk/provider-utils';
 
-export type CompletionRequestOptions = {
+export type CompletionRequestOptions<BODY extends object = object> = {
   /**
    * An optional object of headers to be passed to the API endpoint.
    */
@@ -9,10 +9,10 @@ export type CompletionRequestOptions = {
   /**
    * An optional object to be passed to the API endpoint.
    */
-  body?: object;
+  body?: BODY;
 };
 
-export type UseCompletionOptions = {
+export type UseCompletionOptions<BODY extends object = object> = {
   /**
    * The API endpoint that accepts a `{ prompt: string }` object and returns
    * a stream of tokens of the AI completion response. Defaults to `/api/completion`.
@@ -69,7 +69,7 @@ export type UseCompletionOptions = {
    * })
    * ```
    */
-  body?: object;
+  body?: BODY;
 
   /**
    * Streaming protocol that is used. Defaults to `data`.

--- a/packages/angular/src/lib/completion.ng.test-d.ts
+++ b/packages/angular/src/lib/completion.ng.test-d.ts
@@ -1,0 +1,29 @@
+import type { CompletionRequestOptions } from 'ai';
+import { expectTypeOf } from 'vitest';
+import { Completion } from './completion.ng';
+
+type TestBody = {
+  model: 'fast' | 'smart';
+};
+
+const typedCompletion = new Completion<TestBody>({
+  body: { model: 'fast' },
+});
+
+expectTypeOf(typedCompletion.complete)
+  .parameter(1)
+  .toEqualTypeOf<CompletionRequestOptions<TestBody> | undefined>();
+
+typedCompletion.complete('prompt', { body: { model: 'smart' } });
+typedCompletion.complete('prompt', {
+  body: {
+    // @ts-expect-error - model must match TestBody
+    model: 'slow',
+  },
+});
+
+const untypedCompletion = new Completion({
+  body: { sessionId: 'session-id' },
+});
+
+untypedCompletion.complete('prompt', { body: { model: 'fast' } });

--- a/packages/angular/src/lib/completion.ng.ts
+++ b/packages/angular/src/lib/completion.ng.ts
@@ -7,10 +7,12 @@ import {
 } from 'ai';
 import { normalizeHeaders } from '@ai-sdk/provider-utils';
 
-export type CompletionOptions = Readonly<UseCompletionOptions>;
+export type CompletionOptions<BODY extends object = object> = Readonly<
+  UseCompletionOptions<BODY>
+>;
 
-export class Completion {
-  readonly #options: CompletionOptions;
+export class Completion<BODY extends object = object> {
+  readonly #options: CompletionOptions<BODY>;
 
   // Static config
   readonly id: string;
@@ -25,7 +27,7 @@ export class Completion {
 
   #abortController: AbortController | null = null;
 
-  constructor(options: CompletionOptions = {}) {
+  constructor(options: CompletionOptions<NoInfer<BODY>> = {}) {
     this.#options = options;
     this.#completion.set(options.initialCompletion ?? '');
     this.#input.set(options.initialInput ?? '');
@@ -73,7 +75,7 @@ export class Completion {
   };
 
   /** Send a new prompt to the API endpoint and update the completion state. */
-  complete = async (prompt: string, options?: CompletionRequestOptions) =>
+  complete = async (prompt: string, options?: CompletionRequestOptions<BODY>) =>
     this.#triggerRequest(prompt, options);
 
   /** Form submission handler to automatically reset input and call the completion API */
@@ -86,7 +88,7 @@ export class Completion {
 
   #triggerRequest = async (
     prompt: string,
-    options?: CompletionRequestOptions,
+    options?: CompletionRequestOptions<BODY>,
   ) => {
     return callCompletionApi({
       api: this.api,

--- a/packages/react/src/use-completion.test-d.ts
+++ b/packages/react/src/use-completion.test-d.ts
@@ -1,0 +1,36 @@
+import type { CompletionRequestOptions } from 'ai';
+import { expectTypeOf } from 'vitest';
+import { useCompletion } from './use-completion';
+
+type TestBody = {
+  model: 'fast' | 'smart';
+};
+
+function useTypedCompletion() {
+  const { complete } = useCompletion<TestBody>({
+    body: { model: 'fast' },
+  });
+
+  expectTypeOf(complete)
+    .parameter(1)
+    .toEqualTypeOf<CompletionRequestOptions<TestBody> | undefined>();
+
+  complete('prompt', { body: { model: 'smart' } });
+  complete('prompt', {
+    body: {
+      // @ts-expect-error - model must match TestBody
+      model: 'slow',
+    },
+  });
+}
+
+function useUntypedCompletion() {
+  const { complete } = useCompletion({
+    body: { sessionId: 'session-id' },
+  });
+
+  complete('prompt', { body: { model: 'fast' } });
+}
+
+expectTypeOf(useTypedCompletion).returns.toBeVoid();
+expectTypeOf(useUntypedCompletion).returns.toBeVoid();

--- a/packages/react/src/use-completion.ts
+++ b/packages/react/src/use-completion.ts
@@ -9,7 +9,7 @@ import { throttle } from './throttle';
 
 export type { UseCompletionOptions };
 
-export type UseCompletionHelpers = {
+export type UseCompletionHelpers<BODY extends object = object> = {
   /** The current completion result */
   completion: string;
   /**
@@ -17,7 +17,7 @@ export type UseCompletionHelpers = {
    */
   complete: (
     prompt: string,
-    options?: CompletionRequestOptions,
+    options?: CompletionRequestOptions<BODY>,
   ) => Promise<string | null | undefined>;
   /** The error object of the API request */
   error: undefined | Error;
@@ -61,7 +61,7 @@ export type UseCompletionHelpers = {
   isLoading: boolean;
 };
 
-export function useCompletion({
+export function useCompletion<BODY extends object = object>({
   api = '/api/completion',
   id,
   initialCompletion = '',
@@ -75,7 +75,7 @@ export function useCompletion({
   onError,
   throttle: throttleWait,
   experimental_throttle,
-}: UseCompletionOptions & {
+}: UseCompletionOptions<NoInfer<BODY>> & {
   /**
    * Custom throttle wait in ms for the completion and data updates.
    * Default is undefined, which disables throttling.
@@ -86,7 +86,7 @@ export function useCompletion({
    * @deprecated Use `throttle` instead.
    */
   experimental_throttle?: number;
-} = {}): UseCompletionHelpers {
+} = {}): UseCompletionHelpers<BODY> {
   const throttleWaitMs = throttleWait ?? experimental_throttle;
   // Generate an unique id for the completion if not provided.
   const hookId = useId();
@@ -124,7 +124,7 @@ export function useCompletion({
   }, [credentials, headers, body]);
 
   const triggerRequest = useCallback(
-    async (prompt: string, options?: CompletionRequestOptions) =>
+    async (prompt: string, options?: CompletionRequestOptions<BODY>) =>
       callCompletionApi({
         api,
         prompt,
@@ -176,7 +176,7 @@ export function useCompletion({
     [mutate],
   );
 
-  const complete = useCallback<UseCompletionHelpers['complete']>(
+  const complete = useCallback<UseCompletionHelpers<BODY>['complete']>(
     async (prompt, options) => {
       return triggerRequest(prompt, options);
     },

--- a/packages/svelte/src/completion.svelte.test-d.ts
+++ b/packages/svelte/src/completion.svelte.test-d.ts
@@ -1,0 +1,29 @@
+import type { CompletionRequestOptions } from 'ai';
+import { expectTypeOf } from 'vitest';
+import { Completion } from './completion.svelte.js';
+
+type TestBody = {
+  model: 'fast' | 'smart';
+};
+
+const typedCompletion = new Completion<TestBody>({
+  body: { model: 'fast' },
+});
+
+expectTypeOf(typedCompletion.complete)
+  .parameter(1)
+  .toEqualTypeOf<CompletionRequestOptions<TestBody> | undefined>();
+
+typedCompletion.complete('prompt', { body: { model: 'smart' } });
+typedCompletion.complete('prompt', {
+  body: {
+    // @ts-expect-error - model must match TestBody
+    model: 'slow',
+  },
+});
+
+const untypedCompletion = new Completion({
+  body: { sessionId: 'session-id' },
+});
+
+untypedCompletion.complete('prompt', { body: { model: 'fast' } });

--- a/packages/svelte/src/completion.svelte.ts
+++ b/packages/svelte/src/completion.svelte.ts
@@ -10,10 +10,12 @@ import {
   hasCompletionContext,
 } from './completion-context.svelte.js';
 
-export type CompletionOptions = Readonly<UseCompletionOptions>;
+export type CompletionOptions<BODY extends object = object> = Readonly<
+  UseCompletionOptions<BODY>
+>;
 
-export class Completion {
-  readonly #options: CompletionOptions = {};
+export class Completion<BODY extends object = object> {
+  readonly #options: CompletionOptions<BODY> = {};
   readonly #api = $derived(this.#options.api ?? '/api/completion');
   readonly #id = $derived(this.#options.id ?? generateId());
   readonly #streamProtocol = $derived(this.#options.streamProtocol ?? 'data');
@@ -44,7 +46,7 @@ export class Completion {
     return this.#store.loading;
   }
 
-  constructor(options: CompletionOptions = {}) {
+  constructor(options: CompletionOptions<NoInfer<BODY>> = {}) {
     this.#keyedStore = hasCompletionContext()
       ? getCompletionContext()
       : new KeyedCompletionStore();
@@ -70,7 +72,7 @@ export class Completion {
   /**
    * Send a new prompt to the API endpoint and update the completion state.
    */
-  complete = async (prompt: string, options?: CompletionRequestOptions) =>
+  complete = async (prompt: string, options?: CompletionRequestOptions<BODY>) =>
     this.#triggerRequest(prompt, options);
 
   /** Form submission handler to automatically reset input and call the completion API */
@@ -83,7 +85,7 @@ export class Completion {
 
   #triggerRequest = async (
     prompt: string,
-    options?: CompletionRequestOptions,
+    options?: CompletionRequestOptions<BODY>,
   ) => {
     return callCompletionApi({
       api: this.#api,

--- a/packages/vue/src/use-completion.test-d.ts
+++ b/packages/vue/src/use-completion.test-d.ts
@@ -1,0 +1,36 @@
+import type { CompletionRequestOptions } from 'ai';
+import { expectTypeOf } from 'vitest';
+import { useCompletion } from './use-completion';
+
+type TestBody = {
+  model: 'fast' | 'smart';
+};
+
+function createTypedCompletion() {
+  const { complete } = useCompletion<TestBody>({
+    body: { model: 'fast' },
+  });
+
+  expectTypeOf(complete)
+    .parameter(1)
+    .toEqualTypeOf<CompletionRequestOptions<TestBody> | undefined>();
+
+  complete('prompt', { body: { model: 'smart' } });
+  complete('prompt', {
+    body: {
+      // @ts-expect-error - model must match TestBody
+      model: 'slow',
+    },
+  });
+}
+
+function createUntypedCompletion() {
+  const { complete } = useCompletion({
+    body: { sessionId: 'session-id' },
+  });
+
+  complete('prompt', { body: { model: 'fast' } });
+}
+
+expectTypeOf(createTypedCompletion).returns.toBeVoid();
+expectTypeOf(createUntypedCompletion).returns.toBeVoid();

--- a/packages/vue/src/use-completion.ts
+++ b/packages/vue/src/use-completion.ts
@@ -8,7 +8,7 @@ import swrv from 'swrv';
 import { ref, unref, type Ref } from 'vue';
 export type { UseCompletionOptions };
 
-export type UseCompletionHelpers = {
+export type UseCompletionHelpers<BODY extends object = object> = {
   /** The current completion result */
   completion: Ref<string>;
   /** The error object of the API request */
@@ -18,7 +18,7 @@ export type UseCompletionHelpers = {
    */
   complete: (
     prompt: string,
-    options?: CompletionRequestOptions,
+    options?: CompletionRequestOptions<BODY>,
   ) => Promise<string | null | undefined>;
   /**
    * Abort the current API request but keep the generated tokens.
@@ -50,7 +50,7 @@ let uniqueId = 0;
 const useSWRV = (swrv.default as (typeof SwrvModule)['default']) || swrv;
 const store: Record<string, any> = {};
 
-export function useCompletion({
+export function useCompletion<BODY extends object = object>({
   api = '/api/completion',
   id,
   initialCompletion = '',
@@ -62,7 +62,7 @@ export function useCompletion({
   onFinish,
   onError,
   fetch,
-}: UseCompletionOptions = {}): UseCompletionHelpers {
+}: UseCompletionOptions<NoInfer<BODY>> = {}): UseCompletionHelpers<BODY> {
   // Generate an unique id for the completion if not provided.
   const completionId = id || `completion-${uniqueId++}`;
 
@@ -96,7 +96,7 @@ export function useCompletion({
 
   async function triggerRequest(
     prompt: string,
-    options?: CompletionRequestOptions,
+    options?: CompletionRequestOptions<BODY>,
   ) {
     return callCompletionApi({
       api,
@@ -125,7 +125,7 @@ export function useCompletion({
     });
   }
 
-  const complete: UseCompletionHelpers['complete'] = async (
+  const complete: UseCompletionHelpers<BODY>['complete'] = async (
     prompt,
     options,
   ) => {


### PR DESCRIPTION
## Background

Completion APIs accept a custom body, but type it only as `object`. This prevented applications from checking their Completion bodies against a shared type.

## Summary

Added an optional body generic to the shared Completion types and the React, Vue, Svelte, and Angular APIs. The generic defaults to `object`, which preserves existing untyped usage.

## End-to-End Verification

Used the public APIs with a body type and passed matching bodies. TypeScript accepted valid values and rejected invalid values.

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Future Work

Add similar generics to useChat()

## Related Issues

Closes https://github.com/vercel/ai/issues/3838