### PR TITLE
feat(gateway): add quantization conditions to the has provider option

### DIFF
--- a/.changeset/quantization-has-conditions.md
+++ b/.changeset/quantization-has-conditions.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(gateway): add quantization conditions to the has provider option

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -16,10 +16,21 @@ export type GatewayProviderOptions = {
   disallowPromptTraining?: boolean;
 
   /**
-   * Restrict routing to models that have all of the given capabilities.
-   * Currently supports `'implicit-caching'` and `'vision'` (image input).
+   * Restrict routing to provider-models that satisfy every given entry.
+   *
+   * Entries are capability tags (`'implicit-caching'`, `'vision'`) or
+   * weight-format conditions: `'quantization:fp8'` requires the serving
+   * provider to report that weight format, `'!quantization:fp8'` excludes it
+   * (providers with no recorded format still pass an exclusion). Format
+   * values are an open space; unknown capability names are rejected by the
+   * Gateway with a 400.
    */
-  has?: Array<'implicit-caching' | 'vision'>;
+  has?: Array<
+    | 'implicit-caching'
+    | 'vision'
+    | `quantization:${string}`
+    | `!quantization:${string}`
+  >;
 
   /** Array of model slugs specifying fallback models to use in order. */
   models?: string[];


### PR DESCRIPTION
## Why

The Gateway accepts weight-format entries in `has` ([vercel/ai-gateway#3250](https://github.com/vercel/ai-gateway/pull/3250), [AIG-565](https://linear.app/vercel/issue/AIG-565/route-and-display-on-mpi-weightformat-has-conditions-provider-table)): `quantization:fp8` requires a provider whose serving weight format is fp8, `!quantization:fp8` excludes fp8. Template-literal unions keep the union fully typed (no `string` fallback), so autocomplete still offers the capability literals while condition values stay free-form.

## What

- `has` widened from `Array<'implicit-caching' | 'vision'>` to include ``quantization:${string}`` and ``!quantization:${string}``
- Doc comment updated to describe the condition forms and the server-side 400 for unknown capability names

Server validation stays authoritative, so older SDK versions keep working (the option type also carries an index signature), this just restores type-level parity for the new entries.