### PR TITLE
[v5.0] fix(google): resolve local JSON Schema references

### DIFF
--- a/.changeset/tidy-geckos-resolve.md
+++ b/.changeset/tidy-geckos-resolve.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+Inline local JSON Schema references in Google tool and structured-output schemas.

--- a/packages/google-vertex/src/google-vertex-language-model.test.ts
+++ b/packages/google-vertex/src/google-vertex-language-model.test.ts
@@ -1,0 +1,86 @@
+import type { JSONSchema7, LanguageModelV2Prompt } from '@ai-sdk/provider';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { expect, it, vi } from 'vitest';
+import { createVertex } from './google-vertex-provider';
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const TEST_URL =
+  'https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-2.5-flash:generateContent';
+
+const server = createTestServer({
+  [TEST_URL]: {},
+});
+
+const TEST_PROMPT: LanguageModelV2Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+];
+
+it('should inline local JSON Schema references in tool requests', async () => {
+  server.urls[TEST_URL].response = {
+    type: 'json-value',
+    body: {
+      candidates: [
+        {
+          content: { parts: [{ text: 'Done' }], role: 'model' },
+          finishReason: 'STOP',
+          index: 0,
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 1,
+        totalTokenCount: 2,
+      },
+    },
+  };
+
+  const provider = createVertex({
+    project: 'test-project',
+    location: 'global',
+    baseURL: 'https://aiplatform.googleapis.com/v1/publishers/google',
+    headers: { Authorization: 'Bearer test-token' },
+  });
+
+  await provider('gemini-2.5-flash').doGenerate({
+    tools: [
+      {
+        type: 'function',
+        name: 'format-date',
+        description: 'Format a date',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            locale: {
+              $ref: '#/$defs/Locale',
+              description: 'Locale for formatting',
+            },
+          },
+          required: ['locale'],
+          additionalProperties: false,
+          $defs: {
+            Locale: { type: 'string', enum: ['de', 'en'] },
+          },
+        } as JSONSchema7,
+      },
+    ],
+    prompt: TEST_PROMPT,
+  });
+
+  expect(
+    (await server.calls[0].requestBodyJson).tools[0].functionDeclarations[0]
+      .parameters,
+  ).toEqual({
+    type: 'object',
+    properties: {
+      locale: {
+        type: 'string',
+        enum: ['de', 'en'],
+        description: 'Locale for formatting',
+      },
+    },
+    required: ['locale'],
+  });
+});

--- a/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.test.ts
@@ -1,4 +1,7 @@
-import type { JSONSchema7 } from '@ai-sdk/provider';
+import {
+  UnsupportedFunctionalityError,
+  type JSONSchema7,
+} from '@ai-sdk/provider';
 import { convertJSONSchemaToOpenAPISchema } from './convert-json-schema-to-openapi-schema';
 import { it, expect } from 'vitest';
 
