### PR TITLE
feat(xai): speech timestamps, pronunciation replacements, provider metadata, and error parsing

### DIFF
--- a/.changeset/xai-speech-timestamps-metadata.md
+++ b/.changeset/xai-speech-timestamps-metadata.md
@@ -1,0 +1,14 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat(xai): speech timestamps, pronunciation replacements, provider metadata, and error parsing
+
+- Add `withTimestamps` and `replace` provider options for text to speech. With
+  `withTimestamps`, the JSON envelope is decoded and the audio returned as
+  usual, while duration, content type, and character-level alignment are
+  exposed via `providerMetadata.xai`.
+- Return `providerMetadata.xai.traceId` (from the `x-trace-id` response
+  header) on every speech response.
+- Parse the text to speech error shape (`{"error":"..."}`) so `APICallError`
+  messages carry xAI's real error detail instead of the HTTP reason phrase.

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -768,7 +768,7 @@ xAI speech results include provider-specific metadata under
   `withTimestamps`).
 - **contentType** _string_ — MIME type of the decoded audio, e.g.
   `'audio/mpeg'` (only with `withTimestamps`).
-- **audioTimestamps** _{ graphChars: string[]; graphTimes: [number, number][] }_ —
+- **audioTimestamps** `{ graphChars: string[]; graphTimes: [number, number][] }` —
   per-character alignment data (only with `withTimestamps`). `graphChars[i]`
   is the character spoken during the `[start, end]` interval
   `graphTimes[i]`, in seconds.

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -746,6 +746,45 @@ const result = await generateSpeech({
 
   Whether to normalize written-form input text before synthesizing speech.
 
+- **withTimestamps** _boolean_
+
+  Return character-level timing metadata alongside the audio. The timing data
+  and total duration are exposed via `providerMetadata.xai` (see below).
+
+- **replace** _Record&lt;string, string&gt;_
+
+  Map of phrases to spoken substitutions applied before synthesis. Values may
+  be respellings (`{ 'Acme Mobile': 'Acme Mobull' }`) or IPA phonetics
+  (`{ nginx: '/ˈɛndʒɪn ˈɛks/' }`).
+
+### Provider Metadata
+
+xAI speech results include provider-specific metadata under
+`providerMetadata.xai`:
+
+- **traceId** _string_ — the xAI trace ID for the request, useful for
+  debugging with xAI support.
+- **duration** _number_ — total audio duration in seconds (only with
+  `withTimestamps`).
+- **contentType** _string_ — MIME type of the decoded audio, e.g.
+  `'audio/mpeg'` (only with `withTimestamps`).
+- **audioTimestamps** _{ graphChars: string[]; graphTimes: [number, number][] }_ —
+  per-character alignment data (only with `withTimestamps`). `graphChars[i]`
+  is the character spoken during the `[start, end]` interval
+  `graphTimes[i]`, in seconds.
+
+```ts
+const result = await generateSpeech({
+  model: xai.speech(),
+  text: 'Hello world.',
+  providerOptions: {
+    xai: { withTimestamps: true } satisfies XaiSpeechModelOptions,
+  },
+});
+
+const { traceId, duration, audioTimestamps } = result.providerMetadata.xai;
+```
+
 ### Model Capabilities
 
 | Model     | Language  | Speed     | Output Formats             |

--- a/examples/ai-functions/src/generate-speech/xai/basic.ts
+++ b/examples/ai-functions/src/generate-speech/xai/basic.ts
@@ -12,6 +12,7 @@ run(async () => {
   console.log('Audio:', result.audio);
   console.log('Warnings:', result.warnings);
   console.log('Responses:', result.responses);
+  console.log('Provider Metadata:', result.providerMetadata);
 
   await saveAudioFile(result.audio);
 });

--- a/examples/ai-functions/src/generate-speech/xai/error-handling.ts
+++ b/examples/ai-functions/src/generate-speech/xai/error-handling.ts
@@ -1,0 +1,81 @@
+import { createXai } from '@ai-sdk/xai';
+import { APICallError } from '@ai-sdk/provider';
+import { generateSpeech } from 'ai';
+import { run } from '../../lib/run';
+
+/**
+ * Checks that xAI error details survive to the caller.
+ *
+ * xAI's /v1/tts error body is usually `{"error":"..."}` (no code), while
+ * other xAI APIs use `{"code":"...","error":"..."}` or the chat completions
+ * `{"error":{"message":"..."}}` shape. If the provider's error schema does
+ * not match the actual shape, the message falls back to the HTTP reason
+ * phrase ("Bad Request", "Not Found") and the real cause is lost.
+ *
+ * Print `message` next to the raw `body`: a message that is only a status
+ * phrase while the body holds real text means the schema does not match.
+ */
+
+const CASES: Array<{
+  name: string;
+  expect: string;
+  run: () => Promise<unknown>;
+}> = [
+  {
+    name: 'unknown voice',
+    expect: 'names the rejected voice',
+    run: () =>
+      generateSpeech({
+        model: createXai({}).speech(),
+        voice: 'not-a-real-voice',
+        text: 'Hello, world!',
+      }),
+  },
+  {
+    name: 'out-of-range speed',
+    expect: 'mentions the speed range',
+    run: () =>
+      generateSpeech({
+        model: createXai({}).speech(),
+        speed: 2,
+        text: 'Hello, world!',
+      }),
+  },
+  {
+    name: 'invalid replace key',
+    expect: 'explains the replace key constraint',
+    run: () =>
+      generateSpeech({
+        model: createXai({}).speech(),
+        text: 'C++ is a language.',
+        providerOptions: { xai: { replace: { 'C++': 'C plus plus' } } },
+      }),
+  },
+  {
+    name: 'invalid api key',
+    expect: 'mentions authentication',
+    run: () =>
+      generateSpeech({
+        model: createXai({ apiKey: 'not-a-real-key' }).speech(),
+        text: 'Hello, world!',
+      }),
+  },
+];
+
+run(async () => {
+  for (const testCase of CASES) {
+    try {
+      await testCase.run();
+      console.log(`\n${testCase.name}  unexpectedly succeeded`);
+    } catch (error) {
+      const apiError = APICallError.isInstance(error) ? error : undefined;
+      console.log(`\n${testCase.name}  (expect ${testCase.expect})`);
+      console.log(`  status   : ${apiError?.statusCode ?? '-'}`);
+      console.log(`  message  : ${(error as Error)?.message}`);
+      console.log(`  body     : ${apiError?.responseBody ?? '-'}`);
+      console.log(
+        `  trace id : ${apiError?.responseHeaders?.['x-trace-id'] ?? '-'}`,
+      );
+    }
+  }
+});

--- a/examples/ai-functions/src/generate-speech/xai/output-format.ts
+++ b/examples/ai-functions/src/generate-speech/xai/output-format.ts
@@ -22,6 +22,7 @@ run(async () => {
   console.log('Audio:', result.audio);
   console.log('Warnings:', result.warnings);
   console.log('Responses:', result.responses);
+  console.log('Provider Metadata:', result.providerMetadata);
 
   await saveAudioFile(result.audio);
 });

--- a/examples/ai-functions/src/generate-speech/xai/speech-tags.ts
+++ b/examples/ai-functions/src/generate-speech/xai/speech-tags.ts
@@ -14,6 +14,7 @@ run(async () => {
   console.log('Audio:', result.audio);
   console.log('Warnings:', result.warnings);
   console.log('Responses:', result.responses);
+  console.log('Provider Metadata:', result.providerMetadata);
 
   await saveAudioFile(result.audio);
 });

--- a/examples/ai-functions/src/generate-speech/xai/timestamps.ts
+++ b/examples/ai-functions/src/generate-speech/xai/timestamps.ts
@@ -1,0 +1,39 @@
+import { xai, type XaiSpeechModelOptions } from '@ai-sdk/xai';
+import { generateSpeech } from 'ai';
+import { saveAudioFile } from '../../lib/save-audio';
+import { run } from '../../lib/run';
+
+// xAI's `with_timestamps` option returns character-level alignment and
+// duration metadata alongside the audio. The audio is delivered as usual;
+// the timing data is exposed via `providerMetadata.xai`.
+run(async () => {
+  const result = await generateSpeech({
+    model: xai.speech(),
+    text: 'Hello world.',
+    voice: 'eve',
+    language: 'en',
+    providerOptions: {
+      xai: {
+        withTimestamps: true,
+      } satisfies XaiSpeechModelOptions,
+    },
+  });
+
+  console.log('Warnings:', result.warnings);
+  console.log('Provider Metadata:', result.providerMetadata);
+
+  const timestamps = result.providerMetadata.xai?.audioTimestamps as
+    | { graphChars: string[]; graphTimes: [number, number][] }
+    | undefined;
+  if (timestamps) {
+    console.log('\nCharacter timings:');
+    timestamps.graphChars.forEach((char, i) => {
+      const [start, end] = timestamps.graphTimes[i];
+      console.log(
+        `  ${JSON.stringify(char).padStart(5)}  ${start.toFixed(2)}s - ${end.toFixed(2)}s`,
+      );
+    });
+  }
+
+  await saveAudioFile(result.audio);
+});

--- a/examples/ai-functions/src/generate-speech/xai/voice.ts
+++ b/examples/ai-functions/src/generate-speech/xai/voice.ts
@@ -14,6 +14,7 @@ run(async () => {
   console.log('Audio:', result.audio);
   console.log('Warnings:', result.warnings);
   console.log('Responses:', result.responses);
+  console.log('Provider Metadata:', result.providerMetadata);
 
   await saveAudioFile(result.audio);
 });

--- a/packages/xai/src/xai-error.test.ts
+++ b/packages/xai/src/xai-error.test.ts
@@ -50,4 +50,19 @@ describe('xaiFailedResponseHandler', () => {
       'Client specified an invalid argument: Invalid request content: Each message must have at least one content element.',
     );
   });
+
+  it('extracts message from text to speech error shape', async () => {
+    const response = makeResponse({
+      error: 'speed must be between 0.7 and 1.5',
+    });
+
+    const { value } = await xaiFailedResponseHandler({
+      url: 'https://api.x.ai/v1/tts',
+      requestBodyValues: {},
+      response,
+    });
+
+    expect(value).toBeInstanceOf(APICallError);
+    expect(value.message).toBe('speed must be between 0.7 and 1.5');
+  });
 });

