### PR TITLE
feat(provider/moonshotai): normalize tool schemas for Moonshot's MFJS validator

### DIFF
--- a/.changeset/moonshotai-mfjs-normalize.md
+++ b/.changeset/moonshotai-mfjs-normalize.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+feat(provider/moonshotai): normalize tool schemas for Moonshot's MFJS validator. Tuple `items` arrays become `prefixItems`, `type` next to `anyOf` moves into the branches, and non-`object` root schemas fail with a clear client-side error instead of Moonshot's opaque 400. Everything else passes through unchanged; the original schema is still used for AI SDK result validation.

--- a/examples/ai-functions/src/generate-text/moonshot/tool-schema-normalization.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/tool-schema-normalization.ts
@@ -1,0 +1,65 @@
+import { moonshotai } from '@ai-sdk/moonshotai';
+import { generateText, isStepCount, jsonSchema, tool } from 'ai';
+import { z } from 'zod';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const tupleResult = await generateText({
+    model: moonshotai('kimi-k3'),
+    tools: {
+      weatherAtPoint: tool({
+        description: 'Get the weather at a [latitude, longitude] pair',
+        inputSchema: z.object({
+          // zod tuple, sent as prefixItems
+          point: z.tuple([z.number(), z.number()]),
+        }),
+        execute: async ({ point: [latitude, longitude] }) => ({
+          latitude,
+          longitude,
+          temperature: 72,
+        }),
+      }),
+    },
+    stopWhen: isStepCount(2),
+    include: { requestBody: true },
+    prompt: 'What is the weather at 37.7749, -122.4194?',
+  });
+
+  console.log('--- tuple items -> prefixItems ---');
+  console.log(tupleResult.text);
+  print('Request:', tupleResult.request.body);
+  console.log();
+
+  const anyOfResult = await generateText({
+    model: moonshotai('kimi-k3'),
+    tools: {
+      weatherInLocation: tool({
+        description:
+          'Get the weather in a city by name (3+ characters) or US zip code',
+        inputSchema: jsonSchema<{ location: string }>({
+          type: 'object',
+          properties: {
+            // type next to anyOf, sent with type inside the branches
+            location: {
+              type: 'string',
+              anyOf: [{ minLength: 3 }, { pattern: '^\\d{5}$' }],
+            },
+          },
+          required: ['location'],
+        }),
+        execute: async ({ location }) => ({
+          location,
+          temperature: 72,
+        }),
+      }),
+    },
+    stopWhen: isStepCount(2),
+    include: { requestBody: true },
+    prompt: 'What is the weather in 94103?',
+  });
+
+  console.log('--- type + anyOf -> type inside branches ---');
+  console.log(anyOfResult.text);
+  print('Request:', anyOfResult.request.body);
+});

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -369,6 +369,41 @@ describe('doGenerate', () => {
       prepareJsonFixtureResponse('moonshotai-tool-call');
     });
 
