### PR TITLE
feat(harness): local workspaces

### DIFF
--- a/.changeset/harness-local-workspace.md
+++ b/.changeset/harness-local-workspace.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness': patch
+---
+
+feat (harness): run harnesses against a local project directory. `HarnessAgent` gains a `workspace` setting — `workspace: localWorkspace({ path })` — that runs the harness on the local machine as the current user, with the project directory as its working directory, reusing the CLI configuration and credentials already there. `sandbox` becomes optional and mutually exclusive with `workspace`; when both are omitted, an implicit workspace at `process.cwd()` is used and a warning is emitted once per process (suppress via the `AI_SDK_LOG_WARNINGS` global). The project stays clean: all Harness SDK state (bridge dependencies, setup markers, per-session run state) lives in a central per-project store at `~/.ai-sdk/harness/projects/<basename>-<hash>/` whose `manifest.json` maps it back to the project (relocatable via `AI_SDK_HARNESS_STATE_DIR`). A workspace provides **no isolation** — it is the same trust level as running the agent's CLI in a terminal — and, because the environment is user-owned, nothing is installed into it without explicit consent.

--- a/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
+++ b/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
@@ -15,9 +15,62 @@ Install the core harness package, a harness adapter, and a sandbox provider:
 
 <InstallPackages packages="@ai-sdk/harness @ai-sdk/harness-claude-code @ai-sdk/sandbox-vercel" />
 
-Bridge-backed harnesses such as Claude Code and Codex require using real network sandbox
-like `@ai-sdk/sandbox-vercel`. Host-runtime harnesses such as Pi can also run with
-`@ai-sdk/sandbox-just-bash` because they do not need a sandbox-exposed port.
+Bridge-backed harnesses such as Claude Code and Codex require a sandbox provider that can
+spawn processes and expose a reachable port, such as `@ai-sdk/sandbox-vercel`. Host-runtime
+harnesses such as Pi can also run with `@ai-sdk/sandbox-just-bash` because they do not need
+a sandbox-exposed port.
+
+## Working on a Local Project
+
+Instead of a sandbox, you can point the agent at a project directory on the local machine
+with `workspace`:
+
+```ts
+import { HarnessAgent, localWorkspace } from '@ai-sdk/harness';
+
+const agent = new HarnessAgent({
+  harness: claudeCode,
+  workspace: localWorkspace({ path: '/path/to/project' }),
+});
+```
+
+When neither `sandbox` nor `workspace` is given, the harness runs in an implicit local
+workspace at `process.cwd()` and a warning is emitted once per process (silence it by
+setting the `AI_SDK_LOG_WARNINGS` global to `false` or to your own logger).
+
+A workspace runs the harness **on your own machine**, as the current user, with the
+project directory as its working directory. It reuses the CLI configuration, credentials,
+and skills the harness already has on your machine, so there is nothing to provision — and
+conversations belong to the runtime's own store, so you can continue them directly in the
+agent's own CLI (e.g. `claude --resume`).
+
+<Note type="warning">
+  A workspace provides **no isolation**. The harness has every permission the
+  current user has, and each one ships a shell tool that can read and write
+  anywhere you can. It is the same trust level as running `claude` or `codex` in
+  your terminal. For untrusted input or untrusted output, pass a real sandbox
+  provider.
+</Note>
+
+### Where State Lives
+
+Your project stays clean: all Harness SDK state — bridge dependencies, setup markers, and
+per-session run state — lives in a central per-project store:
+
+```
+~/.ai-sdk/harness/projects/<basename>-<hash>/
+  manifest.json        # maps the store back to the project path
+  .harness-bootstrap/  # bridge dependencies and setup markers
+  .agent-runs/         # per-session harness state
+```
+
+The store is keyed by the project's resolved path, `manifest.json` records which project
+it belongs to, and deleting a project's store just forces its bootstrap to run again. Set
+`AI_SDK_HARNESS_STATE_DIR` to relocate the root.
+
+Because the runtime executable is the environment's own and installing one requires
+consent (see `onInstallRequest`), a workspace never installs anything onto your machine
+without being asked.
 
 ## Create an Agent
 
@@ -530,7 +583,11 @@ console.log(preparation.identity);
 - `harness`: the adapter instance.
 - `model`: optional harness-specific model identifier. When omitted, the
   harness uses its default model.
-- `sandbox`: a `HarnessV1SandboxProvider`.
+- `sandbox`: a `HarnessV1SandboxProvider`. Mutually exclusive with `workspace`.
+- `workspace`: a local project directory created with `localWorkspace({ path })`;
+  runs the harness on the local machine with no isolation. When both `sandbox`
+  and `workspace` are omitted, an implicit workspace at `process.cwd()` is used
+  and a warning is emitted once per process.
 - `id`: optional stable agent identifier.
 - `instructions`: instructions appended to the runtime's system or developer
   prompt when supported, or prepended to the user prompt otherwise.

