### PR TITLE
fix(harness): keep the runtime error message on failed provider-executed tool results

### DIFF
--- a/.changeset/fluffy-hounds-repeat.md
+++ b/.changeset/fluffy-hounds-repeat.md
@@ -2,4 +2,4 @@
 '@ai-sdk/harness': patch
 ---
 
-Keep the runtime's error message on failed provider-executed tool results.
+fix(harness): keep the runtime's error message on failed provider-executed tool results

--- a/.changeset/fluffy-hounds-repeat.md
+++ b/.changeset/fluffy-hounds-repeat.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness': patch
+---
+
+Keep the runtime's error message on failed provider-executed tool results.

--- a/packages/harness/src/agent/internal/harness-stream-text-result.ts
+++ b/packages/harness/src/agent/internal/harness-stream-text-result.ts
@@ -741,6 +741,11 @@ export class HarnessStreamTextResult<
           ...(part as object),
         } as ContentPart<TOOLS>);
         return;
+      case 'tool-error':
+        this.currentStepContent.push({
+          ...(part as object),
+        } as ContentPart<TOOLS>);
+        return;
       default:
         // text-start/end, reasoning-*, raw, error, finish-step, finish are
         // not directly stored as ContentParts. (Reasoning content parts

--- a/packages/harness/src/agent/internal/harness-stream-text-result.ts
+++ b/packages/harness/src/agent/internal/harness-stream-text-result.ts
@@ -722,25 +722,9 @@ export class HarnessStreamTextResult<
         return;
       }
       case 'tool-call':
-        this.currentStepContent.push({
-          ...(part as object),
-        } as ContentPart<TOOLS>);
-        return;
       case 'tool-approval-request':
-        this.currentStepContent.push({
-          ...(part as object),
-        } as ContentPart<TOOLS>);
-        return;
       case 'tool-approval-response':
-        this.currentStepContent.push({
-          ...(part as object),
-        } as ContentPart<TOOLS>);
-        return;
       case 'tool-result':
-        this.currentStepContent.push({
-          ...(part as object),
-        } as ContentPart<TOOLS>);
-        return;
       case 'tool-error':
         this.currentStepContent.push({
           ...(part as object),

--- a/packages/harness/src/agent/internal/run-prompt.test.ts
+++ b/packages/harness/src/agent/internal/run-prompt.test.ts
@@ -489,6 +489,62 @@ describe('runPrompt step accounting', () => {
     ]);
   });
 
