### PR TITLE
feat(harness): stream tool input to the client as the model writes it

### DIFF
--- a/.changeset/quiet-donkeys-shave.md
+++ b/.changeset/quiet-donkeys-shave.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/harness-claude-code': patch
+'@ai-sdk/workflow-harness': patch
+'@ai-sdk/harness': patch
+---
+
+feat(harness): stream tool input as the model writes it

--- a/.changeset/quiet-donkeys-shave.md
+++ b/.changeset/quiet-donkeys-shave.md
@@ -5,3 +5,12 @@
 ---
 
 feat(harness): stream tool input as the model writes it
+
+Adds `tool-input-start`, `tool-input-delta` and `tool-input-end` to
+`HarnessV1StreamPart` and the bridge outbound union, and emits them from the
+Claude Code adapter while a tool call's input JSON is being written. The
+settled `tool-call` still follows under the same tool call id.
+
+These are new members of two public discriminated unions, so a consumer that
+switches exhaustively over `HarnessV1StreamPart` (or validates bridge frames
+against its own allowlist) will see variants it did not before.

--- a/content/docs/03-ai-sdk-harnesses/03-tools.mdx
+++ b/content/docs/03-ai-sdk-harnesses/03-tools.mdx
@@ -261,6 +261,39 @@ support it will error if an unsupported tool approval mode is specified.
 Host-executed tool approvals are handled by `HarnessAgent`, so they work across
 adapters.
 
+## Streaming Tool Input
+
+Adapters that can observe a tool call's input as the model writes it stream that
+input ahead of the settled call, so a UI can render the tool the moment it
+starts rather than after its input finishes:
+
+- `tool-input-start` — the tool call opened. Carries `id` (the tool call id),
+  `toolName`, and the same `dynamic` / `providerExecuted` flags the eventual
+  `tool-call` carries.
+- `tool-input-delta` — one fragment of the input JSON.
+- `tool-input-end` — the input is complete.
+
+```ts
+for await (const part of result.stream) {
+  if (part.type === 'tool-input-start') {
+    console.log('tool starting:', part.toolName);
+  }
+  if (part.type === 'tool-input-delta') {
+    process.stdout.write(part.delta);
+  }
+}
+```
+
+The deltas are raw JSON fragments and are only valid JSON once complete. The
+`tool-call` part still follows under the same tool call id, carrying the parsed
+input — so consumers that ignore these parts behave exactly as before.
+
+Support is per adapter: an adapter whose runtime does not report partial input
+emits the `tool-call` alone. Claude Code streams the input of built-in and
+external MCP tool calls. Your own host-executed tools do not stream — the
+adapter routes them through an internal MCP server that reports them only once
+their input is complete.
+
 ## File Changes and Compaction
 
 Some harness events are not ordinary tool calls. For UI compatibility,

--- a/examples/ai-functions/src/harness-agent/claude-code/tool-input-streaming.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/tool-input-streaming.ts
@@ -1,5 +1,6 @@
 import { HarnessAgent } from '@ai-sdk/harness/agent';
 import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 
@@ -10,9 +11,9 @@ import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
  * long enough that a UI showing nothing until it lands looks stalled. The
  * adapter streams the input as it arrives: `tool-input-start` when the tool
  * call opens, `tool-input-delta` per fragment, `tool-input-end` when the input
- * is complete. The settled `tool-call` still follows, carrying the same
- * `toolCallId` and the parsed input — these parts are additive, so consumers
- * that ignore them are unaffected.
+ * is complete — printed below under "TOOL INPUT". The settled `tool-call`
+ * still follows under the same tool call id with the parsed input, so
+ * consumers that ignore these parts are unaffected.
  *
  * The prompt asks for a file whose contents are long enough that the `write`
  * tool's input takes several seconds to stream.
@@ -35,40 +36,7 @@ run(async () => {
         'Write it in one tool call; do not read anything first.',
     });
 