--- a/examples/ai-functions/src/harness-agent/claude-code/local-workspace.ts
+++ b/examples/ai-functions/src/harness-agent/claude-code/local-workspace.ts
@@ -1,0 +1,44 @@
+import { mkdtemp, readFile, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { localWorkspace } from '@ai-sdk/harness';
+import { HarnessAgent } from '@ai-sdk/harness/agent';
+import { createClaudeCode } from './_create';
+import { run } from '../../lib/run';
+
+const claudeCode = createClaudeCode();
+
+// Runs the harness on THIS machine, as the current user, with no isolation:
+// the same trust level as running `claude` in your terminal. It drives your
+// own `claude` installation and credentials; Harness SDK state lives in
+// ~/.ai-sdk/harness/projects/…, never inside the project.
+run(async () => {
+  const projectPath = await mkdtemp(
+    join(await realpath(tmpdir()), 'local-workspace-example-'),
+  );
+  console.log('project:', projectPath);
+
+  const agent = new HarnessAgent({
+    harness: claudeCode,
+    workspace: localWorkspace({ path: projectPath }),
+  });
+
+  const session = await agent.createSession();
+  try {
+    const result = await agent.generate({
+      session,
+      prompt:
+        'Create a file named NOTES.md in the working directory containing ' +
+        'a one-sentence description of this directory. Then stop.',
+    });
+    console.log('text:', result.text);
+
+    // The file landed in the local project directory itself.
+    console.log(
+      'NOTES.md:',
+      await readFile(join(projectPath, 'NOTES.md'), 'utf8'),
+    );
+  } finally {
+    await session.destroy();
+  }
+});

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -104,7 +104,9 @@ Use `session.detach()` to park a bridge-backed session for later attach, `sessio
 Set `model` on `HarnessAgent` to select the model used when the harness session
 starts. Model identifiers are harness-specific, so `model` accepts any string.
 
-`sandbox` is an optional `HarnessV1SandboxProvider`. When omitted, pass a `HarnessV1NetworkSandboxSession` to every `agent.createSession({ sandboxSession })` call. Use `sandboxConfig` for agent specific sandbox configuration that works independently from the sandbox provider that is used:
+`sandbox` is an optional `HarnessV1SandboxProvider` — the agent calls `provider.createSession()` when a session starts. Alternatively, pass a `HarnessV1NetworkSandboxSession` to every `agent.createSession({ sandboxSession })` call, or pass `workspace: localWorkspace({ path })` to work on a local project directory instead: the harness then runs on the local machine as the current user, reusing the CLI configuration and credentials already there, with all Harness SDK state kept in `~/.ai-sdk/harness/projects/…` rather than inside the project. A workspace provides **no isolation** — use a sandbox provider for untrusted input or output. When neither `sandbox`, `workspace`, nor a caller-owned `sandboxSession` is given, an implicit workspace at `process.cwd()` is used and a warning is emitted once per process (suppress via the `AI_SDK_LOG_WARNINGS` global).
+
+Use `sandboxConfig` for agent specific sandbox configuration that works independently from the sandbox provider that is used:
 
 - Use `sandboxConfig.onSession` to prepare the acquired sandbox before the harness adapter starts. The hook runs for fresh and resumed sessions, so keep it idempotent.
 - Use `sandboxConfig.onBootstrap` for expensive sandbox setup that should be baked into a reusable snapshot, such as installing tools or cloning a large repository. Provide `sandboxConfig.bootstrapHash` with it and change that value whenever the bootstrap output should invalidate the cached snapshot.

--- a/packages/harness/src/agent/harness-agent-settings.ts
+++ b/packages/harness/src/agent/harness-agent-settings.ts
@@ -3,6 +3,7 @@ import type {
   HarnessDiagnostic,
 } from './observability/types';
 import type { HarnessV1SandboxProvider } from '../v1';
+import type { LocalWorkspace } from '../workspace/local-workspace';
 import type {
   HarnessAgentAdapter,
   HarnessAgentPermissionMode,
@@ -260,10 +261,32 @@ export type HarnessAgentSettings<
 
   /**
    * Optional sandbox provider used to create or resume network sandbox
-   * sessions. When omitted, every `createSession()` call must provide an
-   * existing network sandbox session.
+   * sessions.
+   *
+   * Mutually exclusive with `workspace`. When neither is set and a
+   * `createSession()` call provides no existing network sandbox session, the
+   * harness runs in an implicit local workspace at `process.cwd()` (see
+   * `workspace`) and a warning is emitted once per process; suppress it by
+   * setting the `AI_SDK_LOG_WARNINGS` global to `false` or to your own
+   * logger.
    */
   readonly sandbox?: HarnessV1SandboxProvider;
+
+  /**
+   * A local project directory the harness works in, created with
+   * `localWorkspace({ path })`. Mutually exclusive with `sandbox`.
+   *
+   * The harness runs **on the local machine** as the current user, reusing
+   * the CLI configuration and credentials already there. Harness SDK state
+   * lives in `~/.ai-sdk/harness/projects/…`, never inside the project, and
+   * conversations belong to the runtime's own store so they can be continued
+   * directly in the agent's own CLI.
+   *
+   * **This provides no isolation**: the harness has every permission the
+   * current user has. Pass a `sandbox` provider for untrusted input or
+   * untrusted output.
+   */
+  readonly workspace?: LocalWorkspace;
 
   /**
    * Consent policy for installing the runtime's executable (declared by the

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -1859,13 +1859,45 @@ describe('HarnessAgent', () => {
     ).toThrow(/workDir/);
   });
 
-  test('requires a configured provider or a provided sandbox session', async () => {
-    const { harness } = mockHarness({ script: () => [] });
-    const agent = new HarnessAgent({ harness });
-
-    await expect(agent.createSession()).rejects.toThrow(
-      'HarnessAgent.createSession: configure `sandbox` on HarnessAgent or pass `sandboxSession` to createSession().',
+  test('falls back to an implicit local workspace without a provider or provided sandbox session', async () => {
+    const previousStateRoot = process.env.AI_SDK_HARNESS_STATE_DIR;
+    const previousWarnings = globalThis.AI_SDK_LOG_WARNINGS;
+    const warnings: string[] = [];
+    globalThis.AI_SDK_LOG_WARNINGS = options => {
+      for (const warning of options.warnings) {
+        warnings.push(
+          warning.type === 'other' ? warning.message : warning.type,
+        );
+      }
+    };
+    const { mkdtemp, realpath } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    process.env.AI_SDK_HARNESS_STATE_DIR = await mkdtemp(
+      join(await realpath(tmpdir()), 'implicit-state-'),
     );
+    try {
+      const { harness } = mockHarness({ script: () => [] });
+      const agent = new HarnessAgent({ harness });
+
+      const session = await agent.createSession();
+      try {
+        // The harness runs on the local machine, in the current working
+        // directory, and says so once per process.
+        expect(warnings.some(message => message.includes('no isolation'))).toBe(
+          true,
+        );
+      } finally {
+        await session.destroy();
+      }
+    } finally {
+      globalThis.AI_SDK_LOG_WARNINGS = previousWarnings;
+      if (previousStateRoot == null) {
+        delete process.env.AI_SDK_HARNESS_STATE_DIR;
+      } else {
+        process.env.AI_SDK_HARNESS_STATE_DIR = previousStateRoot;
+      }
+    }
   });
 
   test('uses a provided basic sandbox session, resolves its working directory, and applies the harness bootstrap recipe', async () => {
@@ -2128,6 +2160,19 @@ describe('HarnessAgent', () => {
     );
 
     await session.destroy();
+  });
+
+  test('rejects sandbox and workspace together', async () => {
+    const { harness } = mockHarness({ script: () => [] });
+    const { localWorkspace } = await import('../workspace/local-workspace');
+    expect(
+      () =>
+        new HarnessAgent({
+          harness,
+          sandbox: makeSandboxProvider(),
+          workspace: localWorkspace({ path: '/tmp/some-project' }),
+        }),
+    ).toThrow(/mutually exclusive/);
   });
 
   test('readHistory() reads the runtime history through the adapter', async () => {

--- a/packages/harness/src/agent/harness-agent.ts
+++ b/packages/harness/src/agent/harness-agent.ts
@@ -5,6 +5,7 @@ import {
   type HarnessV1JSONSchema,
   type HarnessV1NetworkSandboxSession,
   type HarnessV1ResponseFormat,
+  type HarnessV1SandboxProvider,
 } from '../v1';
 import {
   asArray,
@@ -220,6 +221,13 @@ export class HarnessAgent<
   ) {
     const sandboxConfig = resolveSandboxConfig(settings);
     validateSandboxBootstrapSettings(sandboxConfig);
+    if (settings.sandbox != null && settings.workspace != null) {
+      throw new Error(
+        'HarnessAgent: `sandbox` and `workspace` are mutually exclusive. ' +
+          'Pass a sandbox provider for an isolated environment, or a local ' +
+          'workspace to run on this machine — not both.',
+      );
+    }
     this.settings = settings;
     this.stopConditions =
       settings.stopWhen == null ? [] : asArray(settings.stopWhen);
@@ -259,6 +267,31 @@ export class HarnessAgent<
   /** Identifier of the harness backing this agent. */
   get harnessId(): string {
     return this.settings.harness.harnessId;
+  }
+
+  /**
+   * Provider used when the consumer supplied neither `sandbox` nor
+   * `workspace`: an implicit local workspace at `process.cwd()`, with a
+   * once-per-process warning since nothing was chosen explicitly.
+   *
+   * Imported lazily and cached so that requiring `HarnessAgent` does not pull
+   * `node:child_process` and `node:net` into the module graph of consumers
+   * who pass their own provider.
+   */
+  private implicitWorkspaceProvider: HarnessV1SandboxProvider | undefined;
+
+  private async resolveImplicitLocalWorkspace(): Promise<HarnessV1SandboxProvider> {
+    const existing = this.implicitWorkspaceProvider;
+    if (existing != null) return existing;
+    const [{ localWorkspace }, { warnAboutImplicitLocalWorkspace }] =
+      await Promise.all([
+        import('../workspace/local-workspace'),
+        import('../workspace/warn-implicit-local-workspace'),
+      ]);
+    warnAboutImplicitLocalWorkspace();
+    const provider = localWorkspace().provider;
+    this.implicitWorkspaceProvider = provider;
+    return provider;
   }
 
   /**
@@ -302,8 +335,20 @@ export class HarnessAgent<
     const providedSandboxSession = options?.sandboxSession;
     const abortSignal = options?.abortSignal;
     const harness = this.settings.harness;
-    const sandboxProvider = this.settings.sandbox;
     const ownsSandboxLifecycle = providedSandboxSession == null;
+    const sandboxProvider =
+      this.settings.sandbox ??
+      this.settings.workspace?.provider ??
+      (providedSandboxSession == null
+        ? await this.resolveImplicitLocalWorkspace()
+        : undefined);
+    // In workspace mode the project directory itself is the session's working
+    // directory: the whole point of a workspace is to work on the user's own
+    // files, and a per-session subdirectory would run the harness in an empty
+    // folder beside them. An explicit `sandboxConfig.workDir` still wins, and
+    // a caller-owned sandbox session keeps the per-session subdirectory.
+    const workspaceIsSessionWorkDir =
+      providedSandboxSession == null && this.settings.sandbox == null;
 
     if (resumeFrom != null && continueFrom != null) {
       throw new Error(
@@ -408,6 +453,7 @@ export class HarnessAgent<
           harnessId: harness.harnessId,
           sessionId,
           workDir: this.sandboxConfig.workDir,
+          workspaceIsSessionWorkDir,
         });
 
         // Ensure the harness bootstrap recipe on resumed sessions too. The
@@ -460,6 +506,7 @@ export class HarnessAgent<
           harnessId: harness.harnessId,
           sessionId,
           workDir: sandboxBootstrapPlan.workDir,
+          workspaceIsSessionWorkDir,
         });
 
         // In case the sandbox session was created with a custom sandbox, or in

--- a/packages/harness/src/agent/internal/sandbox-bootstrap.ts
+++ b/packages/harness/src/agent/internal/sandbox-bootstrap.ts
@@ -65,17 +65,33 @@ export function normalizeSandboxWorkDir(workDir: string): string {
   return normalized;
 }
 
+/**
+ * Where the harness runs for this session.
+ *
+ * Normally a per-session subdirectory of the sandbox's default working
+ * directory, since a hosted sandbox is freshly provisioned and that directory
+ * is not itself a workspace.
+ *
+ * `workspaceIsSessionWorkDir` is for workspace mode, whose root *is* the
+ * user's project: a per-session subdirectory there would run the harness in
+ * an empty folder beside their files. An explicit `workDir` still wins.
+ */
 export function resolveSessionWorkDir({
   defaultWorkingDirectory,
   harnessId,
   sessionId,
   workDir,
+  workspaceIsSessionWorkDir = false,
 }: {
   readonly defaultWorkingDirectory: string;
   readonly harnessId: string;
   readonly sessionId: string;
   readonly workDir?: string;
+  readonly workspaceIsSessionWorkDir?: boolean;
 }): string {
+  if (workDir == null && workspaceIsSessionWorkDir) {
+    return defaultWorkingDirectory;
+  }
   return joinSandboxPath({
     base: defaultWorkingDirectory,
     path: workDir ?? `${harnessId}-${sessionId}`,

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,4 +1,5 @@
 export * from './v1';
+export * from './workspace';
 export * from './errors/harness-error';
 export * from './errors/harness-capability-unsupported-error';
 export * from './errors/harness-executable-missing-error';

--- a/packages/harness/src/workspace/implicit-local-workspace.test.ts
+++ b/packages/harness/src/workspace/implicit-local-workspace.test.ts
@@ -1,0 +1,139 @@
+import { existsSync } from 'node:fs';
+import { mkdtemp, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveSessionWorkDir } from '../agent/internal/sandbox-bootstrap';
+import { localWorkspace } from './local-workspace';
+import {
+  resetImplicitLocalWorkspaceWarning,
+  warnAboutImplicitLocalWorkspace,
+} from './warn-implicit-local-workspace';
+
+describe('resolveSessionWorkDir in workspace mode', () => {
+  // A hosted sandbox is fresh, so a per-session subdirectory is right. A
+  // workspace is rooted at the user's own project, where a subdirectory would
+  // run the harness in an empty folder beside their files.
+  it('uses the workspace root itself in workspace mode', () => {
+    expect(
+      resolveSessionWorkDir({
+        defaultWorkingDirectory: '/repo',
+        harnessId: 'claude-code',
+        sessionId: 's1',
+        workspaceIsSessionWorkDir: true,
+      }),
+    ).toBe('/repo');
+  });
+
+  it('uses a per-session subdirectory otherwise', () => {
+    expect(
+      resolveSessionWorkDir({
+        defaultWorkingDirectory: '/sandbox',
+        harnessId: 'claude-code',
+        sessionId: 's1',
+      }),
+    ).toBe('/sandbox/claude-code-s1');
+  });
+
+  it('lets an explicit workDir win over workspace mode', () => {
+    expect(
+      resolveSessionWorkDir({
+        defaultWorkingDirectory: '/repo',
+        harnessId: 'claude-code',
+        sessionId: 's1',
+        workDir: 'sub',
+        workspaceIsSessionWorkDir: true,
+      }),
+    ).toBe('/repo/sub');
+  });
+});
+
+describe('implicit-workspace warning', () => {
+  beforeEach(() => {
+    resetImplicitLocalWorkspaceWarning();
+    globalThis.AI_SDK_LOG_WARNINGS = undefined;
+  });
+
+  afterEach(() => {
+    globalThis.AI_SDK_LOG_WARNINGS = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it('warns once per process, not once per session', () => {
+    const emitted: string[] = [];
+    globalThis.AI_SDK_LOG_WARNINGS = options => {
+      for (const warning of options.warnings) {
+        emitted.push(warning.type === 'other' ? warning.message : warning.type);
+      }
+    };
+
+    warnAboutImplicitLocalWorkspace();
+    warnAboutImplicitLocalWorkspace();
+    warnAboutImplicitLocalWorkspace();
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toContain('no isolation');
+  });
+
+  // Consumers of a library should be able to turn its output off, and this
+  // reuses the switch the rest of the AI SDK already documents.
+  it('is silenced by AI_SDK_LOG_WARNINGS === false', () => {
+    globalThis.AI_SDK_LOG_WARNINGS = false;
+    const emitWarning = vi.spyOn(process, 'emitWarning');
+    const consoleWarn = vi.spyOn(console, 'warn');
+
+    warnAboutImplicitLocalWorkspace();
+
+    expect(emitWarning).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to process.emitWarning when no logger is set', () => {
+    const emitWarning = vi
+      .spyOn(process, 'emitWarning')
+      .mockImplementation(() => {});
+
+    warnAboutImplicitLocalWorkspace();
+
+    expect(emitWarning).toHaveBeenCalledOnce();
+    expect(String(emitWarning.mock.calls[0][0])).toContain(
+      'neither `sandbox` nor `workspace`',
+    );
+  });
+});
+
+describe('workspace mode session work dir', () => {
+  it('runs the session in the project directory itself, not a subdirectory', async () => {
+    const stateRoot = await mkdtemp(
+      join(await realpath(tmpdir()), 'ilw-state-'),
+    );
+    const previous = process.env.AI_SDK_HARNESS_STATE_DIR;
+    process.env.AI_SDK_HARNESS_STATE_DIR = stateRoot;
+    try {
+      const projectPath = await mkdtemp(join(await realpath(tmpdir()), 'imp-'));
+      const session = await localWorkspace({
+        path: projectPath,
+      }).provider.createSession();
+
+      try {
+        const sessionWorkDir = resolveSessionWorkDir({
+          defaultWorkingDirectory: session.defaultWorkingDirectory,
+          harnessId: 'claude-code',
+          sessionId: 'abc',
+          workspaceIsSessionWorkDir: true,
+        });
+
+        expect(sessionWorkDir).toBe(projectPath);
+        expect(existsSync(sessionWorkDir)).toBe(true);
+      } finally {
+        await session.stop();
+      }
+    } finally {
+      if (previous == null) {
+        delete process.env.AI_SDK_HARNESS_STATE_DIR;
+      } else {
+        process.env.AI_SDK_HARNESS_STATE_DIR = previous;
+      }
+    }
+  });
+});

--- a/packages/harness/src/workspace/index.ts
+++ b/packages/harness/src/workspace/index.ts
@@ -1,0 +1,5 @@
+export {
+  localWorkspace,
+  type LocalWorkspace,
+  type LocalWorkspaceSettings,
+} from './local-workspace';

--- a/packages/harness/src/workspace/local-workspace-network-sandbox-session.ts
+++ b/packages/harness/src/workspace/local-workspace-network-sandbox-session.ts
@@ -1,0 +1,115 @@
+import type { Experimental_SandboxSession as SandboxSession } from '@ai-sdk/provider-utils';
+import type {
+  HarnessV1NetworkSandboxSession,
+  HarnessV1PortEndpoint,
+} from '../v1';
+import {
+  killProcessTree,
+  LocalWorkspaceSandboxSession,
+  type LocalWorkspaceSessionContext,
+  reapChildSetOnExit,
+  stopReapingChildSet,
+} from './local-workspace-sandbox-session';
+
+/**
+ * `HarnessV1NetworkSandboxSession` backed by the local machine. Extends
+ * {@link LocalWorkspaceSandboxSession} with the infra surface the harness
+ * framework needs: an id, a working directory, a state directory, loopback
+ * ports, and lifecycle.
+ *
+ * Ports are real free TCP ports on `127.0.0.1`, allocated when the session is
+ * created, so bridge-backed adapters work. `setNetworkPolicy` and `setPorts`
+ * are deliberately **omitted** rather than stubbed: there is no local
+ * enforcement primitive, and a no-op implementation would be a lie the
+ * framework acts on.
+ */
+export class LocalWorkspaceNetworkSandboxSession
+  extends LocalWorkspaceSandboxSession
+  implements HarnessV1NetworkSandboxSession
+{
+  readonly id: string;
+  readonly ports: ReadonlyArray<number>;
+
+  /**
+   * Harness SDK state lives in the central per-project store
+   * (`~/.ai-sdk/harness/projects/…`), never inside the user's project.
+   */
+  readonly stateDirectory: string;
+
+  /**
+   * The environment is the user's own machine and accounts. Nothing may be
+   * installed into it without explicit consent, and the framework's default
+   * consent policy denies it.
+   */
+  readonly environmentOwner = 'user' as const;
+
+  constructor(input: {
+    id: string;
+    ports: ReadonlyArray<number>;
+    stateDirectory: string;
+    context: LocalWorkspaceSessionContext;
+  }) {
+    super(input.context);
+    this.id = input.id;
+    this.ports = input.ports;
+    this.stateDirectory = input.stateDirectory;
+    reapChildSetOnExit(this.context.children);
+  }
+
+  /** The project directory. Already realpath'd by the provider. */
+  get defaultWorkingDirectory(): string {
+    return this.context.workingDirectory;
+  }
+
+  /**
+   * Resolve any loopback port to an endpoint.
+   *
+   * Deliberately does not check {@link ports}, which lists the free ports
+   * allocated for this session's bridge to *bind*, not what is addressable.
+   * Everything on `127.0.0.1` is.
+   *
+   * Rejecting unknown ports breaks reattach: a detached bridge's coordinates
+   * name the port it is still listening on, and a resumed session has a fresh
+   * pool. Adapters read the failure as "bridge unreachable" and quietly
+   * respawn, orphaning the bridge that detaching meant to preserve.
+   */
+  getPortEndpoint = async ({
+    port,
+    protocol = 'http',
+  }: {
+    port: number;
+    protocol?: 'http' | 'https' | 'ws';
+  }): Promise<HarnessV1PortEndpoint> => ({
+    url: `${protocol}://127.0.0.1:${port}`,
+  });
+
+  /** @deprecated Use `getPortEndpoint` instead. */
+  getPortUrl = async (options: {
+    port: number;
+    protocol?: 'http' | 'https' | 'ws';
+  }): Promise<string> => (await this.getPortEndpoint(options)).url;
+
+  /**
+   * Kill every process this session spawned. Idempotent.
+   *
+   * There is no machine to shut down: the "sandbox" is the user's own
+   * filesystem, which outlives the session by design.
+   */
+  stop = async (): Promise<void> => {
+    for (const child of this.context.children) killProcessTree(child);
+    this.context.children.clear();
+    stopReapingChildSet(this.context.children);
+  };
+
+  /**
+   * Identical to {@link stop}. The project directory is the user's own and is
+   * never deleted.
+   */
+  destroy = async (): Promise<void> => {
+    await this.stop();
+  };
+
+  restricted(): SandboxSession {
+    return new LocalWorkspaceSandboxSession(this.context);
+  }
+}

