### PR TITLE
feat(harness-pi): export pi event translation utils

### DIFF
--- a/.changeset/curvy-carrots-play.md
+++ b/.changeset/curvy-carrots-play.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-pi": patch
+---
+
+feat(harness-pi): export the low-level Pi event translator

--- a/content/providers/02-ai-sdk-harnesses/03-pi.mdx
+++ b/content/providers/02-ai-sdk-harnesses/03-pi.mdx
@@ -116,6 +116,23 @@ factories you explicitly provide. Filesystem extension discovery remains
 disabled, including user, project, and settings-based extensions. Themes and
 prompt templates also remain disabled.
 
+## Low-level Event Translation
+
+Use the `@ai-sdk/harness-pi/translate` subpath when consuming Pi session events
+outside the harness session implementation:
+
+```ts
+import {
+  createPiTranslatorState,
+  translatePiEvent,
+} from '@ai-sdk/harness-pi/translate';
+
+const state = createPiTranslatorState();
+const streamParts = translatePiEvent(event, state);
+```
+
+Reuse the same translator state for every event in a turn.
+
 ## Authentication
 
 The `auth` setting selects which credentials Pi reads from the host environment:

--- a/packages/harness-pi/package.json
+++ b/packages/harness-pi/package.json
@@ -28,6 +28,11 @@
   },
   "exports": {
     "./package.json": "./package.json",
+    "./translate": {
+      "types": "./dist/pi-translate.d.ts",
+      "import": "./dist/pi-translate.js",
+      "default": "./dist/pi-translate.js"
+    },
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",

--- a/packages/harness-pi/tsup.config.ts
+++ b/packages/harness-pi/tsup.config.ts
@@ -5,7 +5,10 @@ const packageVersion = JSON.stringify(
 );
 
 export default defineConfig({
-  entry: { index: 'src/index.ts' },
+  entry: {
+    index: 'src/index.ts',
+    'pi-translate': 'src/pi-translate.ts',
+  },
   format: ['esm'],
   target: 'es2022',
   dts: true,


### PR DESCRIPTION
## Background

`@ai-sdk/harness-pi` doesn't expose the internal pi event translator. seems like it'd be a great package for folks who use pi and want ai-elements compat. i.e. processing pi events outside of the harness impl. 

## Summary

basically just the package export for`@ai-sdk/harness-pi/translate` and release workflow stuff 

## End-to-End Verification

uhhh, lets see how CI does lol. built `@ai-sdk/harness-pi` and made sure the dist had the new exports

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A *patch* changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)