### PR TITLE
Backport: fix(bedrock): wrap invalid tool input in object

### DIFF
--- a/.changeset/two-berries-push.md
+++ b/.changeset/two-berries-push.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix(bedrock): wrap invalid tool input in object

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
@@ -867,6 +867,41 @@ describe('assistant messages', () => {
       },
     ]);
   });
+
+  it('should wrap non-object (invalid) tool call input in an object', async () => {
+    const result = await convertToBedrockChatMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'cityAttractions',
+            // malformed JSON the model produced, kept as a raw string
+            input: '{ "city": "San Francisco", }',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              toolUse: {
+                toolUseId: 'call-1',
+                name: 'cityAttractions',
+                input: { rawInvalidInput: '{ "city": "San Francisco", }' },
+              },
+            },
+          ],
+        },
+      ],
+      system: [],
+    });
+  });
 });
 
 describe('tool messages', () => {

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -1,5 +1,6 @@
 import {
   type JSONObject,
+  type JSONValue,
   type LanguageModelV2Message,
   type LanguageModelV2Prompt,
   type SharedV2ProviderMetadata,
@@ -315,7 +316,7 @@ export async function convertToBedrockChatMessages(
                   toolUse: {
                     toolUseId: part.toolCallId,
                     name: sanitizeToolName(part.toolName),
-                    input: part.input as JSONObject,
+                    input: toBedrockToolInput(part.input),
                   },
                 });
                 break;
@@ -340,6 +341,13 @@ export async function convertToBedrockChatMessages(
   }
 
   return { system, messages };
+}
+
+// wrap invalid tool call input because Bedrock requires it to be an object
+function toBedrockToolInput(input: unknown): JSONObject {
+  return typeof input === 'object' && input !== null && !Array.isArray(input)
+    ? (input as JSONObject)
+    : { rawInvalidInput: input as JSONValue };
 }
 
 function isBedrockImageFormat(format: string): format is BedrockImageFormat {


### PR DESCRIPTION
Manual backport of #16561 to `release-v5.0` (bedrock 3.x / spec v2). Companion to the v6 backport #19018.

## Background

Bedrock Converse requires `toolUse.input` to be a JSON object. When a model produces a tool call with malformed JSON, the tool input is kept as a raw string; replaying that history on a later turn sends a string `toolUse.input`, which Bedrock rejects with 400 `The format of the value at messages.N.content.M.toolUse.input is invalid`. This is hitting AI Gateway traffic in production, where bedrock 3.x/4.x still lack the guard that main got in #16561.

## Notes on the backport

- The original commit targets `convert-to-amazon-bedrock-chat-messages.ts`; on this branch the file is `convert-to-bedrock-chat-messages.ts`, so the change was applied manually: `toBedrockToolInput()` wraps non-object input as `{ rawInvalidInput: input }`, preserving this branch's `sanitizeToolName` handling and V2 types.
- Test adapted to the v5 file/function naming.
- Main-only example files from the original PR were not backported (they use APIs that don't exist on this branch).
- Changeset included (`@ai-sdk/amazon-bedrock` patch).

## Tests

`pnpm vitest run src/convert-to-bedrock-chat-messages.test.ts`: 37/37 pass. `pnpm type-check`: clean.

FYI @n1ckoates