### PR TITLE
add harness example runner tool and modify examples to dynamically use `direct` or `ai-gateway` auth for easier testing

### DIFF
--- a/examples/ai-functions/src/harness-agent/claude-code/_create.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/_create.ts
@@ -1,0 +1,19 @@
+import {
+  createClaudeCode as createClaudeCodeHarness,
+  type ClaudeCodeHarnessSettings,
+} from '@ai-sdk/harness-claude-code';
+
+export function createClaudeCode(
+  settings: ClaudeCodeHarnessSettings = {},
+): ReturnType<typeof createClaudeCodeHarness> {
+  const forceAuth = process.env.HARNESS_FORCE_AUTH;
+
+  if (forceAuth == null) {
+    return createClaudeCodeHarness(settings);
+  }
+
+  return createClaudeCodeHarness({
+    ...settings,
+    auth: forceAuth === 'ai-gateway' ? 'ai-gateway' : 'direct',
+  });
+}

--- a/examples/ai-functions/src/harness-agent/claude-code/active-tools.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/active-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const claudeCode = createClaudeCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -32,7 +34,6 @@ run(async () => {
     activeTools: ['weather'],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/attach.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/attach.ts
@@ -10,7 +10,7 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { createClaudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { mintBridgeToken } from '../../lib/mint-bridge-token';
 import { printFullStream } from '../../lib/print-full-stream';

--- a/examples/ai-functions/src/harness-agent/claude-code/builtin-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/builtin-tool-approval.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import {
@@ -7,6 +7,8 @@ import {
   printFullStreamAndCaptureToolApproval,
 } from '../../lib/harness-tool-approval';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const claudeCode = createClaudeCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -20,7 +22,6 @@ run(async () => {
     permissionMode: 'allow-edits',
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
       }),
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/compaction.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/compaction.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const claudeCode = createClaudeCode();
 
 /*
  * Context compaction (Claude Code).
@@ -27,7 +29,6 @@ run(async () => {
   });
   const agent = new HarnessAgent({ harness: claudeCode, sandbox });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1: build up some context ---');
@@ -44,11 +45,7 @@ run(async () => {
       prompt: '/compact Keep the key technical facts from the explanation.',
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/custom-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/custom-tool-approval.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
@@ -9,6 +9,8 @@ import {
   printFullStreamAndCaptureToolApproval,
 } from '../../lib/harness-tool-approval';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const claudeCode = createClaudeCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -38,7 +40,6 @@ run(async () => {
     },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -61,11 +62,7 @@ run(async () => {
       }),
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/file-edit.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/file-edit.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const claudeCode = createClaudeCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1: create ---');
@@ -38,11 +39,7 @@ run(async () => {
       prompt: 'Read `notes.md` and print its contents in your reply.',
     });
     await printFullStream({ result: third });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/generate-text.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/generate-text.ts
@@ -1,7 +1,9 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const claudeCode = createClaudeCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -14,7 +16,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.generate({
@@ -24,11 +25,7 @@ run(async () => {
     console.log('text:', result.text);
     console.log('finishReason:', result.finishReason);
     console.log('usage:', result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/inactive-tools.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/inactive-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const claudeCode = createClaudeCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -32,7 +34,6 @@ run(async () => {
     inactiveTools: ['read', 'bash', 'glob', 'grep', 'Monitor'],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/multi-turn.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/multi-turn.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const claudeCode = createClaudeCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1 ---');
@@ -31,11 +32,7 @@ run(async () => {
       prompt: 'What is my name? Answer in one word.',
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/resume.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/resume.ts
@@ -11,10 +11,12 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const claudeCode = createClaudeCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({

--- a/examples/ai-functions/src/harness-agent/claude-code/runtime-configuration.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/runtime-configuration.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createClaudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { run } from '../../lib/run';
 
@@ -20,7 +20,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.generate({
@@ -29,11 +28,7 @@ run(async () => {
         'Use Bash to read AI_SDK_EXAMPLE_ENV, then report its value as instructed.',
     });
     console.log('text:', result.text);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/stop-when.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/stop-when.ts
@@ -1,9 +1,11 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { isStepCount } from 'ai';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const claudeCode = createClaudeCode();
 
 const prompt = `
 Create a small TypeScript command-line program in this workspace.
@@ -26,7 +28,6 @@ run(async () => {
     stopWhen: isStepCount(1),
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   let isFirstSlice = true;
   try {
@@ -50,11 +51,7 @@ run(async () => {
       const continueFrom = await session.suspendTurn();
       session = await agent.createSession({ sessionId, continueFrom });
     }
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/stream-text.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/stream-text.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createClaudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
@@ -15,7 +15,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -27,11 +26,7 @@ run(async () => {
 
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/suspend-turn.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/suspend-turn.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const claudeCode = createClaudeCode();
 
 const prompt = `
 Create a complete retro Snake game in this workspace.
@@ -31,7 +33,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   try {
     console.log('--- turn 1: stream ---');
@@ -55,11 +56,7 @@ run(async () => {
 
     console.log('finishReason:', await continued.finishReason);
     console.log('usage:', await continued.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/typed-builtin-tools.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/typed-builtin-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const claudeCode = createClaudeCode();
 
 /*
  * Demonstrates that a HarnessAgent's `fullStream` exposes both the harness's
@@ -32,7 +34,6 @@ run(async () => {
     tools: { today },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/vercel-sandbox-resume.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/vercel-sandbox-resume.ts
@@ -7,9 +7,11 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { run } from '../../lib/run';
+
+const claudeCode = createClaudeCode();
 
 run(async () => {
   process.exitCode = 1;

--- a/examples/ai-functions/src/harness-agent/claude-code/with-client-side-tool.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/with-client-side-tool.ts
@@ -1,11 +1,13 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const claudeCode = createClaudeCode();
 
 const terminal = readline.createInterface({
   input: process.stdin,
@@ -28,7 +30,6 @@ run(async () => {
     tools: { getUserName },
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -78,12 +79,8 @@ run(async () => {
     if (session.hasUnfinishedTurn()) {
       throw new Error('Expected the continued turn to finish.');
     }
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     terminal.close();
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/with-instructions.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/with-instructions.ts
@@ -1,7 +1,9 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { run } from '../../lib/run';
+
+const claudeCode = createClaudeCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -16,7 +18,6 @@ run(async () => {
       'Answer every question in German, even when the user requests another language.',
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.generate({
@@ -32,11 +33,7 @@ run(async () => {
     console.log('second text:', second.text);
     console.log('finishReason:', second.finishReason);
     console.log('usage:', second.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/with-mcp.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/with-mcp.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createClaudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
@@ -36,9 +36,6 @@ run(async () => {
     console.log('toolCalls:', JSON.stringify(toolCalls, null, 2));
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (error) {
-    process.exitCode = 1;
-    throw error;
   } finally {
     await session?.destroy();
   }

--- a/examples/ai-functions/src/harness-agent/claude-code/with-provided-sandbox.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/with-provided-sandbox.ts
@@ -1,9 +1,11 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { Sandbox } from '@vercel/sandbox';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const claudeCode = createClaudeCode();
 
 run(async () => {
   const sandbox = await Sandbox.create({
@@ -17,7 +19,6 @@ run(async () => {
     sandbox: createVercelSandbox({ sandbox }),
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -29,12 +30,8 @@ run(async () => {
 
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
     await sandbox.stop().catch(() => {});
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/with-reasoning.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/with-reasoning.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createClaudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
@@ -18,7 +18,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -28,11 +27,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/with-skills.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/with-skills.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const claudeCode = createClaudeCode();
 
 /*
  * Skills are domain-specific reference material the agent loads on demand
@@ -60,7 +62,6 @@ End the document with the version tag on a line by itself, prefixed with \`v\`.`
     ],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -69,11 +70,7 @@ End the document with the version tag on a line by itself, prefixed with \`v\`.`
         'Draft release notes for our next release, v2.4.0. We added a dark mode toggle in #892, fixed an autofocus bug in the search bar in #901, and renamed the `--legacy` CLI flag to `--compat` (old flag removed, no alias).',
     });
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/claude-code/with-tools.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/with-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { createClaudeCode } from './_create';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const claudeCode = createClaudeCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -31,7 +33,6 @@ run(async () => {
     tools: { weather },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -43,11 +44,7 @@ run(async () => {
     await printFullStream({ result });
 
     console.log('steps:', (await result.steps).length);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex-acp/_create.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/_create.ts
@@ -1,0 +1,24 @@
+import {
+  createCodexACP as createCodexACPHarness,
+  type CodexACPHarnessSettings,
+} from '../../lib/codex-acp-harness';
+
+export function createCodexACP(
+  settings: CodexACPHarnessSettings = {},
+): ReturnType<typeof createCodexACPHarness> {
+  const forceAuth = process.env.HARNESS_FORCE_AUTH;
+
+  if (forceAuth == null) {
+    return createCodexACPHarness(settings);
+  }
+
+  return createCodexACPHarness({
+    ...settings,
+    auth:
+      forceAuth === 'ai-gateway'
+        ? 'ai-gateway'
+        : forceAuth === 'direct'
+          ? 'direct'
+          : settings.auth,
+  });
+}

--- a/examples/ai-functions/src/harness-agent/codex-acp/active-tools.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/active-tools.ts
@@ -2,7 +2,7 @@ import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
@@ -32,7 +32,6 @@ run(async () => {
     activeTools: ['weather'],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +41,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex-acp/attach.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/attach.ts
@@ -11,7 +11,7 @@ import {
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { mintBridgeToken } from '../../lib/mint-bridge-token';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';

--- a/examples/ai-functions/src/harness-agent/codex-acp/bash-shell.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/bash-shell.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/harness-agent/codex-acp/bridge-respawn-lossy-rerun.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/bridge-respawn-lossy-rerun.ts
@@ -9,7 +9,7 @@ import {
   terminateACPBridgeForRecovery,
   writeACPHandoffState,
 } from '../../lib/codex-acp-handoff';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/harness-agent/codex-acp/bridge-respawn-replay.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/bridge-respawn-replay.ts
@@ -10,7 +10,7 @@ import {
   waitForACPCompletedRecoveryLog,
   writeACPHandoffState,
 } from '../../lib/codex-acp-handoff';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/harness-agent/codex-acp/builtin-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/builtin-tool-approval.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import {
   createToolApprovalResponseMessages,
   printFullStreamAndCaptureToolApproval,

--- a/examples/ai-functions/src/harness-agent/codex-acp/cancellation.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/cancellation.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { run } from '../../lib/run';
 
 run(async () => {

--- a/examples/ai-functions/src/harness-agent/codex-acp/changing-host-tools.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/changing-host-tools.ts
@@ -5,7 +5,7 @@ import {
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/harness-agent/codex-acp/compaction.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/compaction.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent, type HarnessAgentSession } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { run } from '../../lib/run';
 
 run(async () => {

--- a/examples/ai-functions/src/harness-agent/codex-acp/custom-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/custom-tool-approval.ts
@@ -2,7 +2,7 @@ import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import {
   createToolApprovalResponseMessages,
   printFullStreamAndCaptureToolApproval,

--- a/examples/ai-functions/src/harness-agent/codex-acp/file-edit.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/file-edit.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/harness-agent/codex-acp/generate-text-locked.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/generate-text-locked.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { run } from '../../lib/run';
 
 run(async () => {
@@ -34,9 +34,6 @@ run(async () => {
     console.log('text:', result.text);
     console.log('finishReason:', result.finishReason);
     console.log('usage:', result.usage);
-  } catch (error) {
-    process.exitCode = 1;
-    throw error;
   } finally {
     await session?.destroy();
   }

--- a/examples/ai-functions/src/harness-agent/codex-acp/generate-text.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/generate-text.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { run } from '../../lib/run';
 
 run(async () => {
@@ -22,9 +22,6 @@ run(async () => {
     console.log('text:', result.text);
     console.log('finishReason:', result.finishReason);
     console.log('usage:', result.usage);
-  } catch (error) {
-    process.exitCode = 1;
-    throw error;
   } finally {
     await session?.destroy();
   }

--- a/examples/ai-functions/src/harness-agent/codex-acp/host-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/host-tool-approval.ts
@@ -2,7 +2,7 @@ import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import {
   createToolApprovalResponseMessages,
   printFullStreamAndCaptureToolApproval,

--- a/examples/ai-functions/src/harness-agent/codex-acp/host-tool.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/host-tool.ts
@@ -2,7 +2,7 @@ import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/harness-agent/codex-acp/inactive-tools.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/inactive-tools.ts
@@ -2,7 +2,7 @@ import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
@@ -32,7 +32,6 @@ run(async () => {
     inactiveTools: ['bash'],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +41,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex-acp/live-attach.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/live-attach.ts
@@ -6,7 +6,7 @@ import {
   removeACPHandoffState,
   writeACPHandoffState,
 } from '../../lib/codex-acp-handoff';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/harness-agent/codex-acp/live-client-tool-handoff.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/live-client-tool-handoff.ts
@@ -8,7 +8,7 @@ import {
   removeACPHandoffState,
   writeACPHandoffState,
 } from '../../lib/codex-acp-handoff';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/harness-agent/codex-acp/live-suspend.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/live-suspend.ts
@@ -6,7 +6,7 @@ import {
   removeACPHandoffState,
   writeACPHandoffState,
 } from '../../lib/codex-acp-handoff';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/harness-agent/codex-acp/multi-turn.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/multi-turn.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
@@ -14,7 +14,6 @@ run(async () => {
     }),
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1 ---');
@@ -30,11 +29,7 @@ run(async () => {
       prompt: 'What is my name? Answer in one word.',
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex-acp/parallel-native-tools.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/parallel-native-tools.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/harness-agent/codex-acp/resume.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/resume.ts
@@ -3,7 +3,7 @@ import {
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { run } from '../../lib/run';
 
 run(async () => {

--- a/examples/ai-functions/src/harness-agent/codex-acp/stop-when.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/stop-when.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/harness-agent/codex-acp/stream-text.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/stream-text.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
@@ -23,9 +23,6 @@ run(async () => {
     await printFullStream({ result });
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (error) {
-    process.exitCode = 1;
-    throw error;
   } finally {
     await session?.destroy();
   }

--- a/examples/ai-functions/src/harness-agent/codex-acp/suspend-turn.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/suspend-turn.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
@@ -30,7 +30,6 @@ run(async () => {
     }),
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   try {
     console.log('--- turn 1: stream ---');
@@ -54,11 +53,7 @@ run(async () => {
 
     console.log('finishReason:', await continued.finishReason);
     console.log('usage:', await continued.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex-acp/vercel-sandbox-resume.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/vercel-sandbox-resume.ts
@@ -6,7 +6,7 @@ import {
   removeACPHandoffState,
   writeACPHandoffState,
 } from '../../lib/codex-acp-handoff';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { run } from '../../lib/run';
 
 const exampleName =

--- a/examples/ai-functions/src/harness-agent/codex-acp/with-client-side-tool.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/with-client-side-tool.ts
@@ -3,7 +3,7 @@ import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
@@ -27,7 +27,6 @@ run(async () => {
     tools: { getUserName },
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -77,12 +76,8 @@ run(async () => {
     if (session.hasUnfinishedTurn()) {
       throw new Error('Expected the continued turn to finish.');
     }
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     terminal.close();
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex-acp/with-instructions.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/with-instructions.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { run } from '../../lib/run';
 
 run(async () => {
@@ -16,7 +16,6 @@ run(async () => {
       'Answer every question in German, even when the user requests another language.',
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.generate({
@@ -32,11 +31,7 @@ run(async () => {
     console.log('second text:', second.text);
     console.log('finishReason:', second.finishReason);
     console.log('usage:', second.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex-acp/with-mcp.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/with-mcp.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
@@ -37,9 +37,6 @@ run(async () => {
     console.log('toolCalls:', JSON.stringify(toolCalls, null, 2));
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (error) {
-    process.exitCode = 1;
-    throw error;
   } finally {
     await session?.destroy();
   }

--- a/examples/ai-functions/src/harness-agent/codex-acp/with-provided-sandbox.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/with-provided-sandbox.ts
@@ -1,7 +1,7 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { Sandbox } from '@vercel/sandbox';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/harness-agent/codex-acp/with-reasoning.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/with-reasoning.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 

--- a/examples/ai-functions/src/harness-agent/codex-acp/with-skills.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/with-skills.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { run } from '../../lib/run';
 
 const expectedCodename = 'ORCHID-NEBULA-47';

--- a/examples/ai-functions/src/harness-agent/codex-acp/with-tools.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/with-tools.ts
@@ -2,7 +2,7 @@ import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
@@ -30,7 +30,6 @@ run(async () => {
     tools: { weather },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +41,7 @@ run(async () => {
     await printFullStream({ result });
 
     console.log('steps:', (await result.steps).length);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex-acp/with-web-search.ts
+++ b/examples/ai-functions/src/harness-agent/codex-acp/with-web-search.ts
@@ -1,6 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
-import { createCodexACP } from '../../lib/codex-acp-harness';
+import { createCodexACP } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
@@ -14,7 +14,6 @@ run(async () => {
     }),
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -23,11 +22,7 @@ run(async () => {
         'Search the web for the latest version of Node.js and report it back.',
     });
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/_create.ts
+++ b/examples/ai-functions/src/harness-agent/codex/_create.ts
@@ -1,0 +1,19 @@
+import {
+  createCodex as createCodexHarness,
+  type CodexHarnessSettings,
+} from '@ai-sdk/harness-codex';
+
+export function createCodex(
+  settings: CodexHarnessSettings = {},
+): ReturnType<typeof createCodexHarness> {
+  const forceAuth = process.env.HARNESS_FORCE_AUTH;
+
+  if (forceAuth == null) {
+    return createCodexHarness(settings);
+  }
+
+  return createCodexHarness({
+    ...settings,
+    auth: forceAuth === 'ai-gateway' ? 'ai-gateway' : 'direct',
+  });
+}

--- a/examples/ai-functions/src/harness-agent/codex/active-tools.ts
+++ b/examples/ai-functions/src/harness-agent/codex/active-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const codex = createCodex();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -32,7 +34,6 @@ run(async () => {
     activeTools: ['weather'],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/attach.ts
+++ b/examples/ai-functions/src/harness-agent/codex/attach.ts
@@ -10,7 +10,7 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { createCodex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { mintBridgeToken } from '../../lib/mint-bridge-token';
 import { printFullStream } from '../../lib/print-full-stream';

--- a/examples/ai-functions/src/harness-agent/codex/bash-shell.ts
+++ b/examples/ai-functions/src/harness-agent/codex/bash-shell.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const codex = createCodex();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -23,11 +24,7 @@ run(async () => {
       prompt: 'Run `uname -a` and tell me what kernel this sandbox is running.',
     });
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/builtin-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/codex/builtin-tool-approval.ts
@@ -1,7 +1,9 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const codex = createCodex();
 
 run(async () => {
   const sandbox = createVercelSandbox({

--- a/examples/ai-functions/src/harness-agent/codex/custom-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/codex/custom-tool-approval.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
@@ -9,6 +9,8 @@ import {
   printFullStreamAndCaptureToolApproval,
 } from '../../lib/harness-tool-approval';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const codex = createCodex();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -38,7 +40,6 @@ run(async () => {
     },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -61,11 +62,7 @@ run(async () => {
       }),
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/file-edit.ts
+++ b/examples/ai-functions/src/harness-agent/codex/file-edit.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const codex = createCodex();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1: create ---');
@@ -38,11 +39,7 @@ run(async () => {
       prompt: 'Read `notes.md` and print its contents in your reply.',
     });
     await printFullStream({ result: third });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/generate-text.ts
+++ b/examples/ai-functions/src/harness-agent/codex/generate-text.ts
@@ -1,7 +1,9 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const codex = createCodex();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -14,7 +16,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.generate({
@@ -24,11 +25,7 @@ run(async () => {
     console.log('text:', result.text);
     console.log('finishReason:', result.finishReason);
     console.log('usage:', result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/inactive-tools.ts
+++ b/examples/ai-functions/src/harness-agent/codex/inactive-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const codex = createCodex();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -32,7 +34,6 @@ run(async () => {
     inactiveTools: ['bash'],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/multi-turn.ts
+++ b/examples/ai-functions/src/harness-agent/codex/multi-turn.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const codex = createCodex();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1 ---');
@@ -31,11 +32,7 @@ run(async () => {
       prompt: 'What is my name? Answer in one word.',
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/resume.ts
+++ b/examples/ai-functions/src/harness-agent/codex/resume.ts
@@ -13,10 +13,12 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const codex = createCodex();
 
 run(async () => {
   const sandbox = createVercelSandbox({

--- a/examples/ai-functions/src/harness-agent/codex/stop-when.ts
+++ b/examples/ai-functions/src/harness-agent/codex/stop-when.ts
@@ -1,9 +1,11 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { isStepCount } from 'ai';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const codex = createCodex();
 
 const prompt = `
 Create a small TypeScript command-line program in this workspace.
@@ -26,7 +28,6 @@ run(async () => {
     stopWhen: isStepCount(1),
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   let isFirstSlice = true;
   try {
@@ -50,11 +51,7 @@ run(async () => {
       const continueFrom = await session.suspendTurn();
       session = await agent.createSession({ sessionId, continueFrom });
     }
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/stream-text.ts
+++ b/examples/ai-functions/src/harness-agent/codex/stream-text.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const codex = createCodex();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -27,11 +28,7 @@ run(async () => {
 
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/suspend-turn.ts
+++ b/examples/ai-functions/src/harness-agent/codex/suspend-turn.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const codex = createCodex();
 
 const prompt = `
 Create a complete retro Snake game in this workspace.
@@ -31,7 +33,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   try {
     console.log('--- turn 1: stream ---');
@@ -55,11 +56,7 @@ run(async () => {
 
     console.log('finishReason:', await continued.finishReason);
     console.log('usage:', await continued.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/typed-builtin-tools.ts
+++ b/examples/ai-functions/src/harness-agent/codex/typed-builtin-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const codex = createCodex();
 
 /*
  * Codex twin of the typed-builtin-tools example. Codex's builtin tool set
@@ -30,7 +32,6 @@ run(async () => {
     tools: { echo },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -40,11 +41,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/vercel-sandbox-resume.ts
+++ b/examples/ai-functions/src/harness-agent/codex/vercel-sandbox-resume.ts
@@ -7,9 +7,11 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { run } from '../../lib/run';
+
+const codex = createCodex();
 
 run(async () => {
   process.exitCode = 1;

--- a/examples/ai-functions/src/harness-agent/codex/with-client-side-tool.ts
+++ b/examples/ai-functions/src/harness-agent/codex/with-client-side-tool.ts
@@ -1,11 +1,13 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const codex = createCodex();
 
 const terminal = readline.createInterface({
   input: process.stdin,
@@ -28,7 +30,6 @@ run(async () => {
     tools: { getUserName },
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -78,12 +79,8 @@ run(async () => {
     if (session.hasUnfinishedTurn()) {
       throw new Error('Expected the continued turn to finish.');
     }
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     terminal.close();
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/with-instructions.ts
+++ b/examples/ai-functions/src/harness-agent/codex/with-instructions.ts
@@ -1,7 +1,9 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { run } from '../../lib/run';
+
+const codex = createCodex();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -16,7 +18,6 @@ run(async () => {
       'Answer every question in German, even when the user requests another language.',
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.generate({
@@ -32,11 +33,7 @@ run(async () => {
     console.log('second text:', second.text);
     console.log('finishReason:', second.finishReason);
     console.log('usage:', second.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/with-mcp.ts
+++ b/examples/ai-functions/src/harness-agent/codex/with-mcp.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createCodex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
@@ -35,9 +35,6 @@ run(async () => {
     console.log('toolCalls:', JSON.stringify(toolCalls, null, 2));
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (error) {
-    process.exitCode = 1;
-    throw error;
   } finally {
     await session?.destroy();
   }

--- a/examples/ai-functions/src/harness-agent/codex/with-reasoning.ts
+++ b/examples/ai-functions/src/harness-agent/codex/with-reasoning.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createCodex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
@@ -15,7 +15,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -24,11 +23,7 @@ run(async () => {
         'Solve this step by step: if f(x) = x^3 - 6x^2 + 11x - 6, find all roots and prove they are correct.',
     });
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/with-skills.ts
+++ b/examples/ai-functions/src/harness-agent/codex/with-skills.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const codex = createCodex();
 
 /*
  * Skills are domain-specific reference material the agent loads on demand
@@ -60,7 +62,6 @@ End the document with the version tag on a line by itself, prefixed with \`v\`.`
     ],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -69,11 +70,7 @@ End the document with the version tag on a line by itself, prefixed with \`v\`.`
         'Draft release notes for our next release, v2.4.0. We added a dark mode toggle in #892, fixed an autofocus bug in the search bar in #901, and renamed the `--legacy` CLI flag to `--compat` (old flag removed, no alias).',
     });
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/with-tools.ts
+++ b/examples/ai-functions/src/harness-agent/codex/with-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { codex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const codex = createCodex();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -31,7 +33,6 @@ run(async () => {
     tools: { weather },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -43,11 +44,7 @@ run(async () => {
     await printFullStream({ result });
 
     console.log('steps:', (await result.steps).length);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/codex/with-web-search.ts
+++ b/examples/ai-functions/src/harness-agent/codex/with-web-search.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createCodex } from '@ai-sdk/harness-codex';
+import { createCodex } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
@@ -15,7 +15,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -24,11 +23,7 @@ run(async () => {
         'Search the web for the latest version of Node.js and report it back.',
     });
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/_create.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/_create.ts
@@ -1,0 +1,19 @@
+import {
+  createDeepAgents as createDeepAgentsHarness,
+  type DeepAgentsHarnessSettings,
+} from '@ai-sdk/harness-deepagents';
+
+export function createDeepAgents(
+  settings: DeepAgentsHarnessSettings = {},
+): ReturnType<typeof createDeepAgentsHarness> {
+  const forceAuth = process.env.HARNESS_FORCE_AUTH;
+
+  if (forceAuth == null) {
+    return createDeepAgentsHarness(settings);
+  }
+
+  return createDeepAgentsHarness({
+    ...settings,
+    auth: forceAuth === 'ai-gateway' ? 'ai-gateway' : 'anthropic',
+  });
+}

--- a/examples/ai-functions/src/harness-agent/deepagents/active-tools.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/active-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -32,7 +34,6 @@ run(async () => {
     activeTools: ['weather'],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/attach.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/attach.ts
@@ -2,7 +2,7 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { createDeepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { mintBridgeToken } from '../../lib/mint-bridge-token';
 import { printFullStream } from '../../lib/print-full-stream';

--- a/examples/ai-functions/src/harness-agent/deepagents/bash-shell.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/bash-shell.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -12,7 +14,6 @@ run(async () => {
   });
   const agent = new HarnessAgent({ harness: deepAgents, sandbox });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -20,11 +21,7 @@ run(async () => {
       prompt: 'Run `uname -a` and tell me what kernel this sandbox is running.',
     });
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/builtin-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/builtin-tool-approval.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import {
@@ -7,6 +7,8 @@ import {
   printFullStreamAndCaptureToolApproval,
 } from '../../lib/harness-tool-approval';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const deepAgents = createDeepAgents();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -20,7 +22,6 @@ run(async () => {
     permissionMode: 'allow-edits',
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
       }),
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/custom-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/custom-tool-approval.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
@@ -9,6 +9,8 @@ import {
 } from '../../lib/harness-tool-approval';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -36,7 +38,6 @@ run(async () => {
     toolApproval: { weather: 'user-approval' },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -59,11 +60,7 @@ run(async () => {
       }),
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/file-edit.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/file-edit.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -12,7 +14,6 @@ run(async () => {
   });
   const agent = new HarnessAgent({ harness: deepAgents, sandbox });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1: create ---');
@@ -35,11 +36,7 @@ run(async () => {
       prompt: 'Read `notes.md` and print its contents in your reply.',
     });
     await printFullStream({ result: third });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/generate-text.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/generate-text.ts
@@ -1,7 +1,9 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -14,7 +16,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.generate({
@@ -24,11 +25,7 @@ run(async () => {
     console.log('text:', result.text);
     console.log('finishReason:', result.finishReason);
     console.log('usage:', result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/inactive-tools.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/inactive-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -32,7 +34,6 @@ run(async () => {
     inactiveTools: ['read', 'bash', 'grep', 'glob', 'ls', 'task'],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/multi-turn.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/multi-turn.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1 ---');
@@ -31,11 +32,7 @@ run(async () => {
       prompt: 'What is my name? Answer in one word.',
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/stop-when.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/stop-when.ts
@@ -1,9 +1,11 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { isStepCount } from 'ai';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 const prompt = `
 Create a small TypeScript command-line program in this workspace.
@@ -26,7 +28,6 @@ run(async () => {
     stopWhen: isStepCount(1),
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   let isFirstSlice = true;
   try {
@@ -50,11 +51,7 @@ run(async () => {
       const continueFrom = await session.suspendTurn();
       session = await agent.createSession({ sessionId, continueFrom });
     }
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/stream-text.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/stream-text.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -27,11 +28,7 @@ run(async () => {
 
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/suspend-turn.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/suspend-turn.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 const prompt = `
 Create a complete retro Snake game in this workspace.
@@ -31,7 +33,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   try {
     console.log('--- turn 1: stream ---');
@@ -55,11 +56,7 @@ run(async () => {
 
     console.log('finishReason:', await continued.finishReason);
     console.log('usage:', await continued.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/typed-builtin-tools.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/typed-builtin-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 // Deep Agents's builtin tool set (read/write/edit/bash/grep/glob/ls/task/write_todos)
 // merges with user tools; TypeScript narrows `toolName`/`input` per tool across both surfaces.
@@ -27,7 +29,6 @@ run(async () => {
     tools: { echo },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -36,11 +37,7 @@ run(async () => {
         'Call the `echo` tool with the message "hello", then run `uname -a` and tell me the kernel.',
     });
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/vercel-sandbox-resume.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/vercel-sandbox-resume.ts
@@ -7,9 +7,11 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 run(async () => {
   process.exitCode = 1;

--- a/examples/ai-functions/src/harness-agent/deepagents/with-client-side-tool.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/with-client-side-tool.ts
@@ -1,11 +1,13 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 const terminal = readline.createInterface({
   input: process.stdin,
@@ -28,7 +30,6 @@ run(async () => {
     tools: { getUserName },
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -78,12 +79,8 @@ run(async () => {
     if (session.hasUnfinishedTurn()) {
       throw new Error('Expected the continued turn to finish.');
     }
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     terminal.close();
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/with-instructions.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/with-instructions.ts
@@ -1,7 +1,9 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -16,7 +18,6 @@ run(async () => {
       'Answer every question in German, even when the user requests another language.',
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.generate({
@@ -32,11 +33,7 @@ run(async () => {
     console.log('second text:', second.text);
     console.log('finishReason:', second.finishReason);
     console.log('usage:', second.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/with-mcp.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/with-mcp.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createDeepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
@@ -36,9 +36,6 @@ run(async () => {
     console.log('toolCalls:', JSON.stringify(toolCalls, null, 2));
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (error) {
-    process.exitCode = 1;
-    throw error;
   } finally {
     await session?.destroy();
   }

--- a/examples/ai-functions/src/harness-agent/deepagents/with-reasoning.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/with-reasoning.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createDeepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
@@ -21,7 +21,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -31,11 +30,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/with-skills.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/with-skills.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 // Skills are loaded on demand by name/description; the harness writes them under `$HOME/.agents/skills`.
 run(async () => {
@@ -49,7 +51,6 @@ End the document with the version tag on a line by itself, prefixed with \`v\`.`
     ],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -58,11 +59,7 @@ End the document with the version tag on a line by itself, prefixed with \`v\`.`
         'Draft release notes for our next release, v2.4.0. We added a dark mode toggle in #892, fixed an autofocus bug in the search bar in #901, and renamed the `--legacy` CLI flag to `--compat` (old flag removed, no alias).',
     });
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/deepagents/with-tools.ts
+++ b/examples/ai-functions/src/harness-agent/deepagents/with-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
+import { createDeepAgents } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const deepAgents = createDeepAgents();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -31,7 +33,6 @@ run(async () => {
     tools: { weather },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -43,11 +44,7 @@ run(async () => {
     await printFullStream({ result });
 
     console.log('steps:', (await result.steps).length);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/_create.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/_create.ts
@@ -1,0 +1,24 @@
+import {
+  createGrokBuild as createGrokBuildHarness,
+  type GrokBuildHarnessSettings,
+} from '@ai-sdk/harness-grok-build';
+
+export function createGrokBuild(
+  settings: GrokBuildHarnessSettings = {},
+): ReturnType<typeof createGrokBuildHarness> {
+  const forceAuth = process.env.HARNESS_FORCE_AUTH;
+
+  if (forceAuth == null) {
+    return createGrokBuildHarness(settings);
+  }
+
+  return createGrokBuildHarness({
+    ...settings,
+    auth:
+      forceAuth === 'ai-gateway'
+        ? 'ai-gateway'
+        : forceAuth === 'direct'
+          ? 'direct'
+          : settings.auth,
+  });
+}

--- a/examples/ai-functions/src/harness-agent/grok-build/active-tools.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/active-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const grokBuild = createGrokBuild();
 
 run(async () => {
   const sandbox = createVercelSandbox({

--- a/examples/ai-functions/src/harness-agent/grok-build/attach.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/attach.ts
@@ -10,7 +10,7 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { createGrokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { mintBridgeToken } from '../../lib/mint-bridge-token';
 import { printFullStream } from '../../lib/print-full-stream';

--- a/examples/ai-functions/src/harness-agent/grok-build/builtin-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/builtin-tool-approval.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import {
@@ -7,6 +7,8 @@ import {
   printFullStreamAndCaptureToolApproval,
 } from '../../lib/harness-tool-approval';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const grokBuild = createGrokBuild();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -20,7 +22,6 @@ run(async () => {
     permissionMode: 'allow-edits',
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -43,11 +44,7 @@ run(async () => {
       }),
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/compaction.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/compaction.ts
@@ -1,7 +1,9 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const grokBuild = createGrokBuild();
 
 /*
  * ACP v1 has no portable manual compaction API. This example deliberately

--- a/examples/ai-functions/src/harness-agent/grok-build/custom-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/custom-tool-approval.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
@@ -9,6 +9,8 @@ import {
   printFullStreamAndCaptureToolApproval,
 } from '../../lib/harness-tool-approval';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const grokBuild = createGrokBuild();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -38,7 +40,6 @@ run(async () => {
     },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -61,11 +62,7 @@ run(async () => {
       }),
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/file-edit.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/file-edit.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const grokBuild = createGrokBuild();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1: create ---');
@@ -38,11 +39,7 @@ run(async () => {
       prompt: 'Read `notes.md` and print its contents in your reply.',
     });
     await printFullStream({ result: third });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/generate-text.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/generate-text.ts
@@ -1,7 +1,9 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const grokBuild = createGrokBuild();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -14,7 +16,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.generate({
@@ -24,11 +25,7 @@ run(async () => {
     console.log('text:', result.text);
     console.log('finishReason:', result.finishReason);
     console.log('usage:', result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/inactive-tools.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/inactive-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const grokBuild = createGrokBuild();
 
 run(async () => {
   const sandbox = createVercelSandbox({

--- a/examples/ai-functions/src/harness-agent/grok-build/multi-turn.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/multi-turn.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const grokBuild = createGrokBuild();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1 ---');
@@ -31,11 +32,7 @@ run(async () => {
       prompt: 'What is my name? Answer in one word.',
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/resume.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/resume.ts
@@ -11,10 +11,12 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const grokBuild = createGrokBuild();
 
 run(async () => {
   const sandbox = createVercelSandbox({

--- a/examples/ai-functions/src/harness-agent/grok-build/stop-when.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/stop-when.ts
@@ -1,9 +1,11 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { isStepCount } from 'ai';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const grokBuild = createGrokBuild();
 
 const prompt = `
 Create a small TypeScript command-line program in this workspace.
@@ -26,7 +28,6 @@ run(async () => {
     stopWhen: isStepCount(1),
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   let isFirstSlice = true;
   try {
@@ -50,11 +51,7 @@ run(async () => {
       const continueFrom = await session.suspendTurn();
       session = await agent.createSession({ sessionId, continueFrom });
     }
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/stream-text.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/stream-text.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const grokBuild = createGrokBuild();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -27,11 +28,7 @@ run(async () => {
 
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/suspend-turn.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/suspend-turn.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const grokBuild = createGrokBuild();
 
 const prompt = `
 Create a complete retro Snake game in this workspace.
@@ -31,7 +33,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   try {
     console.log('--- turn 1: stream ---');
@@ -55,11 +56,7 @@ run(async () => {
 
     console.log('finishReason:', await continued.finishReason);
     console.log('usage:', await continued.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/typed-builtin-tools.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/typed-builtin-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const grokBuild = createGrokBuild();
 
 /*
  * Demonstrates that a HarnessAgent's `fullStream` exposes both the harness's
@@ -32,7 +34,6 @@ run(async () => {
     tools: { today },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/vercel-sandbox-resume.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/vercel-sandbox-resume.ts
@@ -7,9 +7,11 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { run } from '../../lib/run';
+
+const grokBuild = createGrokBuild();
 
 run(async () => {
   process.exitCode = 1;

--- a/examples/ai-functions/src/harness-agent/grok-build/with-client-side-tool.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/with-client-side-tool.ts
@@ -1,11 +1,13 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const grokBuild = createGrokBuild();
 
 const terminal = readline.createInterface({
   input: process.stdin,
@@ -28,7 +30,6 @@ run(async () => {
     tools: { getUserName },
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -78,12 +79,8 @@ run(async () => {
     if (session.hasUnfinishedTurn()) {
       throw new Error('Expected the continued turn to finish.');
     }
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     terminal.close();
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/with-instructions.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/with-instructions.ts
@@ -1,7 +1,9 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { run } from '../../lib/run';
+
+const grokBuild = createGrokBuild();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -16,7 +18,6 @@ run(async () => {
       'Answer every question in German, even when the user requests another language.',
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.generate({
@@ -32,11 +33,7 @@ run(async () => {
     console.log('second text:', second.text);
     console.log('finishReason:', second.finishReason);
     console.log('usage:', second.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/with-mcp.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/with-mcp.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createGrokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
@@ -37,9 +37,6 @@ run(async () => {
     console.log('toolCalls:', JSON.stringify(toolCalls, null, 2));
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (error) {
-    process.exitCode = 1;
-    throw error;
   } finally {
     await session?.destroy();
   }

--- a/examples/ai-functions/src/harness-agent/grok-build/with-provided-sandbox.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/with-provided-sandbox.ts
@@ -1,9 +1,11 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { Sandbox } from '@vercel/sandbox';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const grokBuild = createGrokBuild();
 
 run(async () => {
   const sandbox = await Sandbox.create({
@@ -17,7 +19,6 @@ run(async () => {
     sandbox: createVercelSandbox({ sandbox }),
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -29,12 +30,8 @@ run(async () => {
 
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
     await sandbox.stop().catch(() => {});
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/with-reasoning.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/with-reasoning.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const grokBuild = createGrokBuild();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -25,11 +26,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/with-skills.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/with-skills.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const grokBuild = createGrokBuild();
 
 /*
  * Skills are domain-specific reference material the agent loads on demand
@@ -60,7 +62,6 @@ End the document with the version tag on a line by itself, prefixed with \`v\`.`
     ],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -69,11 +70,7 @@ End the document with the version tag on a line by itself, prefixed with \`v\`.`
         'Draft release notes for our next release, v2.4.0. We added a dark mode toggle in #892, fixed an autofocus bug in the search bar in #901, and renamed the `--legacy` CLI flag to `--compat` (old flag removed, no alias).',
     });
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/grok-build/with-tools.ts
+++ b/examples/ai-functions/src/harness-agent/grok-build/with-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { grokBuild } from '@ai-sdk/harness-grok-build';
+import { createGrokBuild } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const grokBuild = createGrokBuild();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -31,7 +33,6 @@ run(async () => {
     tools: { weather },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -43,11 +44,7 @@ run(async () => {
     await printFullStream({ result });
 
     console.log('steps:', (await result.steps).length);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/_create.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/_create.ts
@@ -1,0 +1,19 @@
+import {
+  createOpenCode as createOpenCodeHarness,
+  type OpenCodeHarnessSettings,
+} from '@ai-sdk/harness-opencode';
+
+export function createOpenCode(
+  settings: OpenCodeHarnessSettings = {},
+): ReturnType<typeof createOpenCodeHarness> {
+  const forceAuth = process.env.HARNESS_FORCE_AUTH;
+
+  if (forceAuth == null) {
+    return createOpenCodeHarness(settings);
+  }
+
+  return createOpenCodeHarness({
+    ...settings,
+    auth: forceAuth === 'ai-gateway' ? 'ai-gateway' : 'anthropic',
+  });
+}

--- a/examples/ai-functions/src/harness-agent/opencode/active-tools.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/active-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const openCode = createOpenCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -32,7 +34,6 @@ run(async () => {
     activeTools: ['weather'],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/attach.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/attach.ts
@@ -10,7 +10,7 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { createOpenCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { mintBridgeToken } from '../../lib/mint-bridge-token';
 import { printFullStream } from '../../lib/print-full-stream';

--- a/examples/ai-functions/src/harness-agent/opencode/bash-shell.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/bash-shell.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const openCode = createOpenCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -23,11 +24,7 @@ run(async () => {
       prompt: 'Run `uname -a` and tell me what kernel this sandbox is running.',
     });
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/builtin-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/builtin-tool-approval.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import {
@@ -7,6 +7,8 @@ import {
   printFullStreamAndCaptureToolApproval,
 } from '../../lib/harness-tool-approval';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const openCode = createOpenCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -20,7 +22,6 @@ run(async () => {
     permissionMode: 'allow-edits',
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
       }),
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/compaction.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/compaction.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const openCode = createOpenCode();
 
 /*
  * Context compaction (OpenCode).
@@ -25,7 +27,6 @@ run(async () => {
   });
   const agent = new HarnessAgent({ harness: openCode, sandbox });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1: build up some context ---');
@@ -47,11 +48,7 @@ run(async () => {
       prompt: 'Now write a short haiku about that explanation.',
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/custom-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/custom-tool-approval.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
@@ -9,6 +9,8 @@ import {
   printFullStreamAndCaptureToolApproval,
 } from '../../lib/harness-tool-approval';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const openCode = createOpenCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -38,7 +40,6 @@ run(async () => {
     },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -61,11 +62,7 @@ run(async () => {
       }),
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/file-edit.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/file-edit.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const openCode = createOpenCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1: create ---');
@@ -38,11 +39,7 @@ run(async () => {
       prompt: 'Read `notes.md` and print its contents in your reply.',
     });
     await printFullStream({ result: third });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/generate-text.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/generate-text.ts
@@ -1,7 +1,9 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const openCode = createOpenCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -14,7 +16,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.generate({
@@ -24,11 +25,7 @@ run(async () => {
     console.log('text:', result.text);
     console.log('finishReason:', result.finishReason);
     console.log('usage:', result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/inactive-tools.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/inactive-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const openCode = createOpenCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -32,7 +34,6 @@ run(async () => {
     inactiveTools: ['read', 'bash', 'glob', 'grep', 'ls', 'agent'],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/multi-turn.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/multi-turn.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const openCode = createOpenCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1 ---');
@@ -31,11 +32,7 @@ run(async () => {
       prompt: 'What is my name? Answer in one word.',
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/resume.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/resume.ts
@@ -12,10 +12,12 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const openCode = createOpenCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({

--- a/examples/ai-functions/src/harness-agent/opencode/stop-when.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/stop-when.ts
@@ -1,9 +1,11 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { isStepCount } from 'ai';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const openCode = createOpenCode();
 
 const prompt = `
 Create a small TypeScript command-line program in this workspace.
@@ -26,7 +28,6 @@ run(async () => {
     stopWhen: isStepCount(1),
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   let isFirstSlice = true;
   try {
@@ -50,11 +51,7 @@ run(async () => {
       const continueFrom = await session.suspendTurn();
       session = await agent.createSession({ sessionId, continueFrom });
     }
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/stream-text.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/stream-text.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const openCode = createOpenCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -27,11 +28,7 @@ run(async () => {
 
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/suspend-turn.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/suspend-turn.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const openCode = createOpenCode();
 
 const prompt = `
 Create a complete retro Snake game in this workspace.
@@ -31,7 +33,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   try {
     console.log('--- turn 1: stream ---');
@@ -55,11 +56,7 @@ run(async () => {
 
     console.log('finishReason:', await continued.finishReason);
     console.log('usage:', await continued.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/typed-builtin-tools.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/typed-builtin-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const openCode = createOpenCode();
 
 /*
  * OpenCode twin of the typed-builtin-tools example. OpenCode's builtin tool
@@ -31,7 +33,6 @@ run(async () => {
     tools: { echo },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -41,11 +42,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/vercel-sandbox-resume.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/vercel-sandbox-resume.ts
@@ -7,9 +7,11 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { run } from '../../lib/run';
+
+const openCode = createOpenCode();
 
 run(async () => {
   process.exitCode = 1;

--- a/examples/ai-functions/src/harness-agent/opencode/with-client-side-tool.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/with-client-side-tool.ts
@@ -1,11 +1,13 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const openCode = createOpenCode();
 
 const terminal = readline.createInterface({
   input: process.stdin,
@@ -28,7 +30,6 @@ run(async () => {
     tools: { getUserName },
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -78,12 +79,8 @@ run(async () => {
     if (session.hasUnfinishedTurn()) {
       throw new Error('Expected the continued turn to finish.');
     }
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     terminal.close();
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/with-instructions.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/with-instructions.ts
@@ -1,7 +1,9 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { run } from '../../lib/run';
+
+const openCode = createOpenCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -16,7 +18,6 @@ run(async () => {
       'Answer every question in German, even when the user requests another language.',
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.generate({
@@ -32,11 +33,7 @@ run(async () => {
     console.log('second text:', second.text);
     console.log('finishReason:', second.finishReason);
     console.log('usage:', second.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/with-mcp.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/with-mcp.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createOpenCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
@@ -38,9 +38,6 @@ run(async () => {
     console.log('toolCalls:', JSON.stringify(toolCalls, null, 2));
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (error) {
-    process.exitCode = 1;
-    throw error;
   } finally {
     await session?.destroy();
   }

--- a/examples/ai-functions/src/harness-agent/opencode/with-provided-sandbox.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/with-provided-sandbox.ts
@@ -1,9 +1,11 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { Sandbox } from '@vercel/sandbox';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const openCode = createOpenCode();
 
 run(async () => {
   const sandbox = await Sandbox.create({
@@ -17,7 +19,6 @@ run(async () => {
     sandbox: createVercelSandbox({ sandbox }),
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -29,12 +30,8 @@ run(async () => {
 
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
     await sandbox.stop().catch(() => {});
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/with-reasoning.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/with-reasoning.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createOpenCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
@@ -15,7 +15,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -25,11 +24,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/with-skills.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/with-skills.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const openCode = createOpenCode();
 
 /*
  * Skills are domain-specific reference material the agent loads on demand
@@ -60,7 +62,6 @@ End the document with the version tag on a line by itself, prefixed with \`v\`.`
     ],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -69,11 +70,7 @@ End the document with the version tag on a line by itself, prefixed with \`v\`.`
         'Draft release notes for our next release, v2.4.0. We added a dark mode toggle in #892, fixed an autofocus bug in the search bar in #901, and renamed the `--legacy` CLI flag to `--compat` (old flag removed, no alias).',
     });
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/opencode/with-tools.ts
+++ b/examples/ai-functions/src/harness-agent/opencode/with-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { openCode } from '@ai-sdk/harness-opencode';
+import { createOpenCode } from './_create';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const openCode = createOpenCode();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -31,7 +33,6 @@ run(async () => {
     tools: { weather },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -43,11 +44,7 @@ run(async () => {
     await printFullStream({ result });
 
     console.log('steps:', (await result.steps).length);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/_create.ts
+++ b/examples/ai-functions/src/harness-agent/pi/_create.ts
@@ -1,0 +1,19 @@
+import {
+  createPi as createPiHarness,
+  type PiHarnessSettings,
+} from '@ai-sdk/harness-pi';
+
+export function createPi(
+  settings: PiHarnessSettings = {},
+): ReturnType<typeof createPiHarness> {
+  const forceAuth = process.env.HARNESS_FORCE_AUTH;
+
+  if (forceAuth == null) {
+    return createPiHarness(settings);
+  }
+
+  return createPiHarness({
+    ...settings,
+    auth: forceAuth === 'ai-gateway' ? 'ai-gateway' : 'anthropic',
+  });
+}

--- a/examples/ai-functions/src/harness-agent/pi/active-tools.ts
+++ b/examples/ai-functions/src/harness-agent/pi/active-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const pi = createPi();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -32,7 +34,6 @@ run(async () => {
     activeTools: ['weather'],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/builtin-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/pi/builtin-tool-approval.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import {
@@ -7,6 +7,8 @@ import {
   printFullStreamAndCaptureToolApproval,
 } from '../../lib/harness-tool-approval';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const pi = createPi();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -19,7 +21,6 @@ run(async () => {
     permissionMode: 'allow-edits',
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -41,11 +42,7 @@ run(async () => {
       }),
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/compaction.ts
+++ b/examples/ai-functions/src/harness-agent/pi/compaction.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const pi = createPi();
 
 /*
  * Context compaction (Pi).
@@ -40,7 +42,6 @@ run(async () => {
   });
   const agent = new HarnessAgent({ harness: pi, sandbox });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1: build up some context ---');
@@ -62,11 +63,7 @@ run(async () => {
       prompt: 'Now write a short haiku about that explanation.',
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/custom-tool-approval.ts
+++ b/examples/ai-functions/src/harness-agent/pi/custom-tool-approval.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
@@ -9,6 +9,8 @@ import {
   printFullStreamAndCaptureToolApproval,
 } from '../../lib/harness-tool-approval';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const pi = createPi();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -37,7 +39,6 @@ run(async () => {
     },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -60,11 +61,7 @@ run(async () => {
       }),
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/file-edit.ts
+++ b/examples/ai-functions/src/harness-agent/pi/file-edit.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const pi = createPi();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -14,7 +16,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1: create ---');
@@ -37,11 +38,7 @@ run(async () => {
       prompt: 'Read `notes.md` and print its contents in your reply.',
     });
     await printFullStream({ result: third });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/generate-text.ts
+++ b/examples/ai-functions/src/harness-agent/pi/generate-text.ts
@@ -1,7 +1,9 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const pi = createPi();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -13,7 +15,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.generate({
@@ -23,11 +24,7 @@ run(async () => {
     console.log('text:', result.text);
     console.log('finishReason:', result.finishReason);
     console.log('usage:', result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/inactive-tools.ts
+++ b/examples/ai-functions/src/harness-agent/pi/inactive-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const pi = createPi();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -32,7 +34,6 @@ run(async () => {
     inactiveTools: ['read', 'bash', 'grep', 'glob', 'ls'],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/multi-turn.ts
+++ b/examples/ai-functions/src/harness-agent/pi/multi-turn.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const pi = createPi();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -14,7 +16,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     console.log('--- turn 1 ---');
@@ -30,11 +31,7 @@ run(async () => {
       prompt: 'What is my name? Answer in one word.',
     });
     await printFullStream({ result: second });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/resume.ts
+++ b/examples/ai-functions/src/harness-agent/pi/resume.ts
@@ -12,10 +12,12 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const pi = createPi();
 
 run(async () => {
   const sandbox = createVercelSandbox({

--- a/examples/ai-functions/src/harness-agent/pi/stop-when.ts
+++ b/examples/ai-functions/src/harness-agent/pi/stop-when.ts
@@ -1,9 +1,11 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { isStepCount } from 'ai';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const pi = createPi();
 
 const prompt = `
 Create a small TypeScript command-line program in this workspace.
@@ -25,7 +27,6 @@ run(async () => {
     stopWhen: isStepCount(1),
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   let isFirstSlice = true;
   try {
@@ -49,11 +50,7 @@ run(async () => {
       const continueFrom = await session.suspendTurn();
       session = await agent.createSession({ sessionId, continueFrom });
     }
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/stream-text.ts
+++ b/examples/ai-functions/src/harness-agent/pi/stream-text.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const pi = createPi();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -14,7 +16,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -26,11 +27,7 @@ run(async () => {
 
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/suspend-turn.ts
+++ b/examples/ai-functions/src/harness-agent/pi/suspend-turn.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const pi = createPi();
 
 const prompt = `
 Create a complete retro Snake game in this workspace.
@@ -30,7 +32,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   try {
     console.log('--- turn 1: stream ---');
@@ -54,11 +55,7 @@ run(async () => {
 
     console.log('finishReason:', await continued.finishReason);
     console.log('usage:', await continued.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/typed-builtin-tools.ts
+++ b/examples/ai-functions/src/harness-agent/pi/typed-builtin-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const pi = createPi();
 
 /*
  * Demonstrates that a HarnessAgent's `fullStream` exposes both Pi's built-in
@@ -31,7 +33,6 @@ run(async () => {
     tools: { today },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -41,11 +42,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/vercel-sandbox-resume.ts
+++ b/examples/ai-functions/src/harness-agent/pi/vercel-sandbox-resume.ts
@@ -7,9 +7,11 @@ import {
   HarnessAgent,
   type HarnessAgentResumeSessionState,
 } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { run } from '../../lib/run';
+
+const pi = createPi();
 
 run(async () => {
   process.exitCode = 1;

--- a/examples/ai-functions/src/harness-agent/pi/with-client-side-tool.ts
+++ b/examples/ai-functions/src/harness-agent/pi/with-client-side-tool.ts
@@ -1,11 +1,13 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { tool } from 'ai';
 import * as readline from 'node:readline/promises';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const pi = createPi();
 
 const terminal = readline.createInterface({
   input: process.stdin,
@@ -28,7 +30,6 @@ run(async () => {
     tools: { getUserName },
   });
 
-  let exitCode = 0;
   let session = await agent.createSession();
   try {
     const first = await agent.stream({
@@ -78,12 +79,8 @@ run(async () => {
     if (session.hasUnfinishedTurn()) {
       throw new Error('Expected the continued turn to finish.');
     }
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     terminal.close();
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/with-instructions.ts
+++ b/examples/ai-functions/src/harness-agent/pi/with-instructions.ts
@@ -1,7 +1,9 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { run } from '../../lib/run';
+
+const pi = createPi();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -15,7 +17,6 @@ run(async () => {
       'Answer every question in German, even when the user requests another language.',
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const first = await agent.generate({
@@ -31,11 +32,7 @@ run(async () => {
     console.log('second text:', second.text);
     console.log('finishReason:', second.finishReason);
     console.log('usage:', second.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/with-mcp.ts
+++ b/examples/ai-functions/src/harness-agent/pi/with-mcp.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createPi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
@@ -36,9 +36,6 @@ run(async () => {
     console.log('toolCalls:', JSON.stringify(toolCalls, null, 2));
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (error) {
-    process.exitCode = 1;
-    throw error;
   } finally {
     await session?.destroy();
   }

--- a/examples/ai-functions/src/harness-agent/pi/with-provided-sandbox.ts
+++ b/examples/ai-functions/src/harness-agent/pi/with-provided-sandbox.ts
@@ -1,9 +1,11 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { Sandbox } from '@vercel/sandbox';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const pi = createPi();
 
 run(async () => {
   const sandbox = await Sandbox.create({
@@ -16,7 +18,6 @@ run(async () => {
     sandbox: createVercelSandbox({ sandbox }),
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -28,12 +29,8 @@ run(async () => {
 
     console.log('finishReason:', await result.finishReason);
     console.log('usage:', await result.usage);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
     await sandbox.stop().catch(() => {});
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/with-reasoning.ts
+++ b/examples/ai-functions/src/harness-agent/pi/with-reasoning.ts
@@ -1,5 +1,5 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { createPi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
@@ -14,7 +14,6 @@ run(async () => {
     sandbox,
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -24,11 +23,7 @@ run(async () => {
     });
 
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/with-skills.ts
+++ b/examples/ai-functions/src/harness-agent/pi/with-skills.ts
@@ -1,8 +1,10 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
+
+const pi = createPi();
 
 /*
  * Skills are domain-specific reference material the agent loads on demand
@@ -57,7 +59,6 @@ End the document with the version tag on a line by itself, prefixed with \`v\`.`
     ],
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -66,11 +67,7 @@ End the document with the version tag on a line by itself, prefixed with \`v\`.`
         'Draft release notes for our next release, v2.4.0. We added a dark mode toggle in #892, fixed an autofocus bug in the search bar in #901, and renamed the `--legacy` CLI flag to `--compat` (old flag removed, no alias).',
     });
     await printFullStream({ result });
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/pi/with-tools.ts
+++ b/examples/ai-functions/src/harness-agent/pi/with-tools.ts
@@ -1,10 +1,12 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
-import { pi } from '@ai-sdk/harness-pi';
+import { createPi } from './_create';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const pi = createPi();
 
 run(async () => {
   const sandbox = createVercelSandbox({
@@ -30,7 +32,6 @@ run(async () => {
     tools: { weather },
   });
 
-  let exitCode = 0;
   const session = await agent.createSession();
   try {
     const result = await agent.stream({
@@ -42,11 +43,7 @@ run(async () => {
     await printFullStream({ result });
 
     console.log('steps:', (await result.steps).length);
-  } catch (err) {
-    exitCode = 1;
-    console.error('[example] failed:', err);
   } finally {
     await session.destroy();
-    process.exit(exitCode);
   }
 });

--- a/examples/ai-functions/src/harness-agent/prepare-sandbox-for-harness.ts
+++ b/examples/ai-functions/src/harness-agent/prepare-sandbox-for-harness.ts
@@ -5,15 +5,25 @@ import {
   type HarnessAgentSandboxConfig,
 } from '@ai-sdk/harness/agent';
 import type { HarnessV1NetworkSandboxSession } from '@ai-sdk/harness';
-import { claudeCode } from '@ai-sdk/harness-claude-code';
-import { codex } from '@ai-sdk/harness-codex';
-import { deepAgents } from '@ai-sdk/harness-deepagents';
-import { openCode } from '@ai-sdk/harness-opencode';
-import { pi } from '@ai-sdk/harness-pi';
+import { createClaudeCode } from './claude-code/_create';
+import { createCodex } from './codex/_create';
+import { createDeepAgents } from './deepagents/_create';
+import { createOpenCode } from './opencode/_create';
+import { createPi } from './pi/_create';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 import { Sandbox } from '@vercel/sandbox';
 import { posix } from 'node:path';
 import { run } from '../lib/run';
+
+const pi = createPi();
+
+const openCode = createOpenCode();
+
+const deepAgents = createDeepAgents();
+
+const codex = createCodex();
+
+const claudeCode = createClaudeCode();
 
 const sandboxTimeout = 10 * 60 * 1000;
 const bridgePort = 4000;

--- a/examples/ai-functions/src/lib/codex-acp-harness.ts
+++ b/examples/ai-functions/src/lib/codex-acp-harness.ts
@@ -60,6 +60,15 @@ const CODEX_ACP_PERMISSION_MODE_MAPPING = {
   'allow-all': { type: 'session-mode', modeId: 'agent-full-access' },
 } as const satisfies ACPPermissionModeMapping;
 
+export type CodexACPHarnessSettings = {
+  auth?: ACPAuthOptions;
+  mcpServers?: Record<string, unknown>;
+  mintBridgeToken?: (sandboxId: string) => string;
+  reasoningEffort?: 'low' | 'medium' | 'high';
+  webSearch?: boolean;
+  source?: ACPSource;
+};
+
 export function createCodexACP({
   auth = 'auto',
   mcpServers,
@@ -67,14 +76,7 @@ export function createCodexACP({
   reasoningEffort,
   webSearch,
   source = CODEX_ACP_SOURCE,
-}: {
-  auth?: ACPAuthOptions;
-  mcpServers?: Record<string, unknown>;
-  mintBridgeToken?: (sandboxId: string) => string;
-  reasoningEffort?: 'low' | 'medium' | 'high';
-  webSearch?: boolean;
-  source?: ACPSource;
-} = {}) {
+}: CodexACPHarnessSettings = {}) {
   return createACP({
     harnessId: 'codex-acp',
     auth,

--- a/examples/ai-functions/src/lib/run.ts
+++ b/examples/ai-functions/src/lib/run.ts
@@ -18,5 +18,9 @@ export function run(fn: () => Promise<unknown>) {
         print('Request body:', error.requestBodyValues);
         print('Response body:', error.responseBody);
       }
+
+      if (process.env.FAIL_ON_ERROR === '1') {
+        process.exit(1);
+      }
     });
 }

--- a/tools/run-harness-agent-examples.sh
+++ b/tools/run-harness-agent-examples.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+#
+# Run harness-agent examples from examples/ai-functions/src/harness-agent.
+#
+# Usage:
+#   tools/run-harness-agent-examples.sh [--harness <name>...] [--example <name>...] [--auth <mode>]
+#
+# Flags (all optional, repeatable, combinable):
+#   --harness <name>   Only run examples for the given harness folder(s)
+#                      (e.g. --harness grok-build). Defaults to all harnesses.
+#   --example <name>   Only run the named example(s) across selected harnesses.
+#                      <name> is the file name without the .ts extension
+#                      (e.g. --example with-instructions). Defaults to all.
+#   --auth <mode>      Force an auth mode for every example invocation by
+#                      setting HARNESS_FORCE_AUTH=<mode> inline. Accepted
+#                      values: "direct", "ai-gateway". Unset by default.
+#
+# Every example file must import a `create*()` function from the `_create.ts`
+# helper in its own harness folder. An example missing the required import is
+# not run and reported as ERROR.
+#
+# By default every *.ts example in every harness folder is run (slow!).
+# Only direct children of a harness folder are treated as examples; nested
+# subfolders (e.g. codex-acp/locked-acquisition/) are skipped. Files whose
+# name begins with an underscore (e.g. _shared-helpers.ts) are helpers and
+# are never run; --example rejects such names outright.
+#
+# The working directory is always restored to its original value on exit,
+# regardless of success, failure, or unexpected errors.
+
+set -euo pipefail
+
+# --- Paths -----------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+EXAMPLES_DIR="${REPO_ROOT}/examples/ai-functions"
+HARNESS_DIR="${EXAMPLES_DIR}/src/harness-agent"
+ORIGINAL_PWD="$(pwd)"
+
+# --- Colors ----------------------------------------------------------------
+
+if [ -t 1 ]; then
+  GREEN='\033[0;32m'
+  RED='\033[0;31m'
+  YELLOW='\033[0;33m'
+  RESET='\033[0m'
+else
+  GREEN=''
+  RED=''
+  YELLOW=''
+  RESET=''
+fi
+
+# --- Argument parsing ------------------------------------------------------
+
+SELECTED_HARNESSES=()
+SELECTED_EXAMPLES=()
+AUTH_MODE=''
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --harness)
+      shift
+      if [ $# -eq 0 ]; then
+        echo "Error: --harness requires a value" >&2
+        exit 2
+      fi
+      SELECTED_HARNESSES+=("$1")
+      shift
+      ;;
+    --example)
+      shift
+      if [ $# -eq 0 ]; then
+        echo "Error: --example requires a value" >&2
+        exit 2
+      fi
+      case "$1" in
+        _*)
+          echo "Error: --example must not start with '_' (underscore-prefixed files are helpers, not examples): '$1'" >&2
+          exit 2
+          ;;
+      esac
+      SELECTED_EXAMPLES+=("$1")
+      shift
+      ;;
+    --auth)
+      shift
+      if [ $# -eq 0 ]; then
+        echo "Error: --auth requires a value" >&2
+        exit 2
+      fi
+      case "$1" in
+        direct|ai-gateway)
+          AUTH_MODE="$1"
+          ;;
+        *)
+          echo "Error: --auth must be 'direct' or 'ai-gateway' (got '$1')" >&2
+          exit 2
+          ;;
+      esac
+      shift
+      ;;
+    -h|--help)
+      sed -n '3,29p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Error: unknown argument '$1'" >&2
+      echo "Run with --help for usage." >&2
+      exit 2
+      ;;
+  esac
+done
+
+# `set -u` interacts badly with empty arrays on bash 3.2 (macOS default).
+# This expansion is a no-op for empty arrays and expands normally otherwise.
+HARNESS_COUNT=${#SELECTED_HARNESSES[@]}
+EXAMPLE_COUNT=${#SELECTED_EXAMPLES[@]}
+
+# --- Directory restore -----------------------------------------------------
+
+restore_pwd() {
+  cd "${ORIGINAL_PWD}" 2>/dev/null || true
+}
+trap restore_pwd EXIT
+
+# --- Discover harnesses ----------------------------------------------------
+
+# Harness folders are direct subdirectories of HARNESS_DIR that contain at
+# least one runnable *.ts example. Files beginning with an underscore are
+# excluded everywhere (helpers, not examples), as are loose helpers outside
+# harness folders. Sorted for stable output.
+
+ALL_HARNESSES=()
+if [ -d "${HARNESS_DIR}" ]; then
+  while IFS= read -r line; do
+    ALL_HARNESSES+=("${line}")
+  done < <(
+    find "${HARNESS_DIR}" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null |
+      while IFS= read -r dir; do
+        if [ -n "$(find "${dir}" -mindepth 1 -maxdepth 1 -type f -name '*.ts' ! -name '_*' -print -quit 2>/dev/null)" ]; then
+          basename "${dir}"
+        fi
+      done |
+      sort
+  )
+fi
+
+# --- Select harnesses ------------------------------------------------------
+
+HARNESS_TO_RUN=()
+if [ "${HARNESS_COUNT}" -gt 0 ]; then
+  for requested in ${SELECTED_HARNESSES[@]+"${SELECTED_HARNESSES[@]}"}; do
+    found=0
+    for available in ${ALL_HARNESSES[@]+"${ALL_HARNESSES[@]}"}; do
+      if [ "${requested}" = "${available}" ]; then
+        found=1
+        break
+      fi
+    done
+    if [ "${found}" -eq 0 ]; then
+      echo "Error: harness '${requested}' not found." >&2
+      echo "Available harnesses:" >&2
+      for available in ${ALL_HARNESSES[@]+"${ALL_HARNESSES[@]}"}; do
+        echo "  - ${available}" >&2
+      done
+      exit 2
+    fi
+    HARNESS_TO_RUN+=("${requested}")
+  done
+else
+  for available in ${ALL_HARNESSES[@]+"${ALL_HARNESSES[@]}"}; do
+    HARNESS_TO_RUN+=("${available}")
+  done
+fi
+
+if [ "${#HARNESS_TO_RUN[@]}" -eq 0 ]; then
+  echo "No harness folders found under ${HARNESS_DIR}" >&2
+  exit 1
+fi
+
+# --- Results collection ----------------------------------------------------
+
+# A temp file accumulates "harness|example|STATUS" rows; sorted at the end.
+RESULTS_FILE="$(mktemp -t harness-results)"
+STDERR_DIR="$(mktemp -d -t harness-stderr)"
+trap 'rm -f "${RESULTS_FILE}"; rm -rf "${STDERR_DIR}"; restore_pwd' EXIT
+
+record_result() {
+  printf '%s|%s|%s\n' "$1" "$2" "$3" >>"${RESULTS_FILE}"
+}
+
+# --- Run examples ----------------------------------------------------------
+
+# When examples are explicitly requested, a missing example file is reported
+# as NOT FOUND rather than treated as an error. Otherwise every *.ts file in
+# the harness folder is run.
+
+cd "${EXAMPLES_DIR}"
+
+run_example() {
+  local stderr_file="$2"
+  if [ -n "${AUTH_MODE}" ]; then
+    FAIL_ON_ERROR=1 HARNESS_FORCE_AUTH="${AUTH_MODE}" pnpm tsx "$1" 2> >(tee "${stderr_file}" >&2)
+  else
+    FAIL_ON_ERROR=1 pnpm tsx "$1" 2> >(tee "${stderr_file}" >&2)
+  fi
+}
+
+# Build the breakdown annotation for a failed example from its captured stderr:
+# first line, collapsed whitespace, truncated at 50 characters with an ellipsis
+# appended when it is longer.
+fail_annotation() {
+  local line
+  line="$(grep -m1 . "$1" 2>/dev/null || true)"
+  line="$(printf '%s' "${line}" | tr -s '[:space:]' ' ' | tr '|' '/')"
+  if [ "${#line}" -gt 50 ]; then
+    printf '%s…' "$(printf '%s' "${line}" | cut -c1-50)"
+  else
+    printf '%s' "${line}"
+  fi
+}
+
+# An example must initialize its harness through the folder's custom
+# `create*()` wrapper (`_create.ts`), so that HARNESS_FORCE_AUTH is honored.
+example_uses_custom_create() {
+  grep -qE "import \{[^}]*\bcreate[A-Za-z]+\b[^}]*\} from '\./_create'" "$1"
+}
+
+total=0
+pass=0
+fail=0
+error=0
+notfound=0
+
+for harness in ${HARNESS_TO_RUN[@]+"${HARNESS_TO_RUN[@]}"}; do
+  harness_path="${HARNESS_DIR}/${harness}"
+
+  if [ "${EXAMPLE_COUNT}" -gt 0 ]; then
+    # Explicit example list: run each requested example, or record NOT FOUND.
+    for example in ${SELECTED_EXAMPLES[@]+"${SELECTED_EXAMPLES[@]}"}; do
+      example_file="${harness_path}/${example}.ts"
+      if [ ! -f "${example_file}" ]; then
+        record_result "${harness}" "${example}" "NOT FOUND"
+        notfound=$((notfound + 1))
+        total=$((total + 1))
+        continue
+      fi
+
+      echo
+      echo "▶ ${harness}/${example}"
+      echo "──────────────────────────────────────────────────────────"
+      if ! example_uses_custom_create "${example_file}"; then
+        record_result "${harness}" "${example}" "ERROR (example is not using the custom \`create*()\` function)"
+        error=$((error + 1))
+      elif run_example "src/harness-agent/${harness}/${example}.ts" "${STDERR_DIR}/${harness}-${example}.log"; then
+        record_result "${harness}" "${example}" "PASS"
+        pass=$((pass + 1))
+      else
+        record_result "${harness}" "${example}" "FAIL ($(fail_annotation "${STDERR_DIR}/${harness}-${example}.log"))"
+        fail=$((fail + 1))
+      fi
+      total=$((total + 1))
+    done
+  else
+    # No explicit examples: run every runnable *.ts file in the harness
+    # folder (underscore-prefixed files are helpers, not examples).
+    example_files="$(
+      find "${harness_path}" -mindepth 1 -maxdepth 1 -type f -name '*.ts' ! -name '_*' -print |
+        sort
+    )"
+    while IFS= read -r example_file; do
+      example="$(basename "${example_file}" .ts)"
+      echo
+      echo "▶ ${harness}/${example}"
+      echo "──────────────────────────────────────────────────────────"
+      if ! example_uses_custom_create "${example_file}"; then
+        record_result "${harness}" "${example}" "ERROR (example is not using the custom \`create*()\` function)"
+        error=$((error + 1))
+      elif run_example "src/harness-agent/${harness}/${example}.ts" "${STDERR_DIR}/${harness}-${example}.log"; then
+        record_result "${harness}" "${example}" "PASS"
+        pass=$((pass + 1))
+      else
+        record_result "${harness}" "${example}" "FAIL ($(fail_annotation "${STDERR_DIR}/${harness}-${example}.log"))"
+        fail=$((fail + 1))
+      fi
+      total=$((total + 1))
+    done <<EOF
+${example_files}
+EOF
+  fi
+done
+
+# --- Breakdown -------------------------------------------------------------
+
+echo
+echo
+echo "Breakdown"
+echo "──────────────────────────────────────────────────────────"
+sort -t '|' -k1,1 -k2,2 "${RESULTS_FILE}" | while IFS='|' read -r harness example status; do
+  case "${status}" in
+    PASS)
+      status_colored="${GREEN}PASS${RESET}"
+      ;;
+    FAIL*)
+      status_colored="${RED}FAIL${RESET} ${status#FAIL }"
+      ;;
+    ERROR*)
+      status_colored="${RED}ERROR${RESET} ${status#ERROR }"
+      ;;
+    'NOT FOUND')
+      status_colored="${YELLOW}NOT FOUND${RESET}"
+      ;;
+    *)
+      status_colored="${status}"
+      ;;
+  esac
+  printf -- '- %s/%s: %b\n' "${harness}" "${example}" "${status_colored}"
+done
+
+echo
+echo "Total: ${total} | Pass: ${pass} | Fail: ${fail} | Error: ${error} | Not found: ${notfound}"
+
+if [ "${fail}" -gt 0 ] || [ "${error}" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Background

Running the `examples/ai-functions/src/harness-agent` examples manually or in a controlled way (not just asking your agent) has been tedious, especially when wanting to test the expected behaviors with different ways of authentication.

## Summary

- Add a `tools/run-harness-agent-examples.sh` script that runs harness examples, controlled via `--harness` and `--example` flags.
- Have each harness example use a central harness instantiation function that respects an optional local environment variable `HARNESS_FORCE_AUTH` to easily switch between authentication modes
- Support a `--auth` flag in the script to set that `HARNESS_FORCE_AUTH` environment variable
- Clean up a few examples that would unnecessarily catch errors an `console.error` them rather than letting the surrounding `run()` function handle them

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)