### PR TITLE
fix(ai): throw a descriptive error when a tool is missing an input schema

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,12 @@
+---
+'ai': patch
+---
+
+fix(ai): throw a descriptive error when a tool is missing an input schema
+
+A tool defined without `inputSchema` (for example one still using the AI SDK 4
+`parameters` key) was serialized with an empty input schema, so the invalid tool
+definition only surfaced as a provider error such as Vertex AI's
+"functionDeclaration parameters schema should be of type OBJECT". Such tools now
+fail with an `InvalidArgumentError` that names the tool and the expected
+property.

--- a/examples/ai-functions/src/reproduction/issue-12143-tool-missing-input-schema.ts
+++ b/examples/ai-functions/src/reproduction/issue-12143-tool-missing-input-schema.ts
@@ -1,0 +1,45 @@
+import { InvalidArgumentError, generateText } from 'ai';
+import { MockLanguageModelV4 } from 'ai/test';
+import { z } from 'zod/v4';
+
+// Reproduction for https://github.com/vercel/ai/issues/12143
+//
+// `parameters` was renamed to `inputSchema` in AI SDK 5. A tool that still uses
+// `parameters` leaves `inputSchema` undefined at runtime. Before the fix that
+// tool was serialized with an empty input schema (`{ properties: {} }`), and
+// providers such as Vertex AI rejected the request with a confusing
+// "functionDeclaration parameters schema should be of type OBJECT" error.
+//
+// The tool definition is now rejected with a descriptive error instead.
+
+async function main() {
+  const model = new MockLanguageModelV4({
+    doGenerate: async ({ prompt: _prompt }) => {
+      throw new Error('the request should never reach the provider');
+    },
+  });
+
+  try {
+    await generateText({
+      model,
+      prompt: 'Read package.json',
+      tools: {
+        readFile: {
+          description: 'Read a file',
+          // the AI SDK 4 spelling: leaves `inputSchema` undefined
+          parameters: z.object({ filePath: z.string() }),
+        },
+      } as any,
+    });
+
+    console.log('no error thrown - the bug is still present');
+  } catch (error) {
+    console.log(
+      'InvalidArgumentError:',
+      InvalidArgumentError.isInstance(error),
+    );
+    console.log('message:', (error as Error).message);
+  }
+}
+
+main().catch(console.error);

--- a/packages/ai/src/prompt/prepare-tools.test.ts
+++ b/packages/ai/src/prompt/prepare-tools.test.ts
@@ -344,3 +344,21 @@ describe('prepareTools', () => {
     ]);
   });
 });
+
+describe('prepareTools with a missing input schema', () => {
+  it('throws a descriptive error instead of sending an empty input schema', async () => {
+    await expect(
+      prepareTools({
+        tools: {
+          // simulates the AI SDK 4 `parameters` key, which no longer exists:
+          // `inputSchema` ends up undefined at runtime
+          readFile: {
+            description: 'Read a file',
+          },
+        } as unknown as ToolSet,
+      }),
+    ).rejects.toThrowError(
+      /tool "readFile" .*inputSchema|inputSchema.*tool "readFile"/i,
+    );
+  });
+});

--- a/packages/ai/src/prompt/prepare-tools.ts
+++ b/packages/ai/src/prompt/prepare-tools.ts
@@ -9,6 +9,7 @@ import {
   type Tool,
   type ToolSet,
 } from '@ai-sdk/provider-utils';
+import { InvalidArgumentError } from '../error/invalid-argument-error';
 import type { ToolOrder } from '../generate-text/tool-order';
 import { isNonEmptyObject } from '../util/is-non-empty-object';
 
@@ -48,6 +49,17 @@ export async function prepareTools<TOOLS extends ToolSet>({
         const providerOptions = tool.providerOptions;
         const inputExamples = tool.inputExamples;
         const strict = tool.strict;
+
+        if (tool.inputSchema == null) {
+          throw new InvalidArgumentError({
+            parameter: 'tools',
+            value: tool,
+            message:
+              `tool "${name}" is missing an input schema. ` +
+              `Define the tool with an \`inputSchema\` property ` +
+              `(it was called \`parameters\` in AI SDK 4).`,
+          });
+        }
 
         languageModelTools.push({
           type: 'function' as const,


### PR DESCRIPTION
## Background

`parameters` was renamed to `inputSchema` in AI SDK 5. A tool that still uses the old key leaves `inputSchema` undefined at runtime, and `asSchema` substitutes an empty object schema for a missing schema:

```ts
return schema == null
  ? jsonSchema({ type: 'object', properties: {}, additionalProperties: false })
  : ...
```

So the invalid tool definition is serialized as `{ properties: {} }` and is only rejected by the provider. Vertex AI reports:

> `functionDeclaration parameters schema should be of type OBJECT`

which does not point back at the tool definition, so the cause is hard to find (see #12143).

## Summary

`prepareTools` now rejects a function tool without an input schema with an `InvalidArgumentError` that names the tool and the expected property:

```
Invalid argument for parameter tools: tool "readFile" is missing an input schema.
Define the tool with an `inputSchema` property (it was called `parameters` in AI SDK 4).
```

`inputSchema` is already required by the `Tool` type, so this only affects definitions that are invalid today and currently fail later with a provider-specific message.

## Verification

- Added a regression test in `packages/ai/src/prompt/prepare-tools.test.ts`; it fails on `main` and passes with this change (11/11 in that file).
- Ran the full `packages/ai` node suite before and after: the same two tests fail on `main` without this change (`emits declarations for exported values with inferred output types`, `defines batch support as an experimental LanguageModelV4 capability`), and the passing count goes from 1743 to 1744. No test is affected by this change.
- Added `examples/ai-functions/src/reproduction/issue-12143-tool-missing-input-schema.ts` and ran it; it prints the new error.
- `pnpm check` passes.
- Changeset included (`patch` for `ai`).

Fixes #12143
