### PR TITLE
fix(harness-grok-build): inject bridge `package.json` and `pnpm-lock.yaml` files at build time instead of reading them at runtime to fix runtime errors in certain environments

### DIFF
--- a/.changeset/real-impalas-build.md
+++ b/.changeset/real-impalas-build.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-grok-build": patch
+---
+
+fix(harness-grok-build): inject bridge `package.json` and `pnpm-lock.yaml` files at build time instead of reading them at runtime to fix runtime errors in certain environments

--- a/examples/harness-e2e-next/app/harness/grok-build/ai-sdk-coding/page.tsx
+++ b/examples/harness-e2e-next/app/harness/grok-build/ai-sdk-coding/page.tsx
@@ -2,7 +2,7 @@ import ChatIdProvider from '@/components/chat-id-provider';
 import ACPHarnessChat from '@/components/acp-harness-chat';
 
 export const metadata = {
-  title: 'ACP: Grok Build — AI SDK Checkout',
+  title: 'Grok Build — AI SDK Checkout',
 };
 
 const STORAGE_KEY = 'harness-grok-build-ai-sdk-coding-chat-id';
@@ -13,7 +13,7 @@ export default function GrokBuildAiSdkCodingPage() {
       <ACPHarnessChat
         apiRoute="/api/harness/grok-build/ai-sdk-coding"
         exampleLabel="AI SDK Checkout"
-        harnessLabel="ACP: Grok Build"
+        harnessLabel="Grok Build"
       />
     </ChatIdProvider>
   );

--- a/examples/harness-e2e-next/app/harness/grok-build/basic-with-stop/page.tsx
+++ b/examples/harness-e2e-next/app/harness/grok-build/basic-with-stop/page.tsx
@@ -2,7 +2,7 @@ import ChatIdProvider from '@/components/chat-id-provider';
 import ACPHarnessChat from '@/components/acp-harness-chat';
 
 export const metadata = {
-  title: 'ACP: Grok Build — Basic (with stop)',
+  title: 'Grok Build — Basic (with stop)',
 };
 
 const STORAGE_KEY = 'harness-grok-build-basic-with-stop-chat-id';
@@ -13,7 +13,7 @@ export default function GrokBuildBasicWithStopPage() {
       <ACPHarnessChat
         apiRoute="/api/harness/grok-build/basic-with-stop"
         exampleLabel="Basic (with stop)"
-        harnessLabel="ACP: Grok Build"
+        harnessLabel="Grok Build"
       />
     </ChatIdProvider>
   );

--- a/examples/harness-e2e-next/app/harness/grok-build/basic/page.tsx
+++ b/examples/harness-e2e-next/app/harness/grok-build/basic/page.tsx
@@ -2,7 +2,7 @@ import ChatIdProvider from '@/components/chat-id-provider';
 import ACPHarnessChat from '@/components/acp-harness-chat';
 
 export const metadata = {
-  title: 'ACP: Grok Build — Basic',
+  title: 'Grok Build — Basic',
 };
 
 const STORAGE_KEY = 'harness-grok-build-basic-chat-id';
@@ -13,7 +13,7 @@ export default function GrokBuildBasicPage() {
       <ACPHarnessChat
         apiRoute="/api/harness/grok-build/basic"
         exampleLabel="Basic"
-        harnessLabel="ACP: Grok Build"
+        harnessLabel="Grok Build"
       />
     </ChatIdProvider>
   );

--- a/examples/harness-e2e-next/app/harness/grok-build/weather-approval/page.tsx
+++ b/examples/harness-e2e-next/app/harness/grok-build/weather-approval/page.tsx
@@ -2,7 +2,7 @@ import ChatIdProvider from '@/components/chat-id-provider';
 import WeatherACPHarnessChat from '@/components/weather-acp-harness-chat';
 
 export const metadata = {
-  title: 'ACP: Grok Build — Weather Approval',
+  title: 'Grok Build — Weather Approval',
 };
 
 const STORAGE_KEY = 'harness-grok-build-weather-approval-chat-id';
@@ -13,7 +13,7 @@ export default function GrokBuildWeatherApprovalPage() {
       <WeatherACPHarnessChat
         apiRoute="/api/harness/grok-build/weather-approval"
         exampleLabel="Weather Approval"
-        harnessLabel="ACP: Grok Build"
+        harnessLabel="Grok Build"
       />
     </ChatIdProvider>
   );

