### PR TITLE
docs: redirect AI SDK 4 to archive

### DIFF
--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -14,6 +14,18 @@ const config: NextConfig = {
     ],
   },
   redirects: () => [
+    // AI SDK 4 is archived separately so it remains available without adding
+    // its content families to this app's already memory-intensive build.
+    {
+      source: '/v4',
+      destination: 'https://v4.ai-sdk.dev/docs/introduction',
+      permanent: true,
+    },
+    {
+      source: '/v4/:path*',
+      destination: 'https://v4.ai-sdk.dev/:path*',
+      permanent: true,
+    },
     {
       source: '/v7',
       destination: '/',


### PR DESCRIPTION
## Summary

- redirect legacy /v4 paths to the separately deployed AI SDK 4 archive
- keep AI SDK 4 content out of the new docs app's memory-intensive build
- preserve the rest of each legacy path on v4.ai-sdk.dev

The archive changes are merged in https://github.com/vercel/ai-studio/pull/2142 and the sdk/v4 deployment is ready at dpl_9WBNv3eTZ1SXcHb6NqXpFrJMCzn7.

## Deployment dependency

Keep this PR as a draft until a Vercel project owner assigns v4.ai-sdk.dev to sdk/v4 (or directly to the deployment above). The current caller can deploy and inspect ai-studio but does not have domain-management permission.

## Validation

- pnpm --filter ai-sdk-docs test:site
- pnpm --filter ai-sdk-docs type-check:site
- pnpm type-check:full
- pnpm exec ultracite check apps/docs/next.config.ts

A local production docs build was also attempted. It remained in the existing long-running Next.js compilation phase and was stopped manually; this change adds redirects only and no v4 content to that build.