+    it('should normalize tuple tool schemas to prefixItems on the wire', async () => {
+      await provider.chatModel('kimi-k3').doGenerate({
+        prompt: TEST_PROMPT,
+        tools: [
+          {
+            type: 'function',
+            name: 'probe',
+            description: 'probe',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                a: {
+                  type: 'array',
+                  items: [{ type: 'number' }, { type: 'number' }],
+                },
+              },
+              required: ['a'],
+            },
+          },
+        ],
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.tools[0].function.parameters).toStrictEqual({
+        type: 'object',
+        properties: {
+          a: {
+            type: 'array',
+            prefixItems: [{ type: 'number' }, { type: 'number' }],
+          },
+        },
+        required: ['a'],
+      });
+    });
+
     it('should extract tool calls and finish reason', async () => {
       const result = await provider.chatModel('kimi-k3').doGenerate({
         prompt: TEST_PROMPT,

--- a/packages/moonshotai/src/moonshotai-prepare-tools.ts
+++ b/packages/moonshotai/src/moonshotai-prepare-tools.ts
@@ -3,6 +3,7 @@ import {
   type LanguageModelV4CallOptions,
   type SharedV4Warning,
 } from '@ai-sdk/provider';
+import { normalizeJsonSchemaForMFJS } from './normalize-json-schema-for-mfjs';
 
 export function prepareTools({
   tools,
@@ -61,7 +62,7 @@ export function prepareTools({
         function: {
           name: tool.name,
           description: tool.description,
-          parameters: tool.inputSchema,
+          parameters: normalizeJsonSchemaForMFJS(tool.inputSchema),
           ...(tool.strict != null ? { strict: tool.strict } : {}),
         },
       });

--- a/packages/moonshotai/src/normalize-json-schema-for-mfjs.test.ts
+++ b/packages/moonshotai/src/normalize-json-schema-for-mfjs.test.ts
@@ -1,0 +1,293 @@
+import { UnsupportedFunctionalityError } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { normalizeJsonSchemaForMFJS } from './normalize-json-schema-for-mfjs';
+
+describe('identity (no normalization needed)', () => {
+  it('passes a plain object schema through unchanged', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        city: { type: 'string', description: 'The city' },
+        zip: { type: 'string', pattern: '^[0-9]{5}$' },
+      },
+      required: ['city'],
+      additionalProperties: false,
+    };
+
+    expect(normalizeJsonSchemaForMFJS(schema)).toEqual(schema);
+  });
+
+  it('preserves keywords Moonshot accepts verbatim', () => {
+    const schema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: {
+        a: { type: 'string', enum: ['x', 'y'], format: 'uri' },
+        b: { type: ['string', 'null'] },
+        c: { type: 'array', contains: { type: 'string' } },
+        d: { $ref: '#/$defs/thing' },
+      },
+      $defs: { thing: { type: 'number' } },
+      // A `then` key trips the no-thenable lint rule.
+      not: { type: 'string' },
+    };
+
+    expect(normalizeJsonSchemaForMFJS(schema)).toEqual(schema);
+  });
+
+  it('passes anyOf without a sibling type through unchanged', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        location: {
+          anyOf: [{ type: 'string' }, { type: 'number' }],
+        },
+      },
+      required: ['location'],
+    };
+
+    expect(normalizeJsonSchemaForMFJS(schema)).toEqual(schema);
+  });
+
+  it('leaves oneOf next to type alone (accepted by MFJS)', () => {
+    const schema = {
+      type: 'object',
+      oneOf: [
+        { properties: { city: { type: 'string' } }, required: ['city'] },
+        { properties: { lat: { type: 'number' } }, required: ['lat'] },
+      ],
+    };
+
+    expect(normalizeJsonSchemaForMFJS(schema)).toEqual(schema);
+  });
+
+  it('leaves single-schema items alone', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        a: {
+          type: 'array',
+          items: { type: 'number' },
+          minItems: 2,
+          maxItems: 2,
+        },
+      },
+    };
+
+    expect(normalizeJsonSchemaForMFJS(schema)).toEqual(schema);
+  });
+});
+
+describe('tuple items -> prefixItems', () => {
+  it('rewrites a tuple items array to prefixItems and drops items', () => {
+    const result = normalizeJsonSchemaForMFJS({
+      type: 'object',
+      properties: {
+        a: {
+          type: 'array',
+          items: [{ type: 'number' }, { type: 'number' }],
+        },
+      },
+      required: ['a'],
+    });
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        a: {
+          type: 'array',
+          prefixItems: [{ type: 'number' }, { type: 'number' }],
+        },
+      },
+      required: ['a'],
+    });
+  });
+
+  it('preserves minItems and maxItems when rewriting tuples', () => {
+    const result = normalizeJsonSchemaForMFJS({
+      type: 'object',
+      properties: {
+        a: {
+          type: 'array',
+          items: [{ type: 'string' }, { type: 'number' }],
+          minItems: 2,
+          maxItems: 2,
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        a: {
+          type: 'array',
+          prefixItems: [{ type: 'string' }, { type: 'number' }],
+          minItems: 2,
+          maxItems: 2,
+        },
+      },
+    });
+  });
+
+  it('appends tuple items after existing prefixItems', () => {
+    const result = normalizeJsonSchemaForMFJS({
+      type: 'object',
+      properties: {
+        a: {
+          type: 'array',
+          prefixItems: [{ type: 'string' }],
+          items: [{ type: 'number' }],
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        a: {
+          type: 'array',
+          prefixItems: [{ type: 'string' }, { type: 'number' }],
+        },
+      },
+    });
+  });
+
+  it('rewrites tuples nested in anyOf branches', () => {
+    const result = normalizeJsonSchemaForMFJS({
+      type: 'object',
+      properties: {
+        a: {
+          anyOf: [
+            {
+              type: 'array',
+              items: [{ type: 'string' }, { type: 'number' }],
+            },
+            { type: 'string' },
+          ],
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        a: {
+          anyOf: [
+            {
+              type: 'array',
+              prefixItems: [{ type: 'string' }, { type: 'number' }],
+            },
+            { type: 'string' },
+          ],
+        },
+      },
+    });
+  });
+});
+
+describe('type + anyOf on the same node', () => {
+  it('moves type into anyOf branches that lack one', () => {
+    const result = normalizeJsonSchemaForMFJS({
+      type: 'object',
+      anyOf: [
+        { properties: { city: { type: 'string' } }, required: ['city'] },
+        {
+          properties: { lat: { type: 'number' }, lon: { type: 'number' } },
+          required: ['lat', 'lon'],
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      anyOf: [
+        {
+          type: 'object',
+          properties: { city: { type: 'string' } },
+          required: ['city'],
+        },
+        {
+          type: 'object',
+          properties: { lat: { type: 'number' }, lon: { type: 'number' } },
+          required: ['lat', 'lon'],
+        },
+      ],
+    });
+  });
+
+  it('keeps branch types when already present', () => {
+    const result = normalizeJsonSchemaForMFJS({
+      type: 'object',
+      anyOf: [{ type: 'string' }, { properties: { lat: { type: 'number' } } }],
+    });
+
+    expect(result).toEqual({
+      anyOf: [
+        { type: 'string' },
+        { type: 'object', properties: { lat: { type: 'number' } } },
+      ],
+    });
+  });
+
+  it('splits type at nested levels, not just the root', () => {
+    const result = normalizeJsonSchemaForMFJS({
+      type: 'object',
+      properties: {
+        a: {
+          type: 'object',
+          anyOf: [
+            { properties: { city: { type: 'string' } }, required: ['city'] },
+            { properties: { lat: { type: 'number' } }, required: ['lat'] },
+          ],
+        },
+      },
+      required: ['a'],
+    });
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        a: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: { city: { type: 'string' } },
+              required: ['city'],
+            },
+            {
+              type: 'object',
+              properties: { lat: { type: 'number' } },
+              required: ['lat'],
+            },
+          ],
+        },
+      },
+      required: ['a'],
+    });
+  });
+});
+
+describe('root guard', () => {
+  it('throws for a non-object root type', () => {
+    expect(() =>
+      normalizeJsonSchemaForMFJS({ type: 'array', items: { type: 'number' } }),
+    ).toThrow(UnsupportedFunctionalityError);
+  });
+
+  it('throws for a missing root type', () => {
+    expect(() =>
+      normalizeJsonSchemaForMFJS({ properties: { a: { type: 'string' } } }),
+    ).toThrow(UnsupportedFunctionalityError);
+  });
+
+  it('throws for a boolean root schema', () => {
+    expect(() => normalizeJsonSchemaForMFJS(true)).toThrow(
+      UnsupportedFunctionalityError,
+    );
+  });
+
+  it('produces a clear error message', () => {
+    expect(() => normalizeJsonSchemaForMFJS({ type: 'array' })).toThrow(
+      'tool parameters must be a JSON Schema object with type "object" for moonshotai (MFJS)',
+    );
+  });
+});

