### PR TITLE
fix(harness-claude-code): exclude subagent messages from parent step usage and tool-call tracking

### DIFF
--- a/.changeset/tidy-claude-subagents.md
+++ b/.changeset/tidy-claude-subagents.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-claude-code': patch
+---
+
+fix(harness-claude-code): exclude subagent messages from parent step usage and tool-call tracking

--- a/packages/harness-claude-code/src/bridge/__fixtures__/subagent-step-stream.json
+++ b/packages/harness-claude-code/src/bridge/__fixtures__/subagent-step-stream.json
@@ -1,0 +1,129 @@
+[
+  {
+    "type": "assistant",
+    "parent_tool_use_id": null,
+    "message": {
+      "content": [{ "type": "thinking", "thinking": "Delegating." }],
+      "usage": {
+        "input_tokens": 2,
+        "cache_creation_input_tokens": 5605,
+        "cache_read_input_tokens": 2298,
+        "output_tokens": 5
+      }
+    }
+  },
+  {
+    "type": "assistant",
+    "parent_tool_use_id": null,
+    "message": {
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_main_agent",
+          "name": "Agent",
+          "input": {
+            "description": "Run pwd and echo",
+            "prompt": "Use Bash to run pwd, then echo subagent-done.",
+            "subagent_type": "general-purpose",
+            "run_in_background": false
+          }
+        }
+      ],
+      "usage": {
+        "input_tokens": 2,
+        "cache_creation_input_tokens": 5605,
+        "cache_read_input_tokens": 2298,
+        "output_tokens": 5
+      }
+    }
+  },
+  {
+    "type": "user",
+    "parent_tool_use_id": "toolu_main_agent",
+    "message": {
+      "content": [{ "type": "text", "text": "The subagent started." }]
+    }
+  },
+  {
+    "type": "assistant",
+    "parent_tool_use_id": "toolu_main_agent",
+    "message": {
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_subagent_pwd",
+          "name": "Bash",
+          "input": { "command": "pwd" }
+        }
+      ],
+      "usage": {
+        "input_tokens": 2,
+        "cache_creation_input_tokens": 5024,
+        "cache_read_input_tokens": 3519,
+        "output_tokens": 4
+      }
+    }
+  },
+  {
+    "type": "assistant",
+    "parent_tool_use_id": "toolu_main_agent",
+    "message": {
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_subagent_echo",
+          "name": "Bash",
+          "input": { "command": "echo subagent-done" }
+        }
+      ],
+      "usage": {
+        "input_tokens": 2,
+        "cache_creation_input_tokens": 5024,
+        "cache_read_input_tokens": 3519,
+        "output_tokens": 4
+      }
+    }
+  },
+  {
+    "type": "user",
+    "parent_tool_use_id": "toolu_main_agent",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_subagent_pwd",
+          "content": "/work/packages/harness-claude-code",
+          "is_error": false
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "parent_tool_use_id": "toolu_main_agent",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_subagent_echo",
+          "content": "subagent-done",
+          "is_error": false
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "parent_tool_use_id": null,
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_main_agent",
+          "content": "Both commands ran successfully.",
+          "is_error": false
+        }
+      ]
+    }
+  }
+]

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
+  type ClaudeMessage,
   createClaudeStreamEventState,
   createEmitStreamEvent,
 } from './create-emit-stream-event';
@@ -90,6 +92,79 @@ describe('createEmitStreamEvent', () => {
         },
       ]
     `);
+  });
+
+  it('keeps subagent messages out of the main Agent-tool step', () => {
+    const messages = JSON.parse(
+      readFileSync(
+        new URL('./__fixtures__/subagent-step-stream.json', import.meta.url),
+        'utf8',
+      ),
+    ) as ClaudeMessage[];
+    const state = createClaudeStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: event => emitted.push(event),
+      emitWarning: () => {},
+      emitTerminalError: () => {},
+      onCompactionBoundary: () => {},
+      toCommonName: name => (name === 'Bash' ? 'bash' : name),
+    });
+
+    for (const message of messages) {
+      emitStreamEvent(message);
+    }
+    emitStreamEvent({
+      type: 'stream_event',
+      parent_tool_use_id: 'toolu_main_agent',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text' },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      parent_tool_use_id: 'toolu_main_agent',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 'subagent text' },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      parent_tool_use_id: 'toolu_main_agent',
+      event: { type: 'content_block_stop', index: 0 },
+    });
+
+    const finishStep = emitted.find(event => event.type === 'finish-step');
+    const leakedSubagentEvents = emitted.filter(
+      event =>
+        (event.type === 'text-start' ||
+          event.type === 'text-delta' ||
+          event.type === 'text-end' ||
+          event.type === 'tool-call' ||
+          event.type === 'tool-result') &&
+        (event.delta === 'subagent text' ||
+          (typeof event.toolCallId === 'string' &&
+            event.toolCallId.startsWith('toolu_subagent_'))),
+    );
+
+    expect(finishStep?.usage).toEqual({
+      inputTokens: {
+        total: 7905,
+        noCache: 2,
+        cacheRead: 2298,
+        cacheWrite: 5605,
+      },
+      outputTokens: {
+        total: 5,
+        text: 5,
+      },
+    });
+    expect(leakedSubagentEvents).toEqual([]);
   });
 
   it('preserves retry and compaction handling', () => {

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
@@ -5,6 +5,7 @@ type Emit = (message: Record<string, unknown>) => void;
 export type ClaudeMessage = {
   type?: string;
   subtype?: string;
+  parent_tool_use_id?: string | null;
   model?: string;
   error?: string;
   error_status?: number | null;
@@ -180,6 +181,13 @@ export function createEmitStreamEvent({
             : {}),
         });
       }
+      return;
+    }
+
+    // Messages emitted by a Task-tool subagent carry the parent tool-use id.
+    // They belong to the subagent stream and must not affect the parent step,
+    // including partial stream events that arrive before assistant messages.
+    if (msg.parent_tool_use_id != null) {
       return;
     }
 


### PR DESCRIPTION
Same as #18631 - that PR lacked verified commits. Credit goes to @patrickswedish.

> ## Background
> 
> Claude Code emits messages from Task-tool subagents with a non-null `parent_tool_use_id`.
> 
> The harness currently processes those messages as though they belong to the parent agent step. This causes subagent > activity to affect the parent step's usage accounting and exposes subagent tool calls/results as parent-step events.
> 
> The issue has been reproduced against the current harness behavior with a captured Claude Code stream.
> 
> ## Summary
> 
> This PR keeps the change narrowly scoped:
> 
> - ignore assistant messages associated with a subagent when tracking the parent step
> - ignore corresponding subagent user/tool-result messages
> - preserve normal parent-agent usage and tool-call handling
> - add regression coverage using a representative subagent stream fixture
> - add a patch changeset for `@ai-sdk/harness-claude-code`
> 
> No public API or normal main-agent behavior is changed.
> 
> ## Verification
> 
> The regression covers a stream where subagent messages contain a non-null `parent_tool_use_id`.
> 
> It verifies that:
> 
> - the parent step retains its own token usage
> - subagent tool calls are not emitted as parent-step tool calls
> - subagent tool results are not emitted as parent-step tool results
> 
> Validation on the final branch:
> 
> - TypeScript — passed
> - Lint & Format — passed
> - Build Packages — passed
> - AI test matrix on Node 22, 24, and 26 — passed
> - Codemod test matrix — passed
> - Example builds — passed
> - Changeset verification — passed

## Related Issues

Fixes #18618.

Closes #18619.