### PR TITLE
fix(openai): support built-in and provider-defined tools in Responses allowedTools

### DIFF
--- a/.changeset/olive-donkeys-invite.md
+++ b/.changeset/olive-donkeys-invite.md
@@ -1,0 +1,14 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): support built-in and provider-defined tools in the Responses `allowedTools` option
+
+`allowedTools` emitted every allow-list entry as `{ type: 'function', name }`, but OpenAI identifies
+built-in tools by type. Allow-listing a declared provider-defined tool (web search, image generation,
+MCP, custom, ...) therefore failed with `Tool choice '<name>' not found in 'tools' parameter`. Entries
+are now derived from the declared tool, including the MCP server label and custom tool name.
+
+Tools that OpenAI cannot allow-list (the tool search tool, deferred tools, and namespaced tools) are
+dropped from the allow-list with a warning, and an error is thrown if that would leave the allow-list
+empty rather than silently sending an unrestricted request.

--- a/.changeset/olive-donkeys-invite.md
+++ b/.changeset/olive-donkeys-invite.md
@@ -12,3 +12,8 @@ are now derived from the declared tool, including the MCP server label and custo
 Tools that OpenAI cannot allow-list (the tool search tool, deferred tools, and namespaced tools) are
 dropped from the allow-list with a warning, and an error is thrown if that would leave the allow-list
 empty rather than silently sending an unrestricted request.
