### PR TITLE
[v6.0] fix(ci): make Playwright apt retries recover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           git fetch --no-tags --depth=1 origin "$BASE_SHA"
 
-          if git diff --name-only "$BASE_SHA" "${{ github.sha }}" | grep -E '^(packages/rsc/|pnpm-lock.yaml$|package.json$)'; then
+          if git diff --name-only "$BASE_SHA" "${{ github.sha }}" | grep -E '^(\.github/workflows/ci\.yml$|packages/rsc/|pnpm-lock.yaml$|package.json$)'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
@@ -332,31 +332,55 @@ jobs:
         if: steps.rsc-e2e.outputs.run == 'true'
         working-directory: packages/rsc
         run: |
-          # `playwright install --with-deps` shells out to apt-get. When the
-          # Ubuntu mirror is slow the command can exceed the timeout; `timeout`
-          # only kills the direct child, leaving an orphaned apt-get holding the
-          # dpkg lock so every retry fails instantly with exit code 100. Run each
-          # attempt in its own process group, kill the whole group on timeout,
-          # and wait for the dpkg lock to free before retrying.
+          # `playwright install-deps` shells out through sudo when it is run as
+          # the runner user. sudo can move apt-get outside timeout's process
+          # group, leaving it alive and holding an apt/dpkg lock after timeout
+          # exits. Run Playwright as root so apt-get stays in the process group,
+          # then wait for every apt/dpkg lock before retrying.
           ATTEMPTS=3
           PER_ATTEMPT_TIMEOUT=15m
+          APT_LOCKS=(
+            /var/lib/apt/lists/lock
+            /var/cache/apt/archives/lock
+            /var/lib/dpkg/lock
+            /var/lib/dpkg/lock-frontend
+          )
 
-          wait_for_apt_lock() {
+          # Bound stalled mirror requests so apt can fail over within an
+          # attempt instead of consuming the entire outer timeout.
+          printf '%s\n' \
+            'Acquire::Retries "1";' \
+            'Acquire::http::Timeout "30";' \
+            'Acquire::https::Timeout "30";' \
+            | sudo tee /etc/apt/apt.conf.d/81-playwright-timeouts >/dev/null
+
+          wait_for_apt_locks() {
             for _ in $(seq 1 60); do
-              if ! sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; then
+              LOCK_HELD=false
+              for lock in "${APT_LOCKS[@]}"; do
+                if sudo fuser "$lock" >/dev/null 2>&1; then
+                  LOCK_HELD=true
+                  break
+                fi
+              done
+              if [ "$LOCK_HELD" = false ]; then
                 return 0
               fi
-              echo "Waiting for dpkg lock to be released..."
+              echo "Waiting for apt/dpkg locks to be released..."
               sleep 5
             done
+            echo "::error::apt/dpkg locks were not released after 5 minutes"
+            return 1
           }
 
           for attempt in $(seq 1 "$ATTEMPTS"); do
+            wait_for_apt_locks
             STATUS=0
-            # `setsid` puts the command in a new process group; `timeout
-            # --kill-after` escalates to SIGKILL so the whole group (including
-            # apt-get) is torn down on timeout.
-            setsid timeout --signal=TERM --kill-after=30s "$PER_ATTEMPT_TIMEOUT" \
+            # Preserve PATH because setup-node and setup-pnpm install outside
+            # sudo's secure_path. Running the whole process group as root keeps
+            # Playwright from spawning a nested sudo process for apt-get.
+            sudo env "PATH=$PATH" \
+              setsid timeout --signal=TERM --kill-after=30s "$PER_ATTEMPT_TIMEOUT" \
               pnpm exec playwright install-deps chromium || STATUS=$?
             if [ "$STATUS" -eq 0 ]; then
               break
@@ -370,7 +394,6 @@ jobs:
             else
               echo "Attempt $attempt failed with exit code $STATUS, retrying..."
             fi
-            wait_for_apt_lock
           done
 
       - name: Install Playwright browsers


### PR DESCRIPTION
## Background

Backport of #19133 to the actively maintained v6 release branch. The RSC e2e Playwright dependency install could outlive the outer timeout, retain an apt lock, and make every retry fail immediately.

## Summary

- bound apt download retries and network timeouts
- wait for all apt/dpkg lock files before every attempt
- run the Playwright dependency install as root in its own process group so timeout cleanup reaches apt descendants
- run RSC e2e when its workflow definition changes

## Validation

- the main PR completed the full CI matrix successfully, including Test RSC e2e
- pnpm check
- pnpm type-check:full
- workflow YAML parse and RSC shell syntax checks

No changeset: this only changes CI infrastructure.