### PR TITLE
fix(workflow): resume transformed streams by UI chunk index

### DIFF
--- a/.changeset/curvy-rivers-resume.md
+++ b/.changeset/curvy-rivers-resume.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+fix WorkflowAgent stream resumption to apply UI chunk indexes after converting raw model stream parts

--- a/content/docs/03-agents/07-workflow-agent.mdx
+++ b/content/docs/03-agents/07-workflow-agent.mdx
@@ -207,7 +207,6 @@ export default function Chat() {
       new WorkflowChatTransport({
         api: '/api/chat',
         maxConsecutiveErrors: 5,
-        initialStartIndex: -50, // On page refresh, fetch last 50 chunks
       }),
     [],
   );
@@ -252,11 +251,19 @@ export async function GET(
   const startIndex = Number(
     new URL(request.url).searchParams.get('startIndex') ?? '0',
   );
+  if (!Number.isSafeInteger(startIndex) || startIndex < 0) {
+    return Response.json(
+      { error: 'startIndex must be a non-negative safe integer' },
+      { status: 400 },
+    );
+  }
 
   const run = await getRun(runId);
   const readable = run
-    .getReadable({ startIndex })
-    .pipeThrough(createModelCallToUIChunkTransform());
+    .getReadable({ startIndex: 0 })
+    .pipeThrough(
+      createModelCallToUIChunkTransform({ uiStartIndex: startIndex }),
+    );
 
   return new Response(readable, {
     headers: {
@@ -268,6 +275,12 @@ export async function GET(
   });
 }
 ```
+
+The reconnect cursor counts `UIMessageChunk` objects, while the workflow stream
+stores raw `ModelCallStreamPart` objects. Always replay the raw stream from index
+`0` and apply the cursor during conversion. Negative tail indexes are not
+supported for raw model-call streams; they require a durable stream that already
+stores UI message chunks.
 
 For the full API reference, see [`WorkflowChatTransport`](/docs/reference/ai-sdk-workflow/workflow-chat-transport).
 

--- a/content/docs/04-ai-sdk-ui/21-transport.mdx
+++ b/content/docs/04-ai-sdk-ui/21-transport.mdx
@@ -192,6 +192,14 @@ Key features:
 - **Configurable retries**: `maxConsecutiveErrors` controls how many consecutive reconnection failures to tolerate
 - **Lifecycle callbacks**: `onChatSendMessage` and `onChatEnd` for tracking chat state
 
+<Note>
+  Negative `initialStartIndex` values require the server's durable stream and
+  `x-workflow-stream-tail-index` header to use `UIMessageChunk` indexes. A
+  `WorkflowAgent` stream stores raw `ModelCallStreamPart` objects instead; use
+  the non-negative cursor conversion shown in the [WorkflowAgent
+  guide](/docs/agents/workflow-agent#resumable-streaming-with-workflowchattransport).
+</Note>
+
 For the full API reference, see [`WorkflowChatTransport`](/docs/reference/ai-sdk-workflow/workflow-chat-transport). For server-side endpoint setup, see the [WorkflowAgent guide](/docs/agents/workflow-agent#resumable-streaming-with-workflowchattransport).
 
 ## Building Custom Transports

--- a/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/01-workflow-agent.mdx
@@ -696,7 +696,7 @@ Returns a `Promise<WorkflowAgentStreamResult>` with the following properties:
 
 ## Utilities
 
-### `createModelCallToUIChunkTransform()`
+### `createModelCallToUIChunkTransform(options?)`
 
 Creates a `TransformStream` that converts raw `ModelCallStreamPart` chunks (written by the agent to the `writable` stream) into `UIMessageChunk` objects suitable for client consumption.
 
@@ -707,6 +707,20 @@ return createUIMessageStreamResponse({
   stream: run.readable.pipeThrough(createModelCallToUIChunkTransform()),
 });
 ```
+
+When resuming with a `WorkflowChatTransport` cursor, replay the raw workflow
+stream from index `0` and pass the non-negative UI chunk index to the transform:
+
+```ts
+const readable = run
+  .getReadable({ startIndex: 0 })
+  .pipeThrough(createModelCallToUIChunkTransform({ uiStartIndex: startIndex }));
+```
+
+`uiStartIndex` must be a non-negative safe integer. Raw model stream parts and
+UI message chunks are not one-to-one, so do not pass a UI chunk index to
+`getReadable`. Negative tail indexes require a durable stream that already
+stores `UIMessageChunk` objects.
 
 ### `toUIMessageChunk()`
 

--- a/content/docs/07-reference/04-ai-sdk-workflow/02-workflow-chat-transport.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/02-workflow-chat-transport.mdx
@@ -20,7 +20,6 @@ export default function Chat() {
     transport: new WorkflowChatTransport({
       api: '/api/chat',
       maxConsecutiveErrors: 5,
-      initialStartIndex: -50,
     }),
   });
 
@@ -67,7 +66,7 @@ export default function Chat() {
       type: 'number',
       isOptional: true,
       description:
-        'Default chunk index to start from when reconnecting. Negative values read from the end of the stream (e.g., -50 fetches the last 50 chunks), useful for resuming after a page refresh without replaying the full conversation. Can be overridden per-call via reconnectToStream options. Default: 0.',
+        'Default chunk index to start from when reconnecting. Negative values read from the end of a durable UIMessageChunk stream (e.g., -50 fetches the last 50 chunks), useful for resuming after a page refresh without replaying the full conversation. Raw ModelCallStreamPart streams do not support negative UI chunk indexes. Can be overridden per-call via reconnectToStream options. Default: 0.',
     },
     {
       name: 'onChatSendMessage',
@@ -262,7 +261,7 @@ export default function Chat() {
 }
 ```
 
-### With Callbacks and Page Refresh Recovery
+### With Callbacks
 
 ```tsx
 'use client';
@@ -277,7 +276,6 @@ export default function Chat() {
       new WorkflowChatTransport({
         api: '/api/chat',
         maxConsecutiveErrors: 5,
-        initialStartIndex: -50, // Resume from last 50 chunks on page refresh
         onChatSendMessage: response => {
           const runId = response.headers.get('x-workflow-run-id');
           console.log('Workflow run started:', runId);
@@ -329,11 +327,19 @@ export async function GET(
   const startIndex = Number(
     new URL(request.url).searchParams.get('startIndex') ?? '0',
   );
+  if (!Number.isSafeInteger(startIndex) || startIndex < 0) {
+    return Response.json(
+      { error: 'startIndex must be a non-negative safe integer' },
+      { status: 400 },
+    );
+  }
 
   const run = await getRun(runId);
   const readable = run
-    .getReadable({ startIndex })
-    .pipeThrough(createModelCallToUIChunkTransform());
+    .getReadable({ startIndex: 0 })
+    .pipeThrough(
+      createModelCallToUIChunkTransform({ uiStartIndex: startIndex }),
+    );
 
   return new Response(readable, {
     headers: {
@@ -345,3 +351,11 @@ export async function GET(
   });
 }
 ```
+
+<Note>
+  `WorkflowAgent` writes raw `ModelCallStreamPart` objects, so its reconnect
+  endpoint must use a non-negative UI chunk cursor as shown above. Negative
+  `initialStartIndex` values are available when the durable stream itself stores
+  `UIMessageChunk` objects and the endpoint returns an
+  `x-workflow-stream-tail-index` in the same UI chunk coordinate system.
+</Note>

--- a/examples/next-workflow/app/api/chat/[runId]/stream/route.ts
+++ b/examples/next-workflow/app/api/chat/[runId]/stream/route.ts
@@ -11,11 +11,19 @@ export async function GET(
     const startIndex = Number(
       new URL(request.url).searchParams.get('startIndex') ?? '0',
     );
+    if (!Number.isSafeInteger(startIndex) || startIndex < 0) {
+      return Response.json(
+        { error: 'startIndex must be a non-negative safe integer' },
+        { status: 400 },
+      );
+    }
 
     const run = await getRun(runId);
     const readable = run
-      .getReadable({ startIndex })
-      .pipeThrough(createModelCallToUIChunkTransform());
+      .getReadable({ startIndex: 0 })
+      .pipeThrough(
+        createModelCallToUIChunkTransform({ uiStartIndex: startIndex }),
+      );
 
     return new Response(readable, {
       headers: {

--- a/examples/next-workflow/app/api/sandbox-chat/[runId]/stream/route.ts
+++ b/examples/next-workflow/app/api/sandbox-chat/[runId]/stream/route.ts
@@ -11,10 +11,16 @@ export async function GET(
   const startIndex = Number(
     new URL(request.url).searchParams.get('startIndex') ?? '0',
   );
+  if (!Number.isSafeInteger(startIndex) || startIndex < 0) {
+    return Response.json(
+      { error: 'startIndex must be a non-negative safe integer' },
+      { status: 400 },
+    );
+  }
   const run = await getRun(runId);
 
   return createUIMessageStreamResponse({
-    stream: toUIMessageStream(run.getReadable({ startIndex })),
+    stream: toUIMessageStream(run.getReadable({ startIndex: 0 }), startIndex),
     headers: {
       'x-workflow-run-id': runId,
     },

--- a/examples/next-workflow/app/api/telemetry-chat/[runId]/stream/route.ts
+++ b/examples/next-workflow/app/api/telemetry-chat/[runId]/stream/route.ts
@@ -15,6 +15,12 @@ export async function GET(
   const startIndex = Number(
     new URL(request.url).searchParams.get('startIndex') ?? '0',
   );
+  if (!Number.isSafeInteger(startIndex) || startIndex < 0) {
+    return Response.json(
+      { error: 'startIndex must be a non-negative safe integer' },
+      { status: 400 },
+    );
+  }
   const telemetryRunId = getTelemetryRunIdForWorkflowRun(runId);
 
   if (telemetryRunId != null) {
@@ -27,7 +33,10 @@ export async function GET(
   }
 
   const run = await getRun(runId);
-  const readable = toUIMessageStream(run.getReadable({ startIndex }));
+  const readable = toUIMessageStream(
+    run.getReadable({ startIndex: 0 }),
+    startIndex,
+  );
 
   return createUIMessageStreamResponse({
     stream: readable,

--- a/examples/next-workflow/app/page.tsx
+++ b/examples/next-workflow/app/page.tsx
@@ -12,7 +12,6 @@ export default function Chat() {
       new WorkflowChatTransport({
         api: '/api/chat',
         maxConsecutiveErrors: 5,
-        initialStartIndex: -50,
       }),
     [],
   );

--- a/examples/next-workflow/app/sandbox/page.tsx
+++ b/examples/next-workflow/app/sandbox/page.tsx
@@ -22,7 +22,6 @@ export default function SandboxPage() {
       new WorkflowChatTransport({
         api: '/api/sandbox-chat',
         maxConsecutiveErrors: 5,
-        initialStartIndex: -50,
         onChatSendMessage: response => {
           setWorkflowRunId(
             response.headers.get('x-workflow-run-id') ?? undefined,

--- a/examples/next-workflow/app/telemetry/page.tsx
+++ b/examples/next-workflow/app/telemetry/page.tsx
@@ -97,7 +97,6 @@ export default function TelemetryPage() {
       new WorkflowChatTransport({
         api: '/api/telemetry-chat',
         maxConsecutiveErrors: 5,
-        initialStartIndex: -50,
         prepareSendMessagesRequest: options => {
           const body = (options.body ?? {}) as Record<string, unknown>;
           return {

--- a/examples/next-workflow/workflow/sandbox-agent.ts
+++ b/examples/next-workflow/workflow/sandbox-agent.ts
@@ -104,6 +104,9 @@ export async function sandboxChat(
 
 export function toUIMessageStream(
   readable: ReadableStream<ModelCallStreamPart>,
+  uiStartIndex = 0,
 ) {
-  return readable.pipeThrough(createModelCallToUIChunkTransform());
+  return readable.pipeThrough(
+    createModelCallToUIChunkTransform({ uiStartIndex }),
+  );
 }

--- a/examples/next-workflow/workflow/telemetry-agent.ts
+++ b/examples/next-workflow/workflow/telemetry-agent.ts
@@ -365,6 +365,9 @@ export async function telemetryChat(
 
 export function toUIMessageStream(
   readable: ReadableStream<ModelCallStreamPart>,
+  uiStartIndex = 0,
 ) {
-  return readable.pipeThrough(createModelCallToUIChunkTransform());
+  return readable.pipeThrough(
+    createModelCallToUIChunkTransform({ uiStartIndex }),
+  );
 }

--- a/packages/workflow/src/to-ui-message-chunk.test.ts
+++ b/packages/workflow/src/to-ui-message-chunk.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import type { UIMessageChunk } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+import type { ModelCallStreamPart } from './do-stream-step.js';
 import { normalizeUIMessageStreamParts } from './normalize-ui-message-stream.js';
-import { toUIMessageChunk } from './to-ui-message-chunk.js';
+import {
+  createModelCallToUIChunkTransform,
+  toUIMessageChunk,
+} from './to-ui-message-chunk.js';
+import { WorkflowChatTransport } from './workflow-chat-transport.js';
 
 describe('workflow UI stream reset-step', () => {
   it('converts reset-step model-call parts to UI message chunks', () => {
@@ -30,5 +36,238 @@ describe('workflow UI stream reset-step', () => {
       { type: 'text-delta', id: 'text-1', delta: 'retry' },
       { type: 'text-end', id: 'text-1' },
     ]);
+  });
+});
+
+function rawStream(parts: readonly ModelCallStreamPart[], startIndex = 0) {
+  return new ReadableStream<ModelCallStreamPart>({
+    start(controller) {
+      for (const part of parts.slice(startIndex)) {
+        controller.enqueue(part);
+      }
+      controller.close();
+    },
+  });
+}
+
+async function collect(
+  stream: ReadableStream<UIMessageChunk>,
+): Promise<UIMessageChunk[]> {
+  const chunks: UIMessageChunk[] = [];
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return chunks;
+}
+
+function sseStream(chunks: readonly UIMessageChunk[]) {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const chunk of chunks) {
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`),
+        );
+      }
+      controller.close();
+    },
+  });
+}
+
+const toolCallParts = [
+  { type: 'text-start', id: 'text-1' },
+  { type: 'text-delta', id: 'text-1', text: 'Checking the weather.' },
+  { type: 'text-end', id: 'text-1' },
+  { type: 'tool-input-start', id: 'call-1', toolName: 'getWeather' },
+  { type: 'tool-input-delta', id: 'call-1', delta: '{"city":"Boston"}' },
+  { type: 'tool-input-end', id: 'call-1' },
+  {
+    type: 'tool-call',
+    toolCallId: 'call-1',
+    toolName: 'getWeather',
+    input: { city: 'Boston' },
+  },
+  {
+    type: 'tool-result',
+    toolCallId: 'call-1',
+    toolName: 'getWeather',
+    input: { city: 'Boston' },
+    output: { temperature: 22, unit: 'celsius' },
+  },
+  { type: 'text-start', id: 'text-2' },
+  { type: 'text-delta', id: 'text-2', text: 'It is 22°C.' },
+  { type: 'text-end', id: 'text-2' },
+] as unknown as ModelCallStreamPart[];
+
+const textParts = [
+  { type: 'model-call-start', options: {} },
+  { type: 'text-start', id: 'text-1' },
+  { type: 'text-delta', id: 'text-1', text: 'Hello' },
+  { type: 'raw', rawValue: { provider: 'ignored' } },
+  { type: 'text-end', id: 'text-1' },
+] as unknown as ModelCallStreamPart[];
+
+const toolErrorParts = [
+  { type: 'tool-input-start', id: 'call-2', toolName: 'getWeather' },
+  { type: 'tool-input-delta', id: 'call-2', delta: '{"city":"Mars"}' },
+  { type: 'tool-input-end', id: 'call-2' },
+  {
+    type: 'tool-call',
+    toolCallId: 'call-2',
+    toolName: 'getWeather',
+    input: { city: 'Mars' },
+  },
+  {
+    type: 'tool-error',
+    toolCallId: 'call-2',
+    toolName: 'getWeather',
+    input: { city: 'Mars' },
+    error: 'City not found',
+  },
+] as unknown as ModelCallStreamPart[];
+
+const stepBoundaryParts = [
+  { type: 'text-start', id: 'text-1' },
+  { type: 'text-delta', id: 'text-1', text: 'First step' },
+  { type: 'text-end', id: 'text-1' },
+  { type: 'finish-step' },
+  { type: 'start-step' },
+  { type: 'text-start', id: 'text-2' },
+  { type: 'text-delta', id: 'text-2', text: 'Second step' },
+  { type: 'text-end', id: 'text-2' },
+] as unknown as ModelCallStreamPart[];
+
+const fixtures = [
+  ['text with ignored raw parts', textParts],
+  ['tool call', toolCallParts],
+  ['tool error', toolErrorParts],
+  ['step boundaries', stepBoundaryParts],
+] as const;
+
+describe('createModelCallToUIChunkTransform', () => {
+  it('preserves the existing output when options are omitted', async () => {
+    await expect(
+      collect(
+        rawStream(textParts).pipeThrough(createModelCallToUIChunkTransform()),
+      ),
+    ).resolves.toEqual([
+      { type: 'start' },
+      { type: 'start-step' },
+      { type: 'text-start', id: 'text-1' },
+      { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+      { type: 'text-end', id: 'text-1' },
+      { type: 'finish-step' },
+      { type: 'finish' },
+    ]);
+  });
+
+  describe.each(fixtures)('resuming %s', (_name, parts) => {
+    it('returns the canonical suffix at every UI chunk index', async () => {
+      const canonical = await collect(
+        rawStream(parts).pipeThrough(createModelCallToUIChunkTransform()),
+      );
+
+      for (
+        let uiStartIndex = 0;
+        uiStartIndex <= canonical.length;
+        uiStartIndex++
+      ) {
+        const resumed = await collect(
+          rawStream(parts).pipeThrough(
+            createModelCallToUIChunkTransform({ uiStartIndex }),
+          ),
+        );
+
+        expect(resumed).toEqual(canonical.slice(uiStartIndex));
+        expect([...canonical.slice(0, uiStartIndex), ...resumed]).toEqual(
+          canonical,
+        );
+      }
+    });
+  });
+
+  it('returns no chunks when the UI chunk index is beyond a completed stream', async () => {
+    const resumed = await collect(
+      rawStream(textParts).pipeThrough(
+        createModelCallToUIChunkTransform({ uiStartIndex: 100 }),
+      ),
+    );
+
+    expect(resumed).toEqual([]);
+  });
+
+  it.each([
+    -1,
+    0.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])('rejects invalid UI chunk index %s', uiStartIndex => {
+    expect(() => createModelCallToUIChunkTransform({ uiStartIndex })).toThrow(
+      new RangeError('uiStartIndex must be a non-negative safe integer'),
+    );
+  });
+
+  it('counts lifecycle and mapped chunks but not ignored raw parts', async () => {
+    const resumed = await collect(
+      rawStream(textParts).pipeThrough(
+        createModelCallToUIChunkTransform({ uiStartIndex: 3 }),
+      ),
+    );
+
+    expect(resumed[0]).toEqual({
+      type: 'text-delta',
+      id: 'text-1',
+      delta: 'Hello',
+    });
+  });
+
+  it('composes with WorkflowChatTransport across an interrupted tool stream', async () => {
+    const canonical = await collect(
+      rawStream(toolCallParts).pipeThrough(createModelCallToUIChunkTransform()),
+    );
+    const interruptedAt = 4;
+    const mockFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url === '/api/chat') {
+        return new Response(sseStream(canonical.slice(0, interruptedAt)), {
+          headers: { 'x-workflow-run-id': 'run-1' },
+        });
+      }
+
+      const uiStartIndex = Number(
+        new URL(url, 'http://localhost').searchParams.get('startIndex'),
+      );
+      const resumed = await collect(
+        rawStream(toolCallParts).pipeThrough(
+          createModelCallToUIChunkTransform({ uiStartIndex }),
+        ),
+      );
+      return new Response(sseStream(resumed));
+    });
+    const transport = new WorkflowChatTransport({
+      fetch: mockFetch as unknown as typeof fetch,
+    });
+
+    const stream = await transport.sendMessages({
+      trigger: 'submit-message',
+      chatId: 'chat-1',
+      messages: [],
+    });
+
+    await expect(collect(stream)).resolves.toEqual(canonical);
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      `/api/chat/run-1/stream?startIndex=${interruptedAt}`,
+      expect.any(Object),
+    );
   });
 });

