### PR TITLE
feat (provider/google): add `useParametersJsonSchema` to send tool schemas as JSON Schema

### DIFF
--- a/.changeset/olive-pugs-tap.md
+++ b/.changeset/olive-pugs-tap.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat (provider/google): add `useParametersJsonSchema` to send tool schemas as JSON Schema

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -142,6 +142,23 @@ The following optional provider options are available for Google models:
 
   See [Troubleshooting: Schema Limitations](#schema-limitations) for more details.
 
+- **useParametersJsonSchema** _boolean_
+
+  Optional. Send tool input schemas as JSON Schema via
+  `functionDeclarations[].parametersJsonSchema` instead of the OpenAPI subset in
+  `parameters`. Default is false.
+
+  The two fields are mutually exclusive per function declaration.
+  `parametersJsonSchema` requires Gemini 2.5 or later, and accepts JSON Schema
+  keywords the OpenAPI subset cannot express (`$ref`, `$defs`, and `anyOf`
+  carrying sibling keywords), so schemas the conversion mangles or rejects are
+  sent verbatim. This is useful for tool schemas you do not author, such as
+  those advertised by remote MCP servers.
+
+  Note that Gemini enforces a nesting-depth limit on this field which the lossy
+  conversion can flatten a schema under, so a very deeply nested schema may be
+  accepted on `parameters` but rejected here.
+
 - **safetySettings** _Array\<\{ category: string; threshold: string \}\>_
 
   Optional. Safety settings for the model.

--- a/packages/google/src/google-language-model-options.ts
+++ b/packages/google/src/google-language-model-options.ts
@@ -89,6 +89,23 @@ export const googleLanguageModelOptions = lazySchema(() =>
       structuredOutputs: z.boolean().optional(),
 
       /**
+       * Optional. Send tool input schemas as JSON Schema via
+       * `functionDeclarations[].parametersJsonSchema` instead of the OpenAPI
+       * subset in `parameters`. Default is false.
+       *
+       * The two fields are mutually exclusive per function declaration.
+       * `parametersJsonSchema` requires Gemini 2.5 or later, and accepts JSON
+       * Schema keywords the OpenAPI subset cannot express (`$ref`, `$defs`,
+       * and `anyOf` carrying sibling keywords), so schemas the conversion
+       * mangles or rejects are sent verbatim.
+       *
+       * Note that Gemini enforces a nesting-depth limit on this field which
+       * the lossy conversion can flatten a schema under, so a very deeply
+       * nested schema may be accepted on `parameters` but rejected here.
+       */
+      useParametersJsonSchema: z.boolean().optional(),
+
+      /**
        * Optional. A list of unique safety settings for blocking unsafe content.
        */
       safetySettings: z

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -278,6 +278,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
       toolChoice,
       modelId: this.modelId,
       isVertexProvider,
+      useParametersJsonSchema: googleOptions?.useParametersJsonSchema ?? false,
     });
 
     const resolvedThinking = resolveThinkingConfig({

--- a/packages/google/src/google-prepare-tools.test.ts
+++ b/packages/google/src/google-prepare-tools.test.ts
@@ -1,5 +1,5 @@
 import type { LanguageModelV4ProviderTool } from '@ai-sdk/provider';
-import { expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { prepareTools } from './google-prepare-tools';
 
 it('should return undefined tools and tool_choice when tools are null', () => {
@@ -1014,5 +1014,77 @@ it('should use AUTO mode when no tools have strict: true', () => {
   });
   expect(result.toolConfig).toEqual({
     functionCallingConfig: { mode: 'AUTO' },
+  });
+});
+
+describe('useParametersJsonSchema', () => {
+  // A schema the OpenAPI conversion cannot carry: `$defs`/`$ref` are not in
+  // its keyword list, so it drops them and the parameter reaches the model as
+  // an empty object while still being required.
+  const SCHEMA_WITH_DEFS = {
+    type: 'object',
+    $defs: { Thesis: { type: 'object', properties: { name: { type: 'string' } } } },
+    properties: { thesis: { $ref: '#/$defs/Thesis' } },
+    required: ['thesis'],
+  } as const;
+
+  // A multi-type node. It carries no `anyOf`, but the conversion has no other
+  // way to express it, so it emits `anyOf` while leaving `required`/`properties`
+  // in place — which the API rejects, because `anyOf` must be the only field.
+  const SCHEMA_MULTI_TYPE = {
+    type: 'object',
+    properties: {
+      entries: {
+        type: 'array',
+        items: {
+          type: ['null', 'object'],
+          required: ['path'],
+          properties: { path: { type: 'string' } },
+        },
+      },
+    },
+  } as const;
+
+  const toolWith = (inputSchema: unknown) => [
+    {
+      type: 'function' as const,
+      name: 'testTool',
+      description: 'test',
+      inputSchema: inputSchema as any,
+    },
+  ];
+
+  it('sends the schema verbatim and omits parameters', () => {
+    const { tools } = prepareTools({
+      tools: toolWith(SCHEMA_WITH_DEFS),
+      modelId: 'gemini-2.5-flash',
+      useParametersJsonSchema: true,
+    });
+
+    const declaration = (tools as any)[0].functionDeclarations[0];
+    expect(declaration.parametersJsonSchema).toEqual(SCHEMA_WITH_DEFS);
+    // Mutually exclusive: sending both is an API error.
+    expect(declaration.parameters).toBeUndefined();
+  });
+
+  it('does not turn a multi-type node into anyOf with siblings', () => {
+    const { tools } = prepareTools({
+      tools: toolWith(SCHEMA_MULTI_TYPE),
+      modelId: 'gemini-2.5-flash',
+      useParametersJsonSchema: true,
+    });
+
+    expect(JSON.stringify(tools)).not.toContain('anyOf');
+  });
+
+  it('defaults to the OpenAPI conversion', () => {
+    const { tools } = prepareTools({
+      tools: toolWith(SCHEMA_WITH_DEFS),
+      modelId: 'gemini-2.5-flash',
+    });
+
+    const declaration = (tools as any)[0].functionDeclarations[0];
+    expect(declaration.parameters).toBeDefined();
+    expect(declaration.parametersJsonSchema).toBeUndefined();
   });
 });

--- a/packages/google/src/google-prepare-tools.ts
+++ b/packages/google/src/google-prepare-tools.ts
@@ -7,16 +7,35 @@ import { convertJSONSchemaToOpenAPISchema } from './convert-json-schema-to-opena
 import type { GoogleModelId } from './google-language-model-options';
 import { getGoogleModelCapabilities } from './google-model-capabilities';
 
+/**
+ * The schema fields of one function declaration.
+ *
+ * `parameters` and `parametersJsonSchema` are mutually exclusive, so exactly
+ * one is emitted. The JSON Schema field is sent verbatim: converting it would
+ * defeat the point, since the conversion is what drops `$ref`/`$defs` and
+ * rewrites unions into shapes the API rejects.
+ */
+function toolParameters(
+  inputSchema: unknown,
+  useParametersJsonSchema: boolean,
+): { parameters: unknown } | { parametersJsonSchema: unknown } {
+  return useParametersJsonSchema
+    ? { parametersJsonSchema: inputSchema }
+    : { parameters: convertJSONSchemaToOpenAPISchema(inputSchema as any) };
+}
+
 export function prepareTools({
   tools,
   toolChoice,
   modelId,
   isVertexProvider = false,
+  useParametersJsonSchema = false,
 }: {
   tools: LanguageModelV4CallOptions['tools'];
   toolChoice?: LanguageModelV4CallOptions['toolChoice'];
   modelId: GoogleModelId;
   isVertexProvider?: boolean;
+  useParametersJsonSchema?: boolean;
 }): {
   tools:
     | Array<
@@ -24,7 +43,8 @@ export function prepareTools({
             functionDeclarations: Array<{
               name: string;
               description: string;
-              parameters: unknown;
+              parameters?: unknown;
+              parametersJsonSchema?: unknown;
             }>;
           }
         | Record<string, any>
@@ -175,14 +195,15 @@ export function prepareTools({
       const functionDeclarations: Array<{
         name: string;
         description: string;
-        parameters: unknown;
+        parameters?: unknown;
+        parametersJsonSchema?: unknown;
       }> = [];
       for (const tool of tools) {
         if (tool.type === 'function') {
           functionDeclarations.push({
             name: tool.name,
             description: tool.description ?? '',
-            parameters: convertJSONSchemaToOpenAPISchema(tool.inputSchema),
+            ...toolParameters(tool.inputSchema, useParametersJsonSchema),
           });
         }
       }
@@ -241,7 +262,7 @@ export function prepareTools({
         functionDeclarations.push({
           name: tool.name,
           description: tool.description ?? '',
-          parameters: convertJSONSchemaToOpenAPISchema(tool.inputSchema),
+          ...toolParameters(tool.inputSchema, useParametersJsonSchema),
         });
         if (tool.strict === true) {
           hasStrictTools = true;


### PR DESCRIPTION
## Background

Gemini tool declarations currently go out as `functionDeclarations[].parameters`, which is an OpenAPI 3.0 subset rather than JSON Schema, so `convertJSONSchemaToOpenAPISchema` rewrites every tool schema on the way out. That conversion is lossy in two ways that only surface for schemas the caller does not author — remote MCP servers, connector catalogs — which is why the Zod-shaped test surface does not catch either.

**1. It manufactures shapes the API rejects.** Consider a schema containing no combiner at all:

```jsonc
{ "type": "array", "items": { "type": ["null", "object"], "required": ["path"], "properties": { … } } }
```

The subset cannot express a multi-type node, so the conversion emits `anyOf` — while leaving `required` and `properties` beside it. Gemini requires `anyOf` to be the only field on its node, so the request is rejected:

```
Unable to submit request because `move` functionDeclaration `parameters.entries`
schema specified other fields alongside any_of. When using any_of, it must be
the only field set.
```

Schema validation runs over every declaration before inference, so one such tool fails the entire request, not just that tool. This is a real production schema (Dropbox's `move`, via its MCP server); the same shape is reported in [#14369](https://github.com/vercel/ai/issues/14369)-adjacent form across other ecosystems ([langchain-google#1216](https://github.com/langchain-ai/langchain-google/issues/1216), [google/adk-go#1085](https://github.com/google/adk-go/pull/1085)).

**2. It silently deletes `$ref`/`$defs`.** They are not in the conversion's keyword list, so they are dropped rather than rejected. A parameter defined by a `$ref` arrives as `{}` while still being listed in `required` — the model is asked for a value whose shape it was never given, with no error raised anywhere.

**2b. The same deletion also produces hard 400s**, which is the larger effect and easy to mistake for an unrelated bug. When a `$ref` sits inside the nullable-union idiom, the conversion collapses `[T, null]` by merging in the converted `T` — but `T` is a `$ref`, which converts to `{}`, so the merge contributes nothing and the node ships with no `type`:

```jsonc
// server declares
{ "anyOf": [{ "$ref": "#/$defs/ChatMessageDirection" }, { "type": "null" }], "default": null }
// conversion emits
{ "nullable": true }
```

```
Unable to submit request because `create_interaction` functionDeclaration
`parameters.direction` schema didn't specify the schema type field.
```

Pydantic emits exactly this shape for every `Optional[SomeEnum]` field, so it is common rather than exotic: **16 of the 25 failures** in the corpus below are this, against 5 for the `anyOf` case. 14 of the 16 are fixed by sending the schema as JSON Schema; the other 2 are rejected on the native field for unrelated nesting-depth reasons.

## Summary

Adds a `useParametersJsonSchema` provider option to `@ai-sdk/google`:

- when `true`, tool input schemas are sent unchanged as `functionDeclarations[].parametersJsonSchema`
- when `false` (the default), behavior is unchanged
- the two fields are mutually exclusive per declaration, so exactly one is emitted

`parametersJsonSchema` requires Gemini 2.5+ and accepts `$ref`, `$defs`, and `anyOf` with sibling keywords ([FunctionDeclaration reference](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1beta1/FunctionDeclaration)). It is the tool-side counterpart of `responseJsonSchema`, which #18325 is adding for structured outputs; this follows that PR's shape deliberately — an explicit provider option defaulting to off, rather than sniffing the schema.

## Verification

Verified against live Vertex (`gemini-3.7-flash`, `v1beta1`) over **1201 distinct tool schemas** taken from real connected MCP servers and connector catalogs across 17 providers (Klaviyo, Linear, Notion, GitHub, Slack, Stripe, Dropbox, Affinity, Webflow, Microsoft 365, Google Workspace, Granola, and others). Each schema was submitted as a function declaration on both fields:

| | schemas rejected by the API |
| --- | --- |
| `parameters` (current default) | **25** |
| `parametersJsonSchema` | **5** |

Of the 25 that fail today, 23 are fixed by the new field. The remaining 2 fail on both. The 5 native failures are 3 schemas that pass today plus those same 2 — see below.

Direct before/after on one declaration, same schema:

```
parameters           -> REJECTED 400: ...specified other fields alongside any_of...
parametersJsonSchema -> ACCEPTED
```

## Why it is opt-in

Beyond matching #18325, there is a concrete reason not to flip this by default: `parametersJsonSchema` enforces a nesting-depth limit that the lossy conversion can flatten a schema *under*. In the corpus, every schema at depth ≤ 32 is accepted natively and every one at depth ≥ 34 is rejected, so 3 deeply nested schemas that are accepted on `parameters` today are rejected on `parametersJsonSchema`. Size is not the discriminator — a 138 KB schema at depth 10 is accepted, while a 13 KB schema at depth 34 is not.

That limit does not appear to be documented, and [it has changed without announcement before](https://discuss.ai.google.dev/t/maximum-tool-nesting-depth-update-this-morning/104341), so a default switch would move a failure mode that maintainers cannot characterize. Callers that opt in can route per declaration if they need to: the fields are mutually exclusive per `FunctionDeclaration`, not per request, and a mixed `tools` array is accepted (verified).

## Relation to #17138

[#17138](https://github.com/vercel/ai/pull/17138) proposed the same wire change and was closed with *"This is the wrong approach"*, because it was justified against [#6855](https://github.com/vercel/ai/issues/6855) (Gemini ignoring tool descriptions / shortening values) and the review found no causal improvement — descriptions were already preserved by the conversion, and the before/after runs matched.

That assessment was correct for that issue. This PR makes no claim about descriptions or value fidelity. It targets two different, deterministic failures — a 400 on a schema the conversion itself produces, and silent erasure of `$ref` — both reproducible on demand, and it is gated behind an opt-in flag rather than changing the default.

## Testing

- Three unit tests in `google-prepare-tools.test.ts`: verbatim schema with `parameters` omitted, no `anyOf` manufactured from a multi-type node, and the default path unchanged.
- `packages/google`: 737 tests pass, `tsc --noEmit` clean.
- Live corpus run described above.

