### PR TITLE
fix(amazon-bedrock): support `reasoningContent.redactedContent` from the Converse API

### DIFF
--- a/.changeset/olive-pugs-shave.md
+++ b/.changeset/olive-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix (provider/amazon-bedrock): support `reasoningContent.redactedContent` from the Converse API and replay it on subsequent turns

--- a/packages/amazon-bedrock/src/amazon-bedrock-api-types.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-api-types.ts
@@ -258,6 +258,12 @@ export interface AmazonBedrockRedactedReasoningContentBlock {
   };
 }
 
+export interface AmazonBedrockRedactedContentBlock {
+  reasoningContent: {
+    redactedContent: string;
+  };
+}
+
 export type AmazonBedrockContentBlock =
   | AmazonBedrockDocumentBlock
   | AmazonBedrockGuardrailConverseContentBlock
@@ -268,4 +274,5 @@ export type AmazonBedrockContentBlock =
   | AmazonBedrockToolUseBlock
   | AmazonBedrockReasoningContentBlock
   | AmazonBedrockRedactedReasoningContentBlock
+  | AmazonBedrockRedactedContentBlock
   | AmazonBedrockCachePoint;

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-event-stream.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-event-stream.test.ts
@@ -167,4 +167,191 @@ describe('AmazonBedrockChatLanguageModel doStream', () => {
       ]),
     );
   });