--- a/packages/workflow/src/to-ui-message-chunk.ts
+++ b/packages/workflow/src/to-ui-message-chunk.ts
@@ -214,24 +214,51 @@ export function toUIMessageChunk(
 /**
  * Create a TransformStream that converts ModelCallStreamPart to UIMessageChunk.
  * Wraps toUIMessageChunk with start/start-step/finish-step lifecycle chunks.
+ *
+ * When resuming a stream, provide `uiStartIndex` and replay the source
+ * ModelCallStreamPart stream from index 0. The transform will omit the UI
+ * chunks that the client has already received. Raw model stream parts and UI
+ * message chunks do not have a one-to-one relationship, so a UI chunk index
+ * must not be used as the source stream's start index.
  */
-export function createModelCallToUIChunkTransform(): TransformStream<
-  ModelCallStreamPart<ToolSet>,
-  UIMessageChunk
-> {
+export function createModelCallToUIChunkTransform({
+  uiStartIndex = 0,
+}: {
+  /**
+   * Number of transformed UIMessageChunks to omit from the output.
+   * Must be a non-negative safe integer.
+   */
+  uiStartIndex?: number;
+} = {}): TransformStream<ModelCallStreamPart<ToolSet>, UIMessageChunk> {
+  if (!Number.isSafeInteger(uiStartIndex) || uiStartIndex < 0) {
+    throw new RangeError('uiStartIndex must be a non-negative safe integer');
+  }
+
+  let uiChunkIndex = 0;
+
+  const enqueue = (
+    controller: TransformStreamDefaultController<UIMessageChunk>,
+    chunk: UIMessageChunk,
+  ) => {
+    if (uiChunkIndex >= uiStartIndex) {
+      controller.enqueue(chunk);
+    }
+    uiChunkIndex++;
+  };
+
   return new TransformStream<ModelCallStreamPart<ToolSet>, UIMessageChunk>({
     start: controller => {
-      controller.enqueue({ type: 'start' });
-      controller.enqueue({ type: 'start-step' });
+      enqueue(controller, { type: 'start' });
+      enqueue(controller, { type: 'start-step' });
     },
     flush: controller => {
-      controller.enqueue({ type: 'finish-step' });
-      controller.enqueue({ type: 'finish' });
+      enqueue(controller, { type: 'finish-step' });
+      enqueue(controller, { type: 'finish' });
     },
     transform: (part, controller) => {
       const uiChunk = toUIMessageChunk(part);
       if (uiChunk) {
-        controller.enqueue(uiChunk);
+        enqueue(controller, uiChunk);
       }
     },
   });


### PR DESCRIPTION
## Background

`WorkflowChatTransport` counts `UIMessageChunk` objects, while `WorkflowAgent` stores raw `ModelCallStreamPart` objects in its durable stream. The documented reconnect endpoint passed the UI cursor directly to the raw stream before conversion. Tool turns therefore resumed in the wrong index space, duplicating lifecycle framing and omitting canonical UI chunks.

## Summary

- add an optional, validated `uiStartIndex` to `createModelCallToUIChunkTransform`
- replay raw workflow streams from index 0 and omit already-delivered UI chunks after conversion
- cover every cursor across text, tool, tool-error, ignored-part, and step-boundary streams in Node and Edge
- verify `WorkflowChatTransport` interruption and reconnection against a transformed tool turn
- correct the WorkflowAgent guide, API references, and all affected `next-workflow` raw-stream endpoints
- clarify that negative tail indexes require a durable stream already indexed in `UIMessageChunk` space

The no-options transform behavior is unchanged.

## Contributor Credit

@MintedKenny

## End-to-End Verification

Built and ran the `next-workflow` example, then exercised its deterministic sandbox agent through the real HTTP/SSE endpoints:

1. POSTed a message that produces a sandbox tool call and final text.
2. Confirmed the initial response contained the canonical 11 UI chunks, including tool input/output and step boundaries.
3. Reconnected to the same durable run with `startIndex=4`.
4. Confirmed the response began with canonical chunk 4 (`finish-step`) and exactly matched the remaining suffix, without a duplicate `start` or `start-step`.
5. Confirmed negative and fractional cursors return HTTP 400.

## Validation

- `pnpm --dir packages/workflow test:node` — 204 passed
- `pnpm --dir packages/workflow test:edge` — 204 passed
- `pnpm --dir packages/workflow type-check`
- `pnpm --dir packages/workflow build`
- `pnpm turbo build --filter=@example/next-workflow...` — 13 tasks passed
- `pnpm check`
- `pnpm validate:docs`
- `pnpm type-check:full`
- `pnpm publint --filter=@ai-sdk/workflow`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Negative tail resumption over a raw `ModelCallStreamPart` stream remains out of scope because a raw tail index cannot be translated to a UI tail index without an additional indexing or storage protocol. Existing negative-tail behavior remains available for durable streams that already store `UIMessageChunk` objects and return a tail index in that same coordinate system.

## Related Issues

Fixes #19088
