### PR TITLE
[v6.0] fix: declaration emit failure for exported utilities using Prompt and inferred Output types

### DIFF
--- a/.changeset/warm-hounds-type.md
+++ b/.changeset/warm-hounds-type.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix declaration emit for exported values that infer an `Output` type.

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -15,6 +15,7 @@ export {
   type GeneratedFile,
 } from './generated-file';
 export * as Output from './output';
+export type { Output as OutputInterface } from './output';
 export type {
   InferCompleteOutput as InferGenerateOutput,
   InferPartialOutput as InferStreamOutput,

--- a/packages/ai/src/generate-text/output-declaration.test.ts
+++ b/packages/ai/src/generate-text/output-declaration.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+const isEdgeRuntime =
+  (globalThis as { EdgeRuntime?: unknown }).EdgeRuntime !== undefined;
+
+describe.skipIf(isEdgeRuntime)('Output declaration emit', () => {
+  it('emits declarations for exported values with inferred output types', async () => {
+    const [{ default: path }, { default: ts }] = await Promise.all([
+      import('node:path'),
+      import('typescript'),
+    ]);
+    const compilerOptions = {
+      declaration: true,
+      emitDeclarationOnly: true,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      skipLibCheck: true,
+      strict: true,
+      target: ts.ScriptTarget.ES2022,
+      types: [],
+    };
+    const fileName = path.resolve('test/exported-output.ts');
+    const sourceText = `
+import { Output, type Prompt } from 'ai';
+
+export const aiUtils = {
+  acceptPrompt: (prompt: Prompt) => prompt,
+  textOutput: Output.text(),
+};
+`;
+    const host = ts.createCompilerHost(compilerOptions);
+    const fileExists = host.fileExists.bind(host);
+    const getSourceFile = host.getSourceFile.bind(host);
+    const readFile = host.readFile.bind(host);
+    let declaration = '';
+
+    host.fileExists = candidate =>
+      candidate === fileName || fileExists(candidate);
+    host.getSourceFile = (candidate, languageVersion, ...rest) =>
+      candidate === fileName
+        ? ts.createSourceFile(candidate, sourceText, languageVersion, true)
+        : getSourceFile(candidate, languageVersion, ...rest);
+    host.readFile = candidate =>
+      candidate === fileName ? sourceText : readFile(candidate);
+    host.writeFile = (outputFileName, text) => {
+      if (outputFileName.endsWith('.d.ts')) {
+        declaration = text;
+      }
+    };
+
+    const program = ts.createProgram({
+      rootNames: [fileName],
+      options: compilerOptions,
+      host,
+    });
+    const emitResult = program.emit();
+    const diagnostics = [
+      ...ts.getPreEmitDiagnostics(program),
+      ...emitResult.diagnostics,
+    ];
+
+    expect(
+      diagnostics.map(
+        diagnostic =>
+          `TS${diagnostic.code}: ${ts.flattenDiagnosticMessageText(
+            diagnostic.messageText,
+            '\n',
+          )}`,
+      ),
+    ).toEqual([]);
+    expect(declaration).toContain('export declare const aiUtils');
+    expect(declaration).toContain('textOutput:');
+  });
+});


### PR DESCRIPTION
## Summary

- forward-port #18857 to release-v6.0
- expose the underlying Output interface as OutputInterface while preserving the Output namespace
- add declaration-emit regression coverage and a patch changeset

## Testing

- pnpm --filter ai... build
- pnpm --dir packages/ai test:node src/generate-text/output-declaration.test.ts
- pnpm type-check:full
- pnpm check

## Related Issues

Fixes #9593