+
+  it('streams reasoning redacted as `redactedContent` for replay', async () => {
+    // `redactedContent` is a member of the ReasoningContentBlockDelta union in
+    // the Converse API. OpenAI models on Bedrock (e.g. `us.openai.gpt-5.6-luna`)
+    // stream their encrypted reasoning in this shape. Deltas are accumulated and
+    // attached once via `reasoning-end`, because the merged provider metadata of
+    // a reasoning part is last-write-wins.
+    const model = new AmazonBedrockChatLanguageModel('us.openai.gpt-5.6-luna', {
+      baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      headers: {},
+      fetch: async () =>
+        new Response(
+          createStream([
+            createEvent(
+              'contentBlockDelta',
+              JSON.stringify({
+                contentBlockIndex: 0,
+                delta: {
+                  reasoningContent: {
+                    redactedContent: 'encrypted-reasoning-',
+                  },
+                },
+              }),
+            ),
+            createEvent(
+              'contentBlockDelta',
+              JSON.stringify({
+                contentBlockIndex: 0,
+                delta: {
+                  reasoningContent: {
+                    redactedContent: 'payload',
+                  },
+                },
+              }),
+            ),
+            createEvent(
+              'contentBlockStop',
+              JSON.stringify({ contentBlockIndex: 0 }),
+            ),
+            createEvent(
+              'contentBlockDelta',
+              JSON.stringify({
+                contentBlockIndex: 1,
+                delta: { text: 'The answer is 42.' },
+              }),
+            ),
+            createEvent(
+              'contentBlockStop',
+              JSON.stringify({ contentBlockIndex: 1 }),
+            ),
+            createEvent(
+              'messageStop',
+              JSON.stringify({ stopReason: 'end_turn' }),
+            ),
+          ]),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/vnd.amazon.eventstream',
+            },
+          },
+        ),
+      generateId: () => 'test-id',
+    });
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const parts = await convertReadableStreamToArray(stream);
+
+    expect(parts.filter(part => part.type === 'error')).toStrictEqual([]);
+    expect(parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'reasoning-start',
+          id: '0',
+        }),
+        expect.objectContaining({
+          type: 'reasoning-end',
+          id: '0',
+          providerMetadata: {
+            amazonBedrock: {
+              redactedContent: 'encrypted-reasoning-payload',
+            },
+            bedrock: {
+              redactedContent: 'encrypted-reasoning-payload',
+            },
+          },
+        }),
+        expect.objectContaining({
+          type: 'text-delta',
+          delta: 'The answer is 42.',
+        }),
+      ]),
+    );
+  });
+
+  it('keeps multiple redacted reasoning blocks separate', async () => {
+    // OpenAI models on Bedrock can return several redacted reasoning blocks in
+    // a single response. Each block must surface its own payload.
+    const model = new AmazonBedrockChatLanguageModel('us.openai.gpt-5.6-luna', {
+      baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      headers: {},
+      fetch: async () =>
+        new Response(
+          createStream([
+            createEvent(
+              'contentBlockDelta',
+              JSON.stringify({
+                contentBlockIndex: 0,
+                delta: {
+                  reasoningContent: { redactedContent: 'first-payload' },
+                },
+              }),
+            ),
+            createEvent(
+              'contentBlockStop',
+              JSON.stringify({ contentBlockIndex: 0 }),
+            ),
+            createEvent(
+              'contentBlockDelta',
+              JSON.stringify({
+                contentBlockIndex: 1,
+                delta: {
+                  reasoningContent: { redactedContent: 'second-payload' },
+                },
+              }),
+            ),
+            createEvent(
+              'contentBlockStop',
+              JSON.stringify({ contentBlockIndex: 1 }),
+            ),
+            createEvent(
+              'contentBlockDelta',
+              JSON.stringify({
+                contentBlockIndex: 2,
+                delta: { text: 'The answer is 42.' },
+              }),
+            ),
+            createEvent(
+              'contentBlockStop',
+              JSON.stringify({ contentBlockIndex: 2 }),
+            ),
+            createEvent(
+              'messageStop',
+              JSON.stringify({ stopReason: 'end_turn' }),
+            ),
+          ]),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/vnd.amazon.eventstream',
+            },
+          },
+        ),
+      generateId: () => 'test-id',
+    });
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const parts = await convertReadableStreamToArray(stream);
+
+    expect(parts.filter(part => part.type === 'error')).toStrictEqual([]);
+    expect(parts.filter(part => part.type === 'reasoning-end')).toStrictEqual([
+      {
+        type: 'reasoning-end',
+        id: '0',
+        providerMetadata: {
+          amazonBedrock: { redactedContent: 'first-payload' },
+          bedrock: { redactedContent: 'first-payload' },
+        },
+      },
+      {
+        type: 'reasoning-end',
+        id: '1',
+        providerMetadata: {
+          amazonBedrock: { redactedContent: 'second-payload' },
+          bedrock: { redactedContent: 'second-payload' },
+        },
+      },
+    ]);
+  });
 });

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -5603,6 +5603,58 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should expose reasoning redacted as `redactedContent` for replay', async () => {
+    // `redactedContent` is a member of the ReasoningContentBlock union
+    // in the Converse API. OpenAI models on Bedrock (e.g. `us.openai.gpt-5.6-luna`)
+    // return their encrypted reasoning in this shape. It is surfaced as provider
+    // metadata so that it can be replayed on subsequent turns.
+    server.urls[generateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                reasoningContent: {
+                  redactedContent: 'encrypted-reasoning-payload',
+                },
+              },
+              { type: 'text', text: 'The answer is 42.' },
+            ],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 34, totalTokens: 38 },
+        stopReason: 'stop_sequence',
+      },
+    };
+
+    const result = await model.doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.content).toMatchInlineSnapshot(`
+      [
+        {
+          "providerMetadata": {
+            "amazonBedrock": {
+              "redactedContent": "encrypted-reasoning-payload",
+            },
+            "bedrock": {
+              "redactedContent": "encrypted-reasoning-payload",
+            },
+          },
+          "text": "",
+          "type": "reasoning",
+        },
+        {
+          "text": "The answer is 42.",
+          "type": "text",
+        },
+      ]
+    `);
+  });
+
   it('should handle multiple reasoning blocks', async () => {
     server.urls[generateUrl].response = {
       type: 'json-value',

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -573,6 +573,18 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
               bedrock: redactedPayload,
             },
           });