--- a/packages/harness/src/workspace/local-workspace-provider.ts
+++ b/packages/harness/src/workspace/local-workspace-provider.ts
@@ -1,0 +1,254 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { dirname, join, resolve } from 'node:path';
+import type { Experimental_SandboxSession as SandboxSession } from '@ai-sdk/provider-utils';
+import type {
+  HarnessV1NetworkSandboxSession,
+  HarnessV1SandboxProvider,
+} from '../v1';
+import {
+  assertUsableProjectPath,
+  type LocalWorkspaceSettings,
+} from './local-workspace';
+import { LocalWorkspaceNetworkSandboxSession } from './local-workspace-network-sandbox-session';
+import {
+  LocalWorkspaceSandboxSession,
+  realpathAllowingMissing,
+  type LocalWorkspaceSessionContext,
+} from './local-workspace-sandbox-session';
+import {
+  ensureLocalWorkspaceStateDirectory,
+  localWorkspaceStateDirectory,
+} from './local-workspace-state';
+
+const LOCAL_WORKSPACE_PROVIDER_ID = 'local-workspace';
+
+/**
+ * `onFirstCreate` runs currently in flight, keyed by marker path.
+ *
+ * Module scope, not per provider: two workspaces on the same project share a
+ * state directory and therefore a marker, and a per-instance map would let
+ * them bootstrap on top of each other. Entries are dropped once settled,
+ * leaving the marker file as the durable record.
+ *
+ * Separate processes are not coordinated. That needs a lock file with
+ * staleness detection, which the framework's own recipe application does not
+ * attempt either.
+ */
+const firstCreateRuns = new Map<string, Promise<void>>();
+
+/**
+ * `HarnessV1SandboxProvider` implementation backed by the user's own machine.
+ *
+ * Unlike hosted providers there is no machine to create: sessions bind to a
+ * project directory that already exists and outlives them, and all Harness
+ * SDK state lives in the central per-project store
+ * (`~/.ai-sdk/harness/projects/…`), never inside the project.
+ * `resumeSession` therefore just rebinds to the same root.
+ *
+ * **This provides no isolation.** The session declares
+ * `environmentOwner: 'user'`, so nothing is installed without consent, but
+ * the harness itself has every permission the current user has.
+ */
+export class LocalWorkspaceProvider implements HarnessV1SandboxProvider {
+  readonly specificationVersion = 'harness-sandbox-v1' as const;
+  readonly providerId = LOCAL_WORKSPACE_PROVIDER_ID;
+
+  private readonly projectPath: string;
+  private readonly env: Record<string, string>;
+
+  constructor(settings: LocalWorkspaceSettings = {}) {
+    const projectPath = resolve(settings.path ?? process.cwd());
+
+    // Fails fast on the obvious mistake. The provider contract forbids I/O at
+    // construction, so this cannot follow symlinks; `createSession` repeats
+    // the check once the path has been resolved.
+    assertUsableProjectPath(projectPath);
+
+    this.projectPath = projectPath;
+    this.env = { ...process.env, ...settings.env } as Record<string, string>;
+  }
+
+  createSession = async (options?: {
+    sessionId?: string;
+    abortSignal?: AbortSignal;
+    identity?: string;
+    onFirstCreate?: (
+      session: SandboxSession,
+      opts: { abortSignal?: AbortSignal },
+    ) => Promise<void>;
+  }): Promise<HarnessV1NetworkSandboxSession> => {
+    options?.abortSignal?.throwIfAborted();
+
+    mkdirSync(this.projectPath, { recursive: true });
+
+    // realpath after creating the directory, so the workspace root and every
+    // path derived from it are symlink-stable. Adapters compare a spawned
+    // process's `pwd` against `defaultWorkingDirectory`; on macOS a project
+    // under `/tmp` resolves to `/private/tmp` and the comparison fails
+    // without this.
+    const workingDirectory = await realpathAllowingMissing(this.projectPath);
+
+    // A symlink to `/` or to the home directory passes the constructor's
+    // unresolved check, and is exactly what that check exists to catch.
+    assertUsableProjectPath(
+      workingDirectory,
+      message => `${message} (resolved from \`${this.projectPath}\`)`,
+    );
+
+    const stateDirectory = localWorkspaceStateDirectory(workingDirectory);
+    await ensureLocalWorkspaceStateDirectory({
+      stateDirectory,
+      projectPath: workingDirectory,
+    });
+
+    const children: LocalWorkspaceSessionContext['children'] = new Set();
+    const session = new LocalWorkspaceNetworkSandboxSession({
+      id: options?.sessionId ?? `local-workspace-${randomUUID()}`,
+      ports: [await allocateLoopbackPort()],
+      stateDirectory,
+      context: {
+        workingDirectory,
+        env: this.env,
+        children,
+      },
+    });
+
+    await this.runFirstCreateOnce({
+      // One-time setup is infrastructure work (bootstrap recipes and their
+      // dependencies), so it runs rooted at the state directory: its output
+      // belongs in the store, never in the user's project. The child set is
+      // shared so anything the hook spawns is reaped with the session.
+      setupSession: new LocalWorkspaceSandboxSession({
+        workingDirectory: stateDirectory,
+        env: this.env,
+        children,
+      }),
+      stateDirectory,
+      identity: options?.identity,
+      onFirstCreate: options?.onFirstCreate,
+      abortSignal: options?.abortSignal,
+    });
+
+    return session;
+  };
+
+  /**
+   * Rebind to the same project directory.
+   *
+   * The local filesystem is the durable resource, so there is nothing to
+   * rehydrate.
+   *
+   * Within one process this reattaches to a still-running bridge, which is
+   * what makes `detach()` worthwhile. From a new process it does not:
+   * sessions reap their processes on exit, so the adapter respawns. That
+   * trade is deliberate — stray bridges on a developer's machine are never a
+   * supported mode, and unlike a hosted sandbox there is no separate machine
+   * for a parked session to live on.
+   */
+  resumeSession = async (options: {
+    sessionId: string;
+    abortSignal?: AbortSignal;
+  }): Promise<HarnessV1NetworkSandboxSession> =>
+    this.createSession({
+      sessionId: options.sessionId,
+      ...(options.abortSignal != null
+        ? { abortSignal: options.abortSignal }
+        : {}),
+    });
+
+  /**
+   * Run `onFirstCreate` at most once per identity.
+   *
+   * Snapshot-capable providers bake the hook's side effects into a reusable
+   * image. There are no snapshots locally, so it runs inline and a marker
+   * file in the state directory records that it did.
+   */
+  private async runFirstCreateOnce({
+    setupSession,
+    stateDirectory,
+    identity,
+    onFirstCreate,
+    abortSignal,
+  }: {
+    /** Restricted session rooted at the state directory, not the project. */
+    setupSession: LocalWorkspaceSandboxSession;
+    stateDirectory: string;
+    identity?: string;
+    onFirstCreate?: (
+      session: SandboxSession,
+      opts: { abortSignal?: AbortSignal },
+    ) => Promise<void>;
+    abortSignal?: AbortSignal;
+  }): Promise<void> {
+    if (onFirstCreate == null) return;
+
+    // Without an identity there is no cache key, so the hook must run every
+    // time rather than be skipped.
+    if (identity == null) {
+      await onFirstCreate(setupSession, {
+        ...(abortSignal != null ? { abortSignal } : {}),
+      });
+      return;
+    }
+
+    const markerPath = join(stateDirectory, `.first-create-${identity}.ok`);
+
+    // Keyed by marker path, so providers on unrelated projects never block.
+    const inFlight = firstCreateRuns.get(markerPath);
+    if (inFlight != null) {
+      await inFlight;
+      return;
+    }
+
+    if (existsSync(markerPath)) return;
+
+    const run = (async () => {
+      await onFirstCreate(setupSession, {
+        ...(abortSignal != null ? { abortSignal } : {}),
+      });
+
+      mkdirSync(dirname(markerPath), { recursive: true });
+      try {
+        // `wx` so a racing process cannot be told the work is done before it
+        // is. Losing the race is harmless: both ran the same hook.
+        writeFileSync(markerPath, new Date().toISOString(), { flag: 'wx' });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      }
+    })();
+
+    firstCreateRuns.set(markerPath, run);
+    try {
+      await run;
+    } catch (error) {
+      // A failed bootstrap must not be remembered as done, by this process or
+      // by the next one to look at the marker.
+      rmSync(markerPath, { force: true });
+      throw error;
+    } finally {
+      // The marker file is the durable record. Holding the settled promise
+      // would mean deleting it no longer forces a re-bootstrap.
+      firstCreateRuns.delete(markerPath);
+    }
+  }
+}
+
+function allocateLoopbackPort(): Promise<number> {
+  return new Promise((resolvePort, rejectPort) => {
+    const server = createServer();
+    server.on('error', rejectPort);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (address == null || typeof address === 'string') {
+        server.close(() =>
+          rejectPort(new Error('Failed to allocate a loopback port.')),
+        );
+        return;
+      }
+      const { port } = address;
+      server.close(() => resolvePort(port));
+    });
+  });
+}

