### PR TITLE
feat(minimax): add official text model IDs

### DIFF
--- a/.changeset/fresh-bears-model.md
+++ b/.changeset/fresh-bears-model.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/minimax': patch
+---
+
+Add the official MiniMax-M3 and MiniMax-M2.7 model IDs.

--- a/packages/minimax/src/minimax-chat-options.ts
+++ b/packages/minimax/src/minimax-chat-options.ts
@@ -2,6 +2,8 @@ import { z } from 'zod/v4';
 
 // https://platform.minimax.io/docs/api-reference/text-chat-anthropic
 export type MiniMaxChatModelId =
+  | 'MiniMax-M3'
+  | 'MiniMax-M2.7'
   | 'minimax-m3'
   | 'minimax-m2.7'
   | 'minimax-m2.7-highspeed'

--- a/packages/minimax/src/minimax-provider.test.ts
+++ b/packages/minimax/src/minimax-provider.test.ts
@@ -94,6 +94,15 @@ describe('MiniMaxProvider', () => {
       expect(model).toBeInstanceOf(AnthropicLanguageModel);
     });
 
+    it('should preserve official model IDs', () => {
+      const provider = createMiniMax();
+      provider('MiniMax-M3');
+      provider('MiniMax-M2.7');
+
+      expect(AnthropicLanguageModelMock.mock.calls[0][0]).toBe('MiniMax-M3');
+      expect(AnthropicLanguageModelMock.mock.calls[1][0]).toBe('MiniMax-M2.7');
+    });
+
     it('should construct the model with the Anthropic-compatible config', () => {
       const provider = createMiniMax();
       provider('minimax-m3');


### PR DESCRIPTION
Reason: Expose the official MiniMax text model IDs in the provider's public type.

This adds `MiniMax-M3` and `MiniMax-M2.7` alongside the existing aliases and verifies that the provider passes both identifiers through unchanged.

Checks:

- `pnpm --filter @ai-sdk/minimax... build`
- `pnpm --dir packages/minimax test:node`
- `pnpm --dir packages/minimax type-check`
- `pnpm exec oxfmt --check packages/minimax/src/minimax-chat-options.ts packages/minimax/src/minimax-provider.test.ts .changeset/fresh-bears-model.md`
- `git diff --check`
