### PR TITLE
feat(mcp): harden oauth client registration according to latest protocol

### DIFF
--- a/.changeset/forty-singers-explode.md
+++ b/.changeset/forty-singers-explode.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+feat(mcp): harden oauth client registration according to latest protocol

--- a/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
+++ b/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
@@ -210,6 +210,32 @@ This hook is called before the SDK fetches authorization server metadata, so a
 rejected URL is not requested. It is optional and does not change existing OAuth
 flows unless you implement it.
 
+### OAuth Callback Issuer Validation
+
+When completing an OAuth authorization callback, pass the callback's `iss`
+parameter to `auth` as `callbackIssuer`:
+
+```typescript
+import { auth } from '@ai-sdk/mcp';
+
+const callbackUrl = new URL(request.url);
+
+await auth(myOAuthClientProvider, {
+  serverUrl: 'https://mcp.example.com',
+  authorizationCode: callbackUrl.searchParams.get('code')!,
+  callbackState: callbackUrl.searchParams.get('state') ?? undefined,
+  callbackIssuer: callbackUrl.searchParams.get('iss') ?? undefined,
+});
+```
+
+When `iss` is present, it must exactly match the discovered authorization
+server issuer. The authorization code is not exchanged when it does not match.
+
+Dynamic client registration requests include an OAuth `application_type`. The
+client infers `native` for loopback, localhost, and custom-scheme redirects,
+and `web` for remote HTTP(S) redirects. You can override this by setting
+`application_type` in the provider's `clientMetadata`.
+
 ### Retrying Transient Tool Failures
 
 MCP tool calls can fail for transient transport reasons, such as rate limits,

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -917,11 +917,12 @@ class DefaultMCPClient implements MCPClient {
       resultSchema: ListToolsResultSchema,
       options,
     });
