### PR TITLE
fix(open-responses): close unfinished reasoning stream parts with their original IDs

### DIFF
--- a/.changeset/tidy-reasoning-items-close.md
+++ b/.changeset/tidy-reasoning-items-close.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/open-responses': patch
+---
+
+fix(open-responses): close unfinished reasoning stream parts with their original IDs

--- a/packages/open-responses/src/responses/open-responses-language-model.test.ts
+++ b/packages/open-responses/src/responses/open-responses-language-model.test.ts
@@ -734,6 +734,62 @@ describe('OpenResponsesLanguageModel', () => {
       });
     });
 
+    it('should close unfinished reasoning items with their original ids', async () => {
+      server.urls[URL].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: ${JSON.stringify({
+            type: 'response.output_item.added',
+            sequence_number: 0,
+            output_index: 0,
+            item: {
+              id: 'rs_reasoning_item',
+              type: 'reasoning',
+              summary: [],
+            },
+          })}\n\n`,
+          `data: ${JSON.stringify({
+            type: 'response.incomplete',
+            sequence_number: 1,
+            response: {
+              status: 'incomplete',
+              incomplete_details: { reason: 'max_output_tokens' },
+              usage: {
+                input_tokens: 1,
+                input_tokens_details: { cached_tokens: 0 },
+                output_tokens: 1,
+                output_tokens_details: { reasoning_tokens: 1 },
+                total_tokens: 2,
+              },
+            },
+          })}\n\n`,
+          'data: [DONE]\n\n',
+        ],
+      };
+
+      const result = await createModel().doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      const parts = await convertReadableStreamToArray(result.stream);
+
+      expect(parts).toContainEqual({
+        type: 'reasoning-start',
+        id: 'rs_reasoning_item',
+      });
+      expect(parts).toContainEqual({
+        type: 'reasoning-end',
+        id: 'rs_reasoning_item',
+      });
+      expect(parts.at(-1)).toMatchObject({
+        type: 'finish',
+        finishReason: {
+          unified: 'length',
+          raw: 'max_output_tokens',
+        },
+      });
+    });
+
     it('should not pollute Object.prototype from tool call item ids', async () => {
       const originalArgumentsDescriptor = Object.getOwnPropertyDescriptor(
         Object.prototype,

--- a/packages/open-responses/src/responses/open-responses-language-model.ts
+++ b/packages/open-responses/src/responses/open-responses-language-model.ts
@@ -401,7 +401,7 @@ export class OpenResponsesLanguageModel implements LanguageModelV4 {
       usage.raw = responseUsage;
     };
 
-    let isActiveReasoning = false;
+    let activeReasoningId: string | undefined;
     let hasToolCalls = false;
     let finishReason: LanguageModelV4FinishReason = {
       unified: 'other',
@@ -503,7 +503,7 @@ export class OpenResponsesLanguageModel implements LanguageModelV4 {
                 type: 'reasoning-start',
                 id: chunk.item.id,
               });
-              isActiveReasoning = true;
+              activeReasoningId = chunk.item.id;
             } else if (
               (chunk as { type: string }).type ===
               'response.reasoning_text.delta'
@@ -522,7 +522,9 @@ export class OpenResponsesLanguageModel implements LanguageModelV4 {
               chunk.item.type === 'reasoning'
             ) {
               controller.enqueue({ type: 'reasoning-end', id: chunk.item.id });
-              isActiveReasoning = false;
+              if (activeReasoningId === chunk.item.id) {
+                activeReasoningId = undefined;
+              }
             }
 
             // Text events
@@ -565,8 +567,11 @@ export class OpenResponsesLanguageModel implements LanguageModelV4 {
           },
 
           flush(controller) {
-            if (isActiveReasoning) {
-              controller.enqueue({ type: 'reasoning-end', id: 'reasoning-0' });
+            if (activeReasoningId != null) {
+              controller.enqueue({
+                type: 'reasoning-end',
+                id: activeReasoningId,
+              });
             }
 
             controller.enqueue({


### PR DESCRIPTION
## Background

When an Open Responses stream ended with an unfinished reasoning item, the provider emitted `reasoning-end` with the hardcoded ID `reasoning-0`. This ID did not match the provider-generated ID from `reasoning-start`, which produced an invalid reasoning stream.

## Summary

Track the active reasoning item ID instead of just whether reasoning is active, and use it when closing the item during stream cleanup.

## End-to-End Verification

I couldn't find an open responses server that actually has this behavior. But this does seem more correct to me than hardcoding a fake reasoning ID.

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Future Work

## Related Issues

Fixes https://github.com/vercel/ai/issues/18872

Closes https://github.com/vercel/ai/pull/18881 (superseded)

Closes #18875