### PR TITLE
feat(harness): consent-gated executable installation

### DIFF
--- a/.changeset/harness-install-consent.md
+++ b/.changeset/harness-install-consent.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness': patch
+---
+
+feat (harness): consent-gated runtime executable installation. Adapters can declare how their runtime's executable is installed (`HarnessV1.installation`); when a session's environment is missing it, the framework resolves consent through the new `onInstallRequest` agent setting — a boolean to assume or refuse consent, or a function to decide per request — before the adapter may install. By default, installs into provider-owned (disposable) sandboxes are permitted, while installs into a user-owned environment (sandbox sessions declaring `environmentOwner: 'user'`) are denied and fail with the new `HarnessExecutableMissingError`, which carries the adapter's install command so the failure is actionable.

--- a/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
+++ b/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
@@ -548,6 +548,13 @@ console.log(preparation.identity);
 - `permissionMode`: built-in tool permission mode.
 - `toolApproval`: approval status map for host-executed tools.
 - `sandboxConfig`: sandbox working-directory and lifecycle hook configuration.
+- `onInstallRequest`: consent policy for installing the runtime's executable
+  into the session's environment when it is missing. By default, installs into
+  provider-owned (disposable) sandboxes are permitted while installs into a
+  user-owned environment fail with `HarnessExecutableMissingError` carrying
+  the install command. Pass `true` to assume consent everywhere, `false` to
+  never install, or a function to decide per request (wire it to an
+  interactive prompt in a CLI host, or to policy in a server host).
 - `telemetry`, `debug`, and `onLog`: observability and diagnostics.
 
 Telemetry reports each turn's resolved model, instructions, and active

--- a/packages/harness/src/agent/harness-agent-settings.ts
+++ b/packages/harness/src/agent/harness-agent-settings.ts
@@ -266,6 +266,31 @@ export type HarnessAgentSettings<
   readonly sandbox?: HarnessV1SandboxProvider;
 
   /**
+   * Consent policy for installing the runtime's executable (declared by the
+   * adapter in `HarnessV1.installation`) into the session's environment when
+   * it is missing.
+   *
+   * - Omitted (default): installs into provider-owned (disposable) sandboxes
+   *   are permitted; installs into a user-owned environment (the sandbox
+   *   session declares `environmentOwner: 'user'`) are denied, and the turn
+   *   fails with `HarnessExecutableMissingError` carrying the install
+   *   command.
+   * - `true`: consent is assumed everywhere — the harness installs without
+   *   asking.
+   * - `false`: installation is never permitted, even in disposable sandboxes.
+   * - A function: called with the harness id, the executable, and the install
+   *   command; return `true` to permit the install. Wire this to an
+   *   interactive prompt in a CLI host or to policy in a server host.
+   */
+  readonly onInstallRequest?:
+    | boolean
+    | ((request: {
+        readonly harnessId: string;
+        readonly executable: string;
+        readonly command: string;
+      }) => boolean | PromiseLike<boolean>);
+
+  /**
    * Sandbox working-directory and lifecycle hook configuration.
    */
   readonly sandboxConfig?: HarnessAgentSandboxConfig;

--- a/packages/harness/src/agent/harness-agent.ts
+++ b/packages/harness/src/agent/harness-agent.ts
@@ -50,6 +50,7 @@ import {
   collectHarnessAgentToolResultContinuations,
   type HarnessAgentToolResultContinuation,
 } from './harness-agent-tool-result-continuation';
