### PR TITLE
[v5.0] fix: surface Amazon Bedrock event-stream decoding failures

### DIFF
--- a/.changeset/fast-waves-notice.md
+++ b/.changeset/fast-waves-notice.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Surface Amazon Bedrock event stream frame decoding and processing failures instead of silently completing the stream.

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model-event-stream.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model-event-stream.test.ts
@@ -51,6 +51,29 @@ function createModel(responseChunks: Uint8Array[]) {
 }
 
 describe('BedrockChatLanguageModel doStream event stream handling', () => {
+  it('surfaces event stream decoding failures', async () => {
+    const corruptedFrame = createEvent('contentBlockDelta', {
+      contentBlockIndex: 0,
+      delta: { text: 'corrupted' },
+    });
+    corruptedFrame[corruptedFrame.length - 1] ^= 0xff;
+
+    const { stream } = await createModel([
+      corruptedFrame,
+      createEvent('contentBlockDelta', {
+        contentBlockIndex: 0,
+        delta: { text: 'later' },
+      }),
+    ]).doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    await expect(convertReadableStreamToArray(stream)).rejects.toThrow(
+      'The message checksum',
+    );
+  });
+
   it('rejects a truncated event stream frame at EOF', async () => {
     const textFrame = createEvent('contentBlockDelta', {
       contentBlockIndex: 0,

--- a/packages/amazon-bedrock/src/bedrock-event-stream-decoder.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-event-stream-decoder.test.ts
@@ -28,6 +28,37 @@ function createStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
 }
 
 describe('createBedrockEventStreamDecoder', () => {
+  it('surfaces frame decode errors instead of stranding later frames', async () => {
+    const corruptedFrame = createEvent('corrupted');
+    corruptedFrame[corruptedFrame.length - 1] ^= 0xff;
+    const processEvent = vi.fn();
+
+    const result = convertReadableStreamToArray(
+      createBedrockEventStreamDecoder(
+        createStream([corruptedFrame, createEvent('later')]),
+        processEvent,
+      ),
+    );
+
+    await expect(result).rejects.toThrow();
+    expect(processEvent).not.toHaveBeenCalled();
+  });
+
+  it('surfaces processEvent errors', async () => {
+    const processEventError = new Error('processEvent failed');
+
+    const result = convertReadableStreamToArray(
+      createBedrockEventStreamDecoder(
+        createStream([createEvent('data')]),
+        () => {
+          throw processEventError;
+        },
+      ),
+    );
+
+    await expect(result).rejects.toBe(processEventError);
+  });
+
   it('processes frames split across chunks', async () => {
     const frame = createEvent('data');
     const midpoint = Math.floor(frame.length / 2);

--- a/packages/amazon-bedrock/src/bedrock-event-stream-decoder.ts
+++ b/packages/amazon-bedrock/src/bedrock-event-stream-decoder.ts
@@ -37,21 +37,16 @@ export function createBedrockEventStreamDecoder<T>(
             break;
           }
 
-          try {
-            const subView = buffer.subarray(0, totalLength);
-            const decoded = codec.decode(subView);
+          const subView = buffer.subarray(0, totalLength);
+          const decoded = codec.decode(subView);
 
-            buffer = buffer.slice(totalLength);
+          buffer = buffer.slice(totalLength);
 
-            const messageType = decoded.headers[':message-type']
-              ?.value as string;
-            const eventType = decoded.headers[':event-type']?.value as string;
-            const data = textDecoder.decode(decoded.body);
+          const messageType = decoded.headers[':message-type']?.value as string;
+          const eventType = decoded.headers[':event-type']?.value as string;
+          const data = textDecoder.decode(decoded.body);
 
-            await processEvent({ messageType, eventType, data }, controller);
-          } catch {
-            break;
-          }
+          await processEvent({ messageType, eventType, data }, controller);
         }
       },
       flush() {

--- a/packages/amazon-bedrock/src/bedrock-event-stream-response-handler.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-event-stream-response-handler.test.ts
@@ -179,31 +179,12 @@ describe('createEventSourceResponseHandler', () => {
     expect((value as { success: false; error: Error }).error).toBeDefined();
   });
 
-  it('handles partial messages correctly', async () => {
-    // In this test, we simulate a partial message followed by a complete one.
-    // The first invocation of decode will throw an error (simulated incomplete message),
-    // and the subsequent invocation returns a valid event.
-    const message = {
-      headers: {
-        ':message-type': { value: 'event' },
-        ':event-type': { value: 'chunk' },
-      },
-      body: new TextEncoder().encode(
-        JSON.stringify({ content: 'complete message' }),
-      ),
-    };
-
-    const dummyPayload1 = new Uint8Array([13, 14]); // too short, part of a frame
-    const frame1 = createFrame(dummyPayload1);
-    const dummyPayload2 = new Uint8Array([15, 16, 17, 18]);
-    const frame2 = createFrame(dummyPayload2);
-
-    const mockDecode = vi
-      .fn()
-      .mockImplementationOnce(() => {
-        throw new Error('Incomplete data');
-      })
-      .mockReturnValue(message);
+  it('surfaces event stream decoding failures', async () => {
+    const frame = createFrame(new Uint8Array([13, 14]));
+    const decodeError = new Error('Invalid event stream frame');
+    const mockDecode = vi.fn().mockImplementation(() => {
+      throw decodeError;
+    });
     (EventStreamCodec as unknown as MockInstance).mockImplementation(
       function () {
         return { decode: mockDecode };
@@ -212,10 +193,7 @@ describe('createEventSourceResponseHandler', () => {
 
     const stream = new ReadableStream({
       start(controller) {
-        // Send first, incomplete frame (decode will throw error).
-        controller.enqueue(frame1);
-        // Then send a proper frame.
-        controller.enqueue(frame2);
+        controller.enqueue(frame);
         controller.close();
       },
     });
@@ -229,13 +207,7 @@ describe('createEventSourceResponseHandler', () => {
     });
 
     const reader = result.value.getReader();
-    const { done, value } = await reader.read();
 
-    expect(done).toBe(false);
-    expect(value).toEqual({
-      success: true,
-      value: { chunk: { content: 'complete message' } },
-      rawValue: { chunk: { content: 'complete message' } },
-    });
+    await expect(reader.read()).rejects.toBe(decodeError);
   });
 });


### PR DESCRIPTION
## Summary

Backports #19082 to AI SDK v5.

Amazon Bedrock event-stream frame decoding and event-processing failures now reject the stream instead of being swallowed and leaving the stream stalled or misleadingly completed.

This adapts the regression coverage to the v5 provider interface and retains the newer truncated-frame EOF handling already present on release-v5.0.

## Testing

- pnpm --filter @ai-sdk/amazon-bedrock... build
- pnpm -C packages/amazon-bedrock test:node (237 tests)
- pnpm -C packages/amazon-bedrock test:edge (237 tests)
- pnpm check
- pnpm type-check:full