### PR TITLE
fix: keep chat submitted until response content starts streaming

### DIFF
--- a/.changeset/brave-streams-rest.md
+++ b/.changeset/brave-streams-rest.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Keep chat status submitted until response content begins streaming.

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
@@ -2,6 +2,7 @@ import {
   createStreamingUIMessageState,
   processUIMessageStream,
   type StreamingUIMessageState,
+  type UIMessageStreamWriteOptions,
 } from '../ui/process-ui-message-stream';
 import type { UIMessage } from '../ui/ui-messages';
 import type { ErrorHandler } from '../util/error-handler';
@@ -109,7 +110,7 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
   const runUpdateMessageJob = async (
     job: (options: {
       state: StreamingUIMessageState<UI_MESSAGE>;
-      write: () => void;
+      write: (options?: UIMessageStreamWriteOptions) => void;
     }) => Promise<void>,
   ) => {
     await job({ state, write: () => {} });

--- a/packages/ai/src/ui-message-stream/read-ui-message-stream.ts
+++ b/packages/ai/src/ui-message-stream/read-ui-message-stream.ts
@@ -4,6 +4,7 @@ import {
   createStreamingUIMessageState,
   processUIMessageStream,
   type StreamingUIMessageState,
+  type UIMessageStreamWriteOptions,
 } from '../ui/process-ui-message-stream';
 import {
   createAsyncIterableStream,
@@ -91,7 +92,7 @@ export function readUIMessageStream<UI_MESSAGE extends UIMessage>({
       runUpdateMessageJob(
         job: (options: {
           state: StreamingUIMessageState<UI_MESSAGE>;
-          write: () => void;
+          write: (options?: UIMessageStreamWriteOptions) => void;
         }) => Promise<void>,
       ) {
         return job({

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -1746,6 +1746,77 @@ describe('Chat', () => {
     expect((chat as any).activeResponse).toBeUndefined();
   });
 
+  it.each([
+    {
+      name: 'a message id',
+      chunk: { type: 'start', messageId: 'response-id' } as const,
+    },
+    {
+      name: 'message metadata',
+      chunk: {
+        type: 'start',
+        messageMetadata: { model: 'test-model' },
+      } as const,
+    },
+    {
+      name: 'no message fields',
+      chunk: { type: 'start' } as const,
+    },
+  ])(
+    'should remain submitted after a start chunk with $name until content arrives',
+    async ({ chunk }) => {
+      let controller!: ReadableStreamDefaultController<UIMessageChunk>;
+      const startProcessed = createResolvablePromise<void>();
+      const contentProcessed = createResolvablePromise<void>();
+      const stream = new ReadableStream<UIMessageChunk>({
+        start(streamController) {
+          controller = streamController;
+        },
+      });
+
+      const chat = new TestChat({
+        id: '123',
+        generateId: mockId(),
+        transport: {
+          sendMessages: async () => stream,
+          reconnectToStream: async () => null,
+        },
+      });
+
+      const sendPromise = chat.sendMessage({ text: 'Hello' });
+
+      controller.enqueue(chunk);
+      controller.enqueue({
+        get type() {
+          startProcessed.resolve();
+          return 'start-step' as const;
+        },
+      });
+
+      await startProcessed.promise;
+
+      expect(chat.status).toBe('submitted');
+
+      controller.enqueue({ type: 'text-start', id: 'text-1' });
+      controller.enqueue({
+        get type() {
+          contentProcessed.resolve();
+          return 'start-step' as const;
+        },
+      });
+
+      await contentProcessed.promise;
+
+      expect(chat.status).toBe('streaming');
+
+      controller.enqueue({ type: 'text-end', id: 'text-1' });
+      controller.enqueue({ type: 'finish', finishReason: 'stop' });
+      controller.close();
+
+      await sendPromise;
+    },
+  );
+
   it('should handle error parts', async () => {
     server.urls['http://localhost:3000/api/chat'].response = {
       type: 'stream-chunks',

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -15,6 +15,7 @@ import {
   createStreamingUIMessageState,
   processUIMessageStream,
   type StreamingUIMessageState,
+  type UIMessageStreamWriteOptions,
 } from './process-ui-message-stream';
 import {
   isToolUIPart,
@@ -757,7 +758,7 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
       const runUpdateMessageJob = (
         job: (options: {
           state: StreamingUIMessageState<UI_MESSAGE>;
-          write: () => void;
+          write: (options?: UIMessageStreamWriteOptions) => void;
         }) => Promise<void>,
       ) =>
         // serialize the job execution to avoid race conditions:
@@ -768,13 +769,14 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
 
           return job({
             state: response.state,
-            write: () => {
+            write: ({ updateStatus = true } = {}) => {
               if (response.abortController.signal.aborted) {
                 return;
               }
 
-              // streaming is set on first write (before it should be "submitted")
-              this.setStatus({ status: 'streaming' });
+              if (updateStatus) {
+                this.setStatus({ status: 'streaming' });
+              }
 
               const replaceLastMessage =
                 response.state.message.id === this.lastMessage?.id;

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -5,6 +5,7 @@ import {
   createStreamingUIMessageState,
   processUIMessageStream,
   type StreamingUIMessageState,
+  type UIMessageStreamWriteOptions,
 } from './process-ui-message-stream';
 import type { InferUIMessageData, UIMessage } from './ui-messages';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
@@ -41,7 +42,7 @@ describe('processUIMessageStream', () => {
   const runUpdateMessageJob = async (
     job: (options: {
       state: StreamingUIMessageState<UIMessage>;
-      write: () => void;
+      write: (options?: UIMessageStreamWriteOptions) => void;
     }) => Promise<void>,
   ) => {
     await job({

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -49,6 +49,10 @@ export type StreamingUIMessageState<UI_MESSAGE extends UIMessage> = {
   finishReason?: FinishReason;
 };
 
+export type UIMessageStreamWriteOptions = {
+  updateStatus?: boolean;
+};
+
 export function createStreamingUIMessageState<UI_MESSAGE extends UIMessage>({
   lastMessage,
   messageId,
@@ -95,7 +99,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
   runUpdateMessageJob: (
     job: (options: {
       state: StreamingUIMessageState<UI_MESSAGE>;
-      write: () => void;
+      write: (options?: UIMessageStreamWriteOptions) => void;
     }) => Promise<void>,
   ) => Promise<void>;
   onError: ErrorHandler;
@@ -891,7 +895,7 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
               await updateMessageMetadata(chunk.messageMetadata);
 
               if (chunk.messageId != null || chunk.messageMetadata != null) {
-                write();
+                write({ updateStatus: false });
               }
               break;
             }


### PR DESCRIPTION
## Summary

- keep chat status submitted when start chunks only update the response message ID or metadata
- continue transitioning to streaming when response content arrives
- add regression coverage for start chunks with an ID, metadata, or neither

## Testing

- pnpm -C packages/ai test:node src/ui/chat.test.ts src/ui/process-ui-message-stream.test.ts
- pnpm -C packages/ai test:edge src/ui/chat.test.ts src/ui/process-ui-message-stream.test.ts
- pnpm check
- pnpm type-check:full

## Related

Applies the fix from #18854 to main. Related to #8579.