### PR TITLE
ci: comment snapshot release versions on pull requests

### DIFF
--- a/.github/scripts/notify-released/notify-snapshot.mjs
+++ b/.github/scripts/notify-released/notify-snapshot.mjs
@@ -1,0 +1,201 @@
+// @ts-check
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { Octokit } from 'octokit';
+
+/**
+ * @typedef {{ name: string; version: string; private?: boolean }} PackageJson
+ * @typedef {{ name: string; version: string }} PublishedPackage
+ */
+
+/**
+ * Select the public packages versioned by the current snapshot run.
+ *
+ * @param {PackageJson[]} packageJsons
+ * @param {string} shortSha
+ * @returns {PublishedPackage[]}
+ */
+export function selectSnapshotPackages(packageJsons, shortSha) {
+  const versionPrefix = `0.0.0-${shortSha}-`;
+
+  return packageJsons
+    .filter(
+      pkg =>
+        pkg.private !== true &&
+        typeof pkg.name === 'string' &&
+        typeof pkg.version === 'string' &&
+        pkg.version.startsWith(versionPrefix),
+    )
+    .map(({ name, version }) => ({ name, version }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Find the pull request that matches the workflow branch. The associated pull
+ * requests API already anchors the candidates to the workflow commit, while
+ * matching the branch still works if the PR receives another commit during the
+ * snapshot build.
+ *
+ * @param {Array<{ number: number; state: string; head: { ref: string; repo: { full_name: string } | null } }>} pullRequests
+ * @param {string} refName
+ * @param {string} repository
+ */
+export function selectPullRequest(pullRequests, refName, repository) {
+  const matches = pullRequests.filter(
+    pullRequest =>
+      pullRequest.state === 'open' &&
+      pullRequest.head.ref === refName &&
+      pullRequest.head.repo?.full_name === repository,
+  );
+
+  if (matches.length > 1) {
+    throw new Error(
+      `Found multiple open pull requests for ${repository}:${refName}: ${matches
+        .map(pullRequest => `#${pullRequest.number}`)
+        .join(', ')}`,
+    );
+  }
+
+  return matches[0] ?? null;
+}
+
+/**
+ * @param {PublishedPackage[]} publishedPackages
+ * @param {string} runUrl
+ */
+export function createSnapshotComment(publishedPackages, runUrl) {
+  const packageTable = publishedPackages
+    .map(pkg => {
+      const npmUrl = `https://www.npmjs.com/package/${encodeURIComponent(pkg.name)}/v/${encodeURIComponent(pkg.version)}`;
+      return `| \`${pkg.name}\` | [${pkg.version}](${npmUrl}) |`;
+    })
+    .join('\n');
+
+  return `:test_tube: Snapshot release published:
+
+| Package | Version |
+| --- | --- |
+${packageTable}
+
+[View workflow run](${runUrl})`;
+}
+
+/**
+ * @param {string} packagesDirectory
+ * @param {string} shortSha
+ */
+async function findSnapshotPackages(packagesDirectory, shortSha) {
+  const entries = await fs.readdir(packagesDirectory, { withFileTypes: true });
+  const packageJsons = await Promise.all(
+    entries
+      .filter(entry => entry.isDirectory())
+      .map(async entry =>
+        JSON.parse(
+          await fs.readFile(
+            path.join(packagesDirectory, entry.name, 'package.json'),
+            'utf8',
+          ),
+        ),
+      ),
+  );
+
+  return selectSnapshotPackages(packageJsons, shortSha);
+}
+
+/**
+ * @param {string} name
+ * @param {NodeJS.ProcessEnv} env
+ */
+function requireEnvironmentVariable(name, env) {
+  const value = env[name];
+  if (!value) {
+    throw new Error(`${name} environment variable is required`);
+  }
+  return value;
+}
+
+/**
+ * @param {{ env?: NodeJS.ProcessEnv; dryRun?: boolean }} [options]
+ */
+export async function main({
+  env = process.env,
+  dryRun = process.argv.includes('--dry-run'),
+} = {}) {
+  const githubToken = requireEnvironmentVariable('GITHUB_TOKEN', env);
+  const githubRepository = requireEnvironmentVariable('GITHUB_REPOSITORY', env);
+  const githubSha = requireEnvironmentVariable('GITHUB_SHA', env);
+  const githubRefName = requireEnvironmentVariable('GITHUB_REF_NAME', env);
+  const githubRunId = requireEnvironmentVariable('GITHUB_RUN_ID', env);
+  const shortSha = requireEnvironmentVariable('SHORT_SHA', env);
+  const githubServerUrl = env.GITHUB_SERVER_URL || 'https://github.com';
+  const [owner, repo] = githubRepository.split('/');
+
+  if (!owner || !repo) {
+    throw new Error(
+      `GITHUB_REPOSITORY must use the owner/repository format; received ${githubRepository}`,
+    );
+  }
+
+  const repositoryRoot = fileURLToPath(new URL('../../../', import.meta.url));
+  const publishedPackages = await findSnapshotPackages(
+    path.join(repositoryRoot, 'packages'),
+    shortSha,
+  );
+
+  if (publishedPackages.length === 0) {
+    console.log('No snapshot packages found. Exiting.');
+    return;
+  }
+
+  console.log(`Found ${publishedPackages.length} snapshot package(s):`);
+  for (const pkg of publishedPackages) {
+    console.log(`  - ${pkg.name}@${pkg.version}`);
+  }
+
+  const octokit = new Octokit({ auth: githubToken });
+  const { data: associatedPullRequests } =
+    await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
+      owner,
+      repo,
+      commit_sha: githubSha,
+      per_page: 100,
+    });
+  const pullRequest = selectPullRequest(
+    associatedPullRequests,
+    githubRefName,
+    githubRepository,
+  );
+
+  if (pullRequest == null) {
+    console.log(
+      `No open pull request found for ${githubRefName} at ${githubSha}. Exiting.`,
+    );
+    return;
+  }
+
+  const runUrl = `${githubServerUrl}/${githubRepository}/actions/runs/${githubRunId}`;
+  const body = createSnapshotComment(publishedPackages, runUrl);
+
+  if (dryRun) {
+    console.log(`[dry-run] Would comment on #${pullRequest.number}:\n${body}`);
+    return;
+  }
+
+  await octokit.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: pullRequest.number,
+    body,
+  });
+  console.log(`Commented on #${pullRequest.number}`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  await main();
+}

