### PR TITLE
docs: mention Valibot in inputSchema descriptions

### DIFF
--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -24,7 +24,7 @@ and [`streamText`](/docs/reference/ai-sdk-core/stream-text) by passing one or mo
 A tool consists of three properties:
 
 - **`description`**: An optional description of the tool that can influence when the tool is picked. Function and dynamic tools can use either a string or a function that derives the description from the tool's context and experimental sandbox.
-- **`inputSchema`**: A [Zod schema](/docs/reference/ai-sdk-core/zod-schema) or a [JSON schema](/docs/reference/ai-sdk-core/json-schema) that defines the input required for the tool to run. The schema is consumed by the LLM, and also used to validate the LLM tool calls.
+- **`inputSchema`**: A [Zod schema](/docs/reference/ai-sdk-core/zod-schema), [Valibot schema](/docs/reference/ai-sdk-core/valibot-schema) or [JSON schema](/docs/reference/ai-sdk-core/json-schema) that defines the input required for the tool to run. See [Schemas](#schemas) for all supported libraries. The schema is consumed by the LLM, and also used to validate the LLM tool calls.
 - **`execute`**: An optional async function that is called with the arguments from the tool call.
 
 <Note>

--- a/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
+++ b/content/docs/03-ai-sdk-core/15-tools-and-tool-calling.mdx
@@ -9,7 +9,7 @@ As covered under Foundations, [tools](/docs/foundations/tools) are objects that 
 Function tools and dynamic tools contain several core elements:
 
 - **`description`**: An optional description of the tool that can influence when the tool is picked. It can be a string or a function that derives the description from the tool's context and experimental sandbox.
-- **`inputSchema`**: A [Zod schema](/docs/foundations/tools#schemas) or a [JSON schema](/docs/reference/ai-sdk-core/json-schema) that defines the input parameters. The schema is consumed by the LLM, and also used to validate the LLM tool calls.
+- **`inputSchema`**: A [Zod, Valibot or JSON schema](/docs/foundations/tools#schemas) that defines the input parameters. The schema is consumed by the LLM, and also used to validate the LLM tool calls.
 - **`execute`**: An optional async function that is called with the inputs from the tool call. It produces a value of type `RESULT` (generic type). It is optional because you might want to forward tool calls to the client or to a queue instead of executing them in the same process.
 - **`strict`**: _(optional, boolean)_ Enables strict tool calling when supported by the provider
 

--- a/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/01-generate-text.mdx
@@ -353,7 +353,7 @@ To see `generateText` in action, check out [these examples](#examples).
               name: 'inputSchema',
               type: 'Zod Schema | JSON Schema',
               description:
-                'The schema of the input that the tool expects. The language model will use this to generate the input. It is also used to validate the output of the language model. Use descriptions to make the input understandable for the language model. You can either pass in a Zod schema or a JSON schema (using the `jsonSchema` function).',
+                'The schema of the input that the tool expects. The language model will use this to generate the input. It is also used to validate the output of the language model. Use descriptions to make the input understandable for the language model. You can pass in a Zod schema, a Valibot schema (using the `valibotSchema` function) or a JSON schema (using the `jsonSchema` function).',
             },
             {
               name: 'execute',

--- a/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/02-stream-text.mdx
@@ -354,7 +354,7 @@ To see `streamText` in action, check out [these examples](#examples).
               name: 'inputSchema',
               type: 'Zod Schema | JSON Schema',
               description:
-                'The schema of the input that the tool expects. The language model will use this to generate the input. It is also used to validate the output of the language model. Use descriptions to make the input understandable for the language model. You can either pass in a Zod schema or a JSON schema (using the `jsonSchema` function).',
+                'The schema of the input that the tool expects. The language model will use this to generate the input. It is also used to validate the output of the language model. Use descriptions to make the input understandable for the language model. You can pass in a Zod schema, a Valibot schema (using the `valibotSchema` function) or a JSON schema (using the `jsonSchema` function).',
             },
             {
               name: 'execute',

--- a/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/20-tool.mdx
@@ -83,7 +83,7 @@ export const weatherTool = tool({
               name: 'inputSchema',
               type: 'Zod Schema | JSON Schema',
               description:
-                'The schema of the input that the tool expects. The language model will use this to generate the input. It is also used to validate the output of the language model. Use descriptions to make the input understandable for the language model. You can either pass in a Zod schema or a JSON schema (using the `jsonSchema` function).',
+                'The schema of the input that the tool expects. The language model will use this to generate the input. It is also used to validate the output of the language model. Use descriptions to make the input understandable for the language model. You can pass in a Zod schema, a Valibot schema (using the `valibotSchema` function) or a JSON schema (using the `jsonSchema` function).',
             },
             {
               name: 'inputExamples',

--- a/content/docs/07-reference/02-ai-sdk-ui/03-use-object.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/03-use-object.mdx
@@ -72,7 +72,7 @@ export default function Page() {
       name: 'schema',
       type: 'Zod Schema | JSON Schema',
       description:
-        'A schema that defines the shape of the complete object. You can either pass in a Zod schema or a JSON schema (using the `jsonSchema` function).',
+        'A schema that defines the shape of the complete object. You can pass in a Zod schema, a Valibot schema (using the `valibotSchema` function) or a JSON schema (using the `jsonSchema` function).',
     },
     {
       name: 'id?',


### PR DESCRIPTION
## Background

The tools pages say `inputSchema` accepts a Zod schema or a JSON schema, but since #9338 the SDK also accepts Valibot and other Standard JSON Schema libraries, and the Schemas section of the foundations page already lists them. I'm the author of Valibot.

## Summary

Mentions Valibot in the two `inputSchema` bullets and in the matching reference descriptions of `generateText`, `streamText`, `tool` and `useObject` so users discover this.