+import { buildRequestInstallConsent } from './internal/install-consent';
 import {
   applyBootstrapRecipe,
   hashHarnessBootstrap,
@@ -527,6 +528,11 @@ export class HarnessAgent<
         ...baseStartOptions,
         sandboxSession,
         sessionWorkDir,
+        requestInstallConsent: buildRequestInstallConsent({
+          harness,
+          sandboxSession,
+          onInstallRequest: this.settings.onInstallRequest,
+        }),
       });
       return new HarnessAgentSession({
         sessionId,

--- a/packages/harness/src/agent/internal/install-consent.test.ts
+++ b/packages/harness/src/agent/internal/install-consent.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test, vi } from 'vitest';
+import { buildRequestInstallConsent } from './install-consent';
+import type { HarnessAgentAdapter } from '../harness-agent-types';
+import type { HarnessV1NetworkSandboxSession } from '../../v1';
+
+function makeHarness(
+  installation?: HarnessAgentAdapter['installation'],
+): HarnessAgentAdapter {
+  return {
+    specificationVersion: 'harness-v1',
+    harnessId: 'mock',
+    builtinTools: {},
+    doStart: async () => {
+      throw new Error('unused');
+    },
+    ...(installation != null ? { installation } : {}),
+  } as HarnessAgentAdapter;
+}
+
+function makeSession(
+  environmentOwner?: 'provider' | 'user',
+): HarnessV1NetworkSandboxSession {
+  return {
+    ...(environmentOwner != null ? { environmentOwner } : {}),
+  } as HarnessV1NetworkSandboxSession;
+}
+
+const installation = {
+  executable: 'claude',
+  command: 'npm install -g @anthropic-ai/claude-code',
+};
+
+describe('buildRequestInstallConsent', () => {
+  test('is absent when the adapter declares no installation', () => {
+    expect(
+      buildRequestInstallConsent({
+        harness: makeHarness(),
+        sandboxSession: makeSession(),
+        onInstallRequest: true,
+      }),
+    ).toBeUndefined();
+  });
+
+  test('permits installation into a provider-owned sandbox by default', async () => {
+    const consent = buildRequestInstallConsent({
+      harness: makeHarness(installation),
+      sandboxSession: makeSession(),
+      onInstallRequest: undefined,
+    });
+    await expect(consent!()).resolves.toBe(true);
+
+    const explicit = buildRequestInstallConsent({
+      harness: makeHarness(installation),
+      sandboxSession: makeSession('provider'),
+      onInstallRequest: undefined,
+    });
+    await expect(explicit!()).resolves.toBe(true);
+  });
+
+  test('denies installation into a user-owned environment by default', async () => {
+    const consent = buildRequestInstallConsent({
+      harness: makeHarness(installation),
+      sandboxSession: makeSession('user'),
+      onInstallRequest: undefined,
+    });
+    await expect(consent!()).resolves.toBe(false);
+  });
+
+  test('an explicit boolean setting wins over ownership', async () => {
+    const granted = buildRequestInstallConsent({
+      harness: makeHarness(installation),
+      sandboxSession: makeSession('user'),
+      onInstallRequest: true,
+    });
+    await expect(granted!()).resolves.toBe(true);
+
+    const denied = buildRequestInstallConsent({
+      harness: makeHarness(installation),
+      sandboxSession: makeSession('provider'),
+      onInstallRequest: false,
+    });
+    await expect(denied!()).resolves.toBe(false);
+  });
+
+  test('a function setting is asked with the declared installation', async () => {
+    const onInstallRequest = vi.fn(async () => true);
+    const consent = buildRequestInstallConsent({
+      harness: makeHarness(installation),
+      sandboxSession: makeSession('user'),
+      onInstallRequest,
+    });
+
+    await expect(consent!()).resolves.toBe(true);
+    expect(onInstallRequest).toHaveBeenCalledWith({
+      harnessId: 'mock',
+      executable: 'claude',
+      command: 'npm install -g @anthropic-ai/claude-code',
+    });
+  });
+});

--- a/packages/harness/src/agent/internal/install-consent.ts
+++ b/packages/harness/src/agent/internal/install-consent.ts
@@ -1,0 +1,47 @@
+import type { Experimental_SandboxSession as SandboxSession } from '@ai-sdk/provider-utils';
+import type { HarnessAgentSettings } from '../harness-agent-settings';
+import type { HarnessAgentAdapter } from '../harness-agent-types';
+import type { HarnessV1NetworkSandboxSession } from '../../v1';
+
+/**
+ * Build the `requestInstallConsent` callback handed to `doStart`.
+ *
+ * Resolution order:
+ *  1. An explicit `onInstallRequest` setting always wins — `true`/`false`
+ *     decide outright, a function is asked with the adapter's declared
+ *     installation.
+ *  2. Otherwise ownership decides: a provider-owned (disposable) sandbox
+ *     permits installation, a user-owned environment denies it. Nothing is
+ *     installed on a user's machine without explicit consent.
+ *
+ * Returns `undefined` when the adapter declares no installation — there is
+ * nothing to consent to, and the absence lets adapters skip the check.
+ */
+export function buildRequestInstallConsent({
+  harness,
+  sandboxSession,
+  onInstallRequest,
+}: {
+  harness: HarnessAgentAdapter;
+  sandboxSession: HarnessV1NetworkSandboxSession | SandboxSession;
+  onInstallRequest: HarnessAgentSettings['onInstallRequest'];
+}): (() => Promise<boolean>) | undefined {
+  const installation = harness.installation;
+  if (installation == null) return undefined;
+
+  return async () => {
+    if (typeof onInstallRequest === 'boolean') return onInstallRequest;
+    if (typeof onInstallRequest === 'function') {
+      return await onInstallRequest({
+        harnessId: harness.harnessId,
+        executable: installation.executable,
+        command: installation.command,
+      });
+    }
+    const environmentOwner =
+      'environmentOwner' in sandboxSession
+        ? sandboxSession.environmentOwner
+        : undefined;
+    return (environmentOwner ?? 'provider') === 'provider';
+  };
+}

--- a/packages/harness/src/errors/harness-executable-missing-error.test.ts
+++ b/packages/harness/src/errors/harness-executable-missing-error.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+import { HarnessError } from './harness-error';
+import { HarnessExecutableMissingError } from './harness-executable-missing-error';
+
+describe('HarnessExecutableMissingError', () => {
+  test('is a HarnessError', () => {
+    const err = new HarnessExecutableMissingError({ executable: 'claude' });
+    expect(HarnessError.isInstance(err)).toBe(true);
+    expect(HarnessExecutableMissingError.isInstance(err)).toBe(true);
+  });
+
+  test('composes an actionable default message from the install command', () => {
+    const err = new HarnessExecutableMissingError({
+      harnessId: 'claude-code',
+      executable: 'claude',
+      installCommand: 'npm install -g @anthropic-ai/claude-code',
+    });
+    expect(err.message).toContain("'claude' executable was not found");
+    expect(err.message).toContain('npm install -g @anthropic-ai/claude-code');
+    expect(err.message).toContain('onInstallRequest');
+    expect(err.harnessId).toBe('claude-code');
+    expect(err.executable).toBe('claude');
+    expect(err.installCommand).toBe('npm install -g @anthropic-ai/claude-code');
+  });
+
+  test('a supplied message wins over the default', () => {
+    const err = new HarnessExecutableMissingError({
+      executable: 'claude',
+      message: 'custom',
+    });
+    expect(err.message).toBe('custom');
+  });
+
+  test('isInstance returns false for unrelated errors', () => {
+    expect(HarnessExecutableMissingError.isInstance(new Error('x'))).toBe(
+      false,
+    );
+    expect(HarnessExecutableMissingError.isInstance(null)).toBe(false);
+  });
+});

--- a/packages/harness/src/errors/harness-executable-missing-error.ts
+++ b/packages/harness/src/errors/harness-executable-missing-error.ts
@@ -1,0 +1,56 @@
+import { AISDKError } from '@ai-sdk/provider';
+import { HarnessError } from './harness-error';
+
+const name = 'AI_HarnessExecutableMissingError';
+const marker = `vercel.ai.error.${name}`;
+const symbol = Symbol.for(marker);
+
+/**
+ * Thrown when the runtime's executable is missing from the session's
+ * environment and installing it was not consented to.
+ *
+ * Carries the adapter-declared install command so the error is actionable:
+ * run the command yourself, or pass `onInstallRequest` on the agent to
+ * authorize the harness to run it for you.
+ */
+export class HarnessExecutableMissingError extends HarnessError {
+  private readonly [symbol] = true;
+
+  readonly harnessId?: string;
+  /** The executable that was not found on the environment's `PATH`. */
+  readonly executable: string;
+  /** The adapter's preferred command to install it. */
+  readonly installCommand?: string;
+
+  constructor({
+    message,
+    harnessId,
+    executable,
+    installCommand,
+    cause,
+  }: {
+    message?: string;
+    harnessId?: string;
+    executable: string;
+    installCommand?: string;
+    cause?: unknown;
+  }) {
+    super({
+      message:
+        message ??
+        `The '${executable}' executable was not found in the session's environment.` +
+          (installCommand
+            ? ` Install it with \`${installCommand}\`, or pass \`onInstallRequest\` to authorize the harness to install it.`
+            : ''),
+      cause,
+    });
+    Object.defineProperty(this, 'name', { value: name });
+    this.harnessId = harnessId;
+    this.executable = executable;
+    this.installCommand = installCommand;
+  }
+
+  static isInstance(error: unknown): error is HarnessExecutableMissingError {
+    return AISDKError.hasMarker(error, marker);
+  }
+}

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,5 +1,6 @@
 export * from './v1';
 export * from './errors/harness-error';
 export * from './errors/harness-capability-unsupported-error';
+export * from './errors/harness-executable-missing-error';
 export * from './errors/harness-history-unavailable-error';
 export * from './errors/harness-sandbox-authentication-error';

--- a/packages/harness/src/v1/harness-v1-network-sandbox-session.ts
+++ b/packages/harness/src/v1/harness-v1-network-sandbox-session.ts
@@ -80,6 +80,21 @@ export interface HarnessV1NetworkSandboxSession extends SandboxSession {
    */
   readonly stateDirectory?: string;
 
+  /**
+   * Who owns the environment this session runs in.
+   *
+   * `'provider'` (the default when omitted) means a provisioned, disposable
+   * environment — a hosted microVM, a virtual filesystem — where the harness
+   * machinery may install what it needs without asking. `'user'` means the
+   * environment belongs to the user — their own machine, their own accounts —
+   * where nothing may be installed without explicit consent.
+   *
+   * The framework uses this as the default consent policy for runtime
+   * executable installation; a consumer's `onInstallRequest` setting always
+   * wins over the default.
+   */
+  readonly environmentOwner?: 'provider' | 'user';
+
   /** Ports the sandbox exposes; resolvable via `getPortEndpoint`. */
   readonly ports: ReadonlyArray<number>;
 

--- a/packages/harness/src/v1/harness-v1-session.ts
+++ b/packages/harness/src/v1/harness-v1-session.ts
@@ -69,6 +69,21 @@ export type HarnessV1StartOptions = {
    * consumer has not enabled diagnostics.
    */
   readonly observability?: HarnessV1Observability;
+
+  /**
+   * Ask the host for permission to install the runtime's executable (the one
+   * the adapter declared in `HarnessV1.installation`) into the session's
+   * environment. Populated by the framework from the consumer's
+   * `onInstallRequest` setting and the environment's ownership: installs into
+   * provider-owned (throwaway) sandboxes are permitted by default, installs
+   * into a user-owned environment are denied by default.
+   *
+   * Adapters call this only after discovering the executable is missing.
+   * `false` means the adapter must throw `HarnessExecutableMissingError`
+   * rather than install.
+   */
+  readonly requestInstallConsent?: () => PromiseLike<boolean>;
+
   /**
    * Sandbox session the adapter operates against. Network sandbox sessions
    * expose optional infrastructure capabilities for bridge wiring; caller-

--- a/packages/harness/src/v1/harness-v1.ts
+++ b/packages/harness/src/v1/harness-v1.ts
@@ -86,6 +86,24 @@ export type HarnessV1<TBuiltinTools extends ToolSet = ToolSet> = {
   }) => PromiseLike<HarnessV1Bootstrap>;
 
   /**
+   * How the runtime's executable is installed into an environment that does
+   * not have it. Declared by the adapter — each runtime knows its own
+   * preferred installation — and used by the framework two ways: as the
+   * command executed when installation is consented to (see
+   * `HarnessV1StartOptions.requestInstallConsent`), and as the actionable
+   * instruction inside `HarnessExecutableMissingError` when it is not.
+   *
+   * Adapters whose runtime needs no environment-level executable (fully
+   * bootstrapped runtimes) omit this.
+   */
+  readonly installation?: {
+    /** The executable the runtime needs on `PATH` (e.g. `claude`). */
+    readonly executable: string;
+    /** Shell command that installs it (e.g. `npm install -g …`). */
+    readonly command: string;
+  };
+
+  /**
    * Start a fresh session, resume a parked session via `resumeFrom`, or resume
    * a suspended turn via `continueFrom`. The host then issues prompts against
    * the returned session, ending with `doDetach`, `doStop`, or `doDestroy`.


### PR DESCRIPTION
Stacked on #19104.

## Background

The next PR makes the Claude Code adapter drive the environment's own `claude`. When an environment doesn't have it, someone has to decide whether installing is OK, and on a user's own machine that decision belongs to the user.

## Summary

- Adapters declare their installation (`HarnessV1.installation`: executable and preferred install command).
- New `onInstallRequest` agent setting: `true` to assume consent, `false` to refuse, or a function to decide per request.
- Default policy comes from the new `environmentOwner` field on sandbox sessions: provider-owned (disposable) sandboxes install by default, user-owned environments never install without consent.
- Denials fail with `HarnessExecutableMissingError`, which includes the install command.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
