### PR TITLE
fix(openai-compatible): preserve prompt cache hit usage

### DIFF
--- a/.changeset/openai-compatible-cache-hits.md
+++ b/.changeset/openai-compatible-cache-hits.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+Preserve top-level prompt cache hit usage as cache-read tokens for OpenAI-compatible chat providers.

--- a/packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.test.ts
+++ b/packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.test.ts
@@ -55,4 +55,43 @@ describe('convertOpenAICompatibleChatUsage', () => {
       raw: usage,
     });
   });
+
+  it('uses top-level prompt cache hit tokens as cache read tokens', () => {
+    const usage = {
+      prompt_tokens: 100,
+      completion_tokens: 20,
+      prompt_cache_hit_tokens: 40,
+    };
+
+    expect(convertOpenAICompatibleChatUsage(usage)).toEqual({
+      inputTokens: {
+        total: 100,
+        noCache: 60,
+        cacheRead: 40,
+        cacheWrite: undefined,
+      },
+      outputTokens: { total: 20, text: 20, reasoning: 0 },
+      raw: usage,
+    });
+  });
+
+  it('prefers prompt token details cache tokens over top-level cache hits', () => {
+    const usage = {
+      prompt_tokens: 100,
+      completion_tokens: 20,
+      prompt_cache_hit_tokens: 40,
+      prompt_tokens_details: { cached_tokens: 10 },
+    };
+
+    expect(convertOpenAICompatibleChatUsage(usage)).toEqual({
+      inputTokens: {
+        total: 100,
+        noCache: 90,
+        cacheRead: 10,
+        cacheWrite: undefined,
+      },
+      outputTokens: { total: 20, text: 20, reasoning: 0 },
+      raw: usage,
+    });
+  });
 });

--- a/packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.ts
+++ b/packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.ts
@@ -6,6 +6,7 @@ export function convertOpenAICompatibleChatUsage(
     | {
         prompt_tokens?: number | null;
         completion_tokens?: number | null;
+        prompt_cache_hit_tokens?: number | null;
         prompt_tokens_details?: {
           cached_tokens?: number | null;
         } | null;
@@ -22,7 +23,10 @@ export function convertOpenAICompatibleChatUsage(
 
   const promptTokens = usage.prompt_tokens ?? 0;
   const completionTokens = usage.completion_tokens ?? 0;
-  const cacheReadTokens = usage.prompt_tokens_details?.cached_tokens ?? 0;
+  const cacheReadTokens =
+    usage.prompt_tokens_details?.cached_tokens ??
+    usage.prompt_cache_hit_tokens ??
+    0;
   const reasoningTokens =
     usage.completion_tokens_details?.reasoning_tokens ?? 0;
 

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -737,6 +737,7 @@ const openaiCompatibleTokenUsageSchema = z
     prompt_tokens: z.number().nullish(),
     completion_tokens: z.number().nullish(),
     total_tokens: z.number().nullish(),
+    prompt_cache_hit_tokens: z.number().nullish(),
     prompt_tokens_details: z
       .object({
         cached_tokens: z.number().nullish(),


### PR DESCRIPTION
## Summary

- Preserve top-level `prompt_cache_hit_tokens` from OpenAI-compatible chat usage responses.
- Map those tokens into `inputTokensDetails.cacheRead` when nested `prompt_tokens_details.cached_tokens` is absent.
- Keep nested OpenAI-style cached-token usage as the precedence path when both fields are present.

Fixes #18905.

## Tests

- `corepack pnpm test:node src/chat/convert-openai-compatible-chat-usage.test.ts` in `packages/openai-compatible`
- `corepack pnpm exec ultracite check .changeset/openai-compatible-cache-hits.md packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.ts packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.test.ts`
- `corepack pnpm exec tsc --build` in `packages/openai-compatible`
- `git diff --check`