--- a/packages/harness/src/workspace/local-workspace-sandbox-session.ts
+++ b/packages/harness/src/workspace/local-workspace-sandbox-session.ts
@@ -1,0 +1,364 @@
+import { spawn as spawnChildProcess } from 'node:child_process';
+import { createReadStream } from 'node:fs';
+// Captured at module load, never accessed as namespace properties.
+//
+// Host-runtime adapters patch `node:fs` at runtime: Pi installs a global VFS
+// shim via `syncBuiltinESMExports` that redirects file operations into its own
+// host mirror. Resolving through the namespace at call time would send writes
+// into that mirror, where they vanish with the session. Destructuring binds the
+// real implementations before any adapter loads.
+import {
+  mkdir as mkdirAsync,
+  readFile as readFileAsync,
+  realpath as realpathAsync,
+  stat as statAsync,
+  writeFile as writeFileAsync,
+} from 'node:fs/promises';
+import { dirname, isAbsolute, resolve as resolvePath } from 'node:path';
+import { Readable } from 'node:stream';
+import {
+  extractLines,
+  type Experimental_SandboxProcess as SandboxProcess,
+  type Experimental_SandboxSession as SandboxSession,
+} from '@ai-sdk/provider-utils';
+
+const nodeFs = {
+  mkdir: mkdirAsync,
+  readFile: readFileAsync,
+  realpath: realpathAsync,
+  stat: statAsync,
+  writeFile: writeFileAsync,
+};
+
+/**
+ * Everything a session needs to operate. Constructed by the provider and
+ * shared by reference between a {@link LocalWorkspaceNetworkSandboxSession} and
+ * the reduced session its `restricted()` returns, so both observe the same
+ * child-process set.
+ */
+export type LocalWorkspaceSessionContext = {
+  /** Sandbox root, which is the project directory. Already realpath'd. */
+  readonly workingDirectory: string;
+  /** Inherited process environment plus the caller's overlay. */
+  readonly env: Record<string, string>;
+  /** Live children, so `stop()` can reap the whole tree. */
+  readonly children: Set<ReturnType<typeof spawnChildProcess>>;
+};
+
+/**
+ * Child sets belonging to sessions that have not been stopped.
+ *
+ * Shared so one exit handler covers every session. One handler per session
+ * tripped Node's `MaxListenersExceededWarning` at eleven concurrent sessions,
+ * and detach never calls `stop()`, so they accumulated for the life of the
+ * process.
+ */
+const unstoppedChildSets = new Set<Set<ReturnType<typeof spawnChildProcess>>>();
+let exitReaperInstalled = false;
+
+/**
+ * Reap this session's processes if the host exits without stopping it.
+ *
+ * Leaving processes behind is never a supported mode, so this fires even for
+ * sessions that were detached rather than stopped.
+ */
+export function reapChildSetOnExit(
+  children: Set<ReturnType<typeof spawnChildProcess>>,
+): void {
+  unstoppedChildSets.add(children);
+  if (exitReaperInstalled) return;
+  exitReaperInstalled = true;
+  process.once('exit', () => {
+    for (const childSet of unstoppedChildSets) {
+      for (const child of childSet) killProcessTree(child);
+    }
+  });
+}
+
+/** Stop reaping a session's processes, once it has cleaned up after itself. */
+export function stopReapingChildSet(
+  children: Set<ReturnType<typeof spawnChildProcess>>,
+): void {
+  unstoppedChildSets.delete(children);
+}
+
+/**
+ * Kill a process and everything it spawned.
+ *
+ * Bridge-backed adapters spawn a bridge that spawns a CLI that spawns more
+ * processes, so killing the direct child is not enough: an aborted
+ * orchestrator was observed leaving a bridge alive for twelve minutes.
+ * Children are spawned `detached`, which puts each one in its own process
+ * group, so a negative pid signals the entire group.
+ */
+export function killProcessTree(
+  child: ReturnType<typeof spawnChildProcess>,
+): void {
+  if (child.pid == null) return;
+  try {
+    process.kill(-child.pid, 'SIGKILL');
+  } catch {
+    // The group is already gone, or the platform refused a group signal.
+    // Fall back to the direct child; failing that, it has already exited.
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      // Already gone.
+    }
+  }
+}
+
+/**
+ * `Experimental_SandboxSession` implementation backed by the local machine:
+ * real files, real processes, the user's own environment.
+ *
+ * This is the tool-safe surface returned by
+ * `LocalWorkspaceNetworkSandboxSession.restricted()`, not constructed directly
+ * by consumers.
+ *
+ * It applies **no path containment**. A guard here would constrain nothing:
+ * bridge-backed harnesses never route their built-in tools through this API,
+ * and every harness ships a shell tool. See the package README.
+ */
+export class LocalWorkspaceSandboxSession implements SandboxSession {
+  constructor(protected readonly context: LocalWorkspaceSessionContext) {}
+
+  /**
+   * Consumers put this in the model's instructions, so it has to say where
+   * relative paths actually land.
+   */
+  get description(): string {
+    return [
+      `Local machine project directory: ${this.context.workingDirectory}.`,
+      'Relative paths and commands resolve against that directory.',
+      'Commands run as a normal OS process on the host, as the current user.',
+    ].join('\n');
+  }
+
+  private resolveAgainstWorkingDirectory(path: string): string {
+    return isAbsolute(path)
+      ? path
+      : resolvePath(this.context.workingDirectory, path);
+  }
+
+  /**
+   * Stat rather than read to decide whether the file exists.
+   *
+   * This is the streaming primitive, so it must not buffer. Reading the bytes
+   * first just to return `null` for a missing file pulled the whole file into
+   * memory, twice, before the consumer saw a single chunk.
+   */
+  readFile = async ({
+    path,
+    abortSignal,
+  }: {
+    path: string;
+    abortSignal?: AbortSignal;
+  }): Promise<ReadableStream<Uint8Array> | null> => {
+    abortSignal?.throwIfAborted();
+    const absolutePath = this.resolveAgainstWorkingDirectory(path);
+    try {
+      if (!(await nodeFs.stat(absolutePath)).isFile()) return null;
+    } catch (error) {
+      if (isMissingFileError(error)) return null;
+      throw error;
+    }
+    return Readable.toWeb(
+      createReadStream(absolutePath),
+    ) as ReadableStream<Uint8Array>;
+  };
+
+  readBinaryFile = async ({
+    path,
+    abortSignal,
+  }: {
+    path: string;
+    abortSignal?: AbortSignal;
+  }): Promise<Uint8Array | null> => {
+    abortSignal?.throwIfAborted();
+    try {
+      const buffer = await nodeFs.readFile(
+        this.resolveAgainstWorkingDirectory(path),
+      );
+      return new Uint8Array(buffer);
+    } catch (error) {
+      if (isMissingFileError(error)) return null;
+      throw error;
+    }
+  };
+
+  readTextFile = async ({
+    path,
+    encoding = 'utf-8',
+    startLine,
+    endLine,
+    abortSignal,
+  }: {
+    path: string;
+    encoding?: string;
+    startLine?: number;
+    endLine?: number;
+    abortSignal?: AbortSignal;
+  }): Promise<string | null> => {
+    const bytes = await this.readBinaryFile({ path, abortSignal });
+    if (bytes == null) return null;
+    const text = new TextDecoder(encoding).decode(bytes);
+    return extractLines({ text, startLine, endLine });
+  };
+
+  writeFile = async ({
+    path,
+    content,
+    abortSignal,
+  }: {
+    path: string;
+    content: ReadableStream<Uint8Array>;
+    abortSignal?: AbortSignal;
+  }): Promise<void> => {
+    abortSignal?.throwIfAborted();
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of content as unknown as AsyncIterable<Uint8Array>) {
+      chunks.push(chunk);
+    }
+    await this.writeBinaryFile({
+      path,
+      content: Buffer.concat(chunks),
+      abortSignal,
+    });
+  };
+
+  writeBinaryFile = async ({
+    path,
+    content,
+    abortSignal,
+  }: {
+    path: string;
+    content: Uint8Array;
+    abortSignal?: AbortSignal;
+  }): Promise<void> => {
+    abortSignal?.throwIfAborted();
+    const absolutePath = this.resolveAgainstWorkingDirectory(path);
+    await nodeFs.mkdir(dirname(absolutePath), { recursive: true });
+    await nodeFs.writeFile(absolutePath, content);
+  };
+
+  writeTextFile = async ({
+    path,
+    content,
+    encoding = 'utf-8',
+    abortSignal,
+  }: {
+    path: string;
+    content: string;
+    encoding?: string;
+    abortSignal?: AbortSignal;
+  }): Promise<void> => {
+    await this.writeBinaryFile({
+      path,
+      content: Buffer.from(content, encoding as BufferEncoding),
+      abortSignal,
+    });
+  };
+
+  spawn = async ({
+    command,
+    workingDirectory,
+    env,
+    abortSignal,
+  }: {
+    command: string;
+    workingDirectory?: string;
+    env?: Record<string, string>;
+    abortSignal?: AbortSignal;
+  }): Promise<SandboxProcess> => {
+    abortSignal?.throwIfAborted();
+
+    const child = spawnChildProcess('bash', ['-c', command], {
+      cwd:
+        workingDirectory != null
+          ? this.resolveAgainstWorkingDirectory(workingDirectory)
+          : this.context.workingDirectory,
+      env: { ...this.context.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      // Own process group, so `killProcessTree` can reap the whole tree.
+      detached: true,
+    });
+
+    this.context.children.add(child);
+
+    const onAbort = () => killProcessTree(child);
+    abortSignal?.addEventListener('abort', onAbort, { once: true });
+
+    const exited = new Promise<{ exitCode: number }>(resolveExit => {
+      const settle = (exitCode: number) => {
+        this.context.children.delete(child);
+        abortSignal?.removeEventListener('abort', onAbort);
+        resolveExit({ exitCode });
+      };
+      child.on('exit', code => settle(code ?? -1));
+      child.on('error', () => settle(-1));
+    });
+
+    return {
+      ...(child.pid != null ? { pid: child.pid } : {}),
+      stdout: Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
+      stderr: Readable.toWeb(child.stderr) as ReadableStream<Uint8Array>,
+      wait: () => exited,
+      kill: async () => {
+        killProcessTree(child);
+        await exited;
+      },
+    };
+  };
+
+  run = async (options: {
+    command: string;
+    workingDirectory?: string;
+    env?: Record<string, string>;
+    abortSignal?: AbortSignal;
+  }): Promise<{ exitCode: number; stdout: string; stderr: string }> => {
+    const child = await this.spawn(options);
+    const [stdout, stderr, { exitCode }] = await Promise.all([
+      collectStream(child.stdout),
+      collectStream(child.stderr),
+      child.wait(),
+    ]);
+    return { exitCode, stdout, stderr };
+  };
+}
+
+async function collectStream(
+  stream: ReadableStream<Uint8Array>,
+): Promise<string> {
+  const decoder = new TextDecoder();
+  let text = '';
+  for await (const chunk of stream as unknown as AsyncIterable<Uint8Array>) {
+    text += decoder.decode(chunk, { stream: true });
+  }
+  return text + decoder.decode();
+}
+
+function isMissingFileError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code;
+  return code === 'ENOENT' || code === 'EISDIR';
+}
+
+/**
+ * `realpath` a path that may not exist yet, by resolving the deepest existing
+ * ancestor and re-appending the missing segments.
+ *
+ * Needed because every path comparison in this package must be symlink-stable:
+ * on macOS `/tmp` is a symlink to `/private/tmp`, and a project may itself be
+ * reached through a symlink. Comparing one realpath'd path against one raw path
+ * silently fails.
+ */
+export async function realpathAllowingMissing(path: string): Promise<string> {
+  try {
+    return await nodeFs.realpath(path);
+  } catch {
+    const parent = dirname(path);
+    if (parent === path) return path;
+    const resolvedParent = await realpathAllowingMissing(parent);
+    return resolvePath(resolvedParent, path.slice(parent.length + 1));
+  }
+}

