### PR TITLE
fix(anthropic): replay dynamic-filtering callers without reordering

### DIFF
--- a/.changeset/calm-callers-replay.md
+++ b/.changeset/calm-callers-replay.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+Preserve Anthropic server-tool caller metadata in multi-turn conversations.

--- a/packages/anthropic/src/__snapshots__/anthropic-language-model.test.ts.snap
+++ b/packages/anthropic/src/__snapshots__/anthropic-language-model.test.ts.snap
@@ -785,6 +785,14 @@ exports[`AnthropicLanguageModel > doGenerate > programmatic tool calling > with 
   {
     "input": "{"type":"programmatic-tool-call","code":"\\nimport asyncio\\n\\nasync def main():\\n    player1_wins = 0\\n    player2_wins = 0\\n    round_num = 0\\n    \\n    print(\\"=\\" * 60)\\n    print(\\"DICE GAME: First to 3 Round Wins\\")\\n    print(\\"=\\" * 60)\\n    print()\\n    \\n    while player1_wins < 3 and player2_wins < 3:\\n        round_num += 1\\n        print(f\\"Round {round_num}:\\")\\n        \\n        # Both players roll simultaneously\\n        results = await asyncio.gather(\\n            rollDie({\\"player\\": \\"player1\\"}),\\n            rollDie({\\"player\\": \\"player2\\"})\\n        )\\n        \\n        roll1 = int(results[0])\\n        roll2 = int(results[1])\\n        \\n        print(f\\"  Player 1 rolls: {roll1}\\")\\n        print(f\\"  Player 2 rolls: {roll2}\\")\\n        \\n        # Determine winner\\n        if roll1 > roll2:\\n            player1_wins += 1\\n            print(f\\"  → Player 1 wins this round!\\")\\n        elif roll2 > roll1:\\n            player2_wins += 1\\n            print(f\\"  → Player 2 wins this round!\\")\\n        else:\\n            print(f\\"  → Draw! No points awarded.\\")\\n        \\n        print(f\\"  Score: Player 1: {player1_wins} | Player 2: {player2_wins}\\")\\n        print()\\n    \\n    print(\\"=\\" * 60)\\n    if player1_wins == 3:\\n        print(\\"🏆 PLAYER 1 WINS THE GAME!\\")\\n    else:\\n        print(\\"🏆 PLAYER 2 WINS THE GAME!\\")\\n    print(f\\"Final Score: Player 1: {player1_wins} | Player 2: {player2_wins}\\")\\n    print(f\\"Total Rounds: {round_num}\\")\\n    print(\\"=\\" * 60)\\n\\nasyncio.run(main())\\n"}",
     "providerExecuted": true,
+    "providerMetadata": {
+      "anthropic": {
+        "caller": {
+          "toolId": undefined,
+          "type": "direct",
+        },
+      },
+    },
     "toolCallId": "srvtoolu_01CberhXc9TgYXrCZU8bQoks",
     "toolName": "code_execution",
     "type": "tool-call",
@@ -916,6 +924,14 @@ exports[`AnthropicLanguageModel > doGenerate > tool search tool > bm25 variant >
   {
     "input": "{"query":"weather current conditions San Francisco"}",
     "providerExecuted": true,
+    "providerMetadata": {
+      "anthropic": {
+        "caller": {
+          "toolId": undefined,
+          "type": "direct",
+        },
+      },
+    },
     "toolCallId": "srvtoolu_011Jcb838xqvZyWwDt7bWqAz",
     "toolName": "tool_search",
     "type": "tool-call",
@@ -957,6 +973,14 @@ exports[`AnthropicLanguageModel > doGenerate > tool search tool > regex variant 
   {
     "input": "{"pattern":"weather|SF|San Francisco|forecast|temperature|climate","limit":10}",
     "providerExecuted": true,
+    "providerMetadata": {
+      "anthropic": {
+        "caller": {
+          "toolId": undefined,
+          "type": "direct",
+        },
+      },
+    },
     "toolCallId": "srvtoolu_01SACvPAnp6ucMJsstB5qb3f",
     "toolName": "tool_search",
     "type": "tool-call",
@@ -998,6 +1022,14 @@ exports[`AnthropicLanguageModel > doGenerate > web fetch tool > 20260209 text re
   {
     "input": "{"type":"programmatic-tool-call","code":"\\nimport json\\nresult = await web_fetch({\\"url\\": \\"https://example.com\\"})\\nparsed = json.loads(result) if isinstance(result, str) else result\\nif isinstance(parsed, list):\\n    print(parsed[0][\\"content\\"][:500])\\nelse:\\n    print(parsed)\\n"}",
     "providerExecuted": true,
+    "providerMetadata": {
+      "anthropic": {
+        "caller": {
+          "toolId": undefined,
+          "type": "direct",
+        },
+      },
+    },
     "toolCallId": "srvtoolu_015CSHH7X69AhdK9gNzotEeh",
     "toolName": "code_execution",
     "type": "tool-call",
@@ -1005,11 +1037,27 @@ exports[`AnthropicLanguageModel > doGenerate > web fetch tool > 20260209 text re
   {
     "input": "{"url":"https://example.com"}",
     "providerExecuted": true,
+    "providerMetadata": {
+      "anthropic": {
+        "caller": {
+          "toolId": "srvtoolu_015CSHH7X69AhdK9gNzotEeh",
+          "type": "code_execution_20260120",
+        },
+      },
+    },
     "toolCallId": "srvtoolu_0152eMmZnBDZc4C2miykFWW5",
     "toolName": "web_fetch",
     "type": "tool-call",
   },
   {
+    "providerMetadata": {
+      "anthropic": {
+        "caller": {
+          "toolId": "srvtoolu_015CSHH7X69AhdK9gNzotEeh",
+          "type": "code_execution_20260120",
+        },
+      },
+    },
     "result": {
       "content": {
         "citations": undefined,
@@ -14618,6 +14666,14 @@ exports[`AnthropicLanguageModel > doStream > programmatic tool calling > with fi
   {
     "input": "{"type": "programmatic-tool-call","code": "\\nimport asyncio\\n\\nasync def main():\\n    player1_wins = 0\\n    player2_wins = 0\\n    round_num = 0\\n    \\n    print(\\"=== DICE GAME: First to 3 Wins ===\\\\n\\")\\n    \\n    # Play until one player wins 3 rounds\\n    while player1_wins < 3 and player2_wins < 3:\\n        round_num += 1\\n        print(f\\"--- Round {round_num} ---\\")\\n        \\n        # Both players roll their dice\\n        player1_roll = await rollDie({\\"player\\": \\"player1\\"})\\n        player2_roll = await rollDie({\\"player\\": \\"player2\\"})\\n        \\n        # Extract the numeric values from the results\\n        p1_value = int(player1_roll.strip())\\n        p2_value = int(player2_roll.strip())\\n        \\n        print(f\\"Player 1 rolls: {p1_value}\\")\\n        print(f\\"Player 2 rolls: {p2_value}\\")\\n        \\n        # Determine round winner\\n        if p1_value > p2_value:\\n            player1_wins += 1\\n            print(f\\"Player 1 wins this round!\\")\\n        elif p2_value > p1_value:\\n            player2_wins += 1\\n            print(f\\"Player 2 wins this round!\\")\\n        else:\\n            print(f\\"Draw! No one gets a point.\\")\\n        \\n        print(f\\"Score: Player 1 = {player1_wins}, Player 2 = {player2_wins}\\\\n\\")\\n    \\n    # Announce the game winner\\n    print(\\"=\\" * 40)\\n    if player1_wins == 3:\\n        print(f\\"🏆 GAME OVER: Player 1 wins the game! (3-{player2_wins})\\")\\n    else:\\n        print(f\\"🏆 GAME OVER: Player 2 wins the game! (3-{player1_wins})\\")\\n    print(\\"=\\" * 40)\\n    \\n    # Determine who was cheating based on the results\\n    print(\\"\\\\n📊 Analysis:\\")\\n    print(f\\"Total rounds played: {round_num}\\")\\n    if player1_wins > player2_wins:\\n        print(\\"Player 1 had better results - likely using the loaded die! 🎲\\")\\n    elif player2_wins > player1_wins:\\n        print(\\"Player 2 had better results - likely using the loaded die! 🎲\\")\\n    else:\\n        print(\\"Results were even - hard to determine who was cheating from this game alone.\\")\\n\\nasyncio.run(main())\\n"}",
     "providerExecuted": true,
+    "providerMetadata": {
+      "anthropic": {
+        "caller": {
+          "toolId": undefined,
+          "type": "direct",
+        },
+      },
+    },
     "toolCallId": "srvtoolu_01MzSrFWsmzBdcoQkGWLyRjK",
     "toolName": "code_execution",
     "type": "tool-call",
@@ -16346,6 +16402,14 @@ exports[`AnthropicLanguageModel > doStream > tool search tool > bm25 variant > s
   {
     "input": "{"query": "weather forecast current conditions"}",
     "providerExecuted": true,
+    "providerMetadata": {
+      "anthropic": {
+        "caller": {
+          "toolId": undefined,
+          "type": "direct",
+        },
+      },
+    },
     "toolCallId": "srvtoolu_01Gj33J3YUAAxF9TWRAThxtu",
     "toolName": "tool_search",
     "type": "tool-call",
@@ -16662,6 +16726,14 @@ exports[`AnthropicLanguageModel > doStream > tool search tool > regex variant > 
   {
     "input": "{"pattern": "weather|SF|San Francisco|forecast|temperature|climate", "limit": 10}",
     "providerExecuted": true,
+    "providerMetadata": {
+      "anthropic": {
+        "caller": {
+          "toolId": undefined,
+          "type": "direct",
+        },
+      },
+    },
     "toolCallId": "srvtoolu_01TFsKhwiJYqVMitK2XGtH87",
     "toolName": "tool_search",
     "type": "tool-call",
@@ -17062,6 +17134,14 @@ exports[`AnthropicLanguageModel > doStream > web fetch 20260209 tool > input pro
   {
     "input": "{"type": "programmatic-tool-call","code": "\\nimport json\\nresult = await web_fetch({\\"url\\": \\"https://example.com\\"})\\nif isinstance(result, list):\\n    print(result[0][\\"content\\"][:500])\\nelse:\\n    print(result)\\n"}",
     "providerExecuted": true,
+    "providerMetadata": {
+      "anthropic": {
+        "caller": {
+          "toolId": undefined,
+          "type": "direct",
+        },
+      },
+    },
     "toolCallId": "srvtoolu_01LKcA5qc1HwvLQSe3cLKmcK",
     "toolName": "code_execution",
     "type": "tool-call",
@@ -17079,11 +17159,27 @@ exports[`AnthropicLanguageModel > doStream > web fetch 20260209 tool > input pro
   {
     "input": "{"url":"https://example.com"}",
     "providerExecuted": true,
+    "providerMetadata": {
+      "anthropic": {
+        "caller": {
+          "toolId": "srvtoolu_01LKcA5qc1HwvLQSe3cLKmcK",
+          "type": "code_execution_20260120",
+        },
+      },
+    },
     "toolCallId": "srvtoolu_01SyXFZ4vqqE144ySoN6b5UG",
     "toolName": "web_fetch",
     "type": "tool-call",
   },
   {
+    "providerMetadata": {
+      "anthropic": {
+        "caller": {
+          "toolId": "srvtoolu_01LKcA5qc1HwvLQSe3cLKmcK",
+          "type": "code_execution_20260120",
+        },
+      },
+    },
     "result": {
       "content": {
         "citations": undefined,

--- a/packages/anthropic/src/anthropic-api.ts
+++ b/packages/anthropic/src/anthropic-api.ts
@@ -189,6 +189,7 @@ export interface AnthropicServerToolUseContent {
     // advisor:
     | 'advisor';
   input: unknown;
+  caller?: AnthropicToolCallCaller;
   cache_control: AnthropicCacheControl | undefined;
 }
 
@@ -250,6 +251,7 @@ export interface AnthropicWebSearchToolResultContent {
         type: 'web_search_tool_result_error';
         error_code: string;
       };
+  caller?: AnthropicToolCallCaller;
   cache_control: AnthropicCacheControl | undefined;
 }
 
@@ -398,6 +400,7 @@ export interface AnthropicWebFetchToolResultContent {
         type: 'web_fetch_tool_result_error';
         error_code: string;
       };
+  caller?: AnthropicToolCallCaller;
   cache_control: AnthropicCacheControl | undefined;
 }
 export interface AnthropicMcpToolUseContent {
@@ -638,6 +641,20 @@ const anthropicStopDetailsSchema = z.object({
 
 export type AnthropicStopDetails = z.infer<typeof anthropicStopDetailsSchema>;
 
+const anthropicToolCallCallerSchema = z.union([
+  z.object({
+    type: z.literal('code_execution_20250825'),
+    tool_id: z.string(),
+  }),
+  z.object({
+    type: z.literal('code_execution_20260120'),
+    tool_id: z.string(),
+  }),
+  z.object({
+    type: z.literal('direct'),
+  }),
+]);
+
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
 export const anthropicResponseSchema = lazySchema(() =>
@@ -700,38 +717,14 @@ export const anthropicResponseSchema = lazySchema(() =>
             name: z.string(),
             input: z.unknown(),
             // Programmatic tool calling: caller info when triggered from code execution
-            caller: z
-              .union([
-                z.object({
-                  type: z.literal('code_execution_20250825'),
-                  tool_id: z.string(),
-                }),
-                z.object({
-                  type: z.literal('code_execution_20260120'),
-                  tool_id: z.string(),
-                }),
-                z.object({
-                  type: z.literal('direct'),
-                }),
-              ])
-              .optional(),
+            caller: anthropicToolCallCallerSchema.optional(),
           }),
           z.object({
             type: z.literal('server_tool_use'),
             id: z.string(),
             name: z.string(),
             input: z.record(z.string(), z.unknown()).nullish(),
-            caller: z
-              .union([
-                z.object({
-                  type: z.literal('code_execution_20260120'),
-                  tool_id: z.string(),
-                }),
-                z.object({
-                  type: z.literal('direct'),
-                }),
-              ])
-              .optional(),
+            caller: anthropicToolCallCallerSchema.optional(),
           }),
           z.object({
             type: z.literal('mcp_tool_use'),
@@ -754,6 +747,7 @@ export const anthropicResponseSchema = lazySchema(() =>
           z.object({
             type: z.literal('web_fetch_tool_result'),
             tool_use_id: z.string(),
+            caller: anthropicToolCallCallerSchema.optional(),
             content: z.union([
               z.object({
                 type: z.literal('web_fetch_result'),
@@ -786,6 +780,7 @@ export const anthropicResponseSchema = lazySchema(() =>
           z.object({
             type: z.literal('web_search_tool_result'),
             tool_use_id: z.string(),
+            caller: anthropicToolCallCallerSchema.optional(),
             content: z.union([
               z.array(
                 z.object({
@@ -1044,21 +1039,7 @@ export const anthropicChunkSchema = lazySchema(() =>
                   id: z.string(),
                   name: z.string(),
                   input: z.unknown(),
-                  caller: z
-                    .union([
-                      z.object({
-                        type: z.literal('code_execution_20250825'),
-                        tool_id: z.string(),
-                      }),
-                      z.object({
-                        type: z.literal('code_execution_20260120'),
-                        tool_id: z.string(),
-                      }),
-                      z.object({
-                        type: z.literal('direct'),
-                      }),
-                    ])
-                    .optional(),
+                  caller: anthropicToolCallCallerSchema.optional(),
                 }),
               ]),
             )
@@ -1091,21 +1072,7 @@ export const anthropicChunkSchema = lazySchema(() =>
             // Programmatic tool calling: input may be present directly for deferred tool calls
             input: z.record(z.string(), z.unknown()).optional(),
             // Programmatic tool calling: caller info when triggered from code execution
-            caller: z
-              .union([
-                z.object({
-                  type: z.literal('code_execution_20250825'),
-                  tool_id: z.string(),
-                }),
-                z.object({
-                  type: z.literal('code_execution_20260120'),
-                  tool_id: z.string(),
-                }),
-                z.object({
-                  type: z.literal('direct'),
-                }),
-              ])
-              .optional(),
+            caller: anthropicToolCallCallerSchema.optional(),
           }),
           z.object({
             type: z.literal('redacted_thinking'),
@@ -1120,17 +1087,7 @@ export const anthropicChunkSchema = lazySchema(() =>
             id: z.string(),
             name: z.string(),
             input: z.record(z.string(), z.unknown()).nullish(),
-            caller: z
-              .union([
-                z.object({
-                  type: z.literal('code_execution_20260120'),
-                  tool_id: z.string(),
-                }),
-                z.object({
-                  type: z.literal('direct'),
-                }),
-              ])
-              .optional(),
+            caller: anthropicToolCallCallerSchema.optional(),
           }),
           z.object({
             type: z.literal('mcp_tool_use'),
@@ -1153,6 +1110,7 @@ export const anthropicChunkSchema = lazySchema(() =>
           z.object({
             type: z.literal('web_fetch_tool_result'),
             tool_use_id: z.string(),
+            caller: anthropicToolCallCallerSchema.optional(),
             content: z.union([
               z.object({
                 type: z.literal('web_fetch_result'),
@@ -1185,6 +1143,7 @@ export const anthropicChunkSchema = lazySchema(() =>
           z.object({
             type: z.literal('web_search_tool_result'),
             tool_use_id: z.string(),
+            caller: anthropicToolCallCallerSchema.optional(),
             content: z.union([
               z.array(
                 z.object({

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -3878,6 +3878,32 @@ describe('AnthropicLanguageModel', () => {
         it('should include web fetch 20260209 tool call and result in content', async () => {
           expect(result.content).toMatchSnapshot();
         });
+
+        it('should preserve dynamic filtering callers', async () => {
+          const codeExecutionCall = result.content.find(
+            part =>
+              part.type === 'tool-call' && part.toolName === 'code_execution',
+          );
+          const webFetchCall = result.content.find(
+            part => part.type === 'tool-call' && part.toolName === 'web_fetch',
+          );
+          const webFetchResult = result.content.find(
+            part =>
+              part.type === 'tool-result' && part.toolName === 'web_fetch',
+          );
+
+          expect(
+            codeExecutionCall?.providerMetadata?.anthropic?.caller,
+          ).toEqual({ type: 'direct', toolId: undefined });
+          expect(webFetchCall?.providerMetadata?.anthropic?.caller).toEqual({
+            type: 'code_execution_20260120',
+            toolId: 'srvtoolu_015CSHH7X69AhdK9gNzotEeh',
+          });
+          expect(webFetchResult?.providerMetadata?.anthropic?.caller).toEqual({
+            type: 'code_execution_20260120',
+            toolId: 'srvtoolu_015CSHH7X69AhdK9gNzotEeh',
+          });
+        });
       });
 
       describe('text response without title', () => {
@@ -10290,6 +10316,36 @@ describe('AnthropicLanguageModel', () => {
           expect(
             await convertReadableStreamToArray(result.stream),
           ).toMatchSnapshot();
+        });
+
+        it('should preserve dynamic filtering callers', async () => {
+          const streamArray = await convertReadableStreamToArray(result.stream);
+          const codeExecutionCall = streamArray.find(
+            (part): part is LanguageModelV4StreamPart & { type: 'tool-call' } =>
+              part.type === 'tool-call' && part.toolName === 'code_execution',
+          );
+          const webFetchCall = streamArray.find(
+            (part): part is LanguageModelV4StreamPart & { type: 'tool-call' } =>
+              part.type === 'tool-call' && part.toolName === 'web_fetch',
+          );
+          const webFetchResult = streamArray.find(
+            (
+              part,
+            ): part is LanguageModelV4StreamPart & { type: 'tool-result' } =>
+              part.type === 'tool-result' && part.toolName === 'web_fetch',
+          );
+
+          expect(
+            codeExecutionCall?.providerMetadata?.anthropic?.caller,
+          ).toEqual({ type: 'direct', toolId: undefined });
+          expect(webFetchCall?.providerMetadata?.anthropic?.caller).toEqual({
+            type: 'code_execution_20260120',
+            toolId: 'srvtoolu_01LKcA5qc1HwvLQSe3cLKmcK',
+          });
+          expect(webFetchResult?.providerMetadata?.anthropic?.caller).toEqual({
+            type: 'code_execution_20260120',
+            toolId: 'srvtoolu_01LKcA5qc1HwvLQSe3cLKmcK',
+          });
         });
       });
     });

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -51,6 +51,7 @@ import {
   type AnthropicResponseContextManagement,
   type AnthropicStopDetails,
   type AnthropicTool,
+  type AnthropicToolCallCaller,
   type Citation,
 } from './anthropic-api';
 import {
@@ -125,6 +126,24 @@ function createCitationSource(
             },
     } satisfies SharedV4ProviderMetadata,
   };
+}
+
+function getAnthropicCallerInfo(caller: AnthropicToolCallCaller | undefined) {
+  return caller == null
+    ? undefined
+    : {
+        type: caller.type,
+        toolId: 'tool_id' in caller ? caller.tool_id : undefined,
+      };
+}
+
+function getAnthropicCallerMetadata(
+  caller: AnthropicToolCallCaller | undefined,
+) {
+  const callerInfo = getAnthropicCallerInfo(caller);
+  return callerInfo == null
+    ? {}
+    : { providerMetadata: { anthropic: { caller: callerInfo } } };
 }
 
 export type AnthropicLanguageModelConfig = {
@@ -1061,26 +1080,12 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
               text: JSON.stringify(part.input),
             });
           } else {
-            const caller = part.caller;
-            const callerInfo = caller
-              ? {
-                  type: caller.type,
-                  toolId: 'tool_id' in caller ? caller.tool_id : undefined,
-                }
-              : undefined;
-
             content.push({
               type: 'tool-call',
               toolCallId: part.id,
               toolName: part.name,
               input: JSON.stringify(part.input),
-              ...(callerInfo && {
-                providerMetadata: {
-                  anthropic: {
-                    caller: callerInfo,
-                  },
-                },
-              }),
+              ...getAnthropicCallerMetadata(part.caller),
             });
           }
 
@@ -1109,6 +1114,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
               providerToolName === 'code_execution'
                 ? { dynamic: true }
                 : {}),
+              ...getAnthropicCallerMetadata(part.caller),
             });
           } else if (
             part.name === 'web_search' ||
@@ -1138,6 +1144,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
               ...(markCodeExecutionDynamic && part.name === 'code_execution'
                 ? { dynamic: true }
                 : {}),
+              ...getAnthropicCallerMetadata(part.caller),
             });
           } else if (
             part.name === 'tool_search_tool_regex' ||
@@ -1150,6 +1157,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
               toolName: toolNameMapping.toCustomToolName(part.name),
               input: JSON.stringify(part.input),
               providerExecuted: true,
+              ...getAnthropicCallerMetadata(part.caller),
             });
           } else if (part.name === 'advisor') {
             content.push({
@@ -1158,6 +1166,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
               toolName: toolNameMapping.toCustomToolName('advisor'),
               input: JSON.stringify(part.input),
               providerExecuted: true,
+              ...getAnthropicCallerMetadata(part.caller),
             });
           }
 
@@ -1218,6 +1227,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                   },
                 },
               },
+              ...getAnthropicCallerMetadata(part.caller),
             });
           } else if (part.content.type === 'web_fetch_tool_result_error') {
             content.push({
@@ -1229,6 +1239,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                 type: 'web_fetch_tool_result_error',
                 errorCode: part.content.error_code,
               },
+              ...getAnthropicCallerMetadata(part.caller),
             });
           }
           break;
@@ -1246,6 +1257,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                 encryptedContent: result.encrypted_content,
                 type: result.type,
               })),
+              ...getAnthropicCallerMetadata(part.caller),
             });
 
             for (const result of part.content) {
@@ -1272,6 +1284,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                 type: 'web_search_tool_result_error',
                 errorCode: part.content.error_code,
               },
+              ...getAnthropicCallerMetadata(part.caller),
             });
           }
           break;
@@ -1738,15 +1751,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                       id: String(value.index),
                     });
                   } else {
-                    // Extract caller info for type-safe access
-                    const caller = part.caller;
-                    const callerInfo = caller
-                      ? {
-                          type: caller.type,
-                          toolId:
-                            'tool_id' in caller ? caller.tool_id : undefined,
-                        }
-                      : undefined;
+                    const callerInfo = getAnthropicCallerInfo(part.caller);
 
                     // Programmatic tool calling: for deferred tool calls from code_execution,
                     // input may be present directly in content_block_start.
@@ -1776,6 +1781,8 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                 }
 
                 case 'server_tool_use': {
+                  const callerInfo = getAnthropicCallerInfo(part.caller);
+
                   if (
                     [
                       'web_fetch',
@@ -1832,6 +1839,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                       firstDelta: finalInput.length === 0,
                       providerToolName,
                       providerToolInputType,
+                      ...(callerInfo && { caller: callerInfo }),
                     };
 
                     controller.enqueue({
@@ -1865,6 +1873,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                       providerExecuted: true,
                       firstDelta: true,
                       providerToolName: part.name,
+                      ...(callerInfo && { caller: callerInfo }),
                     };
 
                     controller.enqueue({
@@ -1885,6 +1894,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                       providerExecuted: true,
                       firstDelta: true,
                       providerToolName: part.name,
+                      ...(callerInfo && { caller: callerInfo }),
                     };
 
                     controller.enqueue({
@@ -1923,6 +1933,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                           },
                         },
                       },
+                      ...getAnthropicCallerMetadata(part.caller),
                     });
                   } else if (
                     part.content.type === 'web_fetch_tool_result_error'
@@ -1936,6 +1947,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                         type: 'web_fetch_tool_result_error',
                         errorCode: part.content.error_code,
                       },
+                      ...getAnthropicCallerMetadata(part.caller),
                     });
                   }
 
@@ -1955,6 +1967,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                         encryptedContent: result.encrypted_content,
                         type: result.type,
                       })),
+                      ...getAnthropicCallerMetadata(part.caller),
                     });
 
                     for (const result of part.content) {
@@ -1981,6 +1994,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                         type: 'web_search_tool_result_error',
                         errorCode: part.content.error_code,
                       },
+                      ...getAnthropicCallerMetadata(part.caller),
                     });
                   }
                   return;
