### PR TITLE
feat(siftq): add video model provider

### DIFF
--- a/.changeset/fresh-videos-sift.md
+++ b/.changeset/fresh-videos-sift.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/siftq': patch
+---
+
+Add the fixed-model SiftQ MiniMax-H3 V2 video provider with text, frame, multimodal reference, polling, and webhook support.

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -576,11 +576,13 @@
     "openai-compatible": "OpenAICompatible",
     "opencode": "OpenCode",
     "quiverai": "QuiverAI",
+    "siftq": "SiftQ",
     "togetherai": "TogetherAI"
   },
   "kebabToCamelMap": {
     "acp": "acp",
     "lmnt": "lmnt",
-    "minimax": "minimax"
+    "minimax": "minimax",
+    "siftq": "siftq"
   }
 }

--- a/content/providers/01-ai-sdk-providers/200-siftq.mdx
+++ b/content/providers/01-ai-sdk-providers/200-siftq.mdx
@@ -1,0 +1,177 @@
+---
+title: SiftQ
+description: Learn how to use SiftQ MiniMax-H3 video generation with the AI SDK.
+---
+
+# SiftQ Provider
+
+The SiftQ provider adds asynchronous MiniMax-H3 V2 video generation to the AI SDK. It supports text-to-video, first-frame and first-and-last-frame generation, and reference-to-video with image, video, and audio inputs.
+
+SiftQ exposes one fixed model through this provider. Call `.video()` without a model ID; the provider always submits `MiniMax-H3` in the compatible request body.
+
+## Setup
+
+The provider is available in the `@ai-sdk/siftq` package:
+
+<InstallPackages packages="@ai-sdk/siftq" />
+
+Set the `SIFTQ_API_KEY` environment variable before making requests.
+
+## Provider Instance
+
+Import the default `siftq` provider:
+
+```ts
+import { siftq } from '@ai-sdk/siftq';
+```
+
+Create a customized instance when you need custom headers, a test endpoint, or a custom fetch implementation:
+
+```ts
+import { createSiftQ } from '@ai-sdk/siftq';
+
+const siftq = createSiftQ({
+  apiKey: process.env.SIFTQ_API_KEY,
+  baseURL: 'https://siftq.com/api/minimax/',
+  headers: {
+    'x-project-id': 'my-project',
+  },
+});
+```
+
+The default base URL is `https://siftq.com/api/minimax/`. The provider normalizes the boundary slash, so video creation uses exactly `https://siftq.com/api/minimax/v2/video_generation`, not a double-slash URL. Only `http:` and `https:` base URLs are accepted. API keys are sent as Bearer tokens and default to `SIFTQ_API_KEY`.
+
+## Video Generation
+
+Create the fixed MiniMax-H3 model with `.video()` or `.videoModel()`.
+
+### Text-to-video
+
+```ts
+import { siftq, type SiftQVideoModelOptions } from '@ai-sdk/siftq';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { video } = await generateVideo({
+  model: siftq.video(),
+  prompt: 'A paper boat crossing a moonlit ocean, cinematic lighting',
+  aspectRatio: '16:9',
+  duration: 6,
+  providerOptions: {
+    siftq: {
+      resolution: '2K',
+    } satisfies SiftQVideoModelOptions,
+  },
+});
+```
+
+Text-to-video requires a concrete ratio. When omitted, the provider uses `16:9`.
+
+### First-frame image-to-video
+
+Pass the first frame through the image prompt form. Frame-based generation always uses the input image's ratio.
+
+```ts
+const { video } = await generateVideo({
+  model: siftq.video(),
+  prompt: {
+    image: 'https://example.com/first-frame.png',
+    text: 'The lanterns flicker as the camera moves forward',
+  },
+  duration: 6,
+});
+```
+
+### First-and-last-frame generation
+
+```ts
+const { video } = await generateVideo({
+  model: siftq.video(),
+  prompt: 'Move smoothly from the opening composition to the final frame',
+  frameImages: [
+    {
+      frameType: 'first_frame',
+      image: 'https://example.com/first-frame.png',
+    },
+    {
+      frameType: 'last_frame',
+      image: 'https://example.com/last-frame.png',
+    },
+  ],
+  duration: 6,
+});
+```
+
+A last frame must be paired with a first frame.
+
+### Reference-to-video
+
+Use `inputReferences` for typed image, video, or audio inputs. You can also pass audio locations through `providerOptions.siftq.referenceAudioUrls`.
+
+```ts
+import { type SiftQVideoModelOptions } from '@ai-sdk/siftq';
+
+const { video } = await generateVideo({
+  model: siftq.video(),
+  prompt: 'The character walks through a neon market at night',
+  inputReferences: [
+    {
+      data: 'https://example.com/character.png',
+      mediaType: 'image/png',
+    },
+    {
+      data: 'https://example.com/movement.mp4',
+      mediaType: 'video/mp4',
+    },
+  ],
+  providerOptions: {
+    siftq: {
+      referenceAudioUrls: ['https://example.com/voice-reference.wav'],
+      resolution: '768P',
+      ratio: 'adaptive',
+    } satisfies SiftQVideoModelOptions,
+  },
+});
+```
+
+SiftQ accepts up to nine reference images, three reference videos, and three reference audio inputs per task. Frame roles and reference roles cannot be combined in one request. Untyped URL references are treated as images with a warning; add `mediaType` when passing video or audio URLs.
+
+## Provider Options
+
+The following options are available through `providerOptions.siftq`:
+
+- **resolution** `'768P' | '2K'`
+
+  Named output resolution tier. Defaults to `2K`. Common 2K pixel dimensions such as `2560x1440` are mapped to the `2K` tier; use this provider option for `768P` or when you want to select the tier directly.
+
+- **ratio** `'adaptive' | '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16'`
+
+  Provider-native aspect ratio. It takes precedence over the generic `aspectRatio` option. Frame-based requests always use `adaptive`; text-only requests require a concrete ratio.
+
+- **referenceAudioUrls** _string[]_
+
+  Up to three public URLs, data URIs, or `mm_file://` locations used as audio references.
+
+The prompt must be non-empty and no longer than 7000 characters. Duration must be an integer from 4 through 15 seconds. Custom `fps`, deterministic `seed`, `generateAudio`, and pixel-dimension `resolution` are unsupported and produce warnings.
+
+## Polling, Webhooks, and Cancellation
+
+Configure asynchronous polling with the top-level `poll` option:
+
+```ts
+const { video } = await generateVideo({
+  model: siftq.video(),
+  prompt: 'A time-lapse of clouds passing over a mountain lake',
+  poll: {
+    intervalMs: 5000,
+    timeoutMs: 900000,
+  },
+});
+```
+
+The provider also supports the AI SDK `webhook` option. Its callback URL is sent as `callback_url`; after the notification arrives, the SDK queries the task once to obtain and download the final video. The webhook receiver must echo SiftQ's verification challenge within three seconds and should resolve its `received` promise only for a terminal `succeeded`, `failed`, or `cancelled` notification, not for `queued` or `running` updates.
+
+Passing an `abortSignal` stops local submission, polling, or download work. It does not change an accepted remote task. The compatible REST API can cancel a task only while it is `queued`; a `running` task cannot be cancelled. The AI SDK video model interface does not expose that REST delete operation.
+
+## Result Security
+
+The provider queries `/v2/query/video_generation/{task_id}` and reads successful output from `task.content.url`. Returned URLs are validated before download. Credentials and caller headers are removed for cross-origin CDN downloads and redirects. Empty or non-video responses are rejected.

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -62,6 +62,7 @@
     "@ai-sdk/revai": "workspace:*",
     "@ai-sdk/sandbox-just-bash": "workspace:*",
     "@ai-sdk/sandbox-vercel": "workspace:*",
+    "@ai-sdk/siftq": "workspace:*",
     "@ai-sdk/togetherai": "workspace:*",
     "@ai-sdk/tui": "workspace:*",
     "@ai-sdk/valibot": "workspace:*",

--- a/examples/ai-functions/src/generate-video/siftq/basic.ts
+++ b/examples/ai-functions/src/generate-video/siftq/basic.ts
@@ -1,0 +1,31 @@
+import { siftq, type SiftQVideoModelOptions } from '@ai-sdk/siftq';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { videos, providerMetadata } = await withSpinner(
+    'Generating video...',
+    () =>
+      generateVideo({
+        model: siftq.video(),
+        prompt:
+          'A tiny paper boat crossing a moonlit ocean, cinematic lighting, gentle waves',
+        aspectRatio: '16:9',
+        duration: 6,
+        providerOptions: {
+          siftq: {
+            resolution: '768P',
+          } satisfies SiftQVideoModelOptions,
+        },
+        poll: {
+          intervalMs: 5000,
+          timeoutMs: 900000,
+        },
+      }),
+  );
+
+  console.log('Task ID:', providerMetadata?.siftq?.taskId);
+  await presentVideos(videos);
+});

--- a/examples/ai-functions/src/generate-video/siftq/first-last-frame.ts
+++ b/examples/ai-functions/src/generate-video/siftq/first-last-frame.ts
@@ -1,0 +1,27 @@
+import { siftq } from '@ai-sdk/siftq';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner('Generating video...', () =>
+    generateVideo({
+      model: siftq.video(),
+      prompt: 'Move smoothly from the opening composition to the final frame',
+      frameImages: [
+        {
+          frameType: 'first_frame',
+          image: 'https://example.com/first-frame.png',
+        },
+        {
+          frameType: 'last_frame',
+          image: 'https://example.com/last-frame.png',
+        },
+      ],
+      duration: 6,
+    }),
+  );
+
+  await presentVideos(videos);
+});