--- a/packages/moonshotai/src/normalize-json-schema-for-mfjs.ts
+++ b/packages/moonshotai/src/normalize-json-schema-for-mfjs.ts
@@ -1,0 +1,102 @@
+import { UnsupportedFunctionalityError } from '@ai-sdk/provider';
+import { isRecord } from '@ai-sdk/provider-utils';
+
+const SCHEMA_ARRAY_KEYS = ['allOf', 'anyOf', 'oneOf', 'prefixItems'] as const;
+const SCHEMA_MAP_KEYS = [
+  'properties',
+  'patternProperties',
+  '$defs',
+  'dependentSchemas',
+] as const;
+const SCHEMA_SINGLE_KEYS = [
+  'additionalProperties',
+  'propertyNames',
+  'items',
+  'contains',
+  'not',
+  'if',
+  'then',
+  'else',
+] as const;
+
+/**
+ * Normalizes a JSON Schema to the subset Moonshot's MFJS validator accepts:
+ * `object` root required, tuple `items` become `prefixItems`, and `type` next
+ * to `anyOf` moves into the branches. Everything else passes through. The
+ * full original schema is still used for AI SDK result validation.
+ */
+export function normalizeJsonSchemaForMFJS(schema: unknown): unknown {
+  return normalizeDefinition(schema, true);
+}
+
+function normalizeDefinition(definition: unknown, isRoot: boolean): unknown {
+  if (typeof definition === 'boolean' || !isRecord(definition)) {
+    if (isRoot) {
+      throw new UnsupportedFunctionalityError({
+        functionality:
+          'tool parameters must be a JSON Schema object with type "object" for moonshotai (MFJS)',
+      });
+    }
+    return definition;
+  }
+
+  if (isRoot && definition.type !== 'object') {
+    throw new UnsupportedFunctionalityError({
+      functionality:
+        'tool parameters must be a JSON Schema object with type "object" for moonshotai (MFJS)',
+    });
+  }
+
+  const result: Record<string, unknown> = { ...definition };
+
+  // Existing prefixItems stay first (they are positional).
+  if (Array.isArray(result.items)) {
+    const tuple = result.items;
+    result.prefixItems = [
+      ...(Array.isArray(result.prefixItems) ? result.prefixItems : []),
+      ...tuple.map(item => normalizeDefinition(item, false)),
+    ];
+    delete result.items;
+  } else if (isRecord(result.items)) {
+    result.items = normalizeDefinition(result.items, false);
+  }
+
+  // MFJS requires type to live inside anyOf items.
+  if (typeof result.type === 'string' && Array.isArray(result.anyOf)) {
+    const parentType = result.type;
+    delete result.type;
+    result.anyOf = result.anyOf.map(branch =>
+      isRecord(branch) && branch.type == null
+        ? { type: parentType, ...branch }
+        : branch,
+    );
+  }
+
+  for (const key of SCHEMA_ARRAY_KEYS) {
+    const value = result[key];
+    if (Array.isArray(value)) {
+      result[key] = value.map(item => normalizeDefinition(item, false));
+    }
+  }
+
+  for (const key of SCHEMA_MAP_KEYS) {
+    const value = result[key];
+    if (isRecord(value)) {
+      result[key] = Object.fromEntries(
+        Object.entries(value).map(([k, v]) => [
+          k,
+          normalizeDefinition(v, false),
+        ]),
+      );
+    }
+  }
+
+  for (const key of SCHEMA_SINGLE_KEYS) {
+    const value = result[key];
+    if (isRecord(value) || typeof value === 'boolean') {
+      result[key] = normalizeDefinition(value, false);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION

## Background

Moonshot's chat completions validates tool `parameters` against MFJS ("Moonshot Flavored JSON Schema"), and rejects shapes that are legal JSON Schema, with a 400 before generation. Anything sent to `@ai-sdk/moonshotai` with one of these shapes fails, and on the gateway many of these requests silently retry to another provider, which is why customers report "it worked yesterday" when routing shifts.

From customer reports and probing the live validator, the failures fall into three buckets:

- `type` next to `anyOf` ("type should be defined in anyOf items instead of the parent"), the largest share.
- Tuple `items` arrays ("items must be an object"), a small share.
- Everything else, which is mostly genuine authoring errors (`required` naming undefined properties, non-local `$ref`, wrong property types) that should keep failing.

So the first two buckets are addressable by normalization; the rest is correct validation we should not paper over.

## Summary

Adds `normalize-json-schema-for-mfjs.ts`, applied to tool `parameters` in `prepareTools`, with three rewrites verified against the live validator:

- Tuple `items` arrays become `prefixItems` with `items` dropped entirely (`items: false` is also rejected, so it is never emitted). `minItems`/`maxItems` are preserved.
- A node carrying both `type` and `anyOf` moves `type` into each branch lacking one (MFJS requires `type` inside `anyOf` items). Applies at every level, not just the root.
- Non-`object` root schemas fail client-side with a clear `UnsupportedFunctionalityError` instead of Moonshot's opaque 400.

Everything else passes through unchanged (verified passing live: `enum`, `pattern`, `format`, `$schema`, `additionalProperties`, `contains`, `if`/`then`/`else`, `$ref`, `allOf`, `not`, `dependentRequired`, type arrays, nested objects, `minItems`/`maxItems`, single-schema `items`). The full original schema is still used for AI SDK result validation; only the sent schema is relaxed, matching the framing in #14790 (`sanitize-json-schema.ts`, the direct precedent for this class of change) and Google's `convert-json-schema-to-openapi-schema.ts` (#11326 and successors, which rewires shapes the same way for Gemini's schema subset).

## End-to-End Verification

- Live validator probes against `api.moonshot.ai` (kimi-k3): each rejected shape 400s pre-normalization and passes post-normalization (`prefixItems` in all forms; `anyOf` with `type` only inside branches; `object` root). Non-covered authoring errors still 400, as intended.
- 16 normalizer unit tests (identity pass-throughs for accepted shapes, one case per rule, recursion into `anyOf` branches and nested properties, root-guard error messages) plus a wire-level model test asserting an outgoing tuple becomes `prefixItems`. 80/80 package tests pass on node and edge; `pnpm check` and `tsc -b` clean.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (internal behavior change; capability surface unchanged)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

- Backport to `release-v6.0` (spec v3) so the AI SDK 6 and gateway v3 surfaces get the normalization.
- Optional: `required` entries missing from `properties` could be stripped with a warning instead of a Moonshot 400.
- Keyword stripping for unknown MFJS constraints (the "alter to fit or strip" idea from the gateway team) is deliberately out of scope here; only the three verified rewrites plus the root guard are included.

## Related Issues

Customer reports of tuple-style and `anyOf` tool-schema validation failures against Moonshot models; this addresses them on the direct provider path.
