### PR TITLE
fix(provider/amazon-bedrock): support encrypted reasoningContent.redactedContent in Converse responses and streams

### DIFF
--- a/.changeset/bedrock-redacted-content-reasoning.md
+++ b/.changeset/bedrock-redacted-content-reasoning.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(bedrock): support encrypted `reasoningContent.redactedContent` in Converse responses and streams
+
+The Converse API returns encrypted reasoning as the documented `redactedContent` union member (e.g. for OpenAI models served on Bedrock). Previously these chunks failed stream schema validation and terminated the stream with `AI_TypeValidationError`. They are now surfaced as reasoning parts with `redactedContent` provider metadata and replayed back to the API unchanged.

--- a/packages/amazon-bedrock/src/amazon-bedrock-api-types.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-api-types.ts
@@ -258,6 +258,17 @@ export interface AmazonBedrockRedactedReasoningContentBlock {
   };
 }
 
+/**
+ * Encrypted reasoning content block as documented by the Converse API
+ * (`ReasoningContentBlock.redactedContent`). Returned e.g. by OpenAI models
+ * served on Bedrock. Base64-encoded opaque state.
+ */
+export interface AmazonBedrockRedactedContentReasoningContentBlock {
+  reasoningContent: {
+    redactedContent: string;
+  };
+}
+
 export type AmazonBedrockContentBlock =
   | AmazonBedrockDocumentBlock
   | AmazonBedrockGuardrailConverseContentBlock
@@ -267,5 +278,6 @@ export type AmazonBedrockContentBlock =
   | AmazonBedrockToolResultBlock
   | AmazonBedrockToolUseBlock
   | AmazonBedrockReasoningContentBlock
+  | AmazonBedrockRedactedContentReasoningContentBlock
   | AmazonBedrockRedactedReasoningContentBlock
   | AmazonBedrockCachePoint;

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -2413,6 +2413,103 @@ describe('doStream', () => {
     `);
   });
 
+  it('should stream encrypted redactedContent reasoning', async () => {
+    setupMockEventStreamHandler();
+    server.urls[streamUrl].response = {
+      type: 'stream-chunks',
+      chunks: [
+        JSON.stringify({
+          contentBlockDelta: {
+            contentBlockIndex: 0,
+            delta: {
+              reasoningContent: {
+                redactedContent: 'cnNuX2VuY3J5cHRlZC1yZWFzb25pbmc=',
+              },
+            },
+          },
+        }) + '\n',
+        JSON.stringify({
+          contentBlockDelta: {
+            contentBlockIndex: 1,
+            delta: { text: 'Here is my answer.' },
+          },
+        }) + '\n',
+        JSON.stringify({
+          messageStop: {
+            stopReason: 'stop_sequence',
+          },
+        }) + '\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "stream-start",
+          "warnings": [],
+        },
+        {
+          "id": undefined,
+          "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+          "timestamp": undefined,
+          "type": "response-metadata",
+        },
+        {
+          "id": "0",
+          "type": "reasoning-start",
+        },
+        {
+          "delta": "",
+          "id": "0",
+          "providerMetadata": {
+            "amazonBedrock": {
+              "redactedContent": "cnNuX2VuY3J5cHRlZC1yZWFzb25pbmc=",
+            },
+            "bedrock": {
+              "redactedContent": "cnNuX2VuY3J5cHRlZC1yZWFzb25pbmc=",
+            },
+          },
+          "type": "reasoning-delta",
+        },
+        {
+          "id": "1",
+          "type": "text-start",
+        },
+        {
+          "delta": "Here is my answer.",
+          "id": "1",
+          "type": "text-delta",
+        },
+        {
+          "finishReason": {
+            "raw": "stop_sequence",
+            "unified": "stop",
+          },
+          "type": "finish",
+          "usage": {
+            "inputTokens": {
+              "cacheRead": undefined,
+              "cacheWrite": undefined,
+              "noCache": undefined,
+              "total": undefined,
+            },
+            "outputTokens": {
+              "reasoning": undefined,
+              "text": undefined,
+              "total": undefined,
+            },
+            "raw": undefined,
+          },
+        },
+      ]
+    `);
+  });
+
   it('should include raw chunks when includeRawChunks is true', async () => {
     setupMockEventStreamHandler();
     server.urls[streamUrl].response = {
@@ -5590,6 +5687,54 @@ describe('doGenerate', () => {
             },
             "bedrock": {
               "redactedData": "redacted-reasoning-data",
+            },
+          },
+          "text": "",
+          "type": "reasoning",
+        },
+        {
+          "text": "The answer is 42.",
+          "type": "text",
+        },
+      ]
+    `);
+  });
+
+  it('should extract encrypted redactedContent reasoning', async () => {
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                reasoningContent: {
+                  redactedContent: 'cnNuX2VuY3J5cHRlZC1yZWFzb25pbmc=',
+                },
+              },
+              { type: 'text', text: 'The answer is 42.' },
+            ],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 34, totalTokens: 38 },
+        stopReason: 'stop_sequence',
+      },
+    };
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.content).toMatchInlineSnapshot(`
+      [
+        {
+          "providerMetadata": {
+            "amazonBedrock": {
+              "redactedContent": "cnNuX2VuY3J5cHRlZC1yZWFzb25pbmc=",
+            },
+            "bedrock": {
+              "redactedContent": "cnNuX2VuY3J5cHRlZC1yZWFzb25pbmc=",
             },
           },
           "text": "",

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -573,6 +573,18 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
               bedrock: redactedPayload,
             },
           });
