### PR TITLE
fix(provider/amazon-bedrock): forward thinking `disabled` for adaptive-thinking Anthropic models

### DIFF
--- a/.changeset/lucky-pandas-listen.md
+++ b/.changeset/lucky-pandas-listen.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(provider/amazon-bedrock): forward thinking `disabled` for Anthropic models with adaptive thinking
+
+`reasoningConfig: { type: 'disabled' }` (and the top-level `reasoning: 'none'` that maps to it) was dropped instead of being sent to Bedrock. Models with adaptive thinking such as Claude Sonnet 5 turn thinking on by default, so omitting the field left thinking enabled and kept consuming output tokens with no error or warning. The provider now forwards `thinking: { type: 'disabled' }` for those models, matching `@ai-sdk/anthropic`, and lowers `maxReasoningEffort` to `high` when a model rejects disabled thinking above that effort.

--- a/examples/ai-functions/src/generate-text/amazon-bedrock/anthropic-reasoning-disabled.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock/anthropic-reasoning-disabled.ts
@@ -1,0 +1,31 @@
+import {
+  amazonBedrock,
+  type AmazonBedrockLanguageModelChatOptions,
+} from '@ai-sdk/amazon-bedrock';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  // Models with adaptive thinking turn thinking on by default, so `disabled`
+  // has to reach the API for the request to run without reasoning tokens.
+  const result = await generateText({
+    model: amazonBedrock('us.anthropic.claude-sonnet-5'),
+    prompt: 'How many "r"s are in the word "strawberry"?',
+    providerOptions: {
+      bedrock: {
+        reasoningConfig: { type: 'disabled' },
+      } satisfies AmazonBedrockLanguageModelChatOptions,
+    },
+  });
+
+  console.log('Request body:');
+  console.log(JSON.stringify(result.request?.body, null, 2));
+  console.log();
+
+  console.log('Text:');
+  console.log(result.text);
+  console.log();
+
+  console.log('Usage:');
+  console.log(result.usage);
+});

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -266,6 +266,16 @@ const opus5AnthropicModel = new AmazonBedrockChatLanguageModel(
   },
 );
 
