### PR TITLE
feat(harness): readHistory contract

### DIFF
--- a/.changeset/harness-read-history.md
+++ b/.changeset/harness-read-history.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness': patch
+---
+
+feat (harness): read the runtime's own conversation history back through the contract. `HarnessAgentSession.readHistory({ since })` returns the messages the underlying runtime persisted — including exchanges that happened outside this process, such as the same conversation continued interactively in the agent's own CLI — normalized to the stream-part vocabulary (text, reasoning, tool-call, tool-result with full output) with the runtime's raw record attached for full fidelity. Pass a previous result's `cursor` as `since` to read only the delta. Backed by the new optional `doReadHistory` capability on `HarnessV1Session`; `session.supportsHistory` feature-detects it, `HarnessCapabilityUnsupportedError` is thrown when the adapter lacks it, and the new `HarnessHistoryUnavailableError` when the adapter cannot reach the runtime's store from the current environment.

--- a/.changeset/harness-state-directory.md
+++ b/.changeset/harness-state-directory.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/harness': patch
+'@ai-sdk/harness-claude-code': patch
+'@ai-sdk/harness-codex': patch
+'@ai-sdk/harness-opencode': patch
+'@ai-sdk/harness-deepagents': patch
+'@ai-sdk/harness-acp': patch
+---
+
+feat (harness): let sandbox providers separate harness state from the workspace. `HarnessV1NetworkSandboxSession` gains an optional `stateDirectory`; the framework and every bridge adapter now resolve their generated state — bootstrap recipes and their dependencies (`.harness-bootstrap/…`) and per-session run state (`.agent-runs/…`) — through the new `harnessV1StateDirectory()` helper instead of the sandbox's working directory. Hosted providers change nothing: when `stateDirectory` is omitted, state stays under `defaultWorkingDirectory`, where snapshot machinery preserves it. Providers whose working directory is a directory the user owns can now keep infrastructure out of the workspace entirely.

--- a/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
+++ b/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
@@ -167,6 +167,30 @@ This is different from model calls, where the application usually sends the full
 message history. In chat routes, persist and resume the harness session instead
 of relying on message replay.
 
+### Reading the Runtime's Own History
+
+The runtime's conversation can grow outside your process — the same
+conversation continued interactively in the agent's own CLI, for instance —
+and the live event stream never sees those exchanges. Adapters that can reach
+their runtime's store expose them through `session.readHistory()`:
+
+```ts
+if (session.supportsHistory) {
+  const { messages, cursor } = await session.readHistory();
+  // messages: text, reasoning, tool-call, and tool-result parts, with the
+  // runtime's raw record attached for full fidelity.
+
+  // Later: read only what was recorded since.
+  const delta = await session.readHistory({ since: cursor });
+}
+```
+
+`readHistory()` throws `HarnessCapabilityUnsupportedError` when the adapter
+does not implement history reads, and `HarnessHistoryUnavailableError` when it
+does but cannot reach the runtime's store from this environment (for example,
+the store lives inside a remote sandbox). A conversation with no recorded
+messages yet is not an error; it resolves to an empty `messages` array.
+
 ## Session Lifecycle
 
 End every session explicitly:

--- a/packages/harness-acp/src/v1/acp-v1-harness.ts
+++ b/packages/harness-acp/src/v1/acp-v1-harness.ts
@@ -12,6 +12,7 @@ import {
   type HarnessV1Skill,
   type HarnessV1StreamPart,
   type HarnessV1ToolSpec,
+  harnessV1StateDirectory,
 } from '@ai-sdk/harness';
 import { HarnessBridgeCapabilityUnsupportedError } from '@ai-sdk/harness/bridge';
 import {
@@ -360,8 +361,17 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
           ),
         );
       }
