### PR TITLE
fix(google): preserve JSON Schema references

### DIFF
--- a/.changeset/fresh-maps-reference.md
+++ b/.changeset/fresh-maps-reference.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Preserve root-level `$ref` and `$defs` when converting JSON Schema for Google requests.

--- a/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
@@ -27,6 +27,75 @@ it('should remove additionalProperties and $schema', () => {
   expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
 });
 
+it('should translate $ref and $defs to Google schema references', () => {
+  const input = {
+    type: 'object',
+    properties: {
+      locale: {
+        $ref: '#/$defs/Locale',
+        description: 'Locale for formatting',
+      },
+    },
+    required: ['locale'],
+    additionalProperties: false,
+    $defs: {
+      Locale: { type: 'string', enum: ['de', 'en'] },
+    },
+  } as JSONSchema7 & { $defs: Record<string, JSONSchema7> };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual({
+    type: 'object',
+    properties: {
+      locale: {
+        description: 'Locale for formatting',
+        ref: '#/defs/Locale',
+      },
+    },
+    required: ['locale'],
+    defs: {
+      Locale: { type: 'string', enum: ['de', 'en'] },
+    },
+  });
+});
+
+it('should translate references inside $defs', () => {
+  const input = {
+    type: 'object',
+    properties: {
+      node: { $ref: '#/$defs/Node' },
+    },
+    $defs: {
+      Node: {
+        type: 'object',
+        properties: {
+          child: { $ref: '#/$defs/Node' },
+        },
+      },
+    },
+  } as JSONSchema7 & { $defs: Record<string, JSONSchema7> };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual({
+    type: 'object',
+    properties: {
+      node: { ref: '#/defs/Node' },
+    },
+    defs: {
+      Node: {
+        type: 'object',
+        properties: {
+          child: { ref: '#/defs/Node' },
+        },
+      },
+    },
+  });
+});
+
+it('should reject references outside root-level $defs', () => {
+  expect(() =>
+    convertJSONSchemaToOpenAPISchema({ $ref: '#/properties/value' }),
+  ).toThrow(UnsupportedFunctionalityError);
+});
+
 it('should remove additionalProperties object from nested object schemas', function () {
   const input: JSONSchema7 = {
     type: 'object',

--- a/packages/google/src/convert-json-schema-to-openapi-schema.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.ts
@@ -4,6 +4,10 @@ import {
   type JSONSchema7Definition,
 } from '@ai-sdk/provider';
 
+type JSONSchema7WithDefinitions = JSONSchema7 & {
+  $defs?: Record<string, JSONSchema7Definition>;
+};
+
 /**
  * Converts JSON Schema 7 to OpenAPI Schema 3.0
  */
@@ -32,6 +36,8 @@ export function convertJSONSchemaToOpenAPISchema(
   }
 
   const {
+    $ref,
+    $defs,
     type,
     description,
     required,
@@ -44,13 +50,23 @@ export function convertJSONSchemaToOpenAPISchema(
     const: constValue,
     minLength,
     enum: enumValues,
-  } = jsonSchema;
+  } = jsonSchema as JSONSchema7WithDefinitions;
 
   const result: Record<string, unknown> = {};
 
   if (description) result.description = description;
   if (required) result.required = required;
   if (format) result.format = format;
+  if ($ref != null) result.ref = convertJSONSchemaReference($ref);
+
+  if ($defs) {
+    result.defs = Object.fromEntries(
+      Object.entries($defs).map(([key, value]) => [
+        key,
+        convertJSONSchemaToOpenAPISchema(value, false),
+      ]),
+    );
+  }
 
   // Handle type
   if (type) {
@@ -146,6 +162,27 @@ export function convertJSONSchemaToOpenAPISchema(
   }
 
   return result;
+}
+
+function convertJSONSchemaReference(reference: string): string {
+  const rootDefinitionPrefix = '#/$defs/';
+  const definitionName = reference.startsWith(rootDefinitionPrefix)
+    ? reference.slice(rootDefinitionPrefix.length)
+    : undefined;
+
+  if (
+    definitionName == null ||
+    definitionName.length === 0 ||
+    definitionName.includes('/')
+  ) {
+    throw new UnsupportedFunctionalityError({
+      functionality: `JSON Schema reference: ${reference}`,
+      message:
+        'Google only supports JSON Schema references to direct children of root-level $defs.',
+    });
+  }
+
+  return `#/defs/${definitionName}`;
 }
 
 type EnumValues = NonNullable<JSONSchema7['enum']>;


### PR DESCRIPTION
## Background

Google schema conversion dropped root-level `$defs` and every `$ref`. Tool properties that relied on those definitions were therefore sent without a type, and Google rejected the request.

## Summary

- Translate root-level JSON Schema `$defs` to Google Schema `defs`.
- Translate direct `$ref` pointers from `#/$defs/<name>` to `#/defs/<name>`, including references inside recursive definitions.
- Reject reference shapes Google cannot represent instead of silently producing an invalid schema.
- Add regression coverage and a patch changeset.

## Contributor Credit

Reported and reproduced by @danielo515 in #19002.

## End-to-End Verification

A live Google API request was not run. The outgoing schema conversion was reproduced before the change and verified after it with the issue's tool schema.

## Verification

- A before/after converter harness confirmed that the baseline drops the reference and the updated converter preserves it.
- Focused compatibility checks covered nested references, unsupported references, nullable schemas, and constant enums.
- The repository changeset check and whitespace validation passed.
- Package tests, linting, and type checking could not start because this checkout does not include installed workspace dependencies; the repository CI will run them.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

References outside direct children of root-level `$defs` remain unsupported. They now fail at the SDK boundary instead of reaching Google as an invalid schema.

## Related Issues

Fixes #19002.