+const sonnet5AnthropicModel = new AmazonBedrockChatLanguageModel(
+  sonnet5AnthropicModelId,
+  {
+    baseUrl: () => baseUrl,
+    headers: {},
+    fetch: fakeFetchWithAuth,
+    generateId: () => 'test-id',
+  },
+);
+
 let mockOptions: { success: boolean; errorValue?: any } = { success: true };
 
 describe('doGenerate request metadata', () => {
@@ -6680,9 +6690,9 @@ describe('doGenerate', () => {
       });
 
       const requestBody = await server.calls[0].requestBodyJson;
-      expect(
-        requestBody.additionalModelRequestFields?.thinking,
-      ).toBeUndefined();
+      expect(requestBody.additionalModelRequestFields?.thinking).toEqual({
+        type: 'disabled',
+      });
       expect(
         requestBody.additionalModelRequestFields?.output_config,
       ).toBeUndefined();
@@ -6709,6 +6719,83 @@ describe('doGenerate', () => {
       expect(
         requestBody.additionalModelRequestFields?.output_config?.effort,
       ).toBe('high');
+    });
+
+    it('should forward thinking "disabled" for models that default thinking on', async () => {
+      server.urls[sonnet5AnthropicGenerateUrl].response = simpleResponse;
+
+      await sonnet5AnthropicModel.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          bedrock: { reasoningConfig: { type: 'disabled' } },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.additionalModelRequestFields?.thinking).toEqual({
+        type: 'disabled',
+      });
+    });
+
+    it('should forward thinking "disabled" for reasoning "none" on models that default thinking on', async () => {
+      server.urls[sonnet5AnthropicGenerateUrl].response = simpleResponse;
+
+      await sonnet5AnthropicModel.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'none',
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.additionalModelRequestFields?.thinking).toEqual({
+        type: 'disabled',
+      });
+      expect(
+        requestBody.additionalModelRequestFields?.output_config,
+      ).toBeUndefined();
+    });
+
+    it('should not forward thinking "disabled" for models that default thinking off', async () => {
+      prepareJsonFixtureResponse('amazon-bedrock-text');
+
+      await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          bedrock: { reasoningConfig: { type: 'disabled' } },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(
+        requestBody.additionalModelRequestFields?.thinking,
+      ).toBeUndefined();
+    });
+
+    it('should lower maxReasoningEffort to "high" when thinking is disabled for models that reject higher efforts', async () => {
+      server.urls[opus5AnthropicGenerateUrl].response = simpleResponse;
+
+      const result = await opus5AnthropicModel.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          bedrock: {
+            reasoningConfig: { type: 'disabled', maxReasoningEffort: 'max' },
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.additionalModelRequestFields?.thinking).toEqual({
+        type: 'disabled',
+      });
+      expect(
+        requestBody.additionalModelRequestFields?.output_config?.effort,
+      ).toBe('high');
+      expect(result.warnings).toContainEqual({
+        type: 'unsupported',
+        feature: 'providerOptions.bedrock.reasoningConfig.maxReasoningEffort',
+        details:
+          `maxReasoningEffort 'max' is not supported by ${opus5AnthropicModelId} when thinking is disabled. ` +
+          `The effort has been lowered to 'high'.`,
+      });
     });
 
     it('should let user-specified maxReasoningEffort win over derived for non-Anthropic models', async () => {

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -194,8 +194,11 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
       amazonBedrockOptions.reasoningConfig?.type === 'enabled' ||
       amazonBedrockOptions.reasoningConfig?.type === 'adaptive';
 
-    const { supportsStructuredOutput: modelSupportsStructuredOutput } =
-      getModelCapabilities(this.modelId);
+    const {
+      supportsStructuredOutput: modelSupportsStructuredOutput,
+      supportsAdaptiveThinking,
+      rejectsThinkingDisabledAboveHighEffort,
+    } = getModelCapabilities(this.modelId);
 
     const useNativeStructuredOutput =
       isAnthropicModel &&
@@ -265,6 +268,18 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
         ? amazonBedrockOptions.reasoningConfig?.display
         : undefined;
     const isAnthropicThinkingEnabled = isAnthropicModel && isThinkingEnabled;
+    /*
+     * Mirror anthropic-language-model.ts: `disabled` must still be forwarded to
+     * the API. Models with adaptive thinking (e.g. Sonnet 5) turn thinking on by
+     * default, so omitting the field leaves thinking enabled and keeps consuming
+     * the output token budget. Models without adaptive thinking default to
+     * thinking off, so omitting the field there matches the requested behavior
+     * and avoids sending `thinking` to models whose Bedrock schema predates it.
+     */
+    const sendAnthropicThinkingDisabled =
+      isAnthropicModel &&
+      supportsAdaptiveThinking &&
+      thinkingType === 'disabled';
 
     const inferenceConfig = {
       ...(maxOutputTokens != null && { maxTokens: maxOutputTokens }),
@@ -297,6 +312,13 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
           },
         };
       }
