### PR TITLE
feat(harness-claude-code): implement readHistory

### DIFF
--- a/.changeset/claude-code-read-history.md
+++ b/.changeset/claude-code-read-history.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-claude-code': patch
+---
+
+feat (harness-claude-code): implement `readHistory` from the CLI's own transcripts. The adapter reads the session transcript Claude Code itself persists under `~/.claude/projects/<encoded cwd>/<sessionId>.jsonl` — the same store `claude --resume` uses — and normalizes it to the harness history shape with full fidelity: text, reasoning, tool calls with inputs, tool results with their recorded output, and the raw transcript record on every message. Reads go through the sandbox session, so they work in hosted sandboxes and on the local machine alike. Incremental reads via the cursor return only what was recorded since.

--- a/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
+++ b/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
@@ -199,6 +199,27 @@ const harness = createClaudeCode({
 The supplied record replaces the host environment for authentication
 discovery. Only recognized authentication variables are forwarded.
 
+## Reading Conversation History
+
+Claude Code persists every conversation itself, under
+`~/.claude/projects/<encoded working directory>/<sessionId>.jsonl` in the
+session's environment — the same store `claude --resume` reads. The adapter
+implements `session.readHistory()` on top of it, so exchanges that happened
+outside your process (the user continuing the conversation in their own
+terminal, for instance) can be rendered too:
+
+```ts
+const { messages, cursor } = await session.readHistory();
+// Parts use the stream vocabulary: text, reasoning, tool-call (with input),
+// tool-result (with the full recorded output). Each message also carries the
+// runtime's raw transcript record.
+
+const delta = await session.readHistory({ since: cursor });
+```
+
+Reads go through the sandbox session, so they work in hosted sandboxes and on
+the local machine alike.
+
 ## Sandbox
 
 Claude Code requires a network sandbox with at least one exposed port,

--- a/examples/ai-functions/src/harness-agent/claude-code/read-history.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/read-history.ts
@@ -1,0 +1,68 @@
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+import { createClaudeCode } from './_create';
+import { run } from '../../lib/run';
+
+const claudeCode = createClaudeCode();
+
+run(async () => {
+  const sandbox = createVercelSandbox({
+    runtime: 'node24',
+    ports: [4000],
+    timeout: 10 * 60 * 1000,
+  });
+  const agent = new HarnessAgent({
+    harness: claudeCode,
+    sandbox,
+  });
+
+  const session = await agent.createSession();
+  try {
+    await agent.generate({
+      session,
+      prompt: 'Create a file named NOTES.md containing one haiku about tests.',
+    });
+
+    if (!session.supportsHistory) {
+      console.log('This adapter does not support history reads.');
+      return;
+    }
+
+    // The runtime's own persisted history — including anything that happened
+    // outside this process (e.g. `claude --resume` in a terminal).
+    const { messages, cursor } = await session.readHistory();
+    for (const message of messages) {
+      for (const part of message.parts) {
+        switch (part.type) {
+          case 'text':
+            console.log(`${message.role}: ${part.text}`);
+            break;
+          case 'reasoning':
+            console.log(`${message.role} (reasoning): ${part.text}`);
+            break;
+          case 'tool-call':
+            console.log(
+              `${message.role} -> ${part.toolName}(${JSON.stringify(part.input)})`,
+            );
+            break;
+          case 'tool-result':
+            console.log(
+              `${part.toolName ?? 'tool'} => ${JSON.stringify(part.output)?.slice(0, 120)}`,
+            );
+            break;
+        }
+      }
+    }
+
+    // Incremental read: only what was recorded after the first read.
+    const delta = await agent.generate({ session, prompt: 'Say thanks.' });
+    console.log('second turn:', delta.text);
+    const since = await session.readHistory({ since: cursor });
+    console.log(
+      'messages recorded since the first read:',
+      since.messages.length,
+    );
+  } finally {
+    await session.destroy();
+  }
+});

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -54,6 +54,7 @@ import {
   CLAUDE_CODE_INSTALL_COMMAND,
   getClaudeCodeBootstrap,
 } from './claude-code-bootstrap';
+import { readClaudeCodeHistory } from './claude-code-history';
 import { resolveClaudeExecutable } from './resolve-claude-executable';
 import {
   CLAUDE_CODE_CREDENTIAL_ENVIRONMENT_VARIABLES,
@@ -1028,6 +1029,7 @@ export function createClaudeCode(
           return createSession({
             sessionId: startOpts.sessionId,
             channel: attachChannel,
+            workDir,
             // The live bridge keeps serving turns, and each turn's query runs
             // the environment executable this process resolves.
             claudeExecutablePath: await resolveClaudeExecutable({
@@ -1203,6 +1205,7 @@ export function createClaudeCode(
         sessionId: startOpts.sessionId,
         channel,
         proc,
+        workDir,
         claudeExecutablePath,
         model: settings.model,
         maxTurns: settings.maxTurns,
@@ -1523,6 +1526,7 @@ function createSession({
   sessionId,
   channel,
   proc,
+  workDir,
   claudeExecutablePath,
   model,
   maxTurns,
@@ -1549,6 +1553,8 @@ function createSession({
   channel: ClaudeCodeChannel;
   /** Undefined on `attach` — the live bridge was spawned by another process. */
   proc: Experimental_SandboxProcess | undefined;
+  /** Where the runtime runs; keys its transcript store for history reads. */
+  workDir: string;
   /** The environment's `claude`, resolved (or installed) at start. */
   claudeExecutablePath: string;
   model: string | undefined;
@@ -1572,6 +1578,7 @@ function createSession({
   debug: HarnessV1DebugConfig | undefined;
   permissionMode: HarnessV1PermissionMode | undefined;
   builtinToolFiltering: HarnessV1BuiltinToolFiltering | undefined;
+  /** Tool-safe surface of the sandbox; skill writes and history reads go through it. */
   sandbox: SandboxSession;
   sandboxHomeDir: string;
   mcpServers: Record<string, unknown> | undefined;
@@ -1908,6 +1915,12 @@ function createSession({
 
       return control;
     },
+    doReadHistory: async readOpts =>
+      readClaudeCodeHistory({
+        session: sandbox,
+        workDir,
+        ...(readOpts.since != null ? { since: readOpts.since } : {}),
+      }),
     doCompact: async (customInstructions?: string) => {
       /*
        * Claude Code has no SDK/control method for compaction — the supported

--- a/packages/harness-claude-code/src/claude-code-history.test.ts
+++ b/packages/harness-claude-code/src/claude-code-history.test.ts
@@ -1,0 +1,375 @@
+import { HarnessHistoryUnavailableError } from '@ai-sdk/harness';
+import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseTranscriptLines,
+  readClaudeCodeHistory,
+} from './claude-code-history';
+
+function line(record: unknown): string {
+  return JSON.stringify(record);
+}
+
+describe('parseTranscriptLines', () => {
+  it('normalizes a user → assistant → tool exchange with full fidelity', async () => {
+    const records = [
+      {
+        type: 'user',
+        message: { role: 'user', content: 'make the api use uv properly' },
+        timestamp: '2026-08-06T01:45:39.000Z',
+      },
+      {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'The Dockerfile pins pip.' },
+            { type: 'text', text: "I'll restructure the Dockerfile." },
+          ],
+        },
+        timestamp: '2026-08-06T01:45:42.000Z',
+      },
+      {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_1',
+              name: 'Bash',
+              input: { command: 'vercel build' },
+            },
+          ],
+        },
+      },
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_1',
+              content: 'Build Completed in /vercel/output',
+            },
+          ],
+        },
+      },
+    ];
+
+    const messages = await parseTranscriptLines(records.map(line));
+
+    expect(messages).toEqual([
+      {
+        role: 'user',
+        parts: [{ type: 'text', text: 'make the api use uv properly' }],
+        at: '2026-08-06T01:45:39.000Z',
+        raw: records[0],
+      },
+      {
+        role: 'assistant',
+        parts: [
+          { type: 'reasoning', text: 'The Dockerfile pins pip.' },
+          { type: 'text', text: "I'll restructure the Dockerfile." },
+        ],
+        at: '2026-08-06T01:45:42.000Z',
+        raw: records[1],
+      },
+      {
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-call',
+            toolCallId: 'toolu_1',
+            toolName: 'bash',
+            nativeName: 'Bash',
+            input: { command: 'vercel build' },
+          },
+        ],
+        raw: records[2],
+      },
+      {
+        role: 'user',
+        parts: [
+          {
+            type: 'tool-result',
+            toolCallId: 'toolu_1',
+            toolName: 'bash',
+            output: 'Build Completed in /vercel/output',
+          },
+        ],
+        raw: records[3],
+      },
+    ]);
+  });
+
+  it('maps native tool names to the common vocabulary and keeps the native name', async () => {
+    const messages = await parseTranscriptLines([
+      line({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'tool_use', id: 't1', name: 'Grep', input: {} },
+            { type: 'tool_use', id: 't2', name: 'WebFetch', input: {} },
+            { type: 'tool_use', id: 't3', name: 'Task', input: {} },
+            {
+              type: 'tool_use',
+              id: 't4',
+              name: 'mcp__host__deploy',
+              input: {},
+            },
+          ],
+        },
+      }),
+    ]);
+
+    expect(messages[0]?.parts).toMatchObject([
+      { toolName: 'search', nativeName: 'Grep' },
+      { toolName: 'fetch', nativeName: 'WebFetch' },
+      { toolName: 'Task' },
+      { toolName: 'deploy', nativeName: 'mcp__host__deploy' },
+    ]);
+  });
+
+  it('marks failed tool results and keeps their output', async () => {
+    const messages = await parseTranscriptLines([
+      line({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_9',
+              content: [{ type: 'text', text: 'command not found' }],
+              is_error: true,
+            },
+          ],
+        },
+      }),
+    ]);
+
+    expect(messages[0]?.parts[0]).toMatchObject({
+      type: 'tool-result',
+      isError: true,
+      output: [{ type: 'text', text: 'command not found' }],
+    });
+  });
+
+  it('skips sidechain records, bookkeeping types, and interrupt filler', async () => {
+    const messages = await parseTranscriptLines([
+      line({
+        type: 'assistant',
+        isSidechain: true,
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'subagent chatter' }],
+        },
+      }),
+      line({ type: 'file-history-snapshot', snapshot: {} }),
+      line({ type: 'queue-operation', operation: 'dequeue' }),
+      line({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: '[Request interrupted by user for tool use]',
+        },
+      }),
+      line({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'No response requested.' }],
+        },
+      }),
+      line({
+        type: 'user',
+        message: { role: 'user', content: 'real message' },
+      }),
+    ]);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.parts).toEqual([
+      { type: 'text', text: 'real message' },
+    ]);
+  });
+
+  it('survives a line torn mid-write', async () => {
+    const messages = await parseTranscriptLines([
+      line({
+        type: 'user',
+        message: { role: 'user', content: 'before' },
+      }),
+      '{"type":"assistant","message":{"role":"assis', // torn
+      line({
+        type: 'user',
+        message: { role: 'user', content: 'after' },
+      }),
+    ]);
+
+    expect(messages.map(m => m.parts[0])).toEqual([
+      { type: 'text', text: 'before' },
+      { type: 'text', text: 'after' },
+    ]);
+  });
+});
+
+// ─── readClaudeCodeHistory ─────────────────────────────────────────────
+
+const WORK_DIR = '/work/my-app';
+const PROJECT_DIR = '/home/user/.claude/projects/-work-my-app';
+
+function transcriptContent(texts: string[], cwd = WORK_DIR): string {
+  return (
+    texts
+      .map((text, index) =>
+        line({
+          type: 'user',
+          cwd,
+          message: { role: 'user', content: text },
+          timestamp: `2026-08-06T01:45:0${index}.000Z`,
+        }),
+      )
+      .join('\n') + '\n'
+  );
+}
+
+function makeSession({
+  files = {},
+  listing,
+  home = '/home/user',
+}: {
+  files?: Record<string, string>;
+  listing?: { exitCode: number; stdout: string };
+  home?: string;
+}): Experimental_SandboxSession {
+  return {
+    run: vi.fn(async ({ command }: { command: string }) => {
+      if (command === 'printf "%s" "$HOME"') {
+        return { exitCode: 0, stdout: home, stderr: '' };
+      }
+      if (command.startsWith('ls -t')) {
+        return {
+          stderr: '',
+          ...(listing ?? { exitCode: 2, stdout: '' }),
+        };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }),
+    readTextFile: vi.fn(
+      async ({
+        path,
+        startLine,
+        endLine,
+      }: {
+        path: string;
+        startLine?: number;
+        endLine?: number;
+      }) => {
+        const content = files[path];
+        if (content == null) return null;
+        if (startLine == null && endLine == null) return content;
+        return content
+          .split('\n')
+          .slice((startLine ?? 1) - 1, endLine)
+          .join('\n');
+      },
+    ),
+  } as unknown as Experimental_SandboxSession;
+}
+
+describe('readClaudeCodeHistory', () => {
+  it('resolves an empty result when no transcript exists yet', async () => {
+    const session = makeSession({});
+
+    const result = await readClaudeCodeHistory({ session, workDir: WORK_DIR });
+
+    expect(result.messages).toEqual([]);
+    expect(typeof result.cursor).toBe('string');
+  });
+
+  it('reads the newest transcript that belongs to the working directory', async () => {
+    const session = makeSession({
+      listing: { exitCode: 0, stdout: 'newer.jsonl\nolder.jsonl\n' },
+      files: {
+        // Newest is another conversation from a different cwd.
+        [`${PROJECT_DIR}/newer.jsonl`]: transcriptContent(
+          ['other project'],
+          '/work/other',
+        ),
+        [`${PROJECT_DIR}/older.jsonl`]: transcriptContent(['hello', 'again']),
+      },
+    });
+
+    const result = await readClaudeCodeHistory({ session, workDir: WORK_DIR });
+
+    expect(result.messages.map(m => m.parts[0])).toEqual([
+      { type: 'text', text: 'hello' },
+      { type: 'text', text: 'again' },
+    ]);
+  });
+
+  it('reads only the delta after a cursor, without dropping the next record', async () => {
+    const first = transcriptContent(['one', 'two']);
+    const session1 = makeSession({
+      listing: { exitCode: 0, stdout: 't.jsonl\n' },
+      files: { [`${PROJECT_DIR}/t.jsonl`]: first },
+    });
+    const { cursor } = await readClaudeCodeHistory({
+      session: session1,
+      workDir: WORK_DIR,
+    });
+
+    const session2 = makeSession({
+      listing: { exitCode: 0, stdout: 't.jsonl\n' },
+      files: {
+        [`${PROJECT_DIR}/t.jsonl`]: transcriptContent(['one', 'two', 'three']),
+      },
+    });
+    const delta = await readClaudeCodeHistory({
+      session: session2,
+      workDir: WORK_DIR,
+      since: cursor,
+    });
+
+    expect(delta.messages.map(m => m.parts[0])).toEqual([
+      { type: 'text', text: 'three' },
+    ]);
+  });
+
+  it('re-reads the whole transcript when the cursor names another file', async () => {
+    const session = makeSession({
+      listing: { exitCode: 0, stdout: 't.jsonl\n' },
+      files: { [`${PROJECT_DIR}/t.jsonl`]: transcriptContent(['one']) },
+    });
+
+    const result = await readClaudeCodeHistory({
+      session,
+      workDir: WORK_DIR,
+      since: JSON.stringify({
+        v: 1,
+        file: `${PROJECT_DIR}/gone.jsonl`,
+        line: 5,
+      }),
+    });
+
+    expect(result.messages).toHaveLength(1);
+  });
+
+  it('throws HarnessHistoryUnavailableError when the store cannot be reached', async () => {
+    const session = {
+      run: vi.fn(async () => {
+        throw new Error('sandbox unreachable');
+      }),
+      readTextFile: vi.fn(),
+    } as unknown as Experimental_SandboxSession;
+
+    await expect(
+      readClaudeCodeHistory({ session, workDir: WORK_DIR }),
+    ).rejects.toSatisfy(error =>
+      HarnessHistoryUnavailableError.isInstance(error),
+    );
+  });
+});

--- a/packages/harness-claude-code/src/claude-code-history.ts
+++ b/packages/harness-claude-code/src/claude-code-history.ts
@@ -1,0 +1,329 @@
+import {
+  HarnessHistoryUnavailableError,
+  type HarnessV1HistoryMessage,
+  type HarnessV1HistoryPart,
+  type HarnessV1ReadHistoryResult,
+} from '@ai-sdk/harness';
+import { resolveSandboxHomeDir } from '@ai-sdk/harness/utils';
+import {
+  safeParseJSON,
+  type Experimental_SandboxSession,
+} from '@ai-sdk/provider-utils';
+
+/**
+ * `doReadHistory` for Claude Code: read the session transcript the CLI itself
+ * persists under `~/.claude/projects/<encoded cwd>/<sessionId>.jsonl` and
+ * normalize it to the harness history shape.
+ *
+ * The transcript is the runtime's own store, shared between every way of
+ * driving the same conversation — SDK queries, `claude --resume`,
+ * `claude --continue` — which is exactly why a host reads history through the
+ * adapter: exchanges that happened outside the harness contract (a user
+ * continuing the conversation interactively) exist nowhere else.
+ *
+ * All reads go through the sandbox session, so this works wherever the
+ * runtime runs — the user's own machine and hosted sandboxes alike. A
+ * conversation with no transcript yet resolves to an empty result; a store
+ * that cannot be reached throws `HarnessHistoryUnavailableError`.
+ */
+export async function readClaudeCodeHistory(options: {
+  /** Tool-safe session of the sandbox the runtime runs in. */
+  session: Experimental_SandboxSession;
+  /** The directory Claude Code runs in; keys the transcript store. */
+  workDir: string;
+  /** Cursor from a previous read; only messages after it are returned. */
+  since?: string;
+  abortSignal?: AbortSignal;
+}): Promise<HarnessV1ReadHistoryResult> {
+  const { session, workDir, since, abortSignal } = options;
+
+  let homeDir: string;
+  try {
+    homeDir = await resolveSandboxHomeDir({ sandbox: session, abortSignal });
+  } catch (error) {
+    throw new HarnessHistoryUnavailableError({
+      harnessId: 'claude-code',
+      message:
+        'claude-code: cannot locate the transcript store — the sandbox HOME directory could not be resolved.',
+      cause: error,
+    });
+  }
+
+  const projectDir = `${homeDir}/.claude/projects/${encodeProjectPath(workDir)}`;
+  const transcript = await findLatestTranscript({
+    session,
+    projectDir,
+    workDir,
+    abortSignal,
+  });
+  // No transcript is data, not an error: nothing has been recorded yet for
+  // this working directory.
+  if (transcript == null) {
+    return { messages: [], cursor: emptyCursor() };
+  }
+
+  const content = await Promise.resolve(
+    session.readTextFile({ path: transcript, abortSignal }),
+  ).catch((error: unknown) => {
+    throw new HarnessHistoryUnavailableError({
+      harnessId: 'claude-code',
+      message: `claude-code: the transcript at ${transcript} could not be read.`,
+      cause: error,
+    });
+  });
+  if (content == null) {
+    return { messages: [], cursor: emptyCursor() };
+  }
+
+  const lines = content.split('\n');
+  const cursor = await parseCursor(since);
+  // A cursor from a different transcript means the conversation moved
+  // (resumed under a fork, or a different one opened); the whole current
+  // transcript is the honest answer.
+  const fromLine = cursor?.file === transcript ? cursor.line : 0;
+
+  // `split('\n')` yields a trailing empty element for the newline that
+  // terminates every complete JSONL record, so the next unread slot is
+  // `lines.length - 1`. Storing `lines.length` would place the cursor one
+  // past the next record and silently drop it. When the file does not end in
+  // a newline (a record torn mid-write), that record is re-read once whole.
+  const consumed = Math.max(0, lines.length - 1);
+
+  return {
+    messages: await parseTranscriptLines(lines.slice(fromLine)),
+    cursor: JSON.stringify({ v: 1, file: transcript, line: consumed }),
+  };
+}
+
+/**
+ * Normalize raw transcript lines into history messages. Exported for tests.
+ *
+ * Retains everything a UI needs to reproduce the exchange: text, reasoning
+ * (`thinking` blocks), tool calls with their inputs, tool results with their
+ * full recorded output, and the runtime's raw record on every message.
+ * Skipped entirely: sidechain (subagent) records, bookkeeping types
+ * (`attachment`, `queue-operation`, `file-history-snapshot`, mode records,
+ * …), and interrupt markers plus the filler the CLI writes after them.
+ */
+export async function parseTranscriptLines(
+  lines: readonly string[],
+): Promise<HarnessV1HistoryMessage[]> {
+  const messages: HarnessV1HistoryMessage[] = [];
+  /** tool_use id → common name, so results can carry their tool's name. */
+  const toolNames = new Map<string, string>();
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const parsed = await safeParseJSON({ text: line });
+    // A line torn mid-write costs itself, not the read.
+    if (!parsed.success) continue;
+    const record = parsed.value as TranscriptRecord;
+    if (record == null || typeof record !== 'object') continue;
+
+    if (record.isSidechain === true) continue;
+    if (record.type !== 'user' && record.type !== 'assistant') continue;
+
+    const content = record.message?.content;
+    const parts: HarnessV1HistoryPart[] = [];
+
+    if (typeof content === 'string') {
+      if (isConversationText(content)) {
+        parts.push({ type: 'text', text: content });
+      }
+    } else if (Array.isArray(content)) {
+      for (const block of content) {
+        if (!block || typeof block !== 'object') continue;
+        if (block.type === 'text' && typeof block.text === 'string') {
+          if (isConversationText(block.text)) {
+            parts.push({ type: 'text', text: block.text });
+          }
+        } else if (
+          block.type === 'thinking' &&
+          typeof block.thinking === 'string'
+        ) {
+          parts.push({ type: 'reasoning', text: block.thinking });
+        } else if (
+          block.type === 'tool_use' &&
+          typeof block.name === 'string'
+        ) {
+          const toolName = toCommonToolName(block.name);
+          if (typeof block.id === 'string') toolNames.set(block.id, toolName);
+          parts.push({
+            type: 'tool-call',
+            ...(typeof block.id === 'string' ? { toolCallId: block.id } : {}),
+            toolName,
+            ...(toolName === block.name ? {} : { nativeName: block.name }),
+            input: block.input,
+          });
+        } else if (block.type === 'tool_result') {
+          parts.push({
+            type: 'tool-result',
+            ...(typeof block.tool_use_id === 'string'
+              ? { toolCallId: block.tool_use_id }
+              : {}),
+            ...(typeof block.tool_use_id === 'string' &&
+            toolNames.has(block.tool_use_id)
+              ? { toolName: toolNames.get(block.tool_use_id) }
+              : {}),
+            ...(block.content !== undefined ? { output: block.content } : {}),
+            ...(block.is_error === true ? { isError: true } : {}),
+          });
+        }
+      }
+    }
+
+    if (parts.length === 0) continue;
+
+    messages.push({
+      role: record.type,
+      parts,
+      ...(typeof record.timestamp === 'string' ? { at: record.timestamp } : {}),
+      raw: record,
+    });
+  }
+
+  return messages;
+}
+
+/** Interrupt markers and the CLI's post-interrupt filler are not conversation. */
+function isConversationText(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith('[Request interrupted by user')) return false;
+  if (trimmed === 'No response requested.') return false;
+  return true;
+}
+
+/**
+ * The same native→common mapping the bridge applies to live stream events,
+ * so a host renders history and stream with one vocabulary. Kept in sync
+ * with the bridge's table by the adapter tests.
+ */
+const NATIVE_TO_COMMON: Record<string, string> = {
+  Bash: 'bash',
+  Read: 'read',
+  Write: 'write',
+  Edit: 'edit',
+  MultiEdit: 'edit',
+  NotebookEdit: 'edit',
+  Glob: 'search',
+  Grep: 'search',
+  WebSearch: 'search',
+  WebFetch: 'fetch',
+};
+
+function toCommonToolName(nativeName: string): string {
+  const common = NATIVE_TO_COMMON[nativeName];
+  if (common) return common;
+  // Host tools surface as `mcp__<server>__<tool>`; the tool's own name is
+  // the meaningful part.
+  const mcpMatch = nativeName.match(/^mcp__[^_]+(?:_[^_]+)*__(.+)$/);
+  return mcpMatch ? mcpMatch[1] : nativeName;
+}
+
+/**
+ * Newest transcript in the store that belongs to this working directory, or
+ * `undefined` when none exists yet. The directory encoding is lossy (every
+ * non-alphanumeric character becomes a dash), so the record's own `cwd` is
+ * the authority.
+ */
+async function findLatestTranscript({
+  session,
+  projectDir,
+  workDir,
+  abortSignal,
+}: {
+  session: Experimental_SandboxSession;
+  projectDir: string;
+  workDir: string;
+  abortSignal?: AbortSignal;
+}): Promise<string | undefined> {
+  // Newest first. A missing project directory exits non-zero, which is the
+  // "no conversation yet" case rather than an error.
+  const listing = await Promise.resolve(
+    session.run({
+      command: 'ls -t -- "$PROJECT_DIR"',
+      env: { PROJECT_DIR: projectDir },
+      abortSignal,
+    }),
+  ).catch((error: unknown) => {
+    throw new HarnessHistoryUnavailableError({
+      harnessId: 'claude-code',
+      message: `claude-code: the transcript store at ${projectDir} could not be listed.`,
+      cause: error,
+    });
+  });
+  if (listing.exitCode !== 0) return undefined;
+
+  const names = listing.stdout
+    .split('\n')
+    .map(name => name.trim())
+    .filter(name => name.endsWith('.jsonl'));
+
+  for (const name of names) {
+    const path = `${projectDir}/${name}`;
+    // The head is enough to find the record that names the cwd.
+    const head = await Promise.resolve(
+      session.readTextFile({ path, startLine: 1, endLine: 40, abortSignal }),
+    ).catch(() => null);
+    if (head == null) continue;
+    for (const line of head.split('\n')) {
+      if (!line.trim()) continue;
+      const parsed = await safeParseJSON({ text: line });
+      if (!parsed.success) continue; // Keep scanning the head.
+      const cwd = (parsed.value as { cwd?: unknown } | null)?.cwd;
+      if (cwd === workDir) return path;
+      if (typeof cwd === 'string') break; // Right shape, wrong directory.
+    }
+  }
+  return undefined;
+}
+
+async function parseCursor(
+  since: string | undefined,
+): Promise<{ file: string; line: number } | undefined> {
+  if (!since) return undefined;
+  const parsed = await safeParseJSON({ text: since });
+  // An unreadable cursor reads from the start, which is safe.
+  if (!parsed.success) return undefined;
+  const value = parsed.value as { file?: unknown; line?: unknown } | null;
+  if (typeof value?.file === 'string' && typeof value.line === 'number') {
+    return { file: value.file, line: value.line };
+  }
+  return undefined;
+}
+
+function emptyCursor(): string {
+  return JSON.stringify({ v: 1, file: null, line: 0 });
+}
+
+/**
+ * Claude Code names each project directory after the absolute path with
+ * every non-alphanumeric character replaced by a dash.
+ */
+function encodeProjectPath(absolutePath: string): string {
+  return absolutePath.replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+type TranscriptRecord = {
+  type?: string;
+  isSidechain?: boolean;
+  timestamp?: string;
+  cwd?: string;
+  message?: {
+    role?: string;
+    content?:
+      | string
+      | Array<{
+          type?: string;
+          text?: string;
+          thinking?: string;
+          id?: string;
+          name?: string;
+          input?: unknown;
+          tool_use_id?: string;
+          content?: unknown;
+          is_error?: boolean;
+        }>;
+  };
+} | null;


### PR DESCRIPTION
Stacked on #19106.

## Summary

- Reads the transcript Claude Code itself persists under `~/.claude/projects/<encoded cwd>/<sessionId>.jsonl`, the same store `claude --resume` uses.
- Reads go through the sandbox session, so hosted sandboxes and the local machine both work.
- Keeps full fidelity: text, reasoning, tool calls with inputs, tool results with outputs, timestamps, and the raw record per message.
- Incremental cursor accounts for the trailing newline in JSONL, with a regression test for the off-by-one that would drop the next record.
- Picks the transcript by the record's own `cwd`, since the directory encoding is lossy.
- Example: `harness-agent/claude-code/read-history.ts`.

## End-to-End Verification

Ran against the real `claude` CLI: a full read returns text, tool-call, and tool-result parts with raw records attached; a read with the previous cursor returns only the messages recorded since.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
