### PR TITLE
feat(mcp): add mcp 2026 streamable HTTP support

### DIFF
--- a/.changeset/modern-waves-complain.md
+++ b/.changeset/modern-waves-complain.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+feat(mcp): add mcp 2026 streamable HTTP support

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -7,6 +7,8 @@
     "client:sse": "tsx src/sse/client.ts",
     "server:http": "tsx src/http/server.ts",
     "client:http": "tsx src/http/client.ts",
+    "server:http-2026": "tsx src/http-2026/server.ts",
+    "client:http-2026": "tsx src/http-2026/client.ts",
     "server:mcp-with-auth": "tsx src/mcp-with-auth/server.ts",
     "client:mcp-with-auth": "tsx src/mcp-with-auth/client.ts",
     "server:mcp-prompts": "tsx src/mcp-prompts/server.ts",
@@ -32,7 +34,9 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "workspace:*",
+    "@modelcontextprotocol/node": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "ai": "workspace:*",
     "dotenv": "16.4.5",
     "express": "5.0.1",

--- a/examples/mcp/src/http-2026/client.ts
+++ b/examples/mcp/src/http-2026/client.ts
@@ -1,0 +1,34 @@
+import { createMCPClient } from '@ai-sdk/mcp';
+
+async function main() {
+  const client = await createMCPClient({
+    transport: {
+      type: 'http',
+      url: 'http://localhost:3001/mcp',
+    },
+  });
+
+  try {
+    console.log('serverInfo:', client.serverInfo);
+    console.log('protocolVersion:', client.initializeResult.protocolVersion);
+
+    const { tools } = await client.listTools();
+    console.log(
+      'tools:',
+      tools.map(tool => tool.name),
+    );
+
+    const result = await client.callTool({
+      name: 'greet',
+      arguments: {
+        name: 'Ada',
+        region: 'us-east-1',
+      },
+    });
+    console.log('result:', result);
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch(console.error);

--- a/examples/mcp/src/http-2026/server.ts
+++ b/examples/mcp/src/http-2026/server.ts
@@ -1,0 +1,162 @@
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+const protocolVersion = '2026-07-28';
+
+app.post('/mcp', (request, response) => {
+  const body = request.body as {
+    id?: string | number;
+    method?: string;
+    params?: {
+      name?: string;
+      arguments?: Record<string, unknown>;
+      _meta?: Record<string, unknown>;
+    };
+  };
+
+  console.log(`${body.method}:`, {
+    protocolVersion: request.get('MCP-Protocol-Version'),
+    method: request.get('Mcp-Method'),
+    name: request.get('Mcp-Name'),
+    region: request.get('Mcp-Param-Region'),
+    sessionId: request.get('Mcp-Session-Id'),
+  });
+
+  if (
+    request.get('MCP-Protocol-Version') !== protocolVersion ||
+    body.params?._meta?.['io.modelcontextprotocol/protocolVersion'] !==
+      protocolVersion
+  ) {
+    response.status(400).json({
+      jsonrpc: '2.0',
+      id: body.id,
+      error: {
+        code: -32022,
+        message: 'Unsupported protocol version',
+        data: {
+          requested: request.get('MCP-Protocol-Version'),
+          supported: [protocolVersion],
+        },
+      },
+    });
+    return;
+  }
+
+  if (request.get('Mcp-Method') !== body.method) {
+    response.status(400).json({
+      jsonrpc: '2.0',
+      id: body.id,
+      error: {
+        code: -32020,
+        message: 'Mcp-Method header does not match the request body',
+      },
+    });
+    return;
+  }
+
+  switch (body.method) {
+    case 'server/discover': {
+      response.json({
+        jsonrpc: '2.0',
+        id: body.id,
+        result: {
+          resultType: 'complete',
+          supportedVersions: [protocolVersion],
+          capabilities: { tools: {} },
+          instructions: 'Call greet with a name and deployment region.',
+          ttlMs: 60_000,
+          cacheScope: 'public',
+          _meta: {
+            'io.modelcontextprotocol/serverInfo': {
+              name: 'ai-sdk-mcp-2026-example',
+              version: '1.0.0',
+            },
+          },
+        },
+      });
+      return;
+    }
+
+    case 'tools/list': {
+      response.json({
+        jsonrpc: '2.0',
+        id: body.id,
+        result: {
+          resultType: 'complete',
+          tools: [
+            {
+              name: 'greet',
+              description: 'Greet someone from a deployment region.',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                  region: {
+                    type: 'string',
+                    'x-mcp-header': 'Region',
+                  },
+                },
+                required: ['name', 'region'],
+                additionalProperties: false,
+              },
+            },
+          ],
+          ttlMs: 60_000,
+          cacheScope: 'public',
+        },
+      });
+      return;
+    }
+
+    case 'tools/call': {
+      const region = body.params?.arguments?.region;
+      if (
+        body.params?.name !== 'greet' ||
+        request.get('Mcp-Name') !== 'greet' ||
+        typeof region !== 'string' ||
+        request.get('Mcp-Param-Region') !== region
+      ) {
+        response.status(400).json({
+          jsonrpc: '2.0',
+          id: body.id,
+          error: {
+            code: -32020,
+            message: 'Required MCP request headers do not match the tool call',
+          },
+        });
+        return;
+      }
+
+      const name = body.params.arguments?.name;
+      response.json({
+        jsonrpc: '2.0',
+        id: body.id,
+        result: {
+          resultType: 'complete',
+          content: [
+            {
+              type: 'text',
+              text: `Hello, ${String(name)} from ${region}!`,
+            },
+          ],
+          isError: false,
+        },
+      });
+      return;
+    }
+
+    default: {
+      response.status(404).json({
+        jsonrpc: '2.0',
+        id: body.id,
+        error: { code: -32601, message: 'Method not found' },
+      });
+    }
+  }
+});
+
+app.listen(3001, () => {
+  console.log('MCP 2026 example server listening on http://localhost:3001/mcp');
+});

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -26,8 +26,14 @@ import {
   isCustomMcpTransport,
   type MCPTransport,
   type MCPTransportConfig,
+  type MCPTransportSendOptions,
 } from './mcp-transport';
 import { getMCPAppToolMeta, MCP_APP_MIME_TYPE } from './mcp-apps';