+    } else if (sendAnthropicThinkingDisabled) {
+      amazonBedrockOptions.additionalModelRequestFields = {
+        ...amazonBedrockOptions.additionalModelRequestFields,
+        thinking: {
+          type: 'disabled',
+        },
+      };
     } else if (!isAnthropicModel) {
       if (amazonBedrockOptions.reasoningConfig?.budgetTokens != null) {
         warnings.push({
@@ -316,8 +338,29 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
       }
     }
 
-    const maxReasoningEffort =
+    let maxReasoningEffort =
       amazonBedrockOptions.reasoningConfig?.maxReasoningEffort;
+
+    /*
+     * Newer models only allow disabling thinking at effort levels up to and
+     * including `high`; at `xhigh` and `max` the API returns a validation error.
+     * Lower the effort to `high` to preserve the explicit request to run without
+     * thinking.
+     */
+    if (
+      sendAnthropicThinkingDisabled &&
+      rejectsThinkingDisabledAboveHighEffort &&
+      (maxReasoningEffort === 'xhigh' || maxReasoningEffort === 'max')
+    ) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'providerOptions.bedrock.reasoningConfig.maxReasoningEffort',
+        details:
+          `maxReasoningEffort '${maxReasoningEffort}' is not supported by ${this.modelId} when thinking is disabled. ` +
+          `The effort has been lowered to 'high'.`,
+      });
+      maxReasoningEffort = 'high';
+    }
 
     if (maxReasoningEffort != null) {
       if (isAnthropicModel) {


### PR DESCRIPTION
## Background

`reasoningConfig: { type: 'disabled' }` on `@ai-sdk/amazon-bedrock` has no effect for Claude Sonnet 5. It doesn't error — the configuration just never reaches Bedrock, so thinking stays on and keeps billing output tokens.

This surfaced while investigating a customer's cost regression after migrating from Sonnet 4.6 to Sonnet 5 on Bedrock. Side-by-side runs against `@aws-sdk/client-bedrock-runtime` with the equivalent body (`"thinking": { "type": "disabled" }`) showed thinking blocks eliminated and output tokens dropping 35–46% on medium/complex prompts, while the same request through this provider showed no change.

## Cause

`getArgs` only emits a `thinking` field when the resolved type is `enabled` or `adaptive`:

```ts
const isThinkingEnabled =
  amazonBedrockOptions.reasoningConfig?.type === 'enabled' ||
  amazonBedrockOptions.reasoningConfig?.type === 'adaptive';   // 'disabled' → false
...
if (isAnthropicThinkingEnabled) { /* emit thinking */ }
else if (!isAnthropicModel) { /* warn */ }                     // Anthropic + disabled: nothing
```

So `type: 'disabled'` — and the top-level `reasoning: 'none'` that `resolveAmazonBedrockReasoningConfig` maps to it — produces no `thinking` field and no warning. Because models with adaptive thinking default to thinking **on**, omitting the field is not equivalent to disabling it.

`@ai-sdk/anthropic` already handles this, with a comment naming the same failure mode (`packages/anthropic/src/anthropic-language-model.ts`):

```ts
// `disabled` must still be forwarded to the API: some models (e.g. Sonnet 5)
// default thinking on, so omitting it would leave thinking enabled and
// consume the max_tokens budget.
const sendThinking = isThinking || thinkingType === 'disabled';
```

## Changes

- Forward `thinking: { type: 'disabled' }` for Anthropic models where `getModelCapabilities(...).supportsAdaptiveThinking` is true. Gating on that capability rather than forwarding unconditionally keeps the field off models that default to thinking off (where omitting it already matches the request) and avoids sending `thinking` to older models whose Bedrock schema predates it — Bedrock validates against its own copy of the Messages schema, so this seemed the safer boundary. Happy to widen it to match the Anthropic provider exactly if you'd prefer parity.
- Port the `rejectsThinkingDisabledAboveHighEffort` guard from the Anthropic provider. Now that `disabled` is actually sent, `{ type: 'disabled', maxReasoningEffort: 'max' }` on Opus 5 would hit a validation error; the effort is lowered to `high` with a warning instead.
- Update the existing `should honor reasoning "none" even when partial reasoningConfig is provided` test, which asserted the buggy behavior (`thinking` undefined).
- Add regression tests: `disabled` forwarded for adaptive-thinking models, `reasoning: 'none'` forwarded, `disabled` still omitted for models that default thinking off, and the effort-lowering warning.
- Add `examples/ai-functions/src/generate-text/amazon-bedrock/anthropic-reasoning-disabled.ts` printing the outgoing request body and usage.

`doGenerate` and `doStream` share `getArgs`, so both paths are covered.

## Not changed

`convertAmazonBedrockUsage` hardcodes `outputTokens.text = outputTokens` and `outputTokens.reasoning = undefined`, so all output tokens are reported as text even when thinking runs. Left out of this PR as a separate concern — happy to file it on its own.

## Verification

- `pnpm test` in `packages/amazon-bedrock`: 457 passed (node) / 457 passed (edge)
- `pnpm check`: 0 warnings, 0 errors
- `pnpm type-check:full`: no new errors (6 pre-existing errors in `examples/nuxt-openai` on `main`)

Before the fix, the two new passthrough tests fail with `expected undefined to deeply equal { type: 'disabled' }`.