-    for await (const chunk of result.stream) {
-      switch (chunk.type) {
-        case 'tool-input-start':
-          process.stdout.write(
-            `\n\x1b[32m\x1b[1mTOOL INPUT\x1b[22m ${chunk.toolName} (${chunk.id})\n`,
-          );
-          break;
-
-        // The deltas are raw JSON fragments — they only form valid JSON once
-        // the input is complete. Parse progressively (the AI SDK UI helpers do
-        // this for you) rather than per delta.
-        case 'tool-input-delta':
-          process.stdout.write(chunk.delta);
-          break;
-
-        case 'tool-input-end':
-          process.stdout.write('\x1b[0m\n');
-          break;
-
-        case 'tool-call':
-          console.log(
-            `\n\x1b[32m\x1b[1mTOOL CALL\x1b[22m ${chunk.toolName} (${chunk.toolCallId})\x1b[0m`,
-          );
-          break;
-
-        case 'text-delta':
-          process.stdout.write(chunk.text);
-          break;
-
-        case 'error':
-          console.error('\n[example] stream error:', chunk.error);
-          break;
-      }
-    }
+    await printFullStream({ result });
 
     console.log('\nfinishReason:', await result.finishReason);
   } catch (err) {

--- a/examples/ai-functions/src/harness-agent/claude-code/tool-input-streaming.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/tool-input-streaming.ts
@@ -1,0 +1,81 @@
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { claudeCode } from '@ai-sdk/harness-claude-code';
+import { run } from '../../lib/run';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+/*
+ * Streaming tool input (Claude Code).
+ *
+ * A tool call's input JSON is written token by token, and a large one takes
+ * long enough that a UI showing nothing until it lands looks stalled. The
+ * adapter streams the input as it arrives: `tool-input-start` when the tool
+ * call opens, `tool-input-delta` per fragment, `tool-input-end` when the input
+ * is complete. The settled `tool-call` still follows, carrying the same
+ * `toolCallId` and the parsed input — these parts are additive, so consumers
+ * that ignore them are unaffected.
+ *
+ * The prompt asks for a file whose contents are long enough that the `write`
+ * tool's input takes several seconds to stream.
+ */
+run(async () => {
+  const sandbox = createVercelSandbox({
+    runtime: 'node24',
+    ports: [4000],
+    timeout: 10 * 60 * 1000,
+  });
+  const agent = new HarnessAgent({ harness: claudeCode, sandbox });
+
+  let exitCode = 0;
+  const session = await agent.createSession();
+  try {
+    const result = await agent.stream({
+      session,
+      prompt:
+        'Write a file notes.md containing a 12-bullet summary of how HTTP caching works. ' +
+        'Write it in one tool call; do not read anything first.',
+    });
+
+    for await (const chunk of result.stream) {
+      switch (chunk.type) {
+        case 'tool-input-start':
+          process.stdout.write(
+            `\n\x1b[32m\x1b[1mTOOL INPUT\x1b[22m ${chunk.toolName} (${chunk.id})\n`,
+          );
+          break;
+
+        // The deltas are raw JSON fragments — they only form valid JSON once
+        // the input is complete. Parse progressively (the AI SDK UI helpers do
+        // this for you) rather than per delta.
+        case 'tool-input-delta':
+          process.stdout.write(chunk.delta);
+          break;
+
+        case 'tool-input-end':
+          process.stdout.write('\x1b[0m\n');
+          break;
+
+        case 'tool-call':
+          console.log(
+            `\n\x1b[32m\x1b[1mTOOL CALL\x1b[22m ${chunk.toolName} (${chunk.toolCallId})\x1b[0m`,
+          );
+          break;
+
+        case 'text-delta':
+          process.stdout.write(chunk.text);
+          break;
+
+        case 'error':
+          console.error('\n[example] stream error:', chunk.error);
+          break;
+      }
+    }
+
+    console.log('\nfinishReason:', await result.finishReason);
+  } catch (err) {
+    exitCode = 1;
+    console.error('[example] failed:', err);
+  } finally {
+    await session.destroy();
+    process.exit(exitCode);
+  }
+});

--- a/examples/ai-functions/src/lib/print-full-stream.ts
+++ b/examples/ai-functions/src/lib/print-full-stream.ts
@@ -69,6 +69,26 @@ export async function printFullStream<TOOLS extends ToolSet>({
         break;
       }
 
+      // Streamed while the model writes a tool call's input JSON. The deltas
+      // are raw fragments and only form valid JSON once complete; the settled
+      // `tool-call` above carries the parsed input.
+      case 'tool-input-start': {
+        process.stdout.write(
+          `\n\n\x1b[32m\x1b[1mTOOL INPUT\x1b[22m ${chunk.toolName}\n`,
+        );
+        break;
+      }
+
+      case 'tool-input-delta': {
+        process.stdout.write(chunk.delta);
+        break;
+      }
+
+      case 'tool-input-end': {
+        process.stdout.write('\x1b[0m\n');
+        break;
+      }
+
       case 'reasoning-start': {
         activeReasoning.set(chunk.id, {
           type: 'reasoning',

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
@@ -4,6 +4,7 @@ import {
   type ClaudeMessage,
   createClaudeStreamEventState,
   createEmitStreamEvent,
+  isExternalMcpTool,
 } from './create-emit-stream-event';
 
 describe('createEmitStreamEvent', () => {
@@ -593,5 +594,25 @@ describe('createEmitStreamEvent', () => {
         },
       ]
     `);
+  });
+});
+
+/*
+ * Three sites derive a call's `dynamic` flag from this predicate — the streamed
+ * `tool-input-start`, the `tool-call` (both the assistant-message and the
+ * approval paths), and the `tool-result`. They must agree: a call whose parts
+ * disagree opens a dynamic UI part that never settles plus a duplicate static
+ * one.
+ */
+describe('isExternalMcpTool', () => {
+  it.each([
+    ['mcp__weather__current', true],
+    ['mcp__context7__query-docs', true],
+    // The bridge's own server settles its calls under a synthetic id.
+    ['mcp__harness-tools__lookup', false],
+    ['Bash', false],
+    ['Read', false],
+  ])('%s -> %s', (nativeName, expected) => {
+    expect(isExternalMcpTool(nativeName)).toBe(expected);
   });
 });

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
@@ -181,9 +181,9 @@ describe('createEmitStreamEvent', () => {
   });
 
   /*
-   * An external MCP tool is `dynamic`, matching its own `tool-call`. A tool on
-   * the bridge's own server never produces a `tool-call` here at all, so
-   * streaming its input would leave a tool part with nothing to settle it.
+   * An external MCP tool is `dynamic`, matching its own `tool-call`. Tools on
+   * the bridge's own server and `StructuredOutput` never produce one here at
+   * all, so streaming their input would leave a part with nothing to settle it.
    */
   it.each([
     {
@@ -201,6 +201,7 @@ describe('createEmitStreamEvent', () => {
       ],
     },
     { name: 'mcp__harness-tools__lookup', expected: [] },
+    { name: 'StructuredOutput', expected: [] },
   ])('streams tool input for $name as expected', ({ name, expected }) => {
     const emitted: Record<string, unknown>[] = [];
     const emitStreamEvent = createEmitStreamEvent({

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
@@ -94,6 +94,38 @@ describe('createEmitStreamEvent', () => {
     `);
   });
 
+  /** Drives one `tool_use` content block through its full partial-message lifecycle. */
+  function streamToolInputBlock(options: {
+    emitStreamEvent: (msg: ClaudeMessage) => void;
+    id: string;
+    name: string;
+    fragments: string[];
+  }): void {
+    const { emitStreamEvent, id, name, fragments } = options;
+    emitStreamEvent({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id, name },
+      },
+    });
+    for (const partial_json of fragments) {
+      emitStreamEvent({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'input_json_delta', partial_json },
+        },
+      });
+    }
+    emitStreamEvent({
+      type: 'stream_event',
+      event: { type: 'content_block_stop', index: 0 },
+    });
+  }
+
   it('streams a tool_use block input as tool-input-start/-delta/-end before the tool-call', () => {
     const state = createClaudeStreamEventState();
     const emitted: Record<string, unknown>[] = [];
@@ -106,33 +138,11 @@ describe('createEmitStreamEvent', () => {
       toCommonName: name => (name === 'Bash' ? 'bash' : name),
     });
 
-    emitStreamEvent({
-      type: 'stream_event',
-      event: {
-        type: 'content_block_start',
-        index: 0,
-        content_block: { type: 'tool_use', id: 'tool-1', name: 'Bash' },
-      },
-    });
-    emitStreamEvent({
-      type: 'stream_event',
-      event: {
-        type: 'content_block_delta',
-        index: 0,
-        delta: { type: 'input_json_delta', partial_json: '{"command"' },
-      },
-    });
-    emitStreamEvent({
-      type: 'stream_event',
-      event: {
-        type: 'content_block_delta',
-        index: 0,
-        delta: { type: 'input_json_delta', partial_json: ':"pwd"}' },
-      },
-    });
-    emitStreamEvent({
-      type: 'stream_event',
-      event: { type: 'content_block_stop', index: 0 },
+    streamToolInputBlock({
+      emitStreamEvent,
+      id: 'tool-1',
+      name: 'Bash',
+      fragments: ['{"command"', ':"pwd"}'],
     });
     emitStreamEvent({
       type: 'assistant',
@@ -169,82 +179,48 @@ describe('createEmitStreamEvent', () => {
     ]);
   });
 
-  it('marks a streamed external MCP tool input dynamic, like its tool-call', () => {
-    const state = createClaudeStreamEventState();
+  /*
+   * An external MCP tool is `dynamic`, matching its own `tool-call`. A tool on
+   * the bridge's own server never produces a `tool-call` here at all, so
+   * streaming its input would leave a tool part with nothing to settle it.
+   */
+  it.each([
+    {
+      name: 'mcp__weather__current',
+      expected: [
+        {
+          type: 'tool-input-start',
+          toolCallId: 'tool-1',
+          toolName: 'mcp__weather__current',
+          providerExecuted: true,
+          dynamic: true,
+        },
+        { type: 'tool-input-delta', toolCallId: 'tool-1', delta: '{"q":"x"}' },
+        { type: 'tool-input-end', toolCallId: 'tool-1' },
+      ],
+    },
+    { name: 'mcp__harness-tools__lookup', expected: [] },
+  ])('streams tool input for $name as expected', ({ name, expected }) => {
     const emitted: Record<string, unknown>[] = [];
     const emitStreamEvent = createEmitStreamEvent({
-      state,
+      state: createClaudeStreamEventState(),
       emit: event => emitted.push(event),
       emitWarning: () => {},
       emitTerminalError: () => {},
       onCompactionBoundary: () => {},
-      toCommonName: name => name,
+      toCommonName: toolName => toolName,
     });
 
-    emitStreamEvent({
-      type: 'stream_event',
-      event: {
-        type: 'content_block_start',
-        index: 0,
-        content_block: {
-          type: 'tool_use',
-          id: 'tool-1',
-          name: 'mcp__weather__current',
-        },
-      },
+    streamToolInputBlock({
+      emitStreamEvent,
+      id: 'tool-1',
+      name,
+      fragments: ['{"q":"x"}'],
     });
 
-    expect(emitted.find(event => event.type === 'tool-input-start')).toEqual({
-      type: 'tool-input-start',
-      toolCallId: 'tool-1',
-      toolName: 'mcp__weather__current',
-      providerExecuted: true,
-      dynamic: true,
-    });
-  });
-
-  it('does not stream input for the bridge-hosted harness-tools MCP server', () => {
-    const state = createClaudeStreamEventState();
-    const emitted: Record<string, unknown>[] = [];
-    const emitStreamEvent = createEmitStreamEvent({
-      state,
-      emit: event => emitted.push(event),
-      emitWarning: () => {},
-      emitTerminalError: () => {},
-      onCompactionBoundary: () => {},
-      toCommonName: name => name,
-    });
-
-    emitStreamEvent({
-      type: 'stream_event',
-      event: {
-        type: 'content_block_start',
-        index: 0,
-        content_block: {
-          type: 'tool_use',
-          id: 'tool-1',
-          name: 'mcp__harness-tools__lookup',
-        },
-      },
-    });
-    emitStreamEvent({
-      type: 'stream_event',
-      event: {
-        type: 'content_block_delta',
-        index: 0,
-        delta: { type: 'input_json_delta', partial_json: '{"q":"x"}' },
-      },
-    });
-    emitStreamEvent({
-      type: 'stream_event',
-      event: { type: 'content_block_stop', index: 0 },
-    });
-
-    // Those tools never produce a `tool-call` on this wire, so a streamed
-    // input would leave a tool part streaming with nothing to settle it.
     expect(
       emitted.filter(event => String(event.type).startsWith('tool-input-')),
-    ).toEqual([]);
+    ).toEqual(expected);
   });
 
   it('keeps subagent messages out of the main Agent-tool step', () => {

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
@@ -94,6 +94,159 @@ describe('createEmitStreamEvent', () => {
     `);
   });
 
+  it('streams a tool_use block input as tool-input-start/-delta/-end before the tool-call', () => {
+    const state = createClaudeStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: event => emitted.push(event),
+      emitWarning: () => {},
+      emitTerminalError: () => {},
+      onCompactionBoundary: () => {},
+      toCommonName: name => (name === 'Bash' ? 'bash' : name),
+    });
+
+    emitStreamEvent({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'tool-1', name: 'Bash' },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '{"command"' },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: ':"pwd"}' },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      event: { type: 'content_block_stop', index: 0 },
+    });
+    emitStreamEvent({
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-1',
+            name: 'Bash',
+            input: { command: 'pwd' },
+          },
+        ],
+      },
+    });
+
+    expect(emitted.filter(event => event.type !== 'stream-start')).toEqual([
+      {
+        type: 'tool-input-start',
+        toolCallId: 'tool-1',
+        toolName: 'bash',
+        providerExecuted: true,
+      },
+      { type: 'tool-input-delta', toolCallId: 'tool-1', delta: '{"command"' },
+      { type: 'tool-input-delta', toolCallId: 'tool-1', delta: ':"pwd"}' },
+      { type: 'tool-input-end', toolCallId: 'tool-1' },
+      {
+        type: 'tool-call',
+        toolCallId: 'tool-1',
+        toolName: 'bash',
+        nativeName: 'Bash',
+        input: '{"command":"pwd"}',
+        providerExecuted: true,
+      },
+    ]);
+  });
+
+  it('marks a streamed external MCP tool input dynamic, like its tool-call', () => {
+    const state = createClaudeStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: event => emitted.push(event),
+      emitWarning: () => {},
+      emitTerminalError: () => {},
+      onCompactionBoundary: () => {},
+      toCommonName: name => name,
+    });
+
+    emitStreamEvent({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: {
+          type: 'tool_use',
+          id: 'tool-1',
+          name: 'mcp__weather__current',
+        },
+      },
+    });
+
+    expect(emitted.find(event => event.type === 'tool-input-start')).toEqual({
+      type: 'tool-input-start',
+      toolCallId: 'tool-1',
+      toolName: 'mcp__weather__current',
+      providerExecuted: true,
+      dynamic: true,
+    });
+  });
+
+  it('does not stream input for the bridge-hosted harness-tools MCP server', () => {
+    const state = createClaudeStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: event => emitted.push(event),
+      emitWarning: () => {},
+      emitTerminalError: () => {},
+      onCompactionBoundary: () => {},
+      toCommonName: name => name,
+    });
+
+    emitStreamEvent({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: {
+          type: 'tool_use',
+          id: 'tool-1',
+          name: 'mcp__harness-tools__lookup',
+        },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '{"q":"x"}' },
+      },
+    });
+    emitStreamEvent({
+      type: 'stream_event',
+      event: { type: 'content_block_stop', index: 0 },
+    });
+
+    // Those tools never produce a `tool-call` on this wire, so a streamed
+    // input would leave a tool part streaming with nothing to settle it.
+    expect(
+      emitted.filter(event => String(event.type).startsWith('tool-input-')),
+    ).toEqual([]);
+  });
+
   it('keeps subagent messages out of the main Agent-tool step', () => {
     const messages = JSON.parse(
       readFileSync(

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
@@ -108,7 +108,23 @@ export function createClaudeStreamEventState(): ClaudeStreamEventState {
 const UNRECOVERABLE_API_RETRY_STATUSES = new Set([401, 403, 404]);
 
 /** Native-name prefix of the MCP server the bridge hosts `HarnessAgent` tools on. */
-const HARNESS_TOOLS_MCP_PREFIX = 'mcp__harness-tools__';
+export const HARNESS_TOOLS_MCP_PREFIX = 'mcp__harness-tools__';
+
+/**
+ * Whether a native name belongs to a user-configured MCP server, which makes
+ * its calls `dynamic` on the wire — they are not in the agent's typed tool set.
+ * The bridge's own server is excluded: it emits its calls under a synthetic id
+ * with the user-facing tool name.
+ *
+ * The `tool-call` and the streamed `tool-input-start` for one tool must agree
+ * on this flag, so both derive it here rather than repeating the rule.
+ */
+function isExternalMcpTool(nativeName: string): boolean {
+  return (
+    nativeName.startsWith('mcp__') &&
+    !nativeName.startsWith(HARNESS_TOOLS_MCP_PREFIX)
+  );
+}
 
 /** Native tool the CLI uses to return structured output; carried in `finish`. */
 const STRUCTURED_OUTPUT_TOOL_NAME = 'StructuredOutput';
@@ -255,7 +271,7 @@ export function createEmitStreamEvent({
             continue;
           }
           state.nativeToolCallNames.set(block.id, block.name);
-          const dynamic = block.name.startsWith('mcp__');
+          const dynamic = isExternalMcpTool(block.name);
           if (dynamic) state.externalMcpToolUseIds.add(block.id);
           if (state.approvalRequestedToolUseIds.has(block.id)) {
             continue;
@@ -424,24 +440,21 @@ function handleStreamEvent(
       const id = randomUUID();
       partialBlocks.set(index, { id, kind: 'thinking' });
       send({ type: 'reasoning-start', id });
-    } else if (
-      blockType === 'tool_use' &&
-      typeof block?.id === 'string' &&
-      typeof block.name === 'string' &&
-      emitsToolCall(block.name)
-    ) {
-      /*
-       * The tool-use id is already known here, so the streamed input and the
-       * `tool-call` the assistant message emits later share a `toolCallId`.
-       * `dynamic` must match what that `tool-call` will carry.
-       */
-      partialBlocks.set(index, { id: block.id, kind: 'tool' });
+    } else if (blockType === 'tool_use') {
+      const id = block?.id;
+      const name = block?.name;
+      if (typeof id !== 'string' || typeof name !== 'string') return;
+      if (!emitsToolCall(name)) return;
+
+      // The tool-use id is already known here, so the streamed input and the
+      // `tool-call` the assistant message emits later share a `toolCallId`.
+      partialBlocks.set(index, { id, kind: 'tool' });
       send({
         type: 'tool-input-start',
-        toolCallId: block.id,
-        toolName: toCommonName(block.name),
+        toolCallId: id,
+        toolName: toCommonName(name),
         providerExecuted: true,
-        ...(block.name.startsWith('mcp__') ? { dynamic: true } : {}),
+        ...(isExternalMcpTool(name) ? { dynamic: true } : {}),
       });
     }
     return;
@@ -484,12 +497,24 @@ function handleStreamEvent(
     const block = partialBlocks.get(index);
     if (!block) return;
     partialBlocks.delete(index);
-    if (block.kind === 'text') {
-      send({ type: 'text-end', id: block.id });
-    } else if (block.kind === 'tool') {
-      send({ type: 'tool-input-end', toolCallId: block.id });
-    } else {
-      send({ type: 'reasoning-end', id: block.id });
+    /*
+     * Exhaustive on purpose: a catch-all `else` here would silently close a
+     * future block kind as `reasoning-end`.
+     */
+    switch (block.kind) {
+      case 'text':
+        send({ type: 'text-end', id: block.id });
+        return;
+      case 'thinking':
+        send({ type: 'reasoning-end', id: block.id });
+        return;
+      case 'tool':
+        send({ type: 'tool-input-end', toolCallId: block.id });
+        return;
+      default: {
+        const exhaustive: never = block.kind;
+        void exhaustive;
+      }
     }
   }
 }

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
@@ -53,12 +53,9 @@ type MessageBlock = {
 };
 
 /**
- * A content block the CLI is still streaming, keyed by its block index.
- *
- * `text` and `thinking` blocks carry a generated id (the partial-message
- * events have none); a `tool` block carries the tool-use id the settled
- * `tool_use` block will repeat, so the streamed input and the eventual
- * `tool-call` correlate.
+ * A content block the CLI is still streaming, keyed by block index. `text` and
+ * `thinking` carry a generated id; `tool` carries the tool-use id, so the
+ * streamed input and the eventual `tool-call` correlate.
  */
 type PartialBlock = { id: string; kind: 'text' | 'thinking' | 'tool' };
 
@@ -111,13 +108,9 @@ const UNRECOVERABLE_API_RETRY_STATUSES = new Set([401, 403, 404]);
 export const HARNESS_TOOLS_MCP_PREFIX = 'mcp__harness-tools__';
 
 /**
- * Whether a native name belongs to a user-configured MCP server, which makes
- * its calls `dynamic` on the wire — they are not in the agent's typed tool set.
- * The bridge's own server is excluded: it emits its calls under a synthetic id
- * with the user-facing tool name.
- *
- * The `tool-call` and the streamed `tool-input-start` for one tool must agree
- * on this flag, so both derive it here rather than repeating the rule.
+ * Whether a call is `dynamic` on the wire — a user-configured MCP tool, not in
+ * the agent's typed tool set. A tool's `tool-call`, `tool-input-start` and
+ * `tool-result` must agree on the flag, so all three derive it here.
  */
 export function isExternalMcpTool(nativeName: string): boolean {
   return (
@@ -126,14 +119,10 @@ export function isExternalMcpTool(nativeName: string): boolean {
   );
 }
 
-/** Native tool the CLI uses to return structured output; carried in `finish`. */
-const STRUCTURED_OUTPUT_TOOL_NAME = 'StructuredOutput';
-
 /**
- * Whether a tool call is settled on this wire by a `tool-call` of its own.
- * The bridge swallows the rest — tools on its own MCP server report under a
- * synthetic id, and `StructuredOutput` is folded into the turn result — so a
- * streamed input for one would leave a tool part with nothing to settle it.
+ * Whether a tool call settles on this wire with a `tool-call` of its own. The
+ * ones that do not are swallowed below, so streaming an input for one would
+ * leave a tool part with nothing to settle it.
  */
 function emitsToolCall(nativeName: string): boolean {
   return (
@@ -141,6 +130,8 @@ function emitsToolCall(nativeName: string): boolean {
     nativeName !== STRUCTURED_OUTPUT_TOOL_NAME
   );
 }
+
+const STRUCTURED_OUTPUT_TOOL_NAME = 'StructuredOutput';
 
 export function createEmitStreamEvent({
   state,

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
@@ -119,7 +119,7 @@ export const HARNESS_TOOLS_MCP_PREFIX = 'mcp__harness-tools__';
  * The `tool-call` and the streamed `tool-input-start` for one tool must agree
  * on this flag, so both derive it here rather than repeating the rule.
  */
-function isExternalMcpTool(nativeName: string): boolean {
+export function isExternalMcpTool(nativeName: string): boolean {
   return (
     nativeName.startsWith('mcp__') &&
     !nativeName.startsWith(HARNESS_TOOLS_MCP_PREFIX)

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
@@ -21,8 +21,13 @@ export type ClaudeMessage = {
   event?: {
     type?: string;
     index?: number;
-    content_block?: { type?: string };
-    delta?: { type?: string; text?: string; thinking?: string };
+    content_block?: { type?: string; id?: string; name?: string };
+    delta?: {
+      type?: string;
+      text?: string;
+      thinking?: string;
+      partial_json?: string;
+    };
   };
   message?: {
     content?: ReadonlyArray<MessageBlock>;
@@ -47,6 +52,16 @@ type MessageBlock = {
   is_error?: boolean;
 };
 
+/**
+ * A content block the CLI is still streaming, keyed by its block index.
+ *
+ * `text` and `thinking` blocks carry a generated id (the partial-message
+ * events have none); a `tool` block carries the tool-use id the settled
+ * `tool_use` block will repeat, so the streamed input and the eventual
+ * `tool-call` correlate.
+ */
+type PartialBlock = { id: string; kind: 'text' | 'thinking' | 'tool' };
+
 export type ClaudeStreamEventState = {
   /*
    * Map of native tool-use id → tool name. Claude assistant messages emit
@@ -56,7 +71,7 @@ export type ClaudeStreamEventState = {
    */
   nativeToolCallNames: Map<string, string>;
   approvalRequestedToolUseIds: Set<string>;
-  partialBlocks: Map<number, { id: string; kind: 'text' | 'thinking' }>;
+  partialBlocks: Map<number, PartialBlock>;
   stepUsage: Record<string, unknown> | undefined;
   pendingStepToolUseIds: Set<string>;
   pendingStepUsage: Record<string, unknown> | undefined;
@@ -91,6 +106,25 @@ export function createClaudeStreamEventState(): ClaudeStreamEventState {
 }
 
 const UNRECOVERABLE_API_RETRY_STATUSES = new Set([401, 403, 404]);
+
+/** Native-name prefix of the MCP server the bridge hosts `HarnessAgent` tools on. */
+const HARNESS_TOOLS_MCP_PREFIX = 'mcp__harness-tools__';
+
+/** Native tool the CLI uses to return structured output; carried in `finish`. */
+const STRUCTURED_OUTPUT_TOOL_NAME = 'StructuredOutput';
+
+/**
+ * Whether a tool call is settled on this wire by a `tool-call` of its own.
+ * The bridge swallows the rest — tools on its own MCP server report under a
+ * synthetic id, and `StructuredOutput` is folded into the turn result — so a
+ * streamed input for one would leave a tool part with nothing to settle it.
+ */
+function emitsToolCall(nativeName: string): boolean {
+  return (
+    !nativeName.startsWith(HARNESS_TOOLS_MCP_PREFIX) &&
+    nativeName !== STRUCTURED_OUTPUT_TOOL_NAME
+  );
+}
 
 export function createEmitStreamEvent({
   state,
@@ -195,7 +229,7 @@ export function createEmitStreamEvent({
     }
 
     if (type === 'stream_event') {
-      handleStreamEvent(msg.event, state.partialBlocks, emit);
+      handleStreamEvent(msg.event, state.partialBlocks, emit, toCommonName);
       return;
     }
 
@@ -210,12 +244,11 @@ export function createEmitStreamEvent({
           typeof block.name === 'string'
         ) {
           toolUseIds.push(block.id);
-          if (block.name === 'StructuredOutput') {
+          if (block.name === STRUCTURED_OUTPUT_TOOL_NAME) {
             state.structuredOutputToolUseIds.add(block.id);
             continue;
           }
-          const mcpPrefix = 'mcp__harness-tools__';
-          if (block.name.startsWith(mcpPrefix)) {
+          if (block.name.startsWith(HARNESS_TOOLS_MCP_PREFIX)) {
             state.pendingStepToolUseIds.add(block.id);
             state.mcpToolUseIds.add(block.id);
             opensStep = true;
@@ -373,14 +406,16 @@ function formatApiRetryWarning(msg: ClaudeMessage): string {
 
 function handleStreamEvent(
   event: ClaudeMessage['event'] | undefined,
-  partialBlocks: Map<number, { id: string; kind: 'text' | 'thinking' }>,
+  partialBlocks: Map<number, PartialBlock>,
   send: Emit,
+  toCommonName: (nativeName: string) => string,
 ): void {
   if (!event || typeof event.index !== 'number') return;
   const index = event.index;
 
   if (event.type === 'content_block_start') {
-    const blockType = event.content_block?.type;
+    const block = event.content_block;
+    const blockType = block?.type;
     if (blockType === 'text') {
       const id = randomUUID();
       partialBlocks.set(index, { id, kind: 'text' });
@@ -389,6 +424,25 @@ function handleStreamEvent(
       const id = randomUUID();
       partialBlocks.set(index, { id, kind: 'thinking' });
       send({ type: 'reasoning-start', id });
+    } else if (
+      blockType === 'tool_use' &&
+      typeof block?.id === 'string' &&
+      typeof block.name === 'string' &&
+      emitsToolCall(block.name)
+    ) {
+      /*
+       * The tool-use id is already known here, so the streamed input and the
+       * `tool-call` the assistant message emits later share a `toolCallId`.
+       * `dynamic` must match what that `tool-call` will carry.
+       */
+      partialBlocks.set(index, { id: block.id, kind: 'tool' });
+      send({
+        type: 'tool-input-start',
+        toolCallId: block.id,
+        toolName: toCommonName(block.name),
+        providerExecuted: true,
+        ...(block.name.startsWith('mcp__') ? { dynamic: true } : {}),
+      });
     }
     return;
   }
@@ -412,6 +466,16 @@ function handleStreamEvent(
         id: block.id,
         delta: event.delta.thinking,
       });
+    } else if (
+      block.kind === 'tool' &&
+      event.delta?.type === 'input_json_delta' &&
+      typeof event.delta.partial_json === 'string'
+    ) {
+      send({
+        type: 'tool-input-delta',
+        toolCallId: block.id,
+        delta: event.delta.partial_json,
+      });
     }
     return;
   }
@@ -422,6 +486,8 @@ function handleStreamEvent(
     partialBlocks.delete(index);
     if (block.kind === 'text') {
       send({ type: 'text-end', id: block.id });
+    } else if (block.kind === 'tool') {
+      send({ type: 'tool-input-end', toolCallId: block.id });
     } else {
       send({ type: 'reasoning-end', id: block.id });
     }

--- a/packages/harness-claude-code/src/bridge/index.ts
+++ b/packages/harness-claude-code/src/bridge/index.ts
@@ -43,6 +43,7 @@ import {
   defaultUsage,
   emitFinishStep,
   finishApprovalStep,
+  HARNESS_TOOLS_MCP_PREFIX,
   mapUsage,
   type ClaudeMessage,
 } from './create-emit-stream-event';
@@ -168,7 +169,7 @@ function createPermissionOptions(input: {
       toolInput: Record<string, unknown>,
       options: { toolUseID: string },
     ) => {
-      if (toolName.startsWith('mcp__harness-tools__')) {
+      if (toolName.startsWith(HARNESS_TOOLS_MCP_PREFIX)) {
         return { behavior: 'allow', updatedInput: toolInput };
       }
       if (

--- a/packages/harness-claude-code/src/bridge/index.ts
+++ b/packages/harness-claude-code/src/bridge/index.ts
@@ -44,6 +44,7 @@ import {
   emitFinishStep,
   finishApprovalStep,
   HARNESS_TOOLS_MCP_PREFIX,
+  isExternalMcpTool,
   mapUsage,
   type ClaudeMessage,
 } from './create-emit-stream-event';
@@ -192,6 +193,13 @@ function createPermissionOptions(input: {
         nativeName: toolName,
         input: JSON.stringify(toolInput ?? {}),
         providerExecuted: true,
+        /*
+         * Must match the `dynamic` the streamed `tool-input-start` carried for
+         * this same call, and the one its `tool-result` will carry. Without it
+         * an approval-gated external MCP tool opens a dynamic part that never
+         * settles plus a duplicate static one.
+         */
+        ...(isExternalMcpTool(toolName) ? { dynamic: true } : {}),
       });
       input.emit({
         type: 'tool-approval-request',

--- a/packages/harness-claude-code/src/claude-code-bridge-protocol.test.ts
+++ b/packages/harness-claude-code/src/claude-code-bridge-protocol.test.ts
@@ -19,6 +19,14 @@ describe('outboundMessageSchema', () => {
     { type: 'reasoning-delta', id: 'r', delta: 'thinking' },
     { type: 'reasoning-end', id: 'r' },
     {
+      type: 'tool-input-start',
+      toolCallId: 't1',
+      toolName: 'bash',
+      providerExecuted: true,
+    },
+    { type: 'tool-input-delta', toolCallId: 't1', delta: '{"command"' },
+    { type: 'tool-input-end', toolCallId: 't1' },
+    {
       type: 'tool-call',
       toolCallId: 't1',
       toolName: 'bash',

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -126,10 +126,7 @@ vi.mock('node:fs/promises', async importOriginal => {
 });
 
 // eslint-disable-next-line import/first
-import {
-  createClaudeCode,
-  FORWARDED_BRIDGE_EVENT_TYPES,
-} from './claude-code-harness';
+import { createClaudeCode } from './claude-code-harness';
 
 function textStream(text: string): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
@@ -274,17 +271,6 @@ describe('createClaudeCode adapter', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-  });
-
-  it('forwards the streamed tool-input parts to the turn', () => {
-    /*
-     * The channel buffers a part with no listener instead of raising, so a
-     * type missing here is dropped with no error anywhere — the bridge emits
-     * it, the schema validates it, and the turn never sees it.
-     */
-    expect(FORWARDED_BRIDGE_EVENT_TYPES).toContain('tool-input-start');
-    expect(FORWARDED_BRIDGE_EVENT_TYPES).toContain('tool-input-delta');
-    expect(FORWARDED_BRIDGE_EVENT_TYPES).toContain('tool-input-end');
   });
 
   it('declares the harness id and builtin tools', () => {

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -126,7 +126,10 @@ vi.mock('node:fs/promises', async importOriginal => {
 });
 
 // eslint-disable-next-line import/first
-import { createClaudeCode } from './claude-code-harness';
+import {
+  createClaudeCode,
+  FORWARDED_BRIDGE_EVENT_TYPES,
+} from './claude-code-harness';
 
 function textStream(text: string): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
@@ -271,6 +274,17 @@ describe('createClaudeCode adapter', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('forwards the streamed tool-input parts to the turn', () => {
+    /*
+     * The channel buffers a part with no listener instead of raising, so a
+     * type missing here is dropped with no error anywhere — the bridge emits
+     * it, the schema validates it, and the turn never sees it.
+     */
+    expect(FORWARDED_BRIDGE_EVENT_TYPES).toContain('tool-input-start');
+    expect(FORWARDED_BRIDGE_EVENT_TYPES).toContain('tool-input-delta');
+    expect(FORWARDED_BRIDGE_EVENT_TYPES).toContain('tool-input-end');
   });
 
   it('declares the harness id and builtin tools', () => {

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -1455,13 +1455,15 @@ function formatUnknownError(error: unknown): string {
 
 /**
  * Bridge stream parts forwarded to the turn as-is. `finish` and `error` are
- * subscribed separately because they also settle the turn.
+ * subscribed separately, since they also settle the turn.
  *
- * Every part the bridge can emit needs an entry: the channel buffers a
- * validated frame that has no subscriber instead of raising, so a missing type
- * drops the part silently rather than failing loudly.
+ * This is a subscription list, not the full outbound union — subscribing is
+ * how a part reaches the turn at all, and the channel buffers a validated
+ * frame that has no subscriber rather than raising. A part the bridge emits
+ * but this list omits is therefore dropped silently, so anything added to the
+ * wire that this adapter emits has to be added here too.
  */
-export const FORWARDED_BRIDGE_EVENT_TYPES = [
+const FORWARDED_BRIDGE_EVENT_TYPES = [
   'stream-start',
   'text-start',
   'text-delta',
@@ -1581,11 +1583,7 @@ function createSession({
     };
 
     for (const type of FORWARDED_BRIDGE_EVENT_TYPES) {
-      unsubs.push(
-        channel.on(type, msg => {
-          forward(msg);
-        }),
-      );
+      unsubs.push(channel.on(type, forward));
     }
     unsubs.push(
       channel.on('finish', msg => {

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -1453,6 +1453,32 @@ function formatUnknownError(error: unknown): string {
   return String(error);
 }
 
+/**
+ * Bridge stream parts forwarded to the turn as-is. `finish` and `error` are
+ * subscribed separately because they also settle the turn.
+ *
+ * Every part the bridge can emit needs an entry: the channel buffers a
+ * validated frame that has no subscriber instead of raising, so a missing type
+ * drops the part silently rather than failing loudly.
+ */
+export const FORWARDED_BRIDGE_EVENT_TYPES = [
+  'stream-start',
+  'text-start',
+  'text-delta',
+  'text-end',
+  'reasoning-start',
+  'reasoning-delta',
+  'reasoning-end',
+  'tool-input-start',
+  'tool-input-delta',
+  'tool-input-end',
+  'tool-call',
+  'tool-approval-request',
+  'tool-result',
+  'finish-step',
+  'raw',
+] as const;
+
 function createSession({
   sessionId,
   channel,
@@ -1554,21 +1580,7 @@ function createSession({
       pendingReject!(err);
     };
 
-    const eventTypes = [
-      'stream-start',
-      'text-start',
-      'text-delta',
-      'text-end',
-      'reasoning-start',
-      'reasoning-delta',
-      'reasoning-end',
-      'tool-call',
-      'tool-approval-request',
-      'tool-result',
-      'finish-step',
-      'raw',
-    ] as const;
-    for (const type of eventTypes) {
+    for (const type of FORWARDED_BRIDGE_EVENT_TYPES) {
       unsubs.push(
         channel.on(type, msg => {
           forward(msg);

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -44,6 +44,7 @@ import type { HarnessAgentToolApprovalConfiguration } from '../harness-agent-set
 import { HarnessStreamTextResult } from './harness-stream-text-result';
 import { translateStreamPart } from './translate-stream-part';
 import { stripWorkDir } from './strip-work-dir';
+import { createToolInputWorkDirStripper } from './tool-input-work-dir-stripper';
 import {
   createTurnTelemetry,
   type TurnContentPart,
@@ -259,6 +260,22 @@ export function runPrompt<
       ]),
     );
     const settledHostToolCallIds = new Set<string>();
+    /*
+     * Streamed tool input needs stripping that spans fragments — a work-dir
+     * reference can be split across two deltas. Held state lives for the turn.
+     */
+    const toolInputWorkDirStripper = createToolInputWorkDirStripper(
+      input.sessionWorkDir,
+    );
+    /** Project one wire part into consumer-facing parts and enqueue them. */
+    const forward = (part: HarnessV1StreamPart) => {
+      for (const translated of translateStreamPart<TOOLS>(
+        part,
+        translateOptions,
+      )) {
+        result.enqueue(translated);
+      }
+    };
     let closingResumedStep = false;
     let pendingStopBoundary:
       | {
@@ -649,7 +666,7 @@ export function runPrompt<
          * execution below — the tools need the absolute path to resolve
          * against the sandbox root, so the strip is display-only.
          */
-        const displayValue = stripWorkDir(value, input.sessionWorkDir);
+        let displayValue = stripWorkDir(value, input.sessionWorkDir);
         const settledHostInputReplay =
           (displayValue.type === 'tool-call' ||
             displayValue.type === 'tool-result' ||
@@ -661,6 +678,31 @@ export function runPrompt<
 
         if (settledHostInputReplay) {
           continue;
+        }
+
+        /*
+         * Streamed input fragments go through the stateful stripper instead of
+         * `stripWorkDir`, so a work-dir reference split across two deltas is
+         * caught. It holds back the tail that might begin one, so a delta can
+         * shrink to nothing — forward nothing in that case, and release
+         * whatever is still held as one last delta when the block closes.
+         */
+        if (displayValue.type === 'tool-input-delta') {
+          const delta = toolInputWorkDirStripper.push(
+            displayValue.toolCallId,
+            displayValue.delta,
+          );
+          if (delta.length === 0) continue;
+          displayValue = { ...displayValue, delta };
+        } else if (displayValue.type === 'tool-input-end') {
+          const held = toolInputWorkDirStripper.flush(displayValue.toolCallId);
+          if (held.length > 0) {
+            forward({
+              type: 'tool-input-delta',
+              toolCallId: displayValue.toolCallId,
+              delta: held,
+            });
+          }
         }
 
         if (displayValue.type === 'finish-step' && closingResumedStep) {
@@ -727,12 +769,7 @@ export function runPrompt<
         }
 
         // Forward to consumer as soon as possible.
-        for (const part of translateStreamPart<TOOLS>(
-          displayValue,
-          translateOptions,
-        )) {
-          result.enqueue(part);
-        }
+        forward(displayValue);
 
         // Tool-call validation lives here (not in translateStreamPart) because
         // schema parsing is async and needs the merged tool set in scope.

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -653,7 +653,10 @@ export function runPrompt<
         const settledHostInputReplay =
           (displayValue.type === 'tool-call' ||
             displayValue.type === 'tool-result' ||
-            displayValue.type === 'tool-approval-request') &&
+            displayValue.type === 'tool-approval-request' ||
+            displayValue.type === 'tool-input-start' ||
+            displayValue.type === 'tool-input-delta' ||
+            displayValue.type === 'tool-input-end') &&
           settledHostToolCallIds.has(displayValue.toolCallId);
 
         if (settledHostInputReplay) {

--- a/packages/harness/src/agent/internal/strip-work-dir.test.ts
+++ b/packages/harness/src/agent/internal/strip-work-dir.test.ts
@@ -21,17 +21,15 @@ describe('stripWorkDir', () => {
     });
   });
 
-  it('strips the prefix from a streamed tool-input delta', () => {
+  it('leaves streamed tool-input deltas alone (the stateful stripper owns them)', () => {
     const part: HarnessV1StreamPart = {
       type: 'tool-input-delta',
       toolCallId: 'c1',
       delta: `{"path":"${WORK_DIR}/src/foo.ts"`,
     };
-    const out = stripWorkDir(part, WORK_DIR) as Extract<
-      HarnessV1StreamPart,
-      { type: 'tool-input-delta' }
-    >;
-    expect(out.delta).toBe('{"path":"src/foo.ts"');
+    // Stripping a fragment here would be wrong, not merely incomplete: a
+    // reference split across two deltas needs state this function cannot hold.
+    expect(stripWorkDir(part, WORK_DIR)).toBe(part);
   });
 
   it('strips every occurrence in free-form tool-result string output', () => {

--- a/packages/harness/src/agent/internal/strip-work-dir.test.ts
+++ b/packages/harness/src/agent/internal/strip-work-dir.test.ts
@@ -21,6 +21,19 @@ describe('stripWorkDir', () => {
     });
   });
 
+  it('strips the prefix from a streamed tool-input delta', () => {
+    const part: HarnessV1StreamPart = {
+      type: 'tool-input-delta',
+      toolCallId: 'c1',
+      delta: `{"path":"${WORK_DIR}/src/foo.ts"`,
+    };
+    const out = stripWorkDir(part, WORK_DIR) as Extract<
+      HarnessV1StreamPart,
+      { type: 'tool-input-delta' }
+    >;
+    expect(out.delta).toBe('{"path":"src/foo.ts"');
+  });
+
   it('strips every occurrence in free-form tool-result string output', () => {
     const part: HarnessV1StreamPart = {
       type: 'tool-result',

--- a/packages/harness/src/agent/internal/strip-work-dir.ts
+++ b/packages/harness/src/agent/internal/strip-work-dir.ts
@@ -16,9 +16,11 @@ import type { HarnessV1StreamPart } from '../../v1';
  * impossible. The prefix is long and contains the session id, so it is unique
  * enough that replacing every occurrence is safe.
  *
- * That holds for whole strings. Streamed `tool-input-delta` fragments are the
- * exception — a prefix can straddle two of them — so the strip there is
- * best-effort; see the case below.
+ * This handles whole strings only. Streamed `tool-input-delta` fragments are
+ * split at arbitrary offsets, so a reference can straddle two of them and
+ * neither half matches; those go through the stateful
+ * {@link ../tool-input-work-dir-stripper.createToolInputWorkDirStripper}
+ * instead, which is why there is no case for them below.
  */
 export function stripWorkDir(
   part: HarnessV1StreamPart,
@@ -29,14 +31,6 @@ export function stripWorkDir(
   switch (part.type) {
     case 'tool-call':
       return { ...part, input: stripString(part.input, sessionWorkDir) };
-    /*
-     * Best-effort by construction: this function is stateless and a work-dir
-     * prefix can straddle two deltas, so such a path survives into the
-     * streamed projection. Only the transient display is affected — the
-     * settled `tool-call` below is stripped whole and replaces it.
-     */
-    case 'tool-input-delta':
-      return { ...part, delta: stripString(part.delta, sessionWorkDir) };
     case 'tool-result':
       return {
         ...part,
@@ -61,7 +55,7 @@ export function stripWorkDir(
  * The early return matters: this runs per streamed delta and on every string
  * of a `tool-result` payload, and almost none of them mention the work dir.
  */
-function stripString(value: string, workDir: string): string {
+export function stripString(value: string, workDir: string): string {
   if (!value.includes(workDir)) return value;
   return value.split(`${workDir}/`).join('').split(workDir).join('.');
 }

--- a/packages/harness/src/agent/internal/strip-work-dir.ts
+++ b/packages/harness/src/agent/internal/strip-work-dir.ts
@@ -15,6 +15,10 @@ import type { HarnessV1StreamPart } from '../../v1';
  * output — where paths can appear anywhere and field-aware rewriting is
  * impossible. The prefix is long and contains the session id, so it is unique
  * enough that replacing every occurrence is safe.
+ *
+ * That holds for whole strings. Streamed `tool-input-delta` fragments are the
+ * exception — a prefix can straddle two of them — so the strip there is
+ * best-effort; see the case below.
  */
 export function stripWorkDir(
   part: HarnessV1StreamPart,
@@ -26,9 +30,10 @@ export function stripWorkDir(
     case 'tool-call':
       return { ...part, input: stripString(part.input, sessionWorkDir) };
     /*
-     * Best-effort: a work-dir prefix split across two deltas survives the
-     * streamed projection. It is corrected once the settled `tool-call`
-     * lands — its stripped input replaces the accumulated partial input.
+     * Best-effort by construction: this function is stateless and a work-dir
+     * prefix can straddle two deltas, so such a path survives into the
+     * streamed projection. Only the transient display is affected — the
+     * settled `tool-call` below is stripped whole and replaces it.
      */
     case 'tool-input-delta':
       return { ...part, delta: stripString(part.delta, sessionWorkDir) };
@@ -52,8 +57,12 @@ export function stripWorkDir(
  * directory followed by a separator becomes workspace-relative
  * (`/work/dir/src/a.ts` → `src/a.ts`); a bare reference to the directory itself
  * becomes `.`.
+ *
+ * The early return matters: this runs per streamed delta and on every string
+ * of a `tool-result` payload, and almost none of them mention the work dir.
  */
 function stripString(value: string, workDir: string): string {
+  if (!value.includes(workDir)) return value;
   return value.split(`${workDir}/`).join('').split(workDir).join('.');
 }
 

--- a/packages/harness/src/agent/internal/strip-work-dir.ts
+++ b/packages/harness/src/agent/internal/strip-work-dir.ts
@@ -25,6 +25,13 @@ export function stripWorkDir(
   switch (part.type) {
     case 'tool-call':
       return { ...part, input: stripString(part.input, sessionWorkDir) };
+    /*
+     * Best-effort: a work-dir prefix split across two deltas survives the
+     * streamed projection. It is corrected once the settled `tool-call`
+     * lands — its stripped input replaces the accumulated partial input.
+     */
+    case 'tool-input-delta':
+      return { ...part, delta: stripString(part.delta, sessionWorkDir) };
     case 'tool-result':
       return {
         ...part,

--- a/packages/harness/src/agent/internal/tool-input-work-dir-stripper.test.ts
+++ b/packages/harness/src/agent/internal/tool-input-work-dir-stripper.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { createToolInputWorkDirStripper } from './tool-input-work-dir-stripper';
+
+const WORK_DIR = '/vercel/sandbox/claude-code-abc123';
+
+/** Feed fragments through the stripper and concatenate everything it releases. */
+function streamThrough(fragments: string[], workDir = WORK_DIR): string {
+  const stripper = createToolInputWorkDirStripper(workDir);
+  const out = fragments
+    .map(fragment => stripper.push('call_1', fragment))
+    .join('');
+  return out + stripper.flush('call_1');
+}
+
+describe('createToolInputWorkDirStripper', () => {
+  it('strips a work dir contained in a single fragment', () => {
+    expect(streamThrough([`{"path":"${WORK_DIR}/src/a.ts"}`])).toBe(
+      '{"path":"src/a.ts"}',
+    );
+  });
+
+  it('strips a work dir split across two fragments', () => {
+    // The split falls inside the session id — neither half matches on its own.
+    expect(
+      streamThrough(['{"path":"/vercel/sandbox/claude-code-', 'abc123/a.ts"}']),
+    ).toBe('{"path":"a.ts"}');
+  });
+
+  it('strips a work dir split one character at a time', () => {
+    expect(streamThrough([...`{"path":"${WORK_DIR}/a.ts"}`])).toBe(
+      '{"path":"a.ts"}',
+    );
+  });
+
+  it('strips a bare work dir split across fragments', () => {
+    expect(
+      streamThrough([
+        `{"cwd":"${WORK_DIR.slice(0, 20)}`,
+        `${WORK_DIR.slice(20)}"}`,
+      ]),
+    ).toBe('{"cwd":"."}');
+  });
+
+  it('releases a held tail that turns out not to be a work dir', () => {
+    // `/vercel/sandbox/other` shares a prefix with the work dir, then diverges.
+    expect(streamThrough(['{"path":"/vercel/sandbox/', 'other/a.ts"}'])).toBe(
+      '{"path":"/vercel/sandbox/other/a.ts"}',
+    );
+  });
+
+  it('flushes a partial prefix left dangling when the input ends', () => {
+    const stripper = createToolInputWorkDirStripper(WORK_DIR);
+    // Ends mid-prefix, so it is held...
+    expect(stripper.push('call_1', '{"path":"/vercel/sand')).toBe('{"path":"');
+    // ...and released verbatim once no more fragments can complete it.
+    expect(stripper.flush('call_1')).toBe('/vercel/sand');
+  });
+
+  it('holds no more than the work dir length', () => {
+    const stripper = createToolInputWorkDirStripper(WORK_DIR);
+    const released = stripper.push('call_1', 'a'.repeat(500));
+    expect(released).toBe('a'.repeat(500));
+    expect(stripper.flush('call_1')).toBe('');
+  });
+
+  it('keeps concurrent tool calls independent', () => {
+    const stripper = createToolInputWorkDirStripper(WORK_DIR);
+    const one: string[] = [];
+    const two: string[] = [];
+
+    // Interleaved: call_1 carries a work dir, call_2 an unrelated path whose
+    // leading `/` is briefly held as a possible start of one.
+    one.push(stripper.push('call_1', '{"path":"/vercel/sandbox/claude-code-'));
+    two.push(stripper.push('call_2', '{"path":"/tmp/'));
+    one.push(stripper.push('call_1', 'abc123/a.ts"}'));
+    two.push(stripper.push('call_2', 'b.ts"}'));
+    one.push(stripper.flush('call_1'));
+    two.push(stripper.flush('call_2'));
+
+    expect(one.join('')).toBe('{"path":"a.ts"}');
+    expect(two.join('')).toBe('{"path":"/tmp/b.ts"}');
+  });
+
+  it('passes fragments through untouched when there is no work dir', () => {
+    const stripper = createToolInputWorkDirStripper('');
+    expect(stripper.push('call_1', `{"path":"${WORK_DIR}/a.ts"}`)).toBe(
+      `{"path":"${WORK_DIR}/a.ts"}`,
+    );
+    expect(stripper.flush('call_1')).toBe('');
+  });
+});

--- a/packages/harness/src/agent/internal/tool-input-work-dir-stripper.ts
+++ b/packages/harness/src/agent/internal/tool-input-work-dir-stripper.ts
@@ -1,0 +1,80 @@
+import { stripString } from './strip-work-dir';
+
+/**
+ * Work-directory stripping for streamed tool input, which arrives as JSON
+ * fragments split at arbitrary offsets.
+ *
+ * Stripping each fragment on its own cannot work: the runtime can split a path
+ * anywhere, so `/vercel/sandbox/claude-code-abc123/src/a.ts` may arrive as
+ * `…claude-code-` + `abc123/src/a.ts` and neither half matches the prefix. The
+ * absolute path — which carries the session id — would then reach the client.
+ *
+ * So this holds back the longest suffix of the stream that could still turn
+ * out to be the start of a work-directory reference, and releases it once the
+ * next fragment proves it either is or is not one. The held-back tail is
+ * bounded by the work directory's own length, so a caller never waits on more
+ * than that many characters, and {@link flush} releases whatever is left when
+ * the input ends.
+ */
+export interface ToolInputWorkDirStripper {
+  /** Stripped text safe to forward now. May be empty when all of it is held. */
+  push(toolCallId: string, delta: string): string;
+  /** Remaining held-back text, stripped. Call when the input block closes. */
+  flush(toolCallId: string): string;
+}
+
+export function createToolInputWorkDirStripper(
+  sessionWorkDir: string,
+): ToolInputWorkDirStripper {
+  /*
+   * Correctness guard, not a fast path: with an empty work directory
+   * `stripString` would rewrite every fragment character by character.
+   */
+  if (sessionWorkDir.length === 0) {
+    return { push: (_toolCallId, delta) => delta, flush: () => '' };
+  }
+
+  /*
+   * Match against the directory plus a separator: it has the bare directory as
+   * a prefix, so holding back against it covers both the `workDir/path` and
+   * bare `workDir` forms that `stripString` rewrites.
+   */
+  const pattern = `${sessionWorkDir}/`;
+  const held = new Map<string, string>();
+
+  return {
+    push(toolCallId, delta) {
+      const combined = (held.get(toolCallId) ?? '') + delta;
+      const holdFrom = combined.length - partialSuffixLength(combined, pattern);
+      held.set(toolCallId, combined.slice(holdFrom));
+      return stripString(combined.slice(0, holdFrom), sessionWorkDir);
+    },
+
+    flush(toolCallId) {
+      const remainder = held.get(toolCallId) ?? '';
+      held.delete(toolCallId);
+      return stripString(remainder, sessionWorkDir);
+    },
+  };
+}
+
+/**
+ * Length of the longest suffix of `value` that is a proper prefix of
+ * `pattern` — i.e. how much of the tail might still grow into a full match.
+ * Zero when the tail cannot begin one.
+ */
+function partialSuffixLength(value: string, pattern: string): number {
+  /*
+   * A tail that already completes the pattern is not partial: `stripString`
+   * rewrites it correctly, so hold nothing. Without this the trailing
+   * separator alone reads as a fresh partial match, the bare directory before
+   * it gets released, and `workDir/` is rewritten as `.` + `/` instead of ``.
+   */
+  if (value.endsWith(pattern)) return 0;
+
+  const max = Math.min(value.length, pattern.length - 1);
+  for (let length = max; length > 0; length--) {
+    if (value.endsWith(pattern.slice(0, length))) return length;
+  }
+  return 0;
+}

--- a/packages/harness/src/agent/internal/translate-stream-part.test.ts
+++ b/packages/harness/src/agent/internal/translate-stream-part.test.ts
@@ -15,6 +15,77 @@ describe('translateStreamPart', () => {
     expect(out).toHaveLength(0);
   });
 
+  it('renames toolCallId to id on the streamed tool-input parts', () => {
+    expect(
+      translateStreamPart<ToolSet>({
+        type: 'tool-input-start',
+        toolCallId: 'c1',
+        toolName: 'bash',
+        providerExecuted: true,
+      }),
+    ).toEqual([
+      {
+        type: 'tool-input-start',
+        id: 'c1',
+        toolName: 'bash',
+        providerExecuted: true,
+      },
+    ]);
+
+    expect(
+      translateStreamPart<ToolSet>({
+        type: 'tool-input-delta',
+        toolCallId: 'c1',
+        delta: '{"command":',
+      }),
+    ).toEqual([{ type: 'tool-input-delta', id: 'c1', delta: '{"command":' }]);
+
+    expect(
+      translateStreamPart<ToolSet>({
+        type: 'tool-input-end',
+        toolCallId: 'c1',
+      }),
+    ).toEqual([{ type: 'tool-input-end', id: 'c1' }]);
+  });
+
+  it('carries dynamic and providerMetadata through tool-input-start', () => {
+    const out = translateStreamPart<ToolSet>({
+      type: 'tool-input-start',
+      toolCallId: 'c1',
+      toolName: 'mcp__weather__current',
+      providerExecuted: true,
+      dynamic: true,
+      providerMetadata: {
+        'claude-code': { nativeName: 'mcp__weather__current' },
+      },
+    });
+
+    expect(out).toEqual([
+      {
+        type: 'tool-input-start',
+        id: 'c1',
+        toolName: 'mcp__weather__current',
+        providerExecuted: true,
+        dynamic: true,
+        providerMetadata: {
+          'claude-code': { nativeName: 'mcp__weather__current' },
+        },
+      },
+    ]);
+  });
+
+  it('omits absent optional fields on tool-input-start', () => {
+    const out = translateStreamPart<ToolSet>({
+      type: 'tool-input-start',
+      toolCallId: 'c1',
+      toolName: 'bash',
+    });
+
+    expect(out[0]).not.toHaveProperty('dynamic');
+    expect(out[0]).not.toHaveProperty('providerExecuted');
+    expect(out[0]).not.toHaveProperty('providerMetadata');
+  });
+
   it('preserves dynamic on a tool-result event', () => {
     const out = translateStreamPart<ToolSet>({
       type: 'tool-result',

--- a/packages/harness/src/agent/internal/translate-stream-part.ts
+++ b/packages/harness/src/agent/internal/translate-stream-part.ts
@@ -103,6 +103,45 @@ export function translateStreamPart<TOOLS extends ToolSet>(
         } as TextStreamPart<TOOLS>,
       ];
 
+    case 'tool-input-start':
+      /*
+       * The wire calls the correlation key `toolCallId` (like every other
+       * tool part); the AI SDK part calls it `id`. `dynamic` is forwarded
+       * verbatim — the same field `validateToolCall` forwards from the
+       * settled `tool-call` — so both parts key the same UI part.
+       */
+      return [
+        {
+          type: 'tool-input-start',
+          id: event.toolCallId,
+          toolName: event.toolName,
+          ...(event.providerExecuted !== undefined
+            ? { providerExecuted: event.providerExecuted }
+            : {}),
+          ...(event.dynamic !== undefined ? { dynamic: event.dynamic } : {}),
+          ...(event.providerMetadata !== undefined
+            ? { providerMetadata: event.providerMetadata }
+            : {}),
+        } as TextStreamPart<TOOLS>,
+      ];
+
+    case 'tool-input-delta':
+      return [
+        {
+          type: 'tool-input-delta',
+          id: event.toolCallId,
+          delta: event.delta,
+        } as TextStreamPart<TOOLS>,
+      ];
+
+    case 'tool-input-end':
+      return [
+        {
+          type: 'tool-input-end',
+          id: event.toolCallId,
+        } as TextStreamPart<TOOLS>,
+      ];
+
     case 'tool-call':
       // Tool-call validation is async (it parses input against the tool's
       // schema) and lives in `run-prompt.ts` where the merged tool set is in

--- a/packages/harness/src/v1/harness-v1-bridge-protocol.ts
+++ b/packages/harness/src/v1/harness-v1-bridge-protocol.ts
@@ -21,6 +21,9 @@ import {
   harnessV1TextStartPartSchema,
   harnessV1ToolApprovalRequestPartSchema,
   harnessV1ToolCallPartSchema,
+  harnessV1ToolInputDeltaPartSchema,
+  harnessV1ToolInputEndPartSchema,
+  harnessV1ToolInputStartPartSchema,
   harnessV1ToolResultPartSchema,
 } from './harness-v1-stream-part';
 
@@ -213,6 +216,9 @@ export const harnessV1BridgeOutboundMessageSchema = z.discriminatedUnion(
     harnessV1ReasoningStartPartSchema,
     harnessV1ReasoningDeltaPartSchema,
     harnessV1ReasoningEndPartSchema,
+    harnessV1ToolInputStartPartSchema,
+    harnessV1ToolInputDeltaPartSchema,
+    harnessV1ToolInputEndPartSchema,
     harnessV1ToolCallPartSchema,
     harnessV1ToolApprovalRequestPartSchema,
     harnessV1ToolResultPartSchema,

--- a/packages/harness/src/v1/harness-v1-stream-part.test.ts
+++ b/packages/harness/src/v1/harness-v1-stream-part.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { harnessV1BridgeOutboundMessageSchema } from './harness-v1-bridge-protocol';
+import { harnessV1StreamPartSchema } from './harness-v1-stream-part';
+
+/*
+ * A stream part that is missing from either union is rejected at the sandbox
+ * boundary and never reaches the agent — with nothing on the wire to say why.
+ * These assertions pin the tool-input parts into both.
+ */
+describe('tool-input stream parts', () => {
+  const parts = [
+    {
+      type: 'tool-input-start',
+      toolCallId: 'c1',
+      toolName: 'bash',
+      providerExecuted: true,
+    },
+    { type: 'tool-input-delta', toolCallId: 'c1', delta: '{"command":"ls"}' },
+    { type: 'tool-input-end', toolCallId: 'c1' },
+  ] as const;
+
+  it.each(parts)('is a member of the stream-part union: $type', part => {
+    expect(harnessV1StreamPartSchema.parse(part)).toEqual(part);
+  });
+
+  it.each(parts)('is a member of the bridge outbound union: $type', part => {
+    expect(harnessV1BridgeOutboundMessageSchema.parse(part)).toEqual(part);
+  });
+
+  it('accepts the optional dynamic + providerMetadata fields on the start', () => {
+    const part = {
+      type: 'tool-input-start',
+      toolCallId: 'c1',
+      toolName: 'mcp__weather__current',
+      providerExecuted: true,
+      dynamic: true,
+      providerMetadata: { 'claude-code': { nativeName: 'mcp__weather__x' } },
+    };
+    expect(harnessV1StreamPartSchema.parse(part)).toEqual(part);
+  });
+
+  it('rejects a start without a tool name', () => {
+    expect(
+      harnessV1StreamPartSchema.safeParse({
+        type: 'tool-input-start',
+        toolCallId: 'c1',
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/harness/src/v1/harness-v1-stream-part.ts
+++ b/packages/harness/src/v1/harness-v1-stream-part.ts
@@ -58,6 +58,30 @@ export type HarnessV1StreamPart =
     }
   | { type: 'reasoning-end'; id: string; harnessMetadata?: HarnessV1Metadata }
 
+  // Streaming tool input. Emitted while the runtime writes a tool call's
+  // input JSON, before the settled `tool-call` arrives carrying the same
+  // `toolCallId`. Adapters that can observe partial input opt in; the
+  // `tool-call` is still emitted either way, so consumers that ignore these
+  // parts see no change.
+  //
+  // The correlation key is named `toolCallId` (V4 names it `id` on its own
+  // `tool-input-*` variants) to match every other tool part on this wire —
+  // the agent renames it when projecting to AI SDK parts.
+  //
+  // `dynamic` mirrors what the adapter puts on the matching `tool-call`. It
+  // must agree with the settled call: AI SDK keys dynamic and static tool
+  // parts differently, so a mismatch opens two UI parts for one tool.
+  | {
+      type: 'tool-input-start';
+      toolCallId: string;
+      toolName: string;
+      providerExecuted?: boolean;
+      dynamic?: boolean;
+      providerMetadata?: SharedV4ProviderMetadata;
+    }
+  | { type: 'tool-input-delta'; toolCallId: string; delta: string }
+  | { type: 'tool-input-end'; toolCallId: string }
+
   // Tool calls, approvals, results — reuse V4 primitives.
   //
   // `nativeName` is the only harness-only extension on `tool-call`. It lets
@@ -258,6 +282,26 @@ export const harnessV1ReasoningEndPartSchema = z.object({
   harnessMetadata: harnessV1MetadataSchema.optional(),
 });
 
+export const harnessV1ToolInputStartPartSchema = z.object({
+  type: z.literal('tool-input-start'),
+  toolCallId: z.string(),
+  toolName: z.string(),
+  providerExecuted: z.boolean().optional(),
+  dynamic: z.boolean().optional(),
+  providerMetadata: harnessV1ProviderMetadataSchema.optional(),
+});
+
+export const harnessV1ToolInputDeltaPartSchema = z.object({
+  type: z.literal('tool-input-delta'),
+  toolCallId: z.string(),
+  delta: z.string(),
+});
+
+export const harnessV1ToolInputEndPartSchema = z.object({
+  type: z.literal('tool-input-end'),
+  toolCallId: z.string(),
+});
+
 export const harnessV1ToolCallPartSchema = z.object({
   type: z.literal('tool-call'),
   toolCallId: z.string(),
@@ -341,6 +385,9 @@ export const harnessV1StreamPartSchema = z.discriminatedUnion('type', [
   harnessV1ReasoningStartPartSchema,
   harnessV1ReasoningDeltaPartSchema,
   harnessV1ReasoningEndPartSchema,
+  harnessV1ToolInputStartPartSchema,
+  harnessV1ToolInputDeltaPartSchema,
+  harnessV1ToolInputEndPartSchema,
   harnessV1ToolCallPartSchema,
   harnessV1ToolApprovalRequestPartSchema,
   harnessV1ToolResultPartSchema,

--- a/packages/harness/src/v1/index.ts
+++ b/packages/harness/src/v1/index.ts
@@ -64,6 +64,9 @@ export {
   harnessV1TextStartPartSchema,
   harnessV1ToolApprovalRequestPartSchema,
   harnessV1ToolCallPartSchema,
+  harnessV1ToolInputDeltaPartSchema,
+  harnessV1ToolInputEndPartSchema,
+  harnessV1ToolInputStartPartSchema,
   harnessV1ToolResultPartSchema,
 } from './harness-v1-stream-part';
 export {

--- a/packages/workflow-harness/package.json
+++ b/packages/workflow-harness/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@types/node": "22.19.19",
     "@vercel/ai-tsconfig": "workspace:*",
+    "ai": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "5.8.3",
     "workflow": "4.6.0"

--- a/packages/workflow-harness/src/harness-workflow-state.ts
+++ b/packages/workflow-harness/src/harness-workflow-state.ts
@@ -60,9 +60,23 @@ export interface HarnessWorkflowStreamContext {
    * Cleared once the input settles (`tool-input-available` /
    * `tool-input-error`).
    */
-  readonly activeToolInputStreams?: Record<
+  /**
+   * Tool inputs still streaming when the slice ended, keyed by tool-call id.
+   * Both halves are replayed into the next slice, in order:
+   *
+   *  - `start` re-opens the part. A `tool-input-delta` for a tool call the
+   *    client never saw begin is a stream error.
+   *  - `text` is the input JSON received so far. Re-opening resets the
+   *    client's partial-JSON parser, so without it the next slice's fragments
+   *    parse as a fresh document and the rendered input collapses to whatever
+   *    the tail happens to spell.
+   *
+   * Cleared once the input settles (`tool-input-available` /
+   * `tool-input-error`).
+   */
+  readonly activeToolInputs?: Record<
     string,
-    HarnessWorkflowSerializedChunk
+    { readonly start: HarnessWorkflowSerializedChunk; readonly text: string }
   >;
 }
 

--- a/packages/workflow-harness/src/harness-workflow-state.ts
+++ b/packages/workflow-harness/src/harness-workflow-state.ts
@@ -53,6 +53,17 @@ export interface HarnessWorkflowStreamContext {
     HarnessWorkflowSerializedChunk
   >;
   readonly pendingToolInputs?: Record<string, HarnessWorkflowSerializedChunk>;
+  /**
+   * `tool-input-start` chunks for tool inputs still streaming when the slice
+   * ended, keyed by tool-call id. Replayed as a prelude in the next slice —
+   * a `tool-input-delta` whose start the client never saw is a stream error.
+   * Cleared once the input settles (`tool-input-available` /
+   * `tool-input-error`).
+   */
+  readonly activeToolInputStreams?: Record<
+    string,
+    HarnessWorkflowSerializedChunk
+  >;
 }
 
 /**

--- a/packages/workflow-harness/src/run-harness-agent-slice.test.ts
+++ b/packages/workflow-harness/src/run-harness-agent-slice.test.ts
@@ -573,6 +573,138 @@ describe('runHarnessAgentTimeSlice', () => {
     ]);
   });
 
+  test('continued slice replays tool-input-start before a delta from the previous slice', async () => {
+    const firstSession = fakeSession();
+    const { result: firstResult, closeForSuspend } = streamResult({
+      chunks: [
+        { type: 'start' },
+        {
+          type: 'tool-input-start',
+          toolCallId: 'call_1',
+          toolName: 'write',
+          providerExecuted: true,
+        },
+        {
+          type: 'tool-input-delta',
+          toolCallId: 'call_1',
+          inputTextDelta: '{"path":',
+        },
+      ],
+      blockAfter: true,
+    });
+    const suspendingSession = firstSession as unknown as {
+      suspendTurn: () => Promise<HarnessV1ContinueTurnState>;
+    };
+    const originalSuspend = suspendingSession.suspendTurn.bind(firstSession);
+    suspendingSession.suspendTurn = async () => {
+      closeForSuspend();
+      return originalSuspend();
+    };
+
+    const firstAgent: HarnessWorkflowAgent = {
+      createSession: vi.fn(async () => firstSession),
+      stream: vi.fn(async () => firstResult),
+      continueStream: vi.fn(async () => {
+        throw new Error('continue should not be called on the first slice');
+      }),
+    };
+
+    const readyForNextStep = await runHarnessAgentTimeSlice({
+      agent: firstAgent,
+      state: createHarnessWorkflowState({ prompt: 'hi', sessionId: 'ses_1' }),
+      timeSliceSeconds: 0.05,
+      writable: collectingWritable().writable,
+    });
+
+    expect(readyForNextStep.streamContext?.activeToolInputStreams).toEqual({
+      call_1: {
+        type: 'tool-input-start',
+        toolCallId: 'call_1',
+        toolName: 'write',
+        providerExecuted: true,
+      },
+    });
+
+    // The second slice also suspends, so its stream context is persisted and
+    // the clear-on-settle can be asserted.
+    const secondSession = fakeSession();
+    const { result: secondResult, closeForSuspend: closeSecondForSuspend } =
+      streamResult({
+        chunks: [
+          { type: 'start' },
+          {
+            type: 'tool-input-delta',
+            toolCallId: 'call_1',
+            inputTextDelta: '"app/page.tsx"}',
+          },
+          {
+            type: 'tool-input-available',
+            toolCallId: 'call_1',
+            toolName: 'write',
+            input: { path: 'app/page.tsx' },
+            providerExecuted: true,
+          },
+        ],
+        blockAfter: true,
+      });
+    const secondSuspending = secondSession as unknown as {
+      suspendTurn: () => Promise<HarnessV1ContinueTurnState>;
+    };
+    const originalSecondSuspend =
+      secondSuspending.suspendTurn.bind(secondSession);
+    secondSuspending.suspendTurn = async () => {
+      closeSecondForSuspend();
+      return originalSecondSuspend();
+    };
+    const secondAgent: HarnessWorkflowAgent = {
+      createSession: vi.fn(async () => secondSession),
+      stream: vi.fn(async () => {
+        throw new Error('stream should not be called on a continued slice');
+      }),
+      continueStream: vi.fn(async () => secondResult),
+    };
+    const secondWritable = collectingWritable();
+
+    const afterSecondSlice = await runHarnessAgentTimeSlice({
+      agent: secondAgent,
+      state: readyForNextStep,
+      timeSliceSeconds: 0.05,
+      writable: secondWritable.writable,
+    });
+
+    expect(afterSecondSlice.status).toBe('ready_for_next_step');
+    // The replayed start comes first: without it the client rejects a delta
+    // for a tool call it never saw begin.
+    expect(secondWritable.chunks).toEqual([
+      {
+        type: 'tool-input-start',
+        toolCallId: 'call_1',
+        toolName: 'write',
+        providerExecuted: true,
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'call_1',
+        inputTextDelta: '"app/page.tsx"}',
+      },
+      {
+        type: 'tool-input-available',
+        toolCallId: 'call_1',
+        toolName: 'write',
+        input: { path: 'app/page.tsx' },
+        providerExecuted: true,
+      },
+    ]);
+    // The settled input clears the replay entry, so a later slice does not
+    // re-open a tool part that already resolved.
+    expect(
+      afterSecondSlice.streamContext?.activeToolInputStreams,
+    ).toBeUndefined();
+    expect(
+      Object.keys(afterSecondSlice.streamContext?.pendingToolInputs ?? {}),
+    ).toEqual(['call_1']);
+  });
+
   test('approval response messages resume through stream messages', async () => {
     const session = fakeSession();
     const { result } = streamResult({ chunks: [{ type: 'start' }] });

--- a/packages/workflow-harness/src/run-harness-agent-slice.test.ts
+++ b/packages/workflow-harness/src/run-harness-agent-slice.test.ts
@@ -1,3 +1,4 @@
+import { readUIMessageStream, type UIMessage } from 'ai';
 import { describe, expect, test, vi } from 'vitest';
 import type {
   HarnessV1ContinueTurnState,
@@ -124,6 +125,39 @@ function streamResult(opts: {
     ),
   };
   return { result, closeForSuspend: () => close?.() };
+}
+
+/**
+ * Replay a slice's chunks through the UI reducer, continuing a prior message —
+ * what a `useChat`-style client would end up rendering.
+ */
+async function toUIMessage(
+  chunks: HarnessWorkflowChunk[],
+  previous?: UIMessage,
+): Promise<UIMessage | undefined> {
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+
+  let latest = previous;
+  for await (const message of readUIMessageStream({
+    stream: stream as never,
+    ...(previous != null ? { message: previous } : {}),
+  })) {
+    latest = message;
+  }
+  return latest;
+}
+
+function toolParts(
+  message: UIMessage | undefined,
+): Array<{ state?: string; input?: unknown }> {
+  return (message?.parts ?? []).filter(part =>
+    part.type.startsWith('tool-'),
+  ) as Array<{ state?: string; input?: unknown }>;
 }
 
 function collectingWritable(): {
@@ -559,6 +593,7 @@ describe('runHarnessAgentTimeSlice', () => {
     const { result: firstResult, closeForSuspend } = streamResult({
       chunks: [
         { type: 'start' },
+        { type: 'start-step' },
         {
           type: 'tool-input-start',
           toolCallId: 'call_1',
@@ -583,19 +618,23 @@ describe('runHarnessAgentTimeSlice', () => {
       }),
     };
 
+    const firstWritable = collectingWritable();
     const readyForNextStep = await runHarnessAgentTimeSlice({
       agent: firstAgent,
       state: createHarnessWorkflowState({ prompt: 'hi', sessionId: 'ses_1' }),
       timeSliceSeconds: 0.05,
-      writable: collectingWritable().writable,
+      writable: firstWritable.writable,
     });
 
-    expect(readyForNextStep.streamContext?.activeToolInputStreams).toEqual({
+    expect(readyForNextStep.streamContext?.activeToolInputs).toEqual({
       call_1: {
-        type: 'tool-input-start',
-        toolCallId: 'call_1',
-        toolName: 'write',
-        providerExecuted: true,
+        start: {
+          type: 'tool-input-start',
+          toolCallId: 'call_1',
+          toolName: 'write',
+          providerExecuted: true,
+        },
+        text: '{"path":',
       },
     });
 
@@ -605,6 +644,7 @@ describe('runHarnessAgentTimeSlice', () => {
       streamResult({
         chunks: [
           { type: 'start' },
+          { type: 'start-step' },
           {
             type: 'tool-input-delta',
             toolCallId: 'call_1',
@@ -638,14 +678,19 @@ describe('runHarnessAgentTimeSlice', () => {
     });
 
     expect(afterSecondSlice.status).toBe('ready_for_next_step');
-    // The replayed start comes first: without it the client rejects a delta
-    // for a tool call it never saw begin.
+    // The replayed start, then the input received so far, then this slice's
+    // own chunks. The re-announced `start-step` is dropped.
     expect(secondWritable.chunks).toEqual([
       {
         type: 'tool-input-start',
         toolCallId: 'call_1',
         toolName: 'write',
         providerExecuted: true,
+      },
+      {
+        type: 'tool-input-delta',
+        toolCallId: 'call_1',
+        inputTextDelta: '{"path":',
       },
       {
         type: 'tool-input-delta',
@@ -662,12 +707,37 @@ describe('runHarnessAgentTimeSlice', () => {
     ]);
     // The settled input clears the replay entry, so a later slice does not
     // re-open a tool part that already resolved.
-    expect(
-      afterSecondSlice.streamContext?.activeToolInputStreams,
-    ).toBeUndefined();
+    expect(afterSecondSlice.streamContext?.activeToolInputs).toBeUndefined();
     expect(
       Object.keys(afterSecondSlice.streamContext?.pendingToolInputs ?? {}),
     ).toEqual(['call_1']);
+
+    /*
+     * What the client makes of those chunks, which the assertions above
+     * cannot show. Two things regress silently at the chunk level:
+     *
+     *  - ONE part. `tool-input-*` resolves its part within the current step,
+     *    so a step boundary in the continued slice would open a second part
+     *    and strand the first (#18348, reached from the streaming side).
+     *  - The object CONTINUES. Re-opening resets the incremental parser, so
+     *    without the replayed prefix the second slice parses
+     *    `"app/page.tsx"}` alone and the input collapses to a bare string.
+     */
+    const afterFirstRender = await toUIMessage(firstWritable.chunks);
+    expect(toolParts(afterFirstRender)).toEqual([
+      expect.objectContaining({ state: 'input-streaming' }),
+    ]);
+
+    const afterSecondRender = await toUIMessage(
+      secondWritable.chunks,
+      afterFirstRender,
+    );
+    expect(toolParts(afterSecondRender)).toEqual([
+      expect.objectContaining({
+        state: 'input-available',
+        input: { path: 'app/page.tsx' },
+      }),
+    ]);
   });
 
   test('approval response messages resume through stream messages', async () => {

--- a/packages/workflow-harness/src/run-harness-agent-slice.test.ts
+++ b/packages/workflow-harness/src/run-harness-agent-slice.test.ts
@@ -39,6 +39,11 @@ function fakeSession(
   options: {
     unfinishedTurn?: boolean;
     suspendState?: HarnessV1ContinueTurnState;
+    /**
+     * Runs before the suspend resolves — pair it with `streamResult`'s
+     * `closeForSuspend` so a blocked stream ends when the slice is torn down.
+     */
+    onSuspend?: () => void;
   } = {},
 ): HarnessAgentSession & {
   suspendCalls: number;
@@ -57,6 +62,7 @@ function fakeSession(
     },
     async suspendTurn() {
       session.suspendCalls++;
+      options.onSuspend?.();
       return options.suspendState ?? continueState('suspended');
     },
     async detach() {
@@ -312,19 +318,11 @@ describe('runHarnessAgentTimeSlice', () => {
   });
 
   test('completes the time slice: suspends at the budget and carries the cursor forward', async () => {
-    const session = fakeSession();
     const { result, closeForSuspend } = streamResult({
       chunks: [{ type: 'start' }, { type: 'text-delta', id: 't', delta: 'a' }],
       blockAfter: true,
     });
-    const suspendingSession = session as unknown as {
-      suspendTurn: () => Promise<HarnessV1ContinueTurnState>;
-    };
-    const originalSuspend = suspendingSession.suspendTurn.bind(session);
-    suspendingSession.suspendTurn = async () => {
-      closeForSuspend();
-      return originalSuspend();
-    };
+    const session = fakeSession({ onSuspend: closeForSuspend });
 
     const agent: HarnessWorkflowAgent = {
       createSession: vi.fn(async () => session),
@@ -390,7 +388,6 @@ describe('runHarnessAgentTimeSlice', () => {
   });
 
   test('continued slice reopens active parts and preserves aggregate token usage', async () => {
-    const firstSession = fakeSession();
     const { result: firstResult, closeForSuspend } = streamResult({
       chunks: [
         { type: 'start' },
@@ -401,14 +398,7 @@ describe('runHarnessAgentTimeSlice', () => {
       ],
       blockAfter: true,
     });
-    const suspendingSession = firstSession as unknown as {
-      suspendTurn: () => Promise<HarnessV1ContinueTurnState>;
-    };
-    const originalSuspend = suspendingSession.suspendTurn.bind(firstSession);
-    suspendingSession.suspendTurn = async () => {
-      closeForSuspend();
-      return originalSuspend();
-    };
+    const firstSession = fakeSession({ onSuspend: closeForSuspend });
 
     const firstAgent: HarnessWorkflowAgent = {
       createSession: vi.fn(async () => firstSession),
@@ -483,7 +473,6 @@ describe('runHarnessAgentTimeSlice', () => {
   });
 
   test('continued slice emits a pending tool input only once across the time-slice boundary', async () => {
-    const firstSession = fakeSession();
     const { result: firstResult, closeForSuspend } = streamResult({
       chunks: [
         { type: 'start' },
@@ -498,14 +487,7 @@ describe('runHarnessAgentTimeSlice', () => {
       ],
       blockAfter: true,
     });
-    const suspendingSession = firstSession as unknown as {
-      suspendTurn: () => Promise<HarnessV1ContinueTurnState>;
-    };
-    const originalSuspend = suspendingSession.suspendTurn.bind(firstSession);
-    suspendingSession.suspendTurn = async () => {
-      closeForSuspend();
-      return originalSuspend();
-    };
+    const firstSession = fakeSession({ onSuspend: closeForSuspend });
 
     const firstAgent: HarnessWorkflowAgent = {
       createSession: vi.fn(async () => firstSession),
@@ -574,7 +556,6 @@ describe('runHarnessAgentTimeSlice', () => {
   });
 
   test('continued slice replays tool-input-start before a delta from the previous slice', async () => {
-    const firstSession = fakeSession();
     const { result: firstResult, closeForSuspend } = streamResult({
       chunks: [
         { type: 'start' },
@@ -592,14 +573,7 @@ describe('runHarnessAgentTimeSlice', () => {
       ],
       blockAfter: true,
     });
-    const suspendingSession = firstSession as unknown as {
-      suspendTurn: () => Promise<HarnessV1ContinueTurnState>;
-    };
-    const originalSuspend = suspendingSession.suspendTurn.bind(firstSession);
-    suspendingSession.suspendTurn = async () => {
-      closeForSuspend();
-      return originalSuspend();
-    };
+    const firstSession = fakeSession({ onSuspend: closeForSuspend });
 
     const firstAgent: HarnessWorkflowAgent = {
       createSession: vi.fn(async () => firstSession),
@@ -627,7 +601,6 @@ describe('runHarnessAgentTimeSlice', () => {
 
     // The second slice also suspends, so its stream context is persisted and
     // the clear-on-settle can be asserted.
-    const secondSession = fakeSession();
     const { result: secondResult, closeForSuspend: closeSecondForSuspend } =
       streamResult({
         chunks: [
@@ -647,15 +620,7 @@ describe('runHarnessAgentTimeSlice', () => {
         ],
         blockAfter: true,
       });
-    const secondSuspending = secondSession as unknown as {
-      suspendTurn: () => Promise<HarnessV1ContinueTurnState>;
-    };
-    const originalSecondSuspend =
-      secondSuspending.suspendTurn.bind(secondSession);
-    secondSuspending.suspendTurn = async () => {
-      closeSecondForSuspend();
-      return originalSecondSuspend();
-    };
+    const secondSession = fakeSession({ onSuspend: closeSecondForSuspend });
     const secondAgent: HarnessWorkflowAgent = {
       createSession: vi.fn(async () => secondSession),
       stream: vi.fn(async () => {
@@ -828,19 +793,11 @@ describe('runHarnessAgentStep', () => {
 
 describe('runHarnessAgentSlice', () => {
   test('supports sliceTimeoutSeconds and maps ready_for_next_step to timed_out', async () => {
-    const session = fakeSession();
     const { result, closeForSuspend } = streamResult({
       chunks: [{ type: 'start' }],
       blockAfter: true,
     });
-    const suspendingSession = session as unknown as {
-      suspendTurn: () => Promise<HarnessV1ContinueTurnState>;
-    };
-    const originalSuspend = suspendingSession.suspendTurn.bind(session);
-    suspendingSession.suspendTurn = async () => {
-      closeForSuspend();
-      return originalSuspend();
-    };
+    const session = fakeSession({ onSuspend: closeForSuspend });
     const agent: HarnessWorkflowAgent = {
       createSession: vi.fn(async () => session),
       stream: vi.fn(async () => result),

--- a/packages/workflow-harness/src/run-harness-agent.ts
+++ b/packages/workflow-harness/src/run-harness-agent.ts
@@ -161,6 +161,19 @@ export async function runHarnessAgent(
   (timer as { unref?: () => void } | undefined)?.unref?.();
 
   let sawError = false;
+  /*
+   * A tool input still streaming when the previous slice ended has to finish
+   * inside the step that opened it. `tool-input-start` / `-delta` /
+   * `-available` resolve their part within the current step, so if the
+   * continued slice opens a new one the re-opened input lands in a second
+   * part and the first is left pending forever — the same duplicate-render
+   * failure as #18348, reached from the streaming side. The turn was
+   * suspended mid-step, so the continuation belongs to that same step: drop
+   * the boundary the resumed stream re-announces.
+   */
+  let resumedStepBoundaryToDrop =
+    state.continueFrom != null &&
+    Object.keys(streamContext.activeToolInputs).length > 0;
   // Tracks whether the writable was closed (only on a finished turn). The
   // `finally` then releases the lock only when we did NOT close, since closing
   // already releases it.
@@ -182,6 +195,10 @@ export async function runHarnessAgent(
          */
         if (value.type === 'start' && state.continueFrom != null) continue;
         if (value.type === 'finish') continue;
+        if (value.type === 'start-step' && resumedStepBoundaryToDrop) {
+          resumedStepBoundaryToDrop = false;
+          continue;
+        }
         if (value.type === 'error') {
           const errorText = (value as { errorText?: unknown }).errorText;
           /*
@@ -341,7 +358,10 @@ type MutableStreamContext = {
   activeTextParts: Record<string, HarnessWorkflowSerializedChunk>;
   activeReasoningParts: Record<string, HarnessWorkflowSerializedChunk>;
   pendingToolInputs: Record<string, HarnessWorkflowSerializedChunk>;
-  activeToolInputStreams: Record<string, HarnessWorkflowSerializedChunk>;
+  activeToolInputs: Record<
+    string,
+    { start: HarnessWorkflowSerializedChunk; text: string }
+  >;
 };
 
 type ExecutionPartState = {
@@ -357,7 +377,7 @@ function createMutableStreamContext(
     activeTextParts: { ...(context?.activeTextParts ?? {}) },
     activeReasoningParts: { ...(context?.activeReasoningParts ?? {}) },
     pendingToolInputs: { ...(context?.pendingToolInputs ?? {}) },
-    activeToolInputStreams: { ...(context?.activeToolInputStreams ?? {}) },
+    activeToolInputs: { ...(context?.activeToolInputs ?? {}) },
   };
 }
 
@@ -409,23 +429,35 @@ async function writeRequiredPrelude(options: {
 
   /*
    * A tool input can still be streaming when a slice ends, so its deltas
-   * continue in the next one. Re-open the part first — the client rejects a
-   * `tool-input-delta` for a tool call it never saw start. Only the deltas of
-   * this slice accumulate into the re-opened part; the settled
-   * `tool-input-available` replaces the partial input with the whole thing.
+   * continue in the next one. Re-open the part and restore what the client
+   * had parsed — see `activeToolInputs` for why both halves are needed.
    *
-   * A *settled* input is deliberately not replayed here — see #18348, where
-   * replaying one across a slice boundary opened a second UI part. This
-   * replay is confined to inputs that are still streaming, which the client
-   * rejects outright without their start.
+   * A *settled* input is deliberately not replayed — see #18348, where
+   * replaying one across a slice boundary opened a second UI part. This is
+   * confined to inputs still streaming, which the client rejects outright
+   * without their start.
    */
   if (chunk.type === 'tool-input-delta') {
-    await replayOnce({
-      writer,
-      key: stringProperty({ chunk, key: 'toolCallId' }),
-      carried: streamContext.activeToolInputStreams,
-      written: executionPartState.openedToolInputStreams,
-    });
+    const toolCallId = stringProperty({ chunk, key: 'toolCallId' });
+    if (toolCallId == null) return;
+
+    const carried = streamContext.activeToolInputs[toolCallId];
+    if (
+      carried == null ||
+      executionPartState.openedToolInputStreams.has(toolCallId)
+    ) {
+      return;
+    }
+
+    executionPartState.openedToolInputStreams.add(toolCallId);
+    await writer.write(carried.start);
+    if (carried.text.length > 0) {
+      await writer.write({
+        type: 'tool-input-delta',
+        toolCallId,
+        inputTextDelta: carried.text,
+      });
+    }
   }
 }
 
@@ -480,20 +512,34 @@ function recordWorkflowChunk(options: {
   }
 
   if (chunk.type === 'tool-input-start' && toolCallId != null) {
-    streamContext.activeToolInputStreams[toolCallId] = cloneChunk(chunk);
+    streamContext.activeToolInputs[toolCallId] = {
+      start: cloneChunk(chunk),
+      text: '',
+    };
     executionPartState.openedToolInputStreams.add(toolCallId);
+    return;
+  }
+
+  // Accumulate the input alongside its start; see `activeToolInputs`. Only
+  // while it is still streaming — a delta with no live start is not ours.
+  if (chunk.type === 'tool-input-delta' && toolCallId != null) {
+    const active = streamContext.activeToolInputs[toolCallId];
+    const delta = stringProperty({ chunk, key: 'inputTextDelta' });
+    if (active != null && delta != null) {
+      active.text += delta;
+    }
     return;
   }
 
   if (chunk.type === 'tool-input-available' && toolCallId != null) {
     streamContext.pendingToolInputs[toolCallId] = cloneChunk(chunk);
-    delete streamContext.activeToolInputStreams[toolCallId];
+    delete streamContext.activeToolInputs[toolCallId];
     return;
   }
 
   if (chunk.type === 'tool-input-error' && toolCallId != null) {
     delete streamContext.pendingToolInputs[toolCallId];
-    delete streamContext.activeToolInputStreams[toolCallId];
+    delete streamContext.activeToolInputs[toolCallId];
     return;
   }
 
@@ -543,8 +589,8 @@ function serializeStreamContextField(context: MutableStreamContext): {
     ...(Object.keys(context.pendingToolInputs).length > 0
       ? { pendingToolInputs: context.pendingToolInputs }
       : {}),
-    ...(Object.keys(context.activeToolInputStreams).length > 0
-      ? { activeToolInputStreams: context.activeToolInputStreams }
+    ...(Object.keys(context.activeToolInputs).length > 0
+      ? { activeToolInputs: context.activeToolInputs }
       : {}),
   };
   return Object.keys(streamContext).length > 0 ? { streamContext } : {};

--- a/packages/workflow-harness/src/run-harness-agent.ts
+++ b/packages/workflow-harness/src/run-harness-agent.ts
@@ -389,24 +389,22 @@ async function writeRequiredPrelude(options: {
   const { chunk, writer, streamContext, executionPartState } = options;
   const id = stringProperty({ chunk, key: 'id' });
 
-  if (
-    (chunk.type === 'text-delta' || chunk.type === 'text-end') &&
-    id != null &&
-    streamContext.activeTextParts[id] != null &&
-    !executionPartState.openedTextParts.has(id)
-  ) {
-    await writer.write(streamContext.activeTextParts[id]);
-    executionPartState.openedTextParts.add(id);
+  if (chunk.type === 'text-delta' || chunk.type === 'text-end') {
+    await replayOnce({
+      writer,
+      key: id,
+      carried: streamContext.activeTextParts,
+      written: executionPartState.openedTextParts,
+    });
   }
 
-  if (
-    (chunk.type === 'reasoning-delta' || chunk.type === 'reasoning-end') &&
-    id != null &&
-    streamContext.activeReasoningParts[id] != null &&
-    !executionPartState.openedReasoningParts.has(id)
-  ) {
-    await writer.write(streamContext.activeReasoningParts[id]);
-    executionPartState.openedReasoningParts.add(id);
+  if (chunk.type === 'reasoning-delta' || chunk.type === 'reasoning-end') {
+    await replayOnce({
+      writer,
+      key: id,
+      carried: streamContext.activeReasoningParts,
+      written: executionPartState.openedReasoningParts,
+    });
   }
 
   /*
@@ -422,16 +420,30 @@ async function writeRequiredPrelude(options: {
    * rejects outright without their start.
    */
   if (chunk.type === 'tool-input-delta') {
-    const toolCallId = stringProperty({ chunk, key: 'toolCallId' });
-    if (
-      toolCallId != null &&
-      streamContext.activeToolInputStreams[toolCallId] != null &&
-      !executionPartState.openedToolInputStreams.has(toolCallId)
-    ) {
-      await writer.write(streamContext.activeToolInputStreams[toolCallId]);
-      executionPartState.openedToolInputStreams.add(toolCallId);
-    }
+    await replayOnce({
+      writer,
+      key: stringProperty({ chunk, key: 'toolCallId' }),
+      carried: streamContext.activeToolInputStreams,
+      written: executionPartState.openedToolInputStreams,
+    });
   }
+}
+
+/**
+ * Write a chunk carried over from an earlier slice, at most once per
+ * execution. A no-op when the chunk originated in this slice (nothing was
+ * carried) or when it has already been replayed.
+ */
+async function replayOnce(options: {
+  writer: WritableStreamDefaultWriter<HarnessWorkflowChunk>;
+  key: string | undefined;
+  carried: Record<string, HarnessWorkflowSerializedChunk>;
+  written: Set<string>;
+}): Promise<void> {
+  const { writer, key, carried, written } = options;
+  if (key == null || carried[key] == null || written.has(key)) return;
+  await writer.write(carried[key]);
+  written.add(key);
 }
 
 function recordWorkflowChunk(options: {

--- a/packages/workflow-harness/src/run-harness-agent.ts
+++ b/packages/workflow-harness/src/run-harness-agent.ts
@@ -341,11 +341,13 @@ type MutableStreamContext = {
   activeTextParts: Record<string, HarnessWorkflowSerializedChunk>;
   activeReasoningParts: Record<string, HarnessWorkflowSerializedChunk>;
   pendingToolInputs: Record<string, HarnessWorkflowSerializedChunk>;
+  activeToolInputStreams: Record<string, HarnessWorkflowSerializedChunk>;
 };
 
 type ExecutionPartState = {
   openedTextParts: Set<string>;
   openedReasoningParts: Set<string>;
+  openedToolInputStreams: Set<string>;
 };
 
 function createMutableStreamContext(
@@ -355,6 +357,7 @@ function createMutableStreamContext(
     activeTextParts: { ...(context?.activeTextParts ?? {}) },
     activeReasoningParts: { ...(context?.activeReasoningParts ?? {}) },
     pendingToolInputs: { ...(context?.pendingToolInputs ?? {}) },
+    activeToolInputStreams: { ...(context?.activeToolInputStreams ?? {}) },
   };
 }
 
@@ -362,6 +365,7 @@ function createExecutionPartState(): ExecutionPartState {
   return {
     openedTextParts: new Set(),
     openedReasoningParts: new Set(),
+    openedToolInputStreams: new Set(),
   };
 }
 
@@ -404,6 +408,30 @@ async function writeRequiredPrelude(options: {
     await writer.write(streamContext.activeReasoningParts[id]);
     executionPartState.openedReasoningParts.add(id);
   }
+
+  /*
+   * A tool input can still be streaming when a slice ends, so its deltas
+   * continue in the next one. Re-open the part first — the client rejects a
+   * `tool-input-delta` for a tool call it never saw start. Only the deltas of
+   * this slice accumulate into the re-opened part; the settled
+   * `tool-input-available` replaces the partial input with the whole thing.
+   *
+   * A *settled* input is deliberately not replayed here — see #18348, where
+   * replaying one across a slice boundary opened a second UI part. This
+   * replay is confined to inputs that are still streaming, which the client
+   * rejects outright without their start.
+   */
+  if (chunk.type === 'tool-input-delta') {
+    const toolCallId = stringProperty({ chunk, key: 'toolCallId' });
+    if (
+      toolCallId != null &&
+      streamContext.activeToolInputStreams[toolCallId] != null &&
+      !executionPartState.openedToolInputStreams.has(toolCallId)
+    ) {
+      await writer.write(streamContext.activeToolInputStreams[toolCallId]);
+      executionPartState.openedToolInputStreams.add(toolCallId);
+    }
+  }
 }
 
 function recordWorkflowChunk(options: {
@@ -439,13 +467,21 @@ function recordWorkflowChunk(options: {
     return;
   }
 
+  if (chunk.type === 'tool-input-start' && toolCallId != null) {
+    streamContext.activeToolInputStreams[toolCallId] = cloneChunk(chunk);
+    executionPartState.openedToolInputStreams.add(toolCallId);
+    return;
+  }
+
   if (chunk.type === 'tool-input-available' && toolCallId != null) {
     streamContext.pendingToolInputs[toolCallId] = cloneChunk(chunk);
+    delete streamContext.activeToolInputStreams[toolCallId];
     return;
   }
 
   if (chunk.type === 'tool-input-error' && toolCallId != null) {
     delete streamContext.pendingToolInputs[toolCallId];
+    delete streamContext.activeToolInputStreams[toolCallId];
     return;
   }
 
@@ -494,6 +530,9 @@ function serializeStreamContextField(context: MutableStreamContext): {
       : {}),
     ...(Object.keys(context.pendingToolInputs).length > 0
       ? { pendingToolInputs: context.pendingToolInputs }
+      : {}),
+    ...(Object.keys(context.activeToolInputStreams).length > 0
+      ? { activeToolInputStreams: context.activeToolInputStreams }
       : {}),
   };
   return Object.keys(streamContext).length > 0 ? { streamContext } : {};

--- a/packages/workflow-harness/tsconfig.json
+++ b/packages/workflow-harness/tsconfig.json
@@ -6,5 +6,5 @@
     "outDir": "dist"
   },
   "exclude": ["dist", "build", "node_modules", "tsup.config.ts"],
-  "references": [{ "path": "../harness" }]
+  "references": [{ "path": "../ai" }, { "path": "../harness" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4264,6 +4264,9 @@ importers:
       '@vercel/ai-tsconfig':
         specifier: workspace:*
         version: link:../../tools/tsconfig
+      ai:
+        specifier: workspace:*
+        version: link:../ai
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.26)(tsx@4.22.0)(typescript@5.8.3)(yaml@2.9.0)


### PR DESCRIPTION
## Background

While the model writes a tool call's input JSON, nothing reaches the client. Text and reasoning stream token by token; tool input was the only block type that did not, so a UI has no tool part to render until the whole input is complete — for a large tool call that is 20-30 seconds of an apparently idle thread. The Claude Code bridge already parsed the CLI's `input_json_delta` events and discarded them.

## Summary

Adds three stream parts — `tool-input-start`, `tool-input-delta`, `tool-input-end` — and carries them end to end. The settled `tool-call` still follows under the same tool call id with the parsed input, so consumers that ignore the new parts behave exactly as before.

- `@ai-sdk/harness`: add the three parts to `HarnessV1StreamPart` and its Zod encoding, to the bridge outbound union, and to the agent's `translateStreamPart`, work-dir stripping, and settled-input replay guard.
- `@ai-sdk/harness-claude-code`: emit the parts from the bridge on a `tool_use` block's `content_block_start` / `input_json_delta` / `content_block_stop`, and subscribe to them in the session's forwarded-event list. Tools hosted on the bridge's own MCP server are skipped — they never produce a `tool-call` on this wire, so a streamed input for one would never settle.
- `@ai-sdk/workflow-harness`: track in-flight tool-input streams in the persisted stream context and replay the start as a prelude when a delta arrives in a later slice, the way `activeTextParts` / `activeReasoningParts` already do. A `tool-input-delta` whose start the client never saw is a stream error.
- `tool-input-start` carries the same `dynamic` flag as the matching `tool-call`, so the streamed part and the settled call resolve to one UI part rather than two.
- Adds tests in all three packages, a runnable example, and a "Streaming Tool Input" section to the harness tools documentation.

A new wire part has to land in the adapter emit, both schema unions, the agent's translate step, and the session's forwarded-event list. The last one is the quiet one: the channel buffers a validated frame that has no subscriber rather than raising, so a missing entry drops the part with no error anywhere.

## End-to-End Verification

Verified against a local sandbox by invoking a tool whose input was large enough to take several seconds to write. The tool part appeared on the client as soon as the call opened and its input filled in progressively while the model was still writing it, rather than appearing only once the complete input had landed. The settled tool call then arrived under the same tool call id and replaced the partial input with the parsed one.

The same behavior was confirmed across a durable execution slice boundary: an input still streaming when a slice ended continued to render in the next slice, instead of failing on a delta whose start the client had never seen.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Coalesce `input_json_delta` fragments at the bridge before emitting. Each fragment is currently its own WebSocket frame and its own entry in both the turn's in-memory replay log and the sandbox's `event-log.ndjson`; for a large tool call that is several hundred frames and roughly triples the replay-log bytes on tool-heavy turns. Deltas are documented as arbitrary fragments, so coalescing is semantically free.
- The forwarded-event list in each adapter's `createSession` is hand-maintained and has drifted from the bridge outbound union — `compaction` is emitted by the Claude Code bridge but subscribed nowhere, so it is dropped silently today. Deriving the list from `harnessV1BridgeOutboundMessageSchema` with explicit per-adapter exclusions would remove this class of bug across the five adapters that each keep their own copy.
- An approval-gated external MCP tool's `tool-call` is emitted without `dynamic` while the `tool-result` for the same call carries `dynamic: true`. These should agree.
