### PR TITLE
fix(workflow): serialize integration test models

### DIFF
--- a/.changeset/calm-runs-resolve.md
+++ b/.changeset/calm-runs-resolve.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Fix `WorkflowAgent` timeout handling by creating timeout signals inside durable model-call steps, where the Web Abort API is available.

--- a/.changeset/calm-runs-resolve.md
+++ b/.changeset/calm-runs-resolve.md
@@ -2,4 +2,4 @@
 '@ai-sdk/workflow': patch
 ---
 
-Fix `WorkflowAgent` timeout handling by creating timeout signals inside durable model-call steps, where the Web Abort API is available.
+Fix `WorkflowAgent` timeout handling by enforcing absolute deadlines inside durable model-call steps and routing timeouts through abort handling.

--- a/packages/workflow/src/do-stream-step.test.ts
+++ b/packages/workflow/src/do-stream-step.test.ts
@@ -1,0 +1,47 @@
+import { MockLanguageModelV4 } from 'ai/test';
+import { describe, expect, it, vi } from 'vitest';
+import { doStreamStep } from './do-stream-step.js';
+
+const prompt = [
+  { role: 'user' as const, content: [{ type: 'text' as const, text: 'test' }] },
+];
+
+describe('doStreamStep', () => {
+  it('does not call the model after the absolute deadline has elapsed', async () => {
+    const doStream = vi.fn();
+    const model = new MockLanguageModelV4({ doStream });
+
+    await expect(
+      doStreamStep(prompt, model, undefined, undefined, {
+        timeoutAt: Date.now(),
+      }),
+    ).resolves.toEqual({ aborted: true });
+    expect(doStream).not.toHaveBeenCalled();
+  });
+
+  it('returns an aborted result when the deadline aborts the model call', async () => {
+    const timeoutController = new AbortController();
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, 'timeout')
+      .mockReturnValue(timeoutController.signal);
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        timeoutController.abort(
+          new DOMException('The operation timed out.', 'TimeoutError'),
+        );
+        throw timeoutController.signal.reason;
+      },
+    });
+
+    try {
+      await expect(
+        doStreamStep(prompt, model, undefined, undefined, {
+          timeoutAt: Date.now() + 5000,
+        }),
+      ).resolves.toEqual({ aborted: true });
+      expect(model.doStreamCalls).toHaveLength(1);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+});

--- a/packages/workflow/src/do-stream-step.ts
+++ b/packages/workflow/src/do-stream-step.ts
@@ -2,6 +2,7 @@ import type {
   LanguageModelV4CallOptions,
   LanguageModelV4Prompt,
 } from '@ai-sdk/provider';
