### PR TITLE
feat(harness): stateDirectory on sandbox sessions

### DIFF
--- a/.changeset/harness-state-directory.md
+++ b/.changeset/harness-state-directory.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/harness': patch
+'@ai-sdk/harness-claude-code': patch
+'@ai-sdk/harness-codex': patch
+'@ai-sdk/harness-opencode': patch
+'@ai-sdk/harness-deepagents': patch
+'@ai-sdk/harness-acp': patch
+---
+
+feat (harness): let sandbox providers separate harness state from the workspace. `HarnessV1NetworkSandboxSession` gains an optional `stateDirectory`; the framework and every bridge adapter now resolve their generated state — bootstrap recipes and their dependencies (`.harness-bootstrap/…`) and per-session run state (`.agent-runs/…`) — through the new `harnessV1StateDirectory()` helper instead of the sandbox's working directory. Hosted providers change nothing: when `stateDirectory` is omitted, state stays under `defaultWorkingDirectory`, where snapshot machinery preserves it. Providers whose working directory is a directory the user owns can now keep infrastructure out of the workspace entirely.

--- a/packages/harness-acp/src/v1/acp-v1-harness.ts
+++ b/packages/harness-acp/src/v1/acp-v1-harness.ts
@@ -12,6 +12,7 @@ import {
   type HarnessV1Skill,
   type HarnessV1StreamPart,
   type HarnessV1ToolSpec,
+  harnessV1StateDirectory,
 } from '@ai-sdk/harness';
 import { HarnessBridgeCapabilityUnsupportedError } from '@ai-sdk/harness/bridge';
 import {
@@ -360,8 +361,17 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
           ),
         );
       }
+      // Harness SDK state lives in the provider's state directory, which is
+      // the working directory unless the provider separates the two to keep
+      // the workspace clean.
       const resolvedBridgeDir = posix.resolve(
-        defaultWorkingDirectory,
+        harnessV1StateDirectory({
+          stateDirectory:
+            'stateDirectory' in sandboxSession
+              ? sandboxSession.stateDirectory
+              : undefined,
+          defaultWorkingDirectory,
+        }),
         bootstrap.bootstrapDir,
       );
       const resolvedImplementationDir = `${resolvedBridgeDir}/implementation`;

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -18,6 +18,7 @@ import {
   type HarnessV1Session,
   type HarnessV1Skill,
   type HarnessV1StreamPart,
+  harnessV1StateDirectory,
 } from '@ai-sdk/harness';
 import {
   applyCredentialForwarding,
@@ -929,10 +930,17 @@ export function createClaudeCode(
           credentialForwarding: settings.credentialForwarding,
         });
       }
-      const bootstrapDir = posix.resolve(
+      // Harness SDK state (bootstrap, per-session runs) lives in the
+      // provider's state directory, which is the working directory unless the
+      // provider separates the two to keep the workspace clean.
+      const stateDir = harnessV1StateDirectory({
+        stateDirectory:
+          'stateDirectory' in sandboxSession
+            ? sandboxSession.stateDirectory
+            : undefined,
         defaultWorkingDirectory,
-        BOOTSTRAP_DIR,
-      );
+      });
+      const bootstrapDir = posix.resolve(stateDir, BOOTSTRAP_DIR);
       // The conversation the host wants back, when it is known. Absent on
       // state written before this field existed; those resumes fall back to
       // the `continue` flag as before.
@@ -943,7 +951,7 @@ export function createClaudeCode(
         sandbox: toolSafeSandboxSession,
         abortSignal: startOpts.abortSignal,
       });
