### PR TITLE
feat(harness-codex): allow passing arbitrary `config.toml` values to the harness via `codexConfig`

### DIFF
--- a/.changeset/eight-mangos-act.md
+++ b/.changeset/eight-mangos-act.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-codex": patch
+---
+
+feat(harness-codex): allow passing arbitrary `config.toml` values to the harness via `codexConfig`

--- a/content/providers/02-ai-sdk-harnesses/02-codex.mdx
+++ b/content/providers/02-ai-sdk-harnesses/02-codex.mdx
@@ -80,12 +80,18 @@ const harness = createCodex({
   model: 'gpt-5.5',
   reasoningEffort: 'high',
   webSearch: true,
+  codexConfig: {
+    model_verbosity: 'low',
+  },
 });
 ```
 
 Settings:
 
 - `auth`: authentication mode: `auto`, `direct`, or `ai-gateway`.
+- `codexConfig`: additional native Codex configuration. Values pass through as
+  provided, so use the snake_case keys from Codex's `config.toml` reference.
+  The adapter's managed values take precedence over conflicting entries.
 - `mcpServers`: MCP server definitions keyed by server name.
 - `model`: OpenAI model id. If omitted, the adapter uses its pinned default.
 - `reasoningEffort`: `low`, `medium`, or `high`.

--- a/examples/ai-functions/src/harness-agent/codex/with-config.ts
+++ b/examples/ai-functions/src/harness-agent/codex/with-config.ts
@@ -1,0 +1,39 @@
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+import { run } from '../../lib/run';
+import { createCodex } from './_create';
+
+const marker = 'CODEX_CONFIG_APPLIED';
+
+run(async () => {
+  const agent = new HarnessAgent({
+    harness: createCodex({
+      codexConfig: {
+        instructions: `Include ${marker} in every response.`,
+        model_verbosity: 'low',
+      },
+    }),
+    sandbox: createVercelSandbox({
+      runtime: 'node24',
+      ports: [4000],
+      timeout: 10 * 60 * 1000,
+    }),
+  });
+
+  const session = await agent.createSession();
+  try {
+    const result = await agent.generate({
+      session,
+      prompt: 'In one sentence, what is the capital of France?',
+    });
+    console.log('text:', result.text);
+    console.log('finishReason:', result.finishReason);
+    console.log('usage:', result.usage);
+
+    if (!result.text.includes(marker)) {
+      throw new Error('Codex did not apply the native configuration.');
+    }
+  } finally {
+    await session.destroy();
+  }
+});

--- a/packages/harness-codex/README.md
+++ b/packages/harness-codex/README.md
@@ -20,7 +20,11 @@ import { tool } from 'ai';
 import { z } from 'zod/v4';
 
 const agent = new HarnessAgent({
-  harness: createCodex(),
+  harness: createCodex({
+    codexConfig: {
+      model_verbosity: 'low',
+    },
+  }),
   id: 'demo',
   sandbox: createVercelSandbox({
     runtime: 'node24',
@@ -38,6 +42,11 @@ const agent = new HarnessAgent({
   },
 });
 ```
+
+`codexConfig` accepts additional native Codex configuration. Values pass
+through as provided, so use the snake_case keys from Codex's `config.toml`
+reference. The adapter's managed values take precedence over conflicting
+entries.
 
 > Codex does not auto-discover a skills directory the way the `claude` CLI
 > does, so when you supply `skills: [...]` on the factory the adapter