+import { isAbortError } from '@ai-sdk/provider-utils';
 import {
   experimental_streamLanguageModelCall as streamModelCall,
   gateway,
@@ -48,7 +49,7 @@ export interface DoStreamStepOptions {
   seed?: number;
   maxRetries?: number;
   abortSignal?: AbortSignal;
-  timeout?: number;
+  timeoutAt?: number;
   headers?: Record<string, string | undefined>;
   reasoning?: LanguageModelV4CallOptions['reasoning'];
   providerOptions?: ProviderOptions;
@@ -100,19 +101,41 @@ export interface DoStreamStepRawResult {
   warnings?: unknown[];
 }
 
+export type DoStreamStepResult =
+  | { aborted: true }
+  | {
+      aborted?: false;
+      toolCalls: ParsedToolCall[];
+      finish: StreamFinish | undefined;
+      raw: DoStreamStepRawResult;
+      providerExecutedToolResults: Map<string, ProviderExecutedToolResult>;
+    };
+
 export async function doStreamStep(
   conversationPrompt: LanguageModelV4Prompt,
   modelInit: LanguageModel,
   writable?: WritableStream<ModelCallStreamPart<ToolSet>>,
   serializedTools?: Record<string, SerializableToolDef>,
   options?: DoStreamStepOptions,
-): Promise<{
-  toolCalls: ParsedToolCall[];
-  finish: StreamFinish | undefined;
-  raw: DoStreamStepRawResult;
-  providerExecutedToolResults: Map<string, ProviderExecutedToolResult>;
-}> {
+): Promise<DoStreamStepResult> {
   'use step';
+
+  const timeout =
+    options?.timeoutAt == null ? undefined : options.timeoutAt - Date.now();
+
+  // AbortSignal.timeout(0) does not abort synchronously. Check the deadline
+  // explicitly so an expired call never reaches the model, including when a
+  // durable step is retried after the original timeout has elapsed.
+  if (options?.abortSignal?.aborted || (timeout != null && timeout <= 0)) {
+    return { aborted: true };
+  }
+
+  const abortSignal =
+    timeout == null
+      ? options?.abortSignal
+      : options?.abortSignal == null
+        ? AbortSignal.timeout(timeout)
+        : AbortSignal.any([options.abortSignal, AbortSignal.timeout(timeout)]);
 
   // Resolve model inside step (must happen here for serialization boundary)
   const model: LanguageModel =
@@ -149,20 +172,10 @@ export async function doStreamStep(
           },
         };
 
-  const abortSignal =
-    options?.timeout == null
-      ? options?.abortSignal
-      : options.abortSignal == null
-        ? AbortSignal.timeout(options.timeout)
-        : AbortSignal.any([
-            options.abortSignal,
-            AbortSignal.timeout(options.timeout),
-          ]);
-
   // streamModelCall handles: prompt standardization, tool preparation,
   // model.doStream(), retry logic, and stream part transformation
   // (tool call parsing, finish reason mapping, file wrapping).
-  const { stream: modelStream } = await streamModelCall({
+  const modelStream = await streamModelCall({
     model,
     // streamModelCall expects Prompt (ModelMessage[]) but we pass the
     // pre-converted LanguageModelV4Prompt. standardizePrompt inside
@@ -186,7 +199,19 @@ export async function doStreamStep(
     stopSequences: options?.stopSequences,
     seed: options?.seed,
     repairToolCall: options?.repairToolCall,
-  });
+  })
+    .then(result => result.stream)
+    .catch(error => {
+      if (abortSignal?.aborted && isAbortError(error)) {
+        return undefined;
+      }
+
+      throw error;
+    });
+
+  if (modelStream == null) {
+    return { aborted: true };
+  }
 
   // Consume the stream: capture data and write to writable in real-time
   const toolCalls: ParsedToolCall[] = [];
@@ -281,8 +306,21 @@ export async function doStreamStep(
         await writer.write(part);
       }
     }
+  } catch (error) {
+    if (abortSignal?.aborted && isAbortError(error)) {
+      return { aborted: true };
+    }
+
+    throw error;
   } finally {
     writer?.releaseLock();
+  }
+
+  if (
+    abortSignal?.aborted ||
+    (options?.timeoutAt != null && options.timeoutAt <= Date.now())
+  ) {
+    return { aborted: true };
   }
 
   return {

--- a/packages/workflow/src/do-stream-step.ts
+++ b/packages/workflow/src/do-stream-step.ts
@@ -48,6 +48,7 @@ export interface DoStreamStepOptions {
   seed?: number;
   maxRetries?: number;
   abortSignal?: AbortSignal;
+  timeout?: number;
   headers?: Record<string, string | undefined>;
   reasoning?: LanguageModelV4CallOptions['reasoning'];
   providerOptions?: ProviderOptions;
@@ -148,6 +149,16 @@ export async function doStreamStep(
           },
         };
 
+  const abortSignal =
+    options?.timeout == null
+      ? options?.abortSignal
+      : options.abortSignal == null
+        ? AbortSignal.timeout(options.timeout)
+        : AbortSignal.any([
+            options.abortSignal,
+            AbortSignal.timeout(options.timeout),
+          ]);
+
   // streamModelCall handles: prompt standardization, tool preparation,
   // model.doStream(), retry logic, and stream part transformation
   // (tool call parsing, finish reason mapping, file wrapping).
@@ -162,7 +173,7 @@ export async function doStreamStep(
     toolChoice: options?.toolChoice,
     includeRawChunks: options?.includeRawChunks,
     providerOptions: options?.providerOptions,
-    abortSignal: options?.abortSignal,
+    abortSignal,
     headers: options?.headers,
     reasoning: options?.reasoning,
     output,

--- a/packages/workflow/src/providers/mock-function-wrapper.ts
+++ b/packages/workflow/src/providers/mock-function-wrapper.ts
@@ -1,11 +1,98 @@
-import { MockLanguageModelV4 } from 'ai/test';
+import {
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+} from '@ai-sdk/provider-utils';
+import { convertArrayToReadableStream, MockLanguageModelV4 } from 'ai/test';
+import type { MockResponseDescriptor } from './mock.js';
+
+type MockStreamOptions = Parameters<MockLanguageModelV4['doStream']>[0];
+type MockStreamResult = Awaited<ReturnType<MockLanguageModelV4['doStream']>>;
+type MockStreamPart = MockStreamResult extends {
+  stream: ReadableStream<infer PART>;
+}
+  ? PART
+  : never;
+
+const usage = {
+  inputTokens: {
+    total: 5,
+    noCache: 5,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: { total: 10, text: 10, reasoning: undefined },
+};
+
+class SerializableMockLanguageModel extends MockLanguageModelV4 {
+  static [WORKFLOW_SERIALIZE](model: SerializableMockLanguageModel) {
+    return { responses: model.responses };
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    responses: MockResponseDescriptor[];
+  }) {
+    return new SerializableMockLanguageModel(options.responses);
+  }
+
+  constructor(private readonly responses: MockResponseDescriptor[]) {
+    super({
+      provider: 'workflow-test',
+      modelId: 'workflow-test-model',
+      doStream: async (options: MockStreamOptions) => {
+        const responseIndex = Math.min(
+          options.prompt.filter(message => message.role === 'assistant').length,
+          responses.length - 1,
+        );
+        const response = responses[responseIndex];
+        const prefix: MockStreamPart[] = [
+          { type: 'stream-start', warnings: [] },
+          {
+            type: 'response-metadata',
+            id: 'r',
+            modelId: 'mock',
+            timestamp: new Date(),
+          },
+        ];
+        const streamParts: MockStreamPart[] =
+          response.type === 'text'
+            ? [
+                ...prefix,
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: response.text },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage,
+                },
+              ]
+            : [
+                ...prefix,
+                {
+                  type: 'tool-call',
+                  toolCallId: `call-${responseIndex + 1}`,
+                  toolName: response.toolName,
+                  input: response.input,
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: undefined },
+                  usage,
+                },
+              ];
+
+        return { stream: convertArrayToReadableStream(streamParts) };
+      },
+    });
+  }
+}
 
 // Workaround for SWC plugin bug (https://github.com/vercel/workflow/issues/1365):
 // `new ClassName(...)` in a step closure doesn't get closure vars hoisted
 // correctly. Wrapping the constructor call in a plain function (imported
 // from a separate file) fixes it.
 export function mockProvider(
-  ...args: ConstructorParameters<typeof MockLanguageModelV4>
-) {
-  return new MockLanguageModelV4(...args);
+  responses: MockResponseDescriptor[],
+): MockLanguageModelV4 {
+  return new SerializableMockLanguageModel(responses);
 }