--- a/packages/harness/src/workspace/local-workspace-state.ts
+++ b/packages/harness/src/workspace/local-workspace-state.ts
@@ -1,0 +1,76 @@
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+import { safeParseJSON } from '@ai-sdk/provider-utils';
+
+/**
+ * Root of the Harness SDK's own state on this machine. This is SDK state —
+ * bootstrap recipes and their dependencies, per-session run state — not the
+ * runtimes' stores (`~/.claude`, `~/.codex`, …), which each runtime keeps
+ * managing itself.
+ *
+ * `~/.ai-sdk/harness` by default, matching the dotfile convention of the
+ * runtimes it orchestrates; relocatable via `AI_SDK_HARNESS_STATE_DIR`.
+ */
+export function localWorkspaceStateRoot(): string {
+  const override = process.env.AI_SDK_HARNESS_STATE_DIR;
+  if (override != null && override.length > 0) return override;
+  return join(homedir(), '.ai-sdk', 'harness');
+}
+
+/**
+ * The per-project state directory for a workspace, keyed so a human can find
+ * it (`<project basename>-<hash>`) and a tool can map it back
+ * (`manifest.json` records the absolute project path).
+ *
+ * Keyed by the realpath'd project path, so the same project reached through
+ * different symlinks shares one store, and two projects with the same
+ * basename never collide.
+ */
+export function localWorkspaceStateDirectory(projectPath: string): string {
+  const key = `${sanitizeBasename(basename(projectPath))}-${hashPath(projectPath)}`;
+  return join(localWorkspaceStateRoot(), 'projects', key);
+}
+
+/**
+ * Create the state directory and write/refresh its `manifest.json`, the
+ * reverse mapping from state to project. `createdAt` is preserved across
+ * refreshes; `lastUsedAt` always advances.
+ */
+export async function ensureLocalWorkspaceStateDirectory({
+  stateDirectory,
+  projectPath,
+}: {
+  stateDirectory: string;
+  projectPath: string;
+}): Promise<void> {
+  await mkdir(stateDirectory, { recursive: true });
+
+  const manifestPath = join(stateDirectory, 'manifest.json');
+  const now = new Date().toISOString();
+  let createdAt = now;
+  const existing = await readFile(manifestPath, 'utf8').catch(() => null);
+  if (existing != null) {
+    // A corrupt manifest is rewritten wholesale; it is derived state.
+    const parsed = await safeParseJSON({ text: existing });
+    const parsedCreatedAt = parsed.success
+      ? (parsed.value as { createdAt?: unknown } | null)?.createdAt
+      : undefined;
+    if (typeof parsedCreatedAt === 'string') createdAt = parsedCreatedAt;
+  }
+  await writeFile(
+    manifestPath,
+    `${JSON.stringify({ projectPath, createdAt, lastUsedAt: now }, null, 2)}\n`,
+  );
+}
+
+function sanitizeBasename(name: string): string {
+  const sanitized = name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  const trimmed = sanitized.replace(/^-+|-+$/g, '').slice(0, 40);
+  return trimmed.length > 0 ? trimmed : 'project';
+}
+
+function hashPath(projectPath: string): string {
+  return createHash('sha256').update(projectPath).digest('hex').slice(0, 8);
+}

