### PR TITLE
fix(workflow): surface stream errors as terminal failures

### DIFF
--- a/.changeset/tidy-workflows-fail.md
+++ b/.changeset/tidy-workflows-fail.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Fail workflow model steps with the exact standard stream error after forwarding it to the writable stream.

--- a/packages/workflow/src/do-stream-step.test.ts
+++ b/packages/workflow/src/do-stream-step.test.ts
@@ -1,0 +1,59 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import type { Experimental_LanguageModelStreamPart, ToolSet } from 'ai';
+import { MockLanguageModelV4, convertArrayToReadableStream } from 'ai/test';
+import { describe, expect, it } from 'vitest';
+import { doStreamStep } from './do-stream-step.js';
+
+describe('doStreamStep', () => {
+  it('forwards a stream error once and rejects with its exact value', async () => {
+    const terminalError = new Error('safe-terminal-marker');
+    const forwardedParts: Array<Experimental_LanguageModelStreamPart<ToolSet>> =
+      [];
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start' as const, warnings: [] },
+          { type: 'error' as const, error: terminalError },
+          {
+            type: 'finish' as const,
+            finishReason: { unified: 'error' as const, raw: 'error' },
+            usage: {
+              inputTokens: {
+                total: 1,
+                noCache: 1,
+                cacheRead: undefined,
+                cacheWrite: undefined,
+              },
+              outputTokens: {
+                total: 0,
+                text: 0,
+                reasoning: undefined,
+              },
+            },
+          },
+        ]),
+      }),
+    });
+    const prompt: LanguageModelV4Prompt = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'trigger the terminal error' }],
+      },
+    ];
+
+    const result = doStreamStep(
+      prompt,
+      model,
+      new WritableStream({
+        write(part) {
+          forwardedParts.push(part);
+        },
+      }),
+    );
+
+    await expect(result).rejects.toBe(terminalError);
+    expect(forwardedParts.filter(part => part.type === 'error')).toEqual([
+      { type: 'error', error: terminalError },
+    ]);
+  });
+});

--- a/packages/workflow/src/do-stream-step.ts
+++ b/packages/workflow/src/do-stream-step.ts
@@ -198,6 +198,15 @@ export async function doStreamStep(
 
   try {
     for await (const part of modelStream) {
+      if (part.type === 'error') {
+        // Preserve real-time delivery before terminating the durable step with
+        // the exact error value supplied by the model stream.
+        if (writer) {
+          await writer.write(part);
+        }
+        throw part.error;
+      }
+
       switch (part.type) {
         case 'text-delta':
           text += part.text;


### PR DESCRIPTION
## Summary

- forward a standard model stream error part to the writable exactly once
- terminate the durable model step by throwing the exact supplied error value
- cover the behavior with a focused regression test and patch changeset

## Testing

- `pnpm --filter @ai-sdk/workflow test:node` (167 tests passed)
- `pnpm --filter @ai-sdk/workflow test:edge` (167 tests passed)
- `pnpm --filter @ai-sdk/workflow type-check`
- `pnpm --filter @ai-sdk/workflow build`
- `pnpm type-check`
- `pnpm check`
- `fnm exec --using=24.14.0 pnpm build:packages` (75 packages built)

The full examples-inclusive root build reaches the unrelated `@example/harness-e2e-next` build, then fails while collecting page data for its Grok Build routes with `ERR_INVALID_ARG_TYPE`.

Fixes #18824