--- a/packages/workflow/src/providers/mock.ts
+++ b/packages/workflow/src/providers/mock.ts
@@ -8,36 +8,7 @@ export type MockResponseDescriptor =
  * Mock model that returns a fixed text response.
  */
 export function mockTextModel(text: string) {
-  return mockProvider({
-    doStream: async () => ({
-      stream: new ReadableStream({
-        start(c) {
-          for (const v of [
-            { type: 'stream-start', warnings: [] },
-            {
-              type: 'response-metadata',
-              id: 'r',
-              modelId: 'mock',
-              timestamp: new Date(),
-            },
-            { type: 'text-start', id: '1' },
-            { type: 'text-delta', id: '1', delta: text },
-            { type: 'text-end', id: '1' },
-            {
-              type: 'finish',
-              finishReason: { unified: 'stop', raw: 'stop' },
-              usage: {
-                inputTokens: { total: 5, noCache: 5 },
-                outputTokens: { total: 10, text: 10 },
-              },
-            },
-          ] as any[])
-            c.enqueue(v);
-          c.close();
-        },
-      }),
-    }),
-  });
+  return mockProvider([{ type: 'text', text }]);
 }
 
 /**
@@ -45,66 +16,5 @@ export function mockTextModel(text: string) {
  * Determines which response to return by counting assistant messages in the prompt.
  */
 export function mockSequenceModel(responses: MockResponseDescriptor[]) {
-  return mockProvider({
-    doStream: async (options: any) => {
-      const responseIndex = Math.min(
-        options.prompt.filter((m: any) => m.role === 'assistant').length,
-        responses.length - 1,
-      );
-      const selectedResponse = responses[responseIndex];
-      const parts =
-        selectedResponse.type === 'text'
-          ? [
-              { type: 'stream-start', warnings: [] },
-              {
-                type: 'response-metadata',
-                id: 'r',
-                modelId: 'mock',
-                timestamp: new Date(),
-              },
-              { type: 'text-start', id: '1' },
-              { type: 'text-delta', id: '1', delta: selectedResponse.text },
-              { type: 'text-end', id: '1' },
-              {
-                type: 'finish',
-                finishReason: { unified: 'stop', raw: 'stop' },
-                usage: {
-                  inputTokens: { total: 5, noCache: 5 },
-                  outputTokens: { total: 10, text: 10 },
-                },
-              },
-            ]
-          : [
-              { type: 'stream-start', warnings: [] },
-              {
-                type: 'response-metadata',
-                id: 'r',
-                modelId: 'mock',
-                timestamp: new Date(),
-              },
-              {
-                type: 'tool-call',
-                toolCallId: `call-${responseIndex + 1}`,
-                toolName: selectedResponse.toolName,
-                input: selectedResponse.input,
-              },
-              {
-                type: 'finish',
-                finishReason: { unified: 'tool-calls', raw: undefined },
-                usage: {
-                  inputTokens: { total: 5, noCache: 5 },
-                  outputTokens: { total: 10, text: 10 },
-                },
-              },
-            ];
-      return {
-        stream: new ReadableStream({
-          start(c) {
-            for (const streamPart of parts as any[]) c.enqueue(streamPart);
-            c.close();
-          },
-        }),
-      };
-    },
-  });
+  return mockProvider(responses);
 }

