### PR TITLE
docs: LLM Suspense guide + Node cookbook demo

### DIFF
--- a/content/cookbook/05-node/24-llm-suspense.mdx
+++ b/content/cookbook/05-node/24-llm-suspense.mdx
@@ -1,0 +1,103 @@
+---
+title: LLM Suspense
+description: Rewrite streamed text so users never see a broken intermediate import or URL.
+tags: ['node', 'streaming', 'agents']
+---
+
+# LLM Suspense
+
+v0’s [streaming rewrite layer](https://vercel.com/blog/how-we-made-v0-an-effective-coding-agent)
+(“LLM Suspense”) cleans tokens before they reach the user. In the AI SDK that
+is `experimental_transform` on `streamText`.
+
+This example:
+
+1. Expands a short `blob:` id the model was allowed to emit.
+2. Rewrites a fake `lucide-react` icon to a real export.
+
+```ts file="index.ts"
+import { streamText, type TextStreamPart, type ToolSet } from 'ai';
+
+const BLOB_SHORT = 'blob:hero';
+const BLOB_FULL =
+  'https://blob.vercel-storage.com/hero-9f3c2a1b0e7d4c6f8a2b.png';
+
+const lucideAliases: Record<string, string> = {
+  VercelLogo: 'Triangle',
+};
+
+function llmSuspense<TOOLS extends ToolSet>() {
+  return () => {
+    let buffer = '';
+
+    return new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
+      transform(chunk, controller) {
+        if (chunk.type !== 'text-delta') {
+          emit(controller, buffer);
+          buffer = '';
+          controller.enqueue(chunk);
+          return;
+        }
+        buffer += chunk.text;
+        const nl = buffer.lastIndexOf('\n');
+        if (nl === -1) return;
+        emit(controller, buffer.slice(0, nl + 1), chunk);
+        buffer = buffer.slice(nl + 1);
+      },
+      flush(controller) {
+        emit(controller, buffer);
+      },
+    });
+
+    function emit(
+      controller: TransformStreamDefaultController<TextStreamPart<TOOLS>>,
+      text: string,
+      template?: TextStreamPart<TOOLS>,
+    ) {
+      if (!text) return;
+      const cleaned = rewrite(text);
+      controller.enqueue(
+        template && template.type === 'text-delta'
+          ? { ...template, text: cleaned }
+          : ({ type: 'text-delta', id: 'suspense', text: cleaned } as TextStreamPart<TOOLS>),
+      );
+    }
+  };
+}
+
+function rewrite(text: string): string {
+  return text
+    .replaceAll(BLOB_SHORT, BLOB_FULL)
+    .replace(
+      /import\s+\{([^}]+)\}\s+from\s+['"]lucide-react['"]/g,
+      (_m, names: string) => {
+        const inner = names
+          .split(',')
+          .map((n: string) => n.trim())
+          .filter(Boolean)
+          .map((n: string) =>
+            lucideAliases[n] ? `${lucideAliases[n]} as ${n}` : n,
+          )
+          .join(', ');
+        return `import { ${inner} } from 'lucide-react'`;
+      },
+    );
+}
+
+const result = streamText({
+  model: 'openai/gpt-4.1-mini',
+  prompt:
+    `Write a React hero that imports { VercelLogo } from 'lucide-react' ` +
+    `and uses <img src="${BLOB_SHORT}" />.`,
+  experimental_transform: llmSuspense(),
+});
+
+for await (const delta of result.textStream) {
+  process.stdout.write(delta);
+}
+```
+
+The printed stream should contain `Triangle as VercelLogo` and the full blob
+URL — not the placeholders the model was steered toward.
+
+Docs: [LLM Suspense](/docs/advanced/llm-suspense).

--- a/content/docs/03-ai-sdk-core/05-generating-text.mdx
+++ b/content/docs/03-ai-sdk-core/05-generating-text.mdx
@@ -547,6 +547,10 @@ for await (const part of result.stream) {
 You can use the `experimental_transform` option to transform the stream.
 This is useful for e.g. filtering, changing, or smoothing the text stream.
 
+v0 calls a production version of this pattern [LLM Suspense](/docs/advanced/llm-suspense):
+rewrite the stream (imports, URLs, icons) so the user never sees a broken
+intermediate state.
+
 The transformations are applied before the callbacks are invoked and the promises are resolved.
 If you e.g. have a transformation that changes all text to uppercase, the `onEnd` callback will receive the transformed text.
 

--- a/content/docs/06-advanced/12-llm-suspense.mdx
+++ b/content/docs/06-advanced/12-llm-suspense.mdx
@@ -1,0 +1,130 @@
+---
+title: LLM Suspense
+description: Rewrite model output while it streams so users never see a broken intermediate state.
+---
+
+# LLM Suspense
+
+[v0](https://vercel.com/blog/how-we-made-v0-an-effective-coding-agent) calls the
+layer that rewrites tokens **as they stream** “LLM Suspense”. The user only sees
+the cleaned stream — not the raw model typo, the 200-character blob URL, or an
+icon import that does not exist.
+
+The AI SDK primitive is [`experimental_transform`](/docs/ai-sdk-core/generating-text#stream-transformation)
+on [`streamText`](/docs/reference/ai-sdk-core/stream-text). A transform is a
+`TransformStream` over `TextStreamPart`. It runs **before** `textStream`,
+`onFinish`, and the resolved `text` promise.
+
+Use it when you can fix the output **deterministically** in milliseconds
+(string rewrite, lookup, regex). Use a second model / AST pass after the stream
+for anything that needs a full file.
+
+## Why it exists
+
+| Problem | What Suspense does |
+|---------|-------------------|
+| Long attachment URLs waste tokens | Swap in a short id before the prompt; expand it on the way out |
+| Model invents a `lucide-react` icon | Rewrite the import to a real export (or the nearest name) |
+| Model emits a deprecated package path | Find-and-replace while the line is still streaming |
+
+The user never sees the wrong import flash and then correct.
+
+## Buffer, then emit
+
+Tokens split in the middle of identifiers. Hold a small tail of text until you
+have a complete rewrite unit (for example a full `import … from 'lucide-react'`
+line), then enqueue the cleaned `text-delta`.
+
+```ts filename="llm-suspense.ts"
+import type { TextStreamPart, ToolSet } from 'ai';
+
+const IMPORT_RE = /import\s+\{([^}]+)\}\s+from\s+['"]lucide-react['"]/;
+
+const ICON_ALIASES: Record<string, string> = {
+  VercelLogo: 'Triangle',
+};
+
+export function lucideSuspenseTransform<TOOLS extends ToolSet>() {
+  return () => {
+    let buffer = '';
+
+    return new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
+      transform(chunk, controller) {
+        if (chunk.type !== 'text-delta') {
+          flush(controller);
+          controller.enqueue(chunk);
+          return;
+        }
+
+        buffer += chunk.text;
+        const newline = buffer.lastIndexOf('\n');
+        if (newline === -1) return;
+
+        const complete = buffer.slice(0, newline + 1);
+        buffer = buffer.slice(newline + 1);
+        controller.enqueue({ ...chunk, text: rewriteLucideImport(complete) });
+      },
+      flush(controller) {
+        flush(controller);
+      },
+    });
+
+    function flush(
+      controller: TransformStreamDefaultController<TextStreamPart<TOOLS>>,
+    ) {
+      if (!buffer) return;
+      controller.enqueue({
+        type: 'text-delta',
+        id: 'suspense',
+        text: rewriteLucideImport(buffer),
+      } as TextStreamPart<TOOLS>);
+      buffer = '';
+    }
+  };
+}
+
+function rewriteLucideImport(text: string): string {
+  return text.replace(IMPORT_RE, (_match, names: string) => {
+    const rewritten = names
+      .split(',')
+      .map(part => part.trim())
+      .filter(Boolean)
+      .map(name => {
+        const alias = ICON_ALIASES[name];
+        return alias ? `${alias} as ${name}` : name;
+      })
+      .join(', ');
+    return `import { ${rewritten} } from 'lucide-react'`;
+  });
+}
+```
+
+## Wire it up
+
+```ts
+import { streamText } from 'ai';
+import { lucideSuspenseTransform } from './llm-suspense';
+
+const result = streamText({
+  model: 'openai/gpt-4.1-mini',
+  prompt: 'Write a React header that uses a Vercel logo icon from lucide-react.',
+  experimental_transform: lucideSuspenseTransform(),
+});
+
+for await (const delta of result.textStream) {
+  process.stdout.write(delta);
+}
+```
+
+You can pass an **array** of transforms. Run cheap string rewrites first;
+keep `smoothStream()` last if you also want word-by-word UI.
+
+See the [Node cookbook](/cookbook/node/llm-suspense) for a runnable snippet
+that also expands short blob ids back to full URLs.
+
+## What not to put in Suspense
+
+- Multi-file or AST fixes (wrap a hook in `QueryClientProvider`) — do that
+  **after** the stream, as v0’s autofixers do.
+- Anything that needs another LLM call on the hot path. Keep this layer
+  under ~100ms.

--- a/content/docs/06-advanced/index.mdx
+++ b/content/docs/06-advanced/index.mdx
@@ -9,3 +9,6 @@ collapsed: true
 This section covers advanced topics and concepts for the AI SDK and RSC API. Working with LLMs often requires a different mental model compared to traditional software development.
 
 After these concepts, you should have a better understanding of the paradigms behind the AI SDK and RSC API, and how to use them to build more AI applications.
+
+See also [LLM Suspense](/docs/advanced/llm-suspense) — rewrite streamed text
+(the same idea v0 uses to clean imports and URLs before they hit the UI).


### PR DESCRIPTION
Fixes https://github.com/vercel/ai/issues/13685

v0’s [LLM Suspense](https://vercel.com/blog/how-we-made-v0-an-effective-coding-agent) is a streaming rewrite layer (find-and-replace on tokens so users never see a broken import or a 200-character blob URL).

The AI SDK hook is `experimental_transform` on `streamText`. This PR:

- Adds **[LLM Suspense](https://ai-sdk.dev/docs/advanced/llm-suspense)** under Advanced (buffer-then-emit, lucide rewrite, what *not* to put in this layer)
- Adds a **Node cookbook** that expands short blob ids and rewrites fake lucide icons
- Links from the existing stream-transformation docs

No runtime API change.