--- a/examples/harness-e2e-next/app/harness/grok-build/weather-only/page.tsx
+++ b/examples/harness-e2e-next/app/harness/grok-build/weather-only/page.tsx
@@ -2,7 +2,7 @@ import ChatIdProvider from '@/components/chat-id-provider';
 import WeatherACPHarnessChat from '@/components/weather-acp-harness-chat';
 
 export const metadata = {
-  title: 'ACP: Grok Build — Weather Only',
+  title: 'Grok Build — Weather Only',
 };
 
 const STORAGE_KEY = 'harness-grok-build-weather-only-chat-id';
@@ -13,7 +13,7 @@ export default function GrokBuildWeatherOnlyPage() {
       <WeatherACPHarnessChat
         apiRoute="/api/harness/grok-build/weather-only"
         exampleLabel="Weather Only"
-        harnessLabel="ACP: Grok Build"
+        harnessLabel="Grok Build"
       />
     </ChatIdProvider>
   );

--- a/examples/harness-e2e-next/app/harness/grok-build/weather/page.tsx
+++ b/examples/harness-e2e-next/app/harness/grok-build/weather/page.tsx
@@ -2,7 +2,7 @@ import ChatIdProvider from '@/components/chat-id-provider';
 import WeatherACPHarnessChat from '@/components/weather-acp-harness-chat';
 
 export const metadata = {
-  title: 'ACP: Grok Build — Weather',
+  title: 'Grok Build — Weather',
 };
 
 const STORAGE_KEY = 'harness-grok-build-weather-chat-id';
@@ -13,7 +13,7 @@ export default function GrokBuildWeatherPage() {
       <WeatherACPHarnessChat
         apiRoute="/api/harness/grok-build/weather"
         exampleLabel="Weather"
-        harnessLabel="ACP: Grok Build"
+        harnessLabel="Grok Build"
       />
     </ChatIdProvider>
   );

--- a/examples/harness-e2e-next/app/harness/grok-build/workflow-stepped/page.tsx
+++ b/examples/harness-e2e-next/app/harness/grok-build/workflow-stepped/page.tsx
@@ -2,7 +2,7 @@ import ChatIdProvider from '@/components/chat-id-provider';
 import ACPHarnessChat from '@/components/acp-harness-chat';
 
 export const metadata = {
-  title: 'ACP: Grok Build — Workflow (Stepped)',
+  title: 'Grok Build — Workflow (Stepped)',
 };
 
 const STORAGE_KEY = 'harness-grok-build-workflow-stepped-chat-id';
@@ -13,7 +13,7 @@ export default function GrokBuildWorkflowSteppedPage() {
       <ACPHarnessChat
         apiRoute="/api/harness/grok-build/workflow-stepped"
         exampleLabel="Workflow (Stepped)"
-        harnessLabel="ACP: Grok Build"
+        harnessLabel="Grok Build"
       />
     </ChatIdProvider>
   );

--- a/examples/harness-e2e-next/app/harness/grok-build/workflow-timed/page.tsx
+++ b/examples/harness-e2e-next/app/harness/grok-build/workflow-timed/page.tsx
@@ -2,7 +2,7 @@ import ChatIdProvider from '@/components/chat-id-provider';
 import ACPHarnessChat from '@/components/acp-harness-chat';
 
 export const metadata = {
-  title: 'ACP: Grok Build — Workflow (Timed)',
+  title: 'Grok Build — Workflow (Timed)',
 };
 
 const STORAGE_KEY = 'harness-grok-build-workflow-timed-chat-id';
@@ -13,7 +13,7 @@ export default function GrokBuildWorkflowTimedPage() {
       <ACPHarnessChat
         apiRoute="/api/harness/grok-build/workflow-timed"
         exampleLabel="Workflow (Timed)"
-        harnessLabel="ACP: Grok Build"
+        harnessLabel="Grok Build"
       />
     </ChatIdProvider>
   );

