### PR TITLE
feat(minimax): add speech generation support

### DIFF
--- a/.changeset/fuzzy-taxis-speak.md
+++ b/.changeset/fuzzy-taxis-speak.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/minimax': patch
+---
+
+Add speech generation support for MiniMax text-to-audio models.

--- a/packages/minimax/src/index.ts
+++ b/packages/minimax/src/index.ts
@@ -9,6 +9,8 @@ export type {
   /** @deprecated Use `MiniMaxLanguageModelOptions` instead. */
   MiniMaxLanguageModelOptions as MiniMaxProviderOptions,
 } from './minimax-chat-options';
+export type { MiniMaxSpeechModelId } from './minimax-speech-settings';
+export type { MiniMaxSpeechModelOptions } from './minimax-speech-model-options';
 export type { MiniMaxVideoModelId } from './minimax-video-settings';
 export type { MiniMaxVideoModelOptions } from './minimax-video-model-options';
 export { VERSION } from './version';

--- a/packages/minimax/src/minimax-provider.test.ts
+++ b/packages/minimax/src/minimax-provider.test.ts
@@ -3,9 +3,11 @@ import { loadApiKey } from '@ai-sdk/provider-utils';
 import { NoSuchModelError } from '@ai-sdk/provider';
 import { AnthropicLanguageModel } from '@ai-sdk/anthropic/internal';
 import { createMiniMax } from './minimax-provider';
+import { MiniMaxSpeechModel } from './minimax-speech-model';
 import { MiniMaxVideoModel } from './minimax-video-model';
 
 const AnthropicLanguageModelMock = AnthropicLanguageModel as unknown as Mock;
+const MiniMaxSpeechModelMock = MiniMaxSpeechModel as unknown as Mock;
 const MiniMaxVideoModelMock = MiniMaxVideoModel as unknown as Mock;
 
 vi.mock('@ai-sdk/anthropic/internal', () => {
@@ -35,6 +37,21 @@ vi.mock('./minimax-video-model', () => {
   });
   return {
     MiniMaxVideoModel: mockConstructor,
+  };
+});
+
+vi.mock('./minimax-speech-model', () => {
+  const mockConstructor = vi.fn().mockImplementation(function (
+    this: any,
+    modelId: string,
+    config: any,
+  ) {
+    this.provider = config.provider;
+    this.modelId = modelId;
+    this.config = config;
+  });
+  return {
+    MiniMaxSpeechModel: mockConstructor,
   };
 });
 
