### PR TITLE
fix(workflow): align Vitest harness with runtime

### DIFF
--- a/.changeset/fuzzy-runs-start.md
+++ b/.changeset/fuzzy-runs-start.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Fix the Workflow integration test harness by aligning `@workflow/vitest` with the installed Workflow runtime.

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/node": "22.19.19",
     "@vercel/ai-tsconfig": "workspace:*",
-    "@workflow/vitest": "4.0.1",
+    "@workflow/vitest": "4.0.5",
     "tsup": "^8.5.1",
     "typescript": "5.8.3",
     "vitest": "4.1.6",

--- a/packages/workflow/vitest.integration.config.mjs
+++ b/packages/workflow/vitest.integration.config.mjs
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [workflow()],
   test: {
     include: ['**/*.integration.test.ts'],
+    setupFiles: ['./vitest.integration.setup.mjs'],
     testTimeout: 60_000, // Workflows may take longer than default timeout
   },
 });

--- a/packages/workflow/vitest.integration.setup.mjs
+++ b/packages/workflow/vitest.integration.setup.mjs
@@ -1,0 +1,11 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+// @workflow/vitest emits an ESM step bundle that can contain bundled CommonJS
+// dependencies. Give those dependencies a require scoped to the generated file.
+const stepsBundleUrl = new URL('./.workflow-vitest/steps.mjs', import.meta.url);
+const stepsBundle = await readFile(stepsBundleUrl, 'utf8');
+const requireBanner = `import { createRequire } from 'node:module';\nconst require = createRequire(import.meta.url);\n`;
+
+if (!stepsBundle.startsWith(requireBanner)) {
+  await writeFile(stepsBundleUrl, `${requireBanner}${stepsBundle}`);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4176,8 +4176,8 @@ importers:
         specifier: workspace:*
         version: link:../../tools/tsconfig
       '@workflow/vitest':
-        specifier: 4.0.1
-        version: 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(vitest@4.1.6(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)))(zod@3.25.76)
+        specifier: 4.0.5
+        version: 4.0.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(vitest@4.1.6(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)))(zod@3.25.76)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.25)(tsx@4.22.0)(typescript@5.8.3)(yaml@2.9.0)
@@ -14345,8 +14345,8 @@ packages:
   '@workflow/vite@4.0.4':
     resolution: {integrity: sha512-dEw5Dg6zdlsBwwEFYYqRIXApZ4kgqN/vMzZEyEbisJEofKNPDIYP1/nAh22DkYW55Nxa0YOKdqnhxQq+kdvX2A==}
 
-  '@workflow/vitest@4.0.1':
-    resolution: {integrity: sha512-6h8E6uTwPiSLkeKtOt2oABRtZGDODgqX8dgLEzWt8UMxYcSevL9JULmIaucyFpBznQ+YKQM/+NHNIjWNYIN7CQ==}
+  '@workflow/vitest@4.0.5':
+    resolution: {integrity: sha512-KWYTjyzX6s+NLhh0I8fG72McQbxVT8wvIfiD8dao686znBdQgKd3t2b1dayNaQKrzWvNwtHd3Kwzg465cxIQFg==}
     peerDependencies:
       vite: '>=6.0.0'
       vitest: '>=3.0.0'
@@ -36429,13 +36429,13 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@workflow/vitest@4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(vitest@4.1.6(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)))(zod@3.25.76)':
+  '@workflow/vitest@4.0.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(vitest@4.1.6(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)))(zod@3.25.76)':
     dependencies:
-      '@workflow/builders': 4.0.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
-      '@workflow/core': 4.2.0(@opentelemetry/api@1.9.1)
-      '@workflow/rollup': 4.0.0(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
-      '@workflow/world': 4.1.0(zod@3.25.76)
-      '@workflow/world-local': 4.1.0(@opentelemetry/api@1.9.1)
+      '@workflow/builders': 4.0.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/core': 4.2.4(@opentelemetry/api@1.9.1)
+      '@workflow/rollup': 4.0.4(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)
+      '@workflow/world': 4.1.1(zod@3.25.76)
+      '@workflow/world-local': 4.1.1(@opentelemetry/api@1.9.1)
       vitest: 4.1.6(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))
     optionalDependencies:
       vite: 7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)
@@ -36547,6 +36547,11 @@ snapshots:
     dependencies:
       ulid: 3.0.2
       zod: 4.3.6
+
+  '@workflow/world@4.1.1(zod@3.25.76)':
+    dependencies:
+      ulid: 3.0.2
+      zod: 3.25.76
 
   '@workflow/world@4.1.1(zod@4.3.6)':
     dependencies:


### PR DESCRIPTION
## Background

The automated fix attempts for #18823 and #18824 both stopped before exercising their issue-specific changes because the Workflow integration harness could not create a run entity.

`workflow@4.2.4` uses `@workflow/core@4.2.4`, while `@workflow/vitest@4.0.1` brought in `@workflow/core@4.2.0` and `@workflow/world-local@4.1.0`. That mixed the current runtime event protocol with an older test world and caused setup to fail when processing `run_started`.

After aligning those versions, the generated ESM step bundle exposed a second harness compatibility problem: bundled CommonJS dependencies call `require`, which is otherwise undefined in the emitted `.mjs` file.

## Summary

- upgrade `@workflow/vitest` to 4.0.5 so its core and local-world dependencies match `workflow@4.2.4`
- provide a file-scoped `require` in the generated ESM step bundle during integration setup
- add a patch changeset for `@ai-sdk/workflow`

## Contributor Credit

The reports in #18823 and #18824 were filed by @MintedKenny.

## End-to-End Verification

Started `calculateWorkflow` through `workflow/api`, awaited its three durable step invocations, and verified the returned calculation and terminal `completed` status through the in-process Local World. The smoke integration passes on this branch.

## Validation

- `pnpm --filter @ai-sdk/workflow... build`
- `pnpm --filter @ai-sdk/workflow test:node` — 166 tests passed
- `pnpm --filter @ai-sdk/workflow test:edge` — 166 tests passed
- `pnpm --filter @ai-sdk/workflow type-check`
- `pnpm --filter @ai-sdk/workflow exec vitest --config vitest.integration.config.mjs --run src/workflow-smoke.integration.test.ts` — smoke test passed
- `pnpm check`

The repository-wide `pnpm type-check:full` was also attempted, but this filtered checkout does not install dependencies or generated configs for unrelated packages and examples; the package-scoped Workflow typecheck passes.

## Checklist

- [x] All commits are signed according to the [DCO guide](https://github.com/vercel/ai/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A changeset (`pnpm changeset`) has been added (for bug fixes / features)
- [x] I have reviewed my changes and verified that they are ready to be merged

## Future Work

With harness setup unblocked, the WorkflowAgent integration cases reach a separate existing fixture failure: a `MockLanguageModelV4` class instance cannot be serialized across the durable step boundary. This PR intentionally leaves that fixture problem and the issue-specific fixes for #18823 and #18824 out of scope.

## Related Issues

Unblocks integration verification for #18823 and #18824. It does not close either issue.
