### PR TITLE
ci: increase release notification timeout

### DIFF
--- a/.github/scripts/notify-released/index.mjs
+++ b/.github/scripts/notify-released/index.mjs
@@ -4,7 +4,7 @@ import { Octokit } from 'octokit';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const NPM_VERIFY_TIMEOUT_MS = parseInt(
-  process.env.NPM_VERIFY_TIMEOUT_MS || '300000',
+  process.env.NPM_VERIFY_TIMEOUT_MS || '600000',
   10,
 );
 const NPM_POLL_INTERVAL_MS = 10000;


### PR DESCRIPTION
## Background

The release notification step in https://github.com/vercel/ai/actions/runs/31614181158/job/94172724889 timed out while waiting for ai@7.0.63 to propagate to npm. The package appeared at approximately the existing five-minute boundary.

## Summary

Increase the default npm verification timeout for release notifications from five to ten minutes. The existing environment-variable override and ten-second polling interval remain unchanged.

## End-to-End Verification

Confirmed the failed workflow exhausted the five-minute polling window and compared it with the npm publication timestamp.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run pnpm changeset in the project root)
- [x] I have reviewed this pull request (self-review)

Tests and checks: release-notification tests, pnpm check, and pnpm type-check:full.