### PR TITLE
fix(amazon-bedrock): use template literal for tool warning message

### DIFF
--- a/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.ts
@@ -122,7 +122,7 @@ export async function prepareTools({
           },
         });
       } else {
-        toolWarnings.push({ type: 'unsupported', feature: 'tool ${tool.id}' });
+        toolWarnings.push({ type: 'unsupported', feature: `tool ${tool.id}` });
       }
     }
   } else {


### PR DESCRIPTION
This PR addresses: fix(amazon-bedrock): use template literal for tool warning message