+      // Harness SDK state lives in the provider's state directory, which is
+      // the working directory unless the provider separates the two to keep
+      // the workspace clean.
       const resolvedBridgeDir = posix.resolve(
-        defaultWorkingDirectory,
+        harnessV1StateDirectory({
+          stateDirectory:
+            'stateDirectory' in sandboxSession
+              ? sandboxSession.stateDirectory
+              : undefined,
+          defaultWorkingDirectory,
+        }),
         bootstrap.bootstrapDir,
       );
       const resolvedImplementationDir = `${resolvedBridgeDir}/implementation`;

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -18,6 +18,7 @@ import {
   type HarnessV1Session,
   type HarnessV1Skill,
   type HarnessV1StreamPart,
+  harnessV1StateDirectory,
 } from '@ai-sdk/harness';
 import {
   applyCredentialForwarding,
@@ -929,10 +930,17 @@ export function createClaudeCode(
           credentialForwarding: settings.credentialForwarding,
         });
       }
-      const bootstrapDir = posix.resolve(
+      // Harness SDK state (bootstrap, per-session runs) lives in the
+      // provider's state directory, which is the working directory unless the
+      // provider separates the two to keep the workspace clean.
+      const stateDir = harnessV1StateDirectory({
+        stateDirectory:
+          'stateDirectory' in sandboxSession
+            ? sandboxSession.stateDirectory
+            : undefined,
         defaultWorkingDirectory,
-        BOOTSTRAP_DIR,
-      );
+      });
+      const bootstrapDir = posix.resolve(stateDir, BOOTSTRAP_DIR);
       // The conversation the host wants back, when it is known. Absent on
       // state written before this field existed; those resumes fall back to
       // the `continue` flag as before.
@@ -943,7 +951,7 @@ export function createClaudeCode(
         sandbox: toolSafeSandboxSession,
         abortSignal: startOpts.abortSignal,
       });