+        } else if ('redactedContent' in part.reasoningContent) {
+          const redactedPayload: AmazonBedrockReasoningMetadata = {
+            redactedContent: part.reasoningContent.redactedContent,
+          };
+          content.push({
+            type: 'reasoning',
+            text: '',
+            providerMetadata: {
+              amazonBedrock: redactedPayload,
+              bedrock: redactedPayload,
+            },
+          });
         }
       }
 
@@ -720,7 +732,8 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
           jsonText: string;
           isJsonResponseTool?: boolean;
         }
-      | { type: 'text' | 'reasoning' }
+      | { type: 'text' }
+      | { type: 'reasoning'; redactedContent?: string }
     > = {};
 
     return {
@@ -891,9 +904,21 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
 
               if (contentBlock != null) {
                 if (contentBlock.type === 'reasoning') {
+                  const redactedPayload: AmazonBedrockReasoningMetadata | null =
+                    contentBlock.redactedContent != null
+                      ? { redactedContent: contentBlock.redactedContent }
+                      : null;
                   controller.enqueue({
                     type: 'reasoning-end',
                     id: String(blockIndex),
+                    ...(redactedPayload != null
+                      ? {
+                          providerMetadata: {
+                            amazonBedrock: redactedPayload,
+                            bedrock: redactedPayload,
+                          },
+                        }
+                      : {}),
                   });
                 } else if (contentBlock.type === 'text') {
                   controller.enqueue({
@@ -1007,6 +1032,27 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
                       bedrock: redactedPayload,
                     },
                   });
+                }
+              } else if (
+                'redactedContent' in reasoningContent &&
+                reasoningContent.redactedContent
+              ) {
+                if (contentBlocks[blockIndex] == null) {
+                  contentBlocks[blockIndex] = { type: 'reasoning' };
+                  controller.enqueue({
+                    type: 'reasoning-start',
+                    id: String(blockIndex),
+                  });
+                }
+
+                const contentBlock = contentBlocks[blockIndex];
+                if (contentBlock.type === 'reasoning') {
+                  // accumulate and attach once via reasoning-end: the merged
+                  // provider metadata of a reasoning part is last-write-wins,
+                  // so per-delta metadata would drop earlier chunks
+                  contentBlock.redactedContent =
+                    (contentBlock.redactedContent ?? '') +
+                    reasoningContent.redactedContent;
                 }
               }
             }
@@ -1216,6 +1262,13 @@ const AmazonBedrockResponseSchema = z.object({
               z.object({
                 redactedReasoning: AmazonBedrockRedactedReasoningSchema,
               }),
+              // `redactedContent` is a member of the documented
+              // ReasoningContentBlock union. OpenAI models on Bedrock
+              // (e.g. `us.openai.gpt-5.6-luna`) return their encrypted
+              // reasoning in this shape.
+              z.object({
+                redactedContent: z.string(),
+              }),
             ])
             .nullish(),
         }),
@@ -1261,6 +1314,12 @@ const AmazonBedrockStreamSchema = z.object({
           }),
           z.object({
             reasoningContent: z.object({ data: z.string() }),
+          }),
+          // `redactedContent` is a member of the documented
+          // ReasoningContentBlockDelta union. OpenAI models on Bedrock stream
+          // their encrypted reasoning in this shape.
+          z.object({
+            reasoningContent: z.object({ redactedContent: z.string() }),
           }),
         ])
         .nullish(),

--- a/packages/amazon-bedrock/src/amazon-bedrock-reasoning-metadata.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-reasoning-metadata.ts
@@ -3,6 +3,7 @@ import { z } from 'zod/v4';
 export const amazonBedrockReasoningMetadataSchema = z.object({
   signature: z.string().optional(),
   redactedData: z.string().optional(),
+  redactedContent: z.string().optional(),
 });
 
 export type AmazonBedrockReasoningMetadata = z.infer<

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
@@ -914,6 +914,46 @@ describe('assistant messages', () => {
     });
   });
 
