### PR TITLE
fix(deepinfra): only rewrite the trailing /inference in the image edit URL

### DIFF
--- a/.changeset/deepinfra-anchor-edit-url.md
+++ b/.changeset/deepinfra-anchor-edit-url.md
@@ -1,0 +1,9 @@
+---
+'@ai-sdk/deepinfra': patch
+---
+
+fix (provider/deepinfra): only rewrite the trailing /inference when building the image edit URL
+
+`getEditUrl()` replaced the first `/inference` in the configured baseURL, so a custom
+`baseURL` whose own path contains `/inference` had the wrong segment rewritten and the
+appended one left in place.

--- a/packages/deepinfra/src/deepinfra-image-model.test.ts
+++ b/packages/deepinfra/src/deepinfra-image-model.test.ts
@@ -260,6 +260,16 @@ describe('DeepInfraImageModel', () => {
           },
         },
       },
+      // a custom baseURL whose own path contains '/inference'
+      'https://edit.example.com/inference/v1/openai/images/edits': {
+        response: {
+          type: 'json-value',
+          body: {
+            created: 1234567890,
+            data: [{ b64_json: 'edited-image-base64' }],
+          },
+        },
+      },
     });
 
     // Model with baseURL that will resolve to edit endpoint
@@ -271,6 +281,41 @@ describe('DeepInfraImageModel', () => {
         headers: () => ({ 'api-key': 'test-key' }),
       },
     );
+
+    it('should only rewrite the trailing /inference of the baseURL', async () => {
+      // The provider appends '/inference' to the configured baseURL, so a custom baseURL
+      // whose own path contains '/inference' has two of them. Only the last may be
+      // rewritten to '/openai'.
+      const model = new DeepInfraImageModel(
+        'black-forest-labs/FLUX.1-Kontext-dev',
+        {
+          provider: 'deepinfra',
+          baseURL: 'https://edit.example.com/inference/v1/inference',
+          headers: () => ({ 'api-key': 'test-key' }),
+        },
+      );
+
+      await model.doGenerate({
+        prompt: 'Turn the cat into a dog',
+        files: [
+          {
+            type: 'file',
+            data: new Uint8Array([137, 80, 78, 71]),
+            mediaType: 'image/png',
+          },
+        ],
+        mask: undefined,
+        n: 1,
+        size: '1024x1024',
+        aspectRatio: undefined,
+        seed: undefined,
+        providerOptions: {},
+      });
+
+      expect(editServer.calls[0].requestUrl).toBe(
+        'https://edit.example.com/inference/v1/openai/images/edits',
+      );
+    });
 
     it('should send edit request with files', async () => {
       const imageData = new Uint8Array([137, 80, 78, 71]); // PNG magic bytes

--- a/packages/deepinfra/src/deepinfra-image-model.ts
+++ b/packages/deepinfra/src/deepinfra-image-model.ts
@@ -166,7 +166,10 @@ export class DeepInfraImageModel implements ImageModelV4 {
     // Use OpenAI-compatible endpoint for image editing
     // baseURL is typically https://api.deepinfra.com/v1/inference
     // We need to use https://api.deepinfra.com/v1/openai/images/edits
-    const baseUrl = this.config.baseURL.replace('/inference', '/openai');
+    // Anchored: the provider appends '/inference' to the configured baseURL, so only the
+    // trailing segment may be rewritten. A plain string replace takes the first match, and
+    // a custom baseURL whose own path contains '/inference' loses that one instead.
+    const baseUrl = this.config.baseURL.replace(/\/inference$/, '/openai');
     return `${baseUrl}/images/edits`;
   }
 }


### PR DESCRIPTION
`createDeepInfra` appends a segment to build the image model's baseURL:

```js
baseURL: baseURL ? `${baseURL}/inference` : 'https://api.deepinfra.com/v1/inference',
```

and `getEditUrl()` turns it back with a plain string replace:

```js
const baseUrl = this.config.baseURL.replace('/inference', '/openai');
```

A plain replace rewrites the first match. `baseURL` is user-supplied and an inference proxy often has `/inference` in its own path, so there are two and the wrong one goes.

```js
createDeepInfra({ baseURL: 'https://proxy.example.com/inference/v1' })

// before: https://proxy.example.com/openai/v1/inference/images/edits
// after:  https://proxy.example.com/inference/v1/openai/images/edits
```

The user's own path segment became `/openai` and the appended one survived, so the request goes somewhere that does not exist.

Anchoring the replace fixes it, and matches how the rest of the monorepo does this. `google-files.ts` strips a suffix with `replace(/\/v1beta$/, '')`, the gateway transcription and realtime models rewrite the scheme with `replace(/^http/, 'ws')`, and azure, xai, openai-compatible and several gateway modules parse with `new URL`. This site was the only unanchored one I found.

Worth mentioning for a follow-up you may prefer: `deepinfra-provider.ts` already builds the openai-compatible URL directly as `` `${baseURL}/openai${path}` ``, so the image model could be handed that instead of reconstructing it. I kept this change to one line since that is a wider refactor.

Verified with `pnpm vitest --config vitest.node.config.js --run src/` in `packages/deepinfra`: 25 passed before and 26 after, with the new test failing on the unpatched file. `oxlint`, `oxfmt --check` and `tsc --build` are clean. Changeset included.

This is URL construction, so I tested it without calling the DeepInfra API. Nothing here confirms the live service accepts the corrected URL, and I built and tested only this package, not the monorepo.