@@ -2490,14 +2504,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                 ) {
                   const part = value.message.content[contentIndex];
                   if (part.type === 'tool_use') {
-                    const caller = part.caller;
-                    const callerInfo = caller
-                      ? {
-                          type: caller.type,
-                          toolId:
-                            'tool_id' in caller ? caller.tool_id : undefined,
-                        }
-                      : undefined;
+                    const callerInfo = getAnthropicCallerInfo(part.caller);
 
                     controller.enqueue({
                       type: 'tool-input-start',

--- a/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
@@ -3335,6 +3335,135 @@ describe('assistant messages', () => {
   });
 
   describe('code_execution 20260120', () => {
+    it('should preserve caller metadata and response order for dynamic filtering', async () => {
+      const caller = {
+        anthropic: {
+          caller: {
+            type: 'code_execution_20260120',
+            toolId: 'code-execution-call',
+          },
+        },
+      } as const;
+      const result = await convertToAnthropicPrompt({
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'code-execution-call',
+                toolName: 'code_execution',
+                input: {
+                  type: 'programmatic-tool-call',
+                  code: 'await web_search({ query: "AI SDK" })',
+                },
+                providerExecuted: true,
+                providerOptions: {
+                  anthropic: { caller: { type: 'direct' } },
+                },
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'web-search-call-1',
+                toolName: 'web_search',
+                input: { query: 'AI SDK' },
+                providerExecuted: true,
+                providerOptions: caller,
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'web-search-call-1',
+                toolName: 'web_search',
+                output: { type: 'json', value: [] },
+                providerOptions: caller,
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'web-search-call-2',
+                toolName: 'web_search',
+                input: { query: 'Anthropic' },
+                providerExecuted: true,
+                providerOptions: caller,
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'web-search-call-2',
+                toolName: 'web_search',
+                output: { type: 'json', value: [] },
+                providerOptions: caller,
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'code-execution-call',
+                toolName: 'code_execution',
+                output: {
+                  type: 'json',
+                  value: {
+                    type: 'encrypted_code_execution_result',
+                    encrypted_stdout: 'encrypted-output',
+                    stderr: '',
+                    return_code: 0,
+                    content: [],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        sendReasoning: false,
+        warnings: [],
+        toolNameMapping: defaultToolNameMapping,
+      });
+
+      expect(result.prompt.messages).toHaveLength(1);
+      expect(result.prompt.messages[0]).toMatchObject({
+        role: 'assistant',
+        content: [
+          {
+            type: 'server_tool_use',
+            id: 'code-execution-call',
+            caller: { type: 'direct' },
+          },
+          {
+            type: 'server_tool_use',
+            id: 'web-search-call-1',
+            caller: {
+              type: 'code_execution_20260120',
+              tool_id: 'code-execution-call',
+            },
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: 'web-search-call-1',
+            caller: {
+              type: 'code_execution_20260120',
+              tool_id: 'code-execution-call',
+            },
+          },
+          {
+            type: 'server_tool_use',
+            id: 'web-search-call-2',
+            caller: {
+              type: 'code_execution_20260120',
+              tool_id: 'code-execution-call',
+            },
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: 'web-search-call-2',
+            caller: {
+              type: 'code_execution_20260120',
+              tool_id: 'code-execution-call',
+            },
+          },
+          {
+            type: 'code_execution_tool_result',
+            tool_use_id: 'code-execution-call',
+          },
+        ],
+      });
+    });
+
     it('should replay server_tool_use input without the internal discriminator', async () => {
       const warnings: SharedV4Warning[] = [];
       const result = await convertToAnthropicPrompt({

--- a/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
@@ -3464,6 +3464,121 @@ describe('assistant messages', () => {
       });
     });
 
+    it('should preserve a deferred server result across a client tool continuation', async () => {
+      const result = await convertToAnthropicPrompt({
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'code-execution-call',
+                toolName: 'code_execution',
+                input: {
+                  type: 'programmatic-tool-call',
+                  code: 'await fetch_url({ url: "https://example.com" })',
+                },
+                providerExecuted: true,
+                providerOptions: {
+                  anthropic: { caller: { type: 'direct' } },
+                },
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'client-tool-call',
+                toolName: 'fetch_url',
+                input: { url: 'https://example.com' },
+                providerOptions: {
+                  anthropic: {
+                    caller: {
+                      type: 'code_execution_20260120',
+                      toolId: 'code-execution-call',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'client-tool-call',
+                toolName: 'fetch_url',
+                output: { type: 'text', value: 'Example Domain' },
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'code-execution-call',
+                toolName: 'code_execution',
+                output: {
+                  type: 'json',
+                  value: {
+                    type: 'encrypted_code_execution_result',
+                    encrypted_stdout: 'encrypted-output',
+                    stderr: '',
+                    return_code: 0,
+                    content: [],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        sendReasoning: false,
+        warnings: [],
+        toolNameMapping: defaultToolNameMapping,
+      });
+
+      // Anthropic pairs a deferred server result by tool_use_id across
+      // responses; the intervening client tool exchange must stay intact.
+      expect(result.prompt.messages).toHaveLength(3);
+      expect(result.prompt.messages).toMatchObject([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'server_tool_use',
+              id: 'code-execution-call',
+              caller: { type: 'direct' },
+            },
+            {
+              type: 'tool_use',
+              id: 'client-tool-call',
+              caller: {
+                type: 'code_execution_20260120',
+                tool_id: 'code-execution-call',
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'client-tool-call',
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'code_execution_tool_result',
+              tool_use_id: 'code-execution-call',
+            },
+          ],
+        },
+      ]);
+    });
+
     it('should replay server_tool_use input without the internal discriminator', async () => {
       const warnings: SharedV4Warning[] = [];
       const result = await convertToAnthropicPrompt({

--- a/packages/anthropic/src/convert-to-anthropic-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.ts
@@ -26,6 +26,7 @@ import {
   type AnthropicSystemMessage,
   type AnthropicTextContent,
   type AnthropicToolChangeContent,
+  type AnthropicToolCallCaller,
   type AnthropicToolResultContent,
   type AnthropicUserMessage,
   type AnthropicWebFetchToolResultContent,
@@ -723,6 +724,8 @@ export async function convertToAnthropicPrompt({
               }
 
               case 'tool-call': {
+                const caller = getAnthropicCaller(part.providerOptions);
+
                 if (part.providerExecuted) {
                   const providerToolName = toolNameMapping.toProviderToolName(
                     part.toolName,
@@ -771,6 +774,7 @@ export async function convertToAnthropicPrompt({
                       id: part.toolCallId,
                       name: codeExecutionType, // map back to subtool name
                       input: inputWithoutType,
+                      ...(caller && { caller }),
                       cache_control: cacheControl,
                     });
                   } else if (
@@ -791,6 +795,7 @@ export async function convertToAnthropicPrompt({
                       id: part.toolCallId,
                       name: 'code_execution',
                       input: inputWithoutType,
+                      ...(caller && { caller }),
                       cache_control: cacheControl,
                     });
                   } else {
@@ -804,6 +809,7 @@ export async function convertToAnthropicPrompt({
                         id: part.toolCallId,
                         name: providerToolName,
                         input: part.input,
+                        ...(caller && { caller }),
                         cache_control: cacheControl,
                       });
                     } else if (
@@ -815,6 +821,7 @@ export async function convertToAnthropicPrompt({
                         id: part.toolCallId,
                         name: providerToolName,
                         input: part.input,
+                        ...(caller && { caller }),
                         cache_control: cacheControl,
                       });
                     } else if (providerToolName === 'advisor') {
@@ -824,6 +831,7 @@ export async function convertToAnthropicPrompt({
                         id: part.toolCallId,
                         name: 'advisor',
                         input: {},
+                        ...(caller && { caller }),
                         cache_control: cacheControl,
                       });
                     } else {
@@ -836,26 +844,6 @@ export async function convertToAnthropicPrompt({
 
                   break;
                 }
-
-                // Extract caller info from provider options for programmatic tool calling
-                const callerOptions = part.providerOptions?.anthropic as
-                  | { caller?: { type: string; toolId?: string } }
-                  | undefined;
-                const caller = callerOptions?.caller
-                  ? (callerOptions.caller.type === 'code_execution_20250825' ||
-                      callerOptions.caller.type ===
-                        'code_execution_20260120') &&
-                    callerOptions.caller.toolId
-                    ? {
-                        type: callerOptions.caller.type as
-                          | 'code_execution_20250825'
-                          | 'code_execution_20260120',
-                        tool_id: callerOptions.caller.toolId,
-                      }
-                    : callerOptions.caller.type === 'direct'
-                      ? { type: 'direct' as const }
-                      : undefined
-                  : undefined;
 
                 anthropicContent.push({
                   type: 'tool_use',
@@ -872,6 +860,7 @@ export async function convertToAnthropicPrompt({
                 const providerToolName = toolNameMapping.toProviderToolName(
                   part.toolName,
                 );
+                const caller = getAnthropicCaller(part.providerOptions);
 
                 if (mcpToolUseIds.has(part.toolCallId)) {
                   const output = part.output;
@@ -1078,6 +1067,7 @@ export async function convertToAnthropicPrompt({
                           extractErrorValue(output.value).errorCode ??
                           'unavailable',
                       },
+                      ...(caller && { caller }),
                       cache_control: cacheControl,
                     });
 
@@ -1122,6 +1112,7 @@ export async function convertToAnthropicPrompt({
                         >['content']['source'],
                       },
                     },
+                    ...(caller && { caller }),
                     cache_control: cacheControl,
                   });
 
@@ -1141,6 +1132,7 @@ export async function convertToAnthropicPrompt({
                           extractErrorValue(output.value).errorCode ??
                           'unavailable',
                       },
+                      ...(caller && { caller }),
                       cache_control: cacheControl,
                     });
 
@@ -1174,6 +1166,7 @@ export async function convertToAnthropicPrompt({
                       encrypted_content: result.encryptedContent,
                       type: result.type,
                     })),
+                    ...(caller && { caller }),
                     cache_control: cacheControl,
                   });
 
@@ -1404,6 +1397,29 @@ function moveToolUseBlocksToEnd(
   flushSegment();
 
   return result;
+}
+
+function getAnthropicCaller(
+  providerOptions: SharedV4ProviderMetadata | undefined,
+): AnthropicToolCallCaller | undefined {
+  const caller = (
+    providerOptions?.anthropic as
+      | { caller?: { type: string; toolId?: string } }
+      | undefined
+  )?.caller;
+
+  if (
+    (caller?.type === 'code_execution_20250825' ||
+      caller?.type === 'code_execution_20260120') &&
+    caller.toolId
+  ) {
+    return {
+      type: caller.type,
+      tool_id: caller.toolId,
+    };
+  }
+
+  return caller?.type === 'direct' ? { type: 'direct' } : undefined;
 }
 
 // wrap invalid tool call input because Anthropic requires it to be an object


### PR DESCRIPTION
## Background

This is a smaller alternative to #18794 for #18785.

Anthropic returns `caller` on `server_tool_use` blocks and on dynamic-filtering `web_search_tool_result` / `web_fetch_tool_result` blocks. The provider currently parses caller metadata for client `tool_use`, but discards it for those server calls and results. A later request therefore cannot replay the response Anthropic actually produced.

## Approach

- Parse the documented caller union once and reuse it across response schemas.
- Preserve caller metadata on streaming and non-streaming server calls and web results.
- Serialize that metadata back to Anthropic on the next request.
- Keep the caller's message boundaries and content-block order unchanged.

The regression test intentionally uses two nested searches and asserts this order remains intact:

```text
code_execution call
web_search call 1
web_search result 1
web_search call 2
web_search result 2
code_execution result
```

## Scope

This PR addresses the caller-metadata loss in completed dynamic-filtering turns (Shape 1). It intentionally does not relocate deferred server results across message boundaries (Shape 2).

Anthropic documents mixed server/client continuations as separate responses accumulated in order: the first assistant response containing the open server call, a user message containing the client `tool_result`, and a later assistant response containing the deferred server result. The server call and result pair by `tool_use_id`, not by position. A regression test locks in that `assistant → user → assistant` sequence while preserving caller metadata on the originating calls.

The reported rejection of this split sequence was not reproduced against the current live API; the split history was accepted when `code_execution_20260120` was configured. This PR therefore treats cross-message relocation as out of scope rather than normalizing a documented provider-authored transcript.

Documentation: https://platform.claude.com/docs/en/agents-and-tools/tool-use/server-tools

## Why avoid co-location here?

The provider is an adapter, so its safest default is a lossless round trip. Reordering a provider-authored transcript is a separate compatibility policy with a wider blast radius: it can alter the meaning of interleaved blocks, hide malformed persisted history, and make future Anthropic response shapes harder to reason about.

The issue's call-only experiment did not restore callers on the corresponding web-result blocks. Anthropic's API models caller on both sides; this PR preserves both. The reported cross-message shape was also not reproduced against the current live API, so this alternative does not add speculative cross-message relocation.

If a caller-complete replay in original order is still rejected in live validation, that is useful evidence for a narrowly scoped ordering workaround. It does not need to be coupled to fixing the known metadata loss.

## Existing persisted messages

A one-time migration is possible, but it cannot be universally lossless: older AI SDK versions discarded caller metadata before persistence. The safe policy is to infer only unambiguous same-message dynamic-filtering spans, never move blocks, and report everything else for review.

Below is a storage-agnostic transform for persisted `ModelMessage[]`. A real migration should run it transactionally, record `migrated` / `skipped` counts, and adapt the read/write layer to the application's database.

<details>
<summary>Conservative migration transform</summary>

```ts
type StoredPart = {
  type: string;
  toolCallId?: string;
  toolName?: string;
  providerExecuted?: boolean;
  providerOptions?: Record<string, any>;
  [key: string]: any;
};

type StoredMessage = {
  role: string;
  content: string | StoredPart[];
  [key: string]: any;
};

type Caller =
  | { type: 'direct' }
  | { type: 'code_execution_20260120'; toolId: string };

function addCaller(part: StoredPart, caller: Caller): StoredPart | undefined {
  const existing = part.providerOptions?.anthropic?.caller;

  if (existing != null) {
    return JSON.stringify(existing) === JSON.stringify(caller)
      ? part
      : undefined;
  }

  return {
    ...part,
    providerOptions: {
      ...part.providerOptions,
      anthropic: {
        ...part.providerOptions?.anthropic,
        caller,
      },
    },
  };
}

export function migrateAnthropicDynamicFilteringCallers(
  messages: StoredMessage[],
) {
  let migrated = 0;
  let skipped = 0;

  const output = messages.map((message, messageIndex) => {
    if (message.role !== 'assistant' || !Array.isArray(message.content)) {
      return message;
    }

    const content = [...message.content];
    const parentRanges = content.flatMap((part, start) => {
      if (
        part.type !== 'tool-call' ||
        part.toolName !== 'code_execution' ||
        !part.providerExecuted ||
        part.toolCallId == null
      ) {
        return [];
      }

      const ends = content.flatMap((candidate, end) =>
        end > start &&
        candidate.type === 'tool-result' &&
        candidate.toolName === 'code_execution' &&
        candidate.toolCallId === part.toolCallId
          ? [end]
          : [],
      );

      return ends.length === 1
        ? [{ id: part.toolCallId, start, end: ends[0] }]
        : [];
    });

    for (const [callIndex, call] of content.entries()) {
      if (
        call.type !== 'tool-call' ||
        !call.providerExecuted ||
        (call.toolName !== 'web_search' && call.toolName !== 'web_fetch') ||
        call.toolCallId == null
      ) {
        continue;
      }

      const parents = parentRanges.filter(
        range => range.start < callIndex && callIndex < range.end,
      );
      const resultIndexes = content.flatMap((candidate, index) =>
        candidate.type === 'tool-result' &&
        candidate.toolName === call.toolName &&
        candidate.toolCallId === call.toolCallId &&
        index > callIndex
          ? [index]
          : [],
      );

      if (parents.length !== 1 || resultIndexes.length !== 1) {
        skipped++;
        continue;
      }

      const parent = parents[0];
      const resultIndex = resultIndexes[0];
      if (resultIndex >= parent.end) {
        skipped++;
        continue;
      }

      const nestedCaller: Caller = {
        type: 'code_execution_20260120',
        toolId: parent.id,
      };
      const nextParent = addCaller(content[parent.start], { type: 'direct' });
      const nextCall = addCaller(call, nestedCaller);
      const nextResult = addCaller(content[resultIndex], nestedCaller);

      if (nextParent == null || nextCall == null || nextResult == null) {
        skipped++;
        continue;
      }

      content[parent.start] = nextParent;
      content[callIndex] = nextCall;
      content[resultIndex] = nextResult;
      migrated++;
    }

    return { ...message, content };
  });

  return { messages: output, migrated, skipped };
}
```

</details>

This intentionally does not guess across message boundaries. Persisted `UIMessage[]` use an application-defined parts shape and should be adapted before applying the same matching rules.

## Testing

- Anthropic Node suite: 503 tests passed.
- Anthropic Edge suite: 503 tests passed.
- Anthropic package build and type-check passed.
- Full-workspace type-check passed.
- Repository lint and formatting passed.

The tests use existing captured Anthropic web-fetch fixtures, an outbound multi-search replay regression, and a deferred-result continuation regression. Live API validation was not run in this environment.

## Related

- Anthropic API caller types: https://platform.claude.com/docs/en/api/typescript/messages/create

Fixes https://github.com/vercel/ai/issues/18785
Closes https://github.com/vercel/ai/pull/18794
Closes https://github.com/vercel/ai/pull/18790