@@ -209,6 +226,58 @@ describe('MiniMaxProvider', () => {
 
       const constructorCall = MiniMaxVideoModelMock.mock.calls[0];
       expect(constructorCall[1].fetch).toBe(customFetch);
+    });
+  });
+
+  describe('speech', () => {
+    it('should construct a speech model with the speech provider id', () => {
+      const provider = createMiniMax();
+      const model = provider.speech('speech-2.8-hd');
+
+      expect(model).toBeInstanceOf(MiniMaxSpeechModel);
+
+      const constructorCall = MiniMaxSpeechModelMock.mock.calls[0];
+      expect(constructorCall[0]).toBe('speech-2.8-hd');
+      expect(constructorCall[1].provider).toBe('minimax.speech');
+      expect(constructorCall[1].baseURL).toBe('https://api.minimax.io');
+    });
+
+    it('should use the China speech endpoint when configured', () => {
+      const provider = createMiniMax({
+        speechBaseURL: 'https://api.minimaxi.com',
+      });
+      provider.speech('speech-2.8-hd');
+
+      const constructorCall = MiniMaxSpeechModelMock.mock.calls[0];
+      expect(constructorCall[1].baseURL).toBe('https://api.minimaxi.com');
+    });
+
+    it('should use bearer authentication and pass custom fetch', () => {
+      const customFetch = vi.fn();
+      const provider = createMiniMax({
+        apiKey: 'test-key',
+        fetch: customFetch,
+      });
+      provider.speech('speech-2.8-hd');
+
+      const constructorCall = MiniMaxSpeechModelMock.mock.calls[0];
+      expect(constructorCall[1].headers()).toMatchObject({
+        authorization: 'Bearer mock-api-key',
+        'user-agent': expect.stringMatching(/^ai-sdk\/minimax\//),
+      });
+      expect(constructorCall[1].fetch).toBe(customFetch);
+    });
+  });
+
+  describe('speechModel', () => {
+    it('should construct the same speech model as speech()', () => {
+      const provider = createMiniMax();
+      const model = provider.speechModel('speech-2.8-hd');
+
+      expect(model).toBeInstanceOf(MiniMaxSpeechModel);
+      expect(MiniMaxSpeechModelMock.mock.calls[0][1].provider).toBe(
+        'minimax.speech',
+      );
     });
   });
 

--- a/packages/minimax/src/minimax-provider.ts
+++ b/packages/minimax/src/minimax-provider.ts
@@ -3,6 +3,7 @@ import {
   type Experimental_VideoModelV4,
   type LanguageModelV4,
   type ProviderV4,
+  type SpeechModelV4,
 } from '@ai-sdk/provider';
 import {
   generateId,
@@ -13,6 +14,8 @@ import {
 } from '@ai-sdk/provider-utils';
 import { AnthropicLanguageModel } from '@ai-sdk/anthropic/internal';
 import type { MiniMaxChatModelId } from './minimax-chat-options';
+import { MiniMaxSpeechModel } from './minimax-speech-model';
+import type { MiniMaxSpeechModelId } from './minimax-speech-settings';
 import { MiniMaxVideoModel } from './minimax-video-model';
 import type { MiniMaxVideoModelId } from './minimax-video-settings';
 import { VERSION } from './version';
@@ -33,6 +36,12 @@ export interface MiniMaxProviderSettings {
    * The default prefix is `https://api.minimax.io`.
    */
   videoBaseURL?: string;
+  /**
+   * Use a different URL prefix for speech generation API calls.
+   * The default prefix is `https://api.minimax.io`. Use
+   * `https://api.minimaxi.com` for the China endpoint.
+   */
+  speechBaseURL?: string;
   /**
    * Custom headers to include in the requests.
    */
@@ -61,6 +70,16 @@ export interface MiniMaxProvider extends ProviderV4 {
   chat(modelId: MiniMaxChatModelId): LanguageModelV4;
 
   /**
+   * Creates a MiniMax model for speech generation.
+   */
+  speech(modelId: MiniMaxSpeechModelId): SpeechModelV4;
+
+  /**
+   * Creates a MiniMax model for speech generation.
+   */
+  speechModel(modelId: MiniMaxSpeechModelId): SpeechModelV4;
+
+  /**
    * Creates a MiniMax video model for video generation.
    */
   video(modelId: MiniMaxVideoModelId): Experimental_VideoModelV4;
@@ -77,7 +96,7 @@ export interface MiniMaxProvider extends ProviderV4 {
 }
 
 const defaultBaseURL = 'https://api.minimax.io/anthropic/v1';
-const defaultVideoBaseURL = 'https://api.minimax.io';
+const defaultNativeBaseURL = 'https://api.minimax.io';
 
 export function createMiniMax(
   options: MiniMaxProviderSettings = {},
@@ -86,8 +105,12 @@ export function createMiniMax(
     withoutTrailingSlash(options.baseURL ?? defaultBaseURL) ?? defaultBaseURL;
 
   const videoBaseURL =
-    withoutTrailingSlash(options.videoBaseURL ?? defaultVideoBaseURL) ??
-    defaultVideoBaseURL;
+    withoutTrailingSlash(options.videoBaseURL ?? defaultNativeBaseURL) ??
+    defaultNativeBaseURL;
+
+  const speechBaseURL =
+    withoutTrailingSlash(options.speechBaseURL ?? defaultNativeBaseURL) ??
+    defaultNativeBaseURL;
 
   const getHeaders = () =>
     withUserAgentSuffix(
@@ -113,7 +136,7 @@ export function createMiniMax(
       supportedUrls: () => ({}),
     });
 
-  const getVideoHeaders = () =>
+  const getBearerTokenHeaders = () =>
     withUserAgentSuffix(
       {
         Authorization: `Bearer ${loadApiKey({
@@ -126,11 +149,19 @@ export function createMiniMax(
       `ai-sdk/minimax/${VERSION}`,
     );
 
+  const createSpeechModel = (modelId: MiniMaxSpeechModelId) =>
+    new MiniMaxSpeechModel(modelId, {
+      provider: 'minimax.speech',
+      baseURL: speechBaseURL,
+      headers: getBearerTokenHeaders,
+      fetch: options.fetch,
+    });
+
   const createVideoModel = (modelId: MiniMaxVideoModelId) =>
     new MiniMaxVideoModel(modelId, {
       provider: 'minimax.video',
       baseURL: videoBaseURL,
-      headers: getVideoHeaders,
+      headers: getBearerTokenHeaders,
       fetch: options.fetch,
     });
 
@@ -139,6 +170,8 @@ export function createMiniMax(
   provider.specificationVersion = 'v4' as const;
   provider.languageModel = createChatModel;
   provider.chat = createChatModel;
+  provider.speech = createSpeechModel;
+  provider.speechModel = createSpeechModel;
   provider.video = createVideoModel;
   provider.videoModel = createVideoModel;
 

--- a/packages/minimax/src/minimax-speech-model-options.ts
+++ b/packages/minimax/src/minimax-speech-model-options.ts
@@ -1,0 +1,83 @@
+import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export const minimaxSpeechProviderOptions = z.object({
+  /** Additional voice controls. */
+  voiceSetting: z
+    .object({
+      volume: z.number().positive().max(10).optional(),
+      pitch: z.number().int().min(-12).max(12).optional(),
+      emotion: z
+        .enum([
+          'happy',
+          'sad',
+          'angry',
+          'fearful',
+          'disgusted',
+          'surprised',
+          'calm',
+          'fluent',
+          'whisper',
+        ])
+        .optional(),
+    })
+    .optional(),
+
+  /** Audio encoding controls. */
+  audioSetting: z
+    .object({
+      sampleRate: z
+        .union([
+          z.literal(8000),
+          z.literal(16000),
+          z.literal(22050),
+          z.literal(24000),
+          z.literal(32000),
+          z.literal(44100),
+        ])
+        .optional(),
+      bitrate: z
+        .union([
+          z.literal(32000),
+          z.literal(64000),
+          z.literal(128000),
+          z.literal(256000),
+        ])
+        .optional(),
+      channel: z.union([z.literal(1), z.literal(2)]).optional(),
+    })
+    .optional(),
+
+  /** Pronunciation replacements in `original/replacement` format. */
+  pronunciationDictionary: z
+    .object({
+      tone: z.array(z.string()),
+    })
+    .optional(),
+
+  /** Language or dialect to prioritize, or `auto` for automatic detection. */
+  languageBoost: z.string().optional(),
+
+  /** Post-processing controls for the generated voice. */
+  voiceModify: z
+    .object({
+      pitch: z.number().int().min(-100).max(100).optional(),
+      intensity: z.number().int().min(-100).max(100).optional(),
+      timbre: z.number().int().min(-100).max(100).optional(),
+      soundEffect: z
+        .enum(['spacious_echo', 'auditorium_echo', 'lofi_telephone', 'robotic'])
+        .optional(),
+    })
+    .optional(),
+
+  /** Whether the service should generate subtitle metadata. */
+  subtitleEnable: z.boolean().optional(),
+});
+
+export type MiniMaxSpeechModelOptions = z.infer<
+  typeof minimaxSpeechProviderOptions
+>;
+
+export const minimaxSpeechModelOptionsSchema = lazySchema(() =>
+  zodSchema(minimaxSpeechProviderOptions),
+);

--- a/packages/minimax/src/minimax-speech-model.test.ts
+++ b/packages/minimax/src/minimax-speech-model.test.ts
@@ -1,0 +1,222 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it } from 'vitest';
+import { MiniMaxSpeechModel } from './minimax-speech-model';
+
+const modelId = 'speech-2.8-hd';
+const baseURL = 'https://api.example.com';
+const url = `${baseURL}/v1/t2a_v2`;
+
+function createModel(currentDate?: () => Date) {
+  return new MiniMaxSpeechModel(modelId, {
+    provider: 'minimax.speech',
+    baseURL,
+    headers: () => ({ Authorization: 'Bearer test-api-key' }),
+    _internal: { currentDate },
+  });
+}
+
+const server = createTestServer({
+  [url]: {},
+});
+
+function prepareResponse({
+  audio = '494433',
+  headers,
+}: {
+  audio?: string | null;
+  headers?: Record<string, string>;
+} = {}) {
+  server.urls[url].response = {
+    type: 'json-value',
+    headers,
+    body: {
+      data: { audio, status: 2 },
+      base_resp: { status_code: 0, status_msg: 'success' },
+    },
+  };
+}
+
+describe('MiniMaxSpeechModel', () => {
+  it('should expose correct provider and model information', () => {
+    const model = createModel();
+
+    expect(model.provider).toBe('minimax.speech');
+    expect(model.modelId).toBe(modelId);
+    expect(model.specificationVersion).toBe('v4');
+  });
+
+  it('should send a non-streaming request and request hex audio', async () => {
+    prepareResponse();
+
+    await createModel().doGenerate({
+      text: 'Hello from the AI SDK!',
+    });
+
+    expect(server.calls[0].requestMethod).toBe('POST');
+    expect(server.calls[0].requestUrl).toBe(url);
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: modelId,
+      text: 'Hello from the AI SDK!',
+      stream: false,
+      output_format: 'hex',
+      audio_setting: { format: 'mp3' },
+    });
+  });
+
+  it('should map standard voice, speed, and audio format options', async () => {
+    prepareResponse();
+
+    await createModel().doGenerate({
+      text: 'Hello!',
+      voice: 'English_expressive_narrator',
+      speed: 1.2,
+      outputFormat: 'wav',
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      voice_setting: {
+        voice_id: 'English_expressive_narrator',
+        speed: 1.2,
+      },
+      audio_setting: { format: 'wav' },
+    });
+  });
+
+  it('should ignore voice settings when no voice is provided', async () => {
+    prepareResponse();
+
+    const result = await createModel().doGenerate({
+      text: 'Hello!',
+      speed: 1.2,
+    });
+
+    expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+      'voice_setting',
+    );
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'voice',
+      }),
+    );
+  });
+
+  it.each(['mp3', 'wav', 'flac', 'pcm'])(
+    'should accept %s audio',
+    async format => {
+      prepareResponse();
+
+      await createModel().doGenerate({ text: 'Hello!', outputFormat: format });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        audio_setting: { format },
+      });
+    },
+  );
+
+  it('should map provider-specific request fields', async () => {
+    prepareResponse();
+
+    await createModel().doGenerate({
+      text: 'Hello!',
+      voice: 'voice-id',
+      providerOptions: {
+        minimax: {
+          voiceSetting: { volume: 1.5, pitch: 2, emotion: 'happy' },
+          audioSetting: { sampleRate: 32000, bitrate: 128000, channel: 1 },
+          pronunciationDictionary: { tone: ['AI/ay eye'] },
+          languageBoost: 'English',
+          voiceModify: {
+            pitch: 5,
+            intensity: -2,
+            timbre: 3,
+            soundEffect: 'spacious_echo',
+          },
+          subtitleEnable: true,
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      voice_setting: {
+        voice_id: 'voice-id',
+        vol: 1.5,
+        pitch: 2,
+        emotion: 'happy',
+      },
+      audio_setting: {
+        sample_rate: 32000,
+        bitrate: 128000,
+        format: 'mp3',
+        channel: 1,
+      },
+      pronunciation_dict: { tone: ['AI/ay eye'] },
+      language_boost: 'English',
+      voice_modify: {
+        pitch: 5,
+        intensity: -2,
+        timbre: 3,
+        sound_effects: 'spacious_echo',
+      },
+      subtitle_enable: true,
+    });
+  });
+
+  it('should warn and use mp3 for an unsupported output format', async () => {
+    prepareResponse();
+
+    const result = await createModel().doGenerate({
+      text: 'Hello!',
+      outputFormat: 'aac',
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      audio_setting: { format: 'mp3' },
+    });
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({
+        type: 'unsupported',
+        feature: 'outputFormat',
+      }),
+    );
+  });
+
+  it('should decode the hex response into audio bytes', async () => {
+    prepareResponse({ audio: '494433' });
+
+    const result = await createModel().doGenerate({ text: 'Hello!' });
+
+    expect(result.audio).toStrictEqual(Uint8Array.from([0x49, 0x44, 0x33]));
+  });
+
+  it('should include response data with timestamp, model id, and headers', async () => {
+    prepareResponse({ headers: { 'x-request-id': 'test-request-id' } });
+    const testDate = new Date(0);
+
+    const result = await createModel(() => testDate).doGenerate({
+      text: 'Hello!',
+    });
+
+    expect(result.response).toMatchObject({
+      timestamp: testDate,
+      modelId,
+      headers: expect.objectContaining({
+        'x-request-id': 'test-request-id',
+      }),
+      body: {
+        data: { audio: '494433', status: 2 },
+        base_resp: { status_code: 0, status_msg: 'success' },
+      },
+    });
+  });
+
+  it('should reject a successful response without audio', async () => {
+    prepareResponse({ audio: null });
+
+    await expect(
+      createModel().doGenerate({ text: 'Hello!' }),
+    ).rejects.toMatchObject({
+      name: 'MINIMAX_SPEECH_RESPONSE_MISSING_AUDIO',
+    });
+  });
+});

--- a/packages/minimax/src/minimax-speech-model.ts
+++ b/packages/minimax/src/minimax-speech-model.ts
@@ -1,0 +1,279 @@
+import {
+  AISDKError,
+  type SharedV4Warning,
+  type SpeechModelV4,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  parseProviderOptions,
+  postJsonToApi,
+  resolve,
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+  type FetchFunction,
+  type Resolvable,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import {
+  minimaxSpeechModelOptionsSchema,
+  type MiniMaxSpeechModelOptions,
+} from './minimax-speech-model-options';
+import type { MiniMaxSpeechModelId } from './minimax-speech-settings';
+
+interface MiniMaxSpeechModelConfig {
+  provider: string;
+  baseURL: string;
+  headers: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+type MiniMaxAudioFormat = 'mp3' | 'wav' | 'flac' | 'pcm';
+
+export class MiniMaxSpeechModel implements SpeechModelV4 {
+  readonly specificationVersion = 'v4';
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  static [WORKFLOW_SERIALIZE](model: MiniMaxSpeechModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: MiniMaxSpeechModelId;
+    config: MiniMaxSpeechModelConfig;
+  }) {
+    return new MiniMaxSpeechModel(options.modelId, options.config);
+  }
+
+  constructor(
+    readonly modelId: MiniMaxSpeechModelId,
+    private readonly config: MiniMaxSpeechModelConfig,
+  ) {}
+
+  private async getArgs({
+    text,
+    voice,
+    outputFormat = 'mp3',
+    instructions,
+    speed,
+    language,
+    providerOptions,
+  }: Parameters<SpeechModelV4['doGenerate']>[0]) {
+    const warnings: SharedV4Warning[] = [];
+
+    const minimaxOptions = (await parseProviderOptions({
+      provider: 'minimax',
+      providerOptions,
+      schema: minimaxSpeechModelOptionsSchema,
+    })) as MiniMaxSpeechModelOptions | undefined;
+
+    let audioFormat: MiniMaxAudioFormat = 'mp3';
+    if (['mp3', 'wav', 'flac', 'pcm'].includes(outputFormat)) {
+      audioFormat = outputFormat as MiniMaxAudioFormat;
+    } else {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'outputFormat',
+        details: `Unsupported output format: ${outputFormat}. Using mp3 instead.`,
+      });
+    }
+
+    if (instructions != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'instructions',
+        details:
+          'MiniMax speech models do not support the `instructions` option. It was ignored.',
+      });
+    }
+
+    if (language != null && minimaxOptions?.languageBoost == null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'language',
+        details:
+          'MiniMax requires a provider-specific language name. Use providerOptions.minimax.languageBoost.',
+      });
+    }
+
+    if (
+      voice == null &&
+      (speed != null || minimaxOptions?.voiceSetting != null)
+    ) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'voice',
+        details:
+          'MiniMax requires a voice when voice settings are provided. The voice settings were ignored.',
+      });
+    }
+
+    const voiceSetting =
+      voice == null
+        ? undefined
+        : {
+            voice_id: voice,
+            speed,
+            vol: minimaxOptions?.voiceSetting?.volume,
+            pitch: minimaxOptions?.voiceSetting?.pitch,
+            emotion: minimaxOptions?.voiceSetting?.emotion,
+          };
+
+    const audioSetting = {
+      sample_rate: minimaxOptions?.audioSetting?.sampleRate,
+      bitrate: minimaxOptions?.audioSetting?.bitrate,
+      format: audioFormat,
+      channel: minimaxOptions?.audioSetting?.channel,
+    };
+
+    const voiceModify = minimaxOptions?.voiceModify;
+    const requestBody = {
+      model: this.modelId,
+      text,
+      stream: false,
+      output_format: 'hex',
+      ...(voiceSetting == null ? {} : { voice_setting: voiceSetting }),
+      audio_setting: audioSetting,
+      language_boost: minimaxOptions?.languageBoost,
+      pronunciation_dict:
+        minimaxOptions?.pronunciationDictionary == null
+          ? undefined
+          : { tone: minimaxOptions.pronunciationDictionary.tone },
+      voice_modify:
+        voiceModify == null
+          ? undefined
+          : {
+              pitch: voiceModify.pitch,
+              intensity: voiceModify.intensity,
+              timbre: voiceModify.timbre,
+              sound_effects: voiceModify.soundEffect,
+            },
+      subtitle_enable: minimaxOptions?.subtitleEnable,
+    };
+
+    return { requestBody, warnings };
+  }
+
+  async doGenerate(
+    options: Parameters<SpeechModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<SpeechModelV4['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const { requestBody, warnings } = await this.getArgs(options);
+
+    const {
+      value: response,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url: `${this.config.baseURL}/v1/t2a_v2`,
+      headers: combineHeaders(
+        await resolve(this.config.headers),
+        options.headers,
+      ),
+      body: requestBody,
+      failedResponseHandler: minimaxSpeechFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        minimaxSpeechResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    if (
+      response.base_resp?.status_code != null &&
+      response.base_resp.status_code !== 0
+    ) {
+      throw new AISDKError({
+        name: 'MINIMAX_SPEECH_GENERATION_FAILED',
+        message:
+          response.base_resp.status_msg ??
+          `MiniMax speech generation failed with status ${response.base_resp.status_code}.`,
+      });
+    }
+
+    const audioHex = response.data?.audio;
+    if (audioHex == null) {
+      throw new AISDKError({
+        name: 'MINIMAX_SPEECH_RESPONSE_MISSING_AUDIO',
+        message: 'MiniMax speech generation returned no audio data.',
+      });
+    }
+
+    return {
+      audio: decodeHexAudio(audioHex),
+      warnings,
+      request: {
+        body: JSON.stringify(requestBody),
+      },
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+    };
+  }
+}
+
+function decodeHexAudio(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0 || !/^[0-9a-f]*$/i.test(hex)) {
+    throw new AISDKError({
+      name: 'MINIMAX_SPEECH_RESPONSE_INVALID_AUDIO',
+      message: 'MiniMax speech generation returned invalid hex audio data.',
+    });
+  }
+
+  const audio = new Uint8Array(hex.length / 2);
+  for (let index = 0; index < hex.length; index += 2) {
+    audio[index / 2] = Number.parseInt(hex.slice(index, index + 2), 16);
+  }
+  return audio;
+}
+
+const minimaxSpeechResponseSchema = z.object({
+  data: z
+    .object({
+      audio: z.string().nullish(),
+      status: z.number().nullish(),
+    })
+    .nullish(),
+  base_resp: z
+    .object({
+      status_code: z.number().nullish(),
+      status_msg: z.string().nullish(),
+    })
+    .nullish(),
+});
+
+const minimaxSpeechErrorSchema = z.object({
+  error: z
+    .object({
+      message: z.string().nullish(),
+    })
+    .nullish(),
+  base_resp: z
+    .object({
+      status_code: z.number().nullish(),
+      status_msg: z.string().nullish(),
+    })
+    .nullish(),
+});
+
+const minimaxSpeechFailedResponseHandler = createJsonErrorResponseHandler({
+  errorSchema: minimaxSpeechErrorSchema,
+  errorToMessage: data =>
+    data.error?.message ??
+    data.base_resp?.status_msg ??
+    'MiniMax speech generation error',
+});

--- a/packages/minimax/src/minimax-speech-settings.ts
+++ b/packages/minimax/src/minimax-speech-settings.ts
@@ -1,0 +1,11 @@
+// https://platform.minimax.io/docs/api-reference/speech-t2a-http
+export type MiniMaxSpeechModelId =
+  | 'speech-2.8-hd'
+  | 'speech-2.8-turbo'
+  | 'speech-2.6-hd'
+  | 'speech-2.6-turbo'
+  | 'speech-02-hd'
+  | 'speech-02-turbo'
+  | 'speech-01-hd'
+  | 'speech-01-turbo'
+  | (string & {});


### PR DESCRIPTION
Reason: Add MiniMax speech generation support for synchronous text-to-audio responses.

- Add `speech` and `speechModel` factories with configurable global and China API roots.
- Map standard and provider-specific speech options to the synchronous T2A endpoint and decode returned hex audio.
- Add provider and model unit coverage plus a release changeset.

Checks:

- `pnpm --filter @ai-sdk/minimax type-check`
- `pnpm --filter @ai-sdk/minimax test:node`
- `pnpm --filter @ai-sdk/minimax test:edge`
- `pnpm exec oxfmt --check packages/minimax/src/minimax-provider.ts packages/minimax/src/minimax-provider.test.ts packages/minimax/src/index.ts packages/minimax/src/minimax-speech-settings.ts packages/minimax/src/minimax-speech-model-options.ts packages/minimax/src/minimax-speech-model.ts packages/minimax/src/minimax-speech-model.test.ts .changeset/fuzzy-taxis-speak.md`
- `pnpm exec oxlint packages/minimax/src/minimax-provider.ts packages/minimax/src/minimax-provider.test.ts packages/minimax/src/index.ts packages/minimax/src/minimax-speech-settings.ts packages/minimax/src/minimax-speech-model-options.ts packages/minimax/src/minimax-speech-model.ts packages/minimax/src/minimax-speech-model.test.ts`
