### PR TITLE
fix: preserve useObject results when the API URL changes

### DIFF
--- a/.changeset/tidy-objects-remain.md
+++ b/.changeset/tidy-objects-remain.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+Preserve the generated `useObject` value when the API URL changes.

--- a/packages/react/src/use-object.ts
+++ b/packages/react/src/use-object.ts
@@ -138,7 +138,7 @@ export function useObject<
 
   // Store the completion state in SWR, using the completionId as the key to share states.
   const { data, mutate } = useSWR<DeepPartial<RESULT>>(
-    [api, completionId],
+    [completionId, 'object'],
     null,
     { fallbackData: initialValue },
   );

--- a/packages/react/src/use-object.ui.test.tsx
+++ b/packages/react/src/use-object.ui.test.tsx
@@ -385,6 +385,47 @@ describe('text stream', () => {
       expect(screen.getByTestId('loading')).toHaveTextContent('false');
     });
   });
+
+  it('should preserve the object state when the API changes', async () => {
+    server.urls['/api/use-object'].response = {
+      type: 'stream-chunks',
+      chunks: ['{ ', '"content": "Hello, ', 'world', '!"', '}'],
+    };
+
+    const ApiTestComponent = ({ api }: { api: string }) => {
+      const { object, submit } = useObject({
+        api,
+        schema: z.object({ content: z.string() }),
+      });
+
+      return (
+        <div>
+          <div data-testid="object">{JSON.stringify(object)}</div>
+          <button
+            data-testid="submit-button"
+            onClick={() => submit('test-input')}
+          >
+            Generate
+          </button>
+        </div>
+      );
+    };
+
+    const { rerender } = render(<ApiTestComponent api="/api/use-object" />);
+    await userEvent.click(screen.getByTestId('submit-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('object')).toHaveTextContent(
+        JSON.stringify({ content: 'Hello, world!' }),
+      );
+    });
+
+    rerender(<ApiTestComponent api="/api/changed" />);
+
+    expect(screen.getByTestId('object')).toHaveTextContent(
+      JSON.stringify({ content: 'Hello, world!' }),
+    );
+  });
 });
 
 describe('deprecated experimental_useObject alias', () => {


### PR DESCRIPTION
## Summary

- forward-port #18853 to main
- keep generated useObject state when the API prop changes
- add regression coverage using the stable useObject API and a patch changeset

## Testing

- pnpm --dir packages/react test src/use-object.ui.test.tsx
- pnpm type-check:full
- pnpm check