### PR TITLE
fix(harness-claude-code): preserve general JSON Schema unions

### DIFF
--- a/.changeset/fair-unions-validate.md
+++ b/.changeset/fair-unions-validate.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-claude-code': patch
+---
+
+Preserve general `anyOf` and `oneOf` constraints when registering custom tools with the Claude Code MCP bridge.

--- a/.changeset/fair-unions-validate.md
+++ b/.changeset/fair-unions-validate.md
@@ -2,4 +2,4 @@
 '@ai-sdk/harness-claude-code': patch
 ---
 
-Preserve general `anyOf` and `oneOf` constraints when registering custom tools with the Claude Code MCP bridge.
+fix(harness-claude-code): preserve general `anyOf` and `oneOf` constraints when registering custom tools with the MCP bridge

--- a/packages/harness-claude-code/src/bridge/json-schema-to-zod.test.ts
+++ b/packages/harness-claude-code/src/bridge/json-schema-to-zod.test.ts
@@ -160,6 +160,68 @@ describe('jsonSchemaToZodShape', () => {
     ).toBe(false);
   });
 
+  it('supports recursive anyOf and oneOf unions', () => {
+    const schema = toObjectSchema({
+      type: 'object',
+      properties: {
+        primitive: {
+          anyOf: [{ type: 'string' }, { type: 'number' }],
+        },
+        nested: {
+          oneOf: [
+            { type: 'boolean' },
+            {
+              type: 'object',
+              properties: { id: { type: 'integer' } },
+              required: ['id'],
+            },
+          ],
+        },
+        values: {
+          type: 'array',
+          items: {
+            anyOf: [{ type: 'string' }, { type: 'number' }],
+          },
+        },
+      },
+      required: ['primitive', 'nested', 'values'],
+    });
+
+    expect(
+      schema.safeParse({
+        primitive: 'text',
+        nested: { id: 1 },
+        values: ['text', 1],
+      }).success,
+    ).toBe(true);
+    expect(
+      schema.safeParse({ primitive: 1, nested: false, values: [] }).success,
+    ).toBe(true);
+    expect(
+      schema.safeParse({ primitive: true, nested: false, values: [] }).success,
+    ).toBe(false);
+    expect(
+      schema.safeParse({ primitive: 1, nested: 'text', values: [] }).success,
+    ).toBe(false);
+    expect(
+      schema.safeParse({ primitive: 1, nested: false, values: [true] }).success,
+    ).toBe(false);
+  });
+
+  it('keeps the safe fallback for unsupported union branches', () => {
+    const schema = toObjectSchema({
+      type: 'object',
+      properties: {
+        value: {
+          anyOf: [{ type: 'string' }, { allOf: [{ type: 'number' }] }],
+        },
+      },
+      required: ['value'],
+    });
+
+    expect(schema.safeParse({ value: true }).success).toBe(true);
+  });
+
   it('supports enum and const values when they are representable literals', () => {
     const schema = toObjectSchema({
       type: 'object',

--- a/packages/harness-claude-code/src/bridge/json-schema-to-zod.ts
+++ b/packages/harness-claude-code/src/bridge/json-schema-to-zod.ts
@@ -43,7 +43,7 @@ function toZodType(schema: JsonSchemaObject | undefined): z.ZodTypeAny {
   let zType =
     zodForConst(schema) ??
     zodForEnum(schema) ??
-    zodForNullableUnion(schema) ??
+    zodForUnion(schema) ??
     zodForType(schema);
 
   if (isNullable(schema)) zType = zType.nullable();
@@ -90,16 +90,16 @@ function zodForEnum(schema: JsonSchemaObject): z.ZodTypeAny | undefined {
   return zodForLiterals(schema.enum);
 }
 
-function zodForNullableUnion(
-  schema: JsonSchemaObject,
-): z.ZodTypeAny | undefined {
+function zodForUnion(schema: JsonSchemaObject): z.ZodTypeAny | undefined {
   const unionSchemas = schema.anyOf ?? schema.oneOf;
   if (!unionSchemas || unionSchemas.length < 2) return undefined;
 
-  const nonNullSchemas = unionSchemas.filter(item => !isNullOnlySchema(item));
-  if (nonNullSchemas.length !== 1) return undefined;
-
-  return toZodType(nonNullSchemas[0]).nullable();
+  const options = unionSchemas.map(item => toZodType(item)) as unknown as [
+    z.ZodTypeAny,
+    z.ZodTypeAny,
+    ...z.ZodTypeAny[],
+  ];
+  return z.union(options);
 }
 
 function zodForLiterals(values: JsonLiteral[]): z.ZodTypeAny {
@@ -124,19 +124,6 @@ function isNullable(schema: JsonSchemaObject): boolean {
   return (
     schema.nullable === true ||
     (Array.isArray(schema.type) && schema.type.includes('null'))
-  );
-}
-
-function isNullOnlySchema(schema: JsonSchemaObject): boolean {
-  return (
-    schema.type === 'null' ||
-    (Array.isArray(schema.type) &&
-      schema.type.length === 1 &&
-      schema.type[0] === 'null') ||
-    schema.const === null ||
-    (Array.isArray(schema.enum) &&
-      schema.enum.length === 1 &&
-      schema.enum[0] === null)
   );
 }
 


### PR DESCRIPTION
## Background

The Claude Code harness converts custom tool JSON Schemas to Zod before registering them with its local MCP server. The converter handled nullable `anyOf` and `oneOf` schemas, but general unions fell through to `z.any()`, weakening the schema presented to Claude and the bridge-side input validation.

This is a focused follow-up to #17126 and #17127.

## Summary

- Recursively convert general `anyOf` and `oneOf` members to a Zod union.
- Preserve nullable-union behavior through the same recursive path.
- Retain the existing safe `z.any()` fallback for unsupported branches.
- Add regression coverage for primitive, nested-object, and array-item unions.

## End-to-End Verification

A live Claude Code/Vercel Sandbox run was not performed because it requires external credentials and depends on nondeterministic model output. The deterministic converter boundary was exercised directly with the reported schema: strings and numbers are accepted while a boolean is rejected.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

The shared harness can separately add defense-in-depth by skipping host execution when canonical tool-call validation marks an input invalid.

## Related Issues

Fixes #18909.