-      const sessionDataDir = `${defaultWorkingDirectory}/.agent-runs/${startOpts.sessionId}`;
+      const sessionDataDir = `${stateDir}/.agent-runs/${startOpts.sessionId}`;
       const bridgeStateDir = `${sessionDataDir}/bridge`;
       const timeoutMs = settings.startupTimeoutMs ?? 120_000;
 

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -18,6 +18,7 @@ import {
   type HarnessV1Session,
   type HarnessV1Skill,
   type HarnessV1StreamPart,
+  harnessV1StateDirectory,
 } from '@ai-sdk/harness';
 import {
   applyCredentialForwarding,
@@ -316,17 +317,24 @@ export function createCodex(
       } else {
         warnCredentialBrokeringUnavailable();
       }
-      const bootstrapDir = path.posix.resolve(
+      // Harness SDK state (bootstrap, per-session runs) lives in the
+      // provider's state directory, which is the working directory unless the
+      // provider separates the two to keep the workspace clean.
+      const stateDir = harnessV1StateDirectory({
+        stateDirectory:
+          'stateDirectory' in sandboxSession
+            ? sandboxSession.stateDirectory
+            : undefined,
         defaultWorkingDirectory,
-        BOOTSTRAP_DIR,
-      );
+      });
+      const bootstrapDir = path.posix.resolve(stateDir, BOOTSTRAP_DIR);
 
       const workDir = startOpts.sessionWorkDir;
       const sandboxHomeDir = await resolveSandboxHomeDir({
         sandbox: toolSafeSandboxSession,
         abortSignal: startOpts.abortSignal,
       });
-      const sessionDataDir = `${defaultWorkingDirectory}/.agent-runs/${startOpts.sessionId}`;
+      const sessionDataDir = `${stateDir}/.agent-runs/${startOpts.sessionId}`;
       const bridgeStateDir = `${sessionDataDir}/bridge`;
       const cliShimDir = `${sessionDataDir}/codex`;
       const cliShimPath = `${cliShimDir}/${CLI_SHIM_FILENAME}`;

--- a/packages/harness-deepagents/src/deepagents-harness.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.ts
@@ -17,6 +17,7 @@ import {
   type HarnessV1Session,
   type HarnessV1Skill,
   type HarnessV1StreamPart,
+  harnessV1StateDirectory,
 } from '@ai-sdk/harness';
 import {
   applyCredentialForwarding,
@@ -295,10 +296,17 @@ export function createDeepAgents(
       } else {
         warnCredentialBrokeringUnavailable();
       }
-      const bootstrapDir = posix.resolve(
+      // Harness SDK state (bootstrap, per-session runs) lives in the
+      // provider's state directory, which is the working directory unless the
+      // provider separates the two to keep the workspace clean.
+      const stateDir = harnessV1StateDirectory({
+        stateDirectory:
+          'stateDirectory' in sandboxSession
+            ? sandboxSession.stateDirectory
+            : undefined,
         defaultWorkingDirectory,
-        BOOTSTRAP_DIR,
-      );
+      });
+      const bootstrapDir = posix.resolve(stateDir, BOOTSTRAP_DIR);
 
       const workDir = startOpts.sessionWorkDir;
       /*
@@ -312,7 +320,7 @@ export function createDeepAgents(
       });
       const homeSkillsRoot = `${homeDir}${SKILLS_SOURCE_PATH}`;
       const skillsPaths = [`${workDir}${SKILLS_SOURCE_PATH}`, homeSkillsRoot];
-      const sessionDataDir = `${defaultWorkingDirectory}/.agent-runs/${startOpts.sessionId}`;
+      const sessionDataDir = `${stateDir}/.agent-runs/${startOpts.sessionId}`;
       const bridgeStateDir = `${sessionDataDir}/bridge`;
       const timeoutMs = settings.startupTimeoutMs ?? 120_000;
 

--- a/packages/harness-opencode/src/opencode-harness.ts
+++ b/packages/harness-opencode/src/opencode-harness.ts
@@ -18,6 +18,7 @@ import {
   type HarnessV1Session,
   type HarnessV1Skill,
   type HarnessV1StreamPart,
+  harnessV1StateDirectory,
 } from '@ai-sdk/harness';
 import {
   applyCredentialForwarding,
@@ -339,17 +340,25 @@ export function createOpenCode(
       } else {
         warnCredentialBrokeringUnavailable();
       }
-      const bootstrapDir = path.posix.resolve(
+      // Harness SDK state (bootstrap, per-session runs) lives in the
+      // provider's state directory, which is the working directory unless the
+      // provider separates the two to keep the workspace clean.
+      const stateDir = harnessV1StateDirectory({
+        stateDirectory:
+          'stateDirectory' in sandboxSession
+            ? sandboxSession.stateDirectory
+            : undefined,
         defaultWorkingDirectory,
-        BOOTSTRAP_DIR,
-      );
+      });
+      const bootstrapDir = path.posix.resolve(stateDir, BOOTSTRAP_DIR);
+
       const workDir = startOpts.sessionWorkDir;
       const sandboxHomeDir = await resolveSandboxHomeDir({
         sandbox: toolSafeSandboxSession,
         abortSignal: startOpts.abortSignal,
       });
       const skillsDir = path.posix.join(sandboxHomeDir, '.agents', 'skills');
-      const sessionDataDir = `${defaultWorkingDirectory}/.agent-runs/${startOpts.sessionId}`;
+      const sessionDataDir = `${stateDir}/.agent-runs/${startOpts.sessionId}`;
       const bridgeStateDir = `${sessionDataDir}/bridge`;
       const timeoutMs = settings.startupTimeoutMs ?? 120_000;
       const model = splitOpenCodeModel(

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -2126,6 +2126,55 @@ describe('HarnessAgent', () => {
     await session.destroy();
   });
 
+  test('applies the bootstrap recipe in the provider state directory when the session declares one', async () => {
+    const base = mockHarness({ script: () => [] });
+    const recipe: HarnessV1Bootstrap = {
+      harnessId: 'mock',
+      bootstrapDir: '.harness-bootstrap/mock',
+      files: [{ path: '.harness-bootstrap/mock/bridge.mjs', content: 'x' }],
+      commands: [],
+    };
+    const harness: HarnessV1 = {
+      ...base.harness,
+      getBootstrap: vi.fn(async () => recipe),
+    };
+    const readTextFile = vi.fn(async () => null);
+    const writeTextFile = vi.fn(async () => {});
+    const run = vi.fn(async (args: { command: string }) => ({
+      exitCode: 0,
+      stdout: args.command === 'pwd' ? '/work\n' : '',
+      stderr: '',
+    }));
+    const restrictedSession = { run, readTextFile, writeTextFile };
+    const sandboxSession = makeSandboxSession({
+      run,
+      stateDirectory: '/state',
+      restricted: () => restrictedSession as never,
+    });
+    const agent = new HarnessAgent({
+      harness,
+      sandbox: makeSandboxProvider(sandboxSession),
+      sandboxConfig: { workDir: 'ai-sdk' },
+    });
+
+    const session = await agent.createSession({ sessionId: 's1' });
+
+    // All harness-generated state resolves against the state directory …
+    const writtenPaths = (
+      writeTextFile.mock.calls as unknown as Array<[{ path: string }]>
+    ).map(call => call[0].path);
+    expect(writtenPaths).toContain('/state/.harness-bootstrap/mock/bridge.mjs');
+    for (const path of writtenPaths) {
+      expect(path).toMatch(/^\/state\//);
+    }
+    // … while the session still works in the sandbox working directory.
+    expect(base.doStart.mock.calls[0]![0]).toMatchObject({
+      sessionWorkDir: '/work/ai-sdk',
+    });
+
+    await session.destroy();
+  });
+
   test('ensures the harness bootstrap recipe on resumed sessions', async () => {
     const base = mockHarness({ script: () => [] });
     const recipe: HarnessV1Bootstrap = {

--- a/packages/harness/src/agent/harness-agent.ts
+++ b/packages/harness/src/agent/harness-agent.ts
@@ -1,9 +1,10 @@
 import { HarnessCapabilityUnsupportedError } from '../errors/harness-capability-unsupported-error';
-import type {
-  HarnessV1BuiltinToolFiltering,
-  HarnessV1JSONSchema,
-  HarnessV1NetworkSandboxSession,
-  HarnessV1ResponseFormat,
+import {
+  harnessV1StateDirectory,
+  type HarnessV1BuiltinToolFiltering,
+  type HarnessV1JSONSchema,
+  type HarnessV1NetworkSandboxSession,
+  type HarnessV1ResponseFormat,
 } from '../v1';
 import {
   asArray,
@@ -361,7 +362,15 @@ export class HarnessAgent<
             session: toolSafeSandboxSession,
             recipe,
             identity: recipeIdentity,
-            defaultWorkingDirectory,
+            // State, not workspace: providers that separate the two keep the
+            // recipe's dependencies out of the session's working directory.
+            defaultWorkingDirectory: harnessV1StateDirectory({
+              stateDirectory:
+                'stateDirectory' in sandboxSession
+                  ? sandboxSession.stateDirectory
+                  : undefined,
+              defaultWorkingDirectory,
+            }),
             abortSignal,
           });
         } catch (err) {
@@ -414,8 +423,11 @@ export class HarnessAgent<
               session: resumedSandboxSession.restricted(),
               recipe,
               identity: recipeIdentity,
-              defaultWorkingDirectory:
-                resumedSandboxSession.defaultWorkingDirectory,
+              // State, not workspace: providers that separate the two keep
+              // the recipe's dependencies out of the working directory.
+              defaultWorkingDirectory: harnessV1StateDirectory(
+                resumedSandboxSession,
+              ),
               abortSignal,
             });
           } catch (err) {
@@ -462,8 +474,11 @@ export class HarnessAgent<
               session: createdSandboxSession.restricted(),
               recipe: sandboxBootstrapPlan.recipe,
               identity: sandboxBootstrapPlan.recipeIdentity,
-              defaultWorkingDirectory:
-                createdSandboxSession.defaultWorkingDirectory,
+              // State, not workspace: providers that separate the two keep
+              // the recipe's dependencies out of the working directory.
+              defaultWorkingDirectory: harnessV1StateDirectory(
+                createdSandboxSession,
+              ),
               abortSignal,
             });
           } catch (err) {

--- a/packages/harness/src/v1/harness-v1-network-sandbox-session.ts
+++ b/packages/harness/src/v1/harness-v1-network-sandbox-session.ts
@@ -10,6 +10,24 @@ export type HarnessV1PortEndpoint = {
 };
 
 /**
+ * Where the harness machinery keeps its generated state for this session's
+ * sandbox: the provider's {@link HarnessV1NetworkSandboxSession.stateDirectory}
+ * when it declares one, otherwise the sandbox's default working directory.
+ *
+ * Adapters and the framework must derive every state path (bootstrap
+ * directories, `.agent-runs`, markers) through this so a provider can keep
+ * infrastructure out of the user's workspace.
+ */
+export function harnessV1StateDirectory(
+  session: Pick<
+    HarnessV1NetworkSandboxSession,
+    'stateDirectory' | 'defaultWorkingDirectory'
+  >,
+): string {
+  return session.stateDirectory ?? session.defaultWorkingDirectory;
+}
+
+/**
  * Network sandbox session returned by `HarnessV1SandboxProvider.createSession()`. The
  * harness keeps this for the lifetime of a session. It is itself a
  * {@link SandboxSession} (file I/O, exec, spawn) and adds the infra surface on
@@ -44,6 +62,23 @@ export interface HarnessV1NetworkSandboxSession extends SandboxSession {
    * not bake a provider-specific base into their own paths.
    */
   readonly defaultWorkingDirectory: string;
+
+  /**
+   * Directory where the harness machinery keeps its own generated state —
+   * bootstrap recipes and their dependencies (`.harness-bootstrap/…`), and
+   * per-session adapter state (`.agent-runs/…`). This is Harness SDK state,
+   * not the runtime's own store (Claude Code's `~/.claude`, Codex's
+   * `~/.codex`, …), which each runtime continues to manage itself.
+   *
+   * Optional. When omitted, state lives under {@link defaultWorkingDirectory},
+   * which is correct for hosted sandboxes: their snapshot machinery preserves
+   * the working-directory mount, so state written there survives
+   * stop → snapshot → resume cycles. Providers whose working directory is a
+   * directory the user owns set this elsewhere so the workspace stays free of
+   * infrastructure. Resolve it through {@link harnessV1StateDirectory} rather
+   * than reading the field directly.
+   */
+  readonly stateDirectory?: string;
 
   /** Ports the sandbox exposes; resolvable via `getPortEndpoint`. */
   readonly ports: ReadonlyArray<number>;

--- a/packages/harness/src/v1/index.ts
+++ b/packages/harness/src/v1/index.ts
@@ -53,6 +53,7 @@ export type {
   HarnessV1RequestTransformation,
   HarnessV1RequestTransformationSources,
 } from './harness-v1-network-sandbox-session';
+export { harnessV1StateDirectory } from './harness-v1-network-sandbox-session';
 export type { HarnessV1Skill } from './harness-v1-skill';
 export type { HarnessV1StreamPart } from './harness-v1-stream-part';
 export {


### PR DESCRIPTION
Stacked on #19102.

## Background

Adapters hardcode that generated state (`.harness-bootstrap/`, `.agent-runs/`) lives under the sandbox working directory. That's right for hosted sandboxes, whose snapshots preserve that mount, but it forces infrastructure into the workspace when the working directory is one the user owns. Follows up on the directory discussion in #18383.

## Summary

- Add optional `stateDirectory` to `HarnessV1NetworkSandboxSession`, defaulting to `defaultWorkingDirectory`, plus a `harnessV1StateDirectory()` helper.
- The framework and all bridge adapters resolve their generated state through it.
- Hosted providers are unchanged; a provider can now keep infrastructure out of the user's workspace.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
