### PR TITLE
feat(mcp): add the latest 2026 protocol discovery foundation

### DIFF
--- a/.changeset/two-feet-clap.md
+++ b/.changeset/two-feet-clap.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+feat(mcp): add the latest 2026 protocol discovery foundation

--- a/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
+++ b/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
@@ -25,6 +25,12 @@ Create an MCP client using one of the following transport options:
 - SSE (Server-Sent Events): An alternative HTTP-based transport
 - `stdio`: For local development only. Uses standard input/output streams for local MCP servers
 
+The AI SDK MCP client supports both legacy initialization-based protocol
+versions and stateless MCP `2026-07-28`. The built-in stdio transport probes
+with `server/discover` and automatically falls back to the legacy
+`initialize` handshake for older servers. Custom transports can opt into this
+negotiation with `supportsProtocolVersionDiscovery: true`.
+
 ### HTTP Transport (Recommended)
 
 For production deployments, we recommend using the HTTP transport. You can configure it directly on the client:
@@ -49,8 +55,9 @@ const mcpClient = await createMCPClient({
 });
 ```
 
-If the MCP server uses Streamable HTTP sessions, you can reattach to a saved
-session by restoring both the previous session id and initialize result:
+If a legacy MCP server uses Streamable HTTP sessions, you can reattach to a
+saved session by restoring both the previous session id and initialize result.
+MCP `2026-07-28` is stateless and does not use these options:
 
 ```typescript
 import { createMCPClient } from '@ai-sdk/mcp';

--- a/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-create-mcp-client.mdx
@@ -121,14 +121,14 @@ It currently does not support accepting notifications from an MCP server, and cu
                       type: 'string',
                       isOptional: true,
                       description:
-                        'Initial MCP session id to send with resumed Streamable HTTP requests after initialization. Pair with initialInitializeResult when using createMCPClient. Only used by the HTTP transport.',
+                        'Initial legacy MCP session id to send with resumed Streamable HTTP requests after initialization. Pair with initialInitializeResult when using createMCPClient. Only used by the HTTP transport and initialization-based protocol versions.',
                     },
                     {
                       name: 'initialProtocolVersion',
                       type: 'string',
                       isOptional: true,
                       description:
-                        'Initial MCP protocol version to send before initialize negotiates one. Only used by the HTTP transport.',
+                        'Initial legacy MCP protocol version to send before initialize negotiates one. Only used by the HTTP transport.',
                     },
                     {
                       name: 'onSessionIdChange',
@@ -167,7 +167,7 @@ It currently does not support accepting notifications from an MCP server, and cu
               type: 'RequestOptions',
               isOptional: true,
               description:
-                'Optional signal and timeout settings that bound transport startup and the initialize request. A timeout or abort closes the transport and rejects createMCPClient.',
+                'Optional signal and timeout settings that bound transport startup and protocol negotiation. A timeout or abort closes the transport and rejects createMCPClient.',
             },
             {
               name: 'clientName',
@@ -206,14 +206,14 @@ It currently does not support accepting notifications from an MCP server, and cu
               type: 'InitializeResult',
               isOptional: true,
               description:
-                'Initialize result from a previous MCP session. When provided, the client starts the transport and reuses this metadata without sending a new initialize request.',
+                'Initialize result from a previous legacy MCP session. When provided, the client starts the transport and reuses this metadata without sending a new initialize request.',
             },
             {
               name: 'capabilities',
               type: 'ClientCapabilities',
               isOptional: true,
               description:
-                'Optional client capabilities to advertise during initialization. For example, set { elicitation: {} } to enable handling elicitation requests from the server.',
+                'Optional client capabilities to advertise during legacy initialization or on each stateless modern request. For example, set { elicitation: {} } to enable handling elicitation requests from the server.',
             },
           ],
         },
@@ -232,13 +232,13 @@ Returns a Promise that resolves to an `MCPClient` with the following properties 
       name: 'initializeResult',
       type: 'InitializeResult',
       description:
-        'The full initialize result used by this client, either from the server during initialization or from initialInitializeResult.',
+        'Connection metadata used by this client. For legacy servers this is the initialize result; for modern servers an equivalent value is derived from protocol discovery.',
     },
     {
       name: 'serverInfo',
       type: 'Configuration',
       description:
-        'Information about the connected MCP server (name, version, optional title), as reported during the initialize handshake.',
+        'Information about the connected MCP server (name, version, optional title), as reported during initialization or protocol discovery.',
     },
     {
       name: 'instructions',

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -59,6 +59,17 @@ try {
 The client converts MCP tool definitions into AI SDK tools, so model calls can
 use them through the standard `tools` option.
 
+## Protocol versions
+
+The client supports legacy MCP protocol versions through the `initialize`
+handshake and MCP `2026-07-28` through stateless protocol discovery. The
+built-in stdio transport probes with `server/discover` and falls back to the
+legacy handshake when connected to an older server.
+
+Custom transports can opt into the same negotiation by setting
+`supportsProtocolVersionDiscovery` to `true`. Modern requests include the
+protocol version, client capabilities, and client information in `_meta`.
+
 For streaming responses, close the MCP client when the stream finishes:
 
 ```ts
@@ -89,6 +100,10 @@ for await (const textPart of result.textStream) {
 ## Transports
 
 HTTP is recommended for production deployments:
+
+Session persistence applies only to legacy MCP protocol versions. MCP
+`2026-07-28` is stateless and does not use session ids or cached initialize
+results.
 
 ```ts
 import { createMCPClient } from '@ai-sdk/mcp';

--- a/packages/mcp/src/tool/json-rpc-message.ts
+++ b/packages/mcp/src/tool/json-rpc-message.ts
@@ -27,7 +27,7 @@ export type JSONRPCResponse = z.infer<typeof JSONRPCResponseSchema>;
 const JSONRPCErrorSchema = z
   .object({
     jsonrpc: z.literal(JSONRPC_VERSION),
-    id: z.union([z.string(), z.number().int()]),
+    id: z.optional(z.union([z.string(), z.number().int()])),
     error: z.object({
       code: z.number().int(),
       message: z.string(),

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -7,6 +7,7 @@ import { MockMCPTransport } from './mock-mcp-transport';
 import {
   ListToolsResult,
   ElicitationRequestSchema,
+  LATEST_LEGACY_PROTOCOL_VERSION,
   LATEST_PROTOCOL_VERSION,
   type CallToolResult,
   type CompleteResult,
@@ -70,6 +71,110 @@ class GetterOnlyProtocolVersionTransport implements MCPTransport {
 
   async close(): Promise<void> {
     await this.transport.close();
+  }
+}
+
+class ProtocolDiscoveryTransport implements MCPTransport {
+  readonly supportsProtocolVersionDiscovery = true;
+  readonly sentMessages: JSONRPCMessage[] = [];
+  protocolVersion?: string;
+
+  onmessage?: (message: JSONRPCMessage) => void;
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+
+  constructor(
+    private readonly discoveryBehavior:
+      | 'modern'
+      | 'legacy'
+      | 'unsupported' = 'modern',
+    private readonly includeToolListResultType = true,
+  ) {}
+
+  async start(): Promise<void> {}
+
+  async close(): Promise<void> {
+    this.onclose?.();
+  }
+
+  setProtocolVersion(version: string): void {
+    this.protocolVersion = version;
+  }
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    this.sentMessages.push(message);
+
+    if (!('method' in message) || !('id' in message)) {
+      return;
+    }
+
+    if (message.method === 'server/discover') {
+      if (this.discoveryBehavior === 'legacy') {
+        this.onmessage?.({
+          jsonrpc: '2.0',
+          id: message.id,
+          error: { code: -32601, message: 'Method not found' },
+        });
+        return;
+      }
+
+      if (this.discoveryBehavior === 'unsupported') {
+        this.onmessage?.({
+          jsonrpc: '2.0',
+          id: message.id,
+          error: {
+            code: -32022,
+            message: 'Unsupported protocol version',
+            data: {
+              requested: LATEST_PROTOCOL_VERSION,
+              supported: ['2099-01-01'],
+            },
+          },
+        });
+        return;
+      }
+
+      this.onmessage?.({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          resultType: 'complete',
+          supportedVersions: [LATEST_PROTOCOL_VERSION],
+          capabilities: { tools: {} },
+          _meta: {
+            'io.modelcontextprotocol/serverInfo': {
+              name: 'modern-test-server',
+              version: '1.0.0',
+            },
+          },
+        },
+      });
+      return;
+    }
+
+    if (message.method === 'initialize') {
+      this.onmessage?.({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
+          serverInfo: { name: 'legacy-test-server', version: '1.0.0' },
+          capabilities: { tools: {} },
+        },
+      });
+      return;
+    }
+
+    if (message.method === 'tools/list') {
+      this.onmessage?.({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          ...(this.includeToolListResultType ? { resultType: 'complete' } : {}),
+          tools: [],
+        },
+      });
+    }
   }
 }
 
@@ -2940,9 +3045,8 @@ describe('MCPClient', () => {
         transport: mockTransport,
       });
 
-      // The mock transport returns LATEST_PROTOCOL_VERSION by default
       expect(mockTransport.protocolVersion).toBe(
-        (await import('./types')).LATEST_PROTOCOL_VERSION,
+        LATEST_LEGACY_PROTOCOL_VERSION,
       );
     });
 
@@ -2970,6 +3074,94 @@ describe('MCPClient', () => {
       });
 
       expect(transport.protocolVersion).toBe('2025-06-18');
+    });
+
+    it('should discover a modern server and add metadata to requests', async () => {
+      const transport = new ProtocolDiscoveryTransport();
+
+      client = await createMCPClient({ transport });
+      await client.listTools();
+
+      expect(transport.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+      expect(client.serverInfo).toEqual({
+        name: 'modern-test-server',
+        version: '1.0.0',
+      });
+      expect(
+        transport.sentMessages.map(message =>
+          'method' in message ? message.method : undefined,
+        ),
+      ).toEqual(['server/discover', 'tools/list']);
+
+      for (const message of transport.sentMessages) {
+        if (!('method' in message) || !('id' in message)) {
+          continue;
+        }
+
+        expect(message.params?._meta).toMatchObject({
+          'io.modelcontextprotocol/protocolVersion': LATEST_PROTOCOL_VERSION,
+          'io.modelcontextprotocol/clientCapabilities': {},
+          'io.modelcontextprotocol/clientInfo': {
+            name: 'ai-sdk-mcp-client',
+            version: '1.0.0',
+          },
+        });
+      }
+    });
+
+    it('should fall back to legacy initialization for a legacy server', async () => {
+      const transport = new ProtocolDiscoveryTransport('legacy');
+
+      client = await createMCPClient({ transport });
+      await client.listTools();
+
+      expect(transport.protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
+      expect(
+        transport.sentMessages.map(message =>
+          'method' in message ? message.method : undefined,
+        ),
+      ).toEqual([
+        'server/discover',
+        'initialize',
+        'notifications/initialized',
+        'tools/list',
+      ]);
+
+      const toolListRequest = transport.sentMessages.find(
+        message => 'method' in message && message.method === 'tools/list',
+      );
+      expect(
+        toolListRequest != null && 'params' in toolListRequest
+          ? toolListRequest.params?._meta
+          : undefined,
+      ).toBeUndefined();
+    });
+
+    it('should not fall back for a recognized modern protocol error', async () => {
+      const transport = new ProtocolDiscoveryTransport('unsupported');
+
+      await expect(createMCPClient({ transport })).rejects.toMatchObject({
+        code: -32022,
+        data: {
+          requested: LATEST_PROTOCOL_VERSION,
+          supported: ['2099-01-01'],
+        },
+      });
+      expect(
+        transport.sentMessages.map(message =>
+          'method' in message ? message.method : undefined,
+        ),
+      ).toEqual(['server/discover']);
+    });
+
+    it('should require resultType from modern servers', async () => {
+      const transport = new ProtocolDiscoveryTransport('modern', false);
+
+      client = await createMCPClient({ transport });
+
+      await expect(client.listTools()).rejects.toThrow(
+        'Modern MCP result is missing resultType',
+      );
     });
   });
 });

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -31,9 +31,11 @@ import { getMCPAppToolMeta, MCP_APP_MIME_TYPE } from './mcp-apps';
 import {
   CallToolResultSchema,
   CompleteResultSchema,
+  DiscoverResultSchema,
   ElicitationRequestSchema,
   ElicitResultSchema,
   InitializeResultSchema,
+  LATEST_LEGACY_PROTOCOL_VERSION,
   LATEST_PROTOCOL_VERSION,
   ListResourceTemplatesResultSchema,
   ListResourcesResultSchema,
@@ -66,9 +68,12 @@ import {
   type ToolMeta,
   type McpProviderMetadata,
   type InitializeResult,
+  type DiscoverResult,
 } from './types';
 const CLIENT_VERSION = '1.0.0';
 const DEFAULT_MAX_TOOL_CALL_RETRIES = 0;
+const DEFAULT_PROTOCOL_DISCOVERY_TIMEOUT = 1000;
+const MODERN_PROTOCOL_ERROR_CODES = [-32020, -32021, -32022];
 
 const DEFAULT_RETRY_ERROR_CODES = [
   'ConnectionRefused',
@@ -402,11 +407,13 @@ class DefaultMCPClient implements MCPClient {
   private serverCapabilities: ServerCapabilities = {};
   private _serverInfo: Configuration = { name: '', version: '' };
   private _initializeResult: InitializeResult = {
-    protocolVersion: LATEST_PROTOCOL_VERSION,
+    protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
     capabilities: {},
     serverInfo: this._serverInfo,
   };
   private _serverInstructions?: string;
+  private protocolEra: 'legacy' | 'modern' = 'legacy';
+  private protocolVersion = LATEST_LEGACY_PROTOCOL_VERSION;
   private isClosed = true;
   private elicitationRequestHandler?: (
     request: ElicitationRequest,
@@ -510,11 +517,22 @@ class DefaultMCPClient implements MCPClient {
         return this;
       }
 
+      if (this.transport.supportsProtocolVersionDiscovery) {
+        const discovered = await this.tryProtocolDiscovery(signal);
+        if (discovered) {
+          return this;
+        }
+      }
+
+      this.protocolEra = 'legacy';
+      this.protocolVersion = LATEST_LEGACY_PROTOCOL_VERSION;
+      this.setTransportProtocolVersion(this.protocolVersion);
+
       const result = await this.request({
         request: {
           method: 'initialize',
           params: {
-            protocolVersion: LATEST_PROTOCOL_VERSION,
+            protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
             capabilities: this.clientCapabilities,
             clientInfo: this.clientInfo,
           },
@@ -565,6 +583,75 @@ class DefaultMCPClient implements MCPClient {
     }
   }
 
+  private async tryProtocolDiscovery(
+    signal: AbortSignal | undefined,
+  ): Promise<boolean> {
+    this.protocolEra = 'modern';
+    this.protocolVersion = LATEST_PROTOCOL_VERSION;
+    this.setTransportProtocolVersion(this.protocolVersion);
+
+    try {
+      const result = await this.request({
+        request: { method: 'server/discover' },
+        resultSchema: DiscoverResultSchema,
+        options: {
+          signal,
+          timeout: DEFAULT_PROTOCOL_DISCOVERY_TIMEOUT,
+        },
+      });
+
+      this.applyDiscoverResult(result);
+      return true;
+    } catch (error) {
+      if (
+        MCPClientError.isInstance(error) &&
+        error.code != null &&
+        MODERN_PROTOCOL_ERROR_CODES.includes(error.code)
+      ) {
+        throw error;
+      }
+
+      return false;
+    }
+  }
+
+  private applyDiscoverResult(result: DiscoverResult): void {
+    if (!result.supportedVersions.includes(this.protocolVersion)) {
+      throw new MCPClientError({
+        message: `Server does not support the requested protocol version: ${this.protocolVersion}`,
+      });
+    }
+
+    const serverInfo = result._meta?.['io.modelcontextprotocol/serverInfo'];
+    if (
+      serverInfo != null &&
+      typeof serverInfo === 'object' &&
+      'name' in serverInfo &&
+      typeof serverInfo.name === 'string' &&
+      'version' in serverInfo &&
+      typeof serverInfo.version === 'string'
+    ) {
+      this._serverInfo = serverInfo as Configuration;
+    }
+
+    this.serverCapabilities = result.capabilities;
+    this._serverInstructions = result.instructions;
+    this._initializeResult = {
+      protocolVersion: this.protocolVersion,
+      capabilities: result.capabilities,
+      serverInfo: this._serverInfo,
+      instructions: result.instructions,
+    };
+  }
+
+  private setTransportProtocolVersion(version: string): void {
+    if (this.transport.setProtocolVersion) {
+      this.transport.setProtocolVersion(version);
+    } else {
+      this.transport.protocolVersion = version;
+    }
+  }
+
   private applyInitializeResult(result: InitializeResult): void {
     if (!SUPPORTED_PROTOCOL_VERSIONS.includes(result.protocolVersion)) {
       throw new MCPClientError({
@@ -573,13 +660,11 @@ class DefaultMCPClient implements MCPClient {
     }
 
     this.serverCapabilities = result.capabilities;
+    this.protocolEra = 'legacy';
+    this.protocolVersion = result.protocolVersion;
     this._serverInfo = result.serverInfo;
     this._initializeResult = result;
-    if (this.transport.setProtocolVersion) {
-      this.transport.setProtocolVersion(result.protocolVersion);
-    } else {
-      this.transport.protocolVersion = result.protocolVersion;
-    }
+    this.setTransportProtocolVersion(result.protocolVersion);
     this._serverInstructions = result.instructions;
   }
 
@@ -602,6 +687,7 @@ class DefaultMCPClient implements MCPClient {
   private assertCapability(method: string): void {
     switch (method) {
       case 'initialize':
+      case 'server/discover':
         break;
       case 'completion/complete':
         if (!this.serverCapabilities.completions) {
@@ -677,8 +763,25 @@ class DefaultMCPClient implements MCPClient {
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
       const messageId = this.requestMessageId++;
+      const preparedRequest =
+        this.protocolEra === 'modern'
+          ? {
+              ...request,
+              params: {
+                ...request.params,
+                _meta: {
+                  ...request.params?._meta,
+                  'io.modelcontextprotocol/protocolVersion':
+                    this.protocolVersion,
+                  'io.modelcontextprotocol/clientCapabilities':
+                    this.clientCapabilities,
+                  'io.modelcontextprotocol/clientInfo': this.clientInfo,
+                },
+              },
+            }
+          : request;
       const jsonrpcRequest: JSONRPCRequest = {
-        ...request,
+        ...preparedRequest,
         jsonrpc: '2.0',
         id: messageId,
       };
@@ -729,14 +832,31 @@ class DefaultMCPClient implements MCPClient {
         }
 
         try {
+          if (
+            this.protocolEra === 'modern' &&
+            response.result.resultType == null
+          ) {
+            throw new MCPClientError({
+              message: 'Modern MCP result is missing resultType',
+            });
+          }
+          if (response.result.resultType === 'input_required') {
+            throw new MCPClientError({
+              message:
+                'Server requested additional input, but multi round-trip requests are not supported yet',
+            });
+          }
+
           const result = resultSchema.parse(response.result);
           cleanup();
           resolve(result);
         } catch (error) {
-          const parseError = new MCPClientError({
-            message: 'Failed to parse server response',
-            cause: error,
-          });
+          const parseError = MCPClientError.isInstance(error)
+            ? error
+            : new MCPClientError({
+                message: 'Failed to parse server response',
+                cause: error,
+              });
           rejectAndCleanup(parseError);
         }
       });
@@ -1278,6 +1398,17 @@ class DefaultMCPClient implements MCPClient {
   }
 
   private onResponse(response: JSONRPCResponse | JSONRPCError): void {
+    if (response.id == null) {
+      this.onError(
+        new MCPClientError({
+          message: `Protocol error: Received a response without a message ID: ${JSON.stringify(
+            response,
+          )}`,
+        }),
+      );
+      return;
+    }
+
     const messageId = Number(response.id);
     const handler = this.responseHandlers.get(messageId);
 

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -5,7 +5,10 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMCPClient } from './mcp-client';
 import { HttpMCPTransport } from './mcp-http-transport';
-import { LATEST_PROTOCOL_VERSION } from './types';
+import {
+  LATEST_LEGACY_PROTOCOL_VERSION,
+  LATEST_PROTOCOL_VERSION,
+} from './types';
 import { MCPClientError } from '../error/mcp-client-error';
 import { UnauthorizedError, type OAuthClientProvider } from './oauth';
 import type { OAuthTokens } from './oauth-types';
@@ -78,7 +81,7 @@ describe('HttpMCPTransport', () => {
 
     expect(server.calls[1].requestMethod).toBe('POST');
     expect(server.calls[1].requestHeaders).toEqual({
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
       accept: 'application/json, text/event-stream',
       'content-type': 'application/json',
     });
@@ -930,7 +933,7 @@ describe('HttpMCPTransport', () => {
     await transport.send(message);
 
     expect(server.calls[0].requestHeaders).toEqual({
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
       accept: 'text/event-stream',
       ...customHeaders,
     });
@@ -938,7 +941,7 @@ describe('HttpMCPTransport', () => {
 
     expect(server.calls[1].requestHeaders).toEqual({
       'content-type': 'application/json',
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
       accept: 'application/json, text/event-stream',
       ...customHeaders,
     });
@@ -1317,7 +1320,7 @@ describe('HttpMCPTransport', () => {
   });
 
   describe('protocol version downgrade', () => {
-    it('should use LATEST_PROTOCOL_VERSION by default', async () => {
+    it('should use LATEST_LEGACY_PROTOCOL_VERSION by default', async () => {
       await transport.start();
 
       const message = {
@@ -1330,7 +1333,7 @@ describe('HttpMCPTransport', () => {
       await transport.send(message);
 
       expect(server.calls[1].requestHeaders['mcp-protocol-version']).toBe(
-        LATEST_PROTOCOL_VERSION,
+        LATEST_LEGACY_PROTOCOL_VERSION,
       );
     });
 

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -19,7 +19,7 @@ import {
   type AuthResult,
   type OAuthClientProvider,
 } from './oauth';
-import { LATEST_PROTOCOL_VERSION } from './types';
+import { LATEST_LEGACY_PROTOCOL_VERSION } from './types';
 
 function isMessageEvent(event: string | undefined): boolean {
   return event === undefined || event === 'message';
@@ -111,7 +111,8 @@ export class HttpMCPTransport implements MCPTransport {
     const headers: Record<string, string> = {
       ...this.headers,
       ...base,
-      'mcp-protocol-version': this.protocolVersion ?? LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version':
+        this.protocolVersion ?? LATEST_LEGACY_PROTOCOL_VERSION,
     };
 
     if (includeSessionId && this.sessionId) {

--- a/packages/mcp/src/tool/mcp-sse-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.test.ts
@@ -5,7 +5,7 @@ import {
 import { MCPClientError } from '../error/mcp-client-error';
 import { deserializeMessage, SseMCPTransport } from './mcp-sse-transport';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { LATEST_PROTOCOL_VERSION } from './types';
+import { LATEST_LEGACY_PROTOCOL_VERSION } from './types';
 
 describe('SseMCPTransport', () => {
   const server = createTestServer({
@@ -60,7 +60,7 @@ describe('SseMCPTransport', () => {
     expect(server.calls[0].requestMethod).toBe('GET');
     expect(server.calls[0].requestUrl).toBe('http://localhost:3000/sse');
     expect(server.calls[0].requestHeaders).toEqual({
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
       accept: 'text/event-stream',
     });
   });
@@ -498,7 +498,7 @@ describe('SseMCPTransport', () => {
 
     // Verify SSE connection headers
     expect(server.calls[0].requestHeaders).toEqual({
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
       accept: 'text/event-stream',
       ...customHeaders,
     });
@@ -507,7 +507,7 @@ describe('SseMCPTransport', () => {
     // Verify POST request headers
     expect(server.calls[1].requestHeaders).toEqual({
       'content-type': 'application/json',
-      'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
       ...customHeaders,
     });
     expect(server.calls[1].requestUserAgent).toContain('ai-sdk/');

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -14,7 +14,7 @@ import {
   auth,
   type OAuthClientProvider,
 } from './oauth';
-import { LATEST_PROTOCOL_VERSION } from './types';
+import { LATEST_LEGACY_PROTOCOL_VERSION } from './types';
 
 function isMessageEvent(event: string | undefined): boolean {
   return event === undefined || event === 'message';
@@ -69,7 +69,8 @@ export class SseMCPTransport implements MCPTransport {
     const headers: Record<string, string> = {
       ...this.headers,
       ...base,
-      'mcp-protocol-version': this.protocolVersion ?? LATEST_PROTOCOL_VERSION,
+      'mcp-protocol-version':
+        this.protocolVersion ?? LATEST_LEGACY_PROTOCOL_VERSION,
     };
 
     if (this.authProvider) {

--- a/packages/mcp/src/tool/mcp-stdio/mcp-stdio-transport.ts
+++ b/packages/mcp/src/tool/mcp-stdio/mcp-stdio-transport.ts
@@ -14,6 +14,7 @@ export interface StdioConfig {
 }
 
 export class StdioMCPTransport implements MCPTransport {
+  readonly supportsProtocolVersionDiscovery = true;
   private process?: ChildProcess;
   private abortController: AbortController = new AbortController();
   private readBuffer: ReadBuffer = new ReadBuffer();

--- a/packages/mcp/src/tool/mcp-transport.ts
+++ b/packages/mcp/src/tool/mcp-transport.ts
@@ -40,6 +40,14 @@ export type MCPTransportCloseOptions = {
 
 export interface MCPTransport {
   /**
+   * Whether this transport can probe for stateless MCP protocol versions.
+   *
+   * Custom transports default to the legacy initialization flow unless they
+   * explicitly opt in.
+   */
+  supportsProtocolVersionDiscovery?: boolean;
+
+  /**
    * Initialize and start the transport
    */
   start(): Promise<void>;

--- a/packages/mcp/src/tool/mock-mcp-transport.ts
+++ b/packages/mcp/src/tool/mock-mcp-transport.ts
@@ -2,7 +2,7 @@ import { delay } from '@ai-sdk/provider-utils';
 import type { JSONRPCMessage } from './json-rpc-message';
 import type { MCPTransport } from './mcp-transport';
 import {
-  LATEST_PROTOCOL_VERSION,
+  LATEST_LEGACY_PROTOCOL_VERSION,
   type MCPTool,
   type MCPResource,
   type MCPPrompt,
@@ -163,7 +163,7 @@ export class MockMCPTransport implements MCPTransport {
           jsonrpc: '2.0',
           id: message.id,
           result: this.initializeResult || {
-            protocolVersion: LATEST_PROTOCOL_VERSION,
+            protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
             serverInfo: {
               name: 'mock-mcp-server',
               version: '1.0.0',

--- a/packages/mcp/src/tool/types.ts
+++ b/packages/mcp/src/tool/types.ts
@@ -2,9 +2,11 @@ import { z } from 'zod/v4';
 import type { JSONObject } from '@ai-sdk/provider';
 import type { FlexibleSchema, Tool } from '@ai-sdk/provider-utils';
 
-export const LATEST_PROTOCOL_VERSION = '2025-11-25';
+export const LATEST_PROTOCOL_VERSION = '2026-07-28';
+export const LATEST_LEGACY_PROTOCOL_VERSION = '2025-11-25';
 export const SUPPORTED_PROTOCOL_VERSIONS = [
   LATEST_PROTOCOL_VERSION,
+  LATEST_LEGACY_PROTOCOL_VERSION,
   '2025-06-18',
   '2025-03-26',
   '2024-11-05',
@@ -73,7 +75,9 @@ export const BaseParamsSchema = z.looseObject({
   _meta: z.optional(z.object({}).loose()),
 });
 type BaseParams = z.infer<typeof BaseParamsSchema>;
-export const ResultSchema = BaseParamsSchema;
+export const ResultSchema = BaseParamsSchema.extend({
+  resultType: z.optional(z.string()),
+});
 
 export const RequestSchema = z.object({
   method: z.string(),
@@ -127,6 +131,15 @@ export const ClientCapabilitiesSchema = z
 
 export type ClientCapabilities = z.infer<typeof ClientCapabilitiesSchema>;
 export type ElicitationCapability = z.infer<typeof ElicitationCapabilitySchema>;
+
+export const DiscoverResultSchema = ResultSchema.extend({
+  supportedVersions: z.array(z.string()),
+  capabilities: ServerCapabilitiesSchema,
+  instructions: z.optional(z.string()),
+  ttlMs: z.optional(z.number()),
+  cacheScope: z.optional(z.union([z.literal('public'), z.literal('private')])),
+});
+export type DiscoverResult = z.infer<typeof DiscoverResultSchema>;
 
 export const InitializeResultSchema = ResultSchema.extend({
   protocolVersion: z.string(),


### PR DESCRIPTION
## Background

the latest MCP spec of 2026-07-28 replaces the legacy `initialize` handshake with stateless requests carrying protocol metadata. We needed a foundation that supports both protocol eras without breaking existing servers.

## Summary

- Defines:
  - Latest protocol: 2026-07-28
  - Latest legacy protocol: 2025-11-25
- Adds `server/discover` support for discovery-enabled transports
- Allows custom transports to opt in with `supportsProtocolVersionDiscovery`

## End-to-End Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- [x] Streamable HTTP and required headers
- [ ] subscriptions, and notifications
- [ ] OAuth 2026 compliance

## Related Issues

Towards #19005 