-    return this.prepareToolDefinitions(result);
+    return this.prepareToolDefinitions(result, params?.cursor == null);
   }
 
   private prepareToolDefinitions(
     definitions: ListToolsResult,
+    resetHeaderBindings = false,
   ): ListToolsResult {
     if (
       this.protocolEra !== 'modern' ||
@@ -930,7 +931,9 @@ class DefaultMCPClient implements MCPClient {
       return definitions;
     }
 
-    this.toolHeaderBindings.clear();
+    if (resetHeaderBindings) {
+      this.toolHeaderBindings.clear();
+    }
     const tools = definitions.tools.filter(toolDefinition => {
       const result = getMCPToolHeaderBindings(toolDefinition.inputSchema);
       if (!result.success) {

--- a/packages/mcp/src/tool/oauth-types.ts
+++ b/packages/mcp/src/tool/oauth-types.ts
@@ -39,6 +39,7 @@ export const OAuthTokensSchema = z
     expires_in: z.number().optional(),
     scope: z.string().optional(),
     refresh_token: z.string().optional(),
+    issuer: SafeUrlSchema.optional(),
     authorization_server: SafeUrlSchema.optional(),
     token_endpoint: SafeUrlSchema.optional(),
   })
@@ -66,6 +67,8 @@ export const OAuthMetadataSchema = z.looseObject({
   authorization_endpoint: SafeUrlSchema,
   token_endpoint: SafeUrlSchema,
   registration_endpoint: SafeUrlSchema.optional(),
+  authorization_response_iss_parameter_supported: z.boolean().optional(),
+  client_id_metadata_document_supported: z.boolean().optional(),
   scopes_supported: z.array(z.string()).optional(),
   response_types_supported: z.array(z.string()),
   grant_types_supported: z.array(z.string()).optional(),
@@ -87,6 +90,8 @@ export const OpenIdProviderMetadataSchema = z.looseObject({
   userinfo_endpoint: SafeUrlSchema.optional(),
   jwks_uri: SafeUrlSchema,
   registration_endpoint: SafeUrlSchema.optional(),
+  authorization_response_iss_parameter_supported: z.boolean().optional(),
+  client_id_metadata_document_supported: z.boolean().optional(),
   scopes_supported: z.array(z.string()).optional(),
   response_types_supported: z.array(z.string()),
   grant_types_supported: z.array(z.string()).optional(),
@@ -114,6 +119,7 @@ export const OAuthClientInformationSchema = z
     client_secret: z.string().optional(),
     client_id_issued_at: z.number().optional(),
     client_secret_expires_at: z.number().optional(),
+    issuer: SafeUrlSchema.optional(),
     authorization_server: SafeUrlSchema.optional(),
     token_endpoint: SafeUrlSchema.optional(),
   })
@@ -122,6 +128,9 @@ export const OAuthClientInformationSchema = z
 export const OAuthClientMetadataSchema = z
   .object({
     redirect_uris: z.array(SafeUrlSchema),
+    application_type: z
+      .union([z.literal('native'), z.literal('web')])
+      .optional(),
     token_endpoint_auth_method: z.string().optional(),
     grant_types: z.array(z.string()).optional(),
     response_types: z.array(z.string()).optional(),

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -1512,9 +1512,50 @@ describe('registerClient', () => {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(validClientMetadata),
+        body: JSON.stringify({
+          ...validClientMetadata,
+          application_type: 'native',
+        }),
       }),
     );
+  });
+
+  it('infers web application type for remote redirect URIs', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => validClientInfo,
+    });
+
+    await registerClient('https://auth.example.com', {
+      clientMetadata: {
+        ...validClientMetadata,
+        redirect_uris: ['https://app.example.com/oauth/callback'],
+      },
+    });
+
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toMatchObject({
+      application_type: 'web',
+    });
+  });
+
+  it('preserves an explicit application type', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => validClientInfo,
+    });
+
+    await registerClient('https://auth.example.com', {
+      clientMetadata: {
+        ...validClientMetadata,
+        application_type: 'web',
+      },
+    });
+
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toMatchObject({
+      application_type: 'web',
+    });
   });
 
   it('validates client information response schema', async () => {
@@ -1592,6 +1633,59 @@ describe('auth function', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
+
+  function setupAuthorizationCodeFlow() {
+    mockFetch.mockImplementation(url => {
+      const urlString = url.toString();
+
+      if (urlString.includes('/.well-known/oauth-protected-resource')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            resource: 'https://api.example.com/mcp-server',
+            authorization_servers: ['https://auth.example.com'],
+          }),
+        });
+      }
+
+      if (urlString.includes('/.well-known/oauth-authorization-server')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            issuer: 'https://auth.example.com',
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256'],
+          }),
+        });
+      }
+
+      if (urlString.includes('/token')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            access_token: 'access123',
+            token_type: 'Bearer',
+          }),
+        });
+      }
+
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+
+    (mockProvider.clientInformation as Mock).mockResolvedValue({
+      client_id: 'test-client',
+      client_secret: 'test-secret',
+      authorization_server: 'https://auth.example.com/',
+      token_endpoint: 'https://auth.example.com/token',
+    });
+    (mockProvider.codeVerifier as Mock).mockResolvedValue('test-verifier');
+    (mockProvider.saveTokens as Mock).mockResolvedValue(undefined);
+  }
 
   it('falls back to /.well-known/oauth-authorization-server when no protected-resource-metadata', async () => {
     // Setup: First call to protected resource metadata fails (404)
@@ -1871,6 +1965,34 @@ describe('auth function', () => {
     const body = tokenCall![1].body as URLSearchParams;
     expect(body.get('resource')).toBe('https://api.example.com/mcp-server');
     expect(body.get('code')).toBe('auth-code-123');
+  });
+
+  it('accepts a matching authorization response issuer', async () => {
+    setupAuthorizationCodeFlow();
+
+    await expect(
+      auth(mockProvider, {
+        serverUrl: 'https://api.example.com/mcp-server',
+        authorizationCode: 'auth-code-123',
+        callbackIssuer: 'https://auth.example.com',
+      }),
+    ).resolves.toBe('AUTHORIZED');
+  });
+
+  it('rejects a mismatched authorization response issuer before code exchange', async () => {
+    setupAuthorizationCodeFlow();
+
+    await expect(
+      auth(mockProvider, {
+        serverUrl: 'https://api.example.com/mcp-server',
+        authorizationCode: 'auth-code-123',
+        callbackIssuer: 'https://evil.example',
+      }),
+    ).rejects.toThrow(/does not match expected issuer/);
+
+    expect(
+      mockFetch.mock.calls.some(call => call[0].toString().includes('/token')),
+    ).toBe(false);
   });
 
   it('includes resource in token refresh', async () => {
@@ -2775,6 +2897,7 @@ describe('OAuth state validation', () => {
     expect(result).toBe('AUTHORIZED');
     expect(provider.saveTokens).toHaveBeenCalledWith({
       ...validTokens,
+      issuer: 'https://resource.example.com',
       authorization_server: 'https://resource.example.com/',
       token_endpoint: 'https://auth.example.com/token',
     });

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -31,6 +31,7 @@ import { parseJSON, type FetchFunction } from '@ai-sdk/provider-utils';
 export type AuthResult = 'AUTHORIZED' | 'REDIRECT';
 
 export interface OAuthAuthorizationServerInformation {
+  issuer?: string;
   authorizationServerUrl: string;
   tokenEndpoint: string;
 }
@@ -122,11 +123,26 @@ function normalizeUrl(url: string | URL): string {
   return new URL(url).href;
 }
 
+function validateAuthorizationResponseIssuer({
+  callbackIssuer,
+  expectedIssuer,
+}: {
+  callbackIssuer: string | undefined;
+  expectedIssuer: string;
+}): void {
+  if (callbackIssuer != null && callbackIssuer !== expectedIssuer) {
+    throw new MCPClientOAuthError({
+      message: `OAuth authorization response issuer ${callbackIssuer} does not match expected issuer ${expectedIssuer}`,
+    });
+  }
+}
+
 function createAuthorizationServerInformation(
   authorizationServerUrl: string | URL,
   metadata?: AuthorizationServerMetadata,
 ): OAuthAuthorizationServerInformation {
   return {
+    issuer: metadata?.issuer ?? String(authorizationServerUrl),
     authorizationServerUrl: normalizeUrl(authorizationServerUrl),
     tokenEndpoint: normalizeUrl(
       metadata?.token_endpoint
@@ -142,6 +158,7 @@ function addAuthorizationServerInformationToTokens(
 ): OAuthTokens {
   return {
     ...tokens,
+    issuer: authorizationServerInformation.issuer,
     authorization_server: authorizationServerInformation.authorizationServerUrl,
     token_endpoint: authorizationServerInformation.tokenEndpoint,
   };
@@ -155,12 +172,14 @@ function addAuthorizationServerInformationToClientInformation<
 ): CLIENT_INFORMATION {
   return {
     ...clientInformation,
+    issuer: authorizationServerInformation.issuer,
     authorization_server: authorizationServerInformation.authorizationServerUrl,
     token_endpoint: authorizationServerInformation.tokenEndpoint,
   };
 }
 
 function getAuthorizationServerInformationFromCredentials(credentials?: {
+  issuer?: string;
   authorization_server?: string;
   token_endpoint?: string;
 }): OAuthAuthorizationServerInformation | undefined {
@@ -169,6 +188,7 @@ function getAuthorizationServerInformationFromCredentials(credentials?: {
   }
 
   return {
+    issuer: credentials.issuer,
     authorizationServerUrl: normalizeUrl(credentials.authorization_server),
     tokenEndpoint: normalizeUrl(credentials.token_endpoint),
   };
@@ -193,6 +213,7 @@ async function getStoredAuthorizationServerInformation({
     await provider.authorizationServerInformation?.();
   if (providerAuthorizationServerInformation) {
     return {
+      issuer: providerAuthorizationServerInformation.issuer,
       authorizationServerUrl: normalizeUrl(
         providerAuthorizationServerInformation.authorizationServerUrl,
       ),
@@ -258,6 +279,10 @@ function assertAuthorizationServerInformationMatches({
   currentAuthorizationServerInformation: OAuthAuthorizationServerInformation;
 }): void {
   if (
+    (storedAuthorizationServerInformation.issuer != null &&
+      currentAuthorizationServerInformation.issuer != null &&
+      storedAuthorizationServerInformation.issuer !==
+        currentAuthorizationServerInformation.issuer) ||
     storedAuthorizationServerInformation.authorizationServerUrl !==
       currentAuthorizationServerInformation.authorizationServerUrl ||
     storedAuthorizationServerInformation.tokenEndpoint !==
@@ -1050,12 +1075,18 @@ export async function registerClient(
     registrationUrl = new URL('/register', authorizationServerUrl);
   }
 
+  const applicationType =
+    clientMetadata.application_type ??
+    inferOAuthApplicationType(clientMetadata.redirect_uris);
   const response = await (fetchFn ?? fetch)(registrationUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(clientMetadata),
+    body: JSON.stringify({
+      ...clientMetadata,
+      application_type: applicationType,
+    }),
   });
 
   if (!response.ok) {
@@ -1065,12 +1096,32 @@ export async function registerClient(
   return OAuthClientInformationFullSchema.parse(await response.json());
 }
 
+function inferOAuthApplicationType(redirectUris: string[]): 'native' | 'web' {
+  const isNativeRedirectUri = (redirectUri: string): boolean => {
+    const url = new URL(redirectUri);
+    return (
+      ((url.protocol === 'http:' || url.protocol === 'https:') &&
+        (url.hostname === 'localhost' ||
+          url.hostname.endsWith('.localhost') ||
+          url.hostname === '127.0.0.1' ||
+          url.hostname === '[::1]')) ||
+      (url.protocol !== 'http:' && url.protocol !== 'https:')
+    );
+  };
+
+  return redirectUris.every(isNativeRedirectUri) ? 'native' : 'web';
+}
+
 export async function auth(
   provider: OAuthClientProvider,
   options: {
     serverUrl: string | URL;
     authorizationCode?: string;
     callbackState?: string;
+    /**
+     * Value of the `iss` parameter from the authorization response.
+     */
+    callbackIssuer?: string;
     scope?: string;
     resourceMetadataUrl?: URL;
     fetchFn?: FetchFunction;
@@ -1131,6 +1182,7 @@ async function authInternal(
     serverUrl,
     authorizationCode,
     callbackState,
+    callbackIssuer,
     scope,
     resourceMetadataUrl,
     fetchFn,
@@ -1138,6 +1190,7 @@ async function authInternal(
     serverUrl: string | URL;
     authorizationCode?: string;
     callbackState?: string;
+    callbackIssuer?: string;
     scope?: string;
     resourceMetadataUrl?: URL;
     fetchFn?: FetchFunction;
@@ -1194,6 +1247,20 @@ async function authInternal(
 
   /** Load or register client credentials with the AS pin attached. */
   let clientInformation = await Promise.resolve(provider.clientInformation());
+  if (clientInformation?.issuer != null) {
+    const storedAuthorizationServerInformation =
+      await getStoredAuthorizationServerInformation({
+        provider,
+        clientInformation,
+      });
+    if (storedAuthorizationServerInformation) {
+      assertAuthorizationServerInformationMatches({
+        storedAuthorizationServerInformation,
+        currentAuthorizationServerInformation,
+      });
+    }
+  }
+
   if (!clientInformation) {
     if (authorizationCode !== undefined) {
       throw new Error(
@@ -1242,6 +1309,13 @@ async function authInternal(
           'Stored OAuth authorization server metadata is required when exchanging an authorization code',
       });
     }
+    validateAuthorizationResponseIssuer({
+      callbackIssuer,
+      expectedIssuer:
+        storedAuthorizationServerInformation.issuer ??
+        metadata?.issuer ??
+        String(authorizationServerUrl),
+    });
     assertAuthorizationServerInformationMatches({
       storedAuthorizationServerInformation,
       currentAuthorizationServerInformation,


### PR DESCRIPTION
## Background

MCP 2026-07-28 strengthens OAuth security and registration requirements:

- Authorization responses may include an RFC 9207 `iss` parameter, which clients must validate before exchanging the code
- Dynamic Client Registration must include an appropriate `application_type`
- Persisted credentials must be bound to the authorization server issuer that created them

## Summary

- Added `callbackIssuer` to `auth()`
- Validates a present callback `iss` before exchanging the authorization code
- Persists the canonical issuer with client credentials and tokens
- adds `application_type` to every dynamic registration request

## End-to-End Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #19005