--- a/packages/xai/src/xai-error.ts
+++ b/packages/xai/src/xai-error.ts
@@ -15,15 +15,25 @@ const responsesErrorSchema = z.object({
   error: z.string(),
 });
 
+// Text to Speech error shape, e.g. {"error":"speed must be between 0.7 and 1.5"}
+const speechErrorSchema = z.object({
+  error: z.string(),
+});
+
 export const xaiErrorDataSchema = z.union([
   chatCompletionsErrorSchema,
   responsesErrorSchema,
+  speechErrorSchema,
 ]);
 
 export type XaiErrorData = z.infer<typeof xaiErrorDataSchema>;
 
 export const xaiFailedResponseHandler = createJsonErrorResponseHandler({
   errorSchema: xaiErrorDataSchema,
-  errorToMessage: data =>
-    'code' in data ? `${data.code}: ${data.error}` : data.error.message,
+  errorToMessage: data => {
+    if (typeof data.error === 'string') {
+      return 'code' in data ? `${data.code}: ${data.error}` : data.error;
+    }
+    return data.error.message;
+  },
 });

--- a/packages/xai/src/xai-speech-model-options.ts
+++ b/packages/xai/src/xai-speech-model-options.ts
@@ -46,6 +46,20 @@ export const xaiSpeechModelOptionsSchema = lazySchema(() =>
        * Normalize written-form text into spoken-form text before synthesis.
        */
       textNormalization: z.boolean().nullish(),
+
+      /**
+       * Return character-level timing metadata alongside the audio. When
+       * enabled, the response carries per-character start/end times and the
+       * total duration, exposed via `providerMetadata.xai`.
+       */
+      withTimestamps: z.boolean().nullish(),
+
+      /**
+       * Map of phrases to spoken substitutions applied before synthesis.
+       * Values may be respellings (`{ 'Acme Mobile': 'Acme Mobull' }`) or IPA
+       * phonetics (`{ nginx: '/ˈɛndʒɪn ˈɛks/' }`).
+       */
+      replace: z.record(z.string(), z.string()).nullish(),
     }),
   ),
 );

