### PR TITLE
fix(harness-claude-code): allow sandbox install script

### DIFF
--- a/.changeset/calm-hounds-build.md
+++ b/.changeset/calm-hounds-build.md
@@ -2,4 +2,4 @@
 '@ai-sdk/harness-claude-code': patch
 ---
 
-Allow Claude Code to bootstrap in sandboxes that require explicit dependency build approval.
+fix(harness-claude-code): allow bootstrap in sandboxes that require explicit dependency build approval

--- a/.changeset/calm-hounds-build.md
+++ b/.changeset/calm-hounds-build.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-claude-code': patch
+---
+
+Allow Claude Code to bootstrap in sandboxes that require explicit dependency build approval.

--- a/packages/harness-claude-code/package.json
+++ b/packages/harness-claude-code/package.json
@@ -21,7 +21,7 @@
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json && pnpm copy-bridge-assets",
     "build:watch": "pnpm clean && tsup --watch",
     "clean": "del-cli dist *.tsbuildinfo",
-    "copy-bridge-assets": "node -e \"import('node:fs/promises').then(async fs => { await fs.copyFile('src/bridge/package.json', 'dist/bridge/package.json'); await fs.copyFile('src/bridge/pnpm-lock.yaml', 'dist/bridge/pnpm-lock.yaml'); })\"",
+    "copy-bridge-assets": "node -e \"import('node:fs/promises').then(async fs => { await fs.copyFile('src/bridge/package.json', 'dist/bridge/package.json'); await fs.copyFile('src/bridge/pnpm-lock.yaml', 'dist/bridge/pnpm-lock.yaml'); await fs.copyFile('src/bridge/pnpm-workspace.yaml', 'dist/bridge/pnpm-workspace.yaml'); })\"",
     "type-check": "tsc --build",
     "test": "pnpm test:node",
     "test:watch": "vitest --config vitest.node.config.js",

--- a/packages/harness-claude-code/src/bridge/pnpm-workspace.yaml
+++ b/packages/harness-claude-code/src/bridge/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  '@anthropic-ai/claude-code@2.1.213': true

--- a/packages/harness-claude-code/src/claude-code-bootstrap.ts
+++ b/packages/harness-claude-code/src/claude-code-bootstrap.ts
@@ -20,9 +20,10 @@ let cachedBootstrap: HarnessV1Bootstrap | undefined;
 
 export async function getClaudeCodeBootstrap(): Promise<HarnessV1Bootstrap> {
   if (cachedBootstrap != null) return cachedBootstrap;
-  const [pkg, lock, bridge] = await Promise.all([
+  const [pkg, lock, workspace, bridge] = await Promise.all([
     readBridgeAsset('package.json'),
     readBridgeAsset('pnpm-lock.yaml'),
+    readBridgeAsset('pnpm-workspace.yaml'),
     readBridgeAsset('index.mjs'),
   ]);
   cachedBootstrap = {
@@ -31,6 +32,10 @@ export async function getClaudeCodeBootstrap(): Promise<HarnessV1Bootstrap> {
     files: [
       { path: `${CLAUDE_CODE_BOOTSTRAP_DIR}/package.json`, content: pkg },
       { path: `${CLAUDE_CODE_BOOTSTRAP_DIR}/pnpm-lock.yaml`, content: lock },
+      {
+        path: `${CLAUDE_CODE_BOOTSTRAP_DIR}/pnpm-workspace.yaml`,
+        content: workspace,
+      },
       { path: `${CLAUDE_CODE_BOOTSTRAP_DIR}/bridge.mjs`, content: bridge },
     ],
     commands: [
@@ -38,8 +43,7 @@ export async function getClaudeCodeBootstrap(): Promise<HarnessV1Bootstrap> {
         command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
       },
       {
-        command:
-          'if [ -f node_modules/@anthropic-ai/claude-code/install.cjs ]; then node node_modules/@anthropic-ai/claude-code/install.cjs; fi && ./node_modules/.bin/claude --version',
+        command: './node_modules/.bin/claude --version',
       },
     ],
   };

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -114,6 +114,8 @@ vi.mock('node:fs/promises', async importOriginal => {
       if (path.endsWith('/bridge/package.json')) return '{"name":"mock"}';
       if (path.endsWith('/bridge/pnpm-lock.yaml'))
         return 'lockfileVersion: "9.0"\n';
+      if (path.endsWith('/bridge/pnpm-workspace.yaml'))
+        return "allowBuilds:\n  '@anthropic-ai/claude-code@2.1.213': true\n";
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return (actual.readFile as any)(input, ...rest);
     }),
@@ -934,7 +936,7 @@ describe('createClaudeCode adapter', () => {
       expect(recipe.bootstrapDir).toBe('.harness-bootstrap/claude-code');
     });
 
-    it('includes bridge.mjs, package.json, and pnpm-lock.yaml under the bootstrap dir', async () => {
+    it('includes bridge and package-manager assets under the bootstrap dir', async () => {
       const harness = createClaudeCode();
       const recipe = await harness.getBootstrap!();
       const paths = recipe.files.map(f => f.path).sort();
@@ -942,22 +944,28 @@ describe('createClaudeCode adapter', () => {
         '.harness-bootstrap/claude-code/bridge.mjs',
         '.harness-bootstrap/claude-code/package.json',
         '.harness-bootstrap/claude-code/pnpm-lock.yaml',
+        '.harness-bootstrap/claude-code/pnpm-workspace.yaml',
       ]);
       for (const file of recipe.files) {
         expect(file.content.length).toBeGreaterThan(0);
       }
     });
 
-    it('declares pnpm install and claude post-install commands for the bootstrap cwd', async () => {
+    it('allows the pinned Claude Code build and verifies the installed CLI', async () => {
       const harness = createClaudeCode();
       const recipe = await harness.getBootstrap!();
       const commands = recipe.commands.map(c => c.command);
+      const workspace = recipe.files.find(file =>
+        file.path.endsWith('/pnpm-workspace.yaml'),
+      );
       expect(commands).toHaveLength(2);
       expect(commands[0]).toBe(
         'pnpm install --frozen-lockfile --store-dir .pnpm-store',
       );
-      expect(commands[1]).toContain('claude --version');
-      expect(commands[1]).not.toContain('cd ');
+      expect(commands[1]).toBe('./node_modules/.bin/claude --version');
+      expect(workspace?.content).toContain(
+        "'@anthropic-ai/claude-code@2.1.213': true",
+      );
     });
 
     it('caches the recipe across calls', async () => {


### PR DESCRIPTION
```yaml
allowBuilds:
  "@anthropic-ai/claude-code@2.1.213": true
```

## Root cause

- pnpm 11 enables strict dependency-build enforcement and rejects the unapproved Claude Code `postinstall`
- `pnpm install --frozen-lockfile` exits before the existing manual `install.cjs` command can run
- Claude Code sessions therefore fail during harness bootstrap, before model execution

## Changes

- ship an exact-version `allowBuilds` policy with the Claude Code bridge assets
- let pnpm run the reviewed lifecycle script during installation
- remove the redundant manual `install.cjs` bypass
- assert the bootstrap recipe includes the policy and verifies the installed CLI
- add a patch changeset for `@ai-sdk/harness-claude-code`

## Reproduction

- isolated bridge bootstrap completes with pnpm 11.1.3
- `@anthropic-ai/claude-code@2.1.213` postinstall runs successfully
- installed `claude --version` reports `2.1.213`