### PR TITLE
fix(fireworks): enable structured outputs for chat models

### DIFF
--- a/.changeset/fireworks-structured-outputs.md
+++ b/.changeset/fireworks-structured-outputs.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/fireworks': patch
+---
+
+fix(fireworks): enable structured outputs so response_format json_schema is forwarded instead of degrading to json_object

--- a/packages/fireworks/src/fireworks-provider.test.ts
+++ b/packages/fireworks/src/fireworks-provider.test.ts
@@ -122,6 +122,14 @@ describe('FireworksProvider', () => {
       expect(config.includeUsage).toBe(true);
     });
 
+    it('should set supportsStructuredOutputs so response_format json_schema is forwarded', () => {
+      const provider = createFireworks();
+      provider.chatModel('test-model');
+
+      const config = OpenAICompatibleChatLanguageModelMock.mock.calls[0][1];
+      expect(config.supportsStructuredOutputs).toBe(true);
+    });
+
     // A schema that does not match what Fireworks actually returns fails the
     // parse, and the message silently degrades to the HTTP reason phrase —
     // "Bad Request" over HTTP/1.1, and "" over HTTP/2, which has none.

--- a/packages/fireworks/src/fireworks-provider.ts
+++ b/packages/fireworks/src/fireworks-provider.ts
@@ -146,6 +146,7 @@ export function createFireworks(
       ...getCommonModelConfig('chat'),
       includeUsage: true,
       errorStructure: fireworksErrorStructure,
+      supportsStructuredOutputs: true,
       transformRequestBody: args => {
         const thinking = args.thinking as
           | { type?: string; budgetTokens?: number }


### PR DESCRIPTION
## Background

Requests with `responseFormat: { type: 'json', schema }` (e.g. OpenAI-compatible `response_format: { type: 'json_schema', ... }` via AI Gateway) are silently degraded for Fireworks models: the Fireworks provider constructs `OpenAICompatibleChatLanguageModel` without `supportsStructuredOutputs`, which defaults to `false`, so the openai-compatible chat model rewrites the outbound body to `response_format: { type: 'json_object' }` — the schema, name, and strict flag are discarded and only a call warning is emitted.

Fireworks supports structured outputs natively: https://docs.fireworks.ai/structured-responses/structured-response-formatting

## Summary

Set `supportsStructuredOutputs: true` on the Fireworks chat model config (same as cerebras and azure), so `json_schema` response formats are forwarded to the Fireworks API instead of degrading to plain JSON mode.

## Verification

- New unit test asserting the flag is passed to `OpenAICompatibleChatLanguageModel`
- `pnpm vitest run src/fireworks-provider.test.ts` — 27 passed
- `pnpm build && pnpm type-check` in `packages/fireworks` — clean
- Verified direct Fireworks API honors `response_format: json_schema` for kimi-k3

## Related

- Gateway-side report: response_format silently dropped for Fireworks-provided models (Kimi K3, GLM 5.2 Fast)
- Will need backports to `release-v6.0` and `release-v5.0` for the gateway's spec v3/v2 lines