--- a/packages/xai/src/xai-speech-model.test.ts
+++ b/packages/xai/src/xai-speech-model.test.ts
@@ -43,6 +43,33 @@ describe('doGenerate', () => {
     return audio;
   }
 
+  // 4 bytes of audio; base64 -> 'AQIDBA=='.
+  const timestampAudioBytes = new Uint8Array([1, 2, 3, 4]);
+
+  function prepareTimestampsResponse({
+    headers,
+  }: {
+    headers?: Record<string, string>;
+  } = {}) {
+    server.urls[url].response = {
+      type: 'json-value',
+      headers,
+      body: {
+        audio: 'AQIDBA==',
+        content_type: 'audio/mpeg',
+        duration: 1.19,
+        audio_timestamps: {
+          graph_chars: ['H', 'i'],
+          graph_times: [
+            [0.04, 0.06],
+            [0.06, 0.1],
+          ],
+        },
+      },
+    };
+    return timestampAudioBytes;
+  }
+
   it('should send text with xAI defaults', async () => {
     prepareAudioResponse();
 
@@ -118,6 +145,72 @@ describe('doGenerate', () => {
       optimize_streaming_latency: 1,
       text_normalization: true,
     });
+  });
+
+  it('should pass withTimestamps and replace provider options', async () => {
+    prepareTimestampsResponse();
+
+    await model.doGenerate({
+      text: 'Hello from the AI SDK!',
+      providerOptions: {
+        xai: {
+          withTimestamps: true,
+          replace: { nginx: '/ˈɛndʒɪn ˈɛks/' },
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      with_timestamps: true,
+      replace: { nginx: '/ˈɛndʒɪn ˈɛks/' },
+    });
+  });
+
+  it('should decode the with_timestamps envelope and extract provider metadata', async () => {
+    const audio = prepareTimestampsResponse({
+      headers: { 'x-trace-id': '993675dc-8ea6-4f54-b4ad-a59ac2615026' },
+    });
+
+    const result = await model.doGenerate({
+      text: 'Hi',
+      providerOptions: { xai: { withTimestamps: true } },
+    });
+
+    expect(result.audio).toStrictEqual(audio);
+    expect(result.providerMetadata).toStrictEqual({
+      xai: {
+        traceId: '993675dc-8ea6-4f54-b4ad-a59ac2615026',
+        duration: 1.19,
+        contentType: 'audio/mpeg',
+        audioTimestamps: {
+          graphChars: ['H', 'i'],
+          graphTimes: [
+            [0.04, 0.06],
+            [0.06, 0.1],
+          ],
+        },
+      },
+    });
+  });
+
+  it('should extract the trace id from binary responses', async () => {
+    prepareAudioResponse({
+      headers: { 'x-trace-id': '06e3dab5-e3ba-4c6b-83a6-1e9ea11d78af' },
+    });
+
+    const result = await model.doGenerate({ text: 'Hello from the AI SDK!' });
+
+    expect(result.providerMetadata).toStrictEqual({
+      xai: { traceId: '06e3dab5-e3ba-4c6b-83a6-1e9ea11d78af' },
+    });
+  });
+
+  it('should return empty provider metadata when xAI headers are absent', async () => {
+    prepareAudioResponse();
+
+    const result = await model.doGenerate({ text: 'Hello from the AI SDK!' });
+
+    expect(result.providerMetadata).toStrictEqual({ xai: {} });
   });
 
   it('should warn and use mp3 for unsupported output formats', async () => {

--- a/packages/xai/src/xai-speech-model.ts
+++ b/packages/xai/src/xai-speech-model.ts
@@ -1,7 +1,9 @@
 import type { SharedV4Warning, SpeechModelV4 } from '@ai-sdk/provider';
 import {
   combineHeaders,
+  convertBase64ToUint8Array,
   createBinaryResponseHandler,
+  createJsonResponseHandler,
   parseProviderOptions,
   postJsonToApi,
   resolve,
@@ -11,6 +13,7 @@ import {
   type FetchFunction,
   type Resolvable,
 } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
 import { xaiFailedResponseHandler } from './xai-error';
 import { xaiSpeechModelOptionsSchema } from './xai-speech-model-options';
 
@@ -122,33 +125,70 @@ export class XaiSpeechModel implements SpeechModelV4 {
       speed,
       optimize_streaming_latency: xaiOptions?.optimizeStreamingLatency,
       text_normalization: xaiOptions?.textNormalization,
+      with_timestamps: xaiOptions?.withTimestamps,
+      replace: xaiOptions?.replace,
     };
 
-    return { requestBody, warnings };
+    return {
+      requestBody,
+      warnings,
+      withTimestamps: xaiOptions?.withTimestamps === true,
+    };
   }
 
   async doGenerate(
     options: Parameters<SpeechModelV4['doGenerate']>[0],
   ): Promise<Awaited<ReturnType<SpeechModelV4['doGenerate']>>> {
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
-    const { requestBody, warnings } = await this.getArgs(options);
+    const { requestBody, warnings, withTimestamps } =
+      await this.getArgs(options);
 
-    const {
-      value: audio,
-      responseHeaders,
-      rawValue: rawResponse,
-    } = await postJsonToApi({
-      url: `${this.config.baseURL}/tts`,
-      headers: combineHeaders(
-        this.config.headers ? await resolve(this.config.headers) : undefined,
-        options.headers,
-      ),
-      body: requestBody,
-      failedResponseHandler: xaiFailedResponseHandler,
-      successfulResponseHandler: createBinaryResponseHandler(),
-      abortSignal: options.abortSignal,
-      fetch: this.config.fetch,
-    });
+    const headers = combineHeaders(
+      this.config.headers ? await resolve(this.config.headers) : undefined,
+      options.headers,
+    );
+
+    // With `with_timestamps` the API returns a JSON envelope carrying
+    // base64-encoded audio plus character-level timings instead of raw
+    // audio bytes.
+    const { value, responseHeaders, rawValue } = withTimestamps
+      ? await postJsonToApi({
+          url: `${this.config.baseURL}/tts`,
+          headers,
+          body: requestBody,
+          failedResponseHandler: xaiFailedResponseHandler,
+          successfulResponseHandler: createJsonResponseHandler(
+            xaiSpeechTimestampsResponseSchema,
+          ),
+          abortSignal: options.abortSignal,
+          fetch: this.config.fetch,
+        })
+      : await postJsonToApi({
+          url: `${this.config.baseURL}/tts`,
+          headers,
+          body: requestBody,
+          failedResponseHandler: xaiFailedResponseHandler,
+          successfulResponseHandler: createBinaryResponseHandler(),
+          abortSignal: options.abortSignal,
+          fetch: this.config.fetch,
+        });
+
+    let audio: Uint8Array;
+    let envelope: z.infer<typeof xaiSpeechTimestampsResponseSchema> | undefined;
+    if (value instanceof Uint8Array) {
+      audio = value;
+    } else {
+      envelope = value;
+      // Empty audio is returned as-is so the core layer throws
+      // NoSpeechGeneratedError.
+      audio =
+        envelope.audio != null
+          ? convertBase64ToUint8Array(envelope.audio)
+          : new Uint8Array(0);
+    }
+
+    // xAI returns a trace id on every response (success and error).
+    const traceId = responseHeaders?.['x-trace-id'];
 
     return {
       audio,
@@ -160,8 +200,42 @@ export class XaiSpeechModel implements SpeechModelV4 {
         timestamp: currentDate,
         modelId: this.modelId,
         headers: responseHeaders,
-        body: rawResponse,
+        body: rawValue,
+      },
+      providerMetadata: {
+        xai: {
+          ...(traceId != null ? { traceId } : {}),
+          ...(envelope?.duration != null
+            ? { duration: envelope.duration }
+            : {}),
+          ...(envelope?.content_type != null
+            ? { contentType: envelope.content_type }
+            : {}),
+          ...(envelope?.audio_timestamps != null
+            ? {
+                audioTimestamps: {
+                  graphChars: envelope.audio_timestamps.graph_chars,
+                  graphTimes: envelope.audio_timestamps.graph_times,
+                },
+              }
+            : {}),
+        },
       },
     };
   }
 }
+
+// Minimal schema for the `with_timestamps` JSON envelope: only the fields
+// the implementation reads, with `.nullish()` so provider API changes don't
+// break parsing.
+const xaiSpeechTimestampsResponseSchema = z.object({
+  audio: z.string().nullish(),
+  content_type: z.string().nullish(),
+  duration: z.number().nullish(),
+  audio_timestamps: z
+    .object({
+      graph_chars: z.array(z.string()),
+      graph_times: z.array(z.tuple([z.number(), z.number()])),
+    })
+    .nullish(),
+});

--- a/packages/xai/src/xai-speech-model.ts
+++ b/packages/xai/src/xai-speech-model.ts
@@ -151,30 +151,22 @@ export class XaiSpeechModel implements SpeechModelV4 {
     // With `with_timestamps` the API returns a JSON envelope carrying
     // base64-encoded audio plus character-level timings instead of raw
     // audio bytes.
-    const { value, responseHeaders, rawValue } = withTimestamps
-      ? await postJsonToApi({
-          url: `${this.config.baseURL}/tts`,
-          headers,
-          body: requestBody,
-          failedResponseHandler: xaiFailedResponseHandler,
-          successfulResponseHandler: createJsonResponseHandler(
-            xaiSpeechTimestampsResponseSchema,
-          ),
-          abortSignal: options.abortSignal,
-          fetch: this.config.fetch,
-        })
-      : await postJsonToApi({
-          url: `${this.config.baseURL}/tts`,
-          headers,
-          body: requestBody,
-          failedResponseHandler: xaiFailedResponseHandler,
-          successfulResponseHandler: createBinaryResponseHandler(),
-          abortSignal: options.abortSignal,
-          fetch: this.config.fetch,
-        });
+    const { value, responseHeaders, rawValue } = await postJsonToApi<
+      Uint8Array | XaiSpeechTimestampsResponse
+    >({
+      url: `${this.config.baseURL}/tts`,
+      headers,
+      body: requestBody,
+      failedResponseHandler: xaiFailedResponseHandler,
+      successfulResponseHandler: withTimestamps
+        ? createJsonResponseHandler(xaiSpeechTimestampsResponseSchema)
+        : createBinaryResponseHandler(),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
 
     let audio: Uint8Array;
-    let envelope: z.infer<typeof xaiSpeechTimestampsResponseSchema> | undefined;
+    let envelope: XaiSpeechTimestampsResponse | undefined;
     if (value instanceof Uint8Array) {
       audio = value;
     } else {
@@ -239,3 +231,7 @@ const xaiSpeechTimestampsResponseSchema = z.object({
     })
     .nullish(),
 });
+
+type XaiSpeechTimestampsResponse = z.infer<
+  typeof xaiSpeechTimestampsResponseSchema
+>;

--- a/packages/xai/src/xai-speech-model.ts
+++ b/packages/xai/src/xai-speech-model.ts
@@ -143,11 +143,6 @@ export class XaiSpeechModel implements SpeechModelV4 {
     const { requestBody, warnings, withTimestamps } =
       await this.getArgs(options);
 
-    const headers = combineHeaders(
-      this.config.headers ? await resolve(this.config.headers) : undefined,
-      options.headers,
-    );
-
     // With `with_timestamps` the API returns a JSON envelope carrying
     // base64-encoded audio plus character-level timings instead of raw
     // audio bytes.
@@ -155,7 +150,10 @@ export class XaiSpeechModel implements SpeechModelV4 {
       Uint8Array | XaiSpeechTimestampsResponse
     >({
       url: `${this.config.baseURL}/tts`,
-      headers,
+      headers: combineHeaders(
+        this.config.headers ? await resolve(this.config.headers) : undefined,
+        options.headers,
+      ),
       body: requestBody,
       failedResponseHandler: xaiFailedResponseHandler,
       successfulResponseHandler: withTimestamps


### PR DESCRIPTION
## Summary

xAI's `/v1/tts` supports `with_timestamps` (character-level alignment + duration) and `replace` (pronunciation replacements), but the provider silently dropped both options and returned no xAI metadata. This PR makes xAI speech work like other AI SDK speech providers, following the pattern of #18942 (deepgram). All shapes verified live against the xAI API.

- **`withTimestamps` and `replace` provider options**: both are now in `xaiSpeechModelOptionsSchema` and sent upstream. With `withTimestamps`, the API returns a JSON envelope instead of raw audio bytes — the model switches to a JSON response handler (minimal `.nullish()` schema), base64-decodes the audio (core still detects `audio/mpeg` from the bytes), and surfaces the rest as provider metadata:
  ```ts
  const result = await generateSpeech({
    model: xai.speech(),
    text: 'Hello world.',
    providerOptions: { xai: { withTimestamps: true } },
  });
  // result.providerMetadata.xai:
  // { traceId, duration: 1.03, contentType: 'audio/mpeg',
  //   audioTimestamps: { graphChars: [...], graphTimes: [[start, end], ...] } }
  ```
- **`providerMetadata.xai.traceId`** (from the `x-trace-id` response header, present on success and error responses) is returned on every speech call.
- **Error parsing**: live-probing `/v1/tts` showed its error body is `{"error":"..."}` (no `code`) — a third shape that matched neither existing schema, so bad voice/speed/`replace` errors fell back to the HTTP reason phrase ("Bad Request"/"Not Found") and lost the real message. The union now covers it; `APICallError.message` carries xAI's real error (e.g. `TTS synthesis failed: Voice 'not-a-real-voice' not found`).

Docs page updated; new examples: `timestamps.ts`, `error-handling.ts`; existing examples now log `result.providerMetadata`.

## Changeset

- `patch` (additive, per repo convention)

## Test plan

- 432 package tests, node + edge (envelope decode, metadata extraction incl. trace-id-only and empty cases, request passthrough, TTS error shape)
- `timestamps.ts` and `error-handling.ts` (4 failure cases: unknown voice, out-of-range speed, invalid `replace` key, invalid API key) verified live against the xAI API; all four messages carry the real xAI error detail
- Existing speech examples re-run live (binary path unchanged, `traceId` present)
- `tsc --noEmit` clean (includes examples), `ultracite` clean