### PR TITLE
fix(harness-pi): ensure Pi's `.sessions` infra directory does not pollute the agent's working directory

### DIFF
--- a/.changeset/polite-days-sniff.md
+++ b/.changeset/polite-days-sniff.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-pi": patch
+---
+
+fix(harness-pi): ensure Pi's `.sessions` infra directory does not pollute the agent's working directory

--- a/packages/harness-pi/src/pi-resume-state.test.ts
+++ b/packages/harness-pi/src/pi-resume-state.test.ts
@@ -7,10 +7,10 @@ import {
   persistSessionFileToSandbox,
   piResumeStateSchema,
   pullSessionFileFromSandbox,
+  resolvePiPrivateSessionDirectory,
   safePiSessionFileName,
 } from './pi-resume-state';
 
-type RunCalls = Array<{ command: string }>;
 type ReadCalls = string[];
 type WriteCalls = Array<{ path: string; content: Uint8Array }>;
 
@@ -23,18 +23,13 @@ function makeSandbox(
   readonly run: ReturnType<typeof vi.fn>;
   readonly readBinaryFile: ReturnType<typeof vi.fn>;
   readonly writeBinaryFile: ReturnType<typeof vi.fn>;
-  readonly runCalls: RunCalls;
   readonly readCalls: ReadCalls;
   readonly writeCalls: WriteCalls;
 } {
-  const runCalls: RunCalls = [];
   const readCalls: ReadCalls = [];
   const writeCalls: WriteCalls = [];
 
-  const run = vi.fn(async ({ command }: { command: string }) => {
-    runCalls.push({ command });
-    return { exitCode: 0, stdout: '', stderr: '' };
-  });
+  const run = vi.fn();
   const readBinaryFile = vi.fn(async ({ path }: { path: string }) => {
     readCalls.push(path);
     return input.readBinary?.(path);
@@ -62,7 +57,6 @@ function makeSandbox(
     run,
     readBinaryFile,
     writeBinaryFile,
-    runCalls,
     readCalls,
     writeCalls,
   };
@@ -135,19 +129,51 @@ describe('piResumeStateSchema', () => {
   });
 });
 
+describe('resolvePiPrivateSessionDirectory', () => {
+  it('creates a stable private directory outside the session workspace', () => {
+    const privateSessionDir = resolvePiPrivateSessionDirectory({
+      sandboxHomeDir: '/sandbox/home',
+      sessionWorkDir: '/sandbox/work/pi-s1',
+      sessionId: '../unsafe/session-id',
+    });
+
+    expect(privateSessionDir).toMatch(
+      /^\/sandbox\/home\/\.ai-sdk\/harness-pi\/[a-f0-9]{64}$/,
+    );
+    expect(privateSessionDir).toBe(
+      resolvePiPrivateSessionDirectory({
+        sandboxHomeDir: '/sandbox/home',
+        sessionWorkDir: '/sandbox/work/pi-s1',
+        sessionId: '../unsafe/session-id',
+      }),
+    );
+  });
+
+  it('rejects a private directory inside the session workspace', () => {
+    expect(() =>
+      resolvePiPrivateSessionDirectory({
+        sandboxHomeDir: '/sandbox/work/pi-s1',
+        sessionWorkDir: '/sandbox/work/pi-s1',
+        sessionId: 'session-1',
+      }),
+    ).toThrow(/must be outside sessionWorkDir/);
+  });
+});
+
 describe('pullSessionFileFromSandbox', () => {
   it('copies a safe sandbox session file into the host session directory', async () => {
     const bytes = new TextEncoder().encode('session data');
     const sandbox = makeSandbox({
       readBinary: requestedPath =>
-        requestedPath === '/sandbox/work/.pi-sessions/session.jsonl'
+        requestedPath ===
+        '/sandbox/home/.ai-sdk/harness-pi/session-key/session.jsonl'
           ? bytes
           : undefined,
     });
 
     const hostPath = await pullSessionFileFromSandbox({
       sandbox: sandbox.sandbox,
-      sessionWorkDir: '/sandbox/work',
+      privateSessionDir: '/sandbox/home/.ai-sdk/harness-pi/session-key',
       hostSessionDir,
       sessionFileName: 'session.jsonl',
     });
@@ -155,7 +181,7 @@ describe('pullSessionFileFromSandbox', () => {
     expect(hostPath).toBe(path.join(hostSessionDir, 'session.jsonl'));
     expect(readFileSync(hostPath!, 'utf8')).toBe('session data');
     expect(sandbox.readCalls).toEqual([
-      '/sandbox/work/.pi-sessions/session.jsonl',
+      '/sandbox/home/.ai-sdk/harness-pi/session-key/session.jsonl',
     ]);
   });
 
@@ -165,7 +191,7 @@ describe('pullSessionFileFromSandbox', () => {
     await expect(
       pullSessionFileFromSandbox({
         sandbox: sandbox.sandbox,
-        sessionWorkDir: '/sandbox/work',
+        privateSessionDir: '/sandbox/home/.ai-sdk/harness-pi/session-key',
         hostSessionDir,
         sessionFileName: '../session.jsonl',
       }),
@@ -182,42 +208,34 @@ describe('persistSessionFileToSandbox', () => {
 
     await persistSessionFileToSandbox({
       sandbox: sandbox.sandbox,
-      sessionWorkDir: '/sandbox/work',
+      privateSessionDir: '/sandbox/home/.ai-sdk/harness-pi/session-key',
       hostSessionDir,
       sessionFileName: 'session.jsonl',
     });
 
-    expect(sandbox.runCalls).toEqual([
-      { command: "mkdir -p '/sandbox/work/.pi-sessions'" },
-    ]);
     expect(sandbox.writeCalls[0]?.path).toBe(
-      '/sandbox/work/.pi-sessions/session.jsonl',
+      '/sandbox/home/.ai-sdk/harness-pi/session-key/session.jsonl',
     );
     expect(Buffer.from(sandbox.writeCalls[0]!.content).toString('utf8')).toBe(
       'session data',
     );
   });
 
-  it('quotes the sandbox session directory in shell commands', async () => {
+  it('does not place session state in the agent workspace', async () => {
     const sandbox = makeSandbox();
     writeFileSync(path.join(hostSessionDir, 'session.jsonl'), 'session data');
 
     await persistSessionFileToSandbox({
       sandbox: sandbox.sandbox,
-      sessionWorkDir: '/vercel/sandbox/pi-s1; env > /tmp/leak #',
+      privateSessionDir: '/home/vercel-sandbox/.ai-sdk/harness-pi/session-key',
       hostSessionDir,
       sessionFileName: 'session.jsonl',
     });
 
-    expect(sandbox.runCalls).toEqual([
-      {
-        command:
-          "mkdir -p '/vercel/sandbox/pi-s1; env > /tmp/leak #/.pi-sessions'",
-      },
-    ]);
     expect(sandbox.writeCalls[0]?.path).toBe(
-      '/vercel/sandbox/pi-s1; env > /tmp/leak #/.pi-sessions/session.jsonl',
+      '/home/vercel-sandbox/.ai-sdk/harness-pi/session-key/session.jsonl',
     );
+    expect(sandbox.writeCalls[0]?.path).not.toContain('/vercel/sandbox/pi-s1');
     expect(Buffer.from(sandbox.writeCalls[0]!.content).toString('utf8')).toBe(
       'session data',
     );
@@ -229,13 +247,12 @@ describe('persistSessionFileToSandbox', () => {
     await expect(
       persistSessionFileToSandbox({
         sandbox: sandbox.sandbox,
-        sessionWorkDir: '/sandbox/work',
+        privateSessionDir: '/sandbox/home/.ai-sdk/harness-pi/session-key',
         hostSessionDir,
         sessionFileName: '../session.jsonl',
       }),
     ).rejects.toThrow('Invalid Pi session file name');
 
-    expect(sandbox.run).not.toHaveBeenCalled();
     expect(sandbox.writeBinaryFile).not.toHaveBeenCalled();
   });
 });

--- a/packages/harness-pi/src/pi-resume-state.ts
+++ b/packages/harness-pi/src/pi-resume-state.ts
@@ -1,6 +1,6 @@
+import { createHash } from 'node:crypto';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
-import { shellQuote } from '@ai-sdk/harness/utils';
 import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
@@ -24,8 +24,8 @@ const piSessionFileNameSchema = z
  * Schema for the adapter-specific portion of lifecycle state `data` produced
  * by Pi's resumable lifecycle methods. Carries the basename
  * (including extension) of the Pi session file. The actual session bytes live
- * in the sandbox under `${sessionWorkDir}/.pi-sessions/<sessionFileName>` so
- * they survive cross-process resume via the sandbox snapshot.
+ * in a private, session-scoped directory under sandbox HOME so they survive
+ * cross-process resume without appearing in the agent workspace.
  */
 export const piResumeStateSchema = z.looseObject({
   sessionFileName: piSessionFileNameSchema.optional(),
@@ -33,7 +33,32 @@ export const piResumeStateSchema = z.looseObject({
 
 export type PiResumeStateData = z.infer<typeof piResumeStateSchema>;
 
-const PI_SESSIONS_DIR = '.pi-sessions';
+export function resolvePiPrivateSessionDirectory(input: {
+  readonly sandboxHomeDir: string;
+  readonly sessionWorkDir: string;
+  readonly sessionId: string;
+}): string {
+  const sessionKey = createHash('sha256').update(input.sessionId).digest('hex');
+  const privateSessionDir = path.posix.join(
+    input.sandboxHomeDir,
+    '.ai-sdk',
+    'harness-pi',
+    sessionKey,
+  );
+  const relativePath = path.posix.relative(
+    input.sessionWorkDir,
+    privateSessionDir,
+  );
+  if (
+    relativePath === '' ||
+    (!relativePath.startsWith('../') && !path.posix.isAbsolute(relativePath))
+  ) {
+    throw new Error(
+      `Pi private session directory ${JSON.stringify(privateSessionDir)} must be outside sessionWorkDir ${JSON.stringify(input.sessionWorkDir)}.`,
+    );
+  }
+  return privateSessionDir;
+}
 
 function resolveContainedHostPath(input: {
   readonly baseDir: string;
@@ -56,10 +81,10 @@ function resolveContainedHostPath(input: {
 }
 
 function resolveContainedSandboxPath(input: {
-  readonly sessionWorkDir: string;
+  readonly privateSessionDir: string;
   readonly sessionFileName: string;
 }): string {
-  const sessionDir = path.posix.resolve(input.sessionWorkDir, PI_SESSIONS_DIR);
+  const sessionDir = path.posix.resolve(input.privateSessionDir);
   const filePath = path.posix.resolve(
     sessionDir,
     safePiSessionFileName(input.sessionFileName),
@@ -76,13 +101,13 @@ function resolveContainedSandboxPath(input: {
 }
 
 /**
- * Copy the Pi session file from the host's local mirror to a stable location
- * inside the sandbox workspace. Called during resumable lifecycle methods so
- * the session survives a sandbox snapshot or a process handoff.
+ * Copy the Pi session file from the host's local mirror to private sandbox
+ * state. Called during resumable lifecycle methods so the session survives a
+ * sandbox snapshot or a process handoff.
  */
 export async function persistSessionFileToSandbox(args: {
   readonly sandbox: Experimental_SandboxSession;
-  readonly sessionWorkDir: string;
+  readonly privateSessionDir: string;
   readonly hostSessionDir: string;
   readonly sessionFileName: string;
   readonly abortSignal?: AbortSignal;
@@ -93,13 +118,8 @@ export async function persistSessionFileToSandbox(args: {
   });
   const content = await readFile(hostPath);
   const remotePath = resolveContainedSandboxPath({
-    sessionWorkDir: args.sessionWorkDir,
+    privateSessionDir: args.privateSessionDir,
     sessionFileName: args.sessionFileName,
-  });
-  // Ensure the parent dir exists in the sandbox before writing.
-  await args.sandbox.run({
-    command: `mkdir -p ${shellQuote(path.posix.dirname(remotePath))}`,
-    ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
   });
   await args.sandbox.writeBinaryFile({
     path: remotePath,
@@ -116,20 +136,20 @@ export async function persistSessionFileToSandbox(args: {
  */
 export async function pullSessionFileFromSandbox(args: {
   readonly sandbox: Experimental_SandboxSession;
-  readonly sessionWorkDir: string;
+  readonly privateSessionDir: string;
   readonly hostSessionDir: string;
   readonly sessionFileName: string;
   readonly abortSignal?: AbortSignal;
 }): Promise<string | undefined> {
   const remotePath = resolveContainedSandboxPath({
-    sessionWorkDir: args.sessionWorkDir,
+    privateSessionDir: args.privateSessionDir,
     sessionFileName: args.sessionFileName,
   });
   const bytes = await args.sandbox.readBinaryFile({
     path: remotePath,
     ...(args.abortSignal ? { abortSignal: args.abortSignal } : {}),
   });
-  if (!bytes) return undefined;
+  if (bytes == null) return undefined;
   await mkdir(args.hostSessionDir, { recursive: true });
   const hostPath = resolveContainedHostPath({
     baseDir: args.hostSessionDir,

--- a/packages/harness-pi/src/pi-session.test.ts
+++ b/packages/harness-pi/src/pi-session.test.ts
@@ -620,7 +620,11 @@ function createSandboxSession(): HarnessV1NetworkSandboxSession {
     getPortUrl: vi.fn(),
     readBinaryFile: vi.fn(async () => undefined),
     restricted: vi.fn(() => sandbox),
-    run: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+    run: vi.fn(async ({ command }: { command: string }) => ({
+      stdout: command === 'printf "%s" "$HOME"' ? '/sandbox/home' : '',
+      stderr: '',
+      exitCode: 0,
+    })),
     stop: vi.fn(async () => {}),
     writeBinaryFile: vi.fn(async () => {}),
     writeTextFile: vi.fn(async () => {}),

--- a/packages/harness-pi/src/pi-session.ts
+++ b/packages/harness-pi/src/pi-session.ts
@@ -44,6 +44,7 @@ import { writePiSkills } from './pi-skills';
 import {
   persistSessionFileToSandbox,
   pullSessionFileFromSandbox,
+  resolvePiPrivateSessionDirectory,
   safePiSessionFileName,
 } from './pi-resume-state';
 import {
@@ -289,16 +290,21 @@ export async function createPiSession(
   await mkdir(hostSessionDir, { recursive: true });
 
   const sandbox = input.sandboxSession.restricted();
+  const sandboxHomeDir = await resolveSandboxHomeDir({
+    sandbox,
+    ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
+  });
+  const privateSessionDir = resolvePiPrivateSessionDirectory({
+    sandboxHomeDir,
+    sessionWorkDir: input.sessionWorkDir,
+    sessionId: input.sessionId,
+  });
   const permissionMode = input.permissionMode ?? 'allow-all';
   let sandboxSkillRootDir: string | undefined;
   let harnessSkills: Skill[] = [];
 
   // Materialise harness-provided skills into sandbox HOME, not the workspace.
   if (input.skills.length > 0) {
-    const sandboxHomeDir = await resolveSandboxHomeDir({
-      sandbox,
-      ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
-    });
     sandboxSkillRootDir = path.posix.join(sandboxHomeDir, '.agents', 'skills');
     harnessSkills = createHarnessPiSkills({
       skills: input.skills,
@@ -321,7 +327,7 @@ export async function createPiSession(
     );
     resumeSessionFilePath = await pullSessionFileFromSandbox({
       sandbox,
-      sessionWorkDir: input.sessionWorkDir,
+      privateSessionDir,
       hostSessionDir,
       sessionFileName: resumeSessionFileName,
       ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
@@ -553,7 +559,7 @@ export async function createPiSession(
     if (!sessionFileName) return;
     await persistSessionFileToSandbox({
       sandbox,
-      sessionWorkDir: input.sessionWorkDir,
+      privateSessionDir,
       hostSessionDir,
       sessionFileName,
     });


### PR DESCRIPTION
## Background

The Pi harness persisted resumable session journals inside the agent's working directory, exposing harness infrastructure to the agent and polluting the workspace.

Other harnesses had this already cleaned up / fixed a while ago, so Pi is the only one with this problem left over.

## Summary

- Store Pi session journals in a private, session-scoped directory under sandbox HOME.
- Hash session IDs for stable, safe private directory names.
- Reject storage configurations that would place private state inside the session workspace.
- Add regression coverage for private journal persistence and restoration.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
