### PR TITLE
chore: fix custom mintBridgeToken callback for examples to work without requiring a custom env var

### DIFF
--- a/examples/ai-functions/src/lib/mint-bridge-token.ts
+++ b/examples/ai-functions/src/lib/mint-bridge-token.ts
@@ -1,9 +1,12 @@
-import { createHmac } from 'node:crypto';
+import { createHmac, randomBytes } from 'node:crypto';
+
+let bridgeTokenSecret: string | Buffer | undefined;
 
 export function mintBridgeToken(sandboxId: string): string {
-  const secret = process.env.HARNESS_BRIDGE_TOKEN_SECRET;
-  if (secret == null || secret.length === 0) {
-    throw new Error('HARNESS_BRIDGE_TOKEN_SECRET is required.');
-  }
-  return createHmac('sha256', secret).update(sandboxId).digest('hex');
+  bridgeTokenSecret ??=
+    process.env.HARNESS_BRIDGE_TOKEN_SECRET || randomBytes(32);
+
+  return createHmac('sha256', bridgeTokenSecret)
+    .update(sandboxId)
+    .digest('hex');
 }


### PR DESCRIPTION
## Background

#18643 added an optional `mintBridgeToken` callback for bridge based harnesses, and updated all harnesses' `attach.ts` examples to use it.

However, the callback used required an env var to be set, which is inconvenient when running those examples in bulk. They shouldn't error just because that env var isn't set - it defeats the point of the test.

## Summary

Make the examples only use the env var if set, and otherwise use some reasonable default for testing.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