+        } else if ('redactedContent' in part.reasoningContent) {
+          const redactedContentPayload: AmazonBedrockReasoningMetadata = {
+            redactedContent: part.reasoningContent.redactedContent ?? '',
+          };
+          content.push({
+            type: 'reasoning',
+            text: '',
+            providerMetadata: {
+              amazonBedrock: redactedContentPayload,
+              bedrock: redactedContentPayload,
+            },
+          });
         }
       }
 
@@ -1008,6 +1020,32 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
                     },
                   });
                 }
+              } else if (
+                'redactedContent' in reasoningContent &&
+                reasoningContent.redactedContent
+              ) {
+                if (contentBlocks[blockIndex] == null) {
+                  contentBlocks[blockIndex] = { type: 'reasoning' };
+                  controller.enqueue({
+                    type: 'reasoning-start',
+                    id: String(blockIndex),
+                  });
+                }
+                {
+                  const redactedContentPayload: AmazonBedrockReasoningMetadata =
+                    {
+                      redactedContent: reasoningContent.redactedContent,
+                    };
+                  controller.enqueue({
+                    type: 'reasoning-delta',
+                    id: String(blockIndex),
+                    delta: '',
+                    providerMetadata: {
+                      amazonBedrock: redactedContentPayload,
+                      bedrock: redactedContentPayload,
+                    },
+                  });
+                }
               }
             }
 
@@ -1216,6 +1254,9 @@ const AmazonBedrockResponseSchema = z.object({
               z.object({
                 redactedReasoning: AmazonBedrockRedactedReasoningSchema,
               }),
+              z.object({
+                redactedContent: z.string(),
+              }),
             ])
             .nullish(),
         }),
@@ -1261,6 +1302,9 @@ const AmazonBedrockStreamSchema = z.object({
           }),
           z.object({
             reasoningContent: z.object({ data: z.string() }),
+          }),
+          z.object({
+            reasoningContent: z.object({ redactedContent: z.string() }),
           }),
         ])
         .nullish(),

--- a/packages/amazon-bedrock/src/amazon-bedrock-reasoning-metadata.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-reasoning-metadata.ts
@@ -3,6 +3,12 @@ import { z } from 'zod/v4';
 export const amazonBedrockReasoningMetadataSchema = z.object({
   signature: z.string().optional(),
   redactedData: z.string().optional(),
+  /**
+   * Encrypted reasoning content returned by the model provider
+   * (`reasoningContent.redactedContent` in the Converse API), e.g. for
+   * OpenAI models served via Bedrock. Base64-encoded opaque state.
+   */
+  redactedContent: z.string().optional(),
 });
 
 export type AmazonBedrockReasoningMetadata = z.infer<

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
@@ -914,6 +914,46 @@ describe('assistant messages', () => {
     });
   });
 
