### PR TITLE
backport (v6): feat(google): add gemini-3.7-flash model

### DIFF
--- a/.changeset/fuzzy-plums-smile.md
+++ b/.changeset/fuzzy-plums-smile.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/gateway': patch
+'@ai-sdk/google': patch
+---
+
+feat(google): add `gemini-3.7-flash` model

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -1082,6 +1082,7 @@ The following Zod features are known to not work with Google Generative AI:
 
 | Model                                 | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      | Google Search       | URL Context         |
 | ------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `gemini-3.7-flash`                    | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3.6-flash`                    | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3.5-flash`                    | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3.5-flash-lite`               | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -901,6 +901,7 @@ The following Zod features are known to not work with Google Vertex:
 
 | Model                   | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
 | ----------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `gemini-3.7-flash`      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3.6-flash`      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3.5-flash`      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3.5-flash-lite` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/examples/ai-functions/src/generate-text/google/gemini-3-7-flash.ts
+++ b/examples/ai-functions/src/generate-text/google/gemini-3-7-flash.ts
@@ -4,15 +4,12 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: google.interactions('gemini-3.6-flash'),
+    model: google('gemini-3.7-flash'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
-
-  const googleMetadata = result.providerMetadata?.google;
 
   console.log(result.text);
   console.log();
   console.log('Token usage:', result.usage);
   console.log('Finish reason:', result.finishReason);
-  console.log('Interaction id:', googleMetadata?.interactionId);
 });

--- a/examples/ai-functions/src/generate-text/google/interactions-gemini-3-7-flash.ts
+++ b/examples/ai-functions/src/generate-text/google/interactions-gemini-3-7-flash.ts
@@ -4,12 +4,15 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: google('gemini-3.6-flash'),
+    model: google.interactions('gemini-3.7-flash'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
+
+  const googleMetadata = result.providerMetadata?.google;
 
   console.log(result.text);
   console.log();
   console.log('Token usage:', result.usage);
   console.log('Finish reason:', result.finishReason);
+  console.log('Interaction id:', googleMetadata?.interactionId);
 });

--- a/examples/ai-functions/src/stream-text/google/gemini-3-7-flash.ts
+++ b/examples/ai-functions/src/stream-text/google/gemini-3-7-flash.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: google('gemini-3.6-flash'),
+    model: google('gemini-3.7-flash'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/stream-text/google/interactions-gemini-3-7-flash.ts
+++ b/examples/ai-functions/src/stream-text/google/interactions-gemini-3-7-flash.ts
@@ -4,7 +4,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: google.interactions('gemini-3.6-flash'),
+    model: google.interactions('gemini-3.7-flash'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -73,6 +73,7 @@ export type GatewayModelId =
   | 'google/gemini-3.5-flash'
   | 'google/gemini-3.5-flash-lite'
   | 'google/gemini-3.6-flash'
+  | 'google/gemini-3.7-flash'
   | 'google/gemini-omni-flash-preview'
   | 'google/gemma-4-26b-a4b-it'
   | 'google/gemma-4-31b-it'

--- a/packages/google-vertex/src/google-vertex-options.ts
+++ b/packages/google-vertex/src/google-vertex-options.ts
@@ -3,6 +3,7 @@
 // https://console.cloud.google.com/vertex-ai/studio/
 export type GoogleVertexModelId =
   // Stable models
+  | 'gemini-3.7-flash'
   | 'gemini-3.6-flash'
   | 'gemini-3.5-flash'
   | 'gemini-3.5-flash-lite'

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -33,6 +33,7 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-3.5-flash'
   | 'gemini-3.5-flash-lite'
   | 'gemini-3.6-flash'
+  | 'gemini-3.7-flash'
   // latest version
   // https://ai.google.dev/gemini-api/docs/models#latest
   | 'gemini-pro-latest'

--- a/packages/google/src/interactions/google-interactions-language-model-options.ts
+++ b/packages/google/src/interactions/google-interactions-language-model-options.ts
@@ -35,6 +35,7 @@ export type GoogleInteractionsModelId =
   | 'gemini-3.5-flash'
   | 'gemini-3.5-flash-lite'
   | 'gemini-3.6-flash'
+  | 'gemini-3.7-flash'
   | 'lyria-3-clip-preview'
   | 'lyria-3-pro-preview'
   | (string & {});


### PR DESCRIPTION
## Summary

Backport of #18849 to AI SDK v6.

- add `gemini-3.7-flash` to Google, Google Vertex, and AI Gateway model IDs
- add it to the Google Interactions model IDs
- document its supported capabilities
- update the Gemini Flash generate/stream examples to use 3.7
- add patch changesets for the three published packages

## Verification

- `pnpm --filter @ai-sdk/google test`
- `pnpm --filter @ai-sdk/google-vertex test`
- `pnpm --filter @ai-sdk/gateway test`
- `pnpm check`
- `pnpm type-check:full`

## Checklist

- [x] All commits are signed
- [x] Documentation and examples have been updated
- [x] A patch changeset is included