### PR TITLE
fix(provider-utils): detect QuickTime video instead of falling through to mp4

### DIFF
--- a/.changeset/quicktime-signature-order.md
+++ b/.changeset/quicktime-signature-order.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+fix(provider-utils): detect QuickTime video instead of falling through to mp4

--- a/packages/provider-utils/src/detect-media-type.test.ts
+++ b/packages/provider-utils/src/detect-media-type.test.ts
@@ -840,6 +840,18 @@ describe('detectMediaType', () => {
     ).toBe('video/webm');
   });
 
+  it('detects QuickTime video, whose ftyp header also matches the mp4 signature', () => {
+    const movBytes = new Uint8Array([
+      0x00, 0x00, 0x00, 0x14, 0x66, 0x74, 0x79, 0x70, 0x71, 0x74, 0x20, 0x20,
+    ]);
+    expect(
+      detectMediaType({
+        data: movBytes,
+        topLevelType: 'video',
+      }),
+    ).toBe('video/quicktime');
+  });
+
   it('detects document types when topLevelType is "application"', () => {
     const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x00]);
     expect(

--- a/packages/provider-utils/src/detect-media-type.ts
+++ b/packages/provider-utils/src/detect-media-type.ts
@@ -142,6 +142,21 @@ const audioMediaTypeSignatures = [
 
 const videoMediaTypeSignatures = [
   {
+    mediaType: 'video/quicktime' as const,
+    bytesPrefix: [
+      0x00,
+      0x00,
+      0x00,
+      0x14,
+      0x66,
+      0x74,
+      0x79,
+      0x70,
+      0x71,
+      0x74, // ftypqt
+    ],
+  },
+  {
     mediaType: 'video/mp4' as const,
     bytesPrefix: [
       0x00,
@@ -157,21 +172,6 @@ const videoMediaTypeSignatures = [
   {
     mediaType: 'video/webm' as const,
     bytesPrefix: [0x1a, 0x45, 0xdf, 0xa3], // EBML
-  },
-  {
-    mediaType: 'video/quicktime' as const,
-    bytesPrefix: [
-      0x00,
-      0x00,
-      0x00,
-      0x14,
-      0x66,
-      0x74,
-      0x79,
-      0x70,
-      0x71,
-      0x74, // ftypqt
-    ],
   },
   {
     mediaType: 'video/x-msvideo' as const,


### PR DESCRIPTION
## Background

`detectMediaType` sniffs a file's media type from its leading bytes. The video signature table lists `video/mp4` before `video/quicktime`, and the mp4 prefix leaves the box-size byte open (`00 00 00 ?? 66 74 79 70`), so it matches any ftyp header. Every QuickTime file matches it first and the `video/quicktime` entry below is never reached.

A `.mov` therefore comes back as `video/mp4`, both from `detectMediaType({ data, topLevelType: 'video' })` and from `resolveFullMediaType` when a file part carries the top-level `video` media type without a subtype. That wrong type is what gets sent to the provider.

## Summary

Moved the `video/quicktime` signature ahead of `video/mp4`. It requires `ftypqt`, so mp4 files still fall through to the mp4 entry.

## End-to-End Verification

A QuickTime ftyp header (`00 00 00 14 66 74 79 70 71 74 20 20`) resolves to `video/mp4` on main and to `video/quicktime` with this change. The added test fails without the reorder.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