+
+Ambiguous names are now reported instead of resolved silently. A name that matches both a declared tool
+and another tool's provider tool name resolves to the declared tool and warns; a provider tool name
+shared by several tools in the same request (two MCP servers, for example) is dropped with a warning.
+A name that matches no declared tool keeps its existing behavior and is now warned about.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1438,7 +1438,13 @@ const result = await generateText({
   tools or answer with a message; `'required'` forces it to call at least one of them.
 
 Both function tools and provider-defined tools can be allow-listed, including web search, file search,
-image generation, code interpreter, computer, apply patch, shell, custom tools, and MCP servers.
+image generation, code interpreter, computer, apply patch, shell, programmatic tool calling, custom
+tools, and MCP servers.
+
+If a name matches both a tool you declared and the canonical OpenAI name of a different tool, the tool
+you declared under that name wins, and a warning reports the ambiguity. If several tools share the same
+canonical name — two MCP servers, for example — that name is ambiguous, so it is dropped with a warning;
+name those tools as you declared them instead.
 
 <Note>
   Three kinds of tools cannot be allow-listed, because OpenAI's `allowed_tools`

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1403,6 +1403,58 @@ The custom tool can be configured with:
   - **definition** _string_ - (grammar only) The grammar definition string (a regex pattern or Lark grammar).
 - **execute** _function_ (optional) - An async function that receives the raw string input and returns a string result. Enables multi-turn tool calling.
 
+#### Restricting Callable Tools
+
+The `allowedTools` provider option restricts which of the tools you declared the model is allowed to
+call, while still sending the full `tools` list to OpenAI. Because the tools list stays byte-identical
+across requests, the prompt cache is preserved — unlike `activeTools`, which removes tools from the
+request and invalidates the cache whenever the allow-list changes.
+
+`allowedTools` is only supported by the Responses API, and it overrides the request-level `toolChoice`.
+
+```ts
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: openai.responses('gpt-5.5'),
+  tools: {
+    weather: weatherTool,
+    cityAttractions: cityAttractionsTool,
+    search: openai.tools.webSearch(),
+  },
+  providerOptions: {
+    openai: {
+      allowedTools: { toolNames: ['weather', 'search'], mode: 'auto' },
+    },
+  },
+  prompt: 'What is the weather in San Francisco?',
+});
+```
+
+- **toolNames** _string[]_ - The tools the model may call, named as you declared them in `tools`. For
+  provider-defined tools you may also use the canonical OpenAI name (for example `web_search`).
+- **mode** _'auto' | 'required'_ (optional) - `'auto'` (default) lets the model pick one of the allowed
+  tools or answer with a message; `'required'` forces it to call at least one of them.
+
+Both function tools and provider-defined tools can be allow-listed, including web search, file search,
+image generation, code interpreter, computer, apply patch, shell, custom tools, and MCP servers.
+
+<Note>
+  Three kinds of tools cannot be allow-listed, because OpenAI's `allowed_tools`
+  only sees the eagerly-loaded tool list: the [tool search tool](#tool-search),
+  tools marked with `deferLoading`, and tools grouped into a namespace. Naming
+  one of these in `allowedTools` removes it from the allow-list and emits a
+  warning; if that leaves no tools at all, the request fails with an error
+  instead of silently sending no restriction.
+</Note>
+
+<Note>
+  An MCP server is allow-listed as a whole: the entry carries the server label,
+  so every tool on that server is callable. To restrict which tools on a server
+  the model may call, use the MCP tool's own `allowedTools` argument.
+</Note>
+
 #### Image Inputs
 
 The OpenAI Responses API supports Image inputs for appropriate models.

--- a/examples/ai-functions/src/generate-text/openai/responses-allowed-tools.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-allowed-tools.ts
@@ -12,10 +12,11 @@ run(async () => {
       cityAttractions: tool({
         inputSchema: z.object({ city: z.string() }),
       }),
+      search: openai.tools.webSearch(),
     },
     providerOptions: {
       openai: {
-        allowedTools: { toolNames: ['weather'], mode: 'auto' },
+        allowedTools: { toolNames: ['weather', 'search'], mode: 'auto' },
       },
     },
     prompt:
@@ -26,6 +27,7 @@ run(async () => {
   const calledTools = new Set(result.toolCalls.map(c => c.toolName));
   console.log('called tools:', [...calledTools]);
   console.log('cityAttractions blocked?', !calledTools.has('cityAttractions'));
+  console.log('warnings:', result.warnings);
   console.log(JSON.stringify(result.toolCalls, null, 2));
   console.log(JSON.stringify(result.finishReason, null, 2));
 });

--- a/examples/ai-functions/src/stream-text/openai/responses-allowed-tools.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-allowed-tools.ts
@@ -12,10 +12,11 @@ run(async () => {
       cityAttractions: tool({
         inputSchema: z.object({ city: z.string() }),
       }),
+      search: openai.tools.webSearch(),
     },
     providerOptions: {
       openai: {
-        allowedTools: { toolNames: ['weather'], mode: 'auto' },
+        allowedTools: { toolNames: ['weather', 'search'], mode: 'auto' },
       },
     },
     prompt:
@@ -51,6 +52,7 @@ run(async () => {
           'cityAttractions blocked?',
           !calledTools.has('cityAttractions'),
         );
+        console.log('Warnings:', await result.warnings);
         console.log('Finish reason:', chunk.finishReason);
         console.log('Total Usage:', chunk.totalUsage);
         break;

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -485,6 +485,21 @@ export type OpenAIResponsesFunctionTool = {
   output_schema?: JSONSchema7;
 };
 
+/**
+ * Entry in `tool_choice.allowed_tools.tools`. OpenAI identifies most built-in
+ * tools by type alone; only `function`, `custom` and `mcp` carry an identifier.
+ */
+export type OpenAIResponsesAllowedTool =
+  | { type: 'function'; name: string }
+  | { type: 'custom'; name: string }
+  | { type: 'mcp'; server_label: string }
+  | {
+      type: Exclude<
+        OpenAIResponsesTool['type'],
+        'function' | 'custom' | 'mcp' | 'namespace' | 'tool_search'
+      >;
+    };
+
 export type OpenAIResponsesTool =
   | OpenAIResponsesFunctionTool
   | {

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -3117,6 +3117,56 @@ describe('OpenAIResponsesLanguageModel', () => {
         });
       });
 
+      it('should send derived allowed_tools entries for function, built-in and mcp tools', async () => {
+        await createModel('gpt-4o').doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            ...TEST_TOOLS,
+            {
+              type: 'provider',
+              id: 'openai.web_search',
+              name: 'search',
+              args: {},
+            },
+            {
+              type: 'provider',
+              id: 'openai.mcp',
+              name: 'deepwiki',
+              args: {
+                serverLabel: 'deepwiki',
+                serverUrl: 'https://mcp.deepwiki.com/mcp',
+              },
+            },
+          ],
+          providerOptions: {
+            openai: {
+              allowedTools: { toolNames: ['weather', 'search', 'deepwiki'] },
+            },
+          },
+        });
+
+        const body = (await server.calls[0].requestBodyJson) as {
+          tools: Array<{ type: string; name?: string }>;
+          tool_choice: unknown;
+        };
+
+        expect(body.tools.map(t => t.name ?? t.type)).toEqual([
+          'weather',
+          'cityAttractions',
+          'web_search',
+          'mcp',
+        ]);
+        expect(body.tool_choice).toEqual({
+          type: 'allowed_tools',
+          mode: 'auto',
+          tools: [
+            { type: 'function', name: 'weather' },
+            { type: 'web_search' },
+            { type: 'mcp', server_label: 'deepwiki' },
+          ],
+        });
+      });
+
       it('should send allowed_tools with required mode when allowedTools.mode is required', async () => {
         await createModel('gpt-4o').doGenerate({
           prompt: TEST_PROMPT,

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -2240,6 +2240,14 @@ describe('prepareResponsesTools', () => {
         mode: 'auto',
         tools: [{ type: 'function', name: 'web_search' }],
       });
+      expect(result.toolWarnings).toEqual([
+        {
+          type: 'unsupported',
+          feature: 'allowedTools entry "web_search"',
+          details:
+            'this name is both a tool name and the provider tool name of another tool in this request; the tool with this name is allowed',
+        },
+      ]);
     });
 
     it('should not resolve a function tool by the literal name "function"', async () => {

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -1960,22 +1960,56 @@ describe('prepareResponsesTools', () => {
   });
 
   describe('allowedTools provider option', () => {
+    const functionTool = {
+      type: 'function',
+      name: 'get_weather',
+      description: 'Get weather',
+      inputSchema: { type: 'object', properties: {} },
+    } as const;
+
+    const timeTool = {
+      type: 'function',
+      name: 'get_time',
+      description: 'Get time',
+      inputSchema: { type: 'object', properties: {} },
+    } as const;
+
+    const webSearchTool = {
+      type: 'provider',
+      id: 'openai.web_search',
+      name: 'search',
+      args: {},
+    } as const;
+
+    // mirrors the mapping the language model builds from its providerToolNames
+    // registry, so canonical provider names resolve as they do in a request:
+    const webSearchNameMapping = {
+      toProviderToolName: (name: string) =>
+        name === 'search' ? 'web_search' : name,
+      toCustomToolName: (name: string) =>
+        name === 'web_search' ? 'search' : name,
+    };
+
+    const mcpTool = (name: string, serverLabel: string) =>
+      ({
+        type: 'provider',
+        id: 'openai.mcp',
+        name,
+        args: {
+          serverLabel,
+          serverUrl: `https://${serverLabel}.example.com/mcp`,
+        },
+      }) as const;
+
+    const mcpNameMapping = {
+      toProviderToolName: (name: string) =>
+        name === 'alpha' || name === 'beta' ? 'mcp' : name,
+      toCustomToolName: (name: string) => name,
+    };
+
     it('should emit allowed_tools with default auto mode', async () => {
       const result = await prepareResponsesTools({
-        tools: [
-          {
-            type: 'function',
-            name: 'get_weather',
-            description: 'Get weather',
-            inputSchema: { type: 'object', properties: {} },
-          },
-          {
-            type: 'function',
-            name: 'get_time',
-            description: 'Get time',
-            inputSchema: { type: 'object', properties: {} },
-          },
-        ],
+        tools: [functionTool, timeTool],
         toolChoice: undefined,
         allowedTools: { toolNames: ['get_weather'] },
       });
@@ -1990,20 +2024,7 @@ describe('prepareResponsesTools', () => {
 
     it('should emit allowed_tools with required mode', async () => {
       const result = await prepareResponsesTools({
-        tools: [
-          {
-            type: 'function',
-            name: 'get_weather',
-            description: 'Get weather',
-            inputSchema: { type: 'object', properties: {} },
-          },
-          {
-            type: 'function',
-            name: 'get_time',
-            description: 'Get time',
-            inputSchema: { type: 'object', properties: {} },
-          },
-        ],
+        tools: [functionTool, timeTool],
         toolChoice: undefined,
         allowedTools: {
           toolNames: ['get_weather', 'get_time'],
@@ -2024,14 +2045,7 @@ describe('prepareResponsesTools', () => {
 
     it('should override request-level toolChoice when allowedTools is set', async () => {
       const result = await prepareResponsesTools({
-        tools: [
-          {
-            type: 'function',
-            name: 'get_weather',
-            description: 'Get weather',
-            inputSchema: { type: 'object', properties: {} },
-          },
-        ],
+        tools: [functionTool],
         toolChoice: { type: 'required' },
         allowedTools: { toolNames: ['get_weather'] },
       });
@@ -2042,8 +2056,428 @@ describe('prepareResponsesTools', () => {
         tools: [{ type: 'function', name: 'get_weather' }],
       });
     });
-  });
 
+    describe('entry shapes', () => {
+      it.each([
+        [
+          'web search',
+          {
+            type: 'provider',
+            id: 'openai.web_search',
+            name: 'search',
+            args: {},
+          },
+          'search',
+          { type: 'web_search' },
+        ],
+        [
+          'file search',
+          {
+            type: 'provider',
+            id: 'openai.file_search',
+            name: 'file_search',
+            args: { vectorStoreIds: ['vs-1'] },
+          },
+          'file_search',
+          { type: 'file_search' },
+        ],
+        [
+          'web search preview',
+          {
+            type: 'provider',
+            id: 'openai.web_search_preview',
+            name: 'web_search_preview',
+            args: {},
+          },
+          'web_search_preview',
+          { type: 'web_search_preview' },
+        ],
+        [
+          'image generation',
+          {
+            type: 'provider',
+            id: 'openai.image_generation',
+            name: 'image_generation',
+            args: {},
+          },
+          'image_generation',
+          { type: 'image_generation' },
+        ],
+        [
+          'code interpreter',
+          {
+            type: 'provider',
+            id: 'openai.code_interpreter',
+            name: 'code_interpreter',
+            args: {},
+          },
+          'code_interpreter',
+          { type: 'code_interpreter' },
+        ],
+        [
+          'apply patch',
+          {
+            type: 'provider',
+            id: 'openai.apply_patch',
+            name: 'apply_patch',
+            args: {},
+          },
+          'apply_patch',
+          { type: 'apply_patch' },
+        ],
+        [
+          'shell',
+          { type: 'provider', id: 'openai.shell', name: 'shell', args: {} },
+          'shell',
+          { type: 'shell' },
+        ],
+        [
+          'computer',
+          {
+            type: 'provider',
+            id: 'openai.computer',
+            name: 'computer',
+            args: {},
+          },
+          'computer',
+          { type: 'computer' },
+        ],
+        [
+          'mcp (carries its server label)',
+          {
+            type: 'provider',
+            id: 'openai.mcp',
+            name: 'deepwiki',
+            args: {
+              serverLabel: 'deepwiki',
+              serverUrl: 'https://mcp.deepwiki.com/mcp',
+            },
+          },
+          'deepwiki',
+          { type: 'mcp', server_label: 'deepwiki' },
+        ],
+        [
+          'custom (carries its name)',
+          {
+            type: 'provider',
+            id: 'openai.custom',
+            name: 'write_sql',
+            args: { description: 'Write a SQL SELECT query.' },
+          },
+          'write_sql',
+          { type: 'custom', name: 'write_sql' },
+        ],
+      ])(
+        'should emit the correct allowed_tools entry for %s',
+        async (_label, tool, allowedName, expectedEntry) => {
+          const result = await prepareResponsesTools({
+            tools: [tool as any],
+            toolChoice: undefined,
+            allowedTools: { toolNames: [allowedName as string] },
+          });
+
+          expect(result.toolChoice).toEqual({
+            type: 'allowed_tools',
+            mode: 'auto',
+            tools: [expectedEntry],
+          });
+          expect(result.toolWarnings).toEqual([]);
+        },
+      );
+    });
+
+    it('should preserve the order of mixed function and built-in entries without deduplicating', async () => {
+      const result = await prepareResponsesTools({
+        tools: [functionTool, webSearchTool],
+        toolChoice: undefined,
+        allowedTools: { toolNames: ['search', 'get_weather', 'search'] },
+      });
+
+      expect(result.toolChoice).toEqual({
+        type: 'allowed_tools',
+        mode: 'auto',
+        tools: [
+          { type: 'web_search' },
+          { type: 'function', name: 'get_weather' },
+          { type: 'web_search' },
+        ],
+      });
+    });
+
+    it('should resolve a built-in tool by its canonical provider name', async () => {
+      const result = await prepareResponsesTools({
+        tools: [webSearchTool],
+        toolChoice: undefined,
+        allowedTools: { toolNames: ['web_search'] },
+        toolNameMapping: webSearchNameMapping,
+      });
+
+      expect(result.toolChoice).toEqual({
+        type: 'allowed_tools',
+        mode: 'auto',
+        tools: [{ type: 'web_search' }],
+      });
+    });
+
+    it('should prefer the user tool name over a canonical name alias on collision', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'web_search',
+            description: 'A function that happens to be named web_search',
+            inputSchema: { type: 'object', properties: {} },
+          },
+          webSearchTool,
+        ],
+        toolChoice: undefined,
+        allowedTools: { toolNames: ['web_search'] },
+        toolNameMapping: webSearchNameMapping,
+      });
+
+      expect(result.toolChoice).toEqual({
+        type: 'allowed_tools',
+        mode: 'auto',
+        tools: [{ type: 'function', name: 'web_search' }],
+      });
+    });
+
+    it('should not resolve a function tool by the literal name "function"', async () => {
+      const result = await prepareResponsesTools({
+        tools: [functionTool],
+        toolChoice: undefined,
+        allowedTools: { toolNames: ['function'] },
+      });
+
+      expect(result.toolChoice).toEqual({
+        type: 'allowed_tools',
+        mode: 'auto',
+        tools: [{ type: 'function', name: 'function' }],
+      });
+      expect(result.toolWarnings).toEqual([
+        {
+          type: 'unsupported',
+          feature: 'allowedTools entry "function"',
+          details:
+            'the tool is not part of the tools for this request and is sent as a function tool',
+        },
+      ]);
+    });
+
+    describe('tools that cannot be allow-listed', () => {
+      it.each([
+        [
+          'a deferred tool',
+          {
+            type: 'function',
+            name: 'problem_tool',
+            description: 'Deferred',
+            inputSchema: { type: 'object', properties: {} },
+            providerOptions: { openai: { deferLoading: true } },
+          },
+          'problem_tool',
+          'deferred tools are not visible to tool_choice.allowed_tools; the tool is removed from the allowed tools',
+        ],
+        [
+          'a namespaced tool',
+          {
+            type: 'function',
+            name: 'problem_tool',
+            description: 'Namespaced',
+            inputSchema: { type: 'object', properties: {} },
+            providerOptions: {
+              openai: { namespace: { name: 'crm', description: 'CRM tools' } },
+            },
+          },
+          'problem_tool',
+          'tools inside an OpenAI tool namespace are not visible to tool_choice.allowed_tools; the tool is removed from the allowed tools',
+        ],
+        [
+          'the tool search tool',
+          {
+            type: 'provider',
+            id: 'openai.tool_search',
+            name: 'problem_tool',
+            args: {},
+          },
+          'problem_tool',
+          'OpenAI does not support tool_search tools in tool_choice.allowed_tools; the tool is removed from the allowed tools',
+        ],
+      ])(
+        'should drop %s from the allow-list and warn',
+        async (_label, problemTool, allowedName, expectedDetails) => {
+          const result = await prepareResponsesTools({
+            tools: [functionTool, problemTool as any],
+            toolChoice: undefined,
+            allowedTools: {
+              toolNames: ['get_weather', allowedName as string],
+            },
+          });
+
+          expect(result.toolChoice).toEqual({
+            type: 'allowed_tools',
+            mode: 'auto',
+            tools: [{ type: 'function', name: 'get_weather' }],
+          });
+          expect(result.toolWarnings).toEqual([
+            {
+              type: 'unsupported',
+              feature: `allowedTools entry "${allowedName}"`,
+              details: expectedDetails,
+            },
+          ]);
+        },
+      );
+
+      it('should drop an unlistable provider tool referenced by its canonical name', async () => {
+        const result = await prepareResponsesTools({
+          tools: [
+            functionTool,
+            {
+              type: 'provider',
+              id: 'openai.tool_search',
+              name: 'my_search',
+              args: {},
+            },
+          ],
+          toolChoice: undefined,
+          allowedTools: { toolNames: ['get_weather', 'tool_search'] },
+          toolNameMapping: {
+            toProviderToolName: name =>
+              name === 'my_search' ? 'tool_search' : name,
+            toCustomToolName: name => name,
+          },
+        });
+
+        expect(result.toolChoice).toEqual({
+          type: 'allowed_tools',
+          mode: 'auto',
+          tools: [{ type: 'function', name: 'get_weather' }],
+        });
+        expect(result.toolWarnings).toEqual([
+          {
+            type: 'unsupported',
+            feature: 'allowedTools entry "tool_search"',
+            details:
+              'OpenAI does not support tool_search tools in tool_choice.allowed_tools; the tool is removed from the allowed tools',
+          },
+        ]);
+      });
+
+      it('should drop an ambiguous canonical name when several tools share it', async () => {
+        const result = await prepareResponsesTools({
+          tools: [
+            functionTool,
+            mcpTool('alpha', 'alpha'),
+            mcpTool('beta', 'beta'),
+          ],
+          toolChoice: undefined,
+          allowedTools: { toolNames: ['get_weather', 'mcp'] },
+          toolNameMapping: mcpNameMapping,
+        });
+
+        expect(result.toolChoice).toEqual({
+          type: 'allowed_tools',
+          mode: 'auto',
+          tools: [{ type: 'function', name: 'get_weather' }],
+        });
+        expect(result.toolWarnings).toEqual([
+          {
+            type: 'unsupported',
+            feature: 'allowedTools entry "mcp"',
+            details:
+              'several tools in this request share this provider tool name; use the tool name from the tools for this request instead',
+          },
+        ]);
+      });
+
+      it('should still resolve each mcp server by its own tool name', async () => {
+        const result = await prepareResponsesTools({
+          tools: [mcpTool('alpha', 'alpha'), mcpTool('beta', 'beta')],
+          toolChoice: undefined,
+          allowedTools: { toolNames: ['beta'] },
+          toolNameMapping: mcpNameMapping,
+        });
+
+        expect(result.toolChoice).toEqual({
+          type: 'allowed_tools',
+          mode: 'auto',
+          tools: [{ type: 'mcp', server_label: 'beta' }],
+        });
+        expect(result.toolWarnings).toEqual([]);
+      });
+
+      it('should throw when no allowed tool can be expressed', async () => {
+        await expect(
+          prepareResponsesTools({
+            tools: [
+              {
+                type: 'provider',
+                id: 'openai.tool_search',
+                name: 'tool_search',
+                args: {},
+              },
+              {
+                type: 'function',
+                name: 'deferred_tool',
+                description: 'Deferred',
+                inputSchema: { type: 'object', properties: {} },
+                providerOptions: { openai: { deferLoading: true } },
+              },
+            ],
+            toolChoice: undefined,
+            allowedTools: { toolNames: ['tool_search', 'deferred_tool'] },
+          }),
+        ).rejects.toThrow(
+          'allowedTools with only tools that cannot be allow-listed (tool_search, deferred_tool)',
+        );
+      });
+    });
+
+    it('should warn and still send an entry for a tool that is not part of the request', async () => {
+      const result = await prepareResponsesTools({
+        tools: [functionTool],
+        toolChoice: undefined,
+        allowedTools: { toolNames: ['get_weather', 'typo_tool'] },
+      });
+
+      expect(result.toolChoice).toEqual({
+        type: 'allowed_tools',
+        mode: 'auto',
+        tools: [
+          { type: 'function', name: 'get_weather' },
+          { type: 'function', name: 'typo_tool' },
+        ],
+      });
+      expect(result.toolWarnings).toEqual([
+        {
+          type: 'unsupported',
+          feature: 'allowedTools entry "typo_tool"',
+          details:
+            'the tool is not part of the tools for this request and is sent as a function tool',
+        },
+      ]);
+    });
+
+    it('should apply the tool name mapping for a tool that is not part of the request', async () => {
+      const result = await prepareResponsesTools({
+        tools: [functionTool],
+        toolChoice: undefined,
+        allowedTools: { toolNames: ['my_tool'] },
+        toolNameMapping: {
+          toProviderToolName: name =>
+            name === 'my_tool' ? 'mapped_tool' : name,
+          toCustomToolName: name => name,
+        },
+      });
+
+      expect(result.toolChoice).toEqual({
+        type: 'allowed_tools',
+        mode: 'auto',
+        tools: [{ type: 'function', name: 'mapped_tool' }],
+      });
+    });
+  });
   describe('programmatic tool calling', () => {
     it('should serialize the hosted tool and function tool options', async () => {
       const result = await prepareResponsesTools({

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -22,9 +22,14 @@ import { toolSearchArgsSchema } from '../tool/tool-search';
 import { webSearchArgsSchema } from '../tool/web-search';
 import { webSearchPreviewArgsSchema } from '../tool/web-search-preview';
 import type {
+  OpenAIResponsesAllowedTool,
   OpenAIResponsesFunctionTool,
   OpenAIResponsesTool,
 } from './openai-responses-api';
+
+type AllowedToolResolution =
+  | { supported: true; entry: OpenAIResponsesAllowedTool }
+  | { supported: false; reason: string };
 
 export type OpenAIToolOptions = {
   allowedCallers?: Array<'direct' | 'programmatic'>;
@@ -73,7 +78,7 @@ export async function prepareResponsesTools({
     | {
         type: 'allowed_tools';
         mode: 'auto' | 'required';
-        tools: Array<{ type: 'function'; name: string }>;
+        tools: Array<OpenAIResponsesAllowedTool>;
       };
   toolWarnings: SharedV4Warning[];
 }> {
@@ -93,6 +98,35 @@ export async function prepareResponsesTools({
   >();
   const resolvedCustomProviderToolNames =
     customProviderToolNames ?? new Set<string>();
+
+  const allowedToolResolutions = new Map<string, AllowedToolResolution>();
+  const allowedToolAliases = new Map<
+    string,
+    AllowedToolResolution | 'ambiguous'
+  >();
+
+  const recordAllowedTool = (
+    toolName: string,
+    resolution: AllowedToolResolution,
+    canonicalName: string | undefined,
+  ) => {
+    allowedToolResolutions.set(toolName, resolution);
+
+    if (canonicalName == null || canonicalName === toolName) {
+      return;
+    }
+
+    const existingAlias = allowedToolAliases.get(canonicalName);
+
+    if (existingAlias == null) {
+      allowedToolAliases.set(canonicalName, resolution);
+    } else if (
+      existingAlias !== 'ambiguous' &&
+      !isSameAllowedTool(existingAlias, resolution)
+    ) {
+      allowedToolAliases.set(canonicalName, 'ambiguous');
+    }
+  };
 
   for (const tool of tools) {
     switch (tool.type) {
@@ -131,9 +165,32 @@ export async function prepareResponsesTools({
 
           namespaceTool.tools.push(openaiFunctionTool);
         }
+
+        recordAllowedTool(
+          tool.name,
+          namespace != null
+            ? {
+                supported: false,
+                reason:
+                  'tools inside an OpenAI tool namespace are not visible to tool_choice.allowed_tools',
+              }
+            : openaiOptions?.deferLoading === true
+              ? {
+                  supported: false,
+                  reason:
+                    'deferred tools are not visible to tool_choice.allowed_tools',
+                }
+              : {
+                  supported: true,
+                  entry: { type: 'function', name: tool.name },
+                },
+          undefined,
+        );
         break;
       }
       case 'provider': {
+        const openaiToolCountBefore = openaiTools.length;
+
         switch (tool.id) {
           case 'openai.file_search': {
             const args = await validateTypes({
@@ -349,6 +406,16 @@ export async function prepareResponsesTools({
             break;
           }
         }
+
+        if (openaiTools.length > openaiToolCountBefore) {
+          const openaiTool = openaiTools[openaiToolCountBefore];
+
+          recordAllowedTool(
+            tool.name,
+            toAllowedToolResolution(openaiTool),
+            toolNameMapping?.toProviderToolName(tool.name),
+          );
+        }
         break;
       }
       default:
@@ -361,15 +428,65 @@ export async function prepareResponsesTools({
   }
 
   if (allowedTools != null) {
+    const allowedToolEntries: Array<OpenAIResponsesAllowedTool> = [];
+    const droppedToolNames: string[] = [];
+
+    for (const name of allowedTools.toolNames) {
+      const resolution =
+        allowedToolResolutions.get(name) ?? allowedToolAliases.get(name);
+
+      if (resolution === 'ambiguous') {
+        toolWarnings.push({
+          type: 'unsupported',
+          feature: `allowedTools entry "${name}"`,
+          details:
+            'several tools in this request share this provider tool name; use the tool name from the tools for this request instead',
+        });
+        droppedToolNames.push(name);
+        continue;
+      }
+
+      if (resolution == null) {
+        toolWarnings.push({
+          type: 'unsupported',
+          feature: `allowedTools entry "${name}"`,
+          details:
+            'the tool is not part of the tools for this request and is sent as a function tool',
+        });
+        allowedToolEntries.push({
+          type: 'function',
+          name: toolNameMapping?.toProviderToolName(name) ?? name,
+        });
+        continue;
+      }
+
+      if (!resolution.supported) {
+        toolWarnings.push({
+          type: 'unsupported',
+          feature: `allowedTools entry "${name}"`,
+          details: `${resolution.reason}; the tool is removed from the allowed tools`,
+        });
+        droppedToolNames.push(name);
+        continue;
+      }
+
+      allowedToolEntries.push(resolution.entry);
+    }
+
+    if (allowedToolEntries.length === 0) {
+      throw new UnsupportedFunctionalityError({
+        functionality: `allowedTools with only tools that cannot be allow-listed (${droppedToolNames.join(
+          ', ',
+        )})`,
+      });
+    }
+
     return {
       tools: openaiTools,
       toolChoice: {
         type: 'allowed_tools',
         mode: allowedTools.mode ?? 'auto',
-        tools: allowedTools.toolNames.map(name => ({
-          type: 'function',
-          name: toolNameMapping?.toProviderToolName(name) ?? name,
-        })),
+        tools: allowedToolEntries,
       },
       toolWarnings,
     };
@@ -416,6 +533,63 @@ export async function prepareResponsesTools({
         functionality: `tool choice type: ${_exhaustiveCheck}`,
       });
     }
+  }
+}
+
+function allowedToolKey(entry: OpenAIResponsesAllowedTool): string {
+  switch (entry.type) {
+    case 'mcp':
+      return `mcp:${entry.server_label}`;
+    case 'function':
+    case 'custom':
+      return `${entry.type}:${entry.name}`;
+    default:
+      return entry.type;
+  }
+}
+
+function isSameAllowedTool(
+  a: AllowedToolResolution,
+  b: AllowedToolResolution,
+): boolean {
+  if (a.supported && b.supported) {
+    return allowedToolKey(a.entry) === allowedToolKey(b.entry);
+  }
+
+  if (!a.supported && !b.supported) {
+    return a.reason === b.reason;
+  }
+
+  return false;
+}
+
+function toAllowedToolResolution(
+  tool: OpenAIResponsesTool,
+): AllowedToolResolution {
+  switch (tool.type) {
+    case 'custom':
+      return { supported: true, entry: { type: 'custom', name: tool.name } };
+    case 'mcp':
+      return {
+        supported: true,
+        entry: { type: 'mcp', server_label: tool.server_label },
+      };
+    case 'file_search':
+    case 'web_search':
+    case 'web_search_preview':
+    case 'image_generation':
+    case 'code_interpreter':
+    case 'computer':
+    case 'apply_patch':
+    case 'shell':
+    case 'local_shell':
+    case 'programmatic_tool_calling':
+      return { supported: true, entry: { type: tool.type } };
+    default:
+      return {
+        supported: false,
+        reason: `OpenAI does not support ${tool.type} tools in tool_choice.allowed_tools`,
+      };
   }
 }
 

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -432,8 +432,17 @@ export async function prepareResponsesTools({
     const droppedToolNames: string[] = [];
 
     for (const name of allowedTools.toolNames) {
-      const resolution =
-        allowedToolResolutions.get(name) ?? allowedToolAliases.get(name);
+      const directResolution = allowedToolResolutions.get(name);
+      const resolution = directResolution ?? allowedToolAliases.get(name);
+
+      if (directResolution != null && allowedToolAliases.has(name)) {
+        toolWarnings.push({
+          type: 'unsupported',
+          feature: `allowedTools entry "${name}"`,
+          details:
+            'this name is both a tool name and the provider tool name of another tool in this request; the tool with this name is allowed',
+        });
+      }
 
       if (resolution === 'ambiguous') {
         toolWarnings.push({


### PR DESCRIPTION
## Background

`allowedTools` restricts which tools the model may call while still sending the full `tools` array, so the prompt cache survives. Every allow-list entry was built as `{ type: 'function', name }`, but OpenAI identifies built-in tools by type, not by name. Allow-listing any provider-defined tool therefore failed with `Tool choice 'web_search' not found in 'tools' parameter.` — an error that points at the tool list when the malformed value is the `tool_choice` entry.

Fixes #18997, which has the full reproduction and the live-API evidence.

## Summary

- Derive each `allowed_tools` entry from the tool already built in `prepareResponsesTools` instead of hard-coding `function`: type-only for built-ins, `name` for `function` and `custom`, `server_label` for `mcp`.
- Tool search, deferred (`deferLoading`) and namespaced tools cannot be expressed in `allowed_tools`; they are dropped with an `unsupported` warning, matching the convention already used in this file.
- If dropping them would empty the allow-list, throw instead — sending no restriction would silently let the model call every declared tool.
- Report ambiguous names instead of resolving them silently: a name matching both a declared tool and another tool's provider tool name resolves to the declared tool and warns; a provider tool name shared by several tools is dropped and warns; a name matching nothing keeps its current behavior and warns, so a typo is visible instead of producing an opaque 400.
- Document `allowedTools`, which was previously undocumented, and add a runnable example for `generateText` and `streamText`.

No public API change: tool names are still listed exactly as before.

## End-to-End Verification

Ran the new example against the live OpenAI Responses API on `gpt-5.5` with the same key, before and after the change:

- Before: `400 Tool choice 'web_search' not found in 'tools' parameter.`
- After: 200, no warnings, the built-in is invoked, and the declared-but-not-allow-listed tool is never called.

The entry shape for each tool type was probed directly against the API rather than inferred from the docs, which only show `function` entries. `{ type: 'web_search' }` and `{ type: 'image_generation' }` return 200 and the tool actually runs; `mcp` without `server_label` and `custom` without `name` are rejected as missing required parameters; tool search, deferred and namespaced tools return 400 in every form, which is why they are dropped rather than sent.

Re-verified on a second surface (Azure AI Foundry, `api-version=preview`) across `gpt-5`, `gpt-5.2`, `gpt-5.4`, `gpt-5.5`, `gpt-5.3-codex` and `gpt-5.6`. On `gpt-5.6`, allow-listing `programmatic_tool_calling` by type returns 200 and the program runs; sending it as a function entry fails with the same misleading error.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #18997
