### PR TITLE
fix(provider-utils): merge headers case-insensitively

### DIFF
--- a/.changeset/quiet-headers-merge.md
+++ b/.changeset/quiet-headers-merge.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Normalize combined header names so later values override case-insensitively.

--- a/packages/provider-utils/src/combine-headers.test.ts
+++ b/packages/provider-utils/src/combine-headers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { combineHeaders } from './combine-headers';
+
+function headersInit(
+  headers: Record<string, string | undefined>,
+): [string, string][] {
+  return Object.entries(headers).filter(
+    (entry): entry is [string, string] => entry[1] != null,
+  );
+}
+
+describe('combineHeaders', () => {
+  it('overrides header names case-insensitively', () => {
+    const headers = combineHeaders(
+      { Authorization: 'Bearer config-token' },
+      { authorization: 'Bearer request-token' },
+    );
+
+    expect(new Headers(headersInit(headers)).get('authorization')).toBe(
+      'Bearer request-token',
+    );
+    expect(headers).toEqual({
+      authorization: 'Bearer request-token',
+    });
+  });
+
+  it('preserves header casing when no override is needed', () => {
+    expect(combineHeaders({ 'X-Trace': 'trace-id' })).toEqual({
+      'X-Trace': 'trace-id',
+    });
+  });
+
+  it('keeps later undefined values as deletion markers', () => {
+    expect(
+      combineHeaders(
+        {
+          Authorization: 'Bearer config-token',
+          'X-Trace': 'trace-id',
+        },
+        {
+          authorization: undefined,
+          'X-Other': 'value',
+        },
+      ),
+    ).toEqual({
+      authorization: undefined,
+      'X-Trace': 'trace-id',
+      'X-Other': 'value',
+    });
+  });
+});

--- a/packages/provider-utils/src/combine-headers.ts
+++ b/packages/provider-utils/src/combine-headers.ts
@@ -1,11 +1,13 @@
 export function combineHeaders(
   ...headers: Array<Record<string, string | undefined> | undefined>
 ): Record<string, string | undefined> {
-  return headers.reduce(
-    (combinedHeaders, currentHeaders) => ({
-      ...combinedHeaders,
-      ...(currentHeaders ?? {}),
-    }),
-    {},
-  ) as Record<string, string | undefined>;
+  const combinedHeaders = new Map<string, [string, string | undefined]>();
+
+  for (const currentHeaders of headers) {
+    for (const [key, value] of Object.entries(currentHeaders ?? {})) {
+      combinedHeaders.set(key.toLowerCase(), [key, value]);
+    }
+  }
+
+  return Object.fromEntries(combinedHeaders.values());
 }


### PR DESCRIPTION
## Background

`combineHeaders` merged records with object spread, but JavaScript object keys are case-sensitive while HTTP header names are not. If configuration provides `Authorization` and request options provide `authorization`, both keys survive; constructing Fetch `Headers` then combines both values instead of letting the later request header override the configured value.

## Summary

- Index merged headers case-insensitively while preserving the original casing from the last occurrence.
- Preserve later `undefined` values as deletion markers.
- Add Node and Edge regression coverage and a patch changeset for `@ai-sdk/provider-utils`.

## End-to-End Verification

Constructed Fetch `Headers` from a configured `Authorization: Bearer config` value followed by a request-specific `authorization: Bearer request` value. The resulting header now contains only `Bearer request`; unrelated header names retain their original casing.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