--- a/packages/harness-codex/src/bridge/index.test.ts
+++ b/packages/harness-codex/src/bridge/index.test.ts
@@ -1,16 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 type CodexOptions = {
-  config?: {
-    base_instructions?: unknown;
-    developer_instructions?: unknown;
-    mcp_servers?: unknown;
-    model_provider?: unknown;
-    model_providers?: unknown;
-    model_reasoning_summary?: unknown;
-    model_supports_reasoning_summaries?: unknown;
-    preferred_auth_method?: unknown;
-  };
+  config?: Record<string, unknown>;
 };
 type ThreadOptions = { model?: string };
 const CODEX_ENV_KEYS = [
@@ -25,6 +16,7 @@ const state = vi.hoisted(() => ({
   threadOptions: [] as ThreadOptions[],
   startModel: 'gpt-5.5',
   startInstructions: undefined as string | undefined,
+  startCodexConfig: undefined as Record<string, unknown> | undefined,
   startMcpServers: undefined as Record<string, unknown> | undefined,
   originalArgv: [] as string[],
   originalEnv: {} as Record<
@@ -69,6 +61,7 @@ vi.mock('@ai-sdk/harness/bridge', () => ({
           ? { instructions: state.startInstructions }
           : {}),
         model: state.startModel,
+        codexConfig: state.startCodexConfig,
         mcpServers: state.startMcpServers,
         tools: [
           {
@@ -94,6 +87,7 @@ describe('Codex bridge config', () => {
     state.threadOptions = [];
     state.startModel = 'gpt-5.5';
     state.startInstructions = undefined;
+    state.startCodexConfig = undefined;
     state.startMcpServers = undefined;
     state.originalArgv = [...process.argv];
     state.originalEnv = Object.fromEntries(
@@ -146,6 +140,40 @@ describe('Codex bridge config', () => {
     expect(state.codexOptions[0]?.config?.mcp_servers).toEqual(
       state.startMcpServers,
     );
+  });
+
+  test('passes through native config without mutating it and preserves adapter-owned values', async () => {
+    const codexConfig = {
+      model_verbosity: 'low',
+      features: { multi_agent: false },
+      developer_instructions: 'Caller instructions.',
+      model_reasoning_summary: 'none',
+    };
+    state.startCodexConfig = codexConfig;
+
+    await import('./index');
+
+    expect(state.codexOptions[0]?.config).not.toBe(codexConfig);
+    expect(state.codexOptions[0]?.config).toMatchInlineSnapshot(`
+      {
+        "developer_instructions": "Only respond with your \`final\` message once you have fully addressed the user request.",
+        "features": {
+          "multi_agent": false,
+        },
+        "model_reasoning_summary": "detailed",
+        "model_verbosity": "low",
+      }
+    `);
+    expect(codexConfig).toMatchInlineSnapshot(`
+      {
+        "developer_instructions": "Caller instructions.",
+        "features": {
+          "multi_agent": false,
+        },
+        "model_reasoning_summary": "none",
+        "model_verbosity": "low",
+      }
+    `);
   });
 
   test('requests detailed reasoning summaries by default', async () => {

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -121,6 +121,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   }
 
   const codexConfig: Record<string, unknown> = {
+    ...start.codexConfig,
     developer_instructions: [
       start.instructions,
       'Only respond with your `final` message once you have fully addressed the user request.',

--- a/packages/harness-codex/src/codex-bridge-protocol.test.ts
+++ b/packages/harness-codex/src/codex-bridge-protocol.test.ts
@@ -73,6 +73,10 @@ describe('inboundMessageSchema', () => {
         model: 'gpt-5.1',
         reasoningEffort: 'high',
         webSearch: true,
+        codexConfig: {
+          model_verbosity: 'low',
+          features: { multi_agent: false },
+        },
       }),
     ).not.toThrow();
   });

--- a/packages/harness-codex/src/codex-bridge-protocol.ts
+++ b/packages/harness-codex/src/codex-bridge-protocol.ts
@@ -20,6 +20,7 @@ export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
   instructions: z.string().optional(),
   reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
   webSearch: z.boolean().optional(),
+  codexConfig: z.record(z.string(), z.unknown()).optional(),
   mcpServers: z.record(z.string(), z.unknown()).optional(),
   // Resume signal. When supplied, the bridge calls
   // `codex.resumeThread(resumeThreadId, …)` instead of starting a fresh thread.

--- a/packages/harness-codex/src/codex-harness.test.ts
+++ b/packages/harness-codex/src/codex-harness.test.ts
@@ -327,6 +327,37 @@ describe('createCodex adapter', () => {
     await session.doDestroy();
   });
 
+  it('sends configured Codex config to the bridge', async () => {
+    const codexConfig = {
+      model_verbosity: 'low',
+      features: { multi_agent: false },
+    };
+    const session = await createCodex({ codexConfig }).doStart({
+      sessionId: 's1',
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        runs: [],
+        spawns: [],
+        writes: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/codex-s1',
+    });
+    const control = await session.doPromptTurn({
+      prompt: 'Be concise.',
+      emit: () => {},
+    });
+    void Promise.resolve(control.done).catch(() => {});
+
+    await vi.waitFor(() => {
+      expect(sentMessages.at(-1)).toMatchObject({
+        type: 'start',
+        codexConfig,
+      });
+    });
+
+    await session.doDestroy();
+  });
+
   it('uses a caller-minted bridge token and reuses it when attaching', async () => {
     const runs: string[] = [];
     const spawns: string[] = [];

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -85,6 +85,12 @@ const CODEX_CLIENT_APP = `ai-sdk/harness-codex/${VERSION}`;
 export type CodexHarnessSettings = {
   readonly auth?: CodexAuthOptions;
   /**
+   * Additional configuration passed through to Codex as-is. Codex config keys
+   * typically use snake_case and must be provided in that form. Values managed
+   * by this adapter take precedence over conflicting entries.
+   */
+  readonly codexConfig?: Record<string, unknown>;
+  /**
    * MCP server definitions keyed by server name. Each definition uses the
    * underlying runtime's native MCP server configuration format.
    */
@@ -351,6 +357,7 @@ export function createCodex(
             model: settings.model ?? DEFAULT_CODEX_MODEL,
             reasoningEffort: settings.reasoningEffort,
             webSearch: settings.webSearch,
+            codexConfig: settings.codexConfig,
             mcpServers: settings.mcpServers,
             resumeThreadId: resumeThreadIdString,
             isResume: true,
@@ -502,6 +509,7 @@ export function createCodex(
         model: settings.model ?? DEFAULT_CODEX_MODEL,
         reasoningEffort: settings.reasoningEffort,
         webSearch: settings.webSearch,
+        codexConfig: settings.codexConfig,
         mcpServers: settings.mcpServers,
         resumeThreadId: resumeThreadIdString,
         isResume: respawnStrategy !== undefined,
@@ -606,6 +614,7 @@ function createSession({
   model,
   reasoningEffort,
   webSearch,
+  codexConfig,
   mcpServers,
   resumeThreadId,
   isResume,
@@ -625,6 +634,7 @@ function createSession({
   model: string | undefined;
   reasoningEffort: 'low' | 'medium' | 'high' | undefined;
   webSearch: boolean | undefined;
+  codexConfig: Record<string, unknown> | undefined;
   mcpServers: Record<string, unknown> | undefined;
   resumeThreadId: string | undefined;
   isResume: boolean;
@@ -862,6 +872,7 @@ function createSession({
         model,
         reasoningEffort,
         webSearch,
+        ...(codexConfig == null ? {} : { codexConfig }),
         ...(mcpServers == null ? {} : { mcpServers }),
         ...(permissionMode ? { permissionMode } : {}),
         ...(pendingResumeThreadId
@@ -917,6 +928,7 @@ function createSession({
             model,
             reasoningEffort,
             webSearch,
+            ...(codexConfig == null ? {} : { codexConfig }),
             ...(mcpServers == null ? {} : { mcpServers }),
             ...(permissionMode ? { permissionMode } : {}),
             ...(threadId ? { resumeThreadId: threadId } : {}),


### PR DESCRIPTION
## Background

While the Codex harness exposed a fixed set of runtime settings, callers could not use other native Codex configuration without relying on a file-based `config.toml` setup, which was cumbersome to manage.

## Summary

Add a `codexConfig` escape hatch that forwards native Codex configuration through the sandbox bridge. The adapter clones the supplied object before merging its managed values, and native snake_case keys are preserved without conversion.

- Forward arbitrary `codexConfig` values to the Codex SDK.
- Keep adapter-managed configuration authoritative on conflicts without mutating caller input.
- Add regression coverage, documentation, and a runnable usage example.

## End-to-End Verification

Ran `./tools/run-harness-agent-examples.sh --harness codex --example with-config` and confirmed Codex returned the marker supplied through `codexConfig.instructions`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