--- a/packages/harness/src/workspace/local-workspace.test.ts
+++ b/packages/harness/src/workspace/local-workspace.test.ts
@@ -1,0 +1,810 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs';
+import { mkdtemp, readFile, realpath } from 'node:fs/promises';
+import type * as NodeFsModule from 'node:fs';
+import { createRequire } from 'node:module';
+import type * as NodeModuleModule from 'node:module';
+import { homedir, tmpdir } from 'node:os';
+import { basename, join, parse } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { localWorkspace } from './local-workspace';
+import { localWorkspaceStateDirectory } from './local-workspace-state';
+
+const sessionsToStop: Array<{ stop: () => PromiseLike<void> }> = [];
+let stateRoot: string;
+let previousStateRootOverride: string | undefined;
+
+beforeEach(async () => {
+  // Keep every test's state out of the developer's real ~/.ai-sdk.
+  stateRoot = await mkdtemp(join(await realpath(tmpdir()), 'lws-state-'));
+  previousStateRootOverride = process.env.AI_SDK_HARNESS_STATE_DIR;
+  process.env.AI_SDK_HARNESS_STATE_DIR = stateRoot;
+});
+
+afterEach(async () => {
+  while (sessionsToStop.length > 0) {
+    await sessionsToStop.pop()?.stop();
+  }
+  if (previousStateRootOverride == null) {
+    delete process.env.AI_SDK_HARNESS_STATE_DIR;
+  } else {
+    process.env.AI_SDK_HARNESS_STATE_DIR = previousStateRootOverride;
+  }
+});
+
+async function createTempProject(name = 'myapp') {
+  const root = await mkdtemp(join(await realpath(tmpdir()), 'lws-'));
+  const projectPath = join(root, name);
+  mkdirSync(projectPath, { recursive: true });
+  return { root, projectPath };
+}
+
+function makeProvider(settings?: Parameters<typeof localWorkspace>[0]) {
+  return localWorkspace(settings).provider;
+}
+
+async function startSession(
+  settings?: Parameters<typeof localWorkspace>[0],
+  options?: { sessionId?: string },
+) {
+  const session = await makeProvider(settings).createSession(options);
+  sessionsToStop.push(session);
+  return session;
+}
+
+describe('localWorkspace', () => {
+  it('returns a workspace wrapping a provider with the conventional id', () => {
+    const workspace = localWorkspace({ path: '/tmp/does-not-yet' });
+    expect(workspace.type).toBe('local-workspace');
+    expect(workspace.provider.providerId).toBe('local-workspace');
+    expect(workspace.provider.specificationVersion).toBe('harness-sandbox-v1');
+  });
+
+  it('does no filesystem work until createSession is called', async () => {
+    const { root } = await createTempProject();
+    const projectPath = join(root, 'not-created-yet');
+    localWorkspace({ path: projectPath });
+    expect(existsSync(projectPath)).toBe(false);
+  });
+
+  it('creates the project directory on createSession', async () => {
+    const { root } = await createTempProject();
+    const projectPath = join(root, 'fresh');
+    const session = await startSession({ path: projectPath });
+    expect(existsSync(projectPath)).toBe(true);
+    expect(session.defaultWorkingDirectory).toBe(projectPath);
+  });
+
+  describe('guards', () => {
+    it('refuses the filesystem root at construction', () => {
+      expect(() => localWorkspace({ path: parse(process.cwd()).root })).toThrow(
+        /must not be the filesystem root/,
+      );
+    });
+
+    it('refuses the home directory at construction', () => {
+      expect(() => localWorkspace({ path: homedir() })).toThrow(
+        /must not be the home directory/,
+      );
+    });
+
+    it('refuses a symlink pointing at the home directory once resolved', async () => {
+      const { root } = await createTempProject();
+      const link = join(root, 'home-link');
+      symlinkSync(homedir(), link);
+
+      // The unresolved path passes the eager check …
+      const workspace = localWorkspace({ path: link });
+      // … and the resolved one is caught at session creation, naming both.
+      await expect(workspace.provider.createSession()).rejects.toThrow(
+        /must not be the home directory[\s\S]*resolved from/,
+      );
+    });
+  });
+});
+
+describe('working directory rooting', () => {
+  it('roots defaultWorkingDirectory at the project itself', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+    expect(session.defaultWorkingDirectory).toBe(projectPath);
+  });
+
+  it('defaults to the current working directory', async () => {
+    const session = await startSession();
+    expect(session.defaultWorkingDirectory).toBe(await realpath(process.cwd()));
+  });
+
+  // Adapters compare a spawned process's `pwd` against
+  // `defaultWorkingDirectory`; on macOS /tmp -> /private/tmp, so a raw
+  // `dirname()` would not match.
+  it('resolves symlinked roots so a spawned pwd matches defaultWorkingDirectory', async () => {
+    const { root, projectPath } = await createTempProject();
+    const linkRoot = `${root}-link`;
+    symlinkSync(root, linkRoot);
+
+    const session = await startSession({
+      path: join(linkRoot, basename(projectPath)),
+    });
+
+    expect(session.defaultWorkingDirectory).toBe(projectPath);
+
+    const { stdout, exitCode } = await session.run({ command: 'pwd -P' });
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).toBe(session.defaultWorkingDirectory);
+  });
+});
+
+describe('the central state store', () => {
+  it('declares a state directory in the per-project store, never the project', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+
+    expect(session.stateDirectory).toBe(
+      localWorkspaceStateDirectory(projectPath),
+    );
+    expect(session.stateDirectory).toContain(stateRoot);
+    expect(session.stateDirectory).not.toContain(projectPath);
+    expect(existsSync(session.stateDirectory!)).toBe(true);
+  });
+
+  it('keys the store by basename and path hash, mappable back via manifest.json', async () => {
+    const { projectPath } = await createTempProject('My App.2024');
+    const session = await startSession({ path: projectPath });
+
+    expect(basename(session.stateDirectory!)).toMatch(
+      /^my-app-2024-[0-9a-f]{8}$/,
+    );
+
+    const manifest = JSON.parse(
+      readFileSync(join(session.stateDirectory!, 'manifest.json'), 'utf8'),
+    );
+    expect(manifest.projectPath).toBe(projectPath);
+    expect(typeof manifest.createdAt).toBe('string');
+    expect(typeof manifest.lastUsedAt).toBe('string');
+  });
+
+  it('preserves createdAt while advancing lastUsedAt across sessions', async () => {
+    const { projectPath } = await createTempProject();
+    const provider = makeProvider({ path: projectPath });
+
+    const first = await provider.createSession();
+    sessionsToStop.push(first);
+    const manifestPath = join(first.stateDirectory!, 'manifest.json');
+    const before = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+    await new Promise(done => setTimeout(done, 5));
+    const second = await provider.createSession();
+    sessionsToStop.push(second);
+    const after = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+    expect(after.createdAt).toBe(before.createdAt);
+    expect(after.lastUsedAt >= before.lastUsedAt).toBe(true);
+  });
+
+  it('gives unrelated projects with the same basename distinct stores', async () => {
+    const alpha = await createTempProject('same-name');
+    const beta = await createTempProject('same-name');
+
+    const first = await startSession({ path: alpha.projectPath });
+    const second = await startSession({ path: beta.projectPath });
+
+    expect(first.stateDirectory).not.toBe(second.stateDirectory);
+  });
+
+  it('declares the environment as user-owned', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+    expect(session.environmentOwner).toBe('user');
+  });
+});
+
+describe('file operations', () => {
+  it('round-trips text and resolves relative paths against the project', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+
+    await session.writeTextFile({ path: 'hello.txt', content: 'hi' });
+
+    expect(await readFile(join(projectPath, 'hello.txt'), 'utf8')).toBe('hi');
+    expect(await session.readTextFile({ path: 'hello.txt' })).toBe('hi');
+    expect(
+      await session.readTextFile({ path: join(projectPath, 'hello.txt') }),
+    ).toBe('hi');
+  });
+
+  it('creates parent directories on write', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+    await session.writeTextFile({ path: 'a/b/c.txt', content: 'deep' });
+    expect(await readFile(join(projectPath, 'a/b/c.txt'), 'utf8')).toBe('deep');
+  });
+
+  it('resolves to null for a missing file, on every read variant', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+    expect(await session.readTextFile({ path: 'nope.txt' })).toBeNull();
+    expect(await session.readBinaryFile({ path: 'nope.txt' })).toBeNull();
+    expect(await session.readFile({ path: 'nope.txt' })).toBeNull();
+  });
+
+  // readFile is the streaming primitive, so obtaining the stream must not pull
+  // the file into memory. Deciding null-vs-stream by reading the bytes first
+  // buffered the whole file, twice, before the consumer saw a chunk.
+  it('does not buffer the file when handing back a stream', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+
+    const megabytes = 32;
+    await session.writeBinaryFile({
+      path: 'big.bin',
+      content: new Uint8Array(megabytes * 1024 * 1024),
+    });
+
+    const before = process.memoryUsage().arrayBuffers;
+    const stream = await session.readFile({ path: 'big.bin' });
+    const grewByMb =
+      (process.memoryUsage().arrayBuffers - before) / 1024 / 1024;
+
+    expect(stream).not.toBeNull();
+    expect(grewByMb).toBeLessThan(megabytes / 2);
+
+    await stream?.cancel();
+  });
+
+  it('applies 1-based inclusive line ranges', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+    await session.writeTextFile({
+      path: 'lines.txt',
+      content: 'one\ntwo\nthree\nfour',
+    });
+
+    expect(
+      await session.readTextFile({
+        path: 'lines.txt',
+        startLine: 2,
+        endLine: 3,
+      }),
+    ).toBe('two\nthree');
+    // endLine past EOF reads through EOF without error.
+    expect(
+      await session.readTextFile({
+        path: 'lines.txt',
+        startLine: 3,
+        endLine: 99,
+      }),
+    ).toBe('three\nfour');
+  });
+
+  it('round-trips binary content and streams', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+    const bytes = new Uint8Array([0, 1, 2, 250]);
+
+    await session.writeBinaryFile({ path: 'bin', content: bytes });
+    expect(await session.readBinaryFile({ path: 'bin' })).toEqual(bytes);
+
+    const stream = await session.readFile({ path: 'bin' });
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of stream as unknown as AsyncIterable<Uint8Array>) {
+      chunks.push(chunk);
+    }
+    expect(Buffer.concat(chunks)).toEqual(Buffer.from(bytes));
+  });
+
+  // Pi installs a global node:fs patch via syncBuiltinESMExports. Because the
+  // session destructures its bindings at module load, writes must still hit
+  // the real disk after the namespace is mutated.
+  it('is immune to a node:fs monkey-patch installed after import', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+
+    const require = createRequire(import.meta.url);
+    const fsModule = require('node:fs') as typeof NodeFsModule;
+    const { syncBuiltinESMExports } =
+      require('node:module') as typeof NodeModuleModule;
+
+    const realWriteFile = fsModule.promises.writeFile;
+    let hijacked = 0;
+    // Exactly Pi's shape: replace the binding, then republish the ESM view.
+    (fsModule.promises as { writeFile: unknown }).writeFile = async () => {
+      hijacked++;
+    };
+    syncBuiltinESMExports();
+
+    try {
+      await session.writeTextFile({
+        path: 'REL.md',
+        content: 'must reach disk',
+      });
+    } finally {
+      (fsModule.promises as { writeFile: unknown }).writeFile = realWriteFile;
+      syncBuiltinESMExports();
+    }
+
+    expect(hijacked).toBe(0);
+    expect(readFileSync(join(projectPath, 'REL.md'), 'utf8')).toBe(
+      'must reach disk',
+    );
+  });
+});
+
+describe('processes', () => {
+  it('returns exit codes, stdout and stderr from run', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+
+    const ok = await session.run({ command: 'echo out; echo err >&2' });
+    expect(ok.exitCode).toBe(0);
+    expect(ok.stdout.trim()).toBe('out');
+    expect(ok.stderr.trim()).toBe('err');
+
+    const failed = await session.run({ command: 'exit 3' });
+    expect(failed.exitCode).toBe(3);
+  });
+
+  it('runs in a workingDirectory relative to the project', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+    await session.writeTextFile({ path: 'nested/keep.txt', content: 'x' });
+    const { stdout } = await session.run({
+      command: 'pwd -P',
+      workingDirectory: 'nested',
+    });
+    expect(stdout.trim()).toBe(join(projectPath, 'nested'));
+  });
+
+  it('merges the inherited environment with settings.env and per-call env', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({
+      path: projectPath,
+      env: { FROM_SETTINGS: 'settings', OVERRIDDEN: 'settings' },
+    });
+
+    const { stdout } = await session.run({
+      command: 'echo "$FROM_SETTINGS|$OVERRIDDEN|${PATH:+has-path}"',
+      env: { OVERRIDDEN: 'call' },
+    });
+    expect(stdout.trim()).toBe('settings|call|has-path');
+  });
+
+  it('kills the process when abortSignal fires', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+
+    const controller = new AbortController();
+    const child = await session.spawn({
+      command: 'sleep 30',
+      abortSignal: controller.signal,
+    });
+    controller.abort();
+
+    const { exitCode } = await child.wait();
+    expect(exitCode).not.toBe(0);
+  });
+
+  it('rejects a spawn whose abortSignal is already aborted', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+    await expect(
+      session.run({ command: 'echo x', abortSignal: AbortSignal.abort() }),
+    ).rejects.toThrow();
+  });
+
+  // Bridges spawn CLIs that spawn more processes, so stop() must reap the
+  // whole tree, not just the direct child.
+  it('kills the entire process tree on stop', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await makeProvider({ path: projectPath }).createSession();
+
+    const marker = join(projectPath, 'grandchild.pid');
+    await session.spawn({
+      command: `bash -c 'echo $$ > ${marker}; sleep 30' & sleep 30`,
+    });
+
+    // Wait for the grandchild to record its pid.
+    for (let attempt = 0; attempt < 50 && !existsSync(marker); attempt++) {
+      await new Promise(done => setTimeout(done, 20));
+    }
+    const grandchildPid = Number(readFileSync(marker, 'utf8').trim());
+    expect(grandchildPid).toBeGreaterThan(0);
+    expect(isProcessAlive(grandchildPid)).toBe(true);
+
+    await session.stop();
+    await new Promise(done => setTimeout(done, 100));
+
+    expect(isProcessAlive(grandchildPid)).toBe(false);
+  });
+
+  it('registers a single exit handler no matter how many sessions exist', async () => {
+    const { projectPath } = await createTempProject();
+    const provider = makeProvider({ path: projectPath });
+
+    const before = process.listenerCount('exit');
+    const sessions = await Promise.all(
+      Array.from({ length: 12 }, () => provider.createSession()),
+    );
+    sessionsToStop.push(...sessions);
+
+    expect(process.listenerCount('exit')).toBeLessThanOrEqual(before + 1);
+  });
+
+  it('is idempotent on stop and destroy', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await makeProvider({ path: projectPath }).createSession();
+    await session.stop();
+    await session.stop();
+    await session.destroy?.();
+  });
+});
+
+describe('ports', () => {
+  it('allocates one loopback port by default and resolves endpoints for it', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+
+    expect(session.ports).toHaveLength(1);
+    const [port] = session.ports;
+    expect(port).toBeGreaterThan(0);
+
+    expect(await session.getPortEndpoint({ port, protocol: 'ws' })).toEqual({
+      url: `ws://127.0.0.1:${port}`,
+    });
+    expect(await session.getPortUrl({ port })).toBe(`http://127.0.0.1:${port}`);
+  });
+
+  it('resolves a port from a previous session, as reattach does', async () => {
+    const { projectPath } = await createTempProject();
+    const provider = makeProvider({ path: projectPath });
+
+    const first = await provider.createSession();
+    sessionsToStop.push(first);
+    const detachedPort = first.ports[0];
+    await first.stop();
+
+    const resumed = await provider.resumeSession?.({ sessionId: 'resumed' });
+    expect(resumed).toBeDefined();
+    sessionsToStop.push(resumed!);
+
+    // Fresh pool, but the persisted port still resolves. Rejecting it is what
+    // made every reattach respawn and orphan the running bridge.
+    expect(resumed!.ports).not.toContain(detachedPort);
+    expect(
+      (await resumed!.getPortEndpoint({ port: detachedPort, protocol: 'ws' }))
+        .url,
+    ).toBe(`ws://127.0.0.1:${detachedPort}`);
+  });
+
+  it('omits setNetworkPolicy and setPorts rather than stubbing them', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+    expect(session.setNetworkPolicy).toBeUndefined();
+    expect(session.setPorts).toBeUndefined();
+  });
+});
+
+describe('restricted()', () => {
+  it('exposes the basic surface and hides the infra surface', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+    const restricted = session.restricted();
+
+    expect(typeof restricted.readTextFile).toBe('function');
+    expect(typeof restricted.run).toBe('function');
+    expect((restricted as Record<string, unknown>).stop).toBeUndefined();
+    expect(
+      (restricted as Record<string, unknown>).getPortEndpoint,
+    ).toBeUndefined();
+    expect(
+      (restricted as Record<string, unknown>).setNetworkPolicy,
+    ).toBeUndefined();
+  });
+
+  it('points at the same underlying resource', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+
+    await session.restricted().writeTextFile({
+      path: 'from-restricted.txt',
+      content: 'same box',
+    });
+    expect(await session.readTextFile({ path: 'from-restricted.txt' })).toBe(
+      'same box',
+    );
+  });
+});
+
+describe('onFirstCreate', () => {
+  it('runs once per identity and records its marker in the state store', async () => {
+    const { projectPath } = await createTempProject();
+    const provider = makeProvider({ path: projectPath });
+
+    let calls = 0;
+    const onFirstCreate = async () => {
+      calls++;
+    };
+
+    const first = await provider.createSession({
+      identity: 'abc123',
+      onFirstCreate,
+    });
+    sessionsToStop.push(first);
+    expect(calls).toBe(1);
+    expect(
+      existsSync(join(first.stateDirectory!, '.first-create-abc123.ok')),
+    ).toBe(true);
+    // Nothing lands in the project.
+    expect(existsSync(join(projectPath, '.harness-bootstrap'))).toBe(false);
+
+    const second = await provider.createSession({
+      identity: 'abc123',
+      onFirstCreate,
+    });
+    sessionsToStop.push(second);
+    expect(calls).toBe(1);
+  });
+
+  // The framework's recipe hook writes relative paths (.harness-bootstrap/…)
+  // against whatever session it receives; rooting it at the project would put
+  // infrastructure into the user's files.
+  it('receives a session rooted at the state directory, not the project', async () => {
+    const { projectPath } = await createTempProject();
+    const provider = makeProvider({ path: projectPath });
+
+    let observedPwd: string | undefined;
+    const session = await provider.createSession({
+      identity: 'rooted',
+      onFirstCreate: async setup => {
+        await setup.writeTextFile({
+          path: '.harness-bootstrap/probe.txt',
+          content: 'infra',
+        });
+        observedPwd = (await setup.run({ command: 'pwd -P' })).stdout.trim();
+      },
+    });
+    sessionsToStop.push(session);
+
+    const stateDirectory = localWorkspaceStateDirectory(projectPath);
+    expect(observedPwd).toBe(await realpath(stateDirectory));
+    expect(
+      existsSync(join(stateDirectory, '.harness-bootstrap/probe.txt')),
+    ).toBe(true);
+    expect(existsSync(join(projectPath, '.harness-bootstrap'))).toBe(false);
+  });
+
+  it('runs once even when two sessions race with the same identity', async () => {
+    const { projectPath } = await createTempProject();
+    const provider = makeProvider({ path: projectPath });
+
+    let concurrent = 0;
+    let peakConcurrent = 0;
+    let calls = 0;
+    const onFirstCreate = async () => {
+      calls++;
+      concurrent++;
+      peakConcurrent = Math.max(peakConcurrent, concurrent);
+      await new Promise(done => setTimeout(done, 50));
+      concurrent--;
+    };
+
+    const sessions = await Promise.all([
+      provider.createSession({ identity: 'raced', onFirstCreate }),
+      provider.createSession({ identity: 'raced', onFirstCreate }),
+      provider.createSession({ identity: 'raced', onFirstCreate }),
+    ]);
+    sessionsToStop.push(...sessions);
+
+    expect(peakConcurrent).toBe(1);
+    expect(calls).toBe(1);
+  });
+
+  // A failed bootstrap must not be remembered as done.
+  it('does not record the marker when the hook throws, and retries next time', async () => {
+    const { projectPath } = await createTempProject();
+    const provider = makeProvider({ path: projectPath });
+    const markerPath = join(
+      localWorkspaceStateDirectory(projectPath),
+      '.first-create-flaky.ok',
+    );
+
+    let calls = 0;
+    await expect(
+      provider.createSession({
+        identity: 'flaky',
+        onFirstCreate: async () => {
+          calls++;
+          throw new Error('bootstrap blew up');
+        },
+      }),
+    ).rejects.toThrow(/bootstrap blew up/);
+    expect(existsSync(markerPath)).toBe(false);
+
+    sessionsToStop.push(
+      await provider.createSession({
+        identity: 'flaky',
+        onFirstCreate: async () => {
+          calls++;
+        },
+      }),
+    );
+    expect(calls).toBe(2);
+    expect(existsSync(markerPath)).toBe(true);
+  });
+
+  // No identity means no cache key, so skipping would be wrong.
+  it('runs every time when no identity is supplied', async () => {
+    const { projectPath } = await createTempProject();
+    const provider = makeProvider({ path: projectPath });
+
+    let calls = 0;
+    const onFirstCreate = async () => {
+      calls++;
+    };
+
+    sessionsToStop.push(await provider.createSession({ onFirstCreate }));
+    sessionsToStop.push(await provider.createSession({ onFirstCreate }));
+    expect(calls).toBe(2);
+  });
+
+  it('re-runs after the marker is deleted', async () => {
+    const { projectPath } = await createTempProject();
+    const provider = makeProvider({ path: projectPath });
+
+    let calls = 0;
+    const onFirstCreate = async () => {
+      calls++;
+    };
+
+    sessionsToStop.push(
+      await provider.createSession({ identity: 'redo', onFirstCreate }),
+    );
+    expect(calls).toBe(1);
+
+    rmSync(
+      join(localWorkspaceStateDirectory(projectPath), '.first-create-redo.ok'),
+      { force: true },
+    );
+
+    sessionsToStop.push(
+      await provider.createSession({ identity: 'redo', onFirstCreate }),
+    );
+    expect(calls).toBe(2);
+  });
+
+  it('serialises across separate workspaces on the same project', async () => {
+    const { projectPath } = await createTempProject();
+    const first = makeProvider({ path: projectPath });
+    const second = makeProvider({ path: projectPath });
+
+    let concurrent = 0;
+    let peakConcurrent = 0;
+    let calls = 0;
+    const onFirstCreate = async () => {
+      calls++;
+      concurrent++;
+      peakConcurrent = Math.max(peakConcurrent, concurrent);
+      await new Promise(done => setTimeout(done, 50));
+      concurrent--;
+    };
+
+    const sessions = await Promise.all([
+      first.createSession({ identity: 'cross-provider', onFirstCreate }),
+      second.createSession({ identity: 'cross-provider', onFirstCreate }),
+    ]);
+    sessionsToStop.push(...sessions);
+
+    expect(peakConcurrent).toBe(1);
+    expect(calls).toBe(1);
+  });
+
+  it('does not block workspaces rooted somewhere else', async () => {
+    const alpha = await createTempProject();
+    const beta = await createTempProject();
+
+    let calls = 0;
+    const onFirstCreate = async () => {
+      calls++;
+    };
+
+    const sessions = await Promise.all([
+      makeProvider({ path: alpha.projectPath }).createSession({
+        identity: 'same-id',
+        onFirstCreate,
+      }),
+      makeProvider({ path: beta.projectPath }).createSession({
+        identity: 'same-id',
+        onFirstCreate,
+      }),
+    ]);
+    sessionsToStop.push(...sessions);
+
+    // Same identity, unrelated projects: both must bootstrap.
+    expect(calls).toBe(2);
+  });
+});
+
+describe('sessions', () => {
+  it('uses the supplied sessionId as the durable id', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession(
+      { path: projectPath },
+      { sessionId: 's-1' },
+    );
+    expect(session.id).toBe('s-1');
+  });
+
+  it('mints an id when none is supplied', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+    expect(session.id).toMatch(/^local-workspace-/);
+  });
+
+  it('rebinds to the same project on resumeSession', async () => {
+    const { projectPath } = await createTempProject();
+    const provider = makeProvider({ path: projectPath });
+
+    const first = await provider.createSession({ sessionId: 's-2' });
+    sessionsToStop.push(first);
+    await first.writeTextFile({ path: 'state.txt', content: 'persisted' });
+    await first.stop();
+
+    const resumed = await provider.resumeSession?.({ sessionId: 's-2' });
+    expect(resumed).toBeDefined();
+    sessionsToStop.push(resumed!);
+
+    expect(resumed!.id).toBe('s-2');
+    expect(resumed!.defaultWorkingDirectory).toBe(
+      first.defaultWorkingDirectory,
+    );
+    expect(await resumed!.readTextFile({ path: 'state.txt' })).toBe(
+      'persisted',
+    );
+  });
+
+  it('gives concurrent sessions distinct ports and independent child sets', async () => {
+    const { projectPath } = await createTempProject();
+    const provider = makeProvider({ path: projectPath });
+
+    const first = await provider.createSession();
+    const second = await provider.createSession();
+    sessionsToStop.push(first, second);
+
+    expect(first.ports[0]).not.toBe(second.ports[0]);
+
+    const child = await second.spawn({ command: 'sleep 30' });
+    await first.stop();
+    // Stopping one session must not reap another session's processes.
+    expect(isProcessAlive(child.pid!)).toBe(true);
+  });
+
+  // Pin the text against what the session actually does: a wrong claim here
+  // sends the model's files into a sibling directory.
+  it('describes where relative paths actually resolve', async () => {
+    const { projectPath } = await createTempProject();
+    const session = await startSession({ path: projectPath });
+
+    expect(session.description).toContain(projectPath);
+
+    // The behaviour, verified rather than assumed.
+    await session.writeTextFile({ path: 'in-project.txt', content: 'project' });
+    expect(existsSync(join(projectPath, 'in-project.txt'))).toBe(true);
+
+    const { stdout } = await session.run({ command: 'pwd -P' });
+    expect(stdout.trim()).toBe(projectPath);
+  });
+});
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/harness/src/workspace/local-workspace.ts
+++ b/packages/harness/src/workspace/local-workspace.ts
@@ -1,0 +1,161 @@
+import { homedir } from 'node:os';
+import { parse, resolve } from 'node:path';
+import type { Experimental_SandboxSession as SandboxSession } from '@ai-sdk/provider-utils';
+import type {
+  HarnessV1NetworkSandboxSession,
+  HarnessV1SandboxProvider,
+} from '../v1';
+
+/**
+ * Settings for {@link localWorkspace}.
+ *
+ * Deliberately small. The workspace's job is to get out of the way of the
+ * harness: it supplies no tools, no tool filtering, and no permission-mode
+ * opinions, so each harness keeps its own optimized tools, skills, and user
+ * configuration.
+ */
+export type LocalWorkspaceSettings = {
+  /**
+   * Project directory the harness works in. Defaults to `process.cwd()`.
+   * Resolved to an absolute path, and created if it does not exist.
+   *
+   * This scopes where the harness *works*, not what it can reach.
+   */
+  path?: string;
+
+  /**
+   * Overlay applied on top of the inherited process environment.
+   *
+   * The inherited environment is the credential and configuration reuse
+   * mechanism, since `HOME`, `PATH`, and every harness's own config file are
+   * found through it, so it is never filtered. Use this for additions such as
+   * registry pins or proxy settings.
+   */
+  env?: Record<string, string>;
+};
+
+/**
+ * A local project directory the harness works in, for `HarnessAgent`'s
+ * `workspace` setting.
+ *
+ * The harness runs on the local machine as the current user, reusing the CLI
+ * configuration and credentials already there, with the project directory as
+ * its working directory. Harness SDK state (bootstrap dependencies,
+ * per-session run state) lives in `~/.ai-sdk/harness/projects/…`, never
+ * inside the project. Conversations belong to the runtime's own store, so
+ * they can be continued directly in the agent's own CLI too.
+ *
+ * **This provides no isolation.** The harness has every permission the
+ * current user has, the same trust level as running `claude` or `codex` in a
+ * terminal. Use a sandbox provider for untrusted input or output.
+ */
+export type LocalWorkspace = {
+  /** Discriminates workspaces from sandbox providers in agent settings. */
+  readonly type: 'local-workspace';
+  /** @internal The provider the agent runs sessions through. */
+  readonly provider: HarnessV1SandboxProvider;
+};
+
+/**
+ * Create a {@link LocalWorkspace} rooted at a project directory.
+ *
+ * ```ts
+ * const agent = new HarnessAgent({
+ *   harness: claudeCode,
+ *   workspace: localWorkspace({ path: '/path/to/project' }),
+ * });
+ * ```
+ *
+ * Synchronous and side-effect free; no filesystem or process work happens
+ * until a session is created. The implementation is loaded lazily so that
+ * importing `HarnessAgent` does not pull `node:child_process` and `node:net`
+ * into the module graph of consumers who pass their own sandbox provider.
+ */
+export function localWorkspace(
+  settings: LocalWorkspaceSettings = {},
+): LocalWorkspace {
+  // Fails fast on the obvious mistake, without touching the filesystem. The
+  // provider repeats the check against the symlink-resolved path when a
+  // session is created.
+  assertUsableProjectPath(resolve(settings.path ?? process.cwd()));
+
+  return {
+    type: 'local-workspace',
+    provider: new LazyLocalWorkspaceProvider(settings),
+  };
+}
+
+/**
+ * Reject paths that are never a deliberate choice of project directory.
+ *
+ * A guard against a scoping mistake, not a security boundary: the workspace
+ * provides no isolation, and every harness ships a shell tool that reaches
+ * anywhere the user can. It prevents handing the harness an enormous tree by
+ * accident.
+ */
+export function assertUsableProjectPath(
+  projectPath: string,
+  describe: (message: string) => string = message => message,
+): void {
+  if (projectPath === parse(projectPath).root) {
+    throw new Error(
+      describe('localWorkspace: `path` must not be the filesystem root'),
+    );
+  }
+  if (projectPath === resolve(homedir())) {
+    throw new Error(
+      describe(
+        'localWorkspace: `path` must not be the home directory. ' +
+          'Point it at a specific project directory',
+      ),
+    );
+  }
+}
+
+/**
+ * Defers loading the process-spawning implementation until a session is
+ * actually created, while still validating settings eagerly at construction
+ * through the real provider's constructor once loaded.
+ */
+class LazyLocalWorkspaceProvider implements HarnessV1SandboxProvider {
+  readonly specificationVersion = 'harness-sandbox-v1' as const;
+  readonly providerId = 'local-workspace';
+
+  private readonly settings: LocalWorkspaceSettings;
+  private delegate: Promise<HarnessV1SandboxProvider> | undefined;
+
+  constructor(settings: LocalWorkspaceSettings) {
+    this.settings = settings;
+  }
+
+  private resolveDelegate(): Promise<HarnessV1SandboxProvider> {
+    this.delegate ??= import('./local-workspace-provider').then(
+      module => new module.LocalWorkspaceProvider(this.settings),
+    );
+    return this.delegate;
+  }
+
+  createSession = async (options?: {
+    sessionId?: string;
+    abortSignal?: AbortSignal;
+    identity?: string;
+    onFirstCreate?: (
+      session: SandboxSession,
+      opts: { abortSignal?: AbortSignal },
+    ) => Promise<void>;
+  }): Promise<HarnessV1NetworkSandboxSession> => {
+    const delegate = await this.resolveDelegate();
+    return await delegate.createSession(options);
+  };
+
+  resumeSession = async (options: {
+    sessionId: string;
+    abortSignal?: AbortSignal;
+  }): Promise<HarnessV1NetworkSandboxSession> => {
+    const delegate = await this.resolveDelegate();
+    if (delegate.resumeSession == null) {
+      throw new Error('localWorkspace: resumeSession is not available.');
+    }
+    return await delegate.resumeSession(options);
+  };
+}