+  it('should replay reasoning redacted as `redactedContent`', async () => {
+    const redactedContent = 'encrypted-reasoning-payload';
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Explain your reasoning' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: '',
+            providerOptions: { bedrock: { redactedContent } },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'Explain your reasoning' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              reasoningContent: {
+                redactedContent,
+              },
+            },
+          ],
+        },
+      ],
+      system: [],
+    });
+  });
+
   it('should omit assistant message reasoning parts signed by a foreign provider', async () => {
     const result = await convertToAmazonBedrockChatMessages([
       {

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -520,6 +520,12 @@ export async function convertToAmazonBedrockChatMessages(
                       },
                     },
                   });
+                } else if (reasoningMetadata?.redactedContent != null) {
+                  amazonBedrockContent.push({
+                    reasoningContent: {
+                      redactedContent: reasoningMetadata.redactedContent,
+                    },
+                  });
                 } else if (reasoningMetadata?.redactedData != null) {
                   amazonBedrockContent.push({
                     reasoningContent: {


### PR DESCRIPTION
## Background

`redactedContent` is the second member of the documented [`ReasoningContentBlock`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlock.html) union (`reasoningText | redactedContent`) and a member of [`ReasoningContentBlockDelta`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ReasoningContentBlockDelta.html), but neither the response schema nor the stream schema accepts it. Models that emit it — e.g. OpenAI models on Converse such as `us.openai.gpt-5.6-luna`, which return their encrypted reasoning in this shape alongside tool calls — currently fail validation:

- `generateText` / `generateObject` with tools throw `AI_APICallError: Invalid JSON response` on an HTTP 200 response, making tool calling unusable
- `streamText` with tools emits a spurious `AI_TypeValidationError` error part on every request and loses the reasoning block

## Summary

- Both Zod schemas accept `redactedContent` (response `ReasoningContentBlock` and stream `contentBlockDelta.delta`).
- The payload is surfaced as a `reasoning` part carrying `providerMetadata.{amazonBedrock,bedrock}.redactedContent`, mirroring how `redactedReasoning` is surfaced today.
- `convert-to-amazon-bedrock-chat-messages` replays it as `reasoningContent: { redactedContent }` on subsequent turns.
- Streaming deltas are accumulated in the content-block state and attached once via `reasoning-end`: a reasoning part's merged provider metadata is last-write-wins, so per-delta metadata would drop earlier chunks if the payload ever arrives split.
- Existing `redactedReasoning` / `data` handling is left untouched.

Surfacing + replay (rather than accept-and-drop) matters because the encrypted payload restores the model's reasoning state across tool-use turns. Verified against the raw Converse API with a two-turn tool conversation: replaying the block verbatim yields a correct answer from restored state (22 output tokens); stripping it forces the model to re-reason from scratch (509 output tokens) and it loses its earlier conclusion. Replaying via the legacy `redactedReasoning: { data }` shape is silently ignored by the current API, so a dedicated replay path for the documented shape is required.

## Verification

- `pnpm test` in `packages/amazon-bedrock`: 465 tests pass. The new tests (response mapping, stream accumulation across split deltas, multi-block separation, replay conversion) fail without the fix.
- End-to-end against real Bedrock (`us-east-1`, `us.openai.gpt-5.6-luna`), both `doGenerate` and `doStream`: turn 1 surfaces the reasoning part with `redactedContent` metadata, the turn-2 request contains the replayed `reasoningContent.redactedContent` block on the wire, no error parts, and the model answers from its restored reasoning state.

## Tasks

- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features) — provider docs describe reasoning provider metadata generically; no doc change needed
- [x] A _patch changeset_ for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] Formatting issues have been fixed (run `pnpm prettier-fix` in the project root)

## Future Work

Anthropic models' redacted reasoning on the current Converse API is also documented as `redactedContent`; this change covers them as well, while keeping the legacy `redactedReasoning` / `data` paths for compatibility.

## Related Issues

Closes #19062 (full reproduction and multi-turn replay measurements). Related: #19024 (closed; streaming variant of this validation error), #14720 (precedent for OpenAI-on-Converse reasoning handling).
