### PR TITLE
fix(ai): reject streamObject result promises on error

### DIFF
--- a/.changeset/stream-object-reject-result-promises.md
+++ b/.changeset/stream-object-reject-result-promises.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix (streamObject): reject result promises on error so `result.object` and friends no longer hang forever when `doStream` throws, the provider emits an error part mid-stream, or the raw stream errors

--- a/packages/ai/src/generate-object/stream-object.test.ts
+++ b/packages/ai/src/generate-object/stream-object.test.ts
@@ -94,6 +94,106 @@ describe('streamObject', () => {
   afterEach(() => {
     logWarningsSpy.mockRestore();
   });
+
+  describe('error handling', () => {
+    it('should reject result promises when doStream throws', async () => {
+      const result = streamObject({
+        model: new MockLanguageModelV4({
+          doStream: async () => {
+            throw new Error('transient provider failure');
+          },
+        }),
+        schema: z.object({ content: z.string() }),
+        prompt: 'prompt',
+        maxRetries: 0,
+      });
+
+      await expect(result.object).rejects.toThrow('transient provider failure');
+      await expect(result.usage).rejects.toThrow('transient provider failure');
+      await expect(result.finishReason).rejects.toThrow(
+        'transient provider failure',
+      );
+    });
+
+    it('should reject result promises and report the error through onFinish when the provider emits an error part mid-stream', async () => {
+      const onFinishCalls: Array<{
+        error: unknown;
+        finishReason: unknown;
+      }> = [];
+
+      const result = streamObject({
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: convertArrayToReadableStream<LanguageModelV4StreamPart>([
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'response-metadata',
+                id: 'id-0',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-start', id: '1' },
+              { type: 'text-delta', id: '1', delta: '{ "content": "hi" }' },
+              { type: 'error', error: new Error('mid-stream failure') },
+            ]),
+            warnings: [],
+          }),
+        }),
+        schema: z.object({ content: z.string() }),
+        prompt: 'prompt',
+        onFinish: ({ error, finishReason }) => {
+          onFinishCalls.push({ error, finishReason });
+        },
+      });
+
+      // consume the stream so the error part is processed
+      const parts = await convertAsyncIterableToArray(result.fullStream);
+      expect(parts.some(part => part.type === 'error')).toBe(true);
+
+      await expect(result.object).rejects.toThrow('mid-stream failure');
+      await expect(result.usage).rejects.toThrow('mid-stream failure');
+      await expect(result.finishReason).rejects.toThrow('mid-stream failure');
+
+      expect(onFinishCalls).toHaveLength(1);
+      expect(onFinishCalls[0].error).toStrictEqual(
+        new Error('mid-stream failure'),
+      );
+      expect(onFinishCalls[0].finishReason).toBe('error');
+    });
+
+    it('should reject result promises and call onError when the raw stream errors', async () => {
+      const onErrorCalls: Array<{ error: unknown }> = [];
+
+      const result = streamObject({
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: new ReadableStream<LanguageModelV4StreamPart>({
+              start(controller) {
+                controller.error(new Error('stream failure'));
+              },
+            }),
+            warnings: [],
+          }),
+        }),
+        schema: z.object({ content: z.string() }),
+        prompt: 'prompt',
+        onError(event) {
+          onErrorCalls.push(event);
+        },
+      });
+
+      await expect(
+        convertAsyncIterableToArray(result.fullStream),
+      ).rejects.toThrow('stream failure');
+      await expect(result.object).rejects.toThrow('stream failure');
+      await expect(result.usage).rejects.toThrow('stream failure');
+
+      expect(onErrorCalls).toStrictEqual([
+        { error: new Error('stream failure') },
+      ]);
+    });
+  });
+
   describe('output = "object"', () => {
     describe('result.objectStream', () => {
       it('should send object deltas', async () => {

--- a/packages/ai/src/generate-object/stream-object.ts
+++ b/packages/ai/src/generate-object/stream-object.ts
@@ -69,6 +69,16 @@ import { validateObjectGenerationInput } from './validate-object-generation-inpu
 const originalGenerateId = createIdGenerator({ prefix: 'aiobj', size: 24 });
 
 /**
+ * Awaits a promise and swallows the rejection, preventing unhandled promise
+ * rejections for result promises that were rejected without being accessed.
+ */
+async function markPromiseAsHandled<T>(promise: Promise<T>): Promise<void> {
+  try {
+    await promise;
+  } catch {}
+}
+
+/**
  * Callback that is set using the `onError` option.
  *
  * @param event - The event that is passed to the callback.
@@ -529,6 +539,12 @@ class DefaultStreamObjectResult<
 
     const self = this;
 
+    // Error state shared between the event processor and the setup closure
+    // so that an error stream part rejects the result promises and is
+    // reported through onFinish even when the provider closes the stream
+    // normally afterwards.
+    let streamError: unknown | undefined;
+
     const stitchableStream =
       createStitchableStream<ObjectStreamPart<PARTIAL>>();
 
@@ -540,7 +556,9 @@ class DefaultStreamObjectResult<
         controller.enqueue(chunk);
 
         if (chunk.type === 'error') {
-          onError({ error: wrapGatewayError(chunk.error) });
+          streamError = wrapGatewayError(chunk.error);
+          self.rejectResultPromises(streamError);
+          onError({ error: streamError });
         }
       },
     });
@@ -817,13 +835,23 @@ class DefaultStreamObjectResult<
                   totalTokens: NaN,
                 };
 
+                // An error stream part rejects the result promises; report it
+                // through the finish callbacks too instead of reporting a
+                // successful call with NaN usage. A validation error
+                // (TypeValidationError) keeps the model's finish reason.
+                const combinedError = error ?? streamError;
+                const combinedFinishReason =
+                  streamError !== undefined
+                    ? ('error' as const)
+                    : (finishReason ?? 'other');
+
                 await notify({
                   event: {
                     callId,
                     stepNumber: 0 as const,
                     provider: model.provider,
                     modelId: model.modelId,
-                    finishReason: finishReason ?? 'other',
+                    finishReason: combinedFinishReason,
                     usage: finalUsage,
                     objectText: accumulatedText,
                     msToFirstChunk,
@@ -846,9 +874,9 @@ class DefaultStreamObjectResult<
                   event: {
                     callId,
                     object,
-                    error,
+                    error: combinedError,
                     reasoning: undefined,
-                    finishReason: finishReason ?? 'other',
+                    finishReason: combinedFinishReason,
                     usage: finalUsage,
                     warnings,
                     request: request ?? {},
@@ -867,10 +895,22 @@ class DefaultStreamObjectResult<
           }),
         );
 
-      stitchableStream.addStream(transformedStream);
+      stitchableStream.addStream(transformedStream, {
+        onError: error => {
+          // The raw stream rejected without producing an error stream part:
+          // reject the result promises and notify the user callback
+          // consistently with the error-part path.
+          self.rejectResultPromises(error);
+          onError({ error: wrapGatewayError(error) });
+        },
+      });
     })()
       .catch(async error => {
         await telemetryDispatcher.onError?.({ callId, error });
+
+        // doStream failed before any stream was produced: reject the result
+        // promises so awaiting them surfaces the error instead of hanging.
+        self.rejectResultPromises(error);
 
         stitchableStream.addStream(
           new ReadableStream({
@@ -886,6 +926,32 @@ class DefaultStreamObjectResult<
       });
 
     this.outputStrategy = outputStrategy;
+  }
+
+  private rejectResultPromises(error: unknown) {
+    this.rejectResultPromise({ delayedPromise: this._object, error });
+    this.rejectResultPromise({ delayedPromise: this._usage, error });
+    this.rejectResultPromise({
+      delayedPromise: this._providerMetadata,
+      error,
+    });
+    this.rejectResultPromise({ delayedPromise: this._warnings, error });
+    this.rejectResultPromise({ delayedPromise: this._request, error });
+    this.rejectResultPromise({ delayedPromise: this._response, error });
+    this.rejectResultPromise({ delayedPromise: this._finishReason, error });
+  }
+
+  private rejectResultPromise<T>({
+    delayedPromise,
+    error,
+  }: {
+    delayedPromise: DelayedPromise<T>;
+    error: unknown;
+  }) {
+    if (delayedPromise.isPending()) {
+      delayedPromise.reject(error);
+      markPromiseAsHandled(delayedPromise.promise);
+    }
   }
 
   get object() {


### PR DESCRIPTION
Fixes #18930.

## Problem

`streamObject`'s result promises (`result.object`, `result.usage`, `result.finishReason`, `result.response`, `result.warnings`, `result.request`, `result.providerMetadata`) are only settled in the `'finish'` case of the processing transform. Three error paths leave them pending forever:

1. `doStream` throws (network failure, 5xx, timeout, abort). The setup catch only enqueues an error part and calls telemetry `onError` — the promises stay pending.
2. The provider emits an `error` part mid-stream. The event processor only calls the user `onError`; if the provider then closes the stream normally, `onFinish` reports a successful call with `error: undefined`, `object: undefined` and NaN usage, so callers cannot tell the call failed.
3. The raw stream rejects. The stitchable stream errors out to consumers, but the promises stay pending and the user `onError` is never called — inconsistent with path 2.

`streamText` already handles this with its `rejectResultPromises` helper; `streamObject` has no equivalent.

## Solution

Added a `rejectResultPromises` method to `DefaultStreamObjectResult` (mirroring `streamText`) that rejects every pending result promise and marks each as handled to avoid unhandled rejections:

- **Path 1**: the setup catch now rejects the result promises before enqueueing the error part.
- **Path 2**: the event processor rejects the promises and records the error in a shared `streamError` state; `flush` reports it through `onFinish` (`error` set, `finishReason: 'error'`) instead of a fake success. A schema-validation error keeps the model's finish reason (no behavior change for `TypeValidationError`).
- **Path 3**: `addStream` now passes an `onError` callback that rejects the promises and invokes the user `onError` consistently with the error-part path.

## Tests

Added three tests to `stream-object.test.ts`:
- `doStream` throwing rejects `result.object` / `result.usage` / `result.finishReason`
- a mid-stream error part rejects the promises and `onFinish` receives the error with `finishReason: 'error'`
- a raw stream error rejects the promises and invokes `onError`

Verified non-vacuous: all three fail against the previous implementation. Full `generate-object` suite passes in both node and edge environments (134 tests).