### PR TITLE
backport (v5): feat(google): add gemini-3.7-flash model

### DIFF
--- a/.changeset/fuzzy-plums-smile.md
+++ b/.changeset/fuzzy-plums-smile.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/gateway': patch
+'@ai-sdk/google': patch
+---
+
+feat(google): add `gemini-3.7-flash` model

--- a/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google-generative-ai.mdx
@@ -1013,6 +1013,7 @@ The following Zod features are known to not work with Google Generative AI:
 
 | Model                                 | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      | Google Search       | URL Context         |
 | ------------------------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `gemini-3.7-flash`                    | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3.6-flash`                    | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3.5-flash`                    | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3.5-flash-lite`               | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -674,6 +674,7 @@ The following Zod features are known to not work with Google Vertex:
 
 | Model                   | Image Input         | Object Generation   | Tool Usage          | Tool Streaming      |
 | ----------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `gemini-3.7-flash`      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3.6-flash`      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3.5-flash`      | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `gemini-3.5-flash-lite` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/examples/ai-core/src/generate-text/google-gemini-3-7-flash.ts
+++ b/examples/ai-core/src/generate-text/google-gemini-3-7-flash.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: google('gemini-3.6-flash'),
+    model: google('gemini-3.7-flash'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-core/src/stream-text/google-gemini-3-7-flash.ts
+++ b/examples/ai-core/src/stream-text/google-gemini-3-7-flash.ts
@@ -4,7 +4,7 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: google('gemini-3.6-flash'),
+    model: google('gemini-3.7-flash'),
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -73,6 +73,7 @@ export type GatewayModelId =
   | 'google/gemini-3.5-flash'
   | 'google/gemini-3.5-flash-lite'
   | 'google/gemini-3.6-flash'
+  | 'google/gemini-3.7-flash'
   | 'google/gemini-omni-flash-preview'
   | 'google/gemma-4-26b-a4b-it'
   | 'google/gemma-4-31b-it'

--- a/packages/google-vertex/src/google-vertex-options.ts
+++ b/packages/google-vertex/src/google-vertex-options.ts
@@ -3,6 +3,7 @@
 // https://console.cloud.google.com/vertex-ai/studio/
 export type GoogleVertexModelId =
   // Stable models
+  | 'gemini-3.7-flash'
   | 'gemini-3.6-flash'
   | 'gemini-3.5-flash'
   | 'gemini-3.5-flash-lite'

--- a/packages/google/src/google-generative-ai-options.ts
+++ b/packages/google/src/google-generative-ai-options.ts
@@ -47,6 +47,7 @@ export type GoogleGenerativeAIModelId =
   | 'gemini-3.5-flash'
   | 'gemini-3.5-flash-lite'
   | 'gemini-3.6-flash'
+  | 'gemini-3.7-flash'
   // latest version
   // https://ai.google.dev/gemini-api/docs/models#latest
   | 'gemini-pro-latest'


### PR DESCRIPTION
## Summary

Backport of #18849 to AI SDK v5. The v6 backport is #18850.

- add `gemini-3.7-flash` to Google, Google Vertex, and AI Gateway model IDs
- document its supported capabilities
- update the Gemini Flash generate/stream examples to use 3.7
- add patch changesets for the three published packages

## Verification

- `pnpm --filter @ai-sdk/google test`
- `pnpm --filter @ai-sdk/google-vertex test`
- `pnpm --filter @ai-sdk/gateway test`
- focused type-checks for Google, Google Vertex, Gateway, and the AI Core examples
- `pnpm check`

`pnpm type-check:full` also reaches unrelated pre-existing React type-resolution errors in unchanged legacy examples on the v5 branch; all affected packages and the changed example package type-check successfully.

## Checklist

- [x] All commits are signed
- [x] Documentation and examples have been updated
- [x] A patch changeset is included