### PR TITLE
chore(harness): decouple bridge based harness bootstrap recipe logic from dynamic params and enforce unique harnesses in `prepareSandboxForHarness()` helper

### DIFF
--- a/.changeset/lucky-rivers-juggle.md
+++ b/.changeset/lucky-rivers-juggle.md
@@ -1,0 +1,10 @@
+---
+"@ai-sdk/harness-claude-code": patch
+"@ai-sdk/harness-deepagents": patch
+"@ai-sdk/harness-opencode": patch
+"@ai-sdk/harness-codex": patch
+"@ai-sdk/harness-acp": patch
+"@ai-sdk/harness": patch
+---
+
+chore(harness): decouple bridge based harness bootstrap recipe logic from dynamic params and enforce unique harnesses in `prepareSandboxForHarness()` helper

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -256,7 +256,10 @@
           "for": { "files": ["${harnessId}-harness.ts"] },
           "if": { "hasFile": "bridge/index.ts" },
           "must": {
-            "haveFiles": ["${harnessId}-bridge-protocol.ts"],
+            "haveFiles": [
+              "${harnessId}-bridge-protocol.ts",
+              "${harnessId}-bootstrap.ts"
+            ],
             "exportTypes": [
               {
                 "name": "${harnessId.toPascalCase()}HarnessSettings",
@@ -283,7 +286,10 @@
           "for": { "files": ["${harnessId}-harness.ts"] },
           "if": { "hasFile": "*/bridge/index.ts" },
           "must": {
-            "haveFiles": ["${harnessId}-bridge-protocol.ts"],
+            "haveFiles": [
+              "${harnessId}-bridge-protocol.ts",
+              "${harnessId}-bootstrap.ts"
+            ],
             "exportTypes": [
               {
                 "name": "${harnessId.toPascalCase()}HarnessSettings",
@@ -406,6 +412,27 @@
               "InboundMessage",
               "bridgeReadySchema",
               "BridgeReady"
+            ]
+          }
+        },
+        {
+          "name": "harness-sandbox-bootstrap-file-must-export-relevant-symbols",
+          "description": "Every harness sandbox bootstrap file must export the relevant symbols.",
+          "for": { "files": ["${harnessId}-bootstrap.ts"] },
+          "must": {
+            "importTypes": [
+              {
+                "name": "HarnessV1Bootstrap",
+                "from": "@ai-sdk/harness"
+              }
+            ],
+            "exportConstants": ["${harnessId.toConstantCase()}_BOOTSTRAP_DIR"],
+            "exportFunctions": [
+              {
+                "name": "get${harnessId.toPascalCase()}Bootstrap",
+                "receiveParamsOfTypes": [],
+                "returnValueOfType": "Promise<HarnessV1Bootstrap>"
+              }
             ]
           }
         },

--- a/packages/harness-acp/src/acp-harness.test.ts
+++ b/packages/harness-acp/src/acp-harness.test.ts
@@ -11,10 +11,8 @@ import * as fsPromises from 'node:fs/promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { createACP } from './acp-harness';
-import {
-  resolveBridgeAssetCandidates,
-  serializeBuiltinTools,
-} from './v1/acp-v1-harness';
+import { resolveBridgeAssetCandidates } from './v1/acp-bootstrap';
+import { serializeBuiltinTools } from './v1/acp-v1-harness';
 import { ACP_BRIDGE_CONFIGURATION_ENV } from './v1/bridge/acp-v1-bridge-environment';
 import type { ACPPermissionModeMapping } from './v1/acp-v1-settings';
 

--- a/packages/harness-acp/src/v1/acp-bootstrap.ts
+++ b/packages/harness-acp/src/v1/acp-bootstrap.ts
@@ -1,0 +1,119 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import type { HarnessV1Bootstrap } from '@ai-sdk/harness';
+import {
+  createImplementationDescriptor,
+  createImplementationInstallCommand,
+  createImplementationManifest,
+  getImplementationLockfile,
+  type ACPNpmImplementation,
+} from './implementation';
+
+export function createACPBootstrap({
+  harnessId,
+  implementation,
+}: {
+  readonly harnessId: string;
+  readonly implementation: ACPNpmImplementation;
+}): {
+  readonly bootstrapDir: string;
+  readonly getBootstrap: () => Promise<HarnessV1Bootstrap>;
+} {
+  const bootstrapDir = `.harness-bootstrap/${harnessId}`;
+  let cachedBootstrap: HarnessV1Bootstrap | undefined;
+
+  return {
+    bootstrapDir,
+    getBootstrap: async () => {
+      if (cachedBootstrap != null) return cachedBootstrap;
+      const [bridgePackage, bridgeLock, bridge, hostToolMCP] =
+        await Promise.all([
+          readBridgeAsset({ name: 'package.json' }),
+          readBridgeAsset({ name: 'pnpm-lock.yaml' }),
+          readBridgeAsset({ name: 'index.mjs' }),
+          readBridgeAsset({ name: 'host-tool-mcp.mjs' }),
+        ]);
+      const implementationLock = getImplementationLockfile({
+        implementation,
+      });
+      cachedBootstrap = {
+        harnessId,
+        bootstrapDir,
+        files: [
+          {
+            path: `${bootstrapDir}/package.json`,
+            content: bridgePackage,
+          },
+          {
+            path: `${bootstrapDir}/pnpm-lock.yaml`,
+            content: bridgeLock,
+          },
+          { path: `${bootstrapDir}/bridge.mjs`, content: bridge },
+          {
+            path: `${bootstrapDir}/host-tool-mcp.mjs`,
+            content: hostToolMCP,
+          },
+          {
+            path: `${bootstrapDir}/implementation/package.json`,
+            content: createImplementationManifest({ implementation }),
+          },
+          {
+            path: `${bootstrapDir}/implementation/implementation.json`,
+            content: createImplementationDescriptor({ implementation }),
+          },
+          ...(implementationLock == null
+            ? []
+            : [
+                {
+                  path: `${bootstrapDir}/implementation/pnpm-lock.yaml`,
+                  content: implementationLock,
+                },
+              ]),
+        ],
+        commands: [
+          {
+            command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
+          },
+          {
+            command: createImplementationInstallCommand({
+              implementationDir: 'implementation',
+              storeDir: '../.pnpm-store',
+              implementation,
+            }),
+          },
+        ],
+      };
+      return cachedBootstrap;
+    },
+  };
+}
+
+async function readBridgeAsset({ name }: { name: string }): Promise<string> {
+  const candidates = resolveBridgeAssetCandidates({
+    name,
+    moduleUrl: import.meta.url,
+  });
+  let lastError: unknown;
+  for (const url of candidates) {
+    try {
+      return await readFile(fileURLToPath(url), 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      lastError = error;
+    }
+  }
+  throw lastError ?? new Error(`ACP bridge asset not found: ${name}`);
+}
+
+export function resolveBridgeAssetCandidates({
+  name,
+  moduleUrl,
+}: {
+  name: string;
+  moduleUrl: string | URL;
+}): URL[] {
+  return [
+    new URL(`./bridge/${name}`, moduleUrl),
+    new URL(`../bridge/${name}`, moduleUrl),
+  ];
+}

--- a/packages/harness-acp/src/v1/acp-v1-harness.ts
+++ b/packages/harness-acp/src/v1/acp-v1-harness.ts
@@ -1,12 +1,9 @@
 import { createHash, randomBytes } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
 import { posix } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import {
   HarnessCapabilityUnsupportedError,
   harnessV1DiagnosticFromBridgeFrame,
   type HarnessV1,
-  type HarnessV1Bootstrap,
   type HarnessV1DebugConfig,
   type HarnessV1NetworkSandboxSession,
   type HarnessV1PromptControl,
@@ -45,14 +42,11 @@ import {
 import type { ACPToolCall } from '../acp-tool-call';
 import {
   createACPV1Implementation,
-  createImplementationDescriptor,
   createImplementationIdentity,
-  createImplementationInstallCommand,
-  createImplementationManifest,
-  getImplementationLockfile,
   resolveImplementationEnvironment,
   validateACPV1Implementation,
 } from './implementation';
+import { createACPBootstrap } from './acp-bootstrap';
 import {
   outboundMessageSchema,
   type ACPBuiltinToolMapping,
@@ -157,10 +151,10 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
   }
   const implementation = createACPV1Implementation({ settings });
   validateACPV1Implementation(implementation);
-
-  const BOOTSTRAP_DIR = `.harness-bootstrap/${settings.harnessId}`;
-
-  let cachedBootstrap: HarnessV1Bootstrap | undefined;
+  const bootstrap = createACPBootstrap({
+    harnessId: settings.harnessId,
+    implementation,
+  });
   const permissionModeMapping = isCompletePermissionModeMapping({
     value: settings.permissionModeMapping,
   })
@@ -174,71 +168,7 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
     supportsBuiltinToolApprovals: true,
     supportsBuiltinToolFiltering: false,
     lifecycleStateSchema,
-    getBootstrap: async () => {
-      if (cachedBootstrap != null) return cachedBootstrap;
-      const [bridgePackage, bridgeLock, bridge, hostToolMCP] =
-        await Promise.all([
-          readBridgeAsset({ name: 'package.json' }),
-          readBridgeAsset({ name: 'pnpm-lock.yaml' }),
-          readBridgeAsset({ name: 'index.mjs' }),
-          readBridgeAsset({ name: 'host-tool-mcp.mjs' }),
-        ]);
-      const implementationLock = getImplementationLockfile({
-        implementation,
-      });
-      cachedBootstrap = {
-        harnessId: settings.harnessId,
-        bootstrapDir: BOOTSTRAP_DIR,
-        files: [
-          {
-            path: `${BOOTSTRAP_DIR}/package.json`,
-            content: bridgePackage,
-          },
-          {
-            path: `${BOOTSTRAP_DIR}/pnpm-lock.yaml`,
-            content: bridgeLock,
-          },
-          { path: `${BOOTSTRAP_DIR}/bridge.mjs`, content: bridge },
-          {
-            path: `${BOOTSTRAP_DIR}/host-tool-mcp.mjs`,
-            content: hostToolMCP,
-          },
-          {
-            path: `${BOOTSTRAP_DIR}/implementation/package.json`,
-            content: createImplementationManifest({
-              implementation,
-            }),
-          },
-          {
-            path: `${BOOTSTRAP_DIR}/implementation/implementation.json`,
-            content: createImplementationDescriptor({
-              implementation,
-            }),
-          },
-          ...(implementationLock == null
-            ? []
-            : [
-                {
-                  path: `${BOOTSTRAP_DIR}/implementation/pnpm-lock.yaml`,
-                  content: implementationLock,
-                },
-              ]),
-        ],
-        commands: [
-          {
-            command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
-          },
-          {
-            command: createImplementationInstallCommand({
-              implementationDir: 'implementation',
-              storeDir: '../.pnpm-store',
-              implementation,
-            }),
-          },
-        ],
-      };
-      return cachedBootstrap;
-    },
+    getBootstrap: bootstrap.getBootstrap,
     doStart: async startOptions => {
       if (startOptions.builtinToolFiltering != null) {
         throw unsupported({
@@ -346,7 +276,7 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
       const sandbox = sandboxSession.restricted();
       const resolvedBridgeDir = posix.resolve(
         sandboxSession.defaultWorkingDirectory,
-        BOOTSTRAP_DIR,
+        bootstrap.bootstrapDir,
       );
       const resolvedImplementationDir = `${resolvedBridgeDir}/implementation`;
       const workDir = startOptions.sessionWorkDir;
@@ -799,36 +729,6 @@ function requireResolvedEnvironmentValue({
     throw new Error(`ACP resolved environment value ${name} is unavailable.`);
   }
   return value;
-}
-
-async function readBridgeAsset({ name }: { name: string }): Promise<string> {
-  const candidates = resolveBridgeAssetCandidates({
-    name,
-    moduleUrl: import.meta.url,
-  });
-  let lastError: unknown;
-  for (const url of candidates) {
-    try {
-      return await readFile(fileURLToPath(url), 'utf8');
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
-      lastError = error;
-    }
-  }
-  throw lastError ?? new Error(`ACP bridge asset not found: ${name}`);
-}
-
-export function resolveBridgeAssetCandidates({
-  name,
-  moduleUrl,
-}: {
-  name: string;
-  moduleUrl: string | URL;
-}): URL[] {
-  return [
-    new URL(`./bridge/${name}`, moduleUrl),
-    new URL(`../bridge/${name}`, moduleUrl),
-  ];
 }
 
 function resolveBridgePort({

--- a/packages/harness-claude-code/src/claude-code-bootstrap.ts
+++ b/packages/harness-claude-code/src/claude-code-bootstrap.ts
@@ -1,0 +1,65 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import type { HarnessV1Bootstrap } from '@ai-sdk/harness';
+
+/*
+ * Bootstrap is derived state stored under the sandbox's default working
+ * directory so snapshot-capable providers can preserve the installed CLI,
+ * bridge, and recipe marker without requiring root filesystem access.
+ *
+ * The session work dir (`startOpts.sessionWorkDir`) and the bridge-state dir
+ * derived from `sandboxSession.defaultWorkingDirectory` both live under the sandbox's
+ * default working directory — the provider's persistent mount — so the
+ * workdir's CLI state (Claude's `~/.claude/projects/<dir>/*.jsonl` thread
+ * history is keyed by working directory) and the bridge state files survive
+ * both detach -> attach/replay and stop -> snapshot -> resume cycles.
+ */
+export const CLAUDE_CODE_BOOTSTRAP_DIR = '.harness-bootstrap/claude-code';
+
+let cachedBootstrap: HarnessV1Bootstrap | undefined;
+
+export async function getClaudeCodeBootstrap(): Promise<HarnessV1Bootstrap> {
+  if (cachedBootstrap != null) return cachedBootstrap;
+  const [pkg, lock, bridge] = await Promise.all([
+    readBridgeAsset('package.json'),
+    readBridgeAsset('pnpm-lock.yaml'),
+    readBridgeAsset('index.mjs'),
+  ]);
+  cachedBootstrap = {
+    harnessId: 'claude-code',
+    bootstrapDir: CLAUDE_CODE_BOOTSTRAP_DIR,
+    files: [
+      { path: `${CLAUDE_CODE_BOOTSTRAP_DIR}/package.json`, content: pkg },
+      { path: `${CLAUDE_CODE_BOOTSTRAP_DIR}/pnpm-lock.yaml`, content: lock },
+      { path: `${CLAUDE_CODE_BOOTSTRAP_DIR}/bridge.mjs`, content: bridge },
+    ],
+    commands: [
+      {
+        command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
+      },
+      {
+        command:
+          'if [ -f node_modules/@anthropic-ai/claude-code/install.cjs ]; then node node_modules/@anthropic-ai/claude-code/install.cjs; fi && ./node_modules/.bin/claude --version',
+      },
+    ],
+  };
+  return cachedBootstrap;
+}
+
+async function readBridgeAsset(name: string): Promise<string> {
+  const candidates = [
+    new URL(`./bridge/${name}`, import.meta.url),
+    new URL(`../bridge/${name}`, import.meta.url),
+  ];
+  let lastErr: unknown;
+  for (const url of candidates) {
+    try {
+      return await readFile(fileURLToPath(url), 'utf8');
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') throw err;
+      lastErr = err;
+    }
+  }
+  throw lastErr ?? new Error(`bridge asset not found: ${name}`);
+}

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -899,5 +899,12 @@ describe('createClaudeCode adapter', () => {
       const b = await harness.getBootstrap!();
       expect(a).toBe(b);
     });
+
+    it('shares the getter across configured harness instances', () => {
+      const first = createClaudeCode({ model: 'first-model' });
+      const second = createClaudeCode({ model: 'second-model' });
+
+      expect(first.getBootstrap).toBe(second.getBootstrap);
+    });
   });
 });

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -1,13 +1,10 @@
 import { randomBytes } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
 import { posix } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import {
   commonTool,
   harnessV1DiagnosticFromBridgeFrame,
   HarnessCapabilityUnsupportedError,
   type HarnessV1,
-  type HarnessV1Bootstrap,
   type HarnessV1BuiltinToolFiltering,
   type HarnessV1BuiltinTool,
   type HarnessV1ContinueTurnState,
@@ -44,6 +41,10 @@ import {
 } from '@ai-sdk/provider-utils';
 import { WebSocket } from 'ws';
 import { z } from 'zod/v4';
+import {
+  CLAUDE_CODE_BOOTSTRAP_DIR as BOOTSTRAP_DIR,
+  getClaudeCodeBootstrap,
+} from './claude-code-bootstrap';
 import {
   CLAUDE_CODE_CREDENTIAL_ENVIRONMENT_VARIABLES,
   createClaudeCodeRequestTransformations,
@@ -758,20 +759,6 @@ const CLAUDE_CODE_BUILTIN_TOOLS = {
   },
 } as const satisfies Record<string, HarnessV1BuiltinTool<any, any>>;
 
-/*
- * Bootstrap is derived state stored under the sandbox's default working
- * directory so snapshot-capable providers can preserve the installed CLI,
- * bridge, and recipe marker without requiring root filesystem access.
- *
- * The session work dir (`startOpts.sessionWorkDir`) and the bridge-state dir
- * derived from `sandboxSession.defaultWorkingDirectory` both live under the sandbox's
- * default working directory — the provider's persistent mount — so the
- * workdir's CLI state (Claude's `~/.claude/projects/<dir>/*.jsonl` thread
- * history is keyed by working directory) and the bridge state files survive
- * both detach -> attach/replay and stop -> snapshot -> resume cycles.
- */
-const BOOTSTRAP_DIR = '.harness-bootstrap/claude-code';
-
 /**
  * Live bridge coordinates returned by `doDetach()` and `doSuspendTurn()`. A
  * future process uses them to reopen a socket to the still-running bridge
@@ -810,7 +797,6 @@ export function createClaudeCode(
       'Claude Code MCP server name "harness-tools" is reserved for HarnessAgent tools.',
     );
   }
-  let cachedBootstrap: HarnessV1Bootstrap | undefined;
   const thinking = settings.thinking ?? {
     type: 'adaptive',
     display: 'summarized',
@@ -823,33 +809,7 @@ export function createClaudeCode(
     supportsBuiltinToolApprovals: true,
     supportsBuiltinToolFiltering: true,
     lifecycleStateSchema: claudeCodeResumeStateSchema,
-    getBootstrap: async () => {
-      if (cachedBootstrap != null) return cachedBootstrap;
-      const [pkg, lock, bridge] = await Promise.all([
-        readBridgeAsset('package.json'),
-        readBridgeAsset('pnpm-lock.yaml'),
-        readBridgeAsset('index.mjs'),
-      ]);
-      cachedBootstrap = {
-        harnessId: 'claude-code',
-        bootstrapDir: BOOTSTRAP_DIR,
-        files: [
-          { path: `${BOOTSTRAP_DIR}/package.json`, content: pkg },
-          { path: `${BOOTSTRAP_DIR}/pnpm-lock.yaml`, content: lock },
-          { path: `${BOOTSTRAP_DIR}/bridge.mjs`, content: bridge },
-        ],
-        commands: [
-          {
-            command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
-          },
-          {
-            command:
-              'if [ -f node_modules/@anthropic-ai/claude-code/install.cjs ]; then node node_modules/@anthropic-ai/claude-code/install.cjs; fi && ./node_modules/.bin/claude --version',
-          },
-        ],
-      };
-      return cachedBootstrap;
-    },
+    getBootstrap: getClaudeCodeBootstrap,
     doStart: async startOpts => {
       const sandboxSession = startOpts.sandboxSession;
       const authenticationMode = resolveClaudeCodeAuthenticationMode(
@@ -1196,24 +1156,6 @@ async function writeClaudeCodeSkills({
       `Invalid Claude Code skill file path for ${skillName}: ${filePath}`,
     trailingNewline: true,
   });
-}
-
-async function readBridgeAsset(name: string): Promise<string> {
-  const candidates = [
-    new URL(`./bridge/${name}`, import.meta.url),
-    new URL(`../bridge/${name}`, import.meta.url),
-  ];
-  let lastErr: unknown;
-  for (const url of candidates) {
-    try {
-      return await readFile(fileURLToPath(url), 'utf8');
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code !== 'ENOENT') throw err;
-      lastErr = err;
-    }
-  }
-  throw lastErr ?? new Error(`bridge asset not found: ${name}`);
 }
 
 /**

--- a/packages/harness-codex/src/codex-bootstrap.ts
+++ b/packages/harness-codex/src/codex-bootstrap.ts
@@ -1,0 +1,60 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import type { HarnessV1Bootstrap } from '@ai-sdk/harness';
+
+/*
+ * Bootstrap is derived state stored under the sandbox's default working
+ * directory so snapshot-capable providers can preserve the installed CLI,
+ * bridge, and recipe marker without requiring root filesystem access.
+ *
+ * The session work dir (`startOpts.sessionWorkDir`) lives under the sandbox's
+ * default working directory — the provider's persistent mount — so any files
+ * the agent edits survive both detach -> attach and stop -> snapshot -> resume
+ * cycles. Harness infra derived from `sandboxSession.defaultWorkingDirectory`
+ * lives under `.agent-runs`, outside the agent workdir.
+ */
+export const CODEX_BOOTSTRAP_DIR = '.harness-bootstrap/codex';
+
+let cachedBootstrap: HarnessV1Bootstrap | undefined;
+
+export async function getCodexBootstrap(): Promise<HarnessV1Bootstrap> {
+  if (cachedBootstrap != null) return cachedBootstrap;
+  const [pkg, lock, bridge] = await Promise.all([
+    readBridgeAsset('package.json'),
+    readBridgeAsset('pnpm-lock.yaml'),
+    readBridgeAsset('index.mjs'),
+  ]);
+  cachedBootstrap = {
+    harnessId: 'codex',
+    bootstrapDir: CODEX_BOOTSTRAP_DIR,
+    files: [
+      { path: `${CODEX_BOOTSTRAP_DIR}/package.json`, content: pkg },
+      { path: `${CODEX_BOOTSTRAP_DIR}/pnpm-lock.yaml`, content: lock },
+      { path: `${CODEX_BOOTSTRAP_DIR}/bridge.mjs`, content: bridge },
+    ],
+    commands: [
+      {
+        command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
+      },
+    ],
+  };
+  return cachedBootstrap;
+}
+
+async function readBridgeAsset(name: string): Promise<string> {
+  const candidates = [
+    new URL(`./bridge/${name}`, import.meta.url),
+    new URL(`../bridge/${name}`, import.meta.url),
+  ];
+  let lastErr: unknown;
+  for (const url of candidates) {
+    try {
+      return await readFile(fileURLToPath(url), 'utf8');
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') throw err;
+      lastErr = err;
+    }
+  }
+  throw lastErr ?? new Error(`bridge asset not found: ${name}`);
+}

--- a/packages/harness-codex/src/codex-harness.test.ts
+++ b/packages/harness-codex/src/codex-harness.test.ts
@@ -406,5 +406,15 @@ describe('createCodex adapter', () => {
       const b = await harness.getBootstrap!();
       expect(a).toBe(b);
     });
+
+    it('shares the getter across configured harness instances', () => {
+      const first = createCodex({ model: 'first-model' });
+      const second = createCodex({
+        model: 'second-model',
+        webSearch: true,
+      });
+
+      expect(first.getBootstrap).toBe(second.getBootstrap);
+    });
   });
 });

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -1,13 +1,10 @@
 import { randomBytes } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import {
   commonTool,
   HarnessCapabilityUnsupportedError,
   harnessV1DiagnosticFromBridgeFrame,
   type HarnessV1,
-  type HarnessV1Bootstrap,
   type HarnessV1DebugConfig,
   type HarnessV1BuiltinTool,
   type HarnessV1ContinueTurnState,
@@ -41,6 +38,10 @@ import {
 } from '@ai-sdk/provider-utils';
 import { WebSocket } from 'ws';
 import { z } from 'zod/v4';
+import {
+  CODEX_BOOTSTRAP_DIR as BOOTSTRAP_DIR,
+  getCodexBootstrap,
+} from './codex-bootstrap';
 import {
   CODEX_CREDENTIAL_ENVIRONMENT_VARIABLES,
   createCodexRequestTransformations,
@@ -144,19 +145,6 @@ const CODEX_BUILTIN_TOOLS = {
   }),
 } as const satisfies Record<string, HarnessV1BuiltinTool<any, any>>;
 
-/*
- * Bootstrap is derived state stored under the sandbox's default working
- * directory so snapshot-capable providers can preserve the installed CLI,
- * bridge, and recipe marker without requiring root filesystem access.
- *
- * The session work dir (`startOpts.sessionWorkDir`) lives under the sandbox's
- * default working directory — the provider's persistent mount — so any files
- * the agent edits survive both detach -> attach and stop -> snapshot -> resume
- * cycles. Harness infra derived from `sandboxSession.defaultWorkingDirectory`
- * lives under `.agent-runs`, outside the agent workdir.
- */
-const BOOTSTRAP_DIR = '.harness-bootstrap/codex';
-
 /**
  * Live bridge coordinates returned by `doDetach()` and `doSuspendTurn()`. A
  * future process uses them to reopen a socket to the still-running bridge
@@ -187,37 +175,13 @@ type CodexBridgeCoords = z.infer<typeof codexBridgeCoordsSchema>;
 export function createCodex(
   settings: CodexHarnessSettings = {},
 ): HarnessV1<typeof CODEX_BUILTIN_TOOLS> {
-  let cachedBootstrap: HarnessV1Bootstrap | undefined;
-
   return {
     specificationVersion: 'harness-v1',
     harnessId: 'codex',
     builtinTools: CODEX_BUILTIN_TOOLS,
     supportsBuiltinToolApprovals: false,
     lifecycleStateSchema: codexResumeStateSchema,
-    getBootstrap: async () => {
-      if (cachedBootstrap != null) return cachedBootstrap;
-      const [pkg, lock, bridge] = await Promise.all([
-        readBridgeAsset('package.json'),
-        readBridgeAsset('pnpm-lock.yaml'),
-        readBridgeAsset('index.mjs'),
-      ]);
-      cachedBootstrap = {
-        harnessId: 'codex',
-        bootstrapDir: BOOTSTRAP_DIR,
-        files: [
-          { path: `${BOOTSTRAP_DIR}/package.json`, content: pkg },
-          { path: `${BOOTSTRAP_DIR}/pnpm-lock.yaml`, content: lock },
-          { path: `${BOOTSTRAP_DIR}/bridge.mjs`, content: bridge },
-        ],
-        commands: [
-          {
-            command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
-          },
-        ],
-      };
-      return cachedBootstrap;
-    },
+    getBootstrap: getCodexBootstrap,
     doStart: async startOpts => {
       if (startOpts.builtinToolFiltering != null) {
         throw new HarnessCapabilityUnsupportedError({
@@ -529,24 +493,6 @@ function resolveBridgePort(
       'The codex harness needs a TCP port exposed by the sandbox. ' +
       'Create the sandbox with `ports: [<port>]` or pass `createCodex({ port })`.',
   });
-}
-
-async function readBridgeAsset(name: string): Promise<string> {
-  const candidates = [
-    new URL(`./bridge/${name}`, import.meta.url),
-    new URL(`../bridge/${name}`, import.meta.url),
-  ];
-  let lastErr: unknown;
-  for (const url of candidates) {
-    try {
-      return await readFile(fileURLToPath(url), 'utf8');
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code !== 'ENOENT') throw err;
-      lastErr = err;
-    }
-  }
-  throw lastErr ?? new Error(`bridge asset not found: ${name}`);
 }
 
 async function writeCodexSkills({

--- a/packages/harness-deepagents/src/deepagents-bootstrap.ts
+++ b/packages/harness-deepagents/src/deepagents-bootstrap.ts
@@ -1,0 +1,87 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import type { HarnessV1Bootstrap } from '@ai-sdk/harness';
+
+/*
+ * Bootstrap is derived state stored under the sandbox's default working
+ * directory so snapshot-capable providers preserve its installation and
+ * recipe marker without requiring root filesystem access.
+ */
+export const DEEPAGENTS_BOOTSTRAP_DIR = '.harness-bootstrap/deepagents';
+
+/*
+ * Pinned ripgrep release and per-architecture tarball checksums are verified
+ * before installation.
+ */
+const RIPGREP_VERSION = '14.1.1';
+const RIPGREP_SHA256_X64 =
+  '4cf9f2741e6c465ffdb7c26f38056a59e2a2544b51f7cc128ef28337eeae4d8e';
+const RIPGREP_SHA256_ARM =
+  'c827481c4ff4ea10c9dc7a4022c8de5db34a5737cb74484d62eb94a95841ab2f';
+
+let cachedBootstrap: HarnessV1Bootstrap | undefined;
+
+export async function getDeepAgentsBootstrap(): Promise<HarnessV1Bootstrap> {
+  if (cachedBootstrap != null) return cachedBootstrap;
+  const [bridge, pkg, lock] = await Promise.all([
+    readBridgeAsset('index.mjs'),
+    readBridgeAsset('package.json'),
+    readBridgeAsset('pnpm-lock.yaml'),
+  ]);
+  cachedBootstrap = {
+    harnessId: 'deepagents',
+    bootstrapDir: DEEPAGENTS_BOOTSTRAP_DIR,
+    files: [
+      { path: `${DEEPAGENTS_BOOTSTRAP_DIR}/bridge.mjs`, content: bridge },
+      { path: `${DEEPAGENTS_BOOTSTRAP_DIR}/package.json`, content: pkg },
+      { path: `${DEEPAGENTS_BOOTSTRAP_DIR}/pnpm-lock.yaml`, content: lock },
+    ],
+    commands: [
+      { command: installRipgrepCommand() },
+      {
+        command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
+      },
+    ],
+  };
+  return cachedBootstrap;
+}
+
+/*
+ * DeepAgents' grep shells out to `rg`. Without it, the fallback reads the
+ * entire workdir, including node_modules, into memory and can run out of
+ * memory. The checksum-verified installation is skipped when `rg` exists.
+ */
+function installRipgrepCommand(): string {
+  const v = RIPGREP_VERSION;
+  return [
+    'command -v rg >/dev/null 2>&1 || {',
+    'case "$(uname -m)" in',
+    `aarch64) a=aarch64-unknown-linux-gnu; sha=${RIPGREP_SHA256_ARM} ;;`,
+    `*) a=x86_64-unknown-linux-musl; sha=${RIPGREP_SHA256_X64} ;;`,
+    'esac;',
+    `f=/tmp/ripgrep-${v}.tar.gz;`,
+    `curl -fsSL "https://github.com/BurntSushi/ripgrep/releases/download/${v}/ripgrep-${v}-$a.tar.gz" -o "$f"`,
+    '&& echo "$sha  $f" | sha256sum -c -',
+    '&& tar xzf "$f" -C /tmp',
+    `&& mv "/tmp/ripgrep-${v}-$a/rg" /usr/local/bin/rg && chmod +x /usr/local/bin/rg;`,
+    '}',
+  ].join(' ');
+}
+
+async function readBridgeAsset(name: string): Promise<string> {
+  const candidates = [
+    new URL(`./bridge/${name}`, import.meta.url),
+    new URL(`../bridge/${name}`, import.meta.url),
+  ];
+  let lastErr: unknown;
+  for (const url of candidates) {
+    try {
+      return await readFile(fileURLToPath(url), 'utf8');
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') throw err;
+      lastErr = err;
+    }
+  }
+  throw lastErr ?? new Error(`bridge asset not found: ${name}`);
+}

--- a/packages/harness-deepagents/src/deepagents-harness.test.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.test.ts
@@ -148,6 +148,13 @@ describe('createDeepAgents', () => {
     expect(a).toBe(b);
   });
 
+  it('shares the getter across configured harness instances', () => {
+    const first = createDeepAgents({ model: 'first-model' });
+    const second = createDeepAgents({ model: 'second-model' });
+
+    expect(first.getBootstrap).toBe(second.getBootstrap);
+  });
+
   it('exposes a lifecycle state schema for resume payloads', () => {
     const harness = createDeepAgents();
     expect(harness.lifecycleStateSchema).toBeDefined();

--- a/packages/harness-deepagents/src/deepagents-harness.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.ts
@@ -1,13 +1,10 @@
 import { randomBytes } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
 import { posix } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import {
   commonTool,
   HarnessCapabilityUnsupportedError,
   harnessV1DiagnosticFromBridgeFrame,
   type HarnessV1,
-  type HarnessV1Bootstrap,
   type HarnessV1BuiltinTool,
   type HarnessV1BuiltinToolFiltering,
   type HarnessV1ContinueTurnState,
@@ -38,6 +35,10 @@ import { tool, type Experimental_SandboxProcess } from '@ai-sdk/provider-utils';
 import { WebSocket } from 'ws';
 import { z } from 'zod/v4';
 import {
+  DEEPAGENTS_BOOTSTRAP_DIR as BOOTSTRAP_DIR,
+  getDeepAgentsBootstrap,
+} from './deepagents-bootstrap';
+import {
   createDeepAgentsRequestTransformations,
   DEEPAGENTS_CREDENTIAL_ENVIRONMENT_VARIABLES,
   resolveDeepAgentsAuthenticationMode,
@@ -53,12 +54,6 @@ import { VERSION } from './version';
 
 type DeepAgentsChannel = SandboxChannel<OutboundMessage, InboundMessage>;
 
-/*
- * Bootstrap is derived state stored under the sandbox's default working
- * directory so snapshot-capable providers preserve its installation and
- * recipe marker without requiring root filesystem access.
- */
-const BOOTSTRAP_DIR = '.harness-bootstrap/deepagents';
 /**
  * Value to use in User-Agent and `x-client-app` headers.
  */
@@ -77,32 +72,6 @@ export type DeepAgentsThinkingConfig =
   | {
       readonly type: 'disabled';
     };
-
-// Pinned ripgrep release + per-arch tarball checksums (verified before install).
-const RIPGREP_VERSION = '14.1.1';
-const RIPGREP_SHA256_X64 =
-  '4cf9f2741e6c465ffdb7c26f38056a59e2a2544b51f7cc128ef28337eeae4d8e';
-const RIPGREP_SHA256_ARM =
-  'c827481c4ff4ea10c9dc7a4022c8de5db34a5737cb74484d62eb94a95841ab2f';
-
-// Idempotent, checksum-verified install of a static ripgrep binary into a PATH dir.
-// DeepAgents' grep shells out to `rg`; without it, its fallback reads the whole workdir (incl. node_modules) into memory and OOMs. Skipped if `rg` already exists.
-function installRipgrepCommand(): string {
-  const v = RIPGREP_VERSION;
-  return [
-    'command -v rg >/dev/null 2>&1 || {',
-    'case "$(uname -m)" in',
-    `aarch64) a=aarch64-unknown-linux-gnu; sha=${RIPGREP_SHA256_ARM} ;;`,
-    `*) a=x86_64-unknown-linux-musl; sha=${RIPGREP_SHA256_X64} ;;`,
-    'esac;',
-    `f=/tmp/ripgrep-${v}.tar.gz;`,
-    `curl -fsSL "https://github.com/BurntSushi/ripgrep/releases/download/${v}/ripgrep-${v}-$a.tar.gz" -o "$f"`,
-    '&& echo "$sha  $f" | sha256sum -c -',
-    '&& tar xzf "$f" -C /tmp',
-    `&& mv "/tmp/ripgrep-${v}-$a/rg" /usr/local/bin/rg && chmod +x /usr/local/bin/rg;`,
-    '}',
-  ].join(' ');
-}
 
 // Skills source subpath, written under $HOME (out of the work dir so it can't clash with code cloned into the work dir) and also discovered from <workDir> for repo-provided skills.
 const SKILLS_SOURCE_PATH = '/.agents/skills';
@@ -217,8 +186,6 @@ type DeepAgentsBridgeCoords = z.infer<typeof deepAgentsBridgeCoordsSchema>;
 export function createDeepAgents(
   settings: DeepAgentsHarnessSettings = {},
 ): HarnessV1<typeof DEEPAGENTS_BUILTIN_TOOLS> {
-  let cachedBootstrap: HarnessV1Bootstrap | undefined;
-
   return {
     specificationVersion: 'harness-v1',
     harnessId: 'deepagents',
@@ -226,30 +193,7 @@ export function createDeepAgents(
     // Built-in tool approvals are gated in-bridge via DeepAgents' interruptOn (HITL) middleware.
     supportsBuiltinToolApprovals: true,
     lifecycleStateSchema: deepAgentsResumeStateSchema,
-    getBootstrap: async () => {
-      if (cachedBootstrap != null) return cachedBootstrap;
-      const [bridge, pkg, lock] = await Promise.all([
-        readBridgeAsset('index.mjs'),
-        readBridgeAsset('package.json'),
-        readBridgeAsset('pnpm-lock.yaml'),
-      ]);
-      cachedBootstrap = {
-        harnessId: 'deepagents',
-        bootstrapDir: BOOTSTRAP_DIR,
-        files: [
-          { path: `${BOOTSTRAP_DIR}/bridge.mjs`, content: bridge },
-          { path: `${BOOTSTRAP_DIR}/package.json`, content: pkg },
-          { path: `${BOOTSTRAP_DIR}/pnpm-lock.yaml`, content: lock },
-        ],
-        commands: [
-          { command: installRipgrepCommand() },
-          {
-            command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
-          },
-        ],
-      };
-      return cachedBootstrap;
-    },
+    getBootstrap: getDeepAgentsBootstrap,
     doStart: async startOpts => {
       const permissionMode = startOpts.permissionMode;
       const sandboxSession = startOpts.sandboxSession;
@@ -483,24 +427,6 @@ function resolveBridgePort(
       'The deepagents harness needs a TCP port exposed by the sandbox. ' +
       'Create the sandbox with `ports: [<port>]` or pass `createDeepAgents({ port })`.',
   });
-}
-
-async function readBridgeAsset(name: string): Promise<string> {
-  const candidates = [
-    new URL(`./bridge/${name}`, import.meta.url),
-    new URL(`../bridge/${name}`, import.meta.url),
-  ];
-  let lastErr: unknown;
-  for (const url of candidates) {
-    try {
-      return await readFile(fileURLToPath(url), 'utf8');
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code !== 'ENOENT') throw err;
-      lastErr = err;
-    }
-  }
-  throw lastErr ?? new Error(`bridge asset not found: ${name}`);
 }
 
 // Materialize each skill as a native deepagents `<name>/SKILL.md` folder (+ attached files) under the given root, so skills load on demand and file references resolve.

--- a/packages/harness-opencode/src/opencode-bootstrap.ts
+++ b/packages/harness-opencode/src/opencode-bootstrap.ts
@@ -1,0 +1,58 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import type { HarnessV1Bootstrap } from '@ai-sdk/harness';
+
+export const OPENCODE_BOOTSTRAP_DIR = '.harness-bootstrap/opencode';
+
+let cachedBootstrap: HarnessV1Bootstrap | undefined;
+
+export async function getOpenCodeBootstrap(): Promise<HarnessV1Bootstrap> {
+  if (cachedBootstrap != null) return cachedBootstrap;
+  const [pkg, lock, bridge, hostToolMcp] = await Promise.all([
+    readBridgeAsset('package.json'),
+    readBridgeAsset('pnpm-lock.yaml'),
+    readBridgeAsset('index.mjs'),
+    readBridgeAsset('host-tool-mcp.mjs'),
+  ]);
+  cachedBootstrap = {
+    harnessId: 'opencode',
+    bootstrapDir: OPENCODE_BOOTSTRAP_DIR,
+    files: [
+      { path: `${OPENCODE_BOOTSTRAP_DIR}/package.json`, content: pkg },
+      { path: `${OPENCODE_BOOTSTRAP_DIR}/pnpm-lock.yaml`, content: lock },
+      { path: `${OPENCODE_BOOTSTRAP_DIR}/bridge.mjs`, content: bridge },
+      {
+        path: `${OPENCODE_BOOTSTRAP_DIR}/host-tool-mcp.mjs`,
+        content: hostToolMcp,
+      },
+    ],
+    commands: [
+      {
+        command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
+      },
+      {
+        command:
+          'node node_modules/opencode-ai/postinstall.mjs && ./node_modules/.bin/opencode --version',
+      },
+    ],
+  };
+  return cachedBootstrap;
+}
+
+async function readBridgeAsset(name: string): Promise<string> {
+  const candidates = [
+    new URL(`./bridge/${name}`, import.meta.url),
+    new URL(`../bridge/${name}`, import.meta.url),
+  ];
+  let lastErr: unknown;
+  for (const url of candidates) {
+    try {
+      return await readFile(fileURLToPath(url), 'utf8');
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') throw err;
+      lastErr = err;
+    }
+  }
+  throw lastErr ?? new Error(`bridge asset not found: ${name}`);
+}

--- a/packages/harness-opencode/src/opencode-harness.test.ts
+++ b/packages/harness-opencode/src/opencode-harness.test.ts
@@ -515,5 +515,12 @@ describe('createOpenCode adapter', () => {
           'node node_modules/opencode-ai/postinstall.mjs && ./node_modules/.bin/opencode --version',
       });
     });
+
+    it('shares the getter across configured harness instances', () => {
+      const first = createOpenCode({ model: 'first-model' });
+      const second = createOpenCode({ model: 'second-model' });
+
+      expect(first.getBootstrap).toBe(second.getBootstrap);
+    });
   });
 });

--- a/packages/harness-opencode/src/opencode-harness.ts
+++ b/packages/harness-opencode/src/opencode-harness.ts
@@ -1,13 +1,10 @@
 import { randomBytes } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import {
   commonTool,
   HarnessCapabilityUnsupportedError,
   harnessV1DiagnosticFromBridgeFrame,
   type HarnessV1,
-  type HarnessV1Bootstrap,
   type HarnessV1BuiltinTool,
   type HarnessV1BuiltinToolFiltering,
   type HarnessV1ContinueTurnState,
@@ -43,6 +40,10 @@ import {
 } from '@ai-sdk/provider-utils';
 import { WebSocket } from 'ws';
 import { z } from 'zod/v4';
+import {
+  getOpenCodeBootstrap,
+  OPENCODE_BOOTSTRAP_DIR as BOOTSTRAP_DIR,
+} from './opencode-bootstrap';
 import {
   createOpenCodeRequestTransformations,
   OPENCODE_CREDENTIAL_ENVIRONMENT_VARIABLES,
@@ -197,8 +198,6 @@ const OPENCODE_BUILTIN_TOOLS = {
   }),
 } as const satisfies Record<string, HarnessV1BuiltinTool<any, any>>;
 
-const BOOTSTRAP_DIR = '.harness-bootstrap/opencode';
-
 const openCodeBridgeCoordsSchema = z.object({
   port: z.number(),
   token: z.string(),
@@ -224,46 +223,13 @@ export function createOpenCode(
       'OpenCode MCP server name "harness-tools" is reserved for HarnessAgent tools.',
     );
   }
-  let cachedBootstrap: HarnessV1Bootstrap | undefined;
-
   return {
     specificationVersion: 'harness-v1',
     harnessId: 'opencode',
     builtinTools: OPENCODE_BUILTIN_TOOLS,
     supportsBuiltinToolApprovals: true,
     lifecycleStateSchema: openCodeResumeStateSchema,
-    getBootstrap: async () => {
-      if (cachedBootstrap != null) return cachedBootstrap;
-      const [pkg, lock, bridge, hostToolMcp] = await Promise.all([
-        readBridgeAsset('package.json'),
-        readBridgeAsset('pnpm-lock.yaml'),
-        readBridgeAsset('index.mjs'),
-        readBridgeAsset('host-tool-mcp.mjs'),
-      ]);
-      cachedBootstrap = {
-        harnessId: 'opencode',
-        bootstrapDir: BOOTSTRAP_DIR,
-        files: [
-          { path: `${BOOTSTRAP_DIR}/package.json`, content: pkg },
-          { path: `${BOOTSTRAP_DIR}/pnpm-lock.yaml`, content: lock },
-          { path: `${BOOTSTRAP_DIR}/bridge.mjs`, content: bridge },
-          {
-            path: `${BOOTSTRAP_DIR}/host-tool-mcp.mjs`,
-            content: hostToolMcp,
-          },
-        ],
-        commands: [
-          {
-            command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
-          },
-          {
-            command:
-              'node node_modules/opencode-ai/postinstall.mjs && ./node_modules/.bin/opencode --version',
-          },
-        ],
-      };
-      return cachedBootstrap;
-    },
+    getBootstrap: getOpenCodeBootstrap,
     doStart: async startOpts => {
       const sandboxSession = startOpts.sandboxSession;
       const authenticationMode = resolveOpenCodeAuthenticationMode({
@@ -536,24 +502,6 @@ function resolveBridgePort(
       'The OpenCode harness needs a TCP port exposed by the sandbox. ' +
       'Create the sandbox with `ports: [<port>]` or pass `createOpenCode({ port })`.',
   });
-}
-
-async function readBridgeAsset(name: string): Promise<string> {
-  const candidates = [
-    new URL(`./bridge/${name}`, import.meta.url),
-    new URL(`../bridge/${name}`, import.meta.url),
-  ];
-  let lastErr: unknown;
-  for (const url of candidates) {
-    try {
-      return await readFile(fileURLToPath(url), 'utf8');
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code !== 'ENOENT') throw err;
-      lastErr = err;
-    }
-  }
-  throw lastErr ?? new Error(`bridge asset not found: ${name}`);
 }
 
 async function writeOpenCodeSkills({

--- a/packages/harness/src/agent/prepare-sandbox-for-harness.test.ts
+++ b/packages/harness/src/agent/prepare-sandbox-for-harness.test.ts
@@ -146,16 +146,33 @@ describe('prepareSandboxForHarness', () => {
     expect(run).not.toHaveBeenCalled();
   });
 
-  it('rejects duplicate harness ids', async () => {
-    const first = makeHarness({ harnessId: 'alpha', recipe: makeRecipe('a') });
-    const second = makeHarness({ harnessId: 'alpha', recipe: makeRecipe('b') });
+  it('deduplicates harnesses by id and uses the last adapter', async () => {
+    const firstRecipe = makeRecipe('alpha');
+    const secondRecipe = {
+      ...makeRecipe('alpha'),
+      commands: [{ command: 'echo second' }],
+    };
+    const first = makeHarness({ harnessId: 'alpha', recipe: firstRecipe });
+    const second = makeHarness({ harnessId: 'alpha', recipe: secondRecipe });
+    const { session, run } = makeSession();
 
-    await expect(
-      prepareSandboxForHarness({
-        session: makeSession().session,
-        harnesses: [first, second],
-      }),
-    ).rejects.toThrow(/duplicate harness id/);
+    const result = await prepareSandboxForHarness({
+      session,
+      harnesses: [first, second],
+    });
+
+    expect(result).toEqual({
+      identity: expect.stringMatching(/^[0-9a-f]{16}$/),
+      recipeIdentities: {
+        alpha: await hashHarnessBootstrap(secondRecipe),
+      },
+      skippedHarnessIds: [],
+    });
+    expect(run.mock.calls.map(([args]) => args.command)).toEqual([
+      'pwd',
+      'mkdir -p "$BOOTSTRAP_DIR"',
+      'echo second',
+    ]);
   });
 
   it('validates caller bootstrap settings', async () => {

--- a/packages/harness/src/agent/prepare-sandbox-for-harness.ts
+++ b/packages/harness/src/agent/prepare-sandbox-for-harness.ts
@@ -36,6 +36,9 @@ export type PrepareSandboxForHarnessResult = {
  * When a later `HarnessAgent` session uses a sandbox created from the persisted
  * artifact, the adapter recomputes the same recipe identity and the existing
  * bootstrap marker makes the bootstrap logic a no-op.
+ *
+ * Repeated harness IDs are prepared once. When multiple adapters use the same
+ * ID, the last adapter in `harnesses` is used.
  */
 export async function prepareSandboxForHarness(options: {
   readonly session: SandboxSession;
@@ -52,10 +55,11 @@ export async function prepareSandboxForHarness(options: {
     );
   }
 
-  const harnesses = [...options.harnesses].sort((a, b) =>
-    a.harnessId.localeCompare(b.harnessId),
-  );
-  assertUniqueHarnessIds(harnesses);
+  const harnesses = [
+    ...new Map(
+      options.harnesses.map(harness => [harness.harnessId, harness]),
+    ).values(),
+  ].sort((a, b) => a.harnessId.localeCompare(b.harnessId));
 
   const workDir =
     sandboxConfig.workDir == null
@@ -110,20 +114,6 @@ export async function prepareSandboxForHarness(options: {
     recipeIdentities,
     skippedHarnessIds,
   };
-}
-
-function assertUniqueHarnessIds(
-  harnesses: ReadonlyArray<HarnessAgentAdapter>,
-): void {
-  const seen = new Set<string>();
-  for (const harness of harnesses) {
-    if (seen.has(harness.harnessId)) {
-      throw new Error(
-        `prepareSandboxForHarness: duplicate harness id "${harness.harnessId}".`,
-      );
-    }
-    seen.add(harness.harnessId);
-  }
 }
 
 async function resolvePreparedSandboxIdentity({


### PR DESCRIPTION
## Background

Bridge harness bootstrap recipes should be fixed for a given harness, but their logic previously lived inside configured harness factories where it could access dynamic runtime settings.

When using `prepareSandboxForHarness()`, this meant callers could theoretically pass different harness bootstrap objects for the same harness. This also led to a DX flaw where callers had to sanitize the harness bootstrap objects themselves before passing them to the function.

## Summary

- Move fixed bridge bootstrap recipes into shared parameter-less getters.
- Limit ACP bootstrap creation to its harness ID and implementation definition.
- Deduplicate harnesses by ID in `prepareSandboxForHarness`, using the last adapter.
- Enforce the bootstrap module structure with konsistent.

## End-to-End Verification

Ran various e2e examples for the modified harnesses, which should not have any behavioral changes (this is purely a refactoring for the harnesses).

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
