### PR TITLE
fix(otel): preserve model-call spans across streamText retries

### DIFF
--- a/.changeset/tidy-spans-retry.md
+++ b/.changeset/tidy-spans-retry.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/otel': patch
+---
+
+Preserve failed model-call spans when `streamText` retries provider calls.

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { APICallError, type LanguageModelV4 } from '@ai-sdk/provider';
 import {
   convertArrayToReadableStream,
   convertAsyncIterableToArray,
 } from '@ai-sdk/provider-utils/test';
 import {
+  SpanKind,
+  SpanStatusCode,
   context,
   trace,
   type Attributes,
@@ -1829,6 +1832,97 @@ describe('OpenTelemetry', () => {
     });
   });
 
+  describe('streamText integration', () => {
+    it('preserves failed model-call spans across a successful retry', async () => {
+      const sdkTrace = createSdkTracer();
+      integration = new OpenTelemetry({ tracer: sdkTrace.tracer });
+
+      const doStream = vi
+        .fn<LanguageModelV4['doStream']>()
+        .mockImplementationOnce(async () => {
+          throw createRetryableError();
+        })
+        .mockImplementationOnce(async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'hello' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: { raw: 'stop', unified: 'stop' },
+              usage: {
+                inputTokens: {
+                  total: 1,
+                  noCache: 1,
+                  cacheRead: undefined,
+                  cacheWrite: undefined,
+                },
+                outputTokens: {
+                  total: 1,
+                  text: 1,
+                  reasoning: undefined,
+                },
+              },
+            },
+          ]),
+        }));
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          provider: 'openai.chat',
+          modelId: 'gpt-4',
+          doStream,
+        }),
+        maxRetries: 1,
+        prompt: 'test-input',
+        telemetry: {
+          integrations: integration,
+        },
+      });
+
+      await expect(result.text).resolves.toBe('hello');
+
+      expect(doStream).toHaveBeenCalledTimes(2);
+      expectRetryTrace({
+        chatStatuses: [SpanStatusCode.ERROR, SpanStatusCode.UNSET],
+        exporter: sdkTrace.exporter,
+        operationStatus: SpanStatusCode.UNSET,
+      });
+    });
+
+    it('closes every failed model-call span when retries are exhausted', async () => {
+      const sdkTrace = createSdkTracer();
+      integration = new OpenTelemetry({ tracer: sdkTrace.tracer });
+
+      const doStream = vi.fn<LanguageModelV4['doStream']>(async () => {
+        throw createRetryableError();
+      });
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          provider: 'openai.chat',
+          modelId: 'gpt-4',
+          doStream,
+        }),
+        maxRetries: 1,
+        prompt: 'test-input',
+        telemetry: {
+          integrations: integration,
+        },
+      });
+
+      await expect(result.text).rejects.toThrow();
+
+      expect(doStream).toHaveBeenCalledTimes(2);
+      expectRetryTrace({
+        chatStatuses: [SpanStatusCode.ERROR, SpanStatusCode.ERROR],
+        exporter: sdkTrace.exporter,
+        operationStatus: SpanStatusCode.ERROR,
+      });
+    });
+  });
+
   describe('embed integration', () => {
     it('omits usage attributes when the provider does not return usage', async () => {
       const sdkTrace = createSdkTracer();
@@ -2383,3 +2477,63 @@ describe('OpenTelemetry', () => {
     });
   });
 });