--- a/packages/harness/src/workspace/warn-implicit-local-workspace.ts
+++ b/packages/harness/src/workspace/warn-implicit-local-workspace.ts
@@ -1,0 +1,47 @@
+const WARNING =
+  'HarnessAgent: neither `sandbox` nor `workspace` was given, so the harness runs on the ' +
+  'local machine in the current working directory, as the current user, with no isolation. ' +
+  'Pass `workspace: localWorkspace({ path })` to make this explicit, or a sandbox provider ' +
+  'such as `@ai-sdk/sandbox-vercel` for untrusted input or output. To silence this, set the ' +
+  '`AI_SDK_LOG_WARNINGS` global to `false` or to your own logger.';
+
+let hasWarned = false;
+
+/**
+ * Warn once per process that the implicit local workspace is in use.
+ *
+ * Running an agent against the user's real filesystem with no isolation is
+ * worth saying out loud, but a library that prints on every session is a
+ * nuisance, so this fires once. An **explicit** `workspace:` never warns —
+ * the consumer already made the choice this warning exists to surface.
+ *
+ * Honours the same `AI_SDK_LOG_WARNINGS` switch as the rest of the AI SDK:
+ * `false` silences it, a function receives it instead. `process.emitWarning`
+ * is used where available so Node's own `--no-warnings` and warning
+ * listeners work too.
+ */
+export function warnAboutImplicitLocalWorkspace(): void {
+  if (hasWarned) return;
+  hasWarned = true;
+
+  const logger = globalThis.AI_SDK_LOG_WARNINGS;
+  if (logger === false) return;
+  if (typeof logger === 'function') {
+    logger({ warnings: [{ type: 'other', message: WARNING }] });
+    return;
+  }
+
+  if (
+    typeof process !== 'undefined' &&
+    typeof process.emitWarning === 'function'
+  ) {
+    process.emitWarning(WARNING, { type: 'Warning' });
+  } else {
+    console.warn(WARNING);
+  }
+}
+
+/** Test seam: forget that the warning already fired. */
+export function resetImplicitLocalWorkspaceWarning(): void {
+  hasWarned = false;
+}