+import {
+  createMCPToolHeaders,
+  getMCPToolHeaderBindings,
+  type MCPToolHeaderBinding,
+} from './mcp-http-headers';
 import {
   CallToolResultSchema,
   CompleteResultSchema,
@@ -236,6 +242,16 @@ export interface MCPClientConfig {
   /** Transport configuration for connecting to the MCP server */
   transport: MCPTransportConfig | MCPTransport;
   /**
+   * Whether transports that support stateless protocol discovery should probe
+   * with `server/discover` before falling back to legacy initialization.
+   *
+   * Disable this for legacy servers that require `initialize` to be the first
+   * request.
+   *
+   * @default true
+   */
+  protocolVersionDiscovery?: boolean;
+  /**
    * Options that bound or cancel transport startup and the initialize request.
    */
   initializationOptions?: RequestOptions;
@@ -393,6 +409,7 @@ export interface MCPClient {
  */
 class DefaultMCPClient implements MCPClient {
   private transport: MCPTransport;
+  private protocolVersionDiscovery: boolean;
   private onUncaughtError?: (error: unknown) => void;
   private maxRetries: number;
   private clientInfo: ClientConfiguration;
@@ -414,6 +431,7 @@ class DefaultMCPClient implements MCPClient {
   private _serverInstructions?: string;
   private protocolEra: 'legacy' | 'modern' = 'legacy';
   private protocolVersion = LATEST_LEGACY_PROTOCOL_VERSION;
+  private toolHeaderBindings = new Map<string, MCPToolHeaderBinding[]>();
   private isClosed = true;
   private elicitationRequestHandler?: (
     request: ElicitationRequest,
@@ -429,12 +447,14 @@ class DefaultMCPClient implements MCPClient {
     capabilities,
     initialInitializeResult,
     initializationOptions,
+    protocolVersionDiscovery = true,
   }: MCPClientConfig) {
     this.onUncaughtError = onUncaughtError;
     this.maxRetries = prepareMaxRetries(maxRetries);
     this.clientCapabilities = capabilities ?? {};
     this.initialInitializeResult = initialInitializeResult;
     this.initializationOptions = initializationOptions;
+    this.protocolVersionDiscovery = protocolVersionDiscovery;
 
     if (isCustomMcpTransport(transportConfig)) {
       this.transport = transportConfig;
@@ -517,7 +537,10 @@ class DefaultMCPClient implements MCPClient {
         return this;
       }
 
-      if (this.transport.supportsProtocolVersionDiscovery) {
+      if (
+        this.protocolVersionDiscovery &&
+        this.transport.supportsProtocolVersionDiscovery
+      ) {
         const discovered = await this.tryProtocolDiscovery(signal);
         if (discovered) {
           return this;
@@ -676,12 +699,9 @@ class DefaultMCPClient implements MCPClient {
 
   private send(
     message: JSONRPCMessage,
-    signal: AbortSignal | undefined,
+    options?: MCPTransportSendOptions,
   ): Promise<void> {
-    return this.transport.send(
-      message,
-      signal == null ? undefined : { signal },
-    );
+    return this.transport.send(message, options);
   }
 
   private assertCapability(method: string): void {
@@ -785,6 +805,7 @@ class DefaultMCPClient implements MCPClient {
         jsonrpc: '2.0',
         id: messageId,
       };
+      const headers = this.getToolRequestHeaders(preparedRequest);
 
       const rejectWithAbortError = () => {
         reject(
@@ -867,10 +888,10 @@ class DefaultMCPClient implements MCPClient {
         timeoutId = setTimeout(onTimeout, timeout);
       }
 
-      const sendPromise =
-        transportSignal == null
-          ? this.transport.send(jsonrpcRequest)
-          : this.send(jsonrpcRequest, transportSignal);
+      const sendPromise = this.send(jsonrpcRequest, {
+        ...(transportSignal == null ? {} : { signal: transportSignal }),
+        ...(headers == null ? {} : { headers }),
+      });
 
       sendPromise.catch(error => {
         rejectAndCleanup(error);
@@ -885,11 +906,75 @@ class DefaultMCPClient implements MCPClient {
     params?: PaginatedRequest['params'];
     options?: RequestOptions;
   } = {}): Promise<ListToolsResult> {
-    return this.request({
+    const result = await this.request({
       request: { method: 'tools/list', params },
       resultSchema: ListToolsResultSchema,
       options,
     });
+    return this.prepareToolDefinitions(result);
+  }
+
+  private prepareToolDefinitions(
+    definitions: ListToolsResult,
+  ): ListToolsResult {
+    if (
+      this.protocolEra !== 'modern' ||
+      !this.transport.supportsMcpToolParameterHeaders
+    ) {
+      return definitions;
+    }
+
+    this.toolHeaderBindings.clear();
+    const tools = definitions.tools.filter(toolDefinition => {
+      const result = getMCPToolHeaderBindings(toolDefinition.inputSchema);
+      if (!result.success) {
+        this.onError(
+          new MCPClientError({
+            message: `Ignoring MCP tool "${toolDefinition.name}": ${result.error}`,
+          }),
+        );
+        return false;
+      }
+
+      this.toolHeaderBindings.set(toolDefinition.name, result.bindings);
+      return true;
+    });
+
+    return { ...definitions, tools };
+  }
+
+  private getToolRequestHeaders(
+    request: Request,
+  ): Record<string, string> | undefined {
+    if (
+      this.protocolEra !== 'modern' ||
+      request.method !== 'tools/call' ||
+      typeof request.params?.name !== 'string'
+    ) {
+      return undefined;
+    }
+
+    const bindings = this.toolHeaderBindings.get(request.params.name);
+    if (bindings == null || bindings.length === 0) {
+      return undefined;
+    }
+
+    const args = request.params.arguments;
+    if (args == null || typeof args !== 'object' || Array.isArray(args)) {
+      return undefined;
+    }
+
+    try {
+      return createMCPToolHeaders({
+        bindings,
+        args: args as Record<string, unknown>,
+      });
+    } catch (error) {
+      throw new MCPClientError({
+        message: `Failed to create MCP headers for tool "${request.params.name}"`,
+        cause: error,
+      });
+    }
   }
 
   private async callToolWithRetry({
@@ -1054,7 +1139,10 @@ class DefaultMCPClient implements MCPClient {
       jsonrpc: '2.0',
     };
     await waitForAbort(
-      this.send(jsonrpcNotification, options?.signal),
+      this.send(
+        jsonrpcNotification,
+        options?.signal == null ? undefined : { signal: options.signal },
+      ),
       options?.signal,
     );
   }
@@ -1084,6 +1172,7 @@ class DefaultMCPClient implements MCPClient {
       schemas?: TOOL_SCHEMAS;
     },
   ): McpToolSet<TOOL_SCHEMAS> {
+    definitions = this.prepareToolDefinitions(definitions);
     const tools: Record<string, Tool & { _meta?: ToolMeta }> = {};
 
     for (const {

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -701,7 +701,9 @@ class DefaultMCPClient implements MCPClient {
     message: JSONRPCMessage,
     options?: MCPTransportSendOptions,
   ): Promise<void> {
-    return this.transport.send(message, options);
+    return options == null
+      ? this.transport.send(message)
+      : this.transport.send(message, options);
   }
 
   private assertCapability(method: string): void {
@@ -888,10 +890,14 @@ class DefaultMCPClient implements MCPClient {
         timeoutId = setTimeout(onTimeout, timeout);
       }
 
-      const sendPromise = this.send(jsonrpcRequest, {
+      const sendOptions: MCPTransportSendOptions = {
         ...(transportSignal == null ? {} : { signal: transportSignal }),
         ...(headers == null ? {} : { headers }),
-      });
+      };
+      const sendPromise =
+        Object.keys(sendOptions).length === 0
+          ? this.send(jsonrpcRequest)
+          : this.send(jsonrpcRequest, sendOptions);
 
       sendPromise.catch(error => {
         rejectAndCleanup(error);

--- a/packages/mcp/src/tool/mcp-http-headers.test.ts
+++ b/packages/mcp/src/tool/mcp-http-headers.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createMCPToolHeaders,
+  encodeMCPHeaderValue,
+  getMCPToolHeaderBindings,
+} from './mcp-http-headers';
+
+describe('MCP HTTP headers', () => {
+  it('extracts statically reachable header bindings', () => {
+    expect(
+      getMCPToolHeaderBindings({
+        type: 'object',
+        properties: {
+          region: { type: 'string', 'x-mcp-header': 'Region' },
+          options: {
+            type: 'object',
+            properties: {
+              dryRun: { type: 'boolean', 'x-mcp-header': 'Dry-Run' },
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      success: true,
+      bindings: [
+        { headerName: 'Region', path: ['region'], valueType: 'string' },
+        {
+          headerName: 'Dry-Run',
+          path: ['options', 'dryRun'],
+          valueType: 'boolean',
+        },
+      ],
+    });
+  });
+
+  it.each([
+    {
+      schema: {
+        type: 'object',
+        items: { type: 'string', 'x-mcp-header': 'Invalid' },
+      },
+      error: 'not on a statically reachable property',
+    },
+    {
+      schema: {
+        type: 'object',
+        properties: {
+          count: { type: 'number', 'x-mcp-header': 'Count' },
+        },
+      },
+      error: 'can only annotate boolean, integer, or string',
+    },
+    {
+      schema: {
+        type: 'object',
+        properties: {
+          first: { type: 'string', 'x-mcp-header': 'Region' },
+          second: { type: 'string', 'x-mcp-header': 'region' },
+        },
+      },
+      error: 'is not unique',
+    },
+  ])('rejects invalid x-mcp-header schemas', ({ schema, error }) => {
+    expect(getMCPToolHeaderBindings(schema)).toMatchObject({
+      success: false,
+      error: expect.stringContaining(error),
+    });
+  });
+
+  it('creates encoded headers from tool arguments', () => {
+    const result = getMCPToolHeaderBindings({
+      type: 'object',
+      properties: {
+        region: { type: 'string', 'x-mcp-header': 'Region' },
+        count: { type: 'integer', 'x-mcp-header': 'Count' },
+        options: {
+          type: 'object',
+          properties: {
+            enabled: { type: 'boolean', 'x-mcp-header': 'Enabled' },
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error(result.error);
+    }
+
+    expect(
+      createMCPToolHeaders({
+        bindings: result.bindings,
+        args: {
+          region: 'Hello, 世界',
+          count: 42,
+          options: { enabled: false },
+        },
+      }),
+    ).toEqual({
+      'Mcp-Param-Region': '=?base64?SGVsbG8sIOS4lueVjA==?=',
+      'Mcp-Param-Count': '42',
+      'Mcp-Param-Enabled': 'false',
+    });
+  });
+
+  it.each([
+    ['plain-ascii', 'plain-ascii'],
+    [' padded ', '=?base64?IHBhZGRlZCA=?='],
+    ['=?base64?literal?=', '=?base64?PT9iYXNlNjQ/bGl0ZXJhbD89?='],
+  ])('encodes MCP header values safely', (value, expected) => {
+    expect(encodeMCPHeaderValue(value)).toBe(expected);
+  });
+});

--- a/packages/mcp/src/tool/mcp-http-headers.test.ts
+++ b/packages/mcp/src/tool/mcp-http-headers.test.ts
@@ -43,6 +43,30 @@ describe('MCP HTTP headers', () => {
     },
     {
       schema: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            region: { type: 'string', 'x-mcp-header': 'Region' },
+          },
+        },
+      },
+      error: 'not on a statically reachable property',
+    },
+    {
+      schema: {
+        type: 'object',
+        additionalProperties: {
+          type: 'object',
+          properties: {
+            region: { type: 'string', 'x-mcp-header': 'Region' },
+          },
+        },
+      },
+      error: 'not on a statically reachable property',
+    },
+    {
+      schema: {
         type: 'object',
         properties: {
           count: { type: 'number', 'x-mcp-header': 'Count' },

--- a/packages/mcp/src/tool/mcp-http-headers.ts
+++ b/packages/mcp/src/tool/mcp-http-headers.ts
@@ -53,14 +53,14 @@ export function getMCPToolHeaderBindings(
   const visit = (
     value: unknown,
     path: string[],
-    annotationAllowed: boolean,
+    staticallyReachable: boolean,
   ): void => {
     if (error != null || !isRecord(value)) {
       return;
     }
 
     if ('x-mcp-header' in value) {
-      if (!annotationAllowed) {
+      if (!staticallyReachable || path.length === 0) {
         error = 'x-mcp-header is not on a statically reachable property';
         return;
       }
@@ -102,7 +102,7 @@ export function getMCPToolHeaderBindings(
 
       if (key === 'properties' && isRecord(child)) {
         for (const [propertyName, propertySchema] of Object.entries(child)) {
-          visit(propertySchema, [...path, propertyName], true);
+          visit(propertySchema, [...path, propertyName], staticallyReachable);
         }
       } else {
         visit(child, path, false);
@@ -110,7 +110,7 @@ export function getMCPToolHeaderBindings(
     }
   };
 
-  visit(inputSchema, [], false);
+  visit(inputSchema, [], true);
 
   return error == null
     ? { success: true, bindings }

--- a/packages/mcp/src/tool/mcp-http-headers.ts
+++ b/packages/mcp/src/tool/mcp-http-headers.ts
@@ -1,4 +1,4 @@
-import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
+import { convertUint8ArrayToBase64, isRecord } from '@ai-sdk/provider-utils';
 
 type HeaderValueType = 'boolean' | 'integer' | 'string';
 
@@ -14,10 +14,6 @@ export type MCPToolHeaderBindingsResult =
 
 const HTTP_TOKEN_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 const BASE64_SENTINEL_PATTERN = /^=\?base64\?.*\?=$/;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
-}
 
 export function encodeMCPHeaderValue(value: string): string {
   const isPlainAscii = [...value].every(character => {

--- a/packages/mcp/src/tool/mcp-http-headers.ts
+++ b/packages/mcp/src/tool/mcp-http-headers.ts
@@ -1,0 +1,165 @@
+import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
+
+type HeaderValueType = 'boolean' | 'integer' | 'string';
+
+export type MCPToolHeaderBinding = {
+  headerName: string;
+  path: string[];
+  valueType: HeaderValueType;
+};
+
+export type MCPToolHeaderBindingsResult =
+  | { success: true; bindings: MCPToolHeaderBinding[] }
+  | { success: false; error: string };
+
+const HTTP_TOKEN_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const BASE64_SENTINEL_PATTERN = /^=\?base64\?.*\?=$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function encodeMCPHeaderValue(value: string): string {
+  const isPlainAscii = [...value].every(character => {
+    const code = character.charCodeAt(0);
+    return code === 0x09 || (code >= 0x20 && code <= 0x7e);
+  });
+
+  if (
+    isPlainAscii &&
+    value.trim() === value &&
+    !BASE64_SENTINEL_PATTERN.test(value)
+  ) {
+    return value;
+  }
+
+  return `=?base64?${convertUint8ArrayToBase64(new TextEncoder().encode(value))}?=`;
+}
+
+export function getMCPToolHeaderBindings(
+  inputSchema: unknown,
+): MCPToolHeaderBindingsResult {
+  if (!isRecord(inputSchema)) {
+    return {
+      success: false,
+      error: 'inputSchema must be a JSON Schema object',
+    };
+  }
+
+  const bindings: MCPToolHeaderBinding[] = [];
+  const headerNames = new Set<string>();
+  let error: string | undefined;
+
+  const visit = (
+    value: unknown,
+    path: string[],
+    annotationAllowed: boolean,
+  ): void => {
+    if (error != null || !isRecord(value)) {
+      return;
+    }
+
+    if ('x-mcp-header' in value) {
+      if (!annotationAllowed) {
+        error = 'x-mcp-header is not on a statically reachable property';
+        return;
+      }
+
+      const headerName = value['x-mcp-header'];
+      if (
+        typeof headerName !== 'string' ||
+        !HTTP_TOKEN_PATTERN.test(headerName)
+      ) {
+        error = 'x-mcp-header must be a non-empty HTTP token';
+        return;
+      }
+
+      const normalizedHeaderName = headerName.toLowerCase();
+      if (headerNames.has(normalizedHeaderName)) {
+        error = `x-mcp-header value "${headerName}" is not unique`;
+        return;
+      }
+
+      const valueType = value.type;
+      if (
+        valueType !== 'boolean' &&
+        valueType !== 'integer' &&
+        valueType !== 'string'
+      ) {
+        error =
+          'x-mcp-header can only annotate boolean, integer, or string properties';
+        return;
+      }
+
+      headerNames.add(normalizedHeaderName);
+      bindings.push({ headerName, path, valueType });
+    }
+
+    for (const [key, child] of Object.entries(value)) {
+      if (key === 'x-mcp-header') {
+        continue;
+      }
+
+      if (key === 'properties' && isRecord(child)) {
+        for (const [propertyName, propertySchema] of Object.entries(child)) {
+          visit(propertySchema, [...path, propertyName], true);
+        }
+      } else {
+        visit(child, path, false);
+      }
+    }
+  };
+
+  visit(inputSchema, [], false);
+
+  return error == null
+    ? { success: true, bindings }
+    : { success: false, error };
+}
+
+function getValueAtPath(
+  value: Record<string, unknown>,
+  path: string[],
+): unknown {
+  let current: unknown = value;
+  for (const segment of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+export function createMCPToolHeaders({
+  bindings,
+  args,
+}: {
+  bindings: MCPToolHeaderBinding[];
+  args: Record<string, unknown>;
+}): Record<string, string> {
+  const headers: Record<string, string> = {};
+
+  for (const binding of bindings) {
+    const value = getValueAtPath(args, binding.path);
+    if (value == null) {
+      continue;
+    }
+
+    if (
+      (binding.valueType === 'string' && typeof value !== 'string') ||
+      (binding.valueType === 'boolean' && typeof value !== 'boolean') ||
+      (binding.valueType === 'integer' && !Number.isSafeInteger(value))
+    ) {
+      throw new TypeError(
+        `Tool argument "${binding.path.join('.')}" does not match its x-mcp-header type`,
+      );
+    }
+
+    headers[`Mcp-Param-${binding.headerName}`] = encodeMCPHeaderValue(
+      String(value),
+    );
+  }
+
+  return headers;
+}

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -184,7 +184,7 @@ describe('HttpMCPTransport', () => {
         jsonrpc: '2.0',
         id: 0,
         result: {
-          protocolVersion: LATEST_PROTOCOL_VERSION,
+          protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
           capabilities: {},
           serverInfo: { name: 'test-server', version: '1.0.0' },
         },
@@ -271,7 +271,7 @@ describe('HttpMCPTransport', () => {
               jsonrpc: '2.0',
               id: message.id,
               result: {
-                protocolVersion: LATEST_PROTOCOL_VERSION,
+                protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                 capabilities: {},
                 serverInfo: { name: 'test-server', version: '1.0.0' },
               },
@@ -326,7 +326,7 @@ describe('HttpMCPTransport', () => {
               jsonrpc: '2.0',
               id: message.id,
               result: {
-                protocolVersion: LATEST_PROTOCOL_VERSION,
+                protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                 capabilities: { tools: {} },
                 serverInfo: { name: 'test-server', version: '1.0.0' },
               },
@@ -1029,7 +1029,7 @@ describe('HttpMCPTransport', () => {
             jsonrpc: '2.0',
             id: 0,
             result: {
-              protocolVersion: LATEST_PROTOCOL_VERSION,
+              protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
               capabilities: {},
               serverInfo: { name: 'test-server', version: '1.0.0' },
             },

--- a/packages/mcp/src/tool/mcp-http-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.test.ts
@@ -37,6 +37,15 @@ function createAbortableSseResponse({
   );
 }
 
+function createLegacyHttpTransport(
+  options: ConstructorParameters<typeof HttpMCPTransport>[0],
+): HttpMCPTransport {
+  return new HttpMCPTransport({
+    initialProtocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
+    ...options,
+  });
+}
+
 describe('HttpMCPTransport', () => {
   const server = createTestServer({
     'http://localhost:4000/mcp': {
@@ -53,7 +62,9 @@ describe('HttpMCPTransport', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
-    transport = new HttpMCPTransport({ url: 'http://localhost:4000/mcp' });
+    transport = createLegacyHttpTransport({
+      url: 'http://localhost:4000/mcp',
+    });
   });
 
   afterEach(() => {
@@ -88,7 +99,9 @@ describe('HttpMCPTransport', () => {
   });
 
   it('should handle text/event-stream responses', async () => {
-    transport = new HttpMCPTransport({ url: 'http://localhost:4000/stream' });
+    transport = createLegacyHttpTransport({
+      url: 'http://localhost:4000/stream',
+    });
     const controller = new TestResponseController();
 
     // Avoid locking a single ReadableStream for both GET (start) and POST (send)
@@ -155,6 +168,7 @@ describe('HttpMCPTransport', () => {
     };
 
     const clientPromise = createMCPClient({
+      protocolVersionDiscovery: false,
       transport: {
         type: 'http',
         url: 'http://localhost:4000/stream',
@@ -203,6 +217,7 @@ describe('HttpMCPTransport', () => {
       },
     );
     const clientPromise = createMCPClient({
+      protocolVersionDiscovery: false,
       transport: {
         type: 'http',
         url: 'http://localhost:4000/mcp',
@@ -271,6 +286,7 @@ describe('HttpMCPTransport', () => {
       },
     );
     const clientPromise = createMCPClient({
+      protocolVersionDiscovery: false,
       transport: {
         type: 'http',
         url: 'http://localhost:4000/mcp',
@@ -330,6 +346,7 @@ describe('HttpMCPTransport', () => {
         },
       );
       const client = await createMCPClient({
+        protocolVersionDiscovery: false,
         transport: {
           type: 'http',
           url: 'http://localhost:4000/mcp',
@@ -1060,6 +1077,7 @@ describe('HttpMCPTransport', () => {
     );
 
     const clientPromise = createMCPClient({
+      protocolVersionDiscovery: false,
       transport: {
         type: 'http',
         url: 'http://localhost:4000/mcp',

--- a/packages/mcp/src/tool/mcp-http-transport.ts
+++ b/packages/mcp/src/tool/mcp-http-transport.ts
@@ -10,7 +10,7 @@ import {
   validateJSONRPCMessage,
   type JSONRPCMessage,
 } from './json-rpc-message';
-import type { MCPTransport } from './mcp-transport';
+import type { MCPTransport, MCPTransportSendOptions } from './mcp-transport';
 import { VERSION } from '../version';
 import {
   extractWWWAuthenticateParams,
@@ -19,7 +19,11 @@ import {
   type AuthResult,
   type OAuthClientProvider,
 } from './oauth';
-import { LATEST_LEGACY_PROTOCOL_VERSION } from './types';
+import {
+  LATEST_LEGACY_PROTOCOL_VERSION,
+  LATEST_PROTOCOL_VERSION,
+} from './types';
+import { encodeMCPHeaderValue } from './mcp-http-headers';
 
 function isMessageEvent(event: string | undefined): boolean {
   return event === undefined || event === 'message';
@@ -33,6 +37,8 @@ function isMessageEvent(event: string | undefined): boolean {
  * for receiving messages.
  */
 export class HttpMCPTransport implements MCPTransport {
+  readonly supportsProtocolVersionDiscovery = true;
+  readonly supportsMcpToolParameterHeaders = true;
   private url: URL;
   private abortController?: AbortController;
   private headers?: Record<string, string>;
@@ -90,7 +96,8 @@ export class HttpMCPTransport implements MCPTransport {
     this.authProvider = authProvider;
     this.redirectMode = redirect;
     this.sessionId = initialSessionId;
-    this.protocolVersion = initialProtocolVersion;
+    this.protocolVersion =
+      initialProtocolVersion ?? LATEST_LEGACY_PROTOCOL_VERSION;
     this.onSessionIdChange = onSessionIdChange;
     this.onSessionExpired = onSessionExpired;
     this.terminateSessionOnClose = terminateSessionOnClose;
@@ -99,6 +106,27 @@ export class HttpMCPTransport implements MCPTransport {
 
   setProtocolVersion(version: string): void {
     this.protocolVersion = version;
+
+    if (!this.abortController) {
+      return;
+    }
+
+    if (this.isModernProtocol()) {
+      this.inboundSseConnection?.close();
+      this.inboundSseConnection = undefined;
+      return;
+    }
+
+    if (!this.inboundSseConnection) {
+      this.startInboundSse();
+    }
+  }
+
+  private isModernProtocol(): boolean {
+    return (
+      (this.protocolVersion ?? LATEST_PROTOCOL_VERSION) ===
+      LATEST_PROTOCOL_VERSION
+    );
   }
 
   private async commonHeaders({
@@ -115,7 +143,7 @@ export class HttpMCPTransport implements MCPTransport {
         this.protocolVersion ?? LATEST_LEGACY_PROTOCOL_VERSION,
     };
 
-    if (includeSessionId && this.sessionId) {
+    if (!this.isModernProtocol() && includeSessionId && this.sessionId) {
       headers['mcp-session-id'] = this.sessionId;
     }
 
@@ -143,6 +171,10 @@ export class HttpMCPTransport implements MCPTransport {
   }
 
   private applySessionIdFromResponse(response: Response): void {
+    if (this.isModernProtocol()) {
+      return;
+    }
+
     const sessionId = response.headers.get('mcp-session-id');
     if (sessionId) {
       this.setSessionId(sessionId);
@@ -191,7 +223,12 @@ export class HttpMCPTransport implements MCPTransport {
     }
     this.abortController = new AbortController();
 
-    this.startInboundSse();
+    if (
+      this.protocolVersion != null &&
+      this.protocolVersion !== LATEST_PROTOCOL_VERSION
+    ) {
+      this.startInboundSse();
+    }
   }
 
   async close(options?: { signal?: AbortSignal }): Promise<void> {
@@ -200,6 +237,7 @@ export class HttpMCPTransport implements MCPTransport {
 
     try {
       if (
+        !this.isModernProtocol() &&
         this.sessionId &&
         this.terminateSessionOnClose &&
         this.abortController
@@ -221,7 +259,7 @@ export class HttpMCPTransport implements MCPTransport {
 
   async send(
     message: JSONRPCMessage,
-    options?: { signal?: AbortSignal },
+    options?: MCPTransportSendOptions,
   ): Promise<void> {
     options?.signal?.throwIfAborted();
 
@@ -244,6 +282,12 @@ export class HttpMCPTransport implements MCPTransport {
           base: {
             'Content-Type': 'application/json',
             Accept: 'application/json, text/event-stream',
+            ...(this.isModernProtocol() ? options?.headers : {}),
+            ...(this.isModernProtocol() &&
+            'method' in message &&
+            'id' in message
+              ? this.getStandardRequestHeaders(message)
+              : {}),
           },
           includeSessionId: !isInitializeRequest,
         });
@@ -284,7 +328,7 @@ export class HttpMCPTransport implements MCPTransport {
         if (response.status === 202) {
           // If inbound SSE was not available earlier (e.g. 405 before init), try again now
           // Do not await to avoid blocking send()
-          if (!this.inboundSseConnection) {
+          if (!this.isModernProtocol() && !this.inboundSseConnection) {
             this.startInboundSse();
           }
           return;
@@ -292,15 +336,30 @@ export class HttpMCPTransport implements MCPTransport {
 
         if (!response.ok) {
           const text = await response.text().catch(() => null);
+
+          if ('id' in message && text != null) {
+            const jsonRpcMessage = await parseJSONRPCMessage(text).catch(
+              () => undefined,
+            );
+            if (jsonRpcMessage != null && 'error' in jsonRpcMessage) {
+              this.onmessage?.(
+                jsonRpcMessage.id == null
+                  ? { ...jsonRpcMessage, id: message.id }
+                  : jsonRpcMessage,
+              );
+              return;
+            }
+          }
+
           let errorMessage = `MCP HTTP Transport Error: POSTing to endpoint (HTTP ${response.status}): ${text}`;
 
           if (response.status === 404) {
-            if (sessionIdForRequest) {
+            if (!this.isModernProtocol() && sessionIdForRequest) {
               this.expireSessionId(sessionIdForRequest);
 
               errorMessage +=
                 '. The MCP session expired. Create a new client without `initialSessionId` to start a fresh session';
-            } else {
+            } else if (!this.isModernProtocol()) {
               errorMessage +=
                 '. This server does not support HTTP transport. Try using `sse` transport instead';
             }
@@ -414,6 +473,27 @@ export class HttpMCPTransport implements MCPTransport {
     await attempt();
   }
 
+  private getStandardRequestHeaders(
+    message: Extract<JSONRPCMessage, { method: string; id: unknown }>,
+  ): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Mcp-Method': message.method,
+    };
+    const params = message.params;
+    const name =
+      message.method === 'resources/read'
+        ? params?.uri
+        : message.method === 'tools/call' || message.method === 'prompts/get'
+          ? params?.name
+          : undefined;
+
+    if (typeof name === 'string') {
+      headers['Mcp-Name'] = encodeMCPHeaderValue(name);
+    }
+
+    return headers;
+  }
+
   private getNextReconnectionDelay(attempt: number): number {
     const {
       initialReconnectionDelay,
@@ -449,6 +529,10 @@ export class HttpMCPTransport implements MCPTransport {
     triedAuth: boolean = false,
     resumeToken?: string,
   ): void {
+    if (this.isModernProtocol()) {
+      return;
+    }
+
     void this.openInboundSse(triedAuth, resumeToken).catch(error => {
       if (error instanceof Error && error.name === 'AbortError') {
         return;
@@ -462,6 +546,10 @@ export class HttpMCPTransport implements MCPTransport {
     triedAuth: boolean = false,
     resumeToken?: string,
   ): Promise<void> {
+    if (this.isModernProtocol()) {
+      return;
+    }
+
     try {
       const sessionIdForRequest = this.sessionId;
       const headers = await this.commonHeaders({

--- a/packages/mcp/src/tool/mcp-transport.ts
+++ b/packages/mcp/src/tool/mcp-transport.ts
@@ -4,6 +4,7 @@ import type { JSONRPCMessage } from './json-rpc-message';
 import { SseMCPTransport } from './mcp-sse-transport';
 import { HttpMCPTransport } from './mcp-http-transport';
 import type { OAuthClientProvider } from './oauth';
+import { LATEST_PROTOCOL_VERSION } from './types';
 
 /**
  * Transport interface for MCP (Model Context Protocol) communication.
@@ -14,6 +15,11 @@ export type MCPTransportSendOptions = {
    * Cancels the transport operation for this message.
    */
   signal?: AbortSignal;
+
+  /**
+   * Request-specific HTTP headers produced from MCP tool parameters.
+   */
+  headers?: Record<string, string>;
 
   /**
    * Associates an outgoing message with an incoming request.
@@ -46,6 +52,12 @@ export interface MCPTransport {
    * explicitly opt in.
    */
   supportsProtocolVersionDiscovery?: boolean;
+
+  /**
+   * Whether this transport mirrors x-mcp-header tool parameters into request
+   * headers.
+   */
+  supportsMcpToolParameterHeaders?: boolean;
 
   /**
    * Initialize and start the transport
@@ -169,7 +181,11 @@ export function createMcpTransport(config: MCPTransportConfig): MCPTransport {
     case 'sse':
       return new SseMCPTransport(config);
     case 'http':
-      return new HttpMCPTransport(config);
+      return new HttpMCPTransport({
+        ...config,
+        initialProtocolVersion:
+          config.initialProtocolVersion ?? LATEST_PROTOCOL_VERSION,
+      });
     default:
       throw new MCPClientError({
         message:

--- a/packages/mcp/src/tool/types.ts
+++ b/packages/mcp/src/tool/types.ts
@@ -167,12 +167,10 @@ const ToolSchema = z
      */
     title: z.optional(z.string()),
     description: z.optional(z.string()),
-    inputSchema: z
-      .object({
-        type: z.literal('object'),
-        properties: z.optional(z.object({}).loose()),
-      })
-      .loose(),
+    inputSchema: z.looseObject({
+      type: z.optional(z.unknown()),
+      properties: z.optional(z.object({}).loose()),
+    }),
     /**
      * @see https://modelcontextprotocol.io/specification/2025-06-18/server/tools#output-schema
      */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,25 +84,25 @@ importers:
         version: 3.23.0
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(af581e8afd790b67a7f80ff71718b0a9)
+        version: 2.0.1(a795ef4e3094b1797a50ed740fa12e5b)
       '@vercel/geistdocs':
         specifier: 1.20.1
-        version: 1.20.1(9e4e81e7aea49938da78f0bd382e3a11)
+        version: 1.20.1(2a608f05c441b61ae256496ca918ec3b)
       fumadocs-core:
         specifier: 16.2.2
-        version: 16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       fumadocs-mdx:
         specifier: 14.0.4
-        version: 14.0.4(fumadocs-core@16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react@19.2.6)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))
+        version: 14.0.4(fumadocs-core@16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react@19.2.6)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))
       fumadocs-ui:
         specifier: 16.2.2
-        version: 16.2.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)
+        version: 16.2.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)
       lucide-react:
         specifier: ^0.555.0
         version: 0.555.0(react@19.2.6)
       next:
         specifier: 16.2.12
-        version: 16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
+        version: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
       react:
         specifier: ^19.2.3
         version: 19.2.6
@@ -910,9 +910,15 @@ importers:
       '@ai-sdk/openai':
         specifier: workspace:*
         version: link:../../packages/openai
+      '@modelcontextprotocol/node':
+        specifier: ^2.0.0
+        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.1)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/server':
+        specifier: ^2.0.0
+        version: 2.0.0
       ai:
         specifier: workspace:*
         version: link:../../packages/ai
@@ -1725,7 +1731,7 @@ importers:
         version: 5.55.7
       svelte-check:
         specifier: ^4.4.8
-        version: 4.4.8(picomatch@4.0.4)(svelte@5.55.7)(typescript@5.9.3)
+        version: 4.4.8(picomatch@4.0.5)(svelte@5.55.7)(typescript@5.9.3)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -3074,13 +3080,13 @@ importers:
         version: link:../provider-utils
       '@earendil-works/pi-ai':
         specifier: 0.74.2
-        version: 0.74.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(@opentelemetry/api@1.9.1)(ws@8.21.3)(zod@3.25.76)
+        version: 0.74.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(@opentelemetry/api@1.9.0)(ws@8.21.3)(zod@3.25.76)
       '@earendil-works/pi-coding-agent':
         specifier: ^0.80.10
         version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.21.3)(zod@3.25.76)
       pi-mcp-adapter:
         specifier: 2.12.1
-        version: 2.12.1(@cfworker/json-schema@4.1.1)(@earendil-works/pi-ai@0.74.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(@opentelemetry/api@1.9.1)(ws@8.21.3)(zod@3.25.76))(@earendil-works/pi-tui@0.80.10)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typebox@1.2.2)(zod@3.25.76)
+        version: 2.12.1(@cfworker/json-schema@4.1.1)(@earendil-works/pi-ai@0.74.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(@opentelemetry/api@1.9.0)(ws@8.21.3)(zod@3.25.76))(@earendil-works/pi-tui@0.80.10)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typebox@1.2.2)(zod@3.25.76)
       typebox:
         specifier: ^1.1.38
         version: 1.2.2
@@ -7359,12 +7365,6 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@hono/node-server@2.1.0':
-    resolution: {integrity: sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      hono: ^4
-
   '@hono/node-ws@1.3.1':
     resolution: {integrity: sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA==}
     engines: {node: '>=18.14.1'}
@@ -8749,6 +8749,10 @@ packages:
     resolution: {integrity: sha512-YuuNm5f2TMoFQRje1UqVP8TJRjijCXMz4ckvoVpx1cUXuBEmykWQ2d8R536pek6UKcXT41T5nWc4qR1JFIbEmg==}
     engines: {node: '>=20'}
 
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
   '@modelcontextprotocol/core@2.0.0-beta.5':
     resolution: {integrity: sha512-HKbY9XTbsDy1Y6r2I55TGE3JEapM0vg96e1MUmBIF9LGjos5gjhcIrTz1yvBPLg2aFKHjwhUAQfRdrCEnPxNew==}
     engines: {node: '>=20'}
@@ -8765,6 +8769,16 @@ packages:
       react:
         optional: true
       react-dom:
+        optional: true
+
+  '@modelcontextprotocol/node@2.0.0':
+    resolution: {integrity: sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/server': ^2.0.0
+      hono: ^4.11.4
+    peerDependenciesMeta:
+      hono:
         optional: true
 
   '@modelcontextprotocol/sdk@1.26.0':
@@ -8796,6 +8810,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@mongodb-js/zstd@7.0.0':
     resolution: {integrity: sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA==}
@@ -27788,12 +27806,12 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.74.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(@opentelemetry/api@1.9.1)(ws@8.21.3)(zod@3.25.76)':
+  '@earendil-works/pi-ai@0.74.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(@opentelemetry/api@1.9.0)(ws@8.21.3)(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))
-      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.1)
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       openai: 6.26.0(ws@8.21.3)(zod@3.25.76)
@@ -28589,7 +28607,7 @@ snapshots:
     dependencies:
       hono: 4.12.25
 
-  '@hono/node-server@2.1.0(hono@4.13.1)':
+  '@hono/node-server@1.19.13(hono@4.13.1)':
     dependencies:
       hono: 4.13.1
 
@@ -28602,10 +28620,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@hono/zod-validator@0.7.6(hono@4.12.25)(zod@3.25.76)':
+  '@hono/zod-validator@0.7.6(hono@4.12.25)(zod@4.4.3)':
     dependencies:
       hono: 4.12.25
-      zod: 3.25.76
+      zod: 4.4.3
 
   '@iarna/toml@3.0.0': {}
 
@@ -29932,7 +29950,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@hono/node-server': 1.19.13(hono@4.12.25)
       '@hono/node-ws': 1.3.1(@hono/node-server@1.19.13(hono@4.12.25))(hono@4.12.25)
-      '@hono/zod-validator': 0.7.6(hono@4.12.25)(zod@3.25.76)
+      '@hono/zod-validator': 0.7.6(hono@4.12.25)(zod@4.4.3)
       '@langchain/core': 1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.21.3)(zod@3.25.76))(ws@8.21.3)
       '@langchain/langgraph': 1.4.8(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.21.3)(zod@3.25.76))(ws@8.21.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(svelte@5.55.7)(vue@3.5.38(typescript@5.8.3))(zod@3.25.76)
       '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.21.3)(zod@3.25.76))(ws@8.21.3))
@@ -29954,7 +29972,7 @@ snapshots:
       uuid: 10.0.0
       winston: 3.19.0
       winston-console-format: 1.0.8
-      zod: 3.25.76
+      zod: 4.4.3
     optionalDependencies:
       '@langchain/langgraph-sdk': 1.9.27(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.21.3)(zod@3.25.76))(ws@8.21.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(svelte@5.55.7)(vue@3.5.38(typescript@5.8.3))
     transitivePeerDependencies:
@@ -30071,7 +30089,7 @@ snapshots:
       commander: 13.1.0
       esbuild: 0.25.12
       esbuild-plugin-tailwindcss: 2.2.0
-      zod: 3.25.76
+      zod: 4.4.3
 
   '@langchain/langgraph@1.3.0(@langchain/core@1.1.46(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.21.3)(zod@4.4.3))(ws@8.21.3))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.38.0(ws@8.21.3)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.55.7)(vue@3.5.38(typescript@5.8.3))(ws@8.21.3)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
     dependencies:
@@ -30326,22 +30344,10 @@ snapshots:
     dependencies:
       '@opentelemetry/semantic-conventions': 1.43.0
       ws: 8.21.0
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/semantic-conventions': 1.43.0
-      ws: 8.21.0
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -30358,6 +30364,10 @@ snapshots:
       pkce-challenge: 5.0.1
       zod: 4.4.3
 
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.4.3
+
   '@modelcontextprotocol/core@2.0.0-beta.5':
     dependencies:
       zod: 4.4.3
@@ -30370,6 +30380,13 @@ snapshots:
     optionalDependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+
+  '@modelcontextprotocol/node@2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.1)':
+    dependencies:
+      '@hono/node-server': 1.19.13(hono@4.13.1)
+      '@modelcontextprotocol/server': 2.0.0
+    optionalDependencies:
+      hono: 4.13.1
 
   '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.1.13)':
     dependencies:
@@ -30445,7 +30462,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.1.0(hono@4.13.1)
+      '@hono/node-server': 1.19.13(hono@4.13.1)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -30469,7 +30486,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.1.0(hono@4.13.1)
+      '@hono/node-server': 1.19.13(hono@4.13.1)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -30490,6 +30507,11 @@ snapshots:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.4.3
 
   '@mongodb-js/zstd@7.0.0':
     dependencies:
@@ -36465,17 +36487,17 @@ snapshots:
     dependencies:
       valibot: 1.4.0(typescript@5.8.3)
 
-  '@vercel/agent-readability@0.5.0(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.7)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)))(svelte@5.55.7)(typescript@5.9.3)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)))(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.73)(ws@8.21.3))(h3@1.15.11)(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))':
+  '@vercel/agent-readability@0.5.0(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.7)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)))(svelte@5.55.7)(typescript@5.9.3)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)))(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.73)(ws@8.21.3))(h3@1.15.11)(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))':
     optionalDependencies:
       '@sveltejs/kit': 2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.7)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)))(svelte@5.55.7)(typescript@5.9.3)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))
       '@vercel/functions': 3.7.5(@aws-sdk/credential-provider-web-identity@3.972.73)(ws@8.21.3)
       h3: 1.15.11
-      next: 16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
 
-  '@vercel/analytics@2.0.1(af581e8afd790b67a7f80ff71718b0a9)':
+  '@vercel/analytics@2.0.1(a795ef4e3094b1797a50ed740fa12e5b)':
     optionalDependencies:
       '@sveltejs/kit': 2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.7)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)))(svelte@5.55.7)(typescript@5.9.3)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))
-      next: 16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
       nuxt: 3.21.7(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@upstash/redis@1.38.0)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.73)(ws@8.21.3))(@vue/compiler-sfc@3.5.38)(aws4fetch@1.0.20)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(ioredis@5.11.1)(less@4.4.0)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(oxlint@1.56.0)(rollup-plugin-visualizer@7.0.1(rollup@4.62.4))(rollup@4.62.4)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(typescript@5.9.3)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))(yaml@2.9.0)
       react: 19.2.6
       svelte: 5.55.7
@@ -36534,7 +36556,7 @@ snapshots:
       ws: 8.21.3
     optional: true
 
-  '@vercel/geistdocs@1.20.1(9e4e81e7aea49938da78f0bd382e3a11)':
+  '@vercel/geistdocs@1.20.1(2a608f05c441b61ae256496ca918ec3b)':
     dependencies:
       '@ai-sdk/react': 3.0.223(react@19.2.6)(zod@4.4.3)
       '@clack/prompts': 0.11.0
@@ -36542,7 +36564,7 @@ snapshots:
       '@orama/tokenizers': 3.1.18
       '@streamdown/cjk': 1.0.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(react@19.2.6)(unified@11.0.5)
       '@streamdown/code': 1.1.1(react@19.2.6)
-      '@vercel/agent-readability': 0.5.0(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.7)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)))(svelte@5.55.7)(typescript@5.9.3)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)))(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.73)(ws@8.21.3))(h3@1.15.11)(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))
+      '@vercel/agent-readability': 0.5.0(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.7)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)))(svelte@5.55.7)(typescript@5.9.3)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)))(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.73)(ws@8.21.3))(h3@1.15.11)(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))
       '@vercel/oidc': 3.8.0
       ai: 6.0.221(zod@4.4.3)
       class-variance-authority: 0.7.1
@@ -36550,14 +36572,14 @@ snapshots:
       commander: 14.0.3
       dexie: 4.4.4
       dexie-react-hooks: 4.4.0(dexie@4.4.4)(react@19.2.6)
-      fumadocs-core: 16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      fumadocs-mdx: 14.0.4(fumadocs-core@16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react@19.2.6)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))
-      fumadocs-ui: 16.2.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)
+      fumadocs-core: 16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      fumadocs-mdx: 14.0.4(fumadocs-core@16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react@19.2.6)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0))
+      fumadocs-ui: 16.2.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)
       glob: 11.1.0
       lucide-react: 0.555.0(react@19.2.6)
       mermaid: 11.15.0
       motion: 12.42.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      next: 16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
       next-themes: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       radix-ui: 1.6.4(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -37635,7 +37657,7 @@ snapshots:
       semver: 7.7.4
       watchpack: 2.5.1
     optionalDependencies:
-      next: 16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -37650,7 +37672,7 @@ snapshots:
       semver: 7.7.4
       watchpack: 2.5.1
     optionalDependencies:
-      next: 16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -41222,7 +41244,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  fumadocs-core@16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@orama/orama': 3.1.18
@@ -41246,20 +41268,20 @@ snapshots:
       '@types/react': 18.3.28
       algoliasearch: 5.35.0
       lucide-react: 0.555.0(react@19.2.6)
-      next: 16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.0.4(fumadocs-core@16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react@19.2.6)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)):
+  fumadocs-mdx@14.0.4(fumadocs-core@16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react@19.2.6)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.7
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      fumadocs-core: 16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       js-yaml: 4.2.0
       lru-cache: 11.5.1
       mdast-util-to-markdown: 2.1.2
@@ -41274,13 +41296,13 @@ snapshots:
       vfile: 6.0.3
       zod: 4.4.3
     optionalDependencies:
-      next: 16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
       react: 19.2.6
       vite: 7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.48.0)(tsx@4.22.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.2.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0):
+  fumadocs-ui@16.2.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0):
     dependencies:
       '@radix-ui/react-accordion': 1.2.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -41293,7 +41315,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@18.3.28)(react@19.2.6)
       '@radix-ui/react-tabs': 1.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      fumadocs-core: 16.2.2(@types/react@18.3.28)(algoliasearch@5.35.0)(lucide-react@0.555.0(react@19.2.6))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       lodash.merge: 4.6.2
       next-themes: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       postcss-selector-parser: 7.1.4
@@ -41304,7 +41326,7 @@ snapshots:
       tailwind-merge: 3.6.0
     optionalDependencies:
       '@types/react': 18.3.28
-      next: 16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0)
       tailwindcss: 4.3.0
     transitivePeerDependencies:
       - '@mixedbread/sdk'
@@ -44757,7 +44779,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.12(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0):
+  next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0):
     dependencies:
       '@next/env': 16.2.12
       '@swc/helpers': 0.5.15
@@ -44766,7 +44788,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(react@19.2.6)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.6)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.12
       '@next/swc-darwin-x64': 16.2.12
@@ -45915,7 +45937,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  pi-mcp-adapter@2.12.1(@cfworker/json-schema@4.1.1)(@earendil-works/pi-ai@0.74.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(@opentelemetry/api@1.9.1)(ws@8.21.3)(zod@3.25.76))(@earendil-works/pi-tui@0.80.10)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typebox@1.2.2)(zod@3.25.76):
+  pi-mcp-adapter@2.12.1(@cfworker/json-schema@4.1.1)(@earendil-works/pi-ai@0.74.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(@opentelemetry/api@1.9.0)(ws@8.21.3)(zod@3.25.76))(@earendil-works/pi-tui@0.80.10)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typebox@1.2.2)(zod@3.25.76):
     dependencies:
       '@modelcontextprotocol/client': 2.0.0-beta.5
       '@modelcontextprotocol/ext-apps': 1.7.5(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@3.25.76)
@@ -45926,7 +45948,7 @@ snapshots:
       smol-toml: 1.6.1
       zod: 3.25.76
     optionalDependencies:
-      '@earendil-works/pi-ai': 0.74.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(@opentelemetry/api@1.9.1)(ws@8.21.3)(zod@3.25.76)
+      '@earendil-works/pi-ai': 0.74.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(@opentelemetry/api@1.9.0)(ws@8.21.3)(zod@3.25.76)
       '@earendil-works/pi-tui': 0.80.10
       typebox: 1.2.2
     transitivePeerDependencies:
@@ -48204,6 +48226,13 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.7
 
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.6):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.6
+    optionalDependencies:
+      '@babel/core': 7.29.7
+
   styled-jsx@5.1.6(react@19.0.0-rc-cc1ec60d0d-20240607):
     dependencies:
       client-only: 0.0.1
@@ -48213,11 +48242,6 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 19.0.0-rc.1
-
-  styled-jsx@5.1.6(react@19.2.6):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.6
 
   stylehacks@7.0.11(postcss@8.5.26):
     dependencies:
@@ -48287,18 +48311,6 @@ snapshots:
       supports-color: 10.2.2
 
   supports-preserve-symlinks-flag@1.0.0: {}
-
-  svelte-check@4.4.8(picomatch@4.0.4)(svelte@5.55.7)(typescript@5.9.3):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      chokidar: 4.0.3
-      fdir: 6.5.0(picomatch@4.0.4)
-      picocolors: 1.1.1
-      sade: 1.8.1
-      svelte: 5.55.7
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - picomatch
 
   svelte-check@4.4.8(picomatch@4.0.5)(svelte@5.55.7)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Background

MCP 2026-07-28 removes protocol-level HTTP sessions and requires request metadata to be mirrored into headers. These changes let `@ai-sdk/mcp` communicate with modern servers while preserving compatibility with initialization-based servers.

Reference: https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http

## Summary

- Added Streamable HTTP behavior
- Added required HTTP headers: `Mcp-Method` `Mcp-Name`

## End-to-End Verification

verified by running the example in `examples/mcp/src/http-2026/client.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

towards #19005 