### PR TITLE
fix(otel): record provider-executed tool results and defs

### DIFF
--- a/.changeset/spicy-lobsters-return.md
+++ b/.changeset/spicy-lobsters-return.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/otel": patch
+---
+
+fix(otel): record provider-executed tool results and defs

--- a/packages/otel/src/gen-ai-format-messages.test.ts
+++ b/packages/otel/src/gen-ai-format-messages.test.ts
@@ -476,6 +476,36 @@ describe('formatOutputMessages', () => {
     `);
   });
 
+  it('should format output with tool results', () => {
+    expect(
+      formatOutputMessages({
+        toolResults: [
+          {
+            toolCallId: 'call_abc',
+            output: { temperature: 21 },
+          },
+        ],
+        finishReason: 'stop',
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "finish_reason": "stop",
+          "parts": [
+            {
+              "id": "call_abc",
+              "response": {
+                "temperature": 21,
+              },
+              "type": "tool_call_response",
+            },
+          ],
+          "role": "assistant",
+        },
+      ]
+    `);
+  });
+
   it('should format output with files', () => {
     expect(
       formatOutputMessages({

--- a/packages/otel/src/gen-ai-format-messages.ts
+++ b/packages/otel/src/gen-ai-format-messages.ts
@@ -554,6 +554,7 @@ export function formatOutputMessages({
   text,
   reasoning,
   toolCalls,
+  toolResults,
   files,
   finishReason,
 }: {
@@ -563,6 +564,10 @@ export function formatOutputMessages({
     toolCallId: string;
     toolName: string;
     input: unknown;
+  }>;
+  toolResults?: ReadonlyArray<{
+    toolCallId: string;
+    output: unknown;
   }>;
   files?: ReadonlyArray<{ mediaType: string; base64: string }>;
   finishReason: string;
@@ -588,6 +593,16 @@ export function formatOutputMessages({
         id: tc.toolCallId,
         name: tc.toolName,
         arguments: tc.input,
+      });
+    }
+  }
+
+  if (toolResults) {
+    for (const toolResult of toolResults) {
+      parts.push({
+        type: 'tool_call_response',
+        id: toolResult.toolCallId,
+        response: toolResult.output,
       });
     }
   }

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -849,6 +849,82 @@ describe('OpenTelemetry', () => {
       `);
     });
 
+    it('records provider-executed tool results and observed definitions', () => {
+      integration.onStart!(makeOnStartEvent());
+      integration.onStepStart!(makeStepStartEvent());
+      integration.onLanguageModelCallStart!(
+        makeLanguageModelCallStartEvent({
+          tools: [{ type: 'provider', name: 'mcp', id: 'openai.mcp' }],
+        }),
+      );
+      integration.onLanguageModelCallEnd!(
+        makeLanguageModelCallEndEvent({
+          content: [
+            {
+              type: 'tool-call' as const,
+              toolCallId: 'tc1',
+              toolName: 'mcp.ask_question',
+              input: { question: 'What is this repository?' },
+              providerExecuted: true,
+              dynamic: true,
+            },
+            {
+              type: 'tool-result' as const,
+              toolCallId: 'tc1',
+              toolName: 'mcp.ask_question',
+              input: { question: 'What is this repository?' },
+              output: { answer: 'An AI SDK repository.' },
+              providerExecuted: true,
+              dynamic: true,
+            },
+          ],
+        }),
+      );
+
+      const chatSpan = tracer.spans[2];
+      expect({
+        ...parseJsonAttributes(chatSpan.attributes, 'gen_ai.output.messages'),
+        ...parseJsonAttributes(chatSpan.attributes, 'gen_ai.tool.definitions'),
+      }).toMatchInlineSnapshot(`
+        {
+          "gen_ai.output.messages": [
+            {
+              "finish_reason": "stop",
+              "parts": [
+                {
+                  "arguments": {
+                    "question": "What is this repository?",
+                  },
+                  "id": "tc1",
+                  "name": "mcp.ask_question",
+                  "type": "tool_call",
+                },
+                {
+                  "id": "tc1",
+                  "response": {
+                    "answer": "An AI SDK repository.",
+                  },
+                  "type": "tool_call_response",
+                },
+              ],
+              "role": "assistant",
+            },
+          ],
+          "gen_ai.tool.definitions": [
+            {
+              "id": "openai.mcp",
+              "name": "mcp",
+              "type": "provider",
+            },
+            {
+              "name": "mcp.ask_question",
+              "type": "extension",
+            },
+          ],
+        }
+      `);
+    });
+
     it('sets cache token attributes when available', () => {
       integration.onStart!(makeOnStartEvent());
       integration.onStepStart!(makeStepStartEvent());
@@ -930,6 +1006,27 @@ describe('OpenTelemetry', () => {
           "runtimeAttributes": {},
         }
       `);
+    });
+
+    it('uses extension type for provider-executed tools', () => {
+      integration.onStart!(makeOnStartEvent());
+      integration.onStepStart!(makeStepStartEvent());
+      integration.onToolExecutionStart!(
+        makeToolCallStartEvent({
+          toolCall: {
+            type: 'tool-call',
+            toolCallId: 'tool-call-1',
+            toolName: 'mcp.ask_question',
+            input: { question: 'What is this repository?' },
+            providerExecuted: true,
+            dynamic: true,
+          },
+        }),
+      );
+
+      expect(
+        getSpanStartAttributes(tracer, tracer.spans[2])['gen_ai.tool.type'],
+      ).toBe('extension');
     });
 
     it('parents chat and execute_tool spans under the same step span', () => {

--- a/packages/otel/src/open-telemetry.ts
+++ b/packages/otel/src/open-telemetry.ts
@@ -77,6 +77,7 @@ interface CallState {
   stepContext: OpenTelemetryContext | undefined;
   inferenceSpan: Span | undefined;
   inferenceContext: OpenTelemetryContext | undefined;
+  inferenceToolDefinitions?: ReadonlyArray<Record<string, unknown>>;
   embedSpans: Map<string, { span: Span; context: OpenTelemetryContext }>;
   rerankSpan: { span: Span; context: OpenTelemetryContext } | undefined;
   toolSpans: Map<string, { span: Span; context: OpenTelemetryContext }>;
@@ -682,6 +683,7 @@ export class OpenTelemetry implements Telemetry {
 
     const { telemetry } = state;
     const providerName = mapProviderName(event.provider);
+    state.inferenceToolDefinitions = event.tools;
 
     const inferenceAttributes = selectAttributes(telemetry, {
       'gen_ai.operation.name': 'chat',
@@ -753,6 +755,30 @@ export class OpenTelemetry implements Telemetry {
     if (!state?.inferenceSpan) return;
 
     const { telemetry } = state;
+    const toolDefinitions = [...(state.inferenceToolDefinitions ?? [])];
+    const definedToolNames = new Set(
+      toolDefinitions.flatMap(tool =>
+        typeof tool.name === 'string' ? [tool.name] : [],
+      ),
+    );
+    let hasObservedProviderTools = false;
+
+    for (const part of event.content) {
+      if (
+        part.type !== 'tool-call' ||
+        !part.providerExecuted ||
+        definedToolNames.has(part.toolName)
+      ) {
+        continue;
+      }
+
+      toolDefinitions.push({
+        type: 'extension',
+        name: part.toolName,
+      });
+      definedToolNames.add(part.toolName);
+      hasObservedProviderTools = true;
+    }
 
     state.inferenceSpan.setAttributes(
       selectAttributes(telemetry, {
@@ -777,6 +803,9 @@ export class OpenTelemetry implements Telemetry {
                     .join('') || undefined,
                 reasoning: event.content.filter(p => p.type === 'reasoning'),
                 toolCalls: event.content.filter(p => p.type === 'tool-call'),
+                toolResults: event.content.filter(
+                  p => p.type === 'tool-result',
+                ),
                 files: event.content
                   .filter(p => p.type === 'file')
                   .map(p => p.file),
@@ -784,6 +813,11 @@ export class OpenTelemetry implements Telemetry {
               }),
             ),
         },
+        'gen_ai.tool.definitions': hasObservedProviderTools
+          ? {
+              input: () => JSON.stringify(toolDefinitions),
+            }
+          : undefined,
         ...selectSupplementalAttributes(
           telemetry,
           this.supplementalAttributes,
@@ -802,6 +836,7 @@ export class OpenTelemetry implements Telemetry {
     state.inferenceSpan.end();
     state.inferenceSpan = undefined;
     state.inferenceContext = undefined;
+    state.inferenceToolDefinitions = undefined;
   }
 
   onToolExecutionStart(event: ToolExecutionStartEvent<ToolSet>): void {
@@ -816,7 +851,7 @@ export class OpenTelemetry implements Telemetry {
       'gen_ai.operation.name': 'execute_tool',
       'gen_ai.tool.name': toolCall.toolName,
       'gen_ai.tool.call.id': toolCall.toolCallId,
-      'gen_ai.tool.type': 'function',
+      'gen_ai.tool.type': toolCall.providerExecuted ? 'extension' : 'function',
       'gen_ai.tool.call.arguments': {
         input: () => JSON.stringify(toolCall.input),
       },
@@ -967,6 +1002,7 @@ export class OpenTelemetry implements Telemetry {
                   text?: string;
                 }>,
                 toolCalls: event.toolCalls,
+                toolResults: event.toolResults,
                 files: event.files,
                 finishReason: event.finishReason,
               }),


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/19007

this pr addresses one part of the above issue, specifically the 2nd gap `Provider-executed tool results are not recorded anywhere`

the observed telemetry didn't have the information about the tool call's response for provider executed tools. 
output would just be: 
```
[
    {
        "role": "assistant",
        "parts": [
            {
                "type": "text",
                "content": "........."
            },
            {
                "type": "tool_call",
                "id": "mcp_055f4528fb6802ba006a85dc58673481a3bfd2e0517bb8d43b",
                "name": "mcp.read_wiki_structure",
                "arguments": {
                    "repoName": "vercel/ai"
                }
            },
            {
                "type": "tool_call",
                "id": "mcp_055f4528fb6802ba006a85dc5a063481a38fa1555924726199",
                "name": "mcp.ask_question",
                "arguments": {
                    "repoName": "vercel/ai",
                    "question": "What is the vercel/ai repository for? Summarize its purpose, main components/packages, key features, and intended users."
                }
            }
        ],
        "finish_reason": "stop"
    }
]
```

## Summary

we now track the tool-results and emit that data as the `tool_call_response`

```
[
    {
        "role": "assistant",
        "parts": [
            {
                "type": "text",
                "content": "......"
            },
            {
                "type": "tool_call",
                "id": "mcp_0614d5fa2de8c410006a85ddb90fe8819c8d7a19646cb39d07",
                "name": "mcp.read_wiki_structure",
                "arguments": {
                    "repoName": "vercel/ai"
                }
            },
            {
                "type": "tool_call",
                "id": "mcp_0614d5fa2de8c410006a85ddbbc4f4819caa8b95cd0b193835",
                "name": "mcp.ask_question",
                "arguments": {
                    "repoName": "vercel/ai",
                    "question": "What is the vercel/ai repository for? Give a concise overview of its purpose, main components/packages, supported use cases, and who would use it."
                }
            },
            {
                "type": "tool_call_response",
                "id": "mcp_0614d5fa2de8c410006a85ddb90fe8819c8d7a19646cb39d07",
                "response": {
                    "type": "call",
                    "serverLabel": "deepwiki",
                    "name": "read_wiki_structure",
                    "arguments": {
                        "repoName": "vercel/ai"
                    },
                    "output": ......"
                }
            },
            {
                "type": "tool_call_response",
                "id": "mcp_0614d5fa2de8c410006a85ddbbc4f4819caa8b95cd0b193835",
                "response": {
                    "type": "call",
                    "serverLabel": "deepwiki",
                    "name": "ask_question",
                    "arguments": {
                        "repoName": "vercel/ai",
                        "question": "What is the vercel/ai repository for? Give a concise overview of its purpose, main components/packages, supported use cases, and who would use it."
                    },
                    "output": "........"
                }
            }
        ],
        "finish_reason": "stop"
    }
]
```

## End-to-End Verification

verified by running the following script and observing the UI: 

<details>
<summary>repro:</summary>

```ts
import { openai } from '@ai-sdk/openai';
import { OpenTelemetry } from '@ai-sdk/otel';
import { LangfuseSpanProcessor } from '@langfuse/otel';
import { NodeSDK } from '@opentelemetry/sdk-node';
import type { ReadableSpan } from '@opentelemetry/sdk-trace-node';
import { generateText, registerTelemetry, stepCountIs } from 'ai';
import { run } from '../lib/run';

for (const key of ['LANGFUSE_PUBLIC_KEY', 'LANGFUSE_SECRET_KEY'] as const) {
  if (process.env[key] == null) {
    throw new Error(
      `Set ${key} in examples/ai-functions/.env before running this example.`,
    );
  }
}

const spans: Array<{
  name: string;
  durationMs: number;
  attributes: ReadableSpan['attributes'];
}> = [];
const sdk = new NodeSDK({
  spanProcessors: [
    new LangfuseSpanProcessor(),
    {
      onStart() {},
      onEnd(span) {
        spans.push({
          name: span.name,
          durationMs: span.duration[0] * 1e3 + span.duration[1] / 1e6,
          attributes: { ...span.attributes },
        });
      },
      forceFlush: async () => {},
      shutdown: async () => {},
    },
  ],
});

sdk.start();
registerTelemetry(new OpenTelemetry());

run(async () => {
  const result = await generateText({
    model: openai('gpt-5.5'),
    prompt:
      'Use the deepwiki MCP tools to tell me what the "vercel/ai" repository is for.',
    tools: {
      mcp: openai.tools.mcp({
        serverLabel: 'deepwiki',
        serverUrl: 'https://mcp.deepwiki.com/mcp',
      }),
    },
    stopWhen: stepCountIs(5),
    telemetry: {
      isEnabled: true,
      functionId: 'issue-19007-openai-otel-hosted-mcp',
      recordInputs: true,
      recordOutputs: true,
    },
  });

  for (const step of result.steps) {
    for (const part of step.content) {
      if (part.type === 'tool-call' || part.type === 'tool-result') {
        console.log(
          part.type,
          part.toolName,
          `providerExecuted=${part.providerExecuted}`,
        );
      }
    }
  }

  for (const span of spans) {
    console.log(
      span.name,
      `${Math.round(span.durationMs)}ms`,
      span.attributes['gen_ai.operation.name'],
    );
  }

  const chat = spans.find(span => span.name.startsWith('chat '));
  console.log(chat?.attributes['gen_ai.tool.definitions']);
  for (const message of JSON.parse(
    String(chat?.attributes['gen_ai.output.messages']),
  ) as Array<{ role: string; parts: Array<{ type: string; name?: string }> }>) {
    console.log(
      message.role,
      message.parts.map(part => part.type + (part.name ? `:${part.name}` : '')),
    );
  }

  await sdk.shutdown();
});
```
</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Towards #19007 