### PR DESCRIPTION
Stacked on #19107. Supersedes #18383.

## Background

The shipped sandbox providers are a remote microVM and an in-process virtual filesystem. Neither lets `HarnessAgent` work on a repository on the developer's own machine with the CLI and credentials already there. Compared to #18383: no new package, no per-directory `.gitignore` tricks, and no `runInCwd` flag; state separation comes from the `stateDirectory` contract instead.

## Summary

- New `workspace` setting: `workspace: localWorkspace({ path })` runs the harness on the local machine with the project directory as its working directory. Mutually exclusive with `sandbox`.
- When both are omitted, an implicit workspace at `process.cwd()` is used and a warning fires once per process (`AI_SDK_LOG_WARNINGS` silences it).
- The project stays clean: all SDK state lives in `~/.ai-sdk/harness/projects/<basename>-<hash>/`, with a `manifest.json` mapping it back to the project. `AI_SDK_HARNESS_STATE_DIR` relocates the root.
- Sessions declare `environmentOwner: 'user'`, so nothing is installed without consent.
- No isolation, documented prominently: same trust level as running `claude` or `codex` in a terminal.
- Example: `harness-agent/claude-code/local-workspace.ts`.

## End-to-End Verification

Ran against the real `claude` CLI on macOS (Node 26): the agent wrote a file into the project directory; the project contained no harness state afterwards; the central store existed with a manifest mapping back to the project; the bootstrap measured 40MB with no bundled CLI; stop/resume recalled prior turn state; an aborted turn settled cleanly with no orphaned processes.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Supersedes #18383.