--- a/packages/harness-grok-build/package.json
+++ b/packages/harness-grok-build/package.json
@@ -18,10 +18,9 @@
     "README.md"
   ],
   "scripts": {
-    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json && pnpm copy-bridge-assets",
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
     "build:watch": "pnpm clean && tsup --watch",
     "clean": "del-cli dist *.tsbuildinfo",
-    "copy-bridge-assets": "node -e \"import('node:fs/promises').then(async fs => { await fs.mkdir('dist/bridge', { recursive: true }); await fs.copyFile('src/bridge/package.json', 'dist/bridge/package.json'); await fs.copyFile('src/bridge/pnpm-lock.yaml', 'dist/bridge/pnpm-lock.yaml'); })\"",
     "type-check": "tsc --build",
     "test": "pnpm test:node",
     "test:watch": "vitest --config vitest.node.config.js",

--- a/packages/harness-grok-build/src/grok-build-harness.ts
+++ b/packages/harness-grok-build/src/grok-build-harness.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs';
 import {
   commonTool,
   type HarnessV1,
@@ -12,15 +11,14 @@ import { tool } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 import { VERSION } from './version';
 
+declare const __GROK_BUILD_IMPLEMENTATION_PACKAGE_JSON__: string;
+declare const __GROK_BUILD_IMPLEMENTATION_PNPM_LOCK_YAML__: string;
+
 const GROK_BUILD_CLIENT_APP = `ai-sdk/harness-grok-build/${VERSION}`;
-const GROK_BUILD_IMPLEMENTATION_PACKAGE_JSON = readFileSync(
-  new URL('./bridge/package.json', import.meta.url),
-  'utf8',
-);
-const GROK_BUILD_IMPLEMENTATION_PNPM_LOCK = readFileSync(
-  new URL('./bridge/pnpm-lock.yaml', import.meta.url),
-  'utf8',
-);
+const GROK_BUILD_IMPLEMENTATION_PACKAGE_JSON =
+  __GROK_BUILD_IMPLEMENTATION_PACKAGE_JSON__;
+const GROK_BUILD_IMPLEMENTATION_PNPM_LOCK =
+  __GROK_BUILD_IMPLEMENTATION_PNPM_LOCK_YAML__;
 
 export type GrokBuildHarnessSettings = {
   /**

--- a/packages/harness-grok-build/tsup.config.ts
+++ b/packages/harness-grok-build/tsup.config.ts
@@ -1,7 +1,18 @@
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'tsup';
 
 const packageVersion = JSON.stringify(
   (await import('./package.json', { with: { type: 'json' } })).default.version,
+);
+const implementationPackageJson = JSON.stringify(
+  readFileSync(
+    new URL('./src/bridge/package.json', import.meta.url),
+  ).toString(),
+);
+const implementationPnpmLockYaml = JSON.stringify(
+  readFileSync(
+    new URL('./src/bridge/pnpm-lock.yaml', import.meta.url),
+  ).toString(),
 );
 
 export default defineConfig({
@@ -12,5 +23,7 @@ export default defineConfig({
   sourcemap: true,
   define: {
     __PACKAGE_VERSION__: packageVersion,
+    __GROK_BUILD_IMPLEMENTATION_PACKAGE_JSON__: implementationPackageJson,
+    __GROK_BUILD_IMPLEMENTATION_PNPM_LOCK_YAML__: implementationPnpmLockYaml,
   },
 });

--- a/packages/harness-grok-build/vitest.node.config.js
+++ b/packages/harness-grok-build/vitest.node.config.js
@@ -1,6 +1,22 @@
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'vitest/config';
 
+const implementationPackageJson = JSON.stringify(
+  readFileSync(
+    new URL('./src/bridge/package.json', import.meta.url),
+  ).toString(),
+);
+const implementationPnpmLockYaml = JSON.stringify(
+  readFileSync(
+    new URL('./src/bridge/pnpm-lock.yaml', import.meta.url),
+  ).toString(),
+);
+
 export default defineConfig({
+  define: {
+    __GROK_BUILD_IMPLEMENTATION_PACKAGE_JSON__: implementationPackageJson,
+    __GROK_BUILD_IMPLEMENTATION_PNPM_LOCK_YAML__: implementationPnpmLockYaml,
+  },
   test: {
     environment: 'node',
     include: ['**/*.test.ts', '**/*.test.tsx'],


### PR DESCRIPTION
## Background

The Grok Build harness read its bridge package manifest and lockfile at runtime, which failed when Next.js bundled the package and replaced the asset URLs with non-native URL objects.

## Summary

- Embed the locked Grok Build bridge dependencies into the package during the tsup build.
- Remove runtime filesystem reads and the post-build bridge asset copy.
- Provide the embedded values to the Vitest source build.
- Unrelated cleanup: Rename the Next.js example labels from “ACP: Grok Build” to “Grok Build.” to clearly separate it from the manual testing-only ACP Grok Build implementation

## End-to-End Verification

Ran various `examples/harness-e2e-next` tests with the Grok Build harness to verify the error is gone.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