@@ -22,6 +25,136 @@ it('should remove additionalProperties and $schema', () => {
   };
 
   expect(convertJSONSchemaToOpenAPISchema(input)).toEqual(expected);
+});
+
+it('should inline direct references to root-level $defs', () => {
+  const input = {
+    type: 'object',
+    properties: {
+      locale: {
+        $ref: '#/$defs/Locale',
+        description: 'Locale for formatting',
+      },
+    },
+    required: ['locale'],
+    $defs: {
+      Locale: { type: 'string', enum: ['de', 'en'] },
+    },
+  } as JSONSchema7 & { $defs: Record<string, JSONSchema7> };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual({
+    type: 'object',
+    properties: {
+      locale: {
+        type: 'string',
+        enum: ['de', 'en'],
+        description: 'Locale for formatting',
+      },
+    },
+    required: ['locale'],
+  });
+});
+
+it('should inline a root reference before checking for an empty object', () => {
+  const input = {
+    type: 'object',
+    $ref: '#/$defs/Parameters',
+    $defs: {
+      Parameters: {
+        type: 'object',
+        properties: { value: { type: 'string' } },
+      },
+    },
+  } as JSONSchema7 & { $defs: Record<string, JSONSchema7> };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual({
+    type: 'object',
+    properties: { value: { type: 'string' } },
+  });
+});
+
+it('should inline nested references between root-level definitions', () => {
+  const input = {
+    type: 'object',
+    properties: {
+      settings: { $ref: '#/$defs/Settings' },
+    },
+    $defs: {
+      Locale: { type: 'string', enum: ['de', 'en'] },
+      Settings: {
+        type: 'object',
+        properties: {
+          locale: { $ref: '#/$defs/Locale' },
+        },
+        required: ['locale'],
+      },
+    },
+  } as JSONSchema7 & { $defs: Record<string, JSONSchema7> };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual({
+    type: 'object',
+    properties: {
+      settings: {
+        type: 'object',
+        properties: {
+          locale: { type: 'string', enum: ['de', 'en'] },
+        },
+        required: ['locale'],
+      },
+    },
+  });
+});
+
+it('should inline references to legacy root-level definitions', () => {
+  const input: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      locale: { $ref: '#/definitions/Locale' },
+    },
+    definitions: {
+      Locale: { type: 'string', enum: ['de', 'en'] },
+    },
+  };
+
+  expect(convertJSONSchemaToOpenAPISchema(input)).toEqual({
+    type: 'object',
+    properties: {
+      locale: { type: 'string', enum: ['de', 'en'] },
+    },
+  });
+});
+
+it('should reject unsupported or missing references', () => {
+  expect(() =>
+    convertJSONSchemaToOpenAPISchema({ $ref: '#/properties/value' }),
+  ).toThrow(UnsupportedFunctionalityError);
+
+  expect(() =>
+    convertJSONSchemaToOpenAPISchema({
+      $ref: '#/$defs/Missing',
+    } as JSONSchema7),
+  ).toThrow(UnsupportedFunctionalityError);
+});
+
+it('should reject recursive references', () => {
+  const input = {
+    type: 'object',
+    properties: {
+      node: { $ref: '#/$defs/Node' },
+    },
+    $defs: {
+      Node: {
+        type: 'object',
+        properties: {
+          child: { $ref: '#/$defs/Node' },
+        },
+      },
+    },
+  } as JSONSchema7 & { $defs: Record<string, JSONSchema7> };
+
+  expect(() => convertJSONSchemaToOpenAPISchema(input)).toThrow(
+    UnsupportedFunctionalityError,
+  );
 });
 
 it('should remove additionalProperties object from nested object schemas', function () {

--- a/packages/google/src/convert-json-schema-to-openapi-schema.ts
+++ b/packages/google/src/convert-json-schema-to-openapi-schema.ts
@@ -1,4 +1,18 @@
-import type { JSONSchema7Definition } from '@ai-sdk/provider';
+import {
+  UnsupportedFunctionalityError,
+  type JSONSchema7,
+  type JSONSchema7Definition,
+} from '@ai-sdk/provider';
+
+type JSONSchema7WithDefinitions = JSONSchema7 & {
+  $defs?: Record<string, JSONSchema7Definition>;
+};
+
+type ReferenceContext = {
+  definitions: Record<string, JSONSchema7Definition> | undefined;
+  dollarDefinitions: Record<string, JSONSchema7Definition> | undefined;
+  resolvingReferences: ReadonlySet<string>;
+};
 
 /**
  * Converts JSON Schema 7 to OpenAPI Schema 3.0
@@ -7,24 +21,50 @@ export function convertJSONSchemaToOpenAPISchema(
   jsonSchema: JSONSchema7Definition | undefined,
   isRoot = true,
 ): unknown {
-  // Handle empty object schemas: undefined at root, preserved when nested
+  const rootSchema =
+    typeof jsonSchema === 'object'
+      ? (jsonSchema as JSONSchema7WithDefinitions)
+      : undefined;
+
+  return convertJSONSchemaDefinition(jsonSchema, isRoot, {
+    definitions: rootSchema?.definitions,
+    dollarDefinitions: rootSchema?.$defs,
+    resolvingReferences: new Set(),
+  });
+}
+
+function convertJSONSchemaDefinition(
+  jsonSchema: JSONSchema7Definition | undefined,
+  isRoot: boolean,
+  referenceContext: ReferenceContext,
+): unknown {
   if (jsonSchema == null) {
     return undefined;
   }
 
+  if (typeof jsonSchema === 'boolean') {
+    return { type: 'boolean', properties: {} };
+  }
+
+  if (jsonSchema.$ref != null) {
+    return convertJSONSchemaReference({
+      jsonSchema,
+      reference: jsonSchema.$ref,
+      isRoot,
+      referenceContext,
+    });
+  }
+
+  // Handle empty object schemas: undefined at root, preserved when nested
   if (isEmptyObjectSchema(jsonSchema)) {
     if (isRoot) {
       return undefined;
     }
 
-    if (typeof jsonSchema === 'object' && jsonSchema.description) {
+    if (jsonSchema.description) {
       return { type: 'object', description: jsonSchema.description };
     }
     return { type: 'object' };
-  }
-
-  if (typeof jsonSchema === 'boolean') {
-    return { type: 'boolean', properties: {} };
   }
 
   const {
@@ -81,7 +121,7 @@ export function convertJSONSchemaToOpenAPISchema(
   if (properties != null) {
     result.properties = Object.entries(properties).reduce(
       (acc, [key, value]) => {
-        acc[key] = convertJSONSchemaToOpenAPISchema(value, false);
+        acc[key] = convertJSONSchemaDefinition(value, false, referenceContext);
         return acc;
       },
       {} as Record<string, unknown>,
@@ -90,13 +130,15 @@ export function convertJSONSchemaToOpenAPISchema(
 
   if (items) {
     result.items = Array.isArray(items)
-      ? items.map(item => convertJSONSchemaToOpenAPISchema(item, false))
-      : convertJSONSchemaToOpenAPISchema(items, false);
+      ? items.map(item =>
+          convertJSONSchemaDefinition(item, false, referenceContext),
+        )
+      : convertJSONSchemaDefinition(items, false, referenceContext);
   }
 
   if (allOf) {
     result.allOf = allOf.map(item =>
-      convertJSONSchemaToOpenAPISchema(item, false),
+      convertJSONSchemaDefinition(item, false, referenceContext),
     );
   }
   if (anyOf) {
@@ -112,9 +154,10 @@ export function convertJSONSchemaToOpenAPISchema(
 
       if (nonNullSchemas.length === 1) {
         // If there's only one non-null schema, convert it and make it nullable
-        const converted = convertJSONSchemaToOpenAPISchema(
+        const converted = convertJSONSchemaDefinition(
           nonNullSchemas[0],
           false,
+          referenceContext,
         );
         if (typeof converted === 'object') {
           result.nullable = true;
@@ -123,19 +166,19 @@ export function convertJSONSchemaToOpenAPISchema(
       } else {
         // If there are multiple non-null schemas, keep them in anyOf
         result.anyOf = nonNullSchemas.map(item =>
-          convertJSONSchemaToOpenAPISchema(item, false),
+          convertJSONSchemaDefinition(item, false, referenceContext),
         );
         result.nullable = true;
       }
     } else {
       result.anyOf = anyOf.map(item =>
-        convertJSONSchemaToOpenAPISchema(item, false),
+        convertJSONSchemaDefinition(item, false, referenceContext),
       );
     }
   }
   if (oneOf) {
     result.oneOf = oneOf.map(item =>
-      convertJSONSchemaToOpenAPISchema(item, false),
+      convertJSONSchemaDefinition(item, false, referenceContext),
     );
   }
 
@@ -146,6 +189,123 @@ export function convertJSONSchemaToOpenAPISchema(
   return result;
 }
 
+function convertJSONSchemaReference({
+  jsonSchema,
+  reference,
+  isRoot,
+  referenceContext,
+}: {
+  jsonSchema: JSONSchema7;
+  reference: string;
+  isRoot: boolean;
+  referenceContext: ReferenceContext;
+}): unknown {
+  const { definition, referenceKey } = getReferencedDefinition(
+    reference,
+    referenceContext,
+  );
+
+  if (referenceContext.resolvingReferences.has(referenceKey)) {
+    throw new UnsupportedFunctionalityError({
+      functionality: `recursive JSON Schema reference: ${reference}`,
+      message:
+        'Google schema conversion does not support recursive JSON Schema references.',
+    });
+  }
+
+  const resolvingReferences = new Set(referenceContext.resolvingReferences);
+  resolvingReferences.add(referenceKey);
+
+  // Inline references instead of emitting Google's `ref` / `defs` fields.
+  // Those fields are supported by Vertex AI's Schema representation but are
+  // rejected by the Gemini Developer API representation used by this shared
+  // converter.
+  const { $ref: _reference, ...siblingSchema } = jsonSchema;
+  const resolvedSchema =
+    typeof definition === 'boolean'
+      ? definition
+        ? siblingSchema
+        : false
+      : { ...definition, ...siblingSchema };
+
+  return convertJSONSchemaDefinition(resolvedSchema, isRoot, {
+    ...referenceContext,
+    resolvingReferences,
+  });
+}
+
+function getReferencedDefinition(
+  reference: string,
+  referenceContext: ReferenceContext,
+): {
+  definition: JSONSchema7Definition;
+  referenceKey: string;
+} {
+  const definitionSources = [
+    {
+      prefix: '#/$defs/',
+      definitions: referenceContext.dollarDefinitions,
+    },
+    {
+      prefix: '#/definitions/',
+      definitions: referenceContext.definitions,
+    },
+  ];
+
+  const source = definitionSources.find(({ prefix }) =>
+    reference.startsWith(prefix),
+  );
+  const encodedDefinitionName = source
+    ? reference.slice(source.prefix.length)
+    : undefined;
+
+  if (
+    source == null ||
+    encodedDefinitionName == null ||
+    encodedDefinitionName.length === 0 ||
+    encodedDefinitionName.includes('/')
+  ) {
+    throwUnsupportedReference(reference);
+  }
+
+  let decodedDefinitionName: string;
+  try {
+    decodedDefinitionName = decodeURIComponent(encodedDefinitionName);
+  } catch {
+    throwUnsupportedReference(reference);
+  }
+
+  if (
+    decodedDefinitionName.includes('/') ||
+    /~(?![01])/u.test(decodedDefinitionName) ||
+    source.definitions == null
+  ) {
+    throwUnsupportedReference(reference);
+  }
+
+  const definitionName = decodedDefinitionName.replace(/~[01]/g, match =>
+    match === '~1' ? '/' : '~',
+  );
+
+  if (
+    !Object.prototype.hasOwnProperty.call(source.definitions, definitionName)
+  ) {
+    throwUnsupportedReference(reference);
+  }
+
+  return {
+    definition: source.definitions[definitionName],
+    referenceKey: `${source.prefix}${definitionName}`,
+  };
+}
+
+function throwUnsupportedReference(reference: string): never {
+  throw new UnsupportedFunctionalityError({
+    functionality: `JSON Schema reference: ${reference}`,
+    message:
+      'Google schema conversion only supports references to direct children of root-level $defs or definitions.',
+  });
+}
 function isEmptyObjectSchema(jsonSchema: JSONSchema7Definition): boolean {
   return (
     jsonSchema != null &&

--- a/packages/google/src/google-generative-ai-language-model.test.ts
+++ b/packages/google/src/google-generative-ai-language-model.test.ts
@@ -1,4 +1,5 @@
 import type {
+  JSONSchema7,
   LanguageModelV2Prompt,
   LanguageModelV2ProviderDefinedTool,
 } from '@ai-sdk/provider';
@@ -1005,6 +1006,50 @@ describe('doGenerate', () => {
     });
   });
 
+  it('should inline local JSON Schema references in tool requests', async () => {
+    prepareJsonResponse({});
+
+    await model.doGenerate({
+      tools: [
+        {
+          type: 'function',
+          name: 'format-date',
+          description: 'Format a date',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              locale: {
+                $ref: '#/$defs/Locale',
+                description: 'Locale for formatting',
+              },
+            },
+            required: ['locale'],
+            additionalProperties: false,
+            $defs: {
+              Locale: { type: 'string', enum: ['de', 'en'] },
+            },
+          } as JSONSchema7,
+        },
+      ],
+      prompt: TEST_PROMPT,
+    });
+
+    expect(
+      (await server.calls[0].requestBodyJson).tools[0].functionDeclarations[0]
+        .parameters,
+    ).toEqual({
+      type: 'object',
+      properties: {
+        locale: {
+          type: 'string',
+          enum: ['de', 'en'],
+          description: 'Locale for formatting',
+        },
+      },
+      required: ['locale'],
+    });
+  });
+
   it('should set response mime type with responseFormat', async () => {
     prepareJsonResponse({});
 
@@ -1037,6 +1082,37 @@ describe('doGenerate', () => {
           },
         },
       },
+    });
+  });
+
+  it('should inline local JSON Schema references in response schemas', async () => {
+    prepareJsonResponse({});
+
+    await model.doGenerate({
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            locale: { $ref: '#/$defs/Locale' },
+          },
+          required: ['locale'],
+          $defs: {
+            Locale: { type: 'string', enum: ['de', 'en'] },
+          },
+        } as JSONSchema7,
+      },
+      prompt: TEST_PROMPT,
+    });
+
+    expect(
+      (await server.calls[0].requestBodyJson).generationConfig.responseSchema,
+    ).toEqual({
+      type: 'object',
+      properties: {
+        locale: { type: 'string', enum: ['de', 'en'] },
+      },
+      required: ['locale'],
     });
   });
 


### PR DESCRIPTION
## Background

Backports #19141 to the AI SDK 5 maintenance line. The v5 Google converter has the same behavior that drops local `$ref` and `$defs` from tool and structured-output schemas.

## Summary

- Inline direct local references to root-level `$defs` and legacy `definitions` before Google schema conversion.
- Preserve sibling schema metadata and reject missing, non-local, nested, and recursive references explicitly.
- Add request-level coverage for the v5 Gemini Developer API and Vertex AI paths, plus structured output.
- Adapt the tests to v5's Language Model V2 interfaces and Vertex project/location configuration; Realtime coverage is not applicable because that implementation is not present on `release-v5.0`.

## Contributor Credit

- @danielo515 reported the issue and supplied the reproduction in #19002; the backport commit preserves their co-authorship.
- @Oxygen56 contributed the initial fix in #19006.

## End-to-End Verification

Verified the v5 request-construction paths for Gemini Developer API, Vertex AI, and structured-output response schemas. Each path replaces local references with the corresponding inline schema before serialization.

## Verification Notes

Both affected package type checks and their complete Node/Edge suites pass. The repository-wide type check reaches unrelated legacy examples and currently fails on React type incompatibilities and stale generated Next.js types; none of its diagnostics reference the changed packages.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Backport of #19141 for `release-v5.0`.