--- a/examples/ai-functions/src/generate-video/siftq/image-to-video.ts
+++ b/examples/ai-functions/src/generate-video/siftq/image-to-video.ts
@@ -1,0 +1,20 @@
+import { siftq } from '@ai-sdk/siftq';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner('Generating video...', () =>
+    generateVideo({
+      model: siftq.video(),
+      prompt: {
+        image: 'https://example.com/first-frame.png',
+        text: 'The camera slowly moves forward while the lanterns flicker',
+      },
+      duration: 6,
+    }),
+  );
+
+  await presentVideos(videos);
+});

--- a/examples/ai-functions/src/generate-video/siftq/reference-to-video.ts
+++ b/examples/ai-functions/src/generate-video/siftq/reference-to-video.ts
@@ -1,0 +1,33 @@
+import { siftq, type SiftQVideoModelOptions } from '@ai-sdk/siftq';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner('Generating video...', () =>
+    generateVideo({
+      model: siftq.video(),
+      prompt: 'The character walks through a neon market at night',
+      inputReferences: [
+        {
+          data: 'https://example.com/character.png',
+          mediaType: 'image/png',
+        },
+        {
+          data: 'https://example.com/movement.mp4',
+          mediaType: 'video/mp4',
+        },
+      ],
+      providerOptions: {
+        siftq: {
+          referenceAudioUrls: ['https://example.com/voice-reference.wav'],
+          resolution: '768P',
+          ratio: 'adaptive',
+        } satisfies SiftQVideoModelOptions,
+      },
+    }),
+  );
+
+  await presentVideos(videos);
+});

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -196,6 +196,9 @@
       "path": "../../packages/sandbox-vercel"
     },
     {
+      "path": "../../packages/siftq"
+    },
+    {
       "path": "../../packages/togetherai"
     },
     {

--- a/packages/siftq/CHANGELOG.md
+++ b/packages/siftq/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @ai-sdk/siftq

--- a/packages/siftq/README.md
+++ b/packages/siftq/README.md
@@ -1,0 +1,61 @@
+# AI SDK - SiftQ Provider
+
+The **SiftQ provider** for the [AI SDK](https://ai-sdk.dev/docs) adds asynchronous MiniMax-H3 V2 video generation through SiftQ. The provider has one fixed video model, so callers do not select or pass a model ID.
+
+## Setup
+
+```bash
+npm install @ai-sdk/siftq
+```
+
+Set the API key in your environment:
+
+```bash
+SIFTQ_API_KEY=your-api-key
+```
+
+## Text-to-video
+
+```ts
+import { siftq, type SiftQVideoModelOptions } from '@ai-sdk/siftq';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { video } = await generateVideo({
+  model: siftq.video(),
+  prompt: 'A paper boat crossing a moonlit ocean, cinematic lighting',
+  aspectRatio: '16:9',
+  duration: 6,
+  providerOptions: {
+    siftq: { resolution: '2K' } satisfies SiftQVideoModelOptions,
+  },
+});
+```
+
+## Image-to-video
+
+```ts
+const { video } = await generateVideo({
+  model: siftq.video(),
+  prompt: {
+    image: 'https://example.com/first-frame.png',
+    text: 'The camera slowly moves forward while the lanterns flicker',
+  },
+  duration: 6,
+  poll: { intervalMs: 5000, timeoutMs: 900000 },
+});
+```
+
+## Custom provider instance
+
+```ts
+import { createSiftQ } from '@ai-sdk/siftq';
+
+const siftq = createSiftQ({
+  apiKey: process.env.SIFTQ_API_KEY,
+  baseURL: 'https://siftq.com/api/minimax/',
+});
+```
+
+The final create URL is `https://siftq.com/api/minimax/v2/video_generation` (one slash at the URL boundary).
+
+See the [SiftQ provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers/siftq) for all modes and options.

--- a/packages/siftq/package.json
+++ b/packages/siftq/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@ai-sdk/siftq",
+  "version": "2.0.0",
+  "type": "module",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist *.tsbuildinfo",
+    "type-check": "tsc --build",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:update": "pnpm test:node -u",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@ai-sdk/test-server": "workspace:*",
+    "@types/node": "22.19.19",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "5.8.3",
+    "zod": "3.25.76"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/siftq"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai",
+    "siftq",
+    "video",
+    "text-to-video",
+    "image-to-video"
+  ]
+}

--- a/packages/siftq/src/index.ts
+++ b/packages/siftq/src/index.ts
@@ -1,0 +1,4 @@
+export { createSiftQ, siftq } from './siftq-provider';
+export type { SiftQProvider, SiftQProviderSettings } from './siftq-provider';
+export type { SiftQVideoModelOptions } from './siftq-video-model-options';
+export { VERSION } from './version';

--- a/packages/siftq/src/siftq-provider.test.ts
+++ b/packages/siftq/src/siftq-provider.test.ts
@@ -1,0 +1,92 @@
+import { NoSuchModelError } from '@ai-sdk/provider';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest';
+import { createSiftQ } from './siftq-provider';
+import { SiftQVideoModel } from './siftq-video-model';
+
+const SiftQVideoModelMock = SiftQVideoModel as unknown as Mock;
+
+vi.mock('./siftq-video-model', () => ({
+  SiftQVideoModel: vi.fn().mockImplementation(function (
+    this: any,
+    config: any,
+  ) {
+    this.provider = config.provider;
+    this.modelId = 'MiniMax-H3';
+    this.config = config;
+  }),
+}));
+
+describe('SiftQProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('SIFTQ_API_KEY', 'environment-key');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('creates the fixed MiniMax-H3 model with SiftQ defaults', () => {
+    const model = createSiftQ().video();
+
+    expect(model).toBeInstanceOf(SiftQVideoModel);
+    const [config] = SiftQVideoModelMock.mock.calls[0];
+    expect(config.provider).toBe('siftq.video');
+    expect(config.baseURL).toBe('https://siftq.com/api/minimax');
+    expect(config.headers()).toMatchObject({
+      authorization: 'Bearer environment-key',
+      'user-agent': expect.stringMatching(/^ai-sdk\/siftq\//),
+    });
+  });
+
+  it('supports custom settings and normalizes the boundary slash', () => {
+    const fetch = vi.fn();
+    const provider = createSiftQ({
+      apiKey: 'custom-key',
+      baseURL: 'http://localhost:8787/proxy/',
+      headers: { 'x-project': 'test' },
+      fetch,
+    });
+
+    provider.videoModel();
+    const [config] = SiftQVideoModelMock.mock.calls[0];
+    expect(config.baseURL).toBe('http://localhost:8787/proxy');
+    expect(config.fetch).toBe(fetch);
+    expect(config.headers()).toMatchObject({
+      authorization: 'Bearer custom-key',
+      'x-project': 'test',
+    });
+  });
+
+  it('fails when neither an option nor SIFTQ_API_KEY provides credentials', () => {
+    delete process.env.SIFTQ_API_KEY;
+    const provider = createSiftQ();
+    provider.video();
+    const [config] = SiftQVideoModelMock.mock.calls[0];
+
+    expect(() => config.headers()).toThrow(/SIFTQ_API_KEY/);
+  });
+
+  it.each(['not a url', 'ftp://siftq.com/api/minimax/'])(
+    'rejects invalid base URL configuration: %s',
+    baseURL => {
+      expect(() => createSiftQ({ baseURL })).toThrow(/Invalid SiftQ baseURL/);
+    },
+  );
+
+  it('rejects unsupported model types', () => {
+    const provider = createSiftQ();
+
+    expect(() => provider.languageModel('model')).toThrow(NoSuchModelError);
+    expect(() => provider.embeddingModel('model')).toThrow(NoSuchModelError);
+    expect(() => provider.imageModel('model')).toThrow(NoSuchModelError);
+  });
+});

