### PR TITLE
fix(ai): prevent deferred tools from bypassing unresolved client calls

### DIFF
--- a/.changeset/curvy-tools-approve.md
+++ b/.changeset/curvy-tools-approve.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Prevent pending deferred provider tools from advancing the step loop while client tool calls are unresolved.

--- a/packages/ai/src/generate-text/generate-text.test.ts
+++ b/packages/ai/src/generate-text/generate-text.test.ts
@@ -10374,6 +10374,75 @@ describe('generateText', () => {
     });
   });
 
+  describe('deferred provider tools with unresolved client approvals', () => {
+    it('should not continue to another model call while client approval is pending', async () => {
+      let modelCallCount = 0;
+      const executeClientTool = vi.fn(async () => 'result');
+
+      const result = await generateText({
+        model: new MockLanguageModelV4({
+          doGenerate: async () => {
+            modelCallCount++;
+
+            if (modelCallCount > 1) {
+              throw new Error('unexpected second model call');
+            }
+
+            return {
+              ...dummyResponseValues,
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'deferred-call-1',
+                  toolName: 'deferred_tool',
+                  input: '{}',
+                  providerExecuted: true,
+                },
+                {
+                  type: 'tool-call',
+                  toolCallType: 'function',
+                  toolCallId: 'client-call-1',
+                  toolName: 'client_tool',
+                  input: '{"value":"test"}',
+                },
+              ],
+              finishReason: { unified: 'tool-calls', raw: undefined },
+            };
+          },
+        }),
+        tools: {
+          deferred_tool: {
+            type: 'provider',
+            isProviderExecuted: true,
+            id: 'test.deferred_tool',
+            inputSchema: z.object({}),
+            outputSchema: z.object({ value: z.string() }),
+            args: {},
+            supportsDeferredResults: true,
+          },
+          client_tool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            needsApproval: true,
+            execute: executeClientTool,
+          }),
+        },
+        prompt: 'test-input',
+        stopWhen: isStepCount(3),
+      });
+
+      expect(modelCallCount).toBe(1);
+      expect(result.steps).toHaveLength(1);
+      expect(
+        result.content.some(
+          part =>
+            part.type === 'tool-approval-request' &&
+            part.toolCall.toolName === 'client_tool',
+        ),
+      ).toBe(true);
+      expect(executeClientTool).not.toHaveBeenCalled();
+    });
+  });
+
   describe('logWarnings', () => {
     it('should call logWarnings with warnings from a single step', async () => {
       const expectedWarnings = [

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -834,6 +834,7 @@ export async function generateText<
         ...initialMessages,
         ...initialResponseMessages,
       ];
+      let hasUnresolvedClientToolCalls = false;
 
       // Track provider-executed tool calls that support deferred results
       // (e.g., code_execution in programmatic tool calling scenarios).
@@ -1431,10 +1432,15 @@ export async function generateText<
             clearTimeout(stepTimeoutId);
           }
         }
+        hasUnresolvedClientToolCalls =
+          clientToolCalls.length > 0 &&
+          clientToolOutputs.length + deniedToolApprovalResponses.length !==
+            clientToolCalls.length;
       } while (
-        // Continue if:
-        // 1. There are client tool calls that have all been executed or denied, OR
-        // 2. There are pending deferred results from provider-executed tools
+        // Continue only when there are no unresolved client tool calls and:
+        // 1. client tool calls have all been executed or denied, OR
+        // 2. there are pending deferred results from provider-executed tools
+        !hasUnresolvedClientToolCalls &&
         ((clientToolCalls.length > 0 &&
           clientToolOutputs.length + deniedToolApprovalResponses.length ===
             clientToolCalls.length) ||

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -26120,6 +26120,88 @@ describe('streamText', () => {
     });
   });
 
+  describe('deferred provider tools with unresolved client approvals', () => {
+    it('should not continue to another model call while client approval is pending', async () => {
+      let modelCallCount = 0;
+      const executeClientTool = vi.fn(async () => 'result');
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => {
+            modelCallCount++;
+
+            if (modelCallCount > 1) {
+              throw new Error('unexpected second model call');
+            }
+
+            return {
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'response-metadata',
+                  id: 'msg-1',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'deferred-call-1',
+                  toolName: 'deferred_tool',
+                  input: '{}',
+                  providerExecuted: true,
+                },
+                {
+                  type: 'tool-call',
+                  toolCallType: 'function',
+                  toolCallId: 'client-call-1',
+                  toolName: 'client_tool',
+                  input: '{"value":"test"}',
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: undefined },
+                  usage: testUsage,
+                },
+              ]),
+              response: {},
+            };
+          },
+        }),
+        tools: {
+          deferred_tool: {
+            type: 'provider',
+            isProviderExecuted: true,
+            id: 'test.deferred_tool',
+            inputSchema: z.object({}),
+            outputSchema: z.object({ value: z.string() }),
+            args: {},
+            supportsDeferredResults: true,
+          },
+          client_tool: tool({
+            inputSchema: z.object({ value: z.string() }),
+            needsApproval: true,
+            execute: executeClientTool,
+          }),
+        },
+        ...defaultSettings(),
+        stopWhen: isStepCount(3),
+      });
+
+      const fullStream = await convertAsyncIterableToArray(result.fullStream);
+
+      expect(modelCallCount).toBe(1);
+      expect(await result.steps).toHaveLength(1);
+      expect(
+        fullStream.some(
+          part =>
+            part.type === 'tool-approval-request' &&
+            part.toolCall.toolName === 'client_tool',
+        ),
+      ).toBe(true);
+      expect(fullStream.some(part => part.type === 'error')).toBe(false);
+      expect(executeClientTool).not.toHaveBeenCalled();
+    });
+  });
+
   describe('logWarnings', () => {
     it('should call logWarnings with warnings from a single step', async () => {
       const expectedWarnings = [

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -2421,10 +2421,17 @@ class DefaultStreamTextResult<
                   // Clear this step's timeouts before the next step is started.
                   cleanupStepTimeouts();
 
+                  const hasUnresolvedClientToolCalls =
+                    clientToolCalls.length > 0 &&
+                    clientToolOutputs.length +
+                      deniedToolApprovalResponses.length !==
+                      clientToolCalls.length;
+
                   if (
-                    // Continue if:
-                    // 1. There are client tool calls that have all been executed or denied, OR
-                    // 2. There are pending deferred results from provider-executed tools, OR
+                    // Continue only when there are no unresolved client tool calls and:
+                    // 1. client tool calls have all been executed or denied, OR
+                    // 2. there are pending deferred results from provider-executed tools
+                    !hasUnresolvedClientToolCalls &&
                     ((clientToolCalls.length > 0 &&
                       clientToolCalls.length ===
                         clientToolOutputs.length +


### PR DESCRIPTION
## Background

When a deferred provider-executed tool is pending alongside a client tool call that requires approval, the deferred tool can keep the step loop running before the client approval has been resolved.

This can cause the next model call to start prematurely and result in `AI_MissingToolResultsError`.

## Summary

- prevent pending deferred provider tools from advancing the step loop while client tool calls are unresolved
- apply the same behavior to `generateText` and `streamText`
- add regression coverage for deferred provider tools combined with pending client approval

## End-to-End Verification

Verified with regression scenarios covering both `generateText` and `streamText`: when a deferred provider tool is pending and a client tool requires approval, only one model call is made and the approval request is surfaced without executing the client tool.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #18970
