### PR TITLE
feat(harness-claude-code): drive the environment's own claude

### DIFF
--- a/.changeset/claude-code-system-executable.md
+++ b/.changeset/claude-code-system-executable.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-claude-code': patch
+---
+
+feat (harness-claude-code): always drive the environment's own `claude` executable. The bootstrap now installs only the bridge's JavaScript dependencies (about 40 MB, down from 785 MB) — the bundled CLI copies that `@anthropic-ai/claude-agent-sdk` and `@anthropic-ai/claude-code` ship as platform binaries are never downloaded. The adapter resolves the environment's `claude` at session start, verifying it runs rather than merely finding it on `PATH`, and points the Agent SDK at it. When the environment has none, installation of the pinned version is requested through the agent's `onInstallRequest` consent policy: provider-owned (disposable) sandboxes install by default, user-owned environments fail with `HarnessExecutableMissingError` carrying the exact install command unless consent is given. Conversations remain the user's own — the same threads can be continued directly with `claude --resume` outside the SDK.

--- a/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
+++ b/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
@@ -22,6 +22,39 @@ WebSocket.
 The adapter bootstraps the Claude Code bridge dependencies inside the sandbox
 when the first session starts.
 
+## The Environment's Own `claude`
+
+The adapter always drives the `claude` executable already present in the
+session's environment — the installation the user configured, authenticated,
+and can continue conversations with directly (`claude --resume`). The
+bootstrap installs only the bridge's JavaScript dependencies (about 40 MB),
+never a copy of the CLI.
+
+When the environment has no working `claude`, installation of the pinned
+version is requested through the agent's `onInstallRequest` consent policy:
+
+- In a provider-owned (disposable) sandbox, consent is granted by default and
+  the adapter installs `@anthropic-ai/claude-code` at the version the bridge
+  is tested against.
+- In a user-owned environment, nothing is installed without explicit consent;
+  the session fails with `HarnessExecutableMissingError` carrying the exact
+  install command instead.
+
+```ts
+const agent = new HarnessAgent({
+  harness: claudeCode,
+  sandbox,
+  // Optional: decide per request (e.g. an interactive prompt in a CLI host).
+  onInstallRequest: async ({ command }) => confirmWithUser(command),
+});
+```
+
+<Note>
+  The executable is verified by running it, not merely finding it on `PATH`, and
+  a reused executable is whatever version the environment has — which may differ
+  from the version the bridge is tested against.
+</Note>
+
 ## Import
 
 ```ts

--- a/packages/harness-claude-code/src/bridge/index.test.ts
+++ b/packages/harness-claude-code/src/bridge/index.test.ts
@@ -257,6 +257,19 @@ describe('Claude Code bridge configuration', () => {
     expect(state.queryArgs[0]?.options).toMatchObject({ effort: 'max' });
   });
 
+  test('points the Agent SDK at the environment executable', async () => {
+    state.start = {
+      ...state.start,
+      claudeExecutablePath: '/usr/local/bin/claude',
+    };
+
+    await import('./index');
+
+    expect(state.queryArgs[0]?.options).toMatchObject({
+      pathToClaudeCodeExecutable: '/usr/local/bin/claude',
+    });
+  });
+
   test('resumes the exact conversation when the start names one', async () => {
     state.start = { ...state.start, resumeSessionId: 'claude-session-1' };
     state.firstTurn = false;

--- a/packages/harness-claude-code/src/bridge/index.ts
+++ b/packages/harness-claude-code/src/bridge/index.ts
@@ -378,6 +378,12 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     options: {
       ...(start.model ? { model: start.model } : {}),
       ...(start.maxTurns !== undefined ? { maxTurns: start.maxTurns } : {}),
+      // The environment's own `claude`, resolved by the adapter. The SDK's
+      // bundled binaries are never installed (`--no-optional`), so without
+      // this the SDK has nothing to run.
+      ...(start.claudeExecutablePath
+        ? { pathToClaudeCodeExecutable: start.claudeExecutablePath }
+        : {}),
       ...(start.env !== undefined ? { env: { ...procEnv, ...start.env } } : {}),
       ...(skillsOption ? { skills: skillsOption } : {}),
       ...(nativeTools !== undefined ? { tools: nativeTools } : {}),

--- a/packages/harness-claude-code/src/bridge/package.json
+++ b/packages/harness-claude-code/src/bridge/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.245",
-    "@anthropic-ai/claude-code": "2.1.245",
     "@modelcontextprotocol/sdk": "1.30.0",
     "ws": "8.21.0",
     "zod": "4.4.3"

--- a/packages/harness-claude-code/src/bridge/pnpm-lock.yaml
+++ b/packages/harness-claude-code/src/bridge/pnpm-lock.yaml
@@ -10,10 +10,7 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: 0.3.245
-        version: 0.3.245(@anthropic-ai/sdk@0.97.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)
-      '@anthropic-ai/claude-code':
-        specifier: 2.1.245
-        version: 2.1.245
+        version: 0.3.245(@anthropic-ai/sdk@0.122.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)
       '@modelcontextprotocol/sdk':
         specifier: 1.30.0
         version: 1.30.0(zod@4.4.3)
@@ -78,57 +75,8 @@ packages:
       '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
 
-  '@anthropic-ai/claude-code-darwin-arm64@2.1.245':
-    resolution: {integrity: sha512-jjXl0zI4v3UXpkOlvDdPzJzz0rQ1QwvzDlKMSUIw5rGMReiOErq8o8DJyQJNgERejGG5Et9DiUFm+Bg6Tq9IBw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@anthropic-ai/claude-code-darwin-x64@2.1.245':
-    resolution: {integrity: sha512-4WJJ+nHOuhV00/55I3LoVhfWDBU4KGgYdBe/lZjuufOSFhoREeG8T/HT2bYS/qTbFZUbkBau80M1TBMiBDbnbw==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.245':
-    resolution: {integrity: sha512-Fb6aeNv5NZf8XhFbBqb0HG5gT3Y+3FtrJetPoYbN36i74Jqt5Xsw85o/JyCPBULWBoNHDBm/ljYfn+/KwRerFg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@anthropic-ai/claude-code-linux-arm64@2.1.245':
-    resolution: {integrity: sha512-Qbn5HnZbYeW4GdifVkDGfcVKqj3/f3U9sfVd3LEaUZh08CcS8D/ptJ76zuBfQUGHJHfToAdNVfak86uJ84b1Dg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@anthropic-ai/claude-code-linux-x64-musl@2.1.245':
-    resolution: {integrity: sha512-loThtx/opxdpmwk07VmjQL7ALhOKJJozdJs2T5SXVY7iAEZwX+nPK+Zz0CyvT3XRtxtimbEeNaQPmk43PUkFag==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@anthropic-ai/claude-code-linux-x64@2.1.245':
-    resolution: {integrity: sha512-SRO5w2f9iHKZmREp389kPKxWAr6qEODxggdhhS7zF16OMwaUHjV5Yu7Oq8jSMD57gQiBjOfvFp/SJg3CdfHCtA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@anthropic-ai/claude-code-win32-arm64@2.1.245':
-    resolution: {integrity: sha512-gG/B3EU+nQZA9tjp43JE94p2VoCh0VotfaxyKYOf1eW0JmJRYzcpvV2Iih8/5i/FkL9TWghPAtRV8YcxwzTtow==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@anthropic-ai/claude-code-win32-x64@2.1.245':
-    resolution: {integrity: sha512-/SVV2dUpKIyuNylzsHo0pFqKAn6HGcqNB/fEpluahvUIaYsgluJsBs8m3uIgYLfU4nFnPbemrYj0ekoG626SgA==}
-    cpu: [x64]
-    os: [win32]
-
-  '@anthropic-ai/claude-code@2.1.245':
-    resolution: {integrity: sha512-+7baJddJXZukgd6AgC7xStHGsMTVHDPlRcAoqTSPx2NQ+QwKGtvCZQLgbnKuhjkwq9v9vKvYwIhLOwGiE77mVQ==}
-    engines: {node: '>=22.0.0'}
-    hasBin: true
-
-  '@anthropic-ai/sdk@0.97.1':
-    resolution: {integrity: sha512-wOf7AUeJPitcVpvKO4UMu63mWH5SaVipkGd7OOQJt/G6VYGlV8D2Gp9dLxOrttDJh/9gqPqdaBwDGcBevumeAg==}
+  '@anthropic-ai/sdk@0.122.0':
+    resolution: {integrity: sha512-GGPNftt0caaz9MDlmNQGHX8855Ojaduyy5pm9Sm1h7HalCn0cWNb5/bweadJF+4yzbal+QL6ztBa09WAAOzLmQ==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -269,8 +217,8 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  express-rate-limit@8.6.2:
-    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+  express-rate-limit@8.7.0:
+    resolution: {integrity: sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -323,8 +271,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.13.4:
-    resolution: {integrity: sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==}
+  hono@4.13.5:
+    resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -338,8 +286,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.5.0:
-    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
+  ip-address@10.7.0:
+    resolution: {integrity: sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -426,8 +374,8 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   range-parser@1.3.0:
@@ -484,8 +432,8 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
-  standardwebhooks@1.0.0:
-    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+  standardwebhooks@1.1.1:
+    resolution: {integrity: sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -564,9 +512,9 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.245':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.245(@anthropic-ai/sdk@0.97.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.245(@anthropic-ai/sdk@0.122.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/sdk': 0.97.1(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.122.0(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -579,57 +527,22 @@ snapshots:
       '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.245
       '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.245
 
-  '@anthropic-ai/claude-code-darwin-arm64@2.1.245':
-    optional: true
-
-  '@anthropic-ai/claude-code-darwin-x64@2.1.245':
-    optional: true
-
-  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.245':
-    optional: true
-
-  '@anthropic-ai/claude-code-linux-arm64@2.1.245':
-    optional: true
-
-  '@anthropic-ai/claude-code-linux-x64-musl@2.1.245':
-    optional: true
-
-  '@anthropic-ai/claude-code-linux-x64@2.1.245':
-    optional: true
-
-  '@anthropic-ai/claude-code-win32-arm64@2.1.245':
-    optional: true
-
-  '@anthropic-ai/claude-code-win32-x64@2.1.245':
-    optional: true
-
-  '@anthropic-ai/claude-code@2.1.245':
-    optionalDependencies:
-      '@anthropic-ai/claude-code-darwin-arm64': 2.1.245
-      '@anthropic-ai/claude-code-darwin-x64': 2.1.245
-      '@anthropic-ai/claude-code-linux-arm64': 2.1.245
-      '@anthropic-ai/claude-code-linux-arm64-musl': 2.1.245
-      '@anthropic-ai/claude-code-linux-x64': 2.1.245
-      '@anthropic-ai/claude-code-linux-x64-musl': 2.1.245
-      '@anthropic-ai/claude-code-win32-arm64': 2.1.245
-      '@anthropic-ai/claude-code-win32-x64': 2.1.245
-
-  '@anthropic-ai/sdk@0.97.1(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.122.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
-      standardwebhooks: 1.0.0
+      standardwebhooks: 1.1.1
     optionalDependencies:
       zod: 4.4.3
 
   '@babel/runtime@7.29.7': {}
 
-  '@hono/node-server@2.1.1(hono@4.13.4)':
+  '@hono/node-server@2.1.1(hono@4.13.5)':
     dependencies:
-      hono: 4.13.4
+      hono: 4.13.5
 
   '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.1.1(hono@4.13.4)
+      '@hono/node-server': 2.1.1(hono@4.13.5)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -638,8 +551,8 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.1.1
       express: 5.2.1
-      express-rate-limit: 8.6.2(express@5.2.1)
-      hono: 4.13.4
+      express-rate-limit: 8.7.0(express@5.2.1)
+      hono: 4.13.5
       jose: 6.2.10
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -675,7 +588,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -748,11 +661,11 @@ snapshots:
     dependencies:
       eventsource-parser: 3.1.1
 
-  express-rate-limit@8.6.2(express@5.2.1):
+  express-rate-limit@8.7.0(express@5.2.1):
     dependencies:
       debug: 4.4.3
       express: 5.2.1
-      ip-address: 10.5.0
+      ip-address: 10.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -778,7 +691,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1
@@ -838,7 +751,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.13.4: {}
+  hono@4.13.5: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -854,7 +767,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.5.0: {}
+  ip-address@10.7.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -916,7 +829,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
@@ -1005,7 +918,7 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
-  standardwebhooks@1.0.0:
+  standardwebhooks@1.1.1:
     dependencies:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0

--- a/packages/harness-claude-code/src/bridge/pnpm-workspace.yaml
+++ b/packages/harness-claude-code/src/bridge/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
-allowBuilds:
-  '@anthropic-ai/claude-code@2.1.245': true
+# Marks the bridge install as its own workspace so a surrounding project's
+# pnpm workspace cannot capture it. The bridge deliberately has no build
+# scripts: the Claude Code CLI itself is the environment's own installation,
+# resolved by the adapter, never installed here.

--- a/packages/harness-claude-code/src/claude-code-bootstrap.ts
+++ b/packages/harness-claude-code/src/claude-code-bootstrap.ts
@@ -19,6 +19,21 @@ const readBridgeAsset = createReadBridgeAsset({
  */
 export const CLAUDE_CODE_BOOTSTRAP_DIR = '.harness-bootstrap/claude-code';
 
+/**
+ * The Claude Code CLI version this adapter's bridge (`@anthropic-ai/
+ * claude-agent-sdk`) is built and tested against. The bootstrap installs no
+ * CLI of its own — the adapter drives the environment's `claude`, installing
+ * this version (with consent) only when the environment has none.
+ */
+export const CLAUDE_CODE_PINNED_CLI_VERSION = '2.1.213';
+
+/**
+ * The adapter-preferred command to install the Claude Code CLI into an
+ * environment that lacks it. Declared as `HarnessV1.installation.command`;
+ * run only after the host consents.
+ */
+export const CLAUDE_CODE_INSTALL_COMMAND = `npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_PINNED_CLI_VERSION}`;
+
 let cachedBootstrap: HarnessV1Bootstrap | undefined;
 
 export async function getClaudeCodeBootstrap(): Promise<HarnessV1Bootstrap> {
@@ -43,10 +58,21 @@ export async function getClaudeCodeBootstrap(): Promise<HarnessV1Bootstrap> {
     ],
     commands: [
       {
-        command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
-      },
-      {
-        command: './node_modules/.bin/claude --version',
+        // The bridge's JavaScript dependencies only. `--no-optional` skips
+        // the Agent SDK's bundled platform binaries (hundreds of megabytes of
+        // CLI copies): the adapter always drives the environment's own
+        // `claude`, so the bundled ones would never run. The pnpm store is a
+        // build artifact nothing reads afterwards — pnpm copies rather than
+        // hardlinks here, so it is a second copy of everything — but its
+        // cleanup must not swallow the install's exit status: a failed
+        // install recorded as a completed bootstrap leaves a half-linked
+        // node_modules that every later session trusts.
+        command: [
+          'pnpm install --frozen-lockfile --store-dir .pnpm-store --no-optional',
+          'install_status=$?',
+          'rm -rf .pnpm-store',
+          'exit $install_status',
+        ].join('\n'),
       },
     ],
   };

--- a/packages/harness-claude-code/src/claude-code-bridge-protocol.ts
+++ b/packages/harness-claude-code/src/claude-code-bridge-protocol.ts
@@ -50,6 +50,11 @@ export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
   // a resume that itself started a new thread. Mutually exclusive with
   // `continue` in the SDK, so the bridge sends one or the other.
   resumeSessionId: z.string().optional(),
+  // Absolute path of the `claude` executable the bridge drives — the
+  // environment's own installation, resolved (or consent-installed) by the
+  // adapter at session start. The Agent SDK's bundled binaries are never
+  // installed, so the SDK must always be pointed at this.
+  claudeExecutablePath: z.string().optional(),
 });
 
 export type StartMessage = z.infer<typeof startMessageSchema>;

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -134,11 +134,12 @@ vi.mock('node:fs/promises', async importOriginal => {
     readFile: vi.fn(async (input: unknown, ...rest: unknown[]) => {
       const path = typeof input === 'string' ? input : String(input);
       if (path.endsWith('/bridge/index.mjs')) return '// mock bridge\n';
-      if (path.endsWith('/bridge/package.json')) return '{"name":"mock"}';
+      if (path.endsWith('/bridge/package.json'))
+        return '{"name":"mock","dependencies":{"@anthropic-ai/claude-agent-sdk":"0.3.213"}}';
       if (path.endsWith('/bridge/pnpm-lock.yaml'))
         return 'lockfileVersion: "9.0"\n';
       if (path.endsWith('/bridge/pnpm-workspace.yaml'))
-        return "allowBuilds:\n  '@anthropic-ai/claude-code@2.1.213': true\n";
+        return '# workspace boundary\n';
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return (actual.readFile as any)(input, ...rest);
     }),
@@ -170,11 +171,20 @@ function fakeNetworkSandboxSessionForStartupFailure({
 }): HarnessV1NetworkSandboxSession {
   const port = 4319;
   const session = {
-    run: async ({ command }: { command: string }) => ({
-      exitCode: 0,
-      stdout: command === 'printf "%s" "$HOME"' ? '/home/vercel-sandbox' : '',
-      stderr: '',
-    }),
+    run: async ({ command }: { command: string }) => {
+      if (command === 'command -v claude && claude --version') {
+        return {
+          exitCode: 0,
+          stdout: '/usr/local/bin/claude\n2.1.245 (Claude Code)\n',
+          stderr: '',
+        };
+      }
+      return {
+        exitCode: 0,
+        stdout: command === 'printf "%s" "$HOME"' ? '/home/vercel-sandbox' : '',
+        stderr: '',
+      };
+    },
     readTextFile: async () => null,
     writeTextFile: async () => {},
     spawn: async () => ({
@@ -220,6 +230,13 @@ function fakeNetworkSandboxSessionForStartupSuccess({
       runs.push(command);
       if (command === 'printf "%s" "$HOME"') {
         return { exitCode: 0, stdout: '/home/vercel-sandbox', stderr: '' };
+      }
+      if (command === 'command -v claude && claude --version') {
+        return {
+          exitCode: 0,
+          stdout: '/usr/local/bin/claude\n2.1.213 (Claude Code)\n',
+          stderr: '',
+        };
       }
       return { exitCode: 0, stdout: '', stderr: '' };
     },
@@ -1328,21 +1345,34 @@ describe('createClaudeCode adapter', () => {
       }
     });
 
-    it('allows the pinned Claude Code build and verifies the installed CLI', async () => {
+    it('installs the bridge dependencies only, without bundled CLI binaries', async () => {
       const harness = createClaudeCode();
       const recipe = await harness.getBootstrap!();
       const commands = recipe.commands.map(c => c.command);
-      const workspace = recipe.files.find(file =>
-        file.path.endsWith('/pnpm-workspace.yaml'),
+      const pkg = recipe.files.find(file =>
+        file.path.endsWith('/package.json'),
       );
-      expect(commands).toHaveLength(2);
-      expect(commands[0]).toBe(
-        'pnpm install --frozen-lockfile --store-dir .pnpm-store',
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0]).toContain(
+        'pnpm install --frozen-lockfile --store-dir .pnpm-store --no-optional',
       );
-      expect(commands[1]).toBe('./node_modules/.bin/claude --version');
-      expect(workspace?.content).toContain(
-        "'@anthropic-ai/claude-code@2.1.213': true",
-      );
+      // The CLI is the environment's own; the bridge ships no copy at all.
+      expect(pkg?.content).not.toContain('"@anthropic-ai/claude-code"');
+      expect(pkg?.content).toContain('"@anthropic-ai/claude-agent-sdk"');
+      // The pnpm store is a build artifact, discarded without masking a
+      // failed install's exit status.
+      expect(commands[0]).toContain('install_status=$?');
+      expect(commands[0]).toContain('rm -rf .pnpm-store');
+      expect(commands[0]).toContain('exit $install_status');
+    });
+
+    it('declares how to install the CLI into an environment that lacks it', () => {
+      const harness = createClaudeCode();
+      expect(harness.installation).toEqual({
+        executable: 'claude',
+        command: 'npm install -g @anthropic-ai/claude-code@2.1.213',
+      });
     });
 
     it('caches the recipe across calls', async () => {

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -51,8 +51,10 @@ import { WebSocket } from 'ws';
 import { z } from 'zod/v4';
 import {
   CLAUDE_CODE_BOOTSTRAP_DIR as BOOTSTRAP_DIR,
+  CLAUDE_CODE_INSTALL_COMMAND,
   getClaudeCodeBootstrap,
 } from './claude-code-bootstrap';
+import { resolveClaudeExecutable } from './resolve-claude-executable';
 import {
   CLAUDE_CODE_CREDENTIAL_ENVIRONMENT_VARIABLES,
   createClaudeCodeRequestTransformations,
@@ -843,6 +845,14 @@ export function createClaudeCode(
     supportsBuiltinToolFiltering: true,
     lifecycleStateSchema: claudeCodeResumeStateSchema,
     getBootstrap: getClaudeCodeBootstrap,
+    // The adapter drives the environment's own `claude` — the installation the
+    // user configured, authenticated, and can continue conversations with
+    // directly — and only installs this pinned version, with consent, when the
+    // environment has none.
+    installation: {
+      executable: 'claude',
+      command: CLAUDE_CODE_INSTALL_COMMAND,
+    },
     doStart: async startOpts => {
       const sandboxSession = startOpts.sandboxSession;
       const toolSafeSandboxSession =
@@ -1018,6 +1028,15 @@ export function createClaudeCode(
           return createSession({
             sessionId: startOpts.sessionId,
             channel: attachChannel,
+            // The live bridge keeps serving turns, and each turn's query runs
+            // the environment executable this process resolves.
+            claudeExecutablePath: await resolveClaudeExecutable({
+              session: toolSafeSandboxSession,
+              requestInstallConsent: startOpts.requestInstallConsent,
+              ...(startOpts.abortSignal
+                ? { abortSignal: startOpts.abortSignal }
+                : {}),
+            }),
             ...(resumeSessionId ? { resumeSessionId } : {}),
             // The live bridge was spawned by another process; this one owns no
             // process handle. The session lifecycle method decides whether the
@@ -1075,6 +1094,16 @@ export function createClaudeCode(
       const port = resolveBridgePort({
         sandboxSession,
         override: settings.port,
+      });
+      // The environment's own `claude` is the one the bridge drives; resolve
+      // (or, with consent, install) it before spawning so a missing
+      // executable fails startup rather than the first turn.
+      const claudeExecutablePath = await resolveClaudeExecutable({
+        session: toolSafeSandboxSession,
+        requestInstallConsent: startOpts.requestInstallConsent,
+        ...(startOpts.abortSignal
+          ? { abortSignal: startOpts.abortSignal }
+          : {}),
       });
       const token =
         settings.mintBridgeToken == null
@@ -1174,6 +1203,7 @@ export function createClaudeCode(
         sessionId: startOpts.sessionId,
         channel,
         proc,
+        claudeExecutablePath,
         model: settings.model,
         maxTurns: settings.maxTurns,
         env: sandboxClaudeEnvironment,
@@ -1493,6 +1523,7 @@ function createSession({
   sessionId,
   channel,
   proc,
+  claudeExecutablePath,
   model,
   maxTurns,
   env,
@@ -1518,6 +1549,8 @@ function createSession({
   channel: ClaudeCodeChannel;
   /** Undefined on `attach` — the live bridge was spawned by another process. */
   proc: Experimental_SandboxProcess | undefined;
+  /** The environment's `claude`, resolved (or installed) at start. */
+  claudeExecutablePath: string;
   model: string | undefined;
   maxTurns: number | undefined;
   env: Readonly<Record<string, string>> | undefined;
@@ -1782,6 +1815,7 @@ function createSession({
         ...(permissionMode ? { permissionMode } : {}),
         ...(builtinToolFiltering ? { builtinToolFiltering } : {}),
         ...(debug ? { debug } : {}),
+        claudeExecutablePath,
         ...(lastClaudeSessionId
           ? { resumeSessionId: lastClaudeSessionId }
           : pendingResumeFlag
@@ -1865,6 +1899,7 @@ function createSession({
           ...(permissionMode ? { permissionMode } : {}),
           ...(builtinToolFiltering ? { builtinToolFiltering } : {}),
           ...(debug ? { debug } : {}),
+          claudeExecutablePath,
           ...(lastClaudeSessionId
             ? { resumeSessionId: lastClaudeSessionId }
             : { continue: true }),

--- a/packages/harness-claude-code/src/claude-code-instructions.test.ts
+++ b/packages/harness-claude-code/src/claude-code-instructions.test.ts
@@ -66,11 +66,20 @@ function emptyStream(): ReadableStream<Uint8Array> {
 function fakeNetworkSandboxSession(): HarnessV1NetworkSandboxSession {
   const port = 4319;
   const session = {
-    run: async ({ command }: { command: string }) => ({
-      exitCode: 0,
-      stdout: command === 'printf "%s" "$HOME"' ? '/home/vercel-sandbox' : '',
-      stderr: '',
-    }),
+    run: async ({ command }: { command: string }) => {
+      if (command === 'command -v claude && claude --version') {
+        return {
+          exitCode: 0,
+          stdout: '/usr/local/bin/claude\n2.1.245 (Claude Code)\n',
+          stderr: '',
+        };
+      }
+      return {
+        exitCode: 0,
+        stdout: command === 'printf "%s" "$HOME"' ? '/home/vercel-sandbox' : '',
+        stderr: '',
+      };
+    },
     readTextFile: async () => null,
     writeTextFile: async () => {},
     spawn: async () => ({

--- a/packages/harness-claude-code/src/resolve-claude-executable.test.ts
+++ b/packages/harness-claude-code/src/resolve-claude-executable.test.ts
@@ -1,0 +1,130 @@
+import { HarnessExecutableMissingError } from '@ai-sdk/harness';
+import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { resolveClaudeExecutable } from './resolve-claude-executable';
+
+type RunResult = { exitCode: number; stdout: string; stderr: string };
+
+function makeSession(
+  script: (command: string) => RunResult,
+): Experimental_SandboxSession & { run: ReturnType<typeof vi.fn> } {
+  const run = vi.fn(async ({ command }: { command: string }) =>
+    script(command),
+  );
+  return { run } as unknown as Experimental_SandboxSession & {
+    run: ReturnType<typeof vi.fn>;
+  };
+}
+
+const found: RunResult = {
+  exitCode: 0,
+  stdout: '/usr/local/bin/claude\n2.1.213 (Claude Code)\n',
+  stderr: '',
+};
+const missing: RunResult = { exitCode: 127, stdout: '', stderr: 'not found' };
+
+describe('resolveClaudeExecutable', () => {
+  it('returns the environment executable when it exists and runs', async () => {
+    const session = makeSession(() => found);
+
+    await expect(
+      resolveClaudeExecutable({ session, requestInstallConsent: undefined }),
+    ).resolves.toBe('/usr/local/bin/claude');
+
+    // Verified by running it, not merely finding it on PATH.
+    expect(session.run.mock.calls[0]![0].command).toBe(
+      'command -v claude && claude --version',
+    );
+  });
+
+  it('throws an actionable error when missing and consent is absent', async () => {
+    const session = makeSession(() => missing);
+
+    const error = await resolveClaudeExecutable({
+      session,
+      requestInstallConsent: undefined,
+    }).catch((err: unknown) => err);
+
+    expect(HarnessExecutableMissingError.isInstance(error)).toBe(true);
+    expect((error as HarnessExecutableMissingError).installCommand).toBe(
+      'npm install -g @anthropic-ai/claude-code@2.1.213',
+    );
+    // Nothing was installed without consent.
+    expect(
+      session.run.mock.calls.map(call => call[0].command),
+    ).not.toContainEqual(expect.stringContaining('npm install'));
+  });
+
+  it('throws without installing when consent is denied', async () => {
+    const session = makeSession(() => missing);
+    const requestInstallConsent = vi.fn(async () => false);
+
+    await expect(
+      resolveClaudeExecutable({ session, requestInstallConsent }),
+    ).rejects.toSatisfy(error =>
+      HarnessExecutableMissingError.isInstance(error),
+    );
+    expect(requestInstallConsent).toHaveBeenCalledTimes(1);
+    expect(
+      session.run.mock.calls.map(call => call[0].command),
+    ).not.toContainEqual(expect.stringContaining('npm install'));
+  });
+
+  it('installs the pinned CLI once consent is granted', async () => {
+    let installed = false;
+    const session = makeSession(command => {
+      if (command.startsWith('npm install')) {
+        installed = true;
+        return { exitCode: 0, stdout: '', stderr: '' };
+      }
+      return installed ? found : missing;
+    });
+
+    await expect(
+      resolveClaudeExecutable({
+        session,
+        requestInstallConsent: async () => true,
+      }),
+    ).resolves.toBe('/usr/local/bin/claude');
+
+    expect(session.run.mock.calls.map(call => call[0].command)).toContain(
+      'npm install -g @anthropic-ai/claude-code@2.1.213',
+    );
+  });
+
+  it('reports a consented install that produced no working executable', async () => {
+    const session = makeSession(command =>
+      command.startsWith('npm install')
+        ? { exitCode: 1, stdout: '', stderr: 'EACCES: permission denied' }
+        : missing,
+    );
+
+    const error = await resolveClaudeExecutable({
+      session,
+      requestInstallConsent: async () => true,
+    }).catch((err: unknown) => err);
+
+    expect(HarnessExecutableMissingError.isInstance(error)).toBe(true);
+    expect((error as Error).message).toContain('install exit 1');
+    expect((error as Error).message).toContain('EACCES');
+  });
+
+  it('does not treat a broken executable as present', async () => {
+    // On PATH but does not run (deleted target, wrong platform, …).
+    const session = makeSession(command =>
+      command.startsWith('command -v')
+        ? {
+            exitCode: 1,
+            stdout: '/usr/local/bin/claude\n',
+            stderr: 'exec error',
+          }
+        : missing,
+    );
+
+    await expect(
+      resolveClaudeExecutable({ session, requestInstallConsent: undefined }),
+    ).rejects.toSatisfy(error =>
+      HarnessExecutableMissingError.isInstance(error),
+    );
+  });
+});

--- a/packages/harness-claude-code/src/resolve-claude-executable.ts
+++ b/packages/harness-claude-code/src/resolve-claude-executable.ts
@@ -1,0 +1,94 @@
+import {
+  HarnessExecutableMissingError,
+  type HarnessV1StartOptions,
+} from '@ai-sdk/harness';
+import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
+import { CLAUDE_CODE_INSTALL_COMMAND } from './claude-code-bootstrap';
+
+/**
+ * Resolve the `claude` executable the bridge drives for this session.
+ *
+ * The adapter never runs a CLI of its own: the environment's installation is
+ * the one the user configured, authenticated, and can continue conversations
+ * with directly (`claude --resume`), so it is always preferred. When the
+ * environment has none, installation of the pinned version is requested
+ * through the host's consent callback; without consent — or when the install
+ * does not produce a working executable — the session fails with
+ * `HarnessExecutableMissingError`, which carries the install command so the
+ * failure is actionable.
+ *
+ * The executable is verified by running it, not merely found on `PATH`: this
+ * is the last point where failing is cheap, since the bridge only exercises
+ * the path once a turn runs.
+ */
+export async function resolveClaudeExecutable({
+  session,
+  requestInstallConsent,
+  abortSignal,
+}: {
+  session: Experimental_SandboxSession;
+  requestInstallConsent: HarnessV1StartOptions['requestInstallConsent'];
+  abortSignal?: AbortSignal;
+}): Promise<string> {
+  const existing = await findWorkingExecutable({ session, abortSignal });
+  if (existing != null) return existing;
+
+  const consented =
+    requestInstallConsent == null ? false : await requestInstallConsent();
+  if (!consented) {
+    throw new HarnessExecutableMissingError({
+      harnessId: 'claude-code',
+      executable: 'claude',
+      installCommand: CLAUDE_CODE_INSTALL_COMMAND,
+    });
+  }
+
+  const install = await Promise.resolve(
+    session.run({
+      command: CLAUDE_CODE_INSTALL_COMMAND,
+      ...(abortSignal ? { abortSignal } : {}),
+    }),
+  ).catch(error => ({ exitCode: -1, stdout: '', stderr: String(error) }));
+
+  const installed = await findWorkingExecutable({ session, abortSignal });
+  if (installed != null) return installed;
+
+  throw new HarnessExecutableMissingError({
+    harnessId: 'claude-code',
+    executable: 'claude',
+    installCommand: CLAUDE_CODE_INSTALL_COMMAND,
+    message:
+      `claude-code: installing the Claude Code CLI did not produce a working ` +
+      `\`claude\` executable (install exit ${install.exitCode}). Install it ` +
+      `yourself with \`${CLAUDE_CODE_INSTALL_COMMAND}\` and retry.` +
+      (install.stderr.trim().length > 0
+        ? `\n${truncate(install.stderr.trim(), 2000)}`
+        : ''),
+  });
+}
+
+/**
+ * The absolute path of a `claude` that both exists on `PATH` and actually
+ * runs, or `undefined`.
+ */
+async function findWorkingExecutable({
+  session,
+  abortSignal,
+}: {
+  session: Experimental_SandboxSession;
+  abortSignal?: AbortSignal;
+}): Promise<string | undefined> {
+  const result = await Promise.resolve(
+    session.run({
+      command: 'command -v claude && claude --version',
+      ...(abortSignal ? { abortSignal } : {}),
+    }),
+  ).catch(() => null);
+  if (result == null || result.exitCode !== 0) return undefined;
+  const path = result.stdout.split('\n', 1)[0]?.trim();
+  return path != null && path.length > 0 ? path : undefined;
+}
+
+function truncate(text: string, maxLength: number): string {
+  return text.length <= maxLength ? text : `${text.slice(0, maxLength)}…`;
+}


### PR DESCRIPTION
Stacked on #19105.

## Background

The bootstrap downloads two copies of the Claude Code binary, about 470MB of the 785MB it writes, even when the environment already has `claude` installed and authenticated. This keeps the bootstrap recipe fixed and parameter-less per #18912 (no setting, unlike the earlier attempt in #18448).

## Summary

- The bridge no longer depends on `@anthropic-ai/claude-code`; the bootstrap installs only the bridge's JS dependencies (about 40MB).
- The adapter resolves the environment's `claude` at session start, verifying it runs rather than just checking `PATH`, and the bridge passes it to the SDK as `pathToClaudeCodeExecutable`.
- When missing, installation of the pinned version goes through the consent flow: hosted sandboxes install by default, user machines fail with an actionable error unless consent is given.
- Conversations stay in the user's own store, so `claude --resume` keeps working outside the SDK.

## End-to-End Verification

- Bridge install verified in a scratch directory with pnpm 11: 40MB, no binaries, no build scripts.
- Ran against the real `claude` CLI (2.1.235) on macOS: the system executable is resolved and drives turns, and hiding `claude` from `PATH` fails with `HarnessExecutableMissingError` naming the install command.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