+  test('does not mark a failed host tool result as provider-executed', async () => {
+    const weather = tool({
+      description: 'Get weather',
+      inputSchema: z.object({ city: z.string() }),
+      execute: async () => {
+        throw new Error('weather unavailable');
+      },
+    });
+    const { result, done } = runPrompt({
+      harness,
+      session: fakeSession([
+        {
+          type: 'tool-call',
+          toolCallId: 'c1',
+          toolName: 'weather',
+          input: JSON.stringify({ city: 'SF' }),
+          providerExecuted: false,
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'c1',
+          toolName: 'weather',
+          result: { error: 'Error: weather unavailable' },
+          isError: true,
+        },
+        ...finishEvents,
+      ]),
+      prompt: 'go',
+      instructions: undefined,
+      tools: { weather } as ToolSet,
+      toolSpecs: [],
+      sandboxSession,
+      sessionWorkDir: WORK_DIR,
+      runtimeContext: {} as never,
+      abortSignal: undefined,
+    });
+
+    const parts: TextStreamPart<ToolSet>[] = [];
+    for await (const part of result.fullStream) parts.push(part);
+    await done;
+
+    // A host tool's failure is echoed back on the same wire event as a
+    // provider-executed one; only the originating tool-call tells them apart.
+    // Marking this provider-executed would bypass the consumer's `onError`.
+    expect(parts).not.toContainEqual(
+      expect.objectContaining({ type: 'tool-error', toolCallId: 'c1' }),
+    );
+    expect(parts).toContainEqual(
+      expect.objectContaining({
+        type: 'tool-result',
+        toolCallId: 'c1',
+        output: { error: 'Error: weather unavailable' },
+      }),
+    );
+  });
+
   test('does not expose provider-executed tool calls as pending client results', async () => {
     const pending: unknown[] = [];
     const weather = tool({

--- a/packages/harness/src/agent/internal/run-prompt.test.ts
+++ b/packages/harness/src/agent/internal/run-prompt.test.ts
@@ -489,7 +489,15 @@ describe('runPrompt step accounting', () => {
     ]);
   });
 
-  test('does not mark a failed host tool result as provider-executed', async () => {
+  /*
+   * A host tool's failure is echoed back on the same wire event as a
+   * provider-executed one; only the originating `tool-call` tells them apart.
+   * Stream a failing host tool whose call spells `providerExecuted` the given
+   * way, and return everything the consumer saw.
+   */
+  const streamFailedHostTool = async (
+    providerExecuted: boolean | undefined,
+  ): Promise<TextStreamPart<ToolSet>[]> => {
     const weather = tool({
       description: 'Get weather',
       inputSchema: z.object({ city: z.string() }),
@@ -505,7 +513,7 @@ describe('runPrompt step accounting', () => {
           toolCallId: 'c1',
           toolName: 'weather',
           input: JSON.stringify({ city: 'SF' }),
-          providerExecuted: false,
+          ...(providerExecuted !== undefined ? { providerExecuted } : {}),
         },
         {
           type: 'tool-result',
@@ -529,9 +537,10 @@ describe('runPrompt step accounting', () => {
     const parts: TextStreamPart<ToolSet>[] = [];
     for await (const part of result.fullStream) parts.push(part);
     await done;
+    return parts;
+  };
 
-    // A host tool's failure is echoed back on the same wire event as a
-    // provider-executed one; only the originating tool-call tells them apart.
+  const expectHostToolFailure = (parts: TextStreamPart<ToolSet>[]): void => {
     // Marking this provider-executed would bypass the consumer's `onError`.
     expect(parts).not.toContainEqual(
       expect.objectContaining({ type: 'tool-error', toolCallId: 'c1' }),
@@ -541,6 +550,53 @@ describe('runPrompt step accounting', () => {
         type: 'tool-result',
         toolCallId: 'c1',
         output: { error: 'Error: weather unavailable' },
+      }),
+    );
+  };
+
+  test('does not mark a failed host tool result as provider-executed', async () => {
+    expectHostToolFailure(await streamFailedHostTool(false));
+  });
+
+  test('treats a failed host tool result as host-executed when providerExecuted is omitted', async () => {
+    // `LanguageModelV4ToolCall` defines an omitted flag as client-executed,
+    // and adapters rely on it, emitting it only for their built-in tools.
+    expectHostToolFailure(await streamFailedHostTool(undefined));
+  });
+
+  test('falls back to provider-executed when the originating tool call is not in this slice', async () => {
+    const { result, done } = runPrompt({
+      harness,
+      session: fakeSession([
+        {
+          type: 'tool-result',
+          toolCallId: 'c1',
+          toolName: 'bash',
+          result: 'bash: command not found: pnpmm',
+          isError: true,
+        },
+        ...finishEvents,
+      ]),
+      prompt: 'go',
+      instructions: undefined,
+      tools: {} as ToolSet,
+      toolSpecs: [],
+      sandboxSession,
+      sessionWorkDir: WORK_DIR,
+      runtimeContext: {} as never,
+      abortSignal: undefined,
+    });
+
+    const parts: TextStreamPart<ToolSet>[] = [];
+    for await (const part of result.fullStream) parts.push(part);
+    await done;
+
+    expect(parts).toContainEqual(
+      expect.objectContaining({
+        type: 'tool-error',
+        toolCallId: 'c1',
+        error: 'bash: command not found: pnpmm',
+        providerExecuted: true,
       }),
     );
   });

--- a/packages/harness/src/agent/internal/run-prompt.test.ts
+++ b/packages/harness/src/agent/internal/run-prompt.test.ts
@@ -492,12 +492,10 @@ describe('runPrompt step accounting', () => {
   /*
    * A host tool's failure is echoed back on the same wire event as a
    * provider-executed one; only the originating `tool-call` tells them apart.
-   * Stream a failing host tool whose call spells `providerExecuted` the given
-   * way, and return everything the consumer saw.
    */
-  const streamFailedHostTool = async (
-    providerExecuted: boolean | undefined,
-  ): Promise<TextStreamPart<ToolSet>[]> => {
+  const streamFailedHostTool = async (toolCall: {
+    providerExecuted?: boolean;
+  }): Promise<TextStreamPart<ToolSet>[]> => {
     const weather = tool({
       description: 'Get weather',
       inputSchema: z.object({ city: z.string() }),
@@ -513,7 +511,7 @@ describe('runPrompt step accounting', () => {
           toolCallId: 'c1',
           toolName: 'weather',
           input: JSON.stringify({ city: 'SF' }),
-          ...(providerExecuted !== undefined ? { providerExecuted } : {}),
+          ...toolCall,
         },
         {
           type: 'tool-result',
@@ -555,13 +553,13 @@ describe('runPrompt step accounting', () => {
   };
 
   test('does not mark a failed host tool result as provider-executed', async () => {
-    expectHostToolFailure(await streamFailedHostTool(false));
+    expectHostToolFailure(
+      await streamFailedHostTool({ providerExecuted: false }),
+    );
   });
 
   test('treats a failed host tool result as host-executed when providerExecuted is omitted', async () => {
-    // `LanguageModelV4ToolCall` defines an omitted flag as client-executed,
-    // and adapters rely on it, emitting it only for their built-in tools.
-    expectHostToolFailure(await streamFailedHostTool(undefined));
+    expectHostToolFailure(await streamFailedHostTool({}));
   });
 
   test('falls back to provider-executed when the originating tool call is not in this slice', async () => {

--- a/packages/harness/src/agent/internal/run-prompt.test.ts
+++ b/packages/harness/src/agent/internal/run-prompt.test.ts
@@ -493,7 +493,7 @@ describe('runPrompt step accounting', () => {
     const weather = tool({
       description: 'Get weather',
       inputSchema: z.object({ city: z.string() }),
-      execute: async () => {
+      execute: async (): Promise<{ temperature: number }> => {
         throw new Error('weather unavailable');
       },
     });

--- a/packages/harness/src/agent/internal/run-prompt.test.ts
+++ b/packages/harness/src/agent/internal/run-prompt.test.ts
@@ -431,6 +431,64 @@ describe('runPrompt step accounting', () => {
     expect(await hasToolCall('weather')({ steps })).toBe(true);
   });
 
+  test('surfaces a failed provider-executed tool result as a tool-error carrying the runtime message', async () => {
+    const weather = tool({
+      description: 'Get weather',
+      inputSchema: z.object({ city: z.string() }),
+    });
+    const { result, done } = runPrompt({
+      harness,
+      session: fakeSession([
+        {
+          type: 'tool-call',
+          toolCallId: 'c1',
+          toolName: 'weather',
+          input: JSON.stringify({ city: 'SF' }),
+          providerExecuted: true,
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'c1',
+          toolName: 'weather',
+          result: 'weather service unreachable',
+          isError: true,
+        },
+        ...finishEvents,
+      ]),
+      prompt: 'go',
+      instructions: undefined,
+      tools: { weather } as ToolSet,
+      toolSpecs: [],
+      sandboxSession,
+      sessionWorkDir: WORK_DIR,
+      runtimeContext: {} as never,
+      abortSignal: undefined,
+    });
+
+    const parts: TextStreamPart<ToolSet>[] = [];
+    for await (const part of result.fullStream) parts.push(part);
+    await done;
+
+    expect(parts).toContainEqual(
+      expect.objectContaining({
+        type: 'tool-error',
+        toolCallId: 'c1',
+        toolName: 'weather',
+        error: 'weather service unreachable',
+        providerExecuted: true,
+      }),
+    );
+    expect(parts).not.toContainEqual(
+      expect.objectContaining({ type: 'tool-result', toolCallId: 'c1' }),
+    );
+
+    const steps = await result.steps;
+    expect(steps[0]!.content.map(part => part.type)).toEqual([
+      'tool-call',
+      'tool-error',
+    ]);
+  });
+
   test('does not expose provider-executed tool calls as pending client results', async () => {
     const pending: unknown[] = [];
     const weather = tool({

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -211,6 +211,15 @@ export function runPrompt<
       string,
       Extract<HarnessV1StreamPart, { type: 'tool-call' }>
     >();
+    /*
+     * Host tool results are submitted to the runtime and echoed back as
+     * `tool-result` events, so the event alone cannot say who ran the tool.
+     * The originating `tool-call` can — it is recorded below as it streams by.
+     */
+    const translateOptions = {
+      isProviderExecuted: (toolCallId: string): boolean =>
+        rawToolCallsByToolCallId.get(toolCallId)?.providerExecuted ?? true,
+    };
     const pendingApprovalsByApprovalId = new Map(
       pendingToolApprovals.map(approval => [approval.approvalId, approval]),
     );
@@ -680,7 +689,10 @@ export function runPrompt<
         }
 
         // Forward to consumer as soon as possible.
-        for (const part of translateStreamPart<TOOLS>(displayValue)) {
+        for (const part of translateStreamPart<TOOLS>(
+          displayValue,
+          translateOptions,
+        )) {
           result.enqueue(part);
         }
 

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -212,23 +212,16 @@ export function runPrompt<
       Extract<HarnessV1StreamPart, { type: 'tool-call' }>
     >();
     /*
-     * Host tool results are submitted to the runtime and echoed back as
-     * `tool-result` events, so the event alone cannot say who ran the tool.
-     * The originating `tool-call` can — it is recorded below as it streams by.
-     *
-     * Only an explicit `true` counts: `LanguageModelV4ToolCall` defines an
-     * omitted `providerExecuted` as client-executed, and adapters rely on
-     * that, emitting the flag only for their built-in tools. A call missing
-     * from the map is a different case — it arrived in an earlier slice, so
-     * nothing here can classify it, and the harness runtime executing its own
-     * tools is the likelier reading.
+     * Host results are echoed back as `tool-result` events too, so the event
+     * alone cannot say who ran the tool — classify by the originating
+     * `tool-call`. Only an explicit `true` counts: `LanguageModelV4ToolCall`
+     * defines an omitted flag as client-executed. A call missing from the map
+     * arrived in an earlier slice, where nothing here can classify it.
      */
     const translateOptions = {
       isProviderExecuted: (toolCallId: string): boolean => {
         const rawToolCall = rawToolCallsByToolCallId.get(toolCallId);
-        return rawToolCall == null
-          ? true
-          : rawToolCall.providerExecuted === true;
+        return rawToolCall == null || rawToolCall.providerExecuted === true;
       },
     };
     const pendingApprovalsByApprovalId = new Map(

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -215,10 +215,21 @@ export function runPrompt<
      * Host tool results are submitted to the runtime and echoed back as
      * `tool-result` events, so the event alone cannot say who ran the tool.
      * The originating `tool-call` can — it is recorded below as it streams by.
+     *
+     * Only an explicit `true` counts: `LanguageModelV4ToolCall` defines an
+     * omitted `providerExecuted` as client-executed, and adapters rely on
+     * that, emitting the flag only for their built-in tools. A call missing
+     * from the map is a different case — it arrived in an earlier slice, so
+     * nothing here can classify it, and the harness runtime executing its own
+     * tools is the likelier reading.
      */
     const translateOptions = {
-      isProviderExecuted: (toolCallId: string): boolean =>
-        rawToolCallsByToolCallId.get(toolCallId)?.providerExecuted ?? true,
+      isProviderExecuted: (toolCallId: string): boolean => {
+        const rawToolCall = rawToolCallsByToolCallId.get(toolCallId);
+        return rawToolCall == null
+          ? true
+          : rawToolCall.providerExecuted === true;
+      },
     };
     const pendingApprovalsByApprovalId = new Map(
       pendingToolApprovals.map(approval => [approval.approvalId, approval]),

--- a/packages/harness/src/agent/internal/translate-stream-part.test.ts
+++ b/packages/harness/src/agent/internal/translate-stream-part.test.ts
@@ -21,6 +21,7 @@ describe('translateStreamPart', () => {
       toolCallId: 'c1',
       toolName: 'mcp__weather__current',
       result: { temperature: 72 },
+      isError: false,
       dynamic: true,
     });
 
@@ -52,14 +53,33 @@ describe('translateStreamPart', () => {
         toolCallId: 'c1',
         toolName: 'bash',
         input: undefined,
-        // `providerExecuted` keeps the runtime's own message; without it the
-        // AI SDK replaces `error` with the generic `onError` string.
         error: 'bash: command not found: pnpmm',
         providerExecuted: true,
         providerMetadata: {
           'claude-code': { subtype: 'error_during_execution' },
         },
       },
+    ]);
+  });
+
+  it('leaves a failed host tool result as a tool-result', () => {
+    const out = translateStreamPart<ToolSet>(
+      {
+        type: 'tool-result',
+        toolCallId: 'c1',
+        toolName: 'weather',
+        result: { error: 'Error: boom' },
+        isError: true,
+      },
+      { isProviderExecuted: () => false },
+    );
+
+    expect(out).toEqual([
+      expect.objectContaining({
+        type: 'tool-result',
+        toolCallId: 'c1',
+        output: { error: 'Error: boom' },
+      }),
     ]);
   });
 
@@ -81,25 +101,6 @@ describe('translateStreamPart', () => {
         error: { message: 'upstream timeout' },
         providerExecuted: true,
         dynamic: true,
-      }),
-    ]);
-  });
-
-  it('keeps a tool-result with isError false as a tool-result', () => {
-    const out = translateStreamPart<ToolSet>({
-      type: 'tool-result',
-      toolCallId: 'c1',
-      toolName: 'bash',
-      result: 'ok',
-      isError: false,
-    });
-
-    expect(out).toEqual([
-      expect.objectContaining({
-        type: 'tool-result',
-        toolCallId: 'c1',
-        toolName: 'bash',
-        output: 'ok',
       }),
     ]);
   });

--- a/packages/harness/src/agent/internal/translate-stream-part.test.ts
+++ b/packages/harness/src/agent/internal/translate-stream-part.test.ts
@@ -34,6 +34,76 @@ describe('translateStreamPart', () => {
     ]);
   });
 
+  it('translates a failed tool-result into a provider-executed tool-error', () => {
+    const out = translateStreamPart<ToolSet>({
+      type: 'tool-result',
+      toolCallId: 'c1',
+      toolName: 'bash',
+      result: 'bash: command not found: pnpmm',
+      isError: true,
+      providerMetadata: {
+        'claude-code': { subtype: 'error_during_execution' },
+      },
+    });
+
+    expect(out).toEqual([
+      {
+        type: 'tool-error',
+        toolCallId: 'c1',
+        toolName: 'bash',
+        input: undefined,
+        // `providerExecuted` keeps the runtime's own message; without it the
+        // AI SDK replaces `error` with the generic `onError` string.
+        error: 'bash: command not found: pnpmm',
+        providerExecuted: true,
+        providerMetadata: {
+          'claude-code': { subtype: 'error_during_execution' },
+        },
+      },
+    ]);
+  });
+
+  it('preserves dynamic on a failed tool-result', () => {
+    const out = translateStreamPart<ToolSet>({
+      type: 'tool-result',
+      toolCallId: 'c1',
+      toolName: 'mcp__weather__current',
+      result: { message: 'upstream timeout' },
+      isError: true,
+      dynamic: true,
+    });
+
+    expect(out).toEqual([
+      expect.objectContaining({
+        type: 'tool-error',
+        toolCallId: 'c1',
+        toolName: 'mcp__weather__current',
+        error: { message: 'upstream timeout' },
+        providerExecuted: true,
+        dynamic: true,
+      }),
+    ]);
+  });
+
+  it('keeps a tool-result with isError false as a tool-result', () => {
+    const out = translateStreamPart<ToolSet>({
+      type: 'tool-result',
+      toolCallId: 'c1',
+      toolName: 'bash',
+      result: 'ok',
+      isError: false,
+    });
+
+    expect(out).toEqual([
+      expect.objectContaining({
+        type: 'tool-result',
+        toolCallId: 'c1',
+        toolName: 'bash',
+        output: 'ok',
+      }),
+    ]);
+  });
+
   it('fans file-change out into a dynamic provider-executed tool-call + tool-result pair', () => {
     const out = translateStreamPart<ToolSet>({
       type: 'file-change',

--- a/packages/harness/src/agent/internal/translate-stream-part.ts
+++ b/packages/harness/src/agent/internal/translate-stream-part.ts
@@ -14,6 +14,7 @@ import { generateId, type ToolSet } from '@ai-sdk/provider-utils';
  *   - tool-call events are not translated here — validation against the
  *     merged tool set is async and handled by `validateToolCall` in
  *     `run-prompt.ts`
+ *   - a `tool-result` with `isError` becomes a provider-executed `tool-error`
  *   - the harness `raw` part is forwarded as the AI SDK `raw` part
  *
  * Returns an array of zero or more AI SDK parts. Most harness events project
@@ -101,6 +102,31 @@ export function translateStreamPart<TOOLS extends ToolSet>(
       return [];
 
     case 'tool-result':
+      if (event.isError === true) {
+        /*
+         * A failed provider-executed tool becomes a `tool-error` part, not a
+         * `tool-result` carrying the error as its output. `providerExecuted`
+         * is load-bearing: `toUIMessageChunk` only forwards the real error
+         * text for provider-executed errors — without it the runtime's
+         * failure reason is replaced by the generic `onError` string and
+         * never reaches the consumer.
+         */
+        return [
+          {
+            type: 'tool-error',
+            toolCallId: event.toolCallId,
+            toolName: event.toolName,
+            input: undefined,
+            error: event.result,
+            providerExecuted: true,
+            ...(event.dynamic !== undefined ? { dynamic: event.dynamic } : {}),
+            ...(event.providerMetadata !== undefined
+              ? { providerMetadata: event.providerMetadata }
+              : {}),
+          } as TextStreamPart<TOOLS>,
+        ];
+      }
+
       return [
         {
           type: 'tool-result',

--- a/packages/harness/src/agent/internal/translate-stream-part.ts
+++ b/packages/harness/src/agent/internal/translate-stream-part.ts
@@ -14,7 +14,8 @@ import { generateId, type ToolSet } from '@ai-sdk/provider-utils';
  *   - tool-call events are not translated here — validation against the
  *     merged tool set is async and handled by `validateToolCall` in
  *     `run-prompt.ts`
- *   - a `tool-result` with `isError` becomes a provider-executed `tool-error`
+ *   - a failed `tool-result` from a provider-executed tool becomes a
+ *     `tool-error` (see `isProviderExecuted`)
  *   - the harness `raw` part is forwarded as the AI SDK `raw` part
  *
  * Returns an array of zero or more AI SDK parts. Most harness events project
@@ -27,6 +28,17 @@ import { generateId, type ToolSet } from '@ai-sdk/provider-utils';
  */
 export function translateStreamPart<TOOLS extends ToolSet>(
   event: HarnessV1StreamPart,
+  options: {
+    /**
+     * Whether the tool call that produced this event ran inside the harness
+     * runtime. Host tools travel the same `tool-result` events — their calls
+     * are emitted with `providerExecuted: false` and their failures are
+     * echoed back with `isError` — so the flag cannot be assumed. Defaults to
+     * `true` when the originating call is unknown, which is the case only for
+     * a call that arrived in an earlier slice.
+     */
+    isProviderExecuted?: (toolCallId: string) => boolean;
+  } = {},
 ): ReadonlyArray<TextStreamPart<TOOLS>> {
   switch (event.type) {
     case 'stream-start':
@@ -102,14 +114,19 @@ export function translateStreamPart<TOOLS extends ToolSet>(
       return [];
 
     case 'tool-result':
-      if (event.isError === true) {
+      if (
+        event.isError === true &&
+        (options.isProviderExecuted?.(event.toolCallId) ?? true)
+      ) {
         /*
          * A failed provider-executed tool becomes a `tool-error` part, not a
          * `tool-result` carrying the error as its output. `providerExecuted`
          * is load-bearing: `toUIMessageChunk` only forwards the real error
          * text for provider-executed errors — without it the runtime's
          * failure reason is replaced by the generic `onError` string and
-         * never reaches the consumer.
+         * never reaches the consumer. Host tool failures keep the existing
+         * `tool-result` projection: their error text is the host's own, and
+         * redacting it through `onError` is the consumer's call, not ours.
          */
         return [
           {

--- a/packages/harness/src/agent/internal/translate-stream-part.ts
+++ b/packages/harness/src/agent/internal/translate-stream-part.ts
@@ -31,11 +31,11 @@ export function translateStreamPart<TOOLS extends ToolSet>(
   options: {
     /**
      * Whether the tool call that produced this event ran inside the harness
-     * runtime. Host tools travel the same `tool-result` events — their calls
-     * are emitted with `providerExecuted: false` and their failures are
-     * echoed back with `isError` — so the flag cannot be assumed. Defaults to
-     * `true` when the originating call is unknown, which is the case only for
-     * a call that arrived in an earlier slice.
+     * runtime. Host tools travel the same `tool-result` events and their
+     * failures are echoed back with `isError`, so the event alone cannot say
+     * who ran the tool — only the originating `tool-call` can, and correlating
+     * the two is the caller's job. Omit the callback to treat every failure as
+     * provider-executed.
      */
     isProviderExecuted?: (toolCallId: string) => boolean;
   } = {},
@@ -119,14 +119,10 @@ export function translateStreamPart<TOOLS extends ToolSet>(
         (options.isProviderExecuted?.(event.toolCallId) ?? true)
       ) {
         /*
-         * A failed provider-executed tool becomes a `tool-error` part, not a
-         * `tool-result` carrying the error as its output. `providerExecuted`
-         * is load-bearing: `toUIMessageChunk` only forwards the real error
-         * text for provider-executed errors — without it the runtime's
-         * failure reason is replaced by the generic `onError` string and
-         * never reaches the consumer. Host tool failures keep the existing
-         * `tool-result` projection: their error text is the host's own, and
-         * redacting it through `onError` is the consumer's call, not ours.
+         * `providerExecuted` decides whether the message survives:
+         * `toUIMessageChunk` forwards the real error text only for
+         * provider-executed errors, and replaces every other one with the
+         * generic `onError` string.
          */
         return [
           {


### PR DESCRIPTION
## Background

When a provider-executed tool fails, the harness runtime already sends the real reason across the wire — a failed shell command's stderr, an MCP server's timeout — as a `tool-result` event with `isError: true`.

`translateStreamPart` dropped that flag, projecting the event into a plain AI SDK `tool-result` part whose output happened to be the error text. Consumers saw a tool that _succeeded_ and returned an error-shaped payload — the UI message stream emitted `tool-output-available` — so nothing downstream could distinguish a failed provider-executed tool from a successful one without inspecting its output.

## Summary

- Translate a `tool-result` carrying `isError` into a `tool-error` part, so the failure is typed as one and reaches consumers as `tool-output-error`. Marking it `providerExecuted: true` is load-bearing: `toUIMessageChunk` redacts non-provider-executed errors through `onError`, which would replace the runtime's own message with a generic string. `providerMetadata` and `dynamic` pass through unchanged, keeping the error on the same UI part as its tool call.
- Resolve `providerExecuted` from the originating `tool-call` rather than hardcoding it. Host tools travel the same `tool-result` events — their calls are emitted with `providerExecuted: false` and their failures are submitted back to the runtime and echoed with `isError` — so hardcoding the flag would have marked host failures provider-executed and bypassed the `onError` redaction consumers rely on. Host tool failures keep their existing `tool-result` projection.
- Append `tool-error` parts to the current step content, so a failed provider-executed tool stays visible in `step.content` the way its successful counterpart does. This also covers the host-tool `tool-error` parts the agent loop already emitted and that were being dropped.
- Collapse the five identical arms of `appendToCurrentStepContent` into one fall-through group, matching how `stream-text.ts` accumulates the same set of part types.

## End-to-End Verification

Ran a harness agent against a local sandbox and forced a provider-executed tool to fail. The client now receives that failure typed as a tool error carrying the runtime's own message. Previously the same failure arrived as a completed tool result whose output happened to hold the error text, with nothing marking the tool as having failed; and typing it as an error without `providerExecuted` set replaces the message with a generic placeholder, which is what the flag prevents.

The run exercised this change together with other harness changes in the same batch rather than in isolation.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- A failed host tool still surfaces as a `tool-result` whose output is an error payload, rather than as a `tool-error`. This PR deliberately leaves that path untouched; aligning it with core would be a separate, consumer-visible change.
- `appendToCurrentStepContent` keeps preliminary tool results in step content, where `stream-text.ts` excludes them. Pre-existing drift between the two accumulators, not addressed here.