--- a/packages/siftq/src/siftq-provider.ts
+++ b/packages/siftq/src/siftq-provider.ts
@@ -1,0 +1,117 @@
+import {
+  NoSuchModelError,
+  type Experimental_VideoModelV4,
+  type ProviderV4,
+} from '@ai-sdk/provider';
+import {
+  loadApiKey,
+  withoutTrailingSlash,
+  withUserAgentSuffix,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { SiftQVideoModel } from './siftq-video-model';
+import { VERSION } from './version';
+
+export interface SiftQProviderSettings {
+  /**
+   * SiftQ API key. Defaults to the `SIFTQ_API_KEY` environment variable.
+   */
+  apiKey?: string;
+
+  /**
+   * Base URL for SiftQ MiniMax-compatible API calls.
+   * Defaults to `https://siftq.com/api/minimax/`.
+   */
+  baseURL?: string;
+
+  /**
+   * Custom headers to include in requests.
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Custom fetch implementation for testing or request interception.
+   */
+  fetch?: FetchFunction;
+}
+
+export interface SiftQProvider extends ProviderV4 {
+  /** Creates the fixed MiniMax-H3 video generation model. */
+  video(): Experimental_VideoModelV4;
+
+  /** Creates the fixed MiniMax-H3 video generation model. */
+  videoModel(): Experimental_VideoModelV4;
+}
+
+const defaultBaseURL = 'https://siftq.com/api/minimax/';
+
+function resolveBaseURL(baseURL: string | undefined): string {
+  const normalized = withoutTrailingSlash(baseURL ?? defaultBaseURL);
+  const value = normalized ?? defaultBaseURL;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new TypeError(`Invalid SiftQ baseURL: ${value}`);
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new TypeError(
+      `Invalid SiftQ baseURL protocol: ${parsed.protocol}. Expected http: or https:.`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Creates a SiftQ provider instance.
+ */
+export function createSiftQ(
+  options: SiftQProviderSettings = {},
+): SiftQProvider {
+  const baseURL = resolveBaseURL(options.baseURL);
+
+  const getHeaders = () =>
+    withUserAgentSuffix(
+      {
+        Authorization: `Bearer ${loadApiKey({
+          apiKey: options.apiKey,
+          environmentVariableName: 'SIFTQ_API_KEY',
+          description: 'SiftQ API key',
+        })}`,
+        ...options.headers,
+      },
+      `ai-sdk/siftq/${VERSION}`,
+    );
+
+  const createVideoModel = () => {
+    return new SiftQVideoModel({
+      provider: 'siftq.video',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+  };
+
+  return {
+    specificationVersion: 'v4' as const,
+    languageModel: (modelId: string) => {
+      throw new NoSuchModelError({ modelId, modelType: 'languageModel' });
+    },
+    embeddingModel: (modelId: string) => {
+      throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
+    },
+    imageModel: (modelId: string) => {
+      throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
+    },
+    video: createVideoModel,
+    videoModel: createVideoModel,
+  };
+}
+
+/**
+ * Default SiftQ provider instance.
+ */
+export const siftq = createSiftQ();

--- a/packages/siftq/src/siftq-video-model-options.ts
+++ b/packages/siftq/src/siftq-video-model-options.ts
@@ -1,0 +1,55 @@
+import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+function isSupportedAudioLocation(value: string): boolean {
+  if (/^mm_file:\/\/[^\s/]+$/.test(value)) {
+    return true;
+  }
+  if (/^data:audio\/(wav|x-wav|mp3|mpeg);base64,[a-zA-Z0-9+/=]+$/.test(value)) {
+    return true;
+  }
+
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export type SiftQVideoModelOptions = {
+  /**
+   * Output resolution tier. Defaults to `2K`.
+   */
+  resolution?: '768P' | '2K';
+
+  /**
+   * Output aspect ratio. Frame-based generation always uses `adaptive`.
+   */
+  ratio?: 'adaptive' | '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
+
+  /**
+   * Additional audio references for reference-to-video generation.
+   */
+  referenceAudioUrls?: string[];
+};
+
+export const siftQVideoModelOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      resolution: z.enum(['768P', '2K']).optional(),
+      ratio: z
+        .enum(['adaptive', '21:9', '16:9', '4:3', '1:1', '3:4', '9:16'])
+        .optional(),
+      referenceAudioUrls: z
+        .array(
+          z.string().min(1).refine(isSupportedAudioLocation, {
+            message:
+              'Expected an http(s) URL, audio data URI, or mm_file:// file reference.',
+          }),
+        )
+        .max(3)
+        .optional(),
+    }),
+  ),
+);

--- a/packages/siftq/src/siftq-video-model.test.ts
+++ b/packages/siftq/src/siftq-video-model.test.ts
@@ -1,0 +1,662 @@
+import type { Experimental_VideoModelV4CallOptions } from '@ai-sdk/provider';
+import {
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it } from 'vitest';
+import { SiftQVideoModel } from './siftq-video-model';
+
+const BASE_URL = 'https://siftq.test/api/minimax';
+const CREATE_URL = `${BASE_URL}/v2/video_generation`;
+const STATUS_URL = `${BASE_URL}/v2/query/video_generation/task-123`;
+const CDN_URL = 'https://cdn.siftq.test/video.mp4';
+const MP4_BYTES = Buffer.from([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00,
+  0x00, 0x02, 0x00, 0x69, 0x73, 0x6f, 0x6d, 0x69, 0x73, 0x6f, 0x32,
+]);
+
+const defaultOptions = {
+  prompt: 'A paper boat crossing a moonlit ocean',
+  n: 1,
+  aspectRatio: undefined,
+  resolution: undefined,
+  duration: undefined,
+  fps: undefined,
+  seed: undefined,
+  image: undefined,
+  frameImages: undefined,
+  inputReferences: undefined,
+  generateAudio: undefined,
+  providerOptions: {},
+} satisfies Experimental_VideoModelV4CallOptions;
+
+function createModel({
+  fetch,
+  currentDate,
+  maxRequestBytes,
+}: {
+  fetch?: FetchFunction;
+  currentDate?: () => Date;
+  maxRequestBytes?: number;
+} = {}) {
+  return new SiftQVideoModel({
+    provider: 'siftq.video',
+    baseURL: BASE_URL,
+    headers: () => ({ Authorization: 'Bearer test-key' }),
+    fetch,
+    ...(currentDate != null || maxRequestBytes != null
+      ? { _internal: { currentDate, maxRequestBytes } }
+      : {}),
+  });
+}
+
+const server = createTestServer({
+  [CREATE_URL]: {
+    response: { type: 'json-value', body: { task_id: 'task-123' } },
+  },
+  [STATUS_URL]: {
+    response: {
+      type: 'json-value',
+      body: {
+        task: {
+          id: 'task-123',
+          model: 'MiniMax-H3',
+          status: 'succeeded',
+          content: { url: CDN_URL },
+          resolution: '2K',
+          duration: 5,
+          ratio: '16:9',
+          task_type: 'generation',
+          modality: 'video',
+          usage: { total_seconds: 5, output_seconds: 5 },
+        },
+      },
+    },
+  },
+  [CDN_URL]: {
+    response: {
+      type: 'binary',
+      body: MP4_BYTES,
+      headers: { 'Content-Type': 'video/mp4' },
+    },
+  },
+});
+
+describe('SiftQVideoModel', () => {
+  it('exposes the fixed model and supports workflow serialization', () => {
+    const model = createModel({ fetch: async () => new Response() });
+
+    expect(model.provider).toBe('siftq.video');
+    expect(model.modelId).toBe('MiniMax-H3');
+    expect(model.specificationVersion).toBe('v4');
+    expect(model.maxVideosPerCall).toBe(1);
+
+    const serialized = SiftQVideoModel[WORKFLOW_SERIALIZE](model);
+    expect(serialized).toEqual({
+      modelId: 'MiniMax-H3',
+      config: {
+        provider: 'siftq.video',
+        baseURL: BASE_URL,
+        headers: { Authorization: 'Bearer test-key' },
+      },
+    });
+
+    const restored = SiftQVideoModel[WORKFLOW_DESERIALIZE]({
+      modelId: 'MiniMax-H3',
+      config: serialized.config as {
+        provider: string;
+        baseURL: string;
+        headers: Record<string, string>;
+      },
+    });
+    expect(restored.modelId).toBe('MiniMax-H3');
+  });
+
+  describe('request mapping', () => {
+    it('uses the exact H3 V2 route and default text-to-video body', async () => {
+      const result = await createModel().doStart(defaultOptions);
+
+      expect(server.calls[0].requestUrl).toBe(CREATE_URL);
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'MiniMax-H3',
+        content: [{ type: 'text', text: defaultOptions.prompt }],
+        resolution: '2K',
+        duration: 5,
+        ratio: '16:9',
+      });
+      expect(server.calls[0].requestHeaders).toMatchObject({
+        authorization: 'Bearer test-key',
+        'content-type': 'application/json',
+      });
+      expect(result.operation).toStrictEqual({ taskId: 'task-123' });
+    });
+
+    it('maps provider resolution, ratio, duration, and callback URL', async () => {
+      await createModel().doStart({
+        ...defaultOptions,
+        duration: 15,
+        webhookUrl: 'https://app.test/siftq-callback',
+        providerOptions: {
+          siftq: { resolution: '768P', ratio: '9:16' },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'MiniMax-H3',
+        content: [{ type: 'text', text: defaultOptions.prompt }],
+        resolution: '768P',
+        duration: 15,
+        ratio: '9:16',
+        callback_url: 'https://app.test/siftq-callback',
+      });
+    });
+
+    it('maps first and last frames and forces adaptive ratio', async () => {
+      const result = await createModel().doStart({
+        ...defaultOptions,
+        aspectRatio: '16:9',
+        frameImages: [
+          {
+            frameType: 'first_frame',
+            image: {
+              type: 'file',
+              data: new Uint8Array([137, 80, 78, 71]),
+              mediaType: 'image/png',
+            },
+          },
+          {
+            frameType: 'last_frame',
+            image: {
+              type: 'url',
+              url: 'https://files.test/last.webp',
+              mediaType: 'image/webp',
+            },
+          },
+        ],
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'MiniMax-H3',
+        content: [
+          { type: 'text', text: defaultOptions.prompt },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,iVBORw==' },
+            role: 'first_frame',
+          },
+          {
+            type: 'image_url',
+            image_url: { url: 'https://files.test/last.webp' },
+            role: 'last_frame',
+          },
+        ],
+        resolution: '2K',
+        duration: 5,
+        ratio: 'adaptive',
+      });
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({ feature: 'aspectRatio' }),
+      );
+    });
+
+    it('maps image, video, and audio references with matching roles', async () => {
+      await createModel().doStart({
+        ...defaultOptions,
+        inputReferences: [
+          {
+            type: 'url',
+            url: 'https://files.test/character.jpg',
+            mediaType: 'image/jpeg',
+          },
+          {
+            type: 'url',
+            url: 'https://files.test/motion.mov',
+            mediaType: 'video/quicktime',
+          },
+          {
+            type: 'url',
+            url: 'https://files.test/voice.wav',
+            mediaType: 'audio/wav',
+          },
+        ],
+        providerOptions: {
+          siftq: { referenceAudioUrls: ['mm_file://audio-file-id'] },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'MiniMax-H3',
+        content: [
+          { type: 'text', text: defaultOptions.prompt },
+          {
+            type: 'image_url',
+            image_url: { url: 'https://files.test/character.jpg' },
+            role: 'reference_image',
+          },
+          {
+            type: 'video_url',
+            video_url: { url: 'https://files.test/motion.mov' },
+            role: 'reference_video',
+          },
+          {
+            type: 'audio_url',
+            audio_url: { url: 'https://files.test/voice.wav' },
+            role: 'reference_audio',
+          },
+          {
+            type: 'audio_url',
+            audio_url: { url: 'mm_file://audio-file-id' },
+            role: 'reference_audio',
+          },
+        ],
+        resolution: '2K',
+        duration: 5,
+        ratio: 'adaptive',
+      });
+    });
+
+    it('returns explicit warnings for unsupported generic options', async () => {
+      const result = await createModel().doStart({
+        ...defaultOptions,
+        n: 2,
+        fps: 30,
+        seed: 42,
+        resolution: '1920x1080',
+        generateAudio: false,
+      });
+
+      expect(
+        result.warnings.map(warning =>
+          warning.type === 'unsupported' ? warning.feature : warning.type,
+        ),
+      ).toEqual(['n', 'fps', 'seed', 'generateAudio', 'resolution']);
+    });
+
+    it('maps canonical 2K pixel dimensions to the provider 2K tier', async () => {
+      const result = await createModel().doStart({
+        ...defaultOptions,
+        resolution: '2560x1440',
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        resolution: '2K',
+      });
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({ feature: 'resolution' }),
+      );
+    });
+
+    it.each([4, 15])('accepts duration boundary %s', async duration => {
+      await createModel().doStart({ ...defaultOptions, duration });
+      expect(await server.calls[0].requestBodyJson).toMatchObject({ duration });
+    });
+
+    it.each([3, 4.5, 16])('rejects invalid duration %s', async duration => {
+      await expect(
+        createModel().doStart({ ...defaultOptions, duration }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_INVALID_VIDEO_DURATION' });
+    });
+
+    it('rejects missing and oversized prompts', async () => {
+      await expect(
+        createModel().doStart({ ...defaultOptions, prompt: '   ' }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_INVALID_VIDEO_PROMPT' });
+      await expect(
+        createModel().doStart({ ...defaultOptions, prompt: 'x'.repeat(7001) }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_INVALID_VIDEO_PROMPT' });
+    });
+
+    it('rejects adaptive text ratio and unknown concrete ratios', async () => {
+      await expect(
+        createModel().doStart({ ...defaultOptions, aspectRatio: 'adaptive' }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_INVALID_VIDEO_RATIO' });
+      await expect(
+        createModel().doStart({ ...defaultOptions, aspectRatio: '2:1' }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_INVALID_VIDEO_RATIO' });
+    });
+
+    it('rejects last-frame-only and mixed frame/reference modes', async () => {
+      const lastFrame = {
+        type: 'url' as const,
+        url: 'https://files.test/last.png',
+        mediaType: 'image/png',
+      };
+      await expect(
+        createModel().doStart({
+          ...defaultOptions,
+          frameImages: [{ frameType: 'last_frame', image: lastFrame }],
+        }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_MISSING_FIRST_FRAME' });
+
+      await expect(
+        createModel().doStart({
+          ...defaultOptions,
+          image: lastFrame,
+          inputReferences: [lastFrame],
+        }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_INCOMPATIBLE_VIDEO_INPUTS' });
+    });
+
+    it('rejects unsupported media formats and reference count overflow', async () => {
+      await expect(
+        createModel().doStart({
+          ...defaultOptions,
+          inputReferences: [
+            {
+              type: 'url',
+              url: 'https://files.test/input.gif',
+              mediaType: 'image/gif',
+            },
+          ],
+        }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_UNSUPPORTED_MEDIA_FORMAT' });
+
+      await expect(
+        createModel().doStart({
+          ...defaultOptions,
+          inputReferences: Array.from({ length: 10 }, (_, index) => ({
+            type: 'url' as const,
+            url: `https://files.test/reference-${index}.png`,
+            mediaType: 'image/png',
+          })),
+        }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_TOO_MANY_REFERENCE_IMAGES' });
+    });
+
+    it('rejects unsupported media locations and callback URLs', async () => {
+      await expect(
+        createModel().doStart({
+          ...defaultOptions,
+          inputReferences: [
+            {
+              type: 'url',
+              url: 'file:///private/reference.png',
+              mediaType: 'image/png',
+            },
+          ],
+        }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_INVALID_MEDIA_LOCATION' });
+
+      await expect(
+        createModel().doStart({
+          ...defaultOptions,
+          webhookUrl: 'file:///private/callback',
+        }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_INVALID_CALLBACK_URL' });
+
+      await expect(
+        createModel().doStart({
+          ...defaultOptions,
+          providerOptions: {
+            siftq: { referenceAudioUrls: ['not-a-media-location'] },
+          },
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects null provider options instead of treating them as omission', async () => {
+      await expect(
+        createModel().doStart({
+          ...defaultOptions,
+          providerOptions: {
+            siftq: { resolution: null },
+          },
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('rejects request bodies over the 64 MB transport limit', async () => {
+      await expect(
+        createModel({ maxRequestBytes: 1 }).doStart(defaultOptions),
+      ).rejects.toMatchObject({ name: 'SIFTQ_REQUEST_TOO_LARGE' });
+    });
+
+    it('passes through the SDK webhook factory', async () => {
+      const received = Promise.resolve({ headers: {}, body: {} });
+      await expect(
+        createModel().handleWebhookOption({
+          webhook: async () => ({
+            url: 'https://app.test/webhook',
+            received,
+          }),
+        }),
+      ).resolves.toStrictEqual({
+        webhookUrl: 'https://app.test/webhook',
+        received,
+      });
+    });
+  });
+
+  describe('response handling', () => {
+    it('rejects a missing task id and legacy V1 create envelopes', async () => {
+      server.urls[CREATE_URL].response = {
+        type: 'json-value',
+        body: { task_id: '' },
+      };
+      await expect(createModel().doStart(defaultOptions)).rejects.toMatchObject(
+        {
+          name: 'SIFTQ_VIDEO_GENERATION_ERROR',
+        },
+      );
+
+      server.urls[CREATE_URL].response = {
+        type: 'json-value',
+        body: { base_resp: { status_code: 0 } },
+      };
+      await expect(createModel().doStart(defaultOptions)).rejects.toThrow();
+    });
+
+    it('maps the OpenAI-style error envelope and HTTP status', async () => {
+      server.urls[CREATE_URL].response = {
+        type: 'error',
+        status: 401,
+        body: JSON.stringify({
+          type: 'error',
+          error: {
+            type: 'authorized_error',
+            message: 'invalid SiftQ key',
+            http_code: '401',
+          },
+          request_id: 'request-123',
+        }),
+      };
+
+      await expect(createModel().doStart(defaultOptions)).rejects.toMatchObject(
+        {
+          name: 'AI_APICallError',
+          message: 'invalid SiftQ key',
+          statusCode: 401,
+        },
+      );
+    });
+
+    it('forwards an abort signal to task creation', async () => {
+      const controller = new AbortController();
+      const signals: Array<AbortSignal | null | undefined> = [];
+      const fetch: FetchFunction = async (_url, init) => {
+        signals.push(init?.signal);
+        return new Response(JSON.stringify({ task_id: 'task-123' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      };
+
+      await createModel({ fetch }).doStart({
+        ...defaultOptions,
+        abortSignal: controller.signal,
+      });
+      expect(signals).toStrictEqual([controller.signal]);
+    });
+
+    it.each(['queued', 'running'] as const)(
+      'maps lowercase %s state to pending',
+      async status => {
+        server.urls[STATUS_URL].response = {
+          type: 'json-value',
+          body: {
+            task: {
+              id: 'task-123',
+              model: 'MiniMax-H3',
+              status,
+              task_type: 'generation',
+              modality: 'video',
+            },
+          },
+        };
+
+        await expect(
+          createModel().doStatus({ operation: { taskId: 'task-123' } }),
+        ).resolves.toMatchObject({
+          status: 'pending',
+          providerMetadata: { siftq: { taskId: 'task-123', status } },
+        });
+      },
+    );
+
+    it.each(['failed', 'cancelled'] as const)(
+      'maps lowercase %s state to an error',
+      async status => {
+        server.urls[STATUS_URL].response = {
+          type: 'json-value',
+          body: {
+            task: {
+              id: 'task-123',
+              status,
+              error: { code: '2013', message: 'task stopped' },
+            },
+          },
+        };
+
+        await expect(
+          createModel().doStatus({ operation: { taskId: 'task-123' } }),
+        ).resolves.toMatchObject({
+          status: 'error',
+          error: expect.stringContaining('task stopped'),
+        });
+      },
+    );
+
+    it('downloads task.content.url and returns task metadata', async () => {
+      const date = new Date('2026-08-11T00:00:00Z');
+      const result = await createModel({ currentDate: () => date }).doStatus({
+        operation: { taskId: 'task-123' },
+        headers: { 'x-request': 'request-value' },
+      });
+
+      expect(server.calls[0].requestUrl).toBe(STATUS_URL);
+      expect(result).toMatchObject({
+        status: 'completed',
+        videos: [
+          {
+            type: 'binary',
+            data: new Uint8Array(MP4_BYTES),
+            mediaType: 'video/mp4',
+          },
+        ],
+        providerMetadata: {
+          siftq: {
+            taskId: 'task-123',
+            status: 'succeeded',
+            taskType: 'generation',
+            modality: 'video',
+            resolution: '2K',
+            duration: 5,
+            ratio: '16:9',
+            usage: { total_seconds: 5, output_seconds: 5 },
+            downloadUrl: CDN_URL,
+          },
+        },
+        response: { timestamp: date, modelId: 'MiniMax-H3' },
+      });
+      expect(server.calls[1].requestHeaders).not.toHaveProperty(
+        'authorization',
+      );
+      expect(server.calls[1].requestHeaders).not.toHaveProperty('x-request');
+    });
+
+    it('rejects succeeded tasks without task.content.url', async () => {
+      server.urls[STATUS_URL].response = {
+        type: 'json-value',
+        body: { task: { id: 'task-123', status: 'succeeded' } },
+      };
+
+      await expect(
+        createModel().doStatus({ operation: { taskId: 'task-123' } }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_VIDEO_GENERATION_ERROR' });
+    });
+
+    it('rejects legacy or malformed status envelopes', async () => {
+      server.urls[STATUS_URL].response = {
+        type: 'json-value',
+        body: { status: 'Success', file_id: 'file-123' },
+      };
+      await expect(
+        createModel().doStatus({ operation: { taskId: 'task-123' } }),
+      ).rejects.toThrow();
+
+      await expect(
+        createModel().doStatus({ operation: { taskId: '' } }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_INVALID_VIDEO_OPERATION' });
+    });
+
+    it('rejects empty and non-video downloads', async () => {
+      server.urls[CDN_URL].response = {
+        type: 'binary',
+        body: Buffer.alloc(0),
+        headers: { 'Content-Type': 'video/mp4' },
+      };
+      await expect(
+        createModel().doStatus({ operation: { taskId: 'task-123' } }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_EMPTY_VIDEO_RESULT' });
+
+      server.urls[CDN_URL].response = {
+        type: 'binary',
+        body: Buffer.from('{"not":"video"}'),
+        headers: { 'Content-Type': 'application/json' },
+      };
+      await expect(
+        createModel().doStatus({ operation: { taskId: 'task-123' } }),
+      ).rejects.toMatchObject({ name: 'SIFTQ_INVALID_VIDEO_RESULT' });
+    });
+
+    it('maps status and download failures', async () => {
+      server.urls[STATUS_URL].response = {
+        type: 'error',
+        status: 500,
+        body: JSON.stringify({
+          type: 'error',
+          error: { type: 'server_error', message: 'status unavailable' },
+        }),
+      };
+      await expect(
+        createModel().doStatus({ operation: { taskId: 'task-123' } }),
+      ).rejects.toMatchObject({
+        name: 'AI_APICallError',
+        message: 'status unavailable',
+      });
+
+      server.urls[STATUS_URL].response = {
+        type: 'json-value',
+        body: {
+          task: { status: 'succeeded', content: { url: CDN_URL } },
+        },
+      };
+      server.urls[CDN_URL].response = {
+        type: 'error',
+        status: 502,
+        body: JSON.stringify({
+          type: 'error',
+          error: { type: 'server_error', message: 'download unavailable' },
+        }),
+      };
+      await expect(
+        createModel().doStatus({ operation: { taskId: 'task-123' } }),
+      ).rejects.toMatchObject({
+        name: 'AI_APICallError',
+        message: 'download unavailable',
+      });
+    });
+  });
+});

--- a/packages/siftq/src/siftq-video-model.test.ts
+++ b/packages/siftq/src/siftq-video-model.test.ts
@@ -36,18 +36,22 @@ function createModel({
   fetch,
   currentDate,
   maxRequestBytes,
+  maxDownloadBytes,
 }: {
   fetch?: FetchFunction;
   currentDate?: () => Date;
   maxRequestBytes?: number;
+  maxDownloadBytes?: number;
 } = {}) {
   return new SiftQVideoModel({
     provider: 'siftq.video',
     baseURL: BASE_URL,
     headers: () => ({ Authorization: 'Bearer test-key' }),
     fetch,
-    ...(currentDate != null || maxRequestBytes != null
-      ? { _internal: { currentDate, maxRequestBytes } }
+    ...(currentDate != null ||
+    maxRequestBytes != null ||
+    maxDownloadBytes != null
+      ? { _internal: { currentDate, maxRequestBytes, maxDownloadBytes } }
       : {}),
   });
 }
@@ -85,7 +89,7 @@ const server = createTestServer({
 });
 
 describe('SiftQVideoModel', () => {
-  it('exposes the fixed model and supports workflow serialization', () => {
+  it('exposes the fixed model and securely supports workflow serialization', async () => {
     const model = createModel({ fetch: async () => new Response() });
 
     expect(model.provider).toBe('siftq.video');
@@ -99,19 +103,28 @@ describe('SiftQVideoModel', () => {
       config: {
         provider: 'siftq.video',
         baseURL: BASE_URL,
-        headers: { Authorization: 'Bearer test-key' },
       },
     });
+    expect(JSON.stringify(serialized)).not.toContain('test-key');
+    expect(serialized.config).not.toHaveProperty('headers');
+    expect(serialized.config).not.toHaveProperty('fetch');
 
     const restored = SiftQVideoModel[WORKFLOW_DESERIALIZE]({
       modelId: 'MiniMax-H3',
       config: serialized.config as {
         provider: string;
         baseURL: string;
-        headers: Record<string, string>;
       },
     });
     expect(restored.modelId).toBe('MiniMax-H3');
+
+    await restored.doStart({
+      ...defaultOptions,
+      headers: { Authorization: 'Bearer runtime-key' },
+    });
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      authorization: 'Bearer runtime-key',
+    });
   });
 
   describe('request mapping', () => {
@@ -619,6 +632,62 @@ describe('SiftQVideoModel', () => {
       await expect(
         createModel().doStatus({ operation: { taskId: 'task-123' } }),
       ).rejects.toMatchObject({ name: 'SIFTQ_INVALID_VIDEO_RESULT' });
+    });
+
+    it('rejects downloads whose Content-Length exceeds the limit', async () => {
+      const fetch: FetchFunction = async (input, init) => {
+        const url = input instanceof Request ? input.url : input.toString();
+        if (url !== CDN_URL) {
+          return globalThis.fetch(input, init);
+        }
+
+        return new Response(MP4_BYTES, {
+          headers: {
+            'Content-Type': 'video/mp4',
+            'Content-Length': String(MP4_BYTES.byteLength),
+          },
+        });
+      };
+
+      await expect(
+        createModel({
+          fetch,
+          maxDownloadBytes: MP4_BYTES.byteLength - 1,
+        }).doStatus({ operation: { taskId: 'task-123' } }),
+      ).rejects.toMatchObject({
+        name: 'AI_APICallError',
+        cause: { name: 'AI_DownloadError' },
+      });
+    });
+
+    it('rejects streamed downloads that exceed the limit', async () => {
+      const fetch: FetchFunction = async (input, init) => {
+        const url = input instanceof Request ? input.url : input.toString();
+        if (url !== CDN_URL) {
+          return globalThis.fetch(input, init);
+        }
+
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(MP4_BYTES.subarray(0, 12));
+              controller.enqueue(MP4_BYTES.subarray(12));
+              controller.close();
+            },
+          }),
+          { headers: { 'Content-Type': 'video/mp4' } },
+        );
+      };
+
+      await expect(
+        createModel({
+          fetch,
+          maxDownloadBytes: MP4_BYTES.byteLength - 1,
+        }).doStatus({ operation: { taskId: 'task-123' } }),
+      ).rejects.toMatchObject({
+        name: 'AI_APICallError',
+        cause: { name: 'AI_DownloadError' },
+      });
     });
 
     it('maps status and download failures', async () => {

--- a/packages/siftq/src/siftq-video-model.ts
+++ b/packages/siftq/src/siftq-video-model.ts
@@ -1,0 +1,746 @@
+import {
+  AISDKError,
+  type Experimental_VideoModelV4 as VideoModelV4,
+  type Experimental_VideoModelV4CallOptions as VideoModelV4CallOptions,
+  type Experimental_VideoModelV4File as VideoModelV4File,
+  type Experimental_VideoModelV4OperationStartResult as VideoModelV4OperationStartResult,
+  type Experimental_VideoModelV4OperationStatusResult as VideoModelV4OperationStatusResult,
+  type SharedV4Warning,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertImageModelFileToDataUri,
+  createBinaryResponseHandler,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  detectMediaType,
+  getFromApi,
+  getTopLevelMediaType,
+  parseProviderOptions,
+  postJsonToApi,
+  resolve,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+  type FetchFunction,
+  type Resolvable,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import {
+  siftQVideoModelOptionsSchema,
+  type SiftQVideoModelOptions,
+} from './siftq-video-model-options';
+
+interface SiftQVideoModelConfig {
+  provider: string;
+  baseURL: string;
+  headers?: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+    maxRequestBytes?: number;
+  };
+}
+
+type SiftQVideoOperation = {
+  taskId: string;
+};
+
+type SiftQContentItem =
+  | { type: 'text'; text: string }
+  | {
+      type: 'image_url';
+      image_url: { url: string };
+      role: 'first_frame' | 'last_frame' | 'reference_image';
+    }
+  | {
+      type: 'video_url';
+      video_url: { url: string };
+      role: 'reference_video';
+    }
+  | {
+      type: 'audio_url';
+      audio_url: { url: string };
+      role: 'reference_audio';
+    };
+
+const MODEL_ID = 'MiniMax-H3' as const;
+const DEFAULT_DURATION = 5;
+const DEFAULT_RESOLUTION = '2K' as const;
+const DEFAULT_TEXT_RATIO = '16:9' as const;
+const MAX_PROMPT_LENGTH = 7000;
+const MAX_REQUEST_BYTES = 64 * 1024 * 1024;
+const MAX_REFERENCE_IMAGES = 9;
+const MAX_REFERENCE_VIDEOS = 3;
+const MAX_REFERENCE_AUDIOS = 3;
+
+const supportedRatios = new Set([
+  'adaptive',
+  '21:9',
+  '16:9',
+  '4:3',
+  '1:1',
+  '3:4',
+  '9:16',
+]);
+const supportedImageTypes = new Set([
+  'image/jpg',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+]);
+const supportedVideoTypes = new Set(['video/mp4', 'video/quicktime']);
+const supportedAudioTypes = new Set([
+  'audio/wav',
+  'audio/x-wav',
+  'audio/mp3',
+  'audio/mpeg',
+]);
+const twoKPixelResolutions = new Set([
+  '2048x2048',
+  '2560x1080',
+  '2560x1440',
+  '2048x1536',
+  '1440x2560',
+  '1536x2048',
+]);
+
+function apiError(name: string, message: string): AISDKError {
+  return new AISDKError({ name, message });
+}
+
+function topLevelMediaType(file: VideoModelV4File): string | undefined {
+  return file.mediaType == null
+    ? undefined
+    : getTopLevelMediaType(file.mediaType);
+}
+
+function validateMediaFile(
+  file: VideoModelV4File,
+  kind: 'image' | 'video' | 'audio',
+): void {
+  if (file.type === 'url') {
+    let supportedLocation = /^mm_file:\/\/[^\s/]+$/.test(file.url);
+    if (!supportedLocation) {
+      try {
+        const url = new URL(file.url);
+        supportedLocation =
+          url.protocol === 'http:' || url.protocol === 'https:';
+      } catch {
+        supportedLocation = false;
+      }
+    }
+    if (!supportedLocation) {
+      throw apiError(
+        'SIFTQ_INVALID_MEDIA_LOCATION',
+        'SiftQ media locations must use http(s) or mm_file://.',
+      );
+    }
+  }
+
+  const topLevelType = topLevelMediaType(file);
+  if (topLevelType != null && topLevelType !== kind) {
+    throw apiError(
+      'SIFTQ_INVALID_REFERENCE_MEDIA',
+      `SiftQ expected a ${kind} input, but received ${file.mediaType}.`,
+    );
+  }
+
+  const mediaType = file.mediaType?.split(';', 1)[0].toLowerCase();
+  const supportedTypes =
+    kind === 'image'
+      ? supportedImageTypes
+      : kind === 'video'
+        ? supportedVideoTypes
+        : supportedAudioTypes;
+  if (mediaType != null && !supportedTypes.has(mediaType)) {
+    throw apiError(
+      'SIFTQ_UNSUPPORTED_MEDIA_FORMAT',
+      `SiftQ does not support ${mediaType} as a ${kind} input.`,
+    );
+  }
+
+  if (file.type === 'file') {
+    const size =
+      typeof file.data === 'string'
+        ? Math.floor(file.data.replace(/\s/g, '').length * 0.75)
+        : file.data.byteLength;
+    const limit =
+      kind === 'image'
+        ? 30 * 1024 * 1024
+        : kind === 'video'
+          ? 50 * 1024 * 1024
+          : 15 * 1024 * 1024;
+    if (size > limit) {
+      throw apiError(
+        'SIFTQ_MEDIA_TOO_LARGE',
+        `SiftQ ${kind} inputs must not exceed ${limit / 1024 / 1024} MB.`,
+      );
+    }
+  }
+}
+
+function assertRequestSize(
+  body: Record<string, unknown>,
+  maxRequestBytes = MAX_REQUEST_BYTES,
+): void {
+  const bodySize = new TextEncoder().encode(JSON.stringify(body)).byteLength;
+  if (bodySize > maxRequestBytes) {
+    throw apiError(
+      'SIFTQ_REQUEST_TOO_LARGE',
+      'SiftQ request bodies must not exceed 64 MB.',
+    );
+  }
+}
+
+export class SiftQVideoModel implements VideoModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly maxVideosPerCall = 1;
+  readonly modelId = MODEL_ID;
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  static [WORKFLOW_SERIALIZE](model: SiftQVideoModel) {
+    return serializeModelOptions({
+      modelId: MODEL_ID,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId?: string;
+    config: SiftQVideoModelConfig;
+  }) {
+    return new SiftQVideoModel(options.config);
+  }
+
+  constructor(private readonly config: SiftQVideoModelConfig) {}
+
+  async handleWebhookOption(
+    options: Parameters<NonNullable<VideoModelV4['handleWebhookOption']>>[0],
+  ) {
+    const { url, received } = await options.webhook();
+    return { webhookUrl: url, received };
+  }
+
+  private async buildRequestBody(options: VideoModelV4CallOptions): Promise<{
+    body: Record<string, unknown>;
+    warnings: SharedV4Warning[];
+  }> {
+    const warnings: SharedV4Warning[] = [];
+    const siftQOptions = (await parseProviderOptions({
+      provider: 'siftq',
+      providerOptions: options.providerOptions,
+      schema: siftQVideoModelOptionsSchema,
+    })) as SiftQVideoModelOptions | undefined;
+
+    if (options.n > 1) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'n',
+        details:
+          'SiftQ creates one video per task. Only one video will be generated.',
+      });
+    }
+    if (options.fps != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'fps',
+        details: 'MiniMax-H3 does not accept a custom output frame rate.',
+      });
+    }
+    if (options.seed != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'seed',
+        details: 'MiniMax-H3 does not accept a deterministic seed.',
+      });
+    }
+    if (options.generateAudio != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'generateAudio',
+        details:
+          'MiniMax-H3 V2 does not expose a generate_audio request field.',
+      });
+    }
+    let resolution = siftQOptions?.resolution ?? undefined;
+    if (options.resolution != null) {
+      const mappedResolution = twoKPixelResolutions.has(options.resolution)
+        ? '2K'
+        : undefined;
+      if (resolution == null && mappedResolution != null) {
+        resolution = mappedResolution;
+      } else if (
+        mappedResolution == null ||
+        (resolution != null && mappedResolution !== resolution)
+      ) {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'resolution',
+          details:
+            'SiftQ accepts named tiers (768P or 2K). The pixel resolution could not be honored; use providerOptions.siftq.resolution.',
+        });
+      }
+    }
+
+    const prompt = options.prompt ?? '';
+    if (prompt.trim().length === 0) {
+      throw apiError(
+        'SIFTQ_INVALID_VIDEO_PROMPT',
+        'MiniMax-H3 requires a non-empty text prompt.',
+      );
+    }
+    if (prompt.length > MAX_PROMPT_LENGTH) {
+      throw apiError(
+        'SIFTQ_INVALID_VIDEO_PROMPT',
+        `MiniMax-H3 prompts must not exceed ${MAX_PROMPT_LENGTH} characters.`,
+      );
+    }
+
+    const duration = options.duration ?? DEFAULT_DURATION;
+    if (!Number.isInteger(duration) || duration < 4 || duration > 15) {
+      throw apiError(
+        'SIFTQ_INVALID_VIDEO_DURATION',
+        'MiniMax-H3 duration must be an integer from 4 through 15 seconds.',
+      );
+    }
+
+    const firstFrames =
+      options.frameImages?.filter(frame => frame.frameType === 'first_frame') ??
+      [];
+    const lastFrames =
+      options.frameImages?.filter(frame => frame.frameType === 'last_frame') ??
+      [];
+    if (firstFrames.length > 1 || lastFrames.length > 1) {
+      throw apiError(
+        'SIFTQ_INVALID_FRAME_IMAGES',
+        'MiniMax-H3 accepts at most one first frame and one last frame.',
+      );
+    }
+
+    const firstFrame = firstFrames[0]?.image ?? options.image;
+    const lastFrame = lastFrames[0]?.image;
+    if (lastFrame != null && firstFrame == null) {
+      throw apiError(
+        'SIFTQ_MISSING_FIRST_FRAME',
+        'MiniMax-H3 requires a first frame when a last frame is provided.',
+      );
+    }
+
+    const hasFrameMode = firstFrame != null || lastFrame != null;
+    const hasReferenceInputs =
+      (options.inputReferences?.length ?? 0) > 0 ||
+      (siftQOptions?.referenceAudioUrls?.length ?? 0) > 0;
+    if (hasFrameMode && hasReferenceInputs) {
+      throw apiError(
+        'SIFTQ_INCOMPATIBLE_VIDEO_INPUTS',
+        'MiniMax-H3 frame inputs and reference inputs are mutually exclusive.',
+      );
+    }
+
+    const content: SiftQContentItem[] = [{ type: 'text', text: prompt }];
+    if (firstFrame != null) {
+      validateMediaFile(firstFrame, 'image');
+      content.push({
+        type: 'image_url',
+        image_url: { url: convertImageModelFileToDataUri(firstFrame) },
+        role: 'first_frame',
+      });
+    }
+    if (lastFrame != null) {
+      validateMediaFile(lastFrame, 'image');
+      content.push({
+        type: 'image_url',
+        image_url: { url: convertImageModelFileToDataUri(lastFrame) },
+        role: 'last_frame',
+      });
+    }
+
+    let referenceImageCount = 0;
+    let referenceVideoCount = 0;
+    let referenceAudioCount = 0;
+    for (const reference of options.inputReferences ?? []) {
+      const mediaType = topLevelMediaType(reference);
+      if (mediaType === 'video') {
+        validateMediaFile(reference, 'video');
+        referenceVideoCount++;
+        content.push({
+          type: 'video_url',
+          video_url: { url: convertImageModelFileToDataUri(reference) },
+          role: 'reference_video',
+        });
+      } else if (mediaType === 'audio') {
+        validateMediaFile(reference, 'audio');
+        referenceAudioCount++;
+        content.push({
+          type: 'audio_url',
+          audio_url: { url: convertImageModelFileToDataUri(reference) },
+          role: 'reference_audio',
+        });
+      } else if (mediaType === 'image' || mediaType == null) {
+        if (mediaType == null) {
+          warnings.push({
+            type: 'unsupported',
+            feature: 'inputReferences',
+            details:
+              'An untyped SiftQ input reference was treated as an image. Set mediaType to route it explicitly.',
+          });
+        }
+        validateMediaFile(reference, 'image');
+        referenceImageCount++;
+        content.push({
+          type: 'image_url',
+          image_url: { url: convertImageModelFileToDataUri(reference) },
+          role: 'reference_image',
+        });
+      } else {
+        throw apiError(
+          'SIFTQ_INVALID_REFERENCE_MEDIA',
+          `MiniMax-H3 does not support ${reference.mediaType} references.`,
+        );
+      }
+    }
+
+    for (const url of siftQOptions?.referenceAudioUrls ?? []) {
+      referenceAudioCount++;
+      content.push({
+        type: 'audio_url',
+        audio_url: { url },
+        role: 'reference_audio',
+      });
+    }
+
+    if (referenceImageCount > MAX_REFERENCE_IMAGES) {
+      throw apiError(
+        'SIFTQ_TOO_MANY_REFERENCE_IMAGES',
+        `MiniMax-H3 accepts at most ${MAX_REFERENCE_IMAGES} reference images.`,
+      );
+    }
+    if (referenceVideoCount > MAX_REFERENCE_VIDEOS) {
+      throw apiError(
+        'SIFTQ_TOO_MANY_REFERENCE_VIDEOS',
+        `MiniMax-H3 accepts at most ${MAX_REFERENCE_VIDEOS} reference videos.`,
+      );
+    }
+    if (referenceAudioCount > MAX_REFERENCE_AUDIOS) {
+      throw apiError(
+        'SIFTQ_TOO_MANY_REFERENCE_AUDIOS',
+        `MiniMax-H3 accepts at most ${MAX_REFERENCE_AUDIOS} reference audios.`,
+      );
+    }
+
+    const optionRatio = siftQOptions?.ratio ?? undefined;
+    if (
+      optionRatio != null &&
+      options.aspectRatio != null &&
+      optionRatio !== options.aspectRatio
+    ) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'aspectRatio',
+        details:
+          'providerOptions.siftq.ratio takes precedence over the generic aspectRatio option.',
+      });
+    }
+    const requestedRatio = optionRatio ?? options.aspectRatio;
+    if (requestedRatio != null && !supportedRatios.has(requestedRatio)) {
+      throw apiError(
+        'SIFTQ_INVALID_VIDEO_RATIO',
+        `MiniMax-H3 does not support the ${requestedRatio} ratio.`,
+      );
+    }
+
+    const hasReferenceMode =
+      referenceImageCount + referenceVideoCount + referenceAudioCount > 0;
+    let ratio: string;
+    if (hasFrameMode) {
+      ratio = 'adaptive';
+      if (requestedRatio != null && requestedRatio !== 'adaptive') {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'aspectRatio',
+          details:
+            'MiniMax-H3 derives frame-based output ratio from the input image. The requested ratio was ignored.',
+        });
+      }
+    } else if (hasReferenceMode) {
+      ratio = requestedRatio ?? 'adaptive';
+    } else {
+      ratio = requestedRatio ?? DEFAULT_TEXT_RATIO;
+      if (ratio === 'adaptive') {
+        throw apiError(
+          'SIFTQ_INVALID_VIDEO_RATIO',
+          'MiniMax-H3 text-to-video generation requires a concrete ratio.',
+        );
+      }
+    }
+
+    const body: Record<string, unknown> = {
+      model: MODEL_ID,
+      content,
+      resolution: resolution ?? DEFAULT_RESOLUTION,
+      duration,
+      ratio,
+    };
+    assertRequestSize(body, this.config._internal?.maxRequestBytes);
+    return { body, warnings };
+  }
+
+  async doStart(
+    options: Parameters<NonNullable<VideoModelV4['doStart']>>[0],
+  ): Promise<VideoModelV4OperationStartResult> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const { body, warnings } = await this.buildRequestBody(options);
+    if (options.webhookUrl != null) {
+      let callbackUrl: URL;
+      try {
+        callbackUrl = new URL(options.webhookUrl);
+      } catch {
+        throw apiError(
+          'SIFTQ_INVALID_CALLBACK_URL',
+          'SiftQ callback_url must be an absolute http(s) URL.',
+        );
+      }
+      if (
+        callbackUrl.protocol !== 'http:' &&
+        callbackUrl.protocol !== 'https:'
+      ) {
+        throw apiError(
+          'SIFTQ_INVALID_CALLBACK_URL',
+          'SiftQ callback_url must be an absolute http(s) URL.',
+        );
+      }
+      body.callback_url = options.webhookUrl;
+      assertRequestSize(body, this.config._internal?.maxRequestBytes);
+    }
+
+    const { value, responseHeaders } = await postJsonToApi({
+      url: `${this.config.baseURL}/v2/video_generation`,
+      headers: combineHeaders(
+        await resolve(this.config.headers ?? {}),
+        options.headers,
+      ),
+      body,
+      failedResponseHandler: siftQFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        siftQCreateResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const taskId = value.task_id?.trim();
+    if (!taskId) {
+      throw apiError(
+        'SIFTQ_VIDEO_GENERATION_ERROR',
+        'SiftQ did not return a task_id for the video generation request.',
+      );
+    }
+
+    return {
+      operation: { taskId } satisfies SiftQVideoOperation,
+      warnings,
+      providerMetadata: { siftq: { taskId } },
+      response: {
+        timestamp: currentDate,
+        modelId: MODEL_ID,
+        headers: responseHeaders,
+      },
+    };
+  }
+
+  async doStatus(
+    options: Parameters<NonNullable<VideoModelV4['doStatus']>>[0],
+  ): Promise<VideoModelV4OperationStatusResult> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const operation = siftQOperationSchema.safeParse(options.operation);
+    if (!operation.success || operation.data.taskId.trim().length === 0) {
+      throw apiError(
+        'SIFTQ_INVALID_VIDEO_OPERATION',
+        'SiftQ video status requires an operation containing a non-empty taskId.',
+      );
+    }
+
+    const taskId = operation.data.taskId;
+    const headers = combineHeaders(
+      await resolve(this.config.headers ?? {}),
+      options.headers,
+    );
+    const { value, responseHeaders } = await getFromApi({
+      url: `${this.config.baseURL}/v2/query/video_generation/${encodeURIComponent(taskId)}`,
+      validateUrl: false,
+      headers,
+      failedResponseHandler: siftQFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        siftQStatusResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const task = value.task;
+    const response = {
+      timestamp: currentDate,
+      modelId: MODEL_ID,
+      headers: responseHeaders,
+    };
+    const providerMetadata = {
+      siftq: {
+        taskId,
+        status: task.status,
+        ...(task.task_type != null ? { taskType: task.task_type } : {}),
+        ...(task.modality != null ? { modality: task.modality } : {}),
+        ...(task.resolution != null ? { resolution: task.resolution } : {}),
+        ...(task.duration != null ? { duration: task.duration } : {}),
+        ...(task.ratio != null ? { ratio: task.ratio } : {}),
+        ...(task.usage != null ? { usage: task.usage } : {}),
+      },
+    };
+
+    if (task.status === 'queued' || task.status === 'running') {
+      return { status: 'pending', providerMetadata, response };
+    }
+
+    if (task.status === 'failed' || task.status === 'cancelled') {
+      const reason =
+        task.error?.message ??
+        task.error?.code ??
+        (task.status === 'cancelled'
+          ? 'The task was cancelled.'
+          : 'The task failed without an error message.');
+      return {
+        status: 'error',
+        error: `SiftQ video generation ${task.status}. Task ID: ${taskId}. ${reason}`,
+        providerMetadata,
+        response,
+      };
+    }
+
+    const downloadUrl = task.content?.url?.trim();
+    if (!downloadUrl) {
+      throw apiError(
+        'SIFTQ_VIDEO_GENERATION_ERROR',
+        `SiftQ succeeded task ${taskId} without task.content.url.`,
+      );
+    }
+
+    const { value: videoData, responseHeaders: downloadHeaders } =
+      await getFromApi({
+        url: downloadUrl,
+        validateUrl: true,
+        trustedOrigin: this.config.baseURL,
+        credentialedOrigin: this.config.baseURL,
+        headers,
+        failedResponseHandler: siftQFailedResponseHandler,
+        successfulResponseHandler: createBinaryResponseHandler(),
+        abortSignal: options.abortSignal,
+        fetch: this.config.fetch,
+      });
+
+    if (videoData.byteLength === 0) {
+      throw apiError(
+        'SIFTQ_EMPTY_VIDEO_RESULT',
+        `SiftQ returned an empty video for task ${taskId}.`,
+      );
+    }
+
+    const contentType = downloadHeaders?.['content-type']?.split(';', 1)[0];
+    const detectedMediaType = detectMediaType({
+      data: videoData,
+      topLevelType: 'video',
+    });
+    const mediaType =
+      contentType?.startsWith('video/') === true
+        ? contentType
+        : detectedMediaType;
+    if (mediaType == null) {
+      throw apiError(
+        'SIFTQ_INVALID_VIDEO_RESULT',
+        `SiftQ returned a non-video result for task ${taskId}${
+          contentType == null ? '' : ` (content-type: ${contentType})`
+        }.`,
+      );
+    }
+
+    return {
+      status: 'completed',
+      videos: [{ type: 'binary', data: videoData, mediaType }],
+      warnings: [],
+      providerMetadata: {
+        siftq: { ...providerMetadata.siftq, downloadUrl },
+      },
+      response: {
+        ...response,
+        headers: downloadHeaders ?? responseHeaders,
+      },
+    };
+  }
+}
+
+const siftQOperationSchema = z.object({
+  taskId: z.string(),
+});
+
+const siftQCreateResponseSchema = z.object({
+  task_id: z.string().nullish(),
+});
+
+const siftQUsageSchema = z
+  .object({
+    total_seconds: z.number().nullish(),
+    input_seconds: z.number().nullish(),
+    output_seconds: z.number().nullish(),
+    input_image_count: z.number().nullish(),
+  })
+  .nullish();
+
+const siftQStatusResponseSchema = z.object({
+  task: z.object({
+    id: z.string().nullish(),
+    model: z.string().nullish(),
+    status: z.enum(['queued', 'running', 'succeeded', 'failed', 'cancelled']),
+    error: z
+      .object({
+        code: z.string().nullish(),
+        message: z.string().nullish(),
+      })
+      .nullish(),
+    created_at: z.number().nullish(),
+    updated_at: z.number().nullish(),
+    content: z
+      .object({
+        url: z.string().nullish(),
+      })
+      .nullish(),
+    resolution: z.string().nullish(),
+    duration: z.number().nullish(),
+    ratio: z.string().nullish(),
+    task_type: z
+      .enum(['generation', 'h3_context_ir', 'regeneration'])
+      .nullish(),
+    modality: z.enum(['video', 'text']).nullish(),
+    usage: siftQUsageSchema,
+  }),
+});
+
+const siftQErrorSchema = z.object({
+  type: z.string().nullish(),
+  error: z
+    .object({
+      type: z.string().nullish(),
+      message: z.string().nullish(),
+      http_code: z.union([z.string(), z.number()]).nullish(),
+    })
+    .nullish(),
+  request_id: z.string().nullish(),
+});
+
+const siftQFailedResponseHandler = createJsonErrorResponseHandler({
+  errorSchema: siftQErrorSchema,
+  errorToMessage: data => data.error?.message ?? 'SiftQ API request failed',
+});

--- a/packages/siftq/src/siftq-video-model.ts
+++ b/packages/siftq/src/siftq-video-model.ts
@@ -10,16 +10,18 @@ import {
 import {
   combineHeaders,
   convertImageModelFileToDataUri,
-  createBinaryResponseHandler,
   createJsonErrorResponseHandler,
   createJsonResponseHandler,
   detectMediaType,
   getFromApi,
   getTopLevelMediaType,
+  loadApiKey,
   parseProviderOptions,
   postJsonToApi,
+  readResponseWithSizeLimit,
   resolve,
   serializeModelOptions,
+  withUserAgentSuffix,
   WORKFLOW_DESERIALIZE,
   WORKFLOW_SERIALIZE,
   type FetchFunction,
@@ -30,6 +32,7 @@ import {
   siftQVideoModelOptionsSchema,
   type SiftQVideoModelOptions,
 } from './siftq-video-model-options';
+import { VERSION } from './version';
 
 interface SiftQVideoModelConfig {
   provider: string;
@@ -39,6 +42,7 @@ interface SiftQVideoModelConfig {
   _internal?: {
     currentDate?: () => Date;
     maxRequestBytes?: number;
+    maxDownloadBytes?: number;
   };
 }
 
@@ -70,6 +74,7 @@ const DEFAULT_RESOLUTION = '2K' as const;
 const DEFAULT_TEXT_RATIO = '16:9' as const;
 const MAX_PROMPT_LENGTH = 7000;
 const MAX_REQUEST_BYTES = 64 * 1024 * 1024;
+const MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024;
 const MAX_REFERENCE_IMAGES = 9;
 const MAX_REFERENCE_VIDEOS = 3;
 const MAX_REFERENCE_AUDIOS = 3;
@@ -205,9 +210,16 @@ export class SiftQVideoModel implements VideoModelV4 {
   }
 
   static [WORKFLOW_SERIALIZE](model: SiftQVideoModel) {
+    const config: Pick<SiftQVideoModelConfig, 'provider' | 'baseURL'> & {
+      headers?: SiftQVideoModelConfig['headers'];
+    } = {
+      provider: model.config.provider,
+      baseURL: model.config.baseURL,
+    };
+
     return serializeModelOptions({
       modelId: MODEL_ID,
-      config: model.config,
+      config,
     });
   }
 
@@ -219,6 +231,31 @@ export class SiftQVideoModel implements VideoModelV4 {
   }
 
   constructor(private readonly config: SiftQVideoModelConfig) {}
+
+  private async getRequestHeaders(
+    requestHeaders?: Record<string, string | undefined>,
+  ): Promise<Record<string, string | undefined>> {
+    if (this.config.headers != null) {
+      return combineHeaders(await resolve(this.config.headers), requestHeaders);
+    }
+
+    const headers = new Headers(requestHeaders as HeadersInit | undefined);
+    if (!headers.has('authorization')) {
+      headers.set(
+        'authorization',
+        `Bearer ${loadApiKey({
+          apiKey: undefined,
+          environmentVariableName: 'SIFTQ_API_KEY',
+          description: 'SiftQ API key',
+        })}`,
+      );
+    }
+
+    return withUserAgentSuffix(
+      Object.fromEntries(headers.entries()),
+      `ai-sdk/siftq/${VERSION}`,
+    );
+  }
 
   async handleWebhookOption(
     options: Parameters<NonNullable<VideoModelV4['handleWebhookOption']>>[0],
@@ -521,10 +558,7 @@ export class SiftQVideoModel implements VideoModelV4 {
 
     const { value, responseHeaders } = await postJsonToApi({
       url: `${this.config.baseURL}/v2/video_generation`,
-      headers: combineHeaders(
-        await resolve(this.config.headers ?? {}),
-        options.headers,
-      ),
+      headers: await this.getRequestHeaders(options.headers),
       body,
       failedResponseHandler: siftQFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
@@ -567,10 +601,7 @@ export class SiftQVideoModel implements VideoModelV4 {
     }
 
     const taskId = operation.data.taskId;
-    const headers = combineHeaders(
-      await resolve(this.config.headers ?? {}),
-      options.headers,
-    );
+    const headers = await this.getRequestHeaders(options.headers);
     const { value, responseHeaders } = await getFromApi({
       url: `${this.config.baseURL}/v2/query/video_generation/${encodeURIComponent(taskId)}`,
       validateUrl: false,
@@ -637,7 +668,15 @@ export class SiftQVideoModel implements VideoModelV4 {
         credentialedOrigin: this.config.baseURL,
         headers,
         failedResponseHandler: siftQFailedResponseHandler,
-        successfulResponseHandler: createBinaryResponseHandler(),
+        successfulResponseHandler: async ({ response, url }) => ({
+          value: await readResponseWithSizeLimit({
+            response,
+            url,
+            maxBytes:
+              this.config._internal?.maxDownloadBytes ?? MAX_DOWNLOAD_BYTES,
+          }),
+          responseHeaders: Object.fromEntries(response.headers.entries()),
+        }),
         abortSignal: options.abortSignal,
         fetch: this.config.fetch,
       });

--- a/packages/siftq/src/version.ts
+++ b/packages/siftq/src/version.ts
@@ -1,0 +1,6 @@
+declare const __PACKAGE_VERSION__: string | undefined;
+
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/siftq/tsconfig.build.json
+++ b/packages/siftq/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/siftq/tsconfig.json
+++ b/packages/siftq/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": ["dist", "build", "node_modules", "tsup.config.ts"],
+  "references": [
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    },
+    {
+      "path": "../test-server"
+    }
+  ]
+}

--- a/packages/siftq/tsup.config.ts
+++ b/packages/siftq/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+]);

--- a/packages/siftq/vitest.edge.config.js
+++ b/packages/siftq/vitest.edge.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/packages/siftq/vitest.node.config.js
+++ b/packages/siftq/vitest.node.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -480,6 +480,9 @@ importers:
       '@ai-sdk/sandbox-vercel':
         specifier: workspace:*
         version: link:../../packages/sandbox-vercel
+      '@ai-sdk/siftq':
+        specifier: workspace:*
+        version: link:../../packages/siftq
       '@ai-sdk/togetherai':
         specifier: workspace:*
         version: link:../../packages/togetherai
@@ -3917,6 +3920,34 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+
+  packages/siftq:
+    dependencies:
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+    devDependencies:
+      '@ai-sdk/test-server':
+        specifier: workspace:*
+        version: link:../test-server
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.25)(tsx@4.22.0)(typescript@5.8.3)(yaml@2.9.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
 
   packages/svelte:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -196,6 +196,9 @@
       "path": "packages/sandbox-vercel"
     },
     {
+      "path": "packages/siftq"
+    },
+    {
       "path": "packages/svelte"
     },
     {


### PR DESCRIPTION
## Background

SiftQ provides asynchronous video generation with text, image, frame, and multimodal reference inputs. The AI SDK does not currently include a native SiftQ provider, so applications must implement provider-specific request mapping, task polling, media validation, and result retrieval themselves.

This PR adds a dedicated `@ai-sdk/siftq` package that exposes SiftQ through the AI SDK video model interface.

## Summary

- Add the `@ai-sdk/siftq` provider package.
- Expose a fixed `siftq.video()` entry point without requiring callers to provide a model ID.
- Support text-to-video and image-to-video generation.
- Support first-frame and first-and-last-frame inputs.
- Support reference image, video, and audio inputs.
- Map AI SDK prompts, duration, aspect ratio, and SiftQ provider options to native API requests.
- Implement the AI SDK start/status lifecycle for asynchronous generation.
- Support SDK-managed polling and webhook workflows.
- Parse queued, running, succeeded, failed, and cancelled task states.
- Add structured error handling, input validation, media validation, request-size limits, and secure result downloads.
- Add workflow serialization support.
- Register the package in the workspace and TypeScript project references.
- Add AI Functions examples, provider documentation, package documentation, and release metadata.

## End-to-End Verification

Ran the public AI SDK example with a runtime `SIFTQ_API_KEY`:
```bash
cd examples/ai-functions
pnpm tsx src/generate-video/siftq/basic.ts
```
The example successfully completed the full video generation flow through the public AI SDK interface:

- Submitted a video generation request to the SiftQ API.
- Received a task ID from the start request.
- Polled the task through the AI SDK start/status lifecycle.
- Observed the task progress to a successful terminal state.
- Retrieved and downloaded the generated video through the SDK.
- Confirmed that the downloaded video was non-empty.

No provider-specific polling code was required in the example.

## Verification

The following checks pass:
```bash
pnpm --filter @ai-sdk/siftq test
pnpm --filter @ai-sdk/siftq type-check
pnpm --filter @ai-sdk/siftq build
pnpm type-check:full
pnpm validate:docs
pnpm konsistent
```
The provider contract tests run in both Node.js and Edge environments and cover request serialization, asynchronous task states, provider errors, media inputs, validation boundaries, result downloads, and workflow serialization.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Coordinate npm package and Trusted Publisher setup with the Vercel IT team before the first automated release.

## Related Issues

Closes #18757