### PR TITLE
feat(ai): attach per-call context to HITL approval requests

### DIFF
--- a/.changeset/hitl-approval-request-context.md
+++ b/.changeset/hitl-approval-request-context.md
@@ -1,0 +1,6 @@
+---
+'ai': patch
+'@ai-sdk/provider-utils': patch
+---
+
+Attach per-call context to HITL tool approval requests and bind it to the tool call identity

--- a/content/docs/03-agents/06-tool-approvals.mdx
+++ b/content/docs/03-agents/06-tool-approvals.mdx
@@ -61,6 +61,32 @@ const agent = new ToolLoopAgent({
 
 When `runCommand` is called, the agent returns a `tool-approval-request` instead of executing the tool.
 
+## Attach Per-Call Context to Approval Requests
+
+Return `{ type: 'user-approval', context }` from a `toolApproval` function when the card needs a consequence summary computed at approval time. The context is attached to the same approval request (and the `approval-requested` UI part) as the tool call.
+
+```ts
+toolApproval: {
+  deleteRecords: async ({ ids }) => {
+    const impact = await summarizeDeleteImpact(ids);
+    return {
+      type: 'user-approval',
+      context: {
+        recordCount: impact.total,
+        recentlyModified: impact.recentlyModified,
+        referencedByOthers: impact.referencedByOthers,
+      },
+    };
+  },
+},
+```
+
+In the UI, read `part.approval.context` when `part.state === 'approval-requested'`. Reloading the message history keeps the same context on that approval.
+
+The deprecated `needsApproval` function on a tool can return the same information as `{ approvalRequired: true, context }`.
+
+Approving a request whose tool input changed after the context was computed is rejected as stale. When `experimental_toolApprovalSecret` is set, the HMAC also binds the context so it cannot be swapped onto a different tool call.
+
 ## Decide Based on Tool Input
 
 Use a per-tool approval function when the decision depends on the parsed tool input. The function receives the typed input plus `toolCallId`, `messages`, `toolContext`, and `runtimeContext`.
@@ -291,6 +317,10 @@ const result = await streamText({
 ```
 
 The signature binds the approval to the exact tool name, tool call ID, and input arguments. Changing any of these after signing invalidates the approval.
+
+When per-call context is present, the signature also binds a digest of that context (HMAC v2). Requests without context keep the existing HMAC v1 payload so pending approvals still verify across an upgrade.
+
+Approving a card whose tool input no longer matches the digest issued with the context fails closed.
 
 **Setting up the secret:**
 

--- a/packages/ai/src/generate-text/execute-tools-from-stream.ts
+++ b/packages/ai/src/generate-text/execute-tools-from-stream.ts
@@ -13,7 +13,7 @@ import { getOwn } from '../util/get-own';
 import { executeToolCall } from './execute-tool-call';
 import { resolveToolApproval } from './resolve-tool-approval';
 import type { LanguageModelStreamPart } from './stream-language-model-call';
-import { maybeSignApproval } from './tool-approval-signature';
+import { createToolApprovalRequestFields } from './tool-approval-signature';
 import type { ToolApprovalConfiguration } from './tool-approval-configuration';
 import type { TypedToolCall } from './tool-call';
 import type {
@@ -126,12 +126,16 @@ export function executeToolsFromStream<
             }
 
             const approvalId = generateId();
-            const signature = await maybeSignApproval({
+            const approvalRequestFields = await createToolApprovalRequestFields({
               secret: toolApprovalSecret,
               approvalId,
               toolCallId: chunk.toolCallId,
               toolName: chunk.toolName,
               input: chunk.input,
+              context:
+                toolApprovalStatus.type === 'user-approval'
+                  ? toolApprovalStatus.context
+                  : undefined,
             });
 
             switch (toolApprovalStatus.type) {
@@ -140,7 +144,7 @@ export function executeToolsFromStream<
                   type: 'tool-approval-request',
                   approvalId,
                   toolCall: chunk,
-                  ...(signature != null ? { signature } : {}),
+                  ...approvalRequestFields,
                 });
 
                 return; // don't execute tool
@@ -152,7 +156,7 @@ export function executeToolsFromStream<
                   approvalId,
                   toolCall: chunk,
                   isAutomatic: true,
-                  ...(signature != null ? { signature } : {}),
+                  ...approvalRequestFields,
                 });
                 controller.enqueue({
                   type: 'tool-approval-response',
@@ -172,7 +176,7 @@ export function executeToolsFromStream<
                   approvalId,
                   toolCall: chunk,
                   isAutomatic: true,
-                  ...(signature != null ? { signature } : {}),
+                  ...approvalRequestFields,
                 });
                 controller.enqueue({
                   type: 'tool-approval-response',

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -124,7 +124,7 @@ import type { ToolOrder } from './tool-order';
 import type { ToolOutput } from './tool-output';
 import type { TypedToolResult } from './tool-result';
 import type { ToolsContextParameter } from './tools-context-parameter';
-import { maybeSignApproval } from './tool-approval-signature';
+import { createToolApprovalRequestFields } from './tool-approval-signature';
 import { validateApprovedToolApprovals } from './validate-tool-approvals';
 
 const originalGenerateId = createIdGenerator({
@@ -1166,13 +1166,18 @@ export async function generateText<
                 }
 
                 const approvalId = generateId();
-                const signature = await maybeSignApproval({
-                  secret: experimental_toolApprovalSecret,
-                  approvalId,
-                  toolCallId: toolCall.toolCallId,
-                  toolName: toolCall.toolName,
-                  input: toolCall.input,
-                });
+                const approvalRequestFields =
+                  await createToolApprovalRequestFields({
+                    secret: experimental_toolApprovalSecret,
+                    approvalId,
+                    toolCallId: toolCall.toolCallId,
+                    toolName: toolCall.toolName,
+                    input: toolCall.input,
+                    context:
+                      toolApprovalStatus.type === 'user-approval'
+                        ? toolApprovalStatus.context
+                        : undefined,
+                  });
 
                 switch (toolApprovalStatus.type) {
                   case 'user-approval': {
@@ -1180,7 +1185,7 @@ export async function generateText<
                       type: 'tool-approval-request',
                       approvalId,
                       toolCall,
-                      ...(signature != null ? { signature } : {}),
+                      ...approvalRequestFields,
                     };
                     blockedToolCallIds.add(toolCall.toolCallId);
                     break;
@@ -1192,7 +1197,7 @@ export async function generateText<
                       approvalId,
                       toolCall,
                       isAutomatic: true,
-                      ...(signature != null ? { signature } : {}),
+                      ...approvalRequestFields,
                     };
                     stepToolApprovalResponses[toolCall.toolCallId] = {
                       type: 'tool-approval-response',
@@ -1211,7 +1216,7 @@ export async function generateText<
                       approvalId,
                       toolCall,
                       isAutomatic: true,
-                      ...(signature != null ? { signature } : {}),
+                      ...approvalRequestFields,
                     };
                     stepToolApprovalResponses[toolCall.toolCallId] = {
                       type: 'tool-approval-response',

--- a/packages/ai/src/generate-text/resolve-tool-approval.test.ts
+++ b/packages/ai/src/generate-text/resolve-tool-approval.test.ts
@@ -593,6 +593,76 @@ describe('resolveToolApproval', () => {
     expect(notApplicableToolResult).toEqual({ type: 'not-applicable' });
   });
 
+  it('maps a tool-defined approval object with context to user-approval', async () => {
+    const result = await resolveToolApproval({
+      tools: {
+        weather: tool({
+          inputSchema: z.object({ city: z.string() }),
+          needsApproval: async () => ({
+            approvalRequired: true,
+            context: { recordCount: 47, recentlyModified: 12 },
+          }),
+        }),
+      },
+      toolApproval: undefined,
+      toolCall: createToolCall(),
+      messages: [...messages],
+      toolsContext: {},
+      runtimeContext: {},
+    });
+
+    expect(result).toEqual({
+      type: 'user-approval',
+      context: { recordCount: 47, recentlyModified: 12 },
+    });
+  });
+
+  it('maps a tool-defined approval object with approvalRequired false to not-applicable', async () => {
+    const result = await resolveToolApproval({
+      tools: {
+        weather: tool({
+          inputSchema: z.object({ city: z.string() }),
+          needsApproval: async () => ({
+            approvalRequired: false,
+            context: { ignored: true },
+          }),
+        }),
+      },
+      toolApproval: undefined,
+      toolCall: createToolCall(),
+      messages: [...messages],
+      toolsContext: {},
+      runtimeContext: {},
+    });
+
+    expect(result).toEqual({ type: 'not-applicable' });
+  });
+
+  it('preserves context returned by a user-defined toolApproval function', async () => {
+    const result = await resolveToolApproval({
+      tools: {
+        weather: tool({
+          inputSchema: z.object({ city: z.string() }),
+        }),
+      },
+      toolApproval: {
+        weather: async () => ({
+          type: 'user-approval' as const,
+          context: { blastRadius: 'city-wide' },
+        }),
+      },
+      toolCall: createToolCall(),
+      messages: [...messages],
+      toolsContext: {},
+      runtimeContext: {},
+    });
+
+    expect(result).toEqual({
+      type: 'user-approval',
+      context: { blastRadius: 'city-wide' },
+    });
+  });
+
   it('passes tool input and validated context to a tool-defined approval callback', async () => {
     const toolDefinedNeedsApproval = vi.fn(() => true);
 

--- a/packages/ai/src/generate-text/resolve-tool-approval.ts
+++ b/packages/ai/src/generate-text/resolve-tool-approval.ts
@@ -5,6 +5,7 @@ import type {
   ModelMessage,
   ToolSet,
 } from '@ai-sdk/provider-utils';
+import type { JSONValue } from '@ai-sdk/provider';
 import type {
   ToolApprovalConfiguration,
   ToolApprovalStatus,
@@ -123,7 +124,25 @@ export async function resolveToolApproval<
         })
       : tool.needsApproval;
 
-  return needsApproval ? { type: 'user-approval' } : { type: 'not-applicable' };
+  return normalizeNeedsApprovalDecision(needsApproval);
+}
+
+function normalizeNeedsApprovalDecision(
+  needsApproval: boolean | { approvalRequired: boolean; context?: JSONValue },
+): Exclude<ToolApprovalStatus, string | undefined> {
+  if (typeof needsApproval === 'boolean') {
+    return needsApproval
+      ? { type: 'user-approval' }
+      : { type: 'not-applicable' };
+  }
+
+  if (!needsApproval.approvalRequired) {
+    return { type: 'not-applicable' };
+  }
+
+  return needsApproval.context !== undefined
+    ? { type: 'user-approval', context: needsApproval.context }
+    : { type: 'user-approval' };
 }
 
 function normalizeToolApprovalStatus(

--- a/packages/ai/src/generate-text/to-response-messages.ts
+++ b/packages/ai/src/generate-text/to-response-messages.ts
@@ -135,6 +135,8 @@ export async function toResponseMessages<TOOLS extends ToolSet>({
           toolCallId: part.toolCall.toolCallId,
           isAutomatic: part.isAutomatic,
           ...(part.signature != null ? { signature: part.signature } : {}),
+          ...(part.context !== undefined ? { context: part.context } : {}),
+          ...(part.inputDigest != null ? { inputDigest: part.inputDigest } : {}),
         });
         break;
     }

--- a/packages/ai/src/generate-text/tool-approval-configuration.ts
+++ b/packages/ai/src/generate-text/tool-approval-configuration.ts
@@ -1,3 +1,4 @@
+import type { JSONValue } from '@ai-sdk/provider';
 import type {
   Context,
   InferToolContext,
@@ -31,7 +32,7 @@ export type ToolApprovalStatus =
   | { type: 'not-applicable'; reason?: never }
   | { type: 'approved'; reason?: string }
   | { type: 'denied'; reason?: string }
-  | { type: 'user-approval'; reason?: never };
+  | { type: 'user-approval'; reason?: never; context?: JSONValue };
 
 /**
  * Function that is called to determine if the tool needs approval before it can be executed.

--- a/packages/ai/src/generate-text/tool-approval-request-output.ts
+++ b/packages/ai/src/generate-text/tool-approval-request-output.ts
@@ -1,5 +1,6 @@
-import type { TypedToolCall } from './tool-call';
+import type { JSONValue } from '@ai-sdk/provider';
 import type { ToolSet } from '@ai-sdk/provider-utils';
+import type { TypedToolCall } from './tool-call';
 
 /**
  * Output part that indicates that a tool approval request has been made.
@@ -30,4 +31,14 @@ export type ToolApprovalRequestOutput<TOOLS extends ToolSet> = {
    * HMAC-SHA256 signature binding this approval request to its tool call.
    */
   signature?: string;
+
+  /**
+   * Dynamic, per-call context for the approval card.
+   */
+  context?: JSONValue;
+
+  /**
+   * Canonical digest of the tool input at the time this context was issued.
+   */
+  inputDigest?: string;
 };

--- a/packages/ai/src/generate-text/tool-approval-signature.test.ts
+++ b/packages/ai/src/generate-text/tool-approval-signature.test.ts
@@ -225,4 +225,79 @@ describe('signToolApproval + verifyToolApprovalSignature', () => {
       }),
     ).toBe(false);
   });
+
+  it('should bind context into HMAC v2 and reject a swapped context', async () => {
+    const context = { recordCount: 47 };
+    const signature = await signToolApproval({
+      secret,
+      ...baseParams,
+      context,
+    });
+
+    expect(
+      await verifyToolApprovalSignature({
+        secret,
+        signature,
+        ...baseParams,
+        context,
+      }),
+    ).toBe(true);
+
+    expect(
+      await verifyToolApprovalSignature({
+        secret,
+        signature,
+        ...baseParams,
+        context: { recordCount: 1 },
+      }),
+    ).toBe(false);
+  });
+
+  it('should reject a v1 signature when context is present', async () => {
+    const signature = await signToolApproval({ secret, ...baseParams });
+
+    expect(
+      await verifyToolApprovalSignature({
+        secret,
+        signature,
+        ...baseParams,
+        context: { recordCount: 47 },
+      }),
+    ).toBe(false);
+  });
+
+  it('should reject a v2 signature when verified without context (stripped context)', async () => {
+    const signature = await signToolApproval({
+      secret,
+      ...baseParams,
+      context: { recordCount: 47 },
+    });
+
+    expect(
+      await verifyToolApprovalSignature({
+        secret,
+        signature,
+        ...baseParams,
+      }),
+    ).toBe(false);
+  });
+
+  it('should not verify an approval signed for a different tool call with the same context', async () => {
+    const context = { recordCount: 47 };
+    const signature = await signToolApproval({
+      secret,
+      ...baseParams,
+      context,
+    });
+
+    expect(
+      await verifyToolApprovalSignature({
+        secret,
+        signature,
+        ...baseParams,
+        toolCallId: 'call-2',
+        context,
+      }),
+    ).toBe(false);
+  });
 });

--- a/packages/ai/src/generate-text/tool-approval-signature.ts
+++ b/packages/ai/src/generate-text/tool-approval-signature.ts
@@ -1,3 +1,4 @@
+import type { JSONValue } from '@ai-sdk/provider';
 import { convertBase64ToUint8Array } from '@ai-sdk/provider-utils';
 import { hashCanonical, toBase64url } from '../util/canonical-hash';
 
@@ -21,7 +22,7 @@ async function importKey(secret: string | Uint8Array): Promise<CryptoKey> {
 // Serialize with JSON so the encoding is injective: fields may contain any
 // character (including newlines), and escaping + array structure keeps field
 // boundaries unambiguous. The version prefix provides domain separation.
-function buildPayload(
+function buildPayloadV1(
   approvalId: string,
   toolCallId: string,
   toolName: string,
@@ -34,6 +35,25 @@ function buildPayload(
       toolCallId,
       toolName,
       inputDigest,
+    ]),
+  );
+}
+
+function buildPayloadV2(
+  approvalId: string,
+  toolCallId: string,
+  toolName: string,
+  inputDigest: string,
+  contextDigest: string,
+): Uint8Array {
+  return encoder.encode(
+    JSON.stringify([
+      'ai-sdk-tool-approval-v2',
+      approvalId,
+      toolCallId,
+      toolName,
+      inputDigest,
+      contextDigest,
     ]),
   );
 }
@@ -61,16 +81,27 @@ export async function signToolApproval({
   toolCallId,
   toolName,
   input,
+  context,
 }: {
   secret: string | Uint8Array;
   approvalId: string;
   toolCallId: string;
   toolName: string;
   input: unknown;
+  context?: JSONValue;
 }): Promise<string> {
   const key = await importKey(secret);
   const inputDigest = await hashCanonical(input);
-  const payload = buildPayload(approvalId, toolCallId, toolName, inputDigest);
+  const payload =
+    context !== undefined
+      ? buildPayloadV2(
+          approvalId,
+          toolCallId,
+          toolName,
+          inputDigest,
+          await hashCanonical(context),
+        )
+      : buildPayloadV1(approvalId, toolCallId, toolName, inputDigest);
   const sig = await crypto.subtle.sign('HMAC', key, payload);
   return toBase64url(new Uint8Array(sig));
 }
@@ -82,6 +113,7 @@ export async function verifyToolApprovalSignature({
   toolCallId,
   toolName,
   input,
+  context,
 }: {
   secret: string | Uint8Array;
   signature: string;
@@ -89,12 +121,27 @@ export async function verifyToolApprovalSignature({
   toolCallId: string;
   toolName: string;
   input: unknown;
+  context?: JSONValue;
 }): Promise<boolean> {
   const key = await importKey(secret);
   const inputDigest = await hashCanonical(input);
   const sigBytes = fromBase64url(signature);
 
-  const payload = buildPayload(approvalId, toolCallId, toolName, inputDigest);
+  // Context is bound into HMAC v2. Never accept a v1 or legacy signature
+  // for a request that carries context — that would allow swapping unsigned
+  // consequence text onto a previously signed call.
+  if (context !== undefined) {
+    const payload = buildPayloadV2(
+      approvalId,
+      toolCallId,
+      toolName,
+      inputDigest,
+      await hashCanonical(context),
+    );
+    return crypto.subtle.verify('HMAC', key, sigBytes, payload);
+  }
+
+  const payload = buildPayloadV1(approvalId, toolCallId, toolName, inputDigest);
   if (await crypto.subtle.verify('HMAC', key, sigBytes, payload)) {
     return true;
   }
@@ -129,13 +176,64 @@ export async function maybeSignApproval({
   toolCallId,
   toolName,
   input,
+  context,
 }: {
   secret: string | Uint8Array | undefined;
   approvalId: string;
   toolCallId: string;
   toolName: string;
   input: unknown;
+  context?: JSONValue;
 }): Promise<string | undefined> {
   if (secret == null) return undefined;
-  return signToolApproval({ secret, approvalId, toolCallId, toolName, input });
+  return signToolApproval({
+    secret,
+    approvalId,
+    toolCallId,
+    toolName,
+    input,
+    context,
+  });
+}
+
+/**
+ * Extra fields attached to an issued approval request.
+ *
+ * `inputDigest` and `context` are only present when per-call context was
+ * computed, so existing HMAC-v1 requests stay wire-compatible.
+ */
+export async function createToolApprovalRequestFields({
+  secret,
+  approvalId,
+  toolCallId,
+  toolName,
+  input,
+  context,
+}: {
+  secret: string | Uint8Array | undefined;
+  approvalId: string;
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  context?: JSONValue;
+}): Promise<{
+  signature?: string;
+  inputDigest?: string;
+  context?: JSONValue;
+}> {
+  const signature = await maybeSignApproval({
+    secret,
+    approvalId,
+    toolCallId,
+    toolName,
+    input,
+    context,
+  });
+
+  return {
+    ...(signature != null ? { signature } : {}),
+    ...(context !== undefined
+      ? { context, inputDigest: await hashCanonical(input) }
+      : {}),
+  };
 }

--- a/packages/ai/src/generate-text/validate-tool-approvals.test.ts
+++ b/packages/ai/src/generate-text/validate-tool-approvals.test.ts
@@ -1,6 +1,7 @@
 import { tool } from '@ai-sdk/provider-utils';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
+import { hashCanonical } from '../util/canonical-hash';
 import type { CollectedToolApprovals } from './collect-tool-approvals';
 import { signToolApproval } from './tool-approval-signature';
 import { validateApprovedToolApprovals } from './validate-tool-approvals';
@@ -404,6 +405,132 @@ describe('validateApprovedToolApprovals', () => {
       });
 
       expect(result.approvedToolApprovals).toHaveLength(1);
+    });
+  });
+
+  describe('approval request context binding', () => {
+    const tools = {
+      tool1: tool({
+        inputSchema: z.object({ value: z.string() }),
+        execute: async () => 'ok',
+      }),
+    };
+
+    it('should reject a stale input digest even without an HMAC secret', async () => {
+      const approval: CollectedToolApprovals<any> = {
+        approvalRequest: {
+          type: 'tool-approval-request',
+          approvalId: 'approval-1',
+          toolCallId: 'call-1',
+          context: { recordCount: 47 },
+          inputDigest: await hashCanonical({ value: 'original' }),
+        },
+        approvalResponse: {
+          type: 'tool-approval-response',
+          approvalId: 'approval-1',
+          approved: true,
+        },
+        toolCall: {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'tool1',
+          input: { value: 'forged' },
+        },
+      };
+
+      await expect(
+        validateApprovedToolApprovals({
+          approvedToolApprovals: [approval],
+          tools,
+          toolApproval: undefined,
+          messages: [],
+          toolsContext: {} as any,
+          runtimeContext: {},
+        }),
+      ).rejects.toThrowError(/stale input digest/);
+    });
+
+    it('should keep an approval whose input still matches the issued digest', async () => {
+      const input = { value: 'original' };
+      const approval: CollectedToolApprovals<any> = {
+        approvalRequest: {
+          type: 'tool-approval-request',
+          approvalId: 'approval-1',
+          toolCallId: 'call-1',
+          context: { recordCount: 47 },
+          inputDigest: await hashCanonical(input),
+        },
+        approvalResponse: {
+          type: 'tool-approval-response',
+          approvalId: 'approval-1',
+          approved: true,
+        },
+        toolCall: {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'tool1',
+          input,
+        },
+      };
+
+      const result = await validateApprovedToolApprovals({
+        approvedToolApprovals: [approval],
+        tools,
+        toolApproval: undefined,
+        messages: [],
+        toolsContext: {} as any,
+        runtimeContext: {},
+      });
+
+      expect(result.approvedToolApprovals).toHaveLength(1);
+    });
+
+    it('should reject HMAC verification when context is bound to a different tool call', async () => {
+      const secret = 'test-secret-for-context-bind';
+      const input = { value: 'test' };
+      const context = { recordCount: 47 };
+      const signature = await signToolApproval({
+        secret,
+        approvalId: 'approval-1',
+        toolCallId: 'call-1',
+        toolName: 'tool1',
+        input,
+        context,
+      });
+
+      const approval: CollectedToolApprovals<any> = {
+        approvalRequest: {
+          type: 'tool-approval-request',
+          approvalId: 'approval-1',
+          toolCallId: 'call-2',
+          signature,
+          context,
+          inputDigest: await hashCanonical(input),
+        },
+        approvalResponse: {
+          type: 'tool-approval-response',
+          approvalId: 'approval-1',
+          approved: true,
+        },
+        toolCall: {
+          type: 'tool-call',
+          toolCallId: 'call-2',
+          toolName: 'tool1',
+          input,
+        },
+      };
+
+      await expect(
+        validateApprovedToolApprovals({
+          approvedToolApprovals: [approval],
+          tools,
+          toolApproval: undefined,
+          messages: [],
+          toolsContext: {} as any,
+          runtimeContext: {},
+          toolApprovalSecret: secret,
+        }),
+      ).rejects.toThrowError(/invalid signature/);
     });
   });
 });

--- a/packages/ai/src/generate-text/validate-tool-approvals.ts
+++ b/packages/ai/src/generate-text/validate-tool-approvals.ts
@@ -10,6 +10,7 @@ import {
 import { InvalidToolApprovalSignatureError } from '../error/invalid-tool-approval-signature-error';
 import { InvalidToolInputError } from '../error/invalid-tool-input-error';
 import { getOwn } from '../util/get-own';
+import { hashCanonical } from '../util/canonical-hash';
 import type { CollectedToolApprovals } from './collect-tool-approvals';
 import { resolveToolApproval } from './resolve-tool-approval';
 import { verifyToolApprovalSignature } from './tool-approval-signature';
@@ -54,6 +55,17 @@ export async function validateApprovedToolApprovals<
     // than a prototype value that would silently skip input validation below.
     const tool = getOwn(tools, toolCall.toolName);
 
+    if (approvalRequest.inputDigest != null) {
+      const currentInputDigest = await hashCanonical(toolCall.input);
+      if (currentInputDigest !== approvalRequest.inputDigest) {
+        throw new InvalidToolApprovalSignatureError({
+          approvalId: approvalRequest.approvalId,
+          toolCallId: toolCall.toolCallId,
+          reason: 'stale input digest',
+        });
+      }
+    }
+
     if (toolApprovalSecret != null) {
       if (approvalRequest.signature == null) {
         throw new InvalidToolApprovalSignatureError({
@@ -70,6 +82,7 @@ export async function validateApprovedToolApprovals<
         toolCallId: toolCall.toolCallId,
         toolName: toolCall.toolName,
         input: toolCall.input,
+        context: approvalRequest.context,
       });
 
       if (!valid) {

--- a/packages/ai/src/prompt/content-part.ts
+++ b/packages/ai/src/prompt/content-part.ts
@@ -283,6 +283,10 @@ export const toolApprovalRequestSchema: ZodType<ToolApprovalRequest> = z.object(
     type: z.literal('tool-approval-request'),
     approvalId: z.string(),
     toolCallId: z.string(),
+    isAutomatic: z.boolean().optional(),
+    signature: z.string().optional(),
+    context: jsonValueSchema.optional(),
+    inputDigest: z.string().optional(),
   },
 );
 

--- a/packages/ai/src/ui-message-stream/to-ui-message-chunk.test.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-chunk.test.ts
@@ -603,12 +603,18 @@ describe('toUIMessageChunk', () => {
           input: { value: 'input' },
         },
         isAutomatic: true,
+        context: { recordCount: 47 },
+        inputDigest: 'digest-1',
+        signature: 'sig-1',
       }),
     ).toEqual({
       type: 'tool-approval-request',
       approvalId: 'approval-1',
       toolCallId: 'call-5',
       isAutomatic: true,
+      context: { recordCount: 47 },
+      inputDigest: 'digest-1',
+      signature: 'sig-1',
     });
 
     expect(

--- a/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
@@ -256,6 +256,8 @@ export function toUIMessageChunk<
         toolCallId: part.toolCall.toolCallId,
         ...(part.isAutomatic != null ? { isAutomatic: part.isAutomatic } : {}),
         ...(part.signature != null ? { signature: part.signature } : {}),
+        ...(part.context !== undefined ? { context: part.context } : {}),
+        ...(part.inputDigest != null ? { inputDigest: part.inputDigest } : {}),
       };
     }
 

--- a/packages/ai/src/ui-message-stream/ui-message-chunks.ts
+++ b/packages/ai/src/ui-message-stream/ui-message-chunks.ts
@@ -1,4 +1,4 @@
-import type { JSONObject } from '@ai-sdk/provider';
+import type { JSONObject, JSONValue } from '@ai-sdk/provider';
 import {
   providerMetadataSchema,
   type ProviderMetadata,
@@ -87,6 +87,8 @@ export const uiMessageChunkSchema = lazySchema(() =>
         toolCallId: z.string(),
         isAutomatic: z.boolean().optional(),
         signature: z.string().optional(),
+        context: jsonValueSchema.optional(),
+        inputDigest: z.string().optional(),
       }),
       z.looseObject({
         type: z.literal('tool-approval-response'),
@@ -297,6 +299,8 @@ export type UIMessageChunk<
       toolCallId: string;
       isAutomatic?: boolean;
       signature?: string;
+      context?: JSONValue;
+      inputDigest?: string;
     }
   | {
       type: 'tool-approval-response';

--- a/packages/ai/src/ui/convert-to-model-messages.test.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.test.ts
@@ -1400,6 +1400,54 @@ describe('convertToModelMessages', () => {
       ]);
     });
 
+    it('should round-trip approval context and inputDigest', async () => {
+      const result = await convertToModelMessages(
+        [
+          {
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool-weather',
+                state: 'approval-responded',
+                toolCallId: 'call-1',
+                input: { city: 'Tokyo' },
+                approval: {
+                  id: 'approval-1',
+                  approved: true,
+                  context: { recordCount: 47 },
+                  inputDigest: 'digest-1',
+                  signature: 'sig-1',
+                },
+              },
+            ],
+          },
+        ],
+        { ignoreIncompleteToolCalls: true },
+      );
+
+      expect(result[0]).toEqual({
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'weather',
+            input: { city: 'Tokyo' },
+            providerExecuted: undefined,
+          },
+          {
+            type: 'tool-approval-request',
+            approvalId: 'approval-1',
+            toolCallId: 'call-1',
+            isAutomatic: undefined,
+            signature: 'sig-1',
+            context: { recordCount: 47 },
+            inputDigest: 'digest-1',
+          },
+        ],
+      });
+    });
+
     it('should preserve tool calls with approval responses', async () => {
       const result = await convertToModelMessages(
         [

--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -236,6 +236,12 @@ export async function convertToModelMessages<UI_MESSAGE extends UIMessage>(
                       ...(part.approval.signature != null
                         ? { signature: part.approval.signature }
                         : {}),
+                      ...(part.approval.context !== undefined
+                        ? { context: part.approval.context }
+                        : {}),
+                      ...(part.approval.inputDigest != null
+                        ? { inputDigest: part.approval.inputDigest }
+                        : {}),
                     });
                   }
 

--- a/packages/ai/src/ui/process-ui-message-stream.test.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.test.ts
@@ -7564,6 +7564,84 @@ describe('processUIMessageStream', () => {
     });
   });
 
+  describe('tool approval request context', () => {
+    it('should surface context and inputDigest on approval-requested and preserve them after respond', async () => {
+      const stream = createUIMessageStream([
+        { type: 'start' },
+        { type: 'start-step' },
+        {
+          type: 'tool-input-available',
+          toolCallId: 'call-1',
+          toolName: 'tool1',
+          input: { value: 'value' },
+        },
+        {
+          type: 'tool-approval-request',
+          approvalId: 'id-1',
+          toolCallId: 'call-1',
+          context: { recordCount: 47 },
+          inputDigest: 'digest-1',
+          signature: 'sig-1',
+        },
+        {
+          type: 'tool-approval-response',
+          approvalId: 'id-1',
+          approved: true,
+        },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ]);
+
+      state = createStreamingUIMessageState({
+        messageId: 'msg-123',
+        lastMessage: undefined,
+      });
+
+      await consumeStream({
+        stream: processUIMessageStream({
+          stream,
+          runUpdateMessageJob,
+          onError: error => {
+            throw error;
+          },
+        }),
+      });
+
+      const requested = writeCalls.find(call =>
+        call.message.parts.some(
+          part =>
+            part.type === 'tool-tool1' &&
+            'state' in part &&
+            part.state === 'approval-requested',
+        ),
+      )?.message.parts.find(part => part.type === 'tool-tool1') as {
+        state: string;
+        approval?: Record<string, unknown>;
+      };
+
+      expect(requested?.state).toBe('approval-requested');
+      expect(requested?.approval).toEqual({
+        id: 'id-1',
+        context: { recordCount: 47 },
+        inputDigest: 'digest-1',
+        signature: 'sig-1',
+      });
+
+      const responded = state!.message.parts.find(
+        part => part.type === 'tool-tool1',
+      ) as { state: string; approval?: Record<string, unknown> };
+
+      expect(responded?.state).toBe('approval-responded');
+      expect(responded?.approval).toEqual({
+        id: 'id-1',
+        approved: true,
+        context: { recordCount: 47 },
+        inputDigest: 'digest-1',
+        signature: 'sig-1',
+      });
+    });
+  });
+
   describe('tool approval requests (dynamic tool)', () => {
     beforeEach(async () => {
       const stream = createUIMessageStream([

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -752,6 +752,12 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 ...(chunk.signature != null
                   ? { signature: chunk.signature }
                   : {}),
+                ...(chunk.context !== undefined
+                  ? { context: chunk.context }
+                  : {}),
+                ...(chunk.inputDigest != null
+                  ? { inputDigest: chunk.inputDigest }
+                  : {}),
               };
               write();
               break;
@@ -774,6 +780,12 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
                 ...(approval.isAutomatic === true ? { isAutomatic: true } : {}),
                 ...(approval.signature != null
                   ? { signature: approval.signature }
+                  : {}),
+                ...('context' in approval && approval.context !== undefined
+                  ? { context: approval.context }
+                  : {}),
+                ...('inputDigest' in approval && approval.inputDigest != null
+                  ? { inputDigest: approval.inputDigest }
                   : {}),
               };
               if (chunk.providerExecuted != null) {

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -1,4 +1,4 @@
-import type { JSONObject } from '@ai-sdk/provider';
+import type { JSONObject, JSONValue } from '@ai-sdk/provider';
 import type {
   InferToolInput,
   InferToolOutput,
@@ -322,6 +322,8 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
         reason?: never;
         isAutomatic?: boolean;
         signature?: string;
+        context?: JSONValue;
+        inputDigest?: string;
       };
     }
   | {
@@ -336,6 +338,8 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
         reason?: string;
         isAutomatic?: boolean;
         signature?: string;
+        context?: JSONValue;
+        inputDigest?: string;
       };
     }
   | {
@@ -352,6 +356,8 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
         reason?: string;
         isAutomatic?: boolean;
         signature?: string;
+        context?: JSONValue;
+        inputDigest?: string;
       };
     }
   | {
@@ -368,6 +374,8 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
         reason?: string;
         isAutomatic?: boolean;
         signature?: string;
+        context?: JSONValue;
+        inputDigest?: string;
       };
     }
   | {
@@ -382,6 +390,8 @@ export type UIToolInvocation<TOOL extends UITool | Tool> = {
         reason?: string;
         isAutomatic?: boolean;
         signature?: string;
+        context?: JSONValue;
+        inputDigest?: string;
       };
     }
 );
@@ -440,6 +450,8 @@ export type DynamicToolUIPart = {
         reason?: never;
         isAutomatic?: boolean;
         signature?: string;
+        context?: JSONValue;
+        inputDigest?: string;
       };
     }
   | {
@@ -454,6 +466,8 @@ export type DynamicToolUIPart = {
         reason?: string;
         isAutomatic?: boolean;
         signature?: string;
+        context?: JSONValue;
+        inputDigest?: string;
       };
     }
   | {
@@ -470,6 +484,8 @@ export type DynamicToolUIPart = {
         reason?: string;
         isAutomatic?: boolean;
         signature?: string;
+        context?: JSONValue;
+        inputDigest?: string;
       };
     }
   | {
@@ -485,6 +501,8 @@ export type DynamicToolUIPart = {
         reason?: string;
         isAutomatic?: boolean;
         signature?: string;
+        context?: JSONValue;
+        inputDigest?: string;
       };
     }
   | {
@@ -499,6 +517,8 @@ export type DynamicToolUIPart = {
         reason?: string;
         isAutomatic?: boolean;
         signature?: string;
+        context?: JSONValue;
+        inputDigest?: string;
       };
     }
 );

--- a/packages/ai/src/ui/validate-ui-messages.ts
+++ b/packages/ai/src/ui/validate-ui-messages.ts
@@ -135,6 +135,8 @@ const uiMessagesSchema = lazySchema(() =>
                     reason: z.never().optional(),
                     isAutomatic: z.boolean().optional(),
                     signature: z.string().optional(),
+                    context: jsonValueSchema.optional(),
+                    inputDigest: z.string().optional(),
                   }),
                 }),
                 z.object({
@@ -154,6 +156,8 @@ const uiMessagesSchema = lazySchema(() =>
                     reason: z.string().optional(),
                     isAutomatic: z.boolean().optional(),
                     signature: z.string().optional(),
+                    context: jsonValueSchema.optional(),
+                    inputDigest: z.string().optional(),
                   }),
                 }),
                 z.object({
@@ -176,6 +180,8 @@ const uiMessagesSchema = lazySchema(() =>
                       reason: z.string().optional(),
                       isAutomatic: z.boolean().optional(),
                       signature: z.string().optional(),
+                      context: jsonValueSchema.optional(),
+                      inputDigest: z.string().optional(),
                     })
                     .optional(),
                 }),
@@ -199,6 +205,8 @@ const uiMessagesSchema = lazySchema(() =>
                       reason: z.string().optional(),
                       isAutomatic: z.boolean().optional(),
                       signature: z.string().optional(),
+                      context: jsonValueSchema.optional(),
+                      inputDigest: z.string().optional(),
                     })
                     .optional(),
                 }),
@@ -219,6 +227,8 @@ const uiMessagesSchema = lazySchema(() =>
                     reason: z.string().optional(),
                     isAutomatic: z.boolean().optional(),
                     signature: z.string().optional(),
+                    context: jsonValueSchema.optional(),
+                    inputDigest: z.string().optional(),
                   }),
                 }),
                 z.object({
@@ -261,6 +271,8 @@ const uiMessagesSchema = lazySchema(() =>
                     reason: z.never().optional(),
                     isAutomatic: z.boolean().optional(),
                     signature: z.string().optional(),
+                    context: jsonValueSchema.optional(),
+                    inputDigest: z.string().optional(),
                   }),
                 }),
                 z.object({
@@ -279,6 +291,8 @@ const uiMessagesSchema = lazySchema(() =>
                     reason: z.string().optional(),
                     isAutomatic: z.boolean().optional(),
                     signature: z.string().optional(),
+                    context: jsonValueSchema.optional(),
+                    inputDigest: z.string().optional(),
                   }),
                 }),
                 z.object({
@@ -300,6 +314,8 @@ const uiMessagesSchema = lazySchema(() =>
                       reason: z.string().optional(),
                       isAutomatic: z.boolean().optional(),
                       signature: z.string().optional(),
+                      context: jsonValueSchema.optional(),
+                      inputDigest: z.string().optional(),
                     })
                     .optional(),
                 }),
@@ -322,6 +338,8 @@ const uiMessagesSchema = lazySchema(() =>
                       reason: z.string().optional(),
                       isAutomatic: z.boolean().optional(),
                       signature: z.string().optional(),
+                      context: jsonValueSchema.optional(),
+                      inputDigest: z.string().optional(),
                     })
                     .optional(),
                 }),
@@ -341,6 +359,8 @@ const uiMessagesSchema = lazySchema(() =>
                     reason: z.string().optional(),
                     isAutomatic: z.boolean().optional(),
                     signature: z.string().optional(),
+                    context: jsonValueSchema.optional(),
+                    inputDigest: z.string().optional(),
                   }),
                 }),
               ]),

--- a/packages/provider-utils/src/types/index.ts
+++ b/packages/provider-utils/src/types/index.ts
@@ -59,7 +59,10 @@ export type {
   ToolExecutionOptions,
 } from './tool-execute-function';
 export type { ToolContent, ToolModelMessage } from './tool-model-message';
-export type { ToolNeedsApprovalFunction } from './tool-needs-approval-function';
+export type {
+  ToolNeedsApprovalDecision,
+  ToolNeedsApprovalFunction,
+} from './tool-needs-approval-function';
 export type { ToolResult } from './tool-result';
 export type { ToolSet } from './tool-set';
 export type { UserContent, UserModelMessage } from './user-model-message';

--- a/packages/provider-utils/src/types/tool-approval-request.ts
+++ b/packages/provider-utils/src/types/tool-approval-request.ts
@@ -1,3 +1,5 @@
+import type { JSONValue } from '@ai-sdk/provider';
+
 /**
  * Tool approval request prompt part.
  */
@@ -26,4 +28,16 @@ export type ToolApprovalRequest = {
    * Present only when `experimental_toolApprovalSecret` is configured.
    */
   signature?: string;
+
+  /**
+   * Dynamic, per-call context for the approval card (blast radius,
+   * consequence summary, etc.). Bound to this approval id and tool call.
+   */
+  context?: JSONValue;
+
+  /**
+   * Canonical digest of the tool input at the time this context was issued.
+   * Present when `context` is set. Replay rejects a mismatched digest as stale.
+   */
+  inputDigest?: string;
 };

--- a/packages/provider-utils/src/types/tool-needs-approval-function.test-d.ts
+++ b/packages/provider-utils/src/types/tool-needs-approval-function.test-d.ts
@@ -1,6 +1,9 @@
 import { describe, expectTypeOf, it } from 'vitest';
 import type { ModelMessage } from './model-message';
-import type { ToolNeedsApprovalFunction } from './tool-needs-approval-function';
+import type {
+  ToolNeedsApprovalDecision,
+  ToolNeedsApprovalFunction,
+} from './tool-needs-approval-function';
 
 describe('tool needs approval function type', () => {
   it('should type the input, approval metadata, and context', () => {
@@ -14,7 +17,7 @@ describe('tool needs approval function type', () => {
           messages: ModelMessage[];
           context: { requestId: string };
         },
-      ) => boolean | PromiseLike<boolean>
+      ) => ToolNeedsApprovalDecision | PromiseLike<ToolNeedsApprovalDecision>
     >();
   });
 });

--- a/packages/provider-utils/src/types/tool-needs-approval-function.ts
+++ b/packages/provider-utils/src/types/tool-needs-approval-function.ts
@@ -1,5 +1,29 @@
+import type { JSONValue } from '@ai-sdk/provider';
 import type { Context } from './context';
 import type { ModelMessage } from './model-message';
+
+/**
+ * Per-call decision returned by a `needsApproval` function.
+ *
+ * Use the object form to attach computed consequence context to the
+ * `approval-requested` UI part (bound to that approval id and tool call).
+ */
+export type ToolNeedsApprovalDecision =
+  | boolean
+  | {
+      /**
+       * Whether the tool call requires explicit user approval.
+       */
+      approvalRequired: boolean;
+
+      /**
+       * Dynamic, per-call context for the approval card (blast radius,
+       * consequence summary, etc.). Surfaced on the `approval-requested` part.
+       *
+       * Only used when `approvalRequired` is `true`.
+       */
+      context?: JSONValue;
+    };
 
 /**
  * Function that is called to determine if the tool needs approval before it can be executed.
@@ -36,4 +60,4 @@ export type ToolNeedsApprovalFunction<
      */
     context: CONTEXT;
   },
-) => boolean | PromiseLike<boolean>;
+) => ToolNeedsApprovalDecision | PromiseLike<ToolNeedsApprovalDecision>;


### PR DESCRIPTION
Fixes #15733

## Summary

Uninformed HITL (`Allow deleteRecords?`) is not consent. This adds a first-class, per-call `context` field on the same approval request / `approval-requested` part as the tool call, bound to `approvalId`, `toolCallId`, and a canonical input digest.

- `toolApproval` functions can return `{ type: 'user-approval', context }`
- Deprecated `needsApproval` functions can return `{ approvalRequired: true, context }` (boolean return is unchanged)
- Context and `inputDigest` round-trip through the UI stream and `convertToModelMessages`
- If the tool input changes after context was issued, replay fails closed (`stale input digest`)
- When `experimental_toolApprovalSecret` is set **and** context is present, HMAC v2 also binds a context digest. Requests without context keep HMAC v1 so pending approvals still verify. A v1 signature is never accepted for a request that carries context (unsigned context swap).

This is the approval-request metadata slice only. It does not implement mid-execute `waitForApproval` inside `execute` (#9862).

## Test plan

- [x] `needsApproval` / `toolApproval` attach context on `user-approval`
- [x] Approval-requested part surfaces `context` + `inputDigest`; response preserves them
- [x] History round-trip via `convertToModelMessages`
- [x] Stale input digest fails closed without an HMAC secret
- [x] HMAC v2 rejects swapped context, stripped context, v1+context, and a different `toolCallId` with the same visible context
- [x] Existing HMAC v1 / legacy newline fallback tests still pass

---

If you want this gate proved against a live agent tool path: [Instant Audit ($499)](https://a2zsoc.com/productized-services#instant-audit-tripwire) · [consultation](https://a2zsoc.com/consultation)


Made with [Cursor](https://cursor.com)