+
+function createRetryableError() {
+  return new APICallError({
+    message: 'Internal Server Error',
+    url: 'https://api.example.com/v1/chat',
+    requestBodyValues: { prompt: 'test-input' },
+    statusCode: 500,
+    responseHeaders: { 'retry-after-ms': '1' },
+  });
+}
+
+function expectRetryTrace({
+  chatStatuses,
+  exporter,
+  operationStatus,
+}: {
+  chatStatuses: SpanStatusCode[];
+  exporter: InMemorySpanExporter;
+  operationStatus: SpanStatusCode;
+}) {
+  const spans = exporter.getFinishedSpans();
+  const rootSpan = spans.find(span => span.name === 'invoke_agent gpt-4');
+  const stepSpan = spans.find(span => span.name === 'step 1');
+
+  if (!rootSpan) {
+    throw new Error('Expected one finished root span');
+  }
+  if (!stepSpan) {
+    throw new Error('Expected one finished step span');
+  }
+
+  const chatSpans = spans.filter(span => span.name === 'chat gpt-4');
+
+  expect(spans).toHaveLength(4);
+  expect(chatSpans).toHaveLength(2);
+  expect(chatSpans.map(span => span.kind)).toEqual([
+    SpanKind.CLIENT,
+    SpanKind.CLIENT,
+  ]);
+  expect(chatSpans.map(span => span.status.code)).toEqual(chatStatuses);
+  expect(chatSpans.map(span => span.status.message)).toEqual(
+    chatStatuses.map(status =>
+      status === SpanStatusCode.ERROR ? 'Internal Server Error' : undefined,
+    ),
+  );
+  expect(chatSpans.map(span => span.events.map(event => event.name))).toEqual(
+    chatStatuses.map(status =>
+      status === SpanStatusCode.ERROR ? ['exception'] : [],
+    ),
+  );
+  expect(stepSpan.parentSpanContext?.spanId).toBe(
+    rootSpan.spanContext().spanId,
+  );
+  expect(chatSpans.map(span => span.parentSpanContext?.spanId)).toEqual([
+    stepSpan.spanContext().spanId,
+    stepSpan.spanContext().spanId,
+  ]);
+  expect(rootSpan.status.code).toBe(operationStatus);
+  expect(stepSpan.status.code).toBe(operationStatus);
+}

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -195,7 +195,22 @@ export class OpenTelemetry implements Telemetry {
       return execute();
     }
 
-    return context.with(modelCallContext, execute);
+    return context.with(modelCallContext, async () => {
+      try {
+        return await execute();
+      } catch (error) {
+        const inferenceSpan = state?.inferenceSpan;
+        if (state?.operationId !== 'ai.streamText' || !inferenceSpan) {
+          throw error;
+        }
+
+        recordErrorOnSpan(inferenceSpan, error);
+        inferenceSpan.end();
+        state.inferenceSpan = undefined;
+        state.inferenceContext = undefined;
+        throw error;
+      }
+    });
   }
 
   onStart(
@@ -639,6 +654,7 @@ export class OpenTelemetry implements Telemetry {
   onStepStart(event: OtelStepStartEvent): void {
     const state = this.getCallState(event.callId);
     if (!state?.rootSpan || !state.rootContext) return;
+    if (state.stepSpan) return;
 
     const { telemetry } = state;
     state.runtimeContext = event.runtimeContext as


### PR DESCRIPTION
## Problem

During a `streamText` retry, the OpenTelemetry integration starts new spans before ending the spans from the failed attempt. The new spans overwrite the old references, so the failed model call and the original step span are never exported.

## What this PR changes

This PR ends each failed model-call span before the next attempt starts and reuses one step span across all attempts for the same logical step.

Each provider attempt now produces one finished model-call span, while the overall step produces one finished step span. Tests cover both retry-then-success and exhausted retries.

## Verification

The regression tests exercise the public `streamText` API with a retryable mock model and an in-memory OpenTelemetry exporter.

For retry-then-success, the exported trace contains one root span, one step span, one failed model-call span, and one successful model-call span.

For exhausted retries, it contains one root span, one step span, and two failed model-call spans. Both failed attempts include exception events.

## Testing

`pnpm -C packages/otel test`  
208 tests passed.

`pnpm -C packages/otel type-check`  
Passed.

`pnpm -C packages/otel build`  
Passed.

`pnpm check`  
Passed with zero warnings and zero errors.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
