### PR TITLE
fix(harness-claude-code): keep non-text and scalar MCP tool results intact

### DIFF
--- a/.changeset/loud-moons-brake.md
+++ b/.changeset/loud-moons-brake.md
@@ -2,4 +2,4 @@
 '@ai-sdk/harness-claude-code': patch
 ---
 
-Keep non-text tool result content and scalar MCP tool results intact instead of flattening them to a stringified or re-parsed value.
+fix(harness-claude-code): keep non-text tool result content and scalar MCP tool results intact instead of flattening them to a stringified or re-parsed value

--- a/.changeset/loud-moons-brake.md
+++ b/.changeset/loud-moons-brake.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-claude-code': patch
+---
+
+Keep non-text tool result content and scalar MCP tool results intact instead of flattening them to a stringified or re-parsed value.

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
@@ -7,6 +7,11 @@ import {
 } from './create-emit-stream-event';
 
 describe('createEmitStreamEvent', () => {
+  const mcpImageBlock = {
+    type: 'image',
+    source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0KGgo' },
+  };
+
   it.each([
     {
       name: 'TaskCreate object output',
@@ -701,7 +706,7 @@ describe('createEmitStreamEvent', () => {
     `);
   });
 
-  it('parses external MCP JSON results without parsing native tool results', () => {
+  it('parses external MCP JSON objects while leaving scalars and native tool results as strings', () => {
     const state = createClaudeStreamEventState();
     const emitted: Record<string, unknown>[] = [];
     const emitStreamEvent = createEmitStreamEvent({
@@ -737,6 +742,24 @@ describe('createEmitStreamEvent', () => {
           },
           {
             type: 'tool_use',
+            id: 'mcp-number',
+            name: 'mcp__context7__query-docs',
+            input: {},
+          },
+          {
+            type: 'tool_use',
+            id: 'mcp-boolean',
+            name: 'mcp__context7__query-docs',
+            input: {},
+          },
+          {
+            type: 'tool_use',
+            id: 'mcp-null',
+            name: 'mcp__context7__query-docs',
+            input: {},
+          },
+          {
+            type: 'tool_use',
             id: 'native-tool',
             name: 'Read',
             input: {},
@@ -765,6 +788,21 @@ describe('createEmitStreamEvent', () => {
           },
           {
             type: 'tool_result',
+            tool_use_id: 'mcp-number',
+            content: '42',
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'mcp-boolean',
+            content: 'true',
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'mcp-null',
+            content: 'null',
+          },
+          {
+            type: 'tool_result',
             tool_use_id: 'native-tool',
             content: '{"path":"README.md"}',
           },
@@ -774,45 +812,189 @@ describe('createEmitStreamEvent', () => {
 
     expect(emitted.filter(event => event.type === 'tool-result'))
       .toMatchInlineSnapshot(`
-      [
-        {
-          "dynamic": true,
-          "isError": false,
-          "result": {
-            "library": "next.js",
-            "version": 16,
+        [
+          {
+            "dynamic": true,
+            "isError": false,
+            "result": {
+              "library": "next.js",
+              "version": 16,
+            },
+            "toolCallId": "mcp-object",
+            "toolName": "mcp__context7__query-docs",
+            "type": "tool-result",
           },
-          "toolCallId": "mcp-object",
-          "toolName": "mcp__context7__query-docs",
-          "type": "tool-result",
-        },
-        {
-          "dynamic": true,
-          "isError": false,
-          "result": [
-            "docs",
-            "examples",
-          ],
-          "toolCallId": "mcp-array",
-          "toolName": "mcp__context7__query-docs",
-          "type": "tool-result",
-        },
-        {
-          "dynamic": true,
-          "isError": false,
-          "result": "not JSON",
-          "toolCallId": "mcp-text",
-          "toolName": "mcp__context7__query-docs",
-          "type": "tool-result",
-        },
-        {
-          "isError": false,
-          "result": "{\"path\":\"README.md\"}",
-          "toolCallId": "native-tool",
-          "toolName": "Read",
-          "type": "tool-result",
-        },
-      ]
-    `);
+          {
+            "dynamic": true,
+            "isError": false,
+            "result": [
+              "docs",
+              "examples",
+            ],
+            "toolCallId": "mcp-array",
+            "toolName": "mcp__context7__query-docs",
+            "type": "tool-result",
+          },
+          {
+            "dynamic": true,
+            "isError": false,
+            "result": "not JSON",
+            "toolCallId": "mcp-text",
+            "toolName": "mcp__context7__query-docs",
+            "type": "tool-result",
+          },
+          {
+            "dynamic": true,
+            "isError": false,
+            "result": "42",
+            "toolCallId": "mcp-number",
+            "toolName": "mcp__context7__query-docs",
+            "type": "tool-result",
+          },
+          {
+            "dynamic": true,
+            "isError": false,
+            "result": "true",
+            "toolCallId": "mcp-boolean",
+            "toolName": "mcp__context7__query-docs",
+            "type": "tool-result",
+          },
+          {
+            "dynamic": true,
+            "isError": false,
+            "result": "null",
+            "toolCallId": "mcp-null",
+            "toolName": "mcp__context7__query-docs",
+            "type": "tool-result",
+          },
+          {
+            "isError": false,
+            "result": "{"path":"README.md"}",
+            "toolCallId": "native-tool",
+            "toolName": "Read",
+            "type": "tool-result",
+          },
+        ]
+      `);
+  });
+
+  it('passes non-text tool result content through unparsed', () => {
+    const state = createClaudeStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: event => emitted.push(event),
+      emitWarning: () => {},
+      emitTerminalError: () => {},
+      onCompactionBoundary: () => {},
+      toCommonName: name => name,
+    });
+
+    const imageContent = [
+      { type: 'text', text: 'chart for 2026' },
+      mcpImageBlock,
+    ];
+
+    emitStreamEvent({
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'mcp-image',
+            name: 'mcp__charts__render',
+            input: {},
+          },
+          {
+            type: 'tool_use',
+            id: 'native-image',
+            name: 'Read',
+            input: {},
+          },
+        ],
+      },
+    });
+    emitStreamEvent({
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'mcp-image',
+            content: imageContent,
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'native-image',
+            content: imageContent,
+          },
+        ],
+      },
+    });
+
+    expect(
+      emitted
+        .filter(event => event.type === 'tool-result')
+        .map(event => event.result),
+    ).toEqual([imageContent, imageContent]);
+  });
+
+  it('resolves content when a structured output cannot be paired with parallel MCP results', () => {
+    const state = createClaudeStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: event => emitted.push(event),
+      emitWarning: () => {},
+      emitTerminalError: () => {},
+      onCompactionBoundary: () => {},
+      toCommonName: name => name,
+    });
+
+    const imageContent = [mcpImageBlock];
+
+    emitStreamEvent({
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'mcp-image',
+            name: 'mcp__charts__render',
+            input: {},
+          },
+          {
+            type: 'tool_use',
+            id: 'mcp-scalar',
+            name: 'mcp__charts__count',
+            input: {},
+          },
+        ],
+      },
+    });
+    emitStreamEvent({
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'mcp-image',
+            content: imageContent,
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'mcp-scalar',
+            content: '42',
+          },
+        ],
+      },
+      tool_use_result: { unpairable: true },
+    });
+
+    expect(
+      emitted
+        .filter(event => event.type === 'tool-result')
+        .map(event => event.result),
+    ).toEqual([imageContent, '42']);
   });
 });

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
@@ -298,25 +298,15 @@ export function createEmitStreamEvent({
           const toolName = toCommonName(nativeName);
           const dynamic = state.externalMcpToolUseIds.delete(block.tool_use_id);
           const isError = !!block.is_error;
-          const content = stringifyContent(block.content);
-          /*
-           * Claude Code's Bash tool does not report the command's real
-           * numeric exit code — the SDK exposes only stdout/stderr text and
-           * an is_error flag. Consumers (and the example UI) render bash
-           * failures from an `exitCode` field on a structured result, the
-           * shape Codex's shell tool provides natively. When Claude omits
-           * `tool_use_result`, derive a binary code from is_error: 1 on
-           * failure, 0 on success. This fallback is a stand-in for
-           * failed/succeeded, not the process's true exit status.
-           */
-          const contentResult =
-            toolName === 'bash'
-              ? { exitCode: isError ? 1 : 0, stdout: content }
-              : dynamic
-                ? parseMcpToolResult(content)
-                : content;
           const result =
-            toolUseResult !== undefined ? toolUseResult : contentResult;
+            toolUseResult !== undefined
+              ? toolUseResult
+              : resolveToolResult({
+                  toolName,
+                  dynamic,
+                  isError,
+                  rawContent: block.content,
+                });
           emit({
             type: 'tool-result',
             toolCallId: block.tool_use_id,
@@ -501,23 +491,61 @@ function handleStreamEvent({
   }
 }
 
+function isTextEntry(entry: unknown): entry is { text?: unknown } {
+  return entry != null && typeof entry === 'object' && 'text' in entry;
+}
+
 function stringifyContent(content: unknown): string {
   if (typeof content === 'string') return content;
   if (Array.isArray(content)) {
     return content
       .map(entry =>
-        entry && typeof entry === 'object' && 'text' in entry
-          ? String((entry as { text?: unknown }).text ?? '')
-          : JSON.stringify(entry),
+        isTextEntry(entry) ? String(entry.text ?? '') : JSON.stringify(entry),
       )
       .join('');
   }
   return JSON.stringify(content);
 }
 
+function hasNonTextContent(content: unknown): boolean {
+  return Array.isArray(content) && content.some(entry => !isTextEntry(entry));
+}
+
+function resolveToolResult({
+  toolName,
+  dynamic,
+  isError,
+  rawContent,
+}: {
+  toolName: string;
+  dynamic: boolean;
+  isError: boolean;
+  rawContent: unknown;
+}): unknown {
+  /*
+   * Claude Code's Bash tool does not report the command's real numeric exit
+   * code — the SDK exposes only stdout/stderr text and an is_error flag.
+   * Consumers (and the example UI) render bash failures from an `exitCode`
+   * field on a structured result, the shape Codex's shell tool provides
+   * natively. When Claude omits `tool_use_result`, derive a binary code from
+   * is_error: 1 on failure, 0 on success. This fallback is a stand-in for
+   * failed/succeeded, not the process's true exit status.
+   */
+  if (toolName === 'bash') {
+    return { exitCode: isError ? 1 : 0, stdout: stringifyContent(rawContent) };
+  }
+  // Must precede the MCP branch: flattening a non-text block to base64 text
+  // is not recoverable by parsing it back.
+  if (hasNonTextContent(rawContent)) return rawContent;
+  const content = stringifyContent(rawContent);
+  return dynamic ? parseMcpToolResult(content) : content;
+}
+
 function parseMcpToolResult(content: string): unknown {
   try {
-    return JSON.parse(content);
+    const parsed = JSON.parse(content);
+    // `JSON.parse` also succeeds on scalars; keep those as the string sent.
+    return parsed !== null && typeof parsed === 'object' ? parsed : content;
   } catch {
     return content;
   }


### PR DESCRIPTION
## Background

[#18647](https://github.com/vercel/ai/pull/18647) added `parseMcpToolResult`, so an external MCP tool result that is a JSON object now reaches consumers as structured data instead of an opaque string. Two result shapes still lose information on the way through:

- **Non-text content blocks.** A tool result whose content array contains an image (or any non-text block) is flattened by `stringifyContent`, which turns that block into `JSON.stringify(entry)` — i.e. the base64 payload as text. Parsing that string back cannot recover the block, so consumers that would render a preview render base64 instead.
- **Scalar MCP results.** `JSON.parse` succeeds on scalars, so an MCP tool whose result is `42` or `true` was handed to consumers as a number or a boolean rather than the string the tool actually sent.

Since #20040, a result that can be paired with a single `tool_result` block is served by the Claude Agent SDK's structured `tool_use_result`. Both problems above remain on the content-derived fallback that #20040 keeps, which is the path parallel tool calls take: when a message carries more than one `tool_result` block, `tool_use_result` cannot be paired with either and every result is derived from content.

## Summary

- Return the raw content array untouched when it contains a non-text block, before the MCP branch runs. The order matters: the MCP branch would otherwise parse the already-flattened string.
- Only substitute the parsed value in `parseMcpToolResult` when it is a non-null object, so scalar results stay strings.
- Move the result branching into a `resolveToolResult` helper, so the ordering constraint between the branches is explicit rather than implied by a ternary chain. The pre-existing `bash` special case moves with it, unchanged.
- Share one `isTextEntry` predicate between `stringifyContent` and the new non-text check, so the two cannot drift apart.
- Add regression coverage for both cases, including the parallel-tool-call path where the structured output cannot be paired.

No public API changes: this only affects the value carried in the `result` field of `tool-result` stream parts. The raw content array is already a legal `harnessV1ToolResultValueSchema` value, so it crosses the wire boundary unchanged.

## End-to-End Verification

Verified against a harness running in a local sandbox. Reading an image file from disk produces a tool result whose content array carries a non-text block: before the change that block reached the consumer as base64 text, and after it the content array arrives untouched and renders as an image preview.

That run predates #20040, which now serves a single pairable result from the SDK's structured output, so the sandbox run no longer reproduces the bug for a lone tool result. The path this PR fixes is the content-derived fallback that remains for parallel tool calls; the scalar case was never reachable through a built-in tool. Both are covered by the added regression tests, which fail without the guards.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

`@ai-sdk/harness-pi` has the same two problems, independently implemented. `unwrapPiToolResult` in `packages/harness-pi/src/pi-translate.ts` filters a `(TextContent | ImageContent)[]` envelope down to its text parts, so an image block is dropped rather than passed through, and its own `parseMcpToolResult` has the same scalar coercion this PR fixes.

The other adapters (`harness-codex`, `harness-acp` and the ACP-based harnesses, `harness-deepagents`, `harness-opencode`) already keep tool-result values structured end to end and are unaffected — Claude Code and Pi are the two that flatten content to a string first. Happy to send the Pi fix separately if it's wanted.

## Related Issues

Follow-up to #18647.
