### PR TITLE
fix(harness): ensure the bootstrap recipe on resumed sessions

### DIFF
--- a/.changeset/harness-bootstrap-on-resume.md
+++ b/.changeset/harness-bootstrap-on-resume.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness': patch
+---
+
+fix (harness): ensure the harness bootstrap recipe on resumed sessions too. The marker is keyed by recipe identity, so a resume whose bootstrap is already current costs one file read, while a resume into a sandbox bootstrapped by an older adapter build — a snapshot that outlived the harness version that made it — is re-bootstrapped instead of running a stale bridge against a newer host.

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -2079,6 +2079,64 @@ describe('HarnessAgent', () => {
     await session.destroy();
   });
 
+  test('ensures the harness bootstrap recipe on resumed sessions', async () => {
+    const base = mockHarness({ script: () => [] });
+    const recipe: HarnessV1Bootstrap = {
+      harnessId: 'mock',
+      bootstrapDir: '.harness-bootstrap/mock',
+      files: [],
+      commands: [],
+    };
+    const harness: HarnessV1 = {
+      ...base.harness,
+      getBootstrap: vi.fn(async () => recipe),
+    };
+    // No marker: the sandbox was bootstrapped by an older recipe, or never.
+    const readTextFile = vi.fn(async (_options: { path: string }) => null);
+    const writeTextFile = vi.fn(async () => {});
+    const run = vi.fn(async (args: { command: string }) => ({
+      exitCode: 0,
+      stdout: args.command === 'pwd' ? '/work\n' : '',
+      stderr: '',
+    }));
+    const restrictedSession = { run, readTextFile, writeTextFile };
+    const sandboxSession = makeSandboxSession({
+      run,
+      restricted: () => restrictedSession as never,
+    });
+    const agent = new HarnessAgent({
+      harness,
+      sandbox: makeSandboxProvider(sandboxSession),
+      sandboxConfig: { workDir: 'ai-sdk' },
+    });
+
+    const session = await agent.createSession({
+      sessionId: 's1',
+      resumeFrom: {
+        type: 'resume-session',
+        harnessId: 'mock',
+        specificationVersion: 'harness-v1',
+        data: {},
+      },
+    });
+
+    expect(readTextFile.mock.calls[0]![0]).toEqual(
+      expect.objectContaining({
+        path: expect.stringMatching(
+          /^\/work\/\.harness-bootstrap\/mock\/\.bootstrap-[0-9a-f]{16}\.ok$/,
+        ),
+      }),
+    );
+    const writeCalls = writeTextFile.mock.calls as unknown as Array<
+      [{ path: string }]
+    >;
+    expect(writeCalls.at(-1)?.[0]?.path).toMatch(
+      /^\/work\/\.harness-bootstrap\/mock\/\.bootstrap-[0-9a-f]{16}\.ok$/,
+    );
+
+    await session.destroy();
+  });
+
   test('sandboxConfig.onSession runs for resumed sessions', async () => {
     const { harness } = mockHarness({ script: () => [] });
     const sandboxSessionEvents: Array<{ sessionWorkDir: string }> = [];

--- a/packages/harness/src/agent/harness-agent.ts
+++ b/packages/harness/src/agent/harness-agent.ts
@@ -1,6 +1,5 @@
 import { HarnessCapabilityUnsupportedError } from '../errors/harness-capability-unsupported-error';
 import type {
-  HarnessV1Bootstrap,
   HarnessV1BuiltinToolFiltering,
   HarnessV1JSONSchema,
   HarnessV1NetworkSandboxSession,
@@ -379,6 +378,7 @@ export class HarnessAgent<
         );
       }
 
+      const recipe = await harness.getBootstrap?.({ abortSignal });
       if (isResumedSession) {
         if (sandboxProvider.resumeSession == null) {
           throw new HarnessCapabilityUnsupportedError({
@@ -406,7 +406,6 @@ export class HarnessAgent<
         // the harness version that made it — would otherwise keep running a
         // stale bridge against a newer host, silently missing whatever the
         // newer protocol added.
-        const recipe = await harness.getBootstrap?.({ abortSignal });
         if (recipe != null) {
           const recipeIdentity = await hashHarnessBootstrap(recipe);
           try {
@@ -427,15 +426,6 @@ export class HarnessAgent<
           }
         }
       } else {
-        // The logic in this clause applies the bootstrap plan, including both the harness
-        // bootstrap recipe and agent specific sandbox configuration.
-        // The logic matches largely what `prepareHarnessSandboxTemplate()` and
-        // `prepareSandboxForHarness()` do, so they will have to remain aligned.
-        let recipe: HarnessV1Bootstrap | undefined;
-        if (harness.getBootstrap != null) {
-          recipe = await harness.getBootstrap({ abortSignal });
-        }
-
         // Defines the hashes based on both harness bootstrap recipe and
         // consumer-defined onBootstrap callback.
         const sandboxBootstrapPlan = await createSandboxBootstrapPlan({

--- a/packages/harness/src/agent/harness-agent.ts
+++ b/packages/harness/src/agent/harness-agent.ts
@@ -398,6 +398,34 @@ export class HarnessAgent<
           sessionId,
           workDir: this.sandboxConfig.workDir,
         });
+
+        // Ensure the harness bootstrap recipe on resumed sessions too. The
+        // marker is keyed by recipe identity, so a resume whose bootstrap is
+        // already current costs one file read, while a resume into a sandbox
+        // bootstrapped by an older adapter build — a snapshot that outlived
+        // the harness version that made it — would otherwise keep running a
+        // stale bridge against a newer host, silently missing whatever the
+        // newer protocol added.
+        const recipe = await harness.getBootstrap?.({ abortSignal });
+        if (recipe != null) {
+          const recipeIdentity = await hashHarnessBootstrap(recipe);
+          try {
+            await applyBootstrapRecipe({
+              session: resumedSandboxSession.restricted(),
+              recipe,
+              identity: recipeIdentity,
+              defaultWorkingDirectory:
+                resumedSandboxSession.defaultWorkingDirectory,
+              abortSignal,
+            });
+          } catch (err) {
+            await cleanupAfterStartFailure({
+              sandboxSession,
+              ownsSandboxLifecycle,
+            });
+            throw err;
+          }
+        }
       } else {
         // The logic in this clause applies the bootstrap plan, including both the harness
         // bootstrap recipe and agent specific sandbox configuration.


### PR DESCRIPTION
Stacked on #19099.

## Background

Resumed sessions skip the bootstrap check. A sandbox snapshot created by an older adapter version keeps running its old bridge against a newer host.

## Summary

Run the recipe check on resume too. The marker is keyed by recipe identity, so an up-to-date resume costs a single file read.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
