### PR TITLE
fix(harness-opencode): don't emit a pre-turn assistant message as the turn's reply

### DIFF
--- a/.changeset/olive-taxis-invite.md
+++ b/.changeset/olive-taxis-invite.md
@@ -1,0 +1,14 @@
+---
+'@ai-sdk/harness-opencode': patch
+---
+
+fix (harness-opencode): do not emit a pre-turn assistant message as the turn's reply
+
+When the OpenCode event stream ended without settling the current turn, the
+context fallback emitted the session's newest assistant message with a
+successful finish reason. On a resumed session that message can be the
+previous turn's answer, so the caller received a stale reply — text only,
+without the tool calls that produced it — reported as success. The fallback
+now compares against the newest assistant id observed before the prompt was
+sent and declines to emit when nothing new was recorded, leaving the existing
+`missingContext` path to report the turn honestly.

--- a/packages/harness-opencode/src/bridge/index.ts
+++ b/packages/harness-opencode/src/bridge/index.ts
@@ -1150,6 +1150,7 @@ async function readSessionTokens({
 }
 
 type AssistantSnapshot = {
+  id?: unknown;
   contentParts?: unknown[];
   metadata?: unknown;
   model?: unknown;

--- a/packages/harness-opencode/src/bridge/index.ts
+++ b/packages/harness-opencode/src/bridge/index.ts
@@ -17,6 +17,7 @@ import {
   createTranslationState,
   emitOpenCodeStreamStart,
   getOpenCodeEventSessionId,
+  isStaleAssistantSnapshot,
   isStepSettlementEvent,
   type TranslationState,
   unwrapOpenCodeEvent,
@@ -561,6 +562,12 @@ async function runPrompt({
     client,
     sessionId,
   }).catch(() => undefined);
+  /* The newest assistant BEFORE this prompt. On a resumed session it is the
+     previous turn's answer, and the context fallback below must never mistake
+     it for this turn's reply. */
+  const baselineAssistantId = (
+    await latestAssistantSnapshot({ client, sessionId }).catch(() => undefined)
+  )?.id;
   const eventsReady = createDeferred<void>();
   let stepUsage: HarnessUsage | undefined;
   let latestSessionTokens: OpenCodeTokenUsage | undefined;
@@ -643,6 +650,7 @@ async function runPrompt({
       state,
       emit,
       emitContent: !sawContent,
+      baselineAssistantId,
     }).catch(() => false);
     if (!emittedFallback) {
       emit({
@@ -1087,15 +1095,20 @@ async function emitContextFallback({
   state,
   emit,
   emitContent,
+  baselineAssistantId,
 }: {
   client: OpenCodeClient;
   sessionId: string;
   state: TranslationState;
   emit: Emit;
   emitContent: boolean;
+  /* The newest assistant message id observed before this turn's prompt was
+     sent, when one existed. */
+  baselineAssistantId?: string | undefined;
 }): Promise<boolean> {
   const assistant = await latestAssistantSnapshot({ client, sessionId });
   if (!assistant) return false;
+  if (isStaleAssistantSnapshot({ assistant, baselineAssistantId })) return false;
   emitOpenCodeStreamStart({ info: assistant, state, emit });
   if (emitContent && Array.isArray(assistant.contentParts)) {
     for (const part of assistant.contentParts) {

--- a/packages/harness-opencode/src/bridge/index.ts
+++ b/packages/harness-opencode/src/bridge/index.ts
@@ -562,9 +562,8 @@ async function runPrompt({
     client,
     sessionId,
   }).catch(() => undefined);
-  /* The newest assistant BEFORE this prompt. On a resumed session it is the
-     previous turn's answer, and the context fallback below must never mistake
-     it for this turn's reply. */
+  // The newest assistant before this prompt; the context fallback must not
+  // mistake it for this turn's reply.
   const baselineAssistantId = (
     await latestAssistantSnapshot({ client, sessionId }).catch(() => undefined)
   )?.id;
@@ -1102,13 +1101,12 @@ async function emitContextFallback({
   state: TranslationState;
   emit: Emit;
   emitContent: boolean;
-  /* The newest assistant message id observed before this turn's prompt was
-     sent, when one existed. */
   baselineAssistantId?: string | undefined;
 }): Promise<boolean> {
   const assistant = await latestAssistantSnapshot({ client, sessionId });
   if (!assistant) return false;
-  if (isStaleAssistantSnapshot({ assistant, baselineAssistantId })) return false;
+  if (isStaleAssistantSnapshot({ assistant, baselineAssistantId }))
+    return false;
   emitOpenCodeStreamStart({ info: assistant, state, emit });
   if (emitContent && Array.isArray(assistant.contentParts)) {
     for (const part of assistant.contentParts) {

--- a/packages/harness-opencode/src/bridge/opencode-events.test.ts
+++ b/packages/harness-opencode/src/bridge/opencode-events.test.ts
@@ -6,6 +6,7 @@ import {
   emitMissingFinalDelta,
   emitOpenCodeStreamStart,
   getOpenCodeEventSessionId,
+  isStaleAssistantSnapshot,
   isStepSettlementEvent,
   unwrapOpenCodeEvent,
 } from './opencode-events';
@@ -261,5 +262,45 @@ describe('legacy reasoning part translation', () => {
       { type: 'text-start', id: 'p3' },
       { type: 'text-delta', id: 'p3', delta: 'hello' },
     ]);
+  });
+});
+
+describe('isStaleAssistantSnapshot', () => {
+  it('rejects the assistant that already existed before the prompt', () => {
+    // A resumed session's newest assistant is the PREVIOUS turn's answer;
+    // emitting it as this turn's reply is the bug this guards.
+    expect(
+      isStaleAssistantSnapshot({
+        assistant: { id: 'msg_prev' },
+        baselineAssistantId: 'msg_prev',
+      }),
+    ).toBe(true);
+  });
+
+  it('accepts an assistant recorded after the baseline', () => {
+    expect(
+      isStaleAssistantSnapshot({
+        assistant: { id: 'msg_new' },
+        baselineAssistantId: 'msg_prev',
+      }),
+    ).toBe(false);
+  });
+
+  it('accepts anything when there was no prior assistant (fresh session)', () => {
+    expect(
+      isStaleAssistantSnapshot({
+        assistant: { id: 'msg_first' },
+        baselineAssistantId: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it('is inert without a snapshot to judge', () => {
+    expect(
+      isStaleAssistantSnapshot({
+        assistant: undefined,
+        baselineAssistantId: 'msg_prev',
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/harness-opencode/src/bridge/opencode-events.ts
+++ b/packages/harness-opencode/src/bridge/opencode-events.ts
@@ -313,3 +313,24 @@ function legacyTextPartFromValue(value: unknown): LegacyTextPart | undefined {
     time: asOpenCodeObject(part.time),
   };
 }
+
+/**
+ * Whether a context-fallback snapshot predates the turn that is asking for it.
+ *
+ * The fallback exists to recover a turn whose event stream ended without a
+ * `finish-step`, by reading the session's newest assistant message. On a
+ * RESUMED session that message may be the previous turn's answer: emitting it
+ * would report stale content as the current turn's reply, with a successful
+ * finish reason. Comparing against the newest assistant id observed before the
+ * prompt was sent keeps the fallback to genuinely new content.
+ */
+export function isStaleAssistantSnapshot({
+  assistant,
+  baselineAssistantId,
+}: {
+  assistant: { id?: unknown } | undefined;
+  baselineAssistantId?: string | undefined;
+}): boolean {
+  if (baselineAssistantId == null || !assistant) return false;
+  return assistant.id === baselineAssistantId;
+}

--- a/packages/harness-opencode/src/bridge/opencode-events.ts
+++ b/packages/harness-opencode/src/bridge/opencode-events.ts
@@ -315,14 +315,8 @@ function legacyTextPartFromValue(value: unknown): LegacyTextPart | undefined {
 }
 
 /**
- * Whether a context-fallback snapshot predates the turn that is asking for it.
- *
- * The fallback exists to recover a turn whose event stream ended without a
- * `finish-step`, by reading the session's newest assistant message. On a
- * RESUMED session that message may be the previous turn's answer: emitting it
- * would report stale content as the current turn's reply, with a successful
- * finish reason. Comparing against the newest assistant id observed before the
- * prompt was sent keeps the fallback to genuinely new content.
+ * Whether the context fallback's snapshot predates the turn asking for it — on
+ * a resumed session the newest assistant may be the previous turn's answer.
  */
 export function isStaleAssistantSnapshot({
   assistant,


### PR DESCRIPTION
Fixes #18933

## Problem

When the OpenCode event stream ends without settling the current turn, `emitContextFallback` reads the session's **newest assistant message** and emits its content plus a synthetic **successful** `finish-step`. There is no correlation with the prompt just sent — no baseline id, no `parentID` check, no timestamp fence.

On a **resumed** session the newest assistant is the *previous* turn's answer, so the caller receives a stale reply — text only, without the tool calls that produced it — reported as a normal completion. We hit this three times in production: a user asked "can you write a memo with these cases?" and received the prior turn's full research answer byte-for-byte.

It's silent: no error surfaces, and the turn records as successful.

## Fix

Capture the newest assistant id **before** the prompt is sent, and decline the fallback when the snapshot still points at it:

```ts
const baselineAssistantId = (
  await latestAssistantSnapshot({ client, sessionId }).catch(() => undefined)
)?.id;
```

```ts
const assistant = await latestAssistantSnapshot({ client, sessionId });
if (!assistant) return false;
if (isStaleAssistantSnapshot({ assistant, baselineAssistantId })) return false;
```

When it declines, the existing `missingContext: true` branch reports the turn honestly rather than inventing a successful reply from stale state.

The comparison lives in `opencode-events.ts` as `isStaleAssistantSnapshot` so it's unit-testable — `bridge/index.ts` is a zero-export entry script.

## Scope

Deliberately minimal: this stops the wrong answer. It does **not** address the broader issue that stream closure resolves `turnSettled` via the consumer's `.finally()`, so an interrupted turn still ends without a real `finish-step` — it now ends *visibly* incomplete instead of *invisibly* wrong. Reconnect/poll-on-stream-death and `parentID` correlation would be the fuller fix; happy to extend this PR if you'd prefer that shape.

## Tests

Four cases in `opencode-events.test.ts`: rejects the pre-existing assistant, accepts one recorded after the baseline, accepts anything on a fresh session (no baseline), inert without a snapshot. Verified the first fails against unpatched code.

`pnpm vitest run src/bridge/` — 40 passed (8 files).

## Repro context

Sandboxes are persistent: the VM idle-stops after ~10 minutes, the snapshot survives days. A later turn resumes with a parked `resumeFrom` cursor, OpenCode restarts on preserved on-disk session storage, and any event-stream interruption in that window reaches the `.finally()` before the new turn settles — at which point the newest assistant on disk is necessarily the previous turn's.

This is the documented flow: `resumeFrom` says the adapter "should resume the existing session before accepting a new prompt", and `@ai-sdk/workflow-harness`'s `destroyOnFinish: false` parks the session so the next turn reattaches to the same conversation.
