### PR TITLE
docs: gate jsonrepair on finishReason in the truncation cookbook

### DIFF
--- a/content/cookbook/05-node/85-repair-json-with-jsonrepair.mdx
+++ b/content/cookbook/05-node/85-repair-json-with-jsonrepair.mdx
@@ -53,6 +53,19 @@ const result = await generateText({
   prompt: 'Generate a lasagna recipe.',
 });
 
+// Check this before attempting repair. jsonrepair closes an unterminated
+// string or array as-is, so a response cut off mid-value can come back
+// looking like a complete, valid object — the repair "succeeds" while
+// silently dropping content the model never got to generate. finishReason
+// is the one signal that actually distinguishes "malformed" from
+// "truncated"; the JSON text alone can't.
+if (result.finishReason === 'length') {
+  throw new Error(
+    'Response was cut off by maxOutputTokens. Retry with a higher limit ' +
+      'or a smaller schema rather than repairing a truncated value.',
+  );
+}
+
 const repairedText = jsonrepair(result.text);
 const parseResult = safeParseJSON({ text: repairedText });
 
@@ -66,11 +79,12 @@ console.log(output.recipe);
 
 ## How it Works
 
-This flow has three steps:
+This flow has four steps:
 
 1. Generate plain text from the model (`Output.text()`).
-2. Repair malformed JSON with `jsonrepair`.
-3. Parse safely and validate with your schema.
+2. Check `finishReason` and bail out before repairing if the response was truncated (see [Considerations](#considerations)).
+3. Repair malformed JSON with `jsonrepair`.
+4. Parse safely and validate with your schema.
 
 ## What jsonrepair Can Fix
 
@@ -86,5 +100,5 @@ The `jsonrepair` library can automatically fix many common issues:
 ## Considerations
 
 1. **Repair is Best-Effort** - While `jsonrepair` handles many cases, it cannot fix all malformed JSON (e.g., semantically incorrect data that happens to be valid JSON)
-2. **Schema Validation** - Even after repair, the object must still match your schema. If the model produces structurally wrong data, repair won't help
-3. **Truncated Content** - For severely truncated responses, consider increasing `maxOutputTokens` or simplifying your schema
+2. **Schema Validation** - Even after repair, the object must still match your schema. If the model produces structurally wrong data, repair won't help. Note that schema validation alone doesn't catch truncation either — a string field cut off mid-sentence is still a syntactically valid, schema-conforming string, just the wrong one
+3. **Truncated Content is a Different Problem Than Malformed Content** - `jsonrepair` fixes JSON *syntax* (quotes, brackets, commas). It has no way to know whether a value's *content* is what the model intended or was cut off mid-generation — closing an unterminated string produces a shorter string that still parses and validates successfully. For output with real side effects (writing a file, executing a command, sending a message), don't repair a `finishReason === 'length'` response and treat the result as trustworthy; retry with a higher `maxOutputTokens` or a smaller schema instead, as shown above


### PR DESCRIPTION
### What

The "Repair Malformed JSON with jsonrepair" cookbook names truncated responses (hitting token limits) as one of the problems this pattern solves, but the example calls `jsonrepair(result.text)` unconditionally, with no check on `result.finishReason` first.

### Why this matters

`jsonrepair` closes an unterminated string or array as-is. For a response that was genuinely cut off mid-value, that means the repaired result parses successfully and passes schema validation, but its content is shorter/different than what the model actually intended — with nothing to signal that. A closed array like `["ls","pwd"` → `["ls","pwd"]` is indistinguishable from a genuinely complete one just by looking at the JSON text; `finishReason` is the one signal available that actually tells you which case you're in.

This is reachable in a real, non-hypothetical way: `experimental_repairToolCall` follows the same repair-first shape, and a tool call whose argument string is cut off by `max_tokens` can be silently "repaired" into a plausible-looking value and passed straight to execution — for a tool with a real side effect (writing a file, running a command), the repaired value being subtly wrong instead of visibly failing is the worse outcome.

### The fix

Adds a `result.finishReason === 'length'` check before the repair step, using data `generateText()` already returns — no new dependency, just reordering the existing logic so truncation is handled as its own case instead of falling into the generic repair path. Also expands the "Considerations" section to explain the distinction between a syntax problem (what `jsonrepair` fixes) and a truncation problem (what it can't reliably fix, since it has no way to know whether it's completing something real or has just cut off the model's continuation).

### Scope

Docs-only change to one cookbook page — no code/package changes. Matches the "Fix documentation, examples, or typos" category CONTRIBUTING.md calls out as welcome for PRs. I wasn't able to run the full local build (didn't set up the entire monorepo for a one-file docs change) but matched the file's existing formatting conventions by hand; happy to adjust if prettier/lint flags anything.
