### PR TITLE
ci: increase release notification timeout

### DIFF
--- a/.github/scripts/notify-released/index.mjs
+++ b/.github/scripts/notify-released/index.mjs
@@ -4,7 +4,7 @@ import { Octokit } from 'octokit';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const NPM_VERIFY_TIMEOUT_MS = parseInt(
-  process.env.NPM_VERIFY_TIMEOUT_MS || '300000',
+  process.env.NPM_VERIFY_TIMEOUT_MS || '600000',
   10,
 );
 const NPM_POLL_INTERVAL_MS = 10000;


### PR DESCRIPTION
## Background

Backport of #18787 for the release-v6.0 release workflow. The release notification step in https://github.com/vercel/ai/actions/runs/31614181158/job/94172724889 timed out while waiting for npm propagation.

## Summary

Increase the default npm verification timeout for release notifications from five to ten minutes. The existing environment-variable override and ten-second polling interval remain unchanged.

## End-to-End Verification

Confirmed this branch uses the same notification path and five-minute default. The script passes Node syntax validation.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run pnpm changeset in the project root)
- [x] I have reviewed this pull request (self-review)