### PR TITLE
docs: mention tool approvals don't work with code mode tool

### DIFF
--- a/content/docs/03-ai-sdk-core/18-code-mode.mdx
+++ b/content/docs/03-ai-sdk-core/18-code-mode.mdx
@@ -180,6 +180,17 @@ const result = await runCodeMode({
 `runCodeMode` returns the value returned by the program. It uses the same
 sandbox and execution limits as the AI SDK tool.
 
+## Tool Approval
+
+Code mode does not currently integrate with AI SDK tool approval flows. Tool
+calls made by generated code are nested inside the code mode invocation, so
+they cannot pause the generation and surface a tool approval request to your
+application.
+
+Do not expose tools that rely on user approval to code mode. Keep those tools
+directly callable by the model instead. If a nested tool requires approval,
+the call is rejected rather than executed.
+
 ## Execution Limits
 
 Every invocation has limits for runtime, memory, source size, results, tool
@@ -244,6 +255,3 @@ to code mode.
 
 Tool input schemas are validated before their `execute` functions run. Abort
 signals and AI SDK tool execution context are forwarded to nested tool calls.
-
-Code mode does not currently support approval flows for nested tool calls.
-Tools that require approval are rejected instead of being executed.


### PR DESCRIPTION
## Background

currently the code mode tool doesn't allow for tool approvals for the nested tool calls it makes. 
this should be properly documented.

for nayone wanting to try an unreleased version of code mode with tool approvals, they can check https://github.com/vercel/ai/pull/18299#issuecomment-5257296699

## Summary

docs update

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)