--- a/.github/scripts/notify-released/notify-snapshot.test.mjs
+++ b/.github/scripts/notify-released/notify-snapshot.test.mjs
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  createSnapshotComment,
+  selectPullRequest,
+  selectSnapshotPackages,
+} from './notify-snapshot.mjs';
+
+test('selectSnapshotPackages selects and sorts public packages from the current snapshot', () => {
+  assert.deepEqual(
+    selectSnapshotPackages(
+      [
+        {
+          name: 'ai',
+          version: '0.0.0-12345678-20260811180950',
+        },
+        {
+          name: '@ai-sdk/provider',
+          version: '4.0.0',
+        },
+        {
+          name: '@ai-sdk/code-mode',
+          version: '0.0.0-12345678-20260811180950',
+        },
+        {
+          name: '@example/private',
+          version: '0.0.0-12345678-20260811180950',
+          private: true,
+        },
+        {
+          name: '@ai-sdk/other-snapshot',
+          version: '0.0.0-87654321-20260811180950',
+        },
+      ],
+      '12345678',
+    ),
+    [
+      {
+        name: '@ai-sdk/code-mode',
+        version: '0.0.0-12345678-20260811180950',
+      },
+      {
+        name: 'ai',
+        version: '0.0.0-12345678-20260811180950',
+      },
+    ],
+  );
+});
+
+test('selectPullRequest matches the open pull request head repository and ref', () => {
+  assert.deepEqual(
+    selectPullRequest(
+      [
+        {
+          number: 1,
+          state: 'closed',
+          head: { ref: 'feature', repo: { full_name: 'vercel/ai' } },
+        },
+        {
+          number: 2,
+          state: 'open',
+          head: { ref: 'other-feature', repo: { full_name: 'vercel/ai' } },
+        },
+        {
+          number: 3,
+          state: 'open',
+          head: { ref: 'feature', repo: { full_name: 'vercel/ai' } },
+        },
+      ],
+      'feature',
+      'vercel/ai',
+    ),
+    {
+      number: 3,
+      state: 'open',
+      head: { ref: 'feature', repo: { full_name: 'vercel/ai' } },
+    },
+  );
+});
+
+test('selectPullRequest returns null when the workflow ref has no open pull request', () => {
+  assert.equal(
+    selectPullRequest(
+      [
+        {
+          number: 1,
+          state: 'open',
+          head: { ref: 'feature', repo: { full_name: 'someone/ai' } },
+        },
+      ],
+      'feature',
+      'vercel/ai',
+    ),
+    null,
+  );
+});
+
+test('selectPullRequest rejects an ambiguous workflow ref', () => {
+  assert.throws(
+    () =>
+      selectPullRequest(
+        [
+          {
+            number: 1,
+            state: 'open',
+            head: { ref: 'feature', repo: { full_name: 'vercel/ai' } },
+          },
+          {
+            number: 2,
+            state: 'open',
+            head: { ref: 'feature', repo: { full_name: 'vercel/ai' } },
+          },
+        ],
+        'feature',
+        'vercel/ai',
+      ),
+    /Found multiple open pull requests.*#1, #2/,
+  );
+});
+
+test('createSnapshotComment lists npm-linked package versions and the workflow run', () => {
+  assert.equal(
+    createSnapshotComment(
+      [
+        {
+          name: '@ai-sdk/code-mode',
+          version: '0.0.0-12345678-20260811180950',
+        },
+      ],
+      'https://github.com/vercel/ai/actions/runs/123',
+    ),
+    `:test_tube: Snapshot release published:
+
+| Package | Version |
+| --- | --- |
+| \`@ai-sdk/code-mode\` | [0.0.0-12345678-20260811180950](https://www.npmjs.com/package/%40ai-sdk%2Fcode-mode/v/0.0.0-12345678-20260811180950) |
+
+[View workflow run](https://github.com/vercel/ai/actions/runs/123)`,
+  );
+});

--- a/.github/scripts/notify-released/package.json
+++ b/.github/scripts/notify-released/package.json
@@ -1,6 +1,9 @@
 {
   "private": true,
   "type": "module",
+  "scripts": {
+    "test": "node --test *.test.mjs"
+  },
   "dependencies": {
     "octokit": "^5.0.0"
   }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,3 +126,12 @@ jobs:
         run: pnpm changeset publish --no-git-tag --tag snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify snapshot release pull request
+        if: inputs.snapshot == true
+        run: |
+          cd .github/scripts/notify-released
+          npm install --no-save
+          node notify-snapshot.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- post a snapshot release comment on the matching open pull request after publishing succeeds
- discover all public package versions created by the current snapshot run and link each version to npm
- safely skip branches without an open pull request and reject ambiguous matches
- add unit coverage for package selection, pull request matching, and comment formatting

This addresses the missing comment observed after https://github.com/vercel/ai/actions/runs/31519387142 for https://github.com/vercel/ai/pull/18299.

## Verification

- npm test from .github/scripts/notify-released
- pnpm check
- pnpm type-check:full

No changeset: internal release automation only.