+  it('should properly convert encrypted redactedContent reasoning content type', async () => {
+    const redactedContent = 'cnNuX2VuY3J5cHRlZC1yZWFzb25pbmc=';
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Explain your reasoning' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: '',
+            providerOptions: { bedrock: { redactedContent } },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'Explain your reasoning' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              reasoningContent: {
+                redactedContent,
+              },
+            },
+          ],
+        },
+      ],
+      system: [],
+    });
+  });
+
   it('should omit assistant message reasoning parts signed by a foreign provider', async () => {
     const result = await convertToAmazonBedrockChatMessages([
       {

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -528,6 +528,12 @@ export async function convertToAmazonBedrockChatMessages(
                       },
                     },
                   });
+                } else if (reasoningMetadata?.redactedContent != null) {
+                  amazonBedrockContent.push({
+                    reasoningContent: {
+                      redactedContent: reasoningMetadata.redactedContent,
+                    },
+                  });
                 }
                 // Unsigned reasoning is intentionally not replayed. Some
                 // Bedrock models (for example OpenAI gpt-oss) return reasoning


### PR DESCRIPTION
## Background

The Bedrock Converse API documents encrypted reasoning as the `redactedContent` union member on both [`ReasoningContentBlock`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlock.html) and the streaming [`ReasoningContentBlockDelta`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlockDelta.html). OpenAI models served on Bedrock via Converse (e.g. `global.openai.gpt-5.6-sol`) return encrypted reasoning in this shape:

```json
{
  "contentBlockDelta": {
    "contentBlockIndex": 0,
    "delta": { "reasoningContent": { "redactedContent": "cnNuX..." } }
  }
}
```

The provider's stream schema union only accepted `reasoningContent.{text,signature,data}` (the `data`/`redactedReasoning` shapes are the legacy Anthropic-passthrough forms), so these chunks failed Zod validation and terminated the stream with `AI_TypeValidationError`. This surfaced in production via AI Gateway when requests for `openai/gpt-5.6-sol` failed over to Bedrock (internal incident, Linear AIG-572 / KDA-350).

## Change

Additive support for the documented `redactedContent` member, mirroring the existing redacted reasoning handling and leaving the legacy `redactedReasoning`/`data` path untouched:

- **Stream schema**: accept `reasoningContent.redactedContent` in the `contentBlockDelta.delta` union.
- **`doStream`**: emit lazy `reasoning-start` + `reasoning-delta` (`delta: ''`) with `providerMetadata.{amazonBedrock,bedrock}.redactedContent`.
- **Response schema / `doGenerate`**: accept `reasoningContent.redactedContent` and emit a reasoning part with the same metadata.
- **Round-trip** (`convert-to-amazon-bedrock-chat-messages`): replay `redactedContent` metadata back as `reasoningContent: { redactedContent }` — the documented request shape — kept distinct from the legacy `redactedData` → `redactedReasoning.data` mapping.
- New `AmazonBedrockRedactedContentReasoningContentBlock` API type; `redactedContent` added to the reasoning provider-metadata schema.

## Tests

- `should stream encrypted redactedContent reasoning` (stream parsing + emitted parts)
- `should extract encrypted redactedContent reasoning` (doGenerate)
- `should properly convert encrypted redactedContent reasoning content type` (request round-trip)

`pnpm vitest run` for the touched files passes; `pnpm type-check` passes. Note: 4 pre-existing `doGenerate` failures in `amazon-bedrock-chat-language-model.test.ts` (`sanitizeJsonSchema` missing from the `@ai-sdk/anthropic/internal` mock) fail identically on the base commit and are unrelated.

## Follow-ups

- Backports to `release-v6.0` (bedrock 4.x / spec v3) and `release-v5.0` (bedrock 3.x / spec v2) so AI Gateway can pick this up on all three spec lines.