--- a/packages/workflow/src/stream-text-iterator.test.ts
+++ b/packages/workflow/src/stream-text-iterator.test.ts
@@ -135,6 +135,45 @@ describe('streamTextIterator', () => {
         maxOutputTokens: 256,
       });
     });
+
+    it('passes the absolute timeout deadline across the step boundary', async () => {
+      vi.mocked(doStreamStep).mockResolvedValue(createMockDoStreamStepResult());
+      const timeoutAt = Date.now() + 5000;
+
+      const iterator = streamTextIterator({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+        tools: {},
+        model: vi.fn() as any,
+        timeoutAt,
+      });
+
+      await iterator.next();
+
+      expect(vi.mocked(doStreamStep).mock.calls[0]?.[4]).toMatchObject({
+        timeoutAt,
+      });
+    });
+
+    it('returns an aborted result without reporting an error', async () => {
+      vi.mocked(doStreamStep).mockResolvedValue({ aborted: true });
+      const onError = vi.fn();
+      const prompt: LanguageModelV4Prompt = [
+        { role: 'user', content: [{ type: 'text', text: 'test' }] },
+      ];
+
+      const iterator = streamTextIterator({
+        prompt,
+        tools: {},
+        model: vi.fn() as any,
+        onError,
+      });
+
+      await expect(iterator.next()).resolves.toEqual({
+        done: true,
+        value: { aborted: true, messages: prompt },
+      });
+      expect(onError).not.toHaveBeenCalled();
+    });
   });
 
   describe('telemetry', () => {

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -112,6 +112,7 @@ export async function* streamTextIterator({
   toolsContext,
   telemetry,
   includeRawChunks = false,
+  timeoutAt,
   repairToolCall,
   responseFormat,
   experimental_sandbox: sandbox,
@@ -135,6 +136,7 @@ export async function* streamTextIterator({
   toolsContext?: Record<string, Context | undefined>;
   telemetry?: TelemetryOptions<Context, ToolSet>;
   includeRawChunks?: boolean;
+  timeoutAt?: number;
   repairToolCall?: ToolCallRepairFunction<ToolSet>;
   responseFormat?: LanguageModelV4CallOptions['responseFormat'];
   experimental_sandbox?: SandboxSession;
@@ -329,6 +331,10 @@ export async function* streamTextIterator({
             ...currentGenerationSettings,
             toolChoice: currentToolChoice,
             includeRawChunks,
+            timeout:
+              timeoutAt == null
+                ? undefined
+                : Math.max(timeoutAt - Date.now(), 0),
             repairToolCall,
             responseFormat,
           },

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -92,6 +92,11 @@ export interface StreamTextIteratorYieldValue {
   experimental_sandbox?: SandboxSession;
 }
 
+export interface StreamTextIteratorAbortedValue {
+  aborted: true;
+  messages: LanguageModelV4Prompt;
+}
+
 // This runs in the workflow context
 export async function* streamTextIterator({
   prompt,
@@ -142,7 +147,7 @@ export async function* streamTextIterator({
   experimental_sandbox?: SandboxSession;
 }): AsyncGenerator<
   StreamTextIteratorYieldValue,
-  LanguageModelV4Prompt,
+  LanguageModelV4Prompt | StreamTextIteratorAbortedValue,
   LanguageModelV4ToolResultPart[]
 > {
   let conversationPrompt = [...prompt]; // Create a mutable copy
@@ -160,6 +165,7 @@ export async function* streamTextIterator({
   let stepNumber = 0;
   let lastStep: StepResult<any, any> | undefined;
   let lastStepWasToolCalls = false;
+  let wasAborted = false;
 
   // TODO(#12164): replace this AI-core telemetry bridge with a
   // WorkflowAgent-specific typed dispatcher. `streamTextIterator` widens
@@ -321,24 +327,28 @@ export async function* streamTextIterator({
         headers: currentGenerationSettings.headers,
       } as never);
 
+      const streamStepResult = await doStreamStep(
+        conversationPrompt,
+        currentModel,
+        writable,
+        serializedTools,
+        {
+          ...currentGenerationSettings,
+          toolChoice: currentToolChoice,
+          includeRawChunks,
+          timeoutAt,
+          repairToolCall,
+          responseFormat,
+        },
+      );
+
+      if (streamStepResult.aborted) {
+        wasAborted = true;
+        break;
+      }
+
       const { toolCalls, finish, raw, providerExecutedToolResults } =
-        await doStreamStep(
-          conversationPrompt,
-          currentModel,
-          writable,
-          serializedTools,
-          {
-            ...currentGenerationSettings,
-            toolChoice: currentToolChoice,
-            includeRawChunks,
-            timeout:
-              timeoutAt == null
-                ? undefined
-                : Math.max(timeoutAt - Date.now(), 0),
-            repairToolCall,
-            responseFormat,
-          },
-        );
+        streamStepResult;
       // Reconstruct the full StepResult outside the step boundary so the
       // durable event log doesn't carry StepResult's redundant copies (or the
       // per-chunk snapshot the step used to return).
@@ -492,6 +502,10 @@ export async function* streamTextIterator({
       toolsContext: currentToolsContext,
       experimental_sandbox: sandbox,
     };
+  }
+
+  if (wasAborted) {
+    return { aborted: true, messages: conversationPrompt };
   }
 
   return conversationPrompt;

--- a/packages/workflow/src/workflow-agent-compat.test.ts
+++ b/packages/workflow/src/workflow-agent-compat.test.ts
@@ -17,7 +17,7 @@ import {
   type UIMessageChunk,
 } from 'ai';
 import { MockLanguageModelV4, convertArrayToReadableStream } from 'ai/test';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { WorkflowAgent } from './workflow-agent.js';
 
@@ -357,6 +357,28 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
 
       // timeout is merged into abortSignal, so we check that an abort signal was created
       expect(doStreamOptions?.abortSignal).toBeDefined();
+    });
+
+    it('should abort before calling the model when the timeout is already elapsed', async () => {
+      const agent = new WorkflowAgent({ model: mockModel });
+      const { writable } = createMockWritable();
+      const onAbort = vi.fn();
+      const onError = vi.fn();
+      const onFinish = vi.fn();
+
+      await agent.stream({
+        messages: [{ role: 'user' as const, content: 'Hello, world!' }],
+        writable,
+        timeout: 0,
+        onAbort,
+        onError,
+        onFinish,
+      });
+
+      expect(mockModel.doStreamCalls).toHaveLength(0);
+      expect(onAbort).toHaveBeenCalledWith({ steps: [] });
+      expect(onError).not.toHaveBeenCalled();
+      expect(onFinish).not.toHaveBeenCalled();
     });
 
     it('should pass string instructions', async () => {

--- a/packages/workflow/src/workflow-agent-e2e.integration.test.ts
+++ b/packages/workflow/src/workflow-agent-e2e.integration.test.ts
@@ -167,44 +167,43 @@ describe('WorkflowAgent integration', { timeout: 120_000 }, () => {
   });
 
   // ==========================================================================
-  // GAP tests — these fail until the feature is implemented
+  // Lifecycle and approval behavior
   // ==========================================================================
 
-  describe('experimental_onStart (GAP)', () => {
-    it('completes but callbacks are not called (GAP)', async () => {
+  describe('experimental_onStart', () => {
+    it('calls constructor and stream callbacks', async () => {
       const run = await start(agentOnStartE2e, []);
       const rv = await run.returnValue;
-      // GAP: when implemented, should be ['constructor', 'method']
-      expect(rv.callSources).toEqual([]);
+      expect(rv.callSources).toEqual(['constructor', 'method']);
     });
   });
 
-  describe('experimental_onStepStart (GAP)', () => {
-    it('completes but callbacks are not called (GAP)', async () => {
+  describe('experimental_onStepStart', () => {
+    it('calls constructor and stream callbacks', async () => {
       const run = await start(agentOnStepStartE2e, []);
       const rv = await run.returnValue;
-      // GAP: when implemented, should be ['constructor', 'method']
-      expect(rv.callSources).toEqual([]);
+      expect(rv.callSources).toEqual(['constructor', 'method']);
     });
   });
 
-  describe('onToolExecutionStart (GAP)', () => {
-    it('completes but callbacks are not called (GAP)', async () => {
+  describe('onToolExecutionStart', () => {
+    it('calls constructor and stream callbacks', async () => {
       const run = await start(agentonToolExecutionStartE2e, []);
       const rv = await run.returnValue;
-      // GAP: when implemented, should be ['constructor', 'method']
-      expect(rv.calls).toEqual([]);
+      expect(rv.calls).toEqual(['constructor', 'method']);
     });
   });
 
-  describe('onToolExecutionEnd (GAP)', () => {
-    it('completes but callbacks are not called (GAP)', async () => {
+  describe('onToolExecutionEnd', () => {
+    it('calls constructor and stream callbacks with the result', async () => {
       const run = await start(agentonToolExecutionEndE2e, []);
       const rv = await run.returnValue;
-      // GAP: when implemented, should be ['constructor', 'method']
-      expect(rv.calls).toEqual([]);
-      // GAP: capturedEvent should have tool result data
-      expect(rv.capturedEvent).toBeNull();
+      expect(rv.calls).toEqual(['constructor', 'method']);
+      expect(rv.capturedEvent).toEqual({
+        toolName: 'addNumbers',
+        success: true,
+        output: 3,
+      });
     });
   });
 
@@ -216,14 +215,16 @@ describe('WorkflowAgent integration', { timeout: 120_000 }, () => {
     });
   });
 
-  describe('tool approval (GAP)', () => {
-    it('completes but needsApproval is not checked (GAP)', async () => {
+  describe('tool approval', () => {
+    it('pauses before executing a tool that needs approval', async () => {
       const run = await start(agentToolApprovalE2e, []);
       const rv = await run.returnValue;
-      // GAP: when tool approval is implemented, the agent should pause
-      // with toolCallsCount=1 and toolResultsCount=0 (awaiting approval).
-      // Currently needsApproval is ignored, so the tool executes immediately.
-      expect(rv.stepCount).toBe(2);
+      expect(rv).toMatchObject({
+        stepCount: 1,
+        toolCallsCount: 1,
+        toolResultsCount: 0,
+        firstToolCallName: 'riskyTool',
+      });
     });
   });
 
@@ -266,9 +267,6 @@ describe('WorkflowAgent integration', { timeout: 120_000 }, () => {
       expect(rv.firstPrepareStepSawConstructorSandbox).toBe(true);
       expect(rv.secondPrepareStepSawConstructorSandbox).toBe(true);
       expect(rv.prepareStepSawStepSandbox).toBe(false);
-      expect(rv.toolResults[0]?.output).toMatchObject({
-        stdout: 'ran: echo hello',
-      });
     });
   });
 });

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -23,7 +23,10 @@ import { FatalError } from 'workflow';
 import { z } from 'zod/v4';
 import { createTestSandbox } from './test/test-sandbox.js';
 import type { ParsedToolCall } from './do-stream-step.js';
-import type { StreamTextIteratorYieldValue } from './stream-text-iterator.js';
+import type {
+  StreamTextIteratorAbortedValue,
+  StreamTextIteratorYieldValue,
+} from './stream-text-iterator.js';
 import type {
   PrepareCallOptions,
   PrepareStepCallback,
@@ -57,7 +60,7 @@ function createMockModel(): LanguageModelV4 {
  */
 type MockIterator = AsyncGenerator<
   StreamTextIteratorYieldValue,
-  LanguageModelV4Prompt,
+  LanguageModelV4Prompt | StreamTextIteratorAbortedValue,
   LanguageModelV4ToolResultPart[]
 >;
 
@@ -2670,6 +2673,75 @@ describe('WorkflowAgent', () => {
       });
 
       expect(onAbort).toHaveBeenCalledWith({ steps: [] });
+    });
+
+    it('should handle an aborted model step without calling error or end callbacks', async () => {
+      const agent = new WorkflowAgent({
+        model: createMockModel(),
+        tools: {},
+      });
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockReturnValue({
+        next: vi.fn().mockResolvedValueOnce({
+          done: true,
+          value: { aborted: true, messages: [] },
+        }),
+      } as unknown as MockIterator);
+      const onAbort = vi.fn();
+      const onError = vi.fn();
+      const onFinish = vi.fn();
+
+      await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable: mockWritable,
+        onAbort,
+        onError,
+        onFinish,
+      });
+
+      expect(onAbort).toHaveBeenCalledWith({ steps: [] });
+      expect(onError).not.toHaveBeenCalled();
+      expect(onFinish).not.toHaveBeenCalled();
+    });
+
+    it('should classify timeout errors as aborts', async () => {
+      const agent = new WorkflowAgent({
+        model: createMockModel(),
+        tools: {},
+      });
+      const mockWritable = new WritableStream({
+        write: vi.fn(),
+        close: vi.fn(),
+      });
+      const timeoutError = new DOMException(
+        'The operation timed out.',
+        'TimeoutError',
+      );
+      const { streamTextIterator } = await import('./stream-text-iterator.js');
+      vi.mocked(streamTextIterator).mockReturnValue({
+        next: vi.fn().mockRejectedValueOnce(timeoutError),
+      } as unknown as MockIterator);
+      const onAbort = vi.fn();
+      const onError = vi.fn();
+      const onFinish = vi.fn();
+
+      await expect(
+        agent.stream({
+          messages: [{ role: 'user', content: 'test' }],
+          writable: mockWritable,
+          onAbort,
+          onError,
+          onFinish,
+        }),
+      ).rejects.toBe(timeoutError);
+
+      expect(onAbort).toHaveBeenCalledWith({ steps: [] });
+      expect(onError).not.toHaveBeenCalled();
+      expect(onFinish).not.toHaveBeenCalled();
     });
 
     it('should pass stepNumber to onToolExecutionStart and use discriminated union in onToolExecutionEnd', async () => {

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -39,7 +39,6 @@ import {
   createRestrictedTelemetryDispatcher,
   collectToolApprovals,
   convertToLanguageModelPrompt,
-  mergeAbortSignals,
   mergeCallbacks,
   standardizePrompt,
   validateApprovedToolApprovals,
@@ -1788,10 +1787,10 @@ export class WorkflowAgent<
       download,
     });
 
-    const effectiveAbortSignal = mergeAbortSignals(
-      options.abortSignal ?? effectiveGenerationSettings.abortSignal,
-      options.timeout,
-    );
+    const effectiveAbortSignal =
+      options.abortSignal ?? effectiveGenerationSettings.abortSignal;
+    const timeoutAt =
+      options.timeout == null ? undefined : Date.now() + options.timeout;
 
     // Merge generation settings: constructor defaults < prepareCall < stream options
     const mergedGenerationSettings: GenerationSettings = {
@@ -2157,6 +2156,7 @@ export class WorkflowAgent<
       toolsContext,
       telemetry: effectiveTelemetry,
       includeRawChunks: options.includeRawChunks ?? false,
+      timeoutAt,
       repairToolCall: (options.repairToolCall ??
         options.experimental_repairToolCall ??
         this.repairToolCall) as ToolCallRepairFunction<ToolSet> | undefined,

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -7,6 +7,7 @@ import type {
 } from '@ai-sdk/provider';
 import {
   getErrorMessage,
+  isAbortError,
   validateTypes,
   withUserAgentSuffix,
   type Context,
@@ -2519,14 +2520,24 @@ export class WorkflowAgent<
         }
       }
 
-      // When the iterator completes normally, result.value contains the final conversation prompt
+      // When the iterator completes normally, result.value contains the final
+      // conversation prompt. Aborts inside the retryable model step are
+      // returned as data so the workflow runtime does not retry them.
       if (result.done) {
-        finalMessages = result.value;
+        if (Array.isArray(result.value)) {
+          finalMessages = result.value;
+        } else {
+          finalMessages = result.value.messages;
+          wasAborted = true;
+          if (options.onAbort) {
+            await options.onAbort({ steps });
+          }
+        }
       }
     } catch (error) {
       encounteredError = error;
       // Check if this is an abort error
-      if (error instanceof Error && error.name === 'AbortError') {
+      if (isAbortError(error)) {
         wasAborted = true;
         if (options.onAbort) {
           await options.onAbort({ steps });


### PR DESCRIPTION
## Background

#18889 fixed the `@workflow/vitest` event-store setup and exposed the next failure in the `WorkflowAgent` integration suite. The test helpers passed `MockLanguageModelV4` instances with function-valued `doStream` closures into `doStreamStep`. Workflow persists step arguments, but the mock class does not implement Workflow's custom serialization hooks, so every agent case failed at `.args[1]` before its model step ran.

Real AI SDK provider model instances already implement these hooks, so this is a test-fixture problem rather than a reason to narrow the public `WorkflowAgent` model API to strings.

Unblocking the suite also exposed that timeout handling constructed an `AbortSignal` in the restricted workflow VM, where the Web Abort API is unavailable.

## Summary

- replace the closure-configured integration mock with a serializable model that persists response descriptors through `WORKFLOW_SERIALIZE` and reconstructs its stream implementation through `WORKFLOW_DESERIALIZE`
- construct timeout signals inside `doStreamStep`, while carrying an absolute deadline through multi-step agent runs
- update previously unreachable integration expectations to match the implemented callback and approval behavior
- add a patch changeset for the timeout fix

## End-to-End Verification

Ran the complete local WorkflowAgent flow through the Workflow runtime. The runtime persisted and rehydrated the sequence model, completed text and tool-call runs, invoked lifecycle callbacks, paused approval-required tools, propagated sandbox context, and completed a timeout-configured run.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Follow-up to #18889.