-      const sessionDataDir = `${defaultWorkingDirectory}/.agent-runs/${startOpts.sessionId}`;
+      const sessionDataDir = `${stateDir}/.agent-runs/${startOpts.sessionId}`;
       const bridgeStateDir = `${sessionDataDir}/bridge`;
       const timeoutMs = settings.startupTimeoutMs ?? 120_000;
 

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -18,6 +18,7 @@ import {
   type HarnessV1Session,
   type HarnessV1Skill,
   type HarnessV1StreamPart,
+  harnessV1StateDirectory,
 } from '@ai-sdk/harness';
 import {
   applyCredentialForwarding,
@@ -316,17 +317,24 @@ export function createCodex(
       } else {
         warnCredentialBrokeringUnavailable();
       }
-      const bootstrapDir = path.posix.resolve(
+      // Harness SDK state (bootstrap, per-session runs) lives in the
+      // provider's state directory, which is the working directory unless the
+      // provider separates the two to keep the workspace clean.
+      const stateDir = harnessV1StateDirectory({
+        stateDirectory:
+          'stateDirectory' in sandboxSession
+            ? sandboxSession.stateDirectory
+            : undefined,
         defaultWorkingDirectory,
-        BOOTSTRAP_DIR,
-      );
+      });
+      const bootstrapDir = path.posix.resolve(stateDir, BOOTSTRAP_DIR);
 
       const workDir = startOpts.sessionWorkDir;
       const sandboxHomeDir = await resolveSandboxHomeDir({
         sandbox: toolSafeSandboxSession,
         abortSignal: startOpts.abortSignal,
       });
-      const sessionDataDir = `${defaultWorkingDirectory}/.agent-runs/${startOpts.sessionId}`;
+      const sessionDataDir = `${stateDir}/.agent-runs/${startOpts.sessionId}`;
       const bridgeStateDir = `${sessionDataDir}/bridge`;
       const cliShimDir = `${sessionDataDir}/codex`;
       const cliShimPath = `${cliShimDir}/${CLI_SHIM_FILENAME}`;

--- a/packages/harness-deepagents/src/deepagents-harness.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.ts
@@ -17,6 +17,7 @@ import {
   type HarnessV1Session,
   type HarnessV1Skill,
   type HarnessV1StreamPart,
+  harnessV1StateDirectory,
 } from '@ai-sdk/harness';
 import {
   applyCredentialForwarding,
@@ -295,10 +296,17 @@ export function createDeepAgents(
       } else {
         warnCredentialBrokeringUnavailable();
       }
-      const bootstrapDir = posix.resolve(
+      // Harness SDK state (bootstrap, per-session runs) lives in the
+      // provider's state directory, which is the working directory unless the
+      // provider separates the two to keep the workspace clean.
+      const stateDir = harnessV1StateDirectory({
+        stateDirectory:
+          'stateDirectory' in sandboxSession
+            ? sandboxSession.stateDirectory
+            : undefined,
         defaultWorkingDirectory,
-        BOOTSTRAP_DIR,
-      );
+      });
+      const bootstrapDir = posix.resolve(stateDir, BOOTSTRAP_DIR);
 
       const workDir = startOpts.sessionWorkDir;
       /*
@@ -312,7 +320,7 @@ export function createDeepAgents(
       });
       const homeSkillsRoot = `${homeDir}${SKILLS_SOURCE_PATH}`;
       const skillsPaths = [`${workDir}${SKILLS_SOURCE_PATH}`, homeSkillsRoot];
-      const sessionDataDir = `${defaultWorkingDirectory}/.agent-runs/${startOpts.sessionId}`;
+      const sessionDataDir = `${stateDir}/.agent-runs/${startOpts.sessionId}`;
       const bridgeStateDir = `${sessionDataDir}/bridge`;
       const timeoutMs = settings.startupTimeoutMs ?? 120_000;
 

--- a/packages/harness-opencode/src/opencode-harness.ts
+++ b/packages/harness-opencode/src/opencode-harness.ts
@@ -18,6 +18,7 @@ import {
   type HarnessV1Session,
   type HarnessV1Skill,
   type HarnessV1StreamPart,
+  harnessV1StateDirectory,
 } from '@ai-sdk/harness';
 import {
   applyCredentialForwarding,
@@ -339,17 +340,25 @@ export function createOpenCode(
       } else {
         warnCredentialBrokeringUnavailable();
       }
-      const bootstrapDir = path.posix.resolve(
+      // Harness SDK state (bootstrap, per-session runs) lives in the
+      // provider's state directory, which is the working directory unless the
+      // provider separates the two to keep the workspace clean.
+      const stateDir = harnessV1StateDirectory({
+        stateDirectory:
+          'stateDirectory' in sandboxSession
+            ? sandboxSession.stateDirectory
+            : undefined,
         defaultWorkingDirectory,
-        BOOTSTRAP_DIR,
-      );
+      });
+      const bootstrapDir = path.posix.resolve(stateDir, BOOTSTRAP_DIR);
+
       const workDir = startOpts.sessionWorkDir;
       const sandboxHomeDir = await resolveSandboxHomeDir({
         sandbox: toolSafeSandboxSession,
         abortSignal: startOpts.abortSignal,
       });
       const skillsDir = path.posix.join(sandboxHomeDir, '.agents', 'skills');
-      const sessionDataDir = `${defaultWorkingDirectory}/.agent-runs/${startOpts.sessionId}`;
+      const sessionDataDir = `${stateDir}/.agent-runs/${startOpts.sessionId}`;
       const bridgeStateDir = `${sessionDataDir}/bridge`;
       const timeoutMs = settings.startupTimeoutMs ?? 120_000;
       const model = splitOpenCodeModel(

--- a/packages/harness/src/agent/harness-agent-session.ts
+++ b/packages/harness/src/agent/harness-agent-session.ts
@@ -14,6 +14,7 @@ import type {
   HarnessV1BuiltinToolFiltering,
   HarnessV1NetworkSandboxSession,
   HarnessV1PromptControl,
+  HarnessV1ReadHistoryResult,
   HarnessV1ResponseFormat,
   HarnessV1Skill,
   HarnessV1TurnSettings,
@@ -475,6 +476,49 @@ export class HarnessAgentSession {
     } finally {
       this.endLocalHandle({ sessionState: 'detached' });
     }
+  }
+
+  /**
+   * Whether this session's adapter can read the runtime's persisted
+   * conversation history. Cheap feature detection for `readHistory()`.
+   */
+  get supportsHistory(): boolean {
+    return typeof this.underlyingSession?.doReadHistory === 'function';
+  }
+
+  /**
+   * Read the conversation history the runtime itself persisted, normalized
+   * by the adapter. Includes exchanges that happened outside this process —
+   * the same conversation continued interactively in the agent's own CLI,
+   * for instance — which the live event stream never saw.
+   *
+   * Pass a previous result's `cursor` as `since` to read only the delta. A
+   * conversation with no recorded messages yet resolves to an empty
+   * `messages` array.
+   *
+   * Throws `HarnessCapabilityUnsupportedError` when the adapter does not
+   * implement history reads (check {@link supportsHistory} first), and
+   * `HarnessHistoryUnavailableError` when the adapter supports them but
+   * cannot reach the runtime's store from this environment.
+   */
+  async readHistory(options?: {
+    since?: string;
+  }): Promise<HarnessV1ReadHistoryResult> {
+    if (this.sessionState !== 'active' || this.underlyingSession == null) {
+      throw new Error(
+        `Harness session ${this.sessionId} is not active and cannot read history.`,
+      );
+    }
+    const session = this.underlyingSession;
+    if (typeof session.doReadHistory !== 'function') {
+      throw new HarnessCapabilityUnsupportedError({
+        harnessId: this.harness.harnessId,
+        message: `Harness '${this.harness.harnessId}' does not support reading the runtime's conversation history.`,
+      });
+    }
+    return await session.doReadHistory({
+      ...(options?.since != null ? { since: options.since } : {}),
+    });
   }
 
   /**

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -47,6 +47,7 @@ function mockHarness(options: {
   promptDone?: (options: HarnessV1PromptTurnOptions) => Promise<void>;
   supportsSteering?: boolean;
   onSuspendTurn?: () => void | Promise<void>;
+  doReadHistory?: HarnessV1Session['doReadHistory'];
   continueScript?: (
     submitToolResult: (input: {
       toolCallId: string;
@@ -168,6 +169,9 @@ function mockHarness(options: {
     doDestroy,
     doContinueTurn,
     doSuspendTurn,
+    ...(options.doReadHistory != null
+      ? { doReadHistory: options.doReadHistory }
+      : {}),
   };
 
   return {
@@ -2124,6 +2128,74 @@ describe('HarnessAgent', () => {
     );
 
     await session.destroy();
+  });
+
+  test('readHistory() reads the runtime history through the adapter', async () => {
+    const history = {
+      messages: [
+        {
+          role: 'user' as const,
+          parts: [{ type: 'text' as const, text: 'hello' }],
+        },
+        {
+          role: 'assistant' as const,
+          parts: [
+            { type: 'reasoning' as const, text: 'thinking it over' },
+            {
+              type: 'tool-call' as const,
+              toolName: 'bash',
+              nativeName: 'Bash',
+              input: { command: 'ls' },
+            },
+            {
+              type: 'tool-result' as const,
+              toolName: 'bash',
+              output: 'README.md',
+            },
+            { type: 'text' as const, text: 'done' },
+          ],
+        },
+      ],
+      cursor: 'cursor-1',
+    };
+    const doReadHistory = vi.fn(async () => history);
+    const { harness } = mockHarness({ script: () => [], doReadHistory });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession();
+
+    expect(session.supportsHistory).toBe(true);
+    await expect(session.readHistory()).resolves.toEqual(history);
+    await session.readHistory({ since: 'cursor-1' });
+    expect(doReadHistory).toHaveBeenLastCalledWith({ since: 'cursor-1' });
+
+    await session.destroy();
+  });
+
+  test('readHistory() throws HarnessCapabilityUnsupportedError when the adapter lacks it', async () => {
+    const { harness } = mockHarness({ script: () => [] });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession();
+
+    expect(session.supportsHistory).toBe(false);
+    await expect(session.readHistory()).rejects.toSatisfy(error =>
+      HarnessCapabilityUnsupportedError.isInstance(error),
+    );
+
+    await session.destroy();
+  });
+
+  test('readHistory() rejects once the session is no longer active', async () => {
+    const { harness } = mockHarness({
+      script: () => [],
+      doReadHistory: async () => ({ messages: [], cursor: 'c' }),
+    });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession();
+    await session.destroy();
+
+    await expect(session.readHistory()).rejects.toThrow(
+      /not active and cannot read history/,
+    );
   });
 
   test('applies the bootstrap recipe in the provider state directory when the session declares one', async () => {

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -2126,6 +2126,55 @@ describe('HarnessAgent', () => {
     await session.destroy();
   });
 
+  test('applies the bootstrap recipe in the provider state directory when the session declares one', async () => {
+    const base = mockHarness({ script: () => [] });
+    const recipe: HarnessV1Bootstrap = {
+      harnessId: 'mock',
+      bootstrapDir: '.harness-bootstrap/mock',
+      files: [{ path: '.harness-bootstrap/mock/bridge.mjs', content: 'x' }],
+      commands: [],
+    };
+    const harness: HarnessV1 = {
+      ...base.harness,
+      getBootstrap: vi.fn(async () => recipe),
+    };
+    const readTextFile = vi.fn(async () => null);
+    const writeTextFile = vi.fn(async () => {});
+    const run = vi.fn(async (args: { command: string }) => ({
+      exitCode: 0,
+      stdout: args.command === 'pwd' ? '/work\n' : '',
+      stderr: '',
+    }));
+    const restrictedSession = { run, readTextFile, writeTextFile };
+    const sandboxSession = makeSandboxSession({
+      run,
+      stateDirectory: '/state',
+      restricted: () => restrictedSession as never,
+    });
+    const agent = new HarnessAgent({
+      harness,
+      sandbox: makeSandboxProvider(sandboxSession),
+      sandboxConfig: { workDir: 'ai-sdk' },
+    });
+
+    const session = await agent.createSession({ sessionId: 's1' });
+
+    // All harness-generated state resolves against the state directory …
+    const writtenPaths = (
+      writeTextFile.mock.calls as unknown as Array<[{ path: string }]>
+    ).map(call => call[0].path);
+    expect(writtenPaths).toContain('/state/.harness-bootstrap/mock/bridge.mjs');
+    for (const path of writtenPaths) {
+      expect(path).toMatch(/^\/state\//);
+    }
+    // … while the session still works in the sandbox working directory.
+    expect(base.doStart.mock.calls[0]![0]).toMatchObject({
+      sessionWorkDir: '/work/ai-sdk',
+    });
+
+    await session.destroy();
+  });
+
   test('ensures the harness bootstrap recipe on resumed sessions', async () => {
     const base = mockHarness({ script: () => [] });
     const recipe: HarnessV1Bootstrap = {

--- a/packages/harness/src/agent/harness-agent.ts
+++ b/packages/harness/src/agent/harness-agent.ts
@@ -1,9 +1,10 @@
 import { HarnessCapabilityUnsupportedError } from '../errors/harness-capability-unsupported-error';
-import type {
-  HarnessV1BuiltinToolFiltering,
-  HarnessV1JSONSchema,
-  HarnessV1NetworkSandboxSession,
-  HarnessV1ResponseFormat,
+import {
+  harnessV1StateDirectory,
+  type HarnessV1BuiltinToolFiltering,
+  type HarnessV1JSONSchema,
+  type HarnessV1NetworkSandboxSession,
+  type HarnessV1ResponseFormat,
 } from '../v1';
 import {
   asArray,
@@ -361,7 +362,15 @@ export class HarnessAgent<
             session: toolSafeSandboxSession,
             recipe,
             identity: recipeIdentity,
-            defaultWorkingDirectory,
+            // State, not workspace: providers that separate the two keep the
+            // recipe's dependencies out of the session's working directory.
+            defaultWorkingDirectory: harnessV1StateDirectory({
+              stateDirectory:
+                'stateDirectory' in sandboxSession
+                  ? sandboxSession.stateDirectory
+                  : undefined,
+              defaultWorkingDirectory,
+            }),
             abortSignal,
           });
         } catch (err) {
@@ -414,8 +423,11 @@ export class HarnessAgent<
               session: resumedSandboxSession.restricted(),
               recipe,
               identity: recipeIdentity,
-              defaultWorkingDirectory:
-                resumedSandboxSession.defaultWorkingDirectory,
+              // State, not workspace: providers that separate the two keep
+              // the recipe's dependencies out of the working directory.
+              defaultWorkingDirectory: harnessV1StateDirectory(
+                resumedSandboxSession,
+              ),
               abortSignal,
             });
           } catch (err) {
@@ -462,8 +474,11 @@ export class HarnessAgent<
               session: createdSandboxSession.restricted(),
               recipe: sandboxBootstrapPlan.recipe,
               identity: sandboxBootstrapPlan.recipeIdentity,
-              defaultWorkingDirectory:
-                createdSandboxSession.defaultWorkingDirectory,
+              // State, not workspace: providers that separate the two keep
+              // the recipe's dependencies out of the working directory.
+              defaultWorkingDirectory: harnessV1StateDirectory(
+                createdSandboxSession,
+              ),
               abortSignal,
             });
           } catch (err) {

--- a/packages/harness/src/errors/harness-history-unavailable-error.test.ts
+++ b/packages/harness/src/errors/harness-history-unavailable-error.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest';
+import { HarnessError } from './harness-error';
+import { HarnessHistoryUnavailableError } from './harness-history-unavailable-error';
+
+describe('HarnessHistoryUnavailableError', () => {
+  test('is a HarnessError', () => {
+    const err = new HarnessHistoryUnavailableError({
+      message: 'The transcript store is inside a remote sandbox',
+    });
+    expect(HarnessError.isInstance(err)).toBe(true);
+    expect(HarnessHistoryUnavailableError.isInstance(err)).toBe(true);
+  });
+
+  test('preserves the supplied message, harnessId, and cause', () => {
+    const cause = new Error('ENOENT');
+    const err = new HarnessHistoryUnavailableError({
+      message: 'No transcript directory for this working directory',
+      harnessId: 'claude-code',
+      cause,
+    });
+    expect(err.message).toBe(
+      'No transcript directory for this working directory',
+    );
+    expect(err.harnessId).toBe('claude-code');
+    expect(err.cause).toBe(cause);
+  });
+
+  test('isInstance returns false for unrelated errors', () => {
+    expect(HarnessHistoryUnavailableError.isInstance(new Error('x'))).toBe(
+      false,
+    );
+    expect(HarnessHistoryUnavailableError.isInstance(null)).toBe(false);
+  });
+});

--- a/packages/harness/src/errors/harness-history-unavailable-error.ts
+++ b/packages/harness/src/errors/harness-history-unavailable-error.ts
@@ -1,0 +1,41 @@
+import { AISDKError } from '@ai-sdk/provider';
+import { HarnessError } from './harness-error';
+
+const name = 'AI_HarnessHistoryUnavailableError';
+const marker = `vercel.ai.error.${name}`;
+const symbol = Symbol.for(marker);
+
+/**
+ * Thrown by `readHistory` when the adapter supports history reads but cannot
+ * reach the runtime's store from the current environment — for example the
+ * store lives inside a remote sandbox, or the transcript directory is
+ * missing or unreadable.
+ *
+ * Distinct from `HarnessCapabilityUnsupportedError` (the adapter does not
+ * implement history reads at all) so hosts can retry or degrade differently.
+ * A conversation with no recorded messages yet is not an error; it resolves
+ * to an empty result instead.
+ */
+export class HarnessHistoryUnavailableError extends HarnessError {
+  private readonly [symbol] = true;
+
+  readonly harnessId?: string;
+
+  constructor({
+    message,
+    harnessId,
+    cause,
+  }: {
+    message: string;
+    harnessId?: string;
+    cause?: unknown;
+  }) {
+    super({ message, cause });
+    Object.defineProperty(this, 'name', { value: name });
+    this.harnessId = harnessId;
+  }
+
+  static isInstance(error: unknown): error is HarnessHistoryUnavailableError {
+    return AISDKError.hasMarker(error, marker);
+  }
+}

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,4 +1,5 @@
 export * from './v1';
 export * from './errors/harness-error';
 export * from './errors/harness-capability-unsupported-error';
+export * from './errors/harness-history-unavailable-error';
 export * from './errors/harness-sandbox-authentication-error';

--- a/packages/harness/src/v1/harness-v1-network-sandbox-session.ts
+++ b/packages/harness/src/v1/harness-v1-network-sandbox-session.ts
@@ -10,6 +10,24 @@ export type HarnessV1PortEndpoint = {
 };
 
 /**
+ * Where the harness machinery keeps its generated state for this session's
+ * sandbox: the provider's {@link HarnessV1NetworkSandboxSession.stateDirectory}
+ * when it declares one, otherwise the sandbox's default working directory.
+ *
+ * Adapters and the framework must derive every state path (bootstrap
+ * directories, `.agent-runs`, markers) through this so a provider can keep
+ * infrastructure out of the user's workspace.
+ */
+export function harnessV1StateDirectory(
+  session: Pick<
+    HarnessV1NetworkSandboxSession,
+    'stateDirectory' | 'defaultWorkingDirectory'
+  >,
+): string {
+  return session.stateDirectory ?? session.defaultWorkingDirectory;
+}
+
+/**
  * Network sandbox session returned by `HarnessV1SandboxProvider.createSession()`. The
  * harness keeps this for the lifetime of a session. It is itself a
  * {@link SandboxSession} (file I/O, exec, spawn) and adds the infra surface on
@@ -44,6 +62,23 @@ export interface HarnessV1NetworkSandboxSession extends SandboxSession {
    * not bake a provider-specific base into their own paths.
    */
   readonly defaultWorkingDirectory: string;
+
+  /**
+   * Directory where the harness machinery keeps its own generated state —
+   * bootstrap recipes and their dependencies (`.harness-bootstrap/…`), and
+   * per-session adapter state (`.agent-runs/…`). This is Harness SDK state,
+   * not the runtime's own store (Claude Code's `~/.claude`, Codex's
+   * `~/.codex`, …), which each runtime continues to manage itself.
+   *
+   * Optional. When omitted, state lives under {@link defaultWorkingDirectory},
+   * which is correct for hosted sandboxes: their snapshot machinery preserves
+   * the working-directory mount, so state written there survives
+   * stop → snapshot → resume cycles. Providers whose working directory is a
+   * directory the user owns set this elsewhere so the workspace stays free of
+   * infrastructure. Resolve it through {@link harnessV1StateDirectory} rather
+   * than reading the field directly.
+   */
+  readonly stateDirectory?: string;
 
   /** Ports the sandbox exposes; resolvable via `getPortEndpoint`. */
   readonly ports: ReadonlyArray<number>;

--- a/packages/harness/src/v1/harness-v1-session.ts
+++ b/packages/harness/src/v1/harness-v1-session.ts
@@ -86,6 +86,60 @@ export type HarnessV1StartOptions = {
 };
 
 /**
+ * One content part of a history message, in the same vocabulary as the live
+ * stream parts so a UI renders history and stream with one component set.
+ * History parts are settled rather than streamed: text and reasoning arrive
+ * whole, and a tool call carries its result's data on the matching
+ * `tool-result` part.
+ */
+export type HarnessV1HistoryPart =
+  | { readonly type: 'text'; readonly text: string }
+  | { readonly type: 'reasoning'; readonly text: string }
+  | {
+      readonly type: 'tool-call';
+      /** The runtime's id for the call, when it records one. */
+      readonly toolCallId?: string;
+      /** Common tool name where one exists (`bash`, `read`, …), else native. */
+      readonly toolName: string;
+      /** The runtime's native name when it differs from `toolName`. */
+      readonly nativeName?: string;
+      readonly input?: unknown;
+    }
+  | {
+      readonly type: 'tool-result';
+      readonly toolCallId?: string;
+      readonly toolName?: string;
+      /** The full output as the runtime recorded it. */
+      readonly output?: unknown;
+      readonly isError?: boolean;
+    };
+
+/**
+ * One message from the runtime's persisted conversation history.
+ */
+export type HarnessV1HistoryMessage = {
+  readonly role: 'user' | 'assistant';
+  readonly parts: ReadonlyArray<HarnessV1HistoryPart>;
+  /** ISO timestamp, when the runtime recorded one. */
+  readonly at?: string;
+  /**
+   * The runtime's own record for this message, verbatim. Normalization into
+   * parts is necessarily lossy in the corners; this preserves everything the
+   * runtime wrote so a host can reproduce the exchange exactly.
+   */
+  readonly raw?: unknown;
+};
+
+/**
+ * Result of `HarnessV1Session.doReadHistory`.
+ */
+export type HarnessV1ReadHistoryResult = {
+  readonly messages: ReadonlyArray<HarnessV1HistoryMessage>;
+  /** Opaque position; pass back as `since` to read only what follows. */
+  readonly cursor: string;
+};
+
+/**
  * Options passed to `HarnessV1Session.doPromptTurn`.
  */
 export type HarnessV1PromptTurnOptions = HarnessV1TurnSettings & {
@@ -186,6 +240,34 @@ export type HarnessV1Session = {
    * `customInstructions`, when supported, steer the compaction summary.
    */
   doCompact(customInstructions?: string): PromiseLike<void>;
+
+  /**
+   * Read the conversation history the runtime itself persisted, normalized
+   * to `HarnessV1HistoryMessage`.
+   *
+   * The session's history can grow outside the harness contract: the same
+   * runtime conversation may be continued interactively (`claude --resume`),
+   * by another process, or before this session attached. Hosts that render a
+   * continuous record of the conversation — not just the turns they drove —
+   * need to read that history back, and the runtime's own store is the only
+   * source that has it. The adapter owns its runtime's persistence format,
+   * so the read belongs here rather than in every host.
+   *
+   * `since` is the `cursor` from a previous read; the result then contains
+   * only messages recorded after it. The cursor is adapter-owned and opaque
+   * to the host.
+   *
+   * Optional capability: adapters that cannot read their runtime's store
+   * omit the method entirely, and the agent surfaces that as
+   * `HarnessCapabilityUnsupportedError`. An adapter that implements it but
+   * cannot reach the store from the current environment (e.g. it lives
+   * inside a remote sandbox) throws `HarnessHistoryUnavailableError`. A
+   * conversation with no recorded messages yet is not an error — it resolves
+   * to an empty `messages` array.
+   */
+  doReadHistory?(options: {
+    readonly since?: string;
+  }): PromiseLike<HarnessV1ReadHistoryResult>;
 
   /**
    * Continue the in-flight turn **without a new user prompt**, returning the

--- a/packages/harness/src/v1/index.ts
+++ b/packages/harness/src/v1/index.ts
@@ -11,7 +11,10 @@ export type {
 } from './harness-v1-bootstrap';
 export type {
   HarnessV1ContinueTurnOptions,
+  HarnessV1HistoryMessage,
+  HarnessV1HistoryPart,
   HarnessV1PromptTurnOptions,
+  HarnessV1ReadHistoryResult,
   HarnessV1Session,
   HarnessV1StartOptions,
 } from './harness-v1-session';

--- a/packages/harness/src/v1/index.ts
+++ b/packages/harness/src/v1/index.ts
@@ -53,6 +53,7 @@ export type {
   HarnessV1RequestTransformation,
   HarnessV1RequestTransformationSources,
 } from './harness-v1-network-sandbox-session';
+export { harnessV1StateDirectory } from './harness-v1-network-sandbox-session';
 export type { HarnessV1Skill } from './harness-v1-skill';
 export type { HarnessV1StreamPart } from './harness-v1-stream-part';
 export {


### PR DESCRIPTION
Stacked on #19103.

## Background

A runtime's conversation can grow outside the harness: continued in the agent's own CLI, or by another process. The live event stream never sees those exchanges, and only the adapter knows its runtime's persistence format.

## Summary

- New optional `doReadHistory` capability on `HarnessV1Session`, and `session.readHistory({ since })` with an opaque cursor for incremental reads.
- History messages reuse the stream-part vocabulary (text, reasoning, tool-call with input, tool-result with output) and carry the runtime's raw record, so a UI can render history and live stream with the same components.
- Explicit capability handling: `session.supportsHistory`, `HarnessCapabilityUnsupportedError` when the adapter lacks it, new `HarnessHistoryUnavailableError` when the store can't be reached. An empty conversation is an empty result, not an error.

Contract only; the Claude Code implementation is stacked on top.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
