### PR TITLE
fix(ai): reject malformed retry delay headers

### DIFF
--- a/.changeset/fuzzy-owls-retry.md
+++ b/.changeset/fuzzy-owls-retry.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Reject partially numeric retry delay headers so malformed values fall back to exponential backoff.

--- a/packages/ai/src/util/retry-with-exponential-backoff.test.ts
+++ b/packages/ai/src/util/retry-with-exponential-backoff.test.ts
@@ -194,6 +194,42 @@ describe('retryWithExponentialBackoffRespectingRetryHeaders', () => {
     expect(result).toBe('success');
   });
 
+  it('should fall back to exponential backoff for partially numeric headers', async () => {
+    let attempt = 0;
+    const initialDelay = 2000;
+
+    const fn = vi.fn().mockImplementation(async () => {
+      attempt++;
+      if (attempt === 1) {
+        throw new APICallError({
+          message: 'Rate limited',
+          url: 'https://api.example.com',
+          requestBodyValues: {},
+          isRetryable: true,
+          data: undefined,
+          responseHeaders: {
+            'retry-after-ms': '100invalid',
+            'retry-after': '1invalid',
+          },
+        });
+      }
+      return 'success';
+    });
+
+    const promise = retryWithExponentialBackoffRespectingRetryHeaders({
+      initialDelayInMs: initialDelay,
+    })(fn);
+
+    await vi.advanceTimersByTimeAsync(initialDelay - 100);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    const result = await promise;
+    expect(result).toBe('success');
+  });
+
   describe('with mocked provider responses', () => {
     it('should handle Anthropic 429 response with retry-after-ms header', async () => {
       let attempt = 0;

--- a/packages/ai/src/util/retry-with-exponential-backoff.ts
+++ b/packages/ai/src/util/retry-with-exponential-backoff.ts
@@ -6,6 +6,13 @@ import {
 } from '@ai-sdk/provider-utils';
 import { RetryError } from './retry-error';
 
+function parseRetryDelay(value: string): number | undefined {
+  if (value.trim() === '') return undefined;
+
+  const delay = Number(value);
+  return Number.isFinite(delay) ? delay : undefined;
+}
+
 function getRetryDelayInMs({
   error,
   exponentialBackoffDelay,
@@ -26,8 +33,8 @@ function getRetryDelayInMs({
   // retry-ms is more precise than retry-after and used by e.g. OpenAI
   const retryAfterMs = headers['retry-after-ms'];
   if (retryAfterMs) {
-    const timeoutMs = parseFloat(retryAfterMs);
-    if (!Number.isNaN(timeoutMs)) {
+    const timeoutMs = parseRetryDelay(retryAfterMs);
+    if (timeoutMs !== undefined) {
       ms = timeoutMs;
     }
   }
@@ -35,8 +42,8 @@ function getRetryDelayInMs({
   // About the Retry-After header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
   const retryAfter = headers['retry-after'];
   if (retryAfter && ms === undefined) {
-    const timeoutSeconds = parseFloat(retryAfter);
-    if (!Number.isNaN(timeoutSeconds)) {
+    const timeoutSeconds = parseRetryDelay(retryAfter);
+    if (timeoutSeconds !== undefined) {
       ms = timeoutSeconds * 1000;
     } else {
       ms = Date.parse(retryAfter) - Date.now();


### PR DESCRIPTION
## Background

Provider retry-delay headers can be malformed. `parseFloat` accepts a numeric prefix, so values such as `100invalid` and `1invalid` currently trigger an early retry instead of falling back to the configured exponential backoff.

## Summary

- Parse retry-delay values only when the complete, non-empty value is a finite number.
- Preserve the existing HTTP-date fallback for `retry-after`.
- Add a regression test for partially numeric `retry-after-ms` and `retry-after` values.
- Add the required patch changeset for `ai`.

This change was prepared with OpenAI Codex assistance. The production path, focused diff, and verification results were reviewed locally.

## End-to-End Verification

Ran `generateText` with a model that first throws a retryable `APICallError` containing `retry-after-ms: 100invalid` and `retry-after: 1invalid`, then succeeds. The call retried after the configured two-second exponential delay (about 2017 ms), made two model calls, and returned `success`.

## Validation

- AI package Node tests: 152 files passed; 3,138 tests passed and 3 skipped
- AI package Edge tests: 151 files passed, 1 skipped; 3,137 tests passed and 4 skipped
- Full workspace type-check passed
- Full formatting and lint checks passed
- `ai` package build passed

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (not applicable; no public API change)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
