### PR TITLE
backport: feat (provider/amazon-bedrock): add bedrock mantle provider

### DIFF
--- a/.changeset/bedrock-mantle-provider.md
+++ b/.changeset/bedrock-mantle-provider.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+added bedrock mantle provider

--- a/packages/amazon-bedrock/mantle/index.d.ts
+++ b/packages/amazon-bedrock/mantle/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist/mantle';

--- a/packages/amazon-bedrock/package.json
+++ b/packages/amazon-bedrock/package.json
@@ -9,7 +9,8 @@
   "files": [
     "dist/**/*",
     "CHANGELOG.md",
-    "anthropic/index.d.ts"
+    "anthropic/index.d.ts",
+    "mantle/index.d.ts"
   ],
   "scripts": {
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
@@ -33,10 +34,16 @@
       "types": "./dist/anthropic/index.d.ts",
       "import": "./dist/anthropic/index.mjs",
       "require": "./dist/anthropic/index.js"
+    },
+    "./mantle": {
+      "types": "./dist/mantle/index.d.ts",
+      "import": "./dist/mantle/index.mjs",
+      "require": "./dist/mantle/index.js"
     }
   },
   "dependencies": {
     "@ai-sdk/anthropic": "workspace:*",
+    "@ai-sdk/openai": "workspace:*",
     "@ai-sdk/provider": "workspace:*",
     "@ai-sdk/provider-utils": "workspace:*",
     "@smithy/eventstream-codec": "^4.0.1",

--- a/packages/amazon-bedrock/src/bedrock-sigv4-fetch.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-sigv4-fetch.test.ts
@@ -19,11 +19,14 @@ vi.mock('@ai-sdk/provider-utils', async () => {
 });
 
 // Mock AwsV4Signer so that no real crypto calls are made.
+// Capture constructor options for test assertions.
+let lastSignerOptions: any = null;
 vi.mock('aws4fetch', () => {
   class MockAwsV4Signer {
     options: any;
     constructor(options: any) {
       this.options = options;
+      lastSignerOptions = options;
     }
     async sign() {
       // Return a fake Headers instance with predetermined signing headers.
@@ -378,6 +381,53 @@ describe('createSigV4FetchFunction', () => {
 
     // The underlying fetch should not be called
     expect(dummyFetch).not.toHaveBeenCalled();
+  });
+
+  it('should use default service name "bedrock" when no service parameter is provided', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    lastSignerOptions = null;
+
+    const fetchFn = createSigV4FetchFunction(
+      () => ({
+        region: 'us-west-2',
+        accessKeyId: 'test-access-key',
+        secretAccessKey: 'test-secret',
+      }),
+      dummyFetch,
+    );
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+    });
+
+    expect(lastSignerOptions).not.toBeNull();
+    expect(lastSignerOptions.service).toBe('bedrock');
+  });
+
+  it('should use custom service name when service parameter is provided', async () => {
+    const dummyResponse = new Response('Signed', { status: 200 });
+    const dummyFetch = vi.fn().mockResolvedValue(dummyResponse);
+    lastSignerOptions = null;
+
+    const fetchFn = createSigV4FetchFunction(
+      () => ({
+        region: 'us-west-2',
+        accessKeyId: 'test-access-key',
+        secretAccessKey: 'test-secret',
+      }),
+      dummyFetch,
+      'bedrock-mantle',
+    );
+
+    await fetchFn('http://example.com', {
+      method: 'POST',
+      body: '{"test": "data"}',
+    });
+
+    expect(lastSignerOptions).not.toBeNull();
+    expect(lastSignerOptions.service).toBe('bedrock-mantle');
   });
 });
 

--- a/packages/amazon-bedrock/src/bedrock-sigv4-fetch.ts
+++ b/packages/amazon-bedrock/src/bedrock-sigv4-fetch.ts
@@ -20,11 +20,13 @@ Creates a fetch function that applies AWS Signature Version 4 signing.
 
 @param getCredentials - Function that returns the AWS credentials to use when signing.
 @param fetch - Optional original fetch implementation to wrap. Defaults to global fetch.
+@param service - AWS service name to sign against. Defaults to 'bedrock'.
 @returns A FetchFunction that signs requests before passing them to the underlying fetch.
  */
 export function createSigV4FetchFunction(
   getCredentials: () => BedrockCredentials | PromiseLike<BedrockCredentials>,
   fetch: FetchFunction = globalThis.fetch,
+  service: string = 'bedrock',
 ): FetchFunction {
   return async (
     input: RequestInfo | URL,
@@ -75,7 +77,7 @@ export function createSigV4FetchFunction(
       accessKeyId: credentials.accessKeyId,
       secretAccessKey: credentials.secretAccessKey,
       sessionToken: credentials.sessionToken,
-      service: 'bedrock',
+      service,
     });
 
     const signingResult = await signer.sign();

--- a/packages/amazon-bedrock/src/mantle/bedrock-mantle-options.ts
+++ b/packages/amazon-bedrock/src/mantle/bedrock-mantle-options.ts
@@ -1,0 +1,15 @@
+export type BedrockMantleChatModelId =
+  | 'openai.gpt-oss-20b'
+  | 'openai.gpt-oss-120b'
+  | 'openai.gpt-oss-safeguard-20b'
+  | 'openai.gpt-oss-safeguard-120b'
+  | (string & {});
+
+export type BedrockMantleResponsesModelId =
+  | 'openai.gpt-oss-20b'
+  | 'openai.gpt-oss-120b'
+  | (string & {});
+
+export type BedrockMantleModelId =
+  | BedrockMantleChatModelId
+  | BedrockMantleResponsesModelId;

--- a/packages/amazon-bedrock/src/mantle/bedrock-mantle-provider.test.ts
+++ b/packages/amazon-bedrock/src/mantle/bedrock-mantle-provider.test.ts
@@ -1,0 +1,278 @@
+import { createBedrockMantle } from './bedrock-mantle-provider';
+import { NoSuchModelError } from '@ai-sdk/provider';
+import {
+  OpenAIChatLanguageModel,
+  OpenAIResponsesLanguageModel,
+} from '@ai-sdk/openai/internal';
+import type * as ProviderUtilsModule from '@ai-sdk/provider-utils';
+import {
+  createApiKeyFetchFunction,
+  createSigV4FetchFunction,
+} from '../bedrock-sigv4-fetch';
+import { vi, describe, beforeEach, it, expect } from 'vitest';
+
+vi.mock('@ai-sdk/provider-utils', async importOriginal => {
+  const actual = await importOriginal<typeof ProviderUtilsModule>();
+  return {
+    ...actual,
+    loadOptionalSetting: vi.fn().mockImplementation(({ settingValue }) => {
+      // Return undefined for API key to test SigV4 flow
+      if (settingValue === undefined) return undefined;
+      return settingValue;
+    }),
+    loadSetting: vi.fn().mockImplementation(({ settingValue, settingName }) => {
+      if (settingValue) return settingValue;
+      // Return mock values for required settings
+      if (settingName === 'region') return 'us-east-1';
+      if (settingName === 'accessKeyId') return 'mock-access-key';
+      if (settingName === 'secretAccessKey') return 'mock-secret-key';
+      return settingValue;
+    }),
+    withoutTrailingSlash: vi.fn().mockImplementation(url => url),
+    withUserAgentSuffix: vi.fn().mockImplementation((headers, suffix) => ({
+      ...headers,
+      'user-agent': suffix,
+    })),
+  };
+});
+
+vi.mock('@ai-sdk/openai/internal', async () => {
+  const originalModule = await vi.importActual('@ai-sdk/openai/internal');
+  return {
+    ...originalModule,
+    OpenAIChatLanguageModel: vi.fn(),
+    OpenAIResponsesLanguageModel: vi.fn(),
+  };
+});
+
+vi.mock('../bedrock-sigv4-fetch', () => ({
+  createSigV4FetchFunction: vi.fn().mockReturnValue(vi.fn()),
+  createApiKeyFetchFunction: vi.fn().mockReturnValue(vi.fn()),
+}));
+
+describe('bedrock-mantle-provider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create a chat model with default settings', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('openai.gpt-oss-20b');
+
+    expect(OpenAIChatLanguageModel).toHaveBeenCalledWith(
+      'openai.gpt-oss-20b',
+      expect.objectContaining({
+        provider: 'bedrock-mantle.chat',
+        url: expect.any(Function),
+        headers: expect.any(Function),
+        fetch: expect.any(Function),
+      }),
+    );
+  });
+
+  it('should create a chat model via .chat()', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider.chat('openai.gpt-oss-20b');
+
+    expect(OpenAIChatLanguageModel).toHaveBeenCalledWith(
+      'openai.gpt-oss-20b',
+      expect.objectContaining({
+        provider: 'bedrock-mantle.chat',
+        url: expect.any(Function),
+        headers: expect.any(Function),
+        fetch: expect.any(Function),
+      }),
+    );
+  });
+
+  it('should alias .languageModel() to chat model', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider.languageModel('test-model');
+
+    expect(OpenAIChatLanguageModel).toHaveBeenCalledWith(
+      'test-model',
+      expect.objectContaining({
+        provider: 'bedrock-mantle.chat',
+      }),
+    );
+  });
+
+  it('should create a responses model via .responses()', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider.responses('test-model');
+
+    expect(OpenAIResponsesLanguageModel).toHaveBeenCalledWith(
+      'test-model',
+      expect.objectContaining({
+        provider: 'bedrock-mantle.responses',
+      }),
+    );
+  });
+
+  it('should throw an error when using new keyword', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+
+    expect(() => new (provider as any)('test-model-id')).toThrow(
+      'The Bedrock Mantle model function cannot be called with the new keyword.',
+    );
+  });
+
+  it('should use default base URL with region', () => {
+    const provider = createBedrockMantle({
+      region: 'us-west-2',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model');
+
+    const constructorCall = vi.mocked(OpenAIChatLanguageModel).mock.calls[
+      vi.mocked(OpenAIChatLanguageModel).mock.calls.length - 1
+    ];
+    const config = constructorCall[1];
+
+    const generatedUrl = config.url({
+      path: '/responses',
+      modelId: 'test-model',
+    });
+    expect(generatedUrl).toBe(
+      'https://bedrock-mantle.us-west-2.api.aws/v1/responses',
+    );
+  });
+
+  it('should pass custom baseURL to the model when created', () => {
+    const customBaseURL = 'https://custom-mantle.example.com/v1';
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      baseURL: customBaseURL,
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model');
+
+    const constructorCall = vi.mocked(OpenAIChatLanguageModel).mock.calls[
+      vi.mocked(OpenAIChatLanguageModel).mock.calls.length - 1
+    ];
+    const config = constructorCall[1];
+
+    const generatedUrl = config.url({
+      path: '/chat/completions',
+      modelId: 'test-model',
+    });
+    expect(generatedUrl).toBe(
+      'https://custom-mantle.example.com/v1/chat/completions',
+    );
+  });
+
+  it('should include custom headers with user-agent suffix', () => {
+    const customHeaders = { 'Custom-Header': 'custom-value' };
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      headers: customHeaders,
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider('test-model');
+
+    const constructorCall = vi.mocked(OpenAIChatLanguageModel).mock.calls[
+      vi.mocked(OpenAIChatLanguageModel).mock.calls.length - 1
+    ];
+    const config = constructorCall[1];
+
+    const resolvedHeaders = config.headers!();
+    expect(resolvedHeaders).toMatchObject(customHeaders);
+    expect(resolvedHeaders['user-agent']).toContain('ai-sdk/amazon-bedrock/');
+  });
+
+  it('should use createApiKeyFetchFunction when apiKey is provided', () => {
+    createBedrockMantle({
+      region: 'us-east-1',
+      apiKey: 'test-api-key',
+    });
+
+    expect(createApiKeyFetchFunction).toHaveBeenCalledWith(
+      'test-api-key',
+      undefined,
+    );
+    expect(createSigV4FetchFunction).not.toHaveBeenCalled();
+  });
+
+  it('should use createSigV4FetchFunction with bedrock-mantle service when no apiKey', () => {
+    createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+
+    expect(createSigV4FetchFunction).toHaveBeenCalledWith(
+      expect.any(Function),
+      undefined,
+      'bedrock-mantle',
+    );
+    expect(createApiKeyFetchFunction).not.toHaveBeenCalled();
+  });
+
+  it('should throw NoSuchModelError for embeddingModel', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+
+    expect(() => (provider as any).embeddingModel('invalid-model-id')).toThrow(
+      NoSuchModelError,
+    );
+  });
+
+  it('should throw NoSuchModelError for imageModel', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+
+    expect(() => provider.imageModel('invalid-model-id')).toThrow(
+      NoSuchModelError,
+    );
+  });
+
+  it('should have correct specificationVersion', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+
+    expect((provider as any).specificationVersion).toBe('v2');
+  });
+
+  it('should provide languageModel as alias for responses', () => {
+    const provider = createBedrockMantle({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+
+    expect(provider.languageModel).toBeDefined();
+    expect(typeof provider.languageModel).toBe('function');
+  });
+});

--- a/packages/amazon-bedrock/src/mantle/bedrock-mantle-provider.ts
+++ b/packages/amazon-bedrock/src/mantle/bedrock-mantle-provider.ts
@@ -1,0 +1,281 @@
+import {
+  OpenAIChatLanguageModel,
+  OpenAIResponsesLanguageModel,
+} from '@ai-sdk/openai/internal';
+import {
+  NoSuchModelError,
+  type LanguageModelV2,
+  type ProviderV2,
+} from '@ai-sdk/provider';
+import {
+  loadOptionalSetting,
+  loadSetting,
+  withoutTrailingSlash,
+  withUserAgentSuffix,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import {
+  createApiKeyFetchFunction,
+  createSigV4FetchFunction,
+  type BedrockCredentials,
+} from '../bedrock-sigv4-fetch';
+import type {
+  BedrockMantleChatModelId,
+  BedrockMantleResponsesModelId,
+} from './bedrock-mantle-options';
+import { VERSION } from '../version';
+
+export interface BedrockMantleProvider extends ProviderV2 {
+  /**
+   * Creates a model for text generation using the Chat Completions API.
+   * Chat Completions has the broadest model support on Mantle.
+   */
+  (modelId: BedrockMantleChatModelId): LanguageModelV2;
+
+  /**
+   * Creates a model for text generation using the Chat Completions API.
+   */
+  languageModel(modelId: BedrockMantleChatModelId): LanguageModelV2;
+
+  /**
+   * Creates a model for text generation using the Chat Completions API.
+   */
+  chat(modelId: BedrockMantleChatModelId): LanguageModelV2;
+
+  /**
+   * Creates a model for text generation using the Responses API.
+   * Not all Mantle models support this API. Notably, gpt-oss-safeguard models
+   * are Chat-only.
+   */
+  responses(modelId: BedrockMantleResponsesModelId): LanguageModelV2;
+
+  /**
+   * @deprecated Mantle does not support embedding models.
+   */
+  textEmbeddingModel(modelId: string): never;
+}
+
+export interface BedrockMantleProviderSettings {
+  /**
+   * The AWS region to use for the Bedrock Mantle endpoint. Defaults to the value of the
+   * `AWS_REGION` environment variable.
+   */
+  region?: string;
+
+  /**
+   * API key for authenticating requests using Bearer token authentication.
+   * When provided, this will be used instead of AWS SigV4 authentication.
+   * Defaults to the value of the `AWS_BEARER_TOKEN_BEDROCK` environment variable.
+   */
+  apiKey?: string;
+
+  /**
+   * The AWS access key ID to use for SigV4 authentication. Defaults to the value of the
+   * `AWS_ACCESS_KEY_ID` environment variable.
+   */
+  accessKeyId?: string;
+
+  /**
+   * The AWS secret access key to use for SigV4 authentication. Defaults to the value of the
+   * `AWS_SECRET_ACCESS_KEY` environment variable.
+   */
+  secretAccessKey?: string;
+
+  /**
+   * The AWS session token to use for SigV4 authentication. Defaults to the value of the
+   * `AWS_SESSION_TOKEN` environment variable.
+   */
+  sessionToken?: string;
+
+  /**
+   * Base URL for the Bedrock Mantle API calls.
+   */
+  baseURL?: string;
+
+  /**
+   * Custom headers to include in the requests.
+   */
+  headers?: Record<string, string | undefined>;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept requests,
+   * or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+
+  /**
+   * The AWS credential provider to use for SigV4 authentication to get dynamic
+   * credentials similar to the AWS SDK. Setting a provider here will cause its
+   * credential values to be used instead of the `accessKeyId`, `secretAccessKey`,
+   * and `sessionToken` settings.
+   */
+  credentialProvider?: () => PromiseLike<Omit<BedrockCredentials, 'region'>>;
+}
+
+/**
+ * Create an Amazon Bedrock Mantle provider instance.
+ * This provider uses the OpenAI-compatible Mantle API for models that are
+ * only available through the Mantle endpoint (e.g. openai.gpt-oss-20b).
+ */
+export function createBedrockMantle(
+  options: BedrockMantleProviderSettings = {},
+): BedrockMantleProvider {
+  // Check for API key authentication first
+  const rawApiKey = loadOptionalSetting({
+    settingValue: options.apiKey,
+    environmentVariableName: 'AWS_BEARER_TOKEN_BEDROCK',
+  });
+
+  // Only use API key if it's a non-empty, non-whitespace string
+  const apiKey =
+    rawApiKey && rawApiKey.trim().length > 0 ? rawApiKey.trim() : undefined;
+
+  // Use API key authentication if available, otherwise fall back to SigV4
+  const fetchFunction = apiKey
+    ? createApiKeyFetchFunction(apiKey, options.fetch)
+    : createSigV4FetchFunction(
+        async () => {
+          const region = loadSetting({
+            settingValue: options.region,
+            settingName: 'region',
+            environmentVariableName: 'AWS_REGION',
+            description: 'AWS region',
+          });
+
+          // If a credential provider is provided, use it to get the credentials.
+          if (options.credentialProvider) {
+            try {
+              return {
+                ...(await options.credentialProvider()),
+                region,
+              };
+            } catch (error) {
+              const errorMessage =
+                error instanceof Error ? error.message : String(error);
+              throw new Error(
+                `AWS credential provider failed: ${errorMessage}. ` +
+                  'Please ensure your credential provider returns valid AWS credentials ' +
+                  'with accessKeyId and secretAccessKey properties.',
+              );
+            }
+          }
+
+          try {
+            return {
+              region,
+              accessKeyId: loadSetting({
+                settingValue: options.accessKeyId,
+                settingName: 'accessKeyId',
+                environmentVariableName: 'AWS_ACCESS_KEY_ID',
+                description: 'AWS access key ID',
+              }),
+              secretAccessKey: loadSetting({
+                settingValue: options.secretAccessKey,
+                settingName: 'secretAccessKey',
+                environmentVariableName: 'AWS_SECRET_ACCESS_KEY',
+                description: 'AWS secret access key',
+              }),
+              sessionToken: loadOptionalSetting({
+                settingValue: options.sessionToken,
+                environmentVariableName: 'AWS_SESSION_TOKEN',
+              }),
+            };
+          } catch (error) {
+            const errorMessage =
+              error instanceof Error ? error.message : String(error);
+            if (
+              errorMessage.includes('AWS_ACCESS_KEY_ID') ||
+              errorMessage.includes('accessKeyId')
+            ) {
+              throw new Error(
+                'AWS SigV4 authentication requires AWS credentials. Please provide either:\n' +
+                  '1. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables\n' +
+                  '2. Provide accessKeyId and secretAccessKey in options\n' +
+                  '3. Use a credentialProvider function\n' +
+                  '4. Use API key authentication with AWS_BEARER_TOKEN_BEDROCK or apiKey option\n' +
+                  `Original error: ${errorMessage}`,
+              );
+            }
+            if (
+              errorMessage.includes('AWS_SECRET_ACCESS_KEY') ||
+              errorMessage.includes('secretAccessKey')
+            ) {
+              throw new Error(
+                'AWS SigV4 authentication requires both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. ' +
+                  'Please ensure both credentials are provided.\n' +
+                  `Original error: ${errorMessage}`,
+              );
+            }
+            throw error;
+          }
+        },
+        options.fetch,
+        'bedrock-mantle',
+      );
+
+  const getBaseURL = (): string =>
+    withoutTrailingSlash(
+      options.baseURL ??
+        `https://bedrock-mantle.${loadSetting({
+          settingValue: options.region,
+          settingName: 'region',
+          environmentVariableName: 'AWS_REGION',
+          description: 'AWS region',
+        })}.api.aws/v1`,
+    ) ?? 'https://bedrock-mantle.us-east-1.api.aws/v1';
+
+  const getHeaders = (): Record<string, string | undefined> =>
+    withUserAgentSuffix(
+      options.headers ?? {},
+      `ai-sdk/amazon-bedrock/${VERSION}`,
+    );
+
+  const url = ({ path }: { path: string; modelId: string }): string =>
+    `${getBaseURL()}${path}`;
+
+  const createChatModel = (modelId: BedrockMantleChatModelId) =>
+    new OpenAIChatLanguageModel(modelId, {
+      provider: 'bedrock-mantle.chat',
+      url,
+      headers: getHeaders,
+      fetch: fetchFunction,
+    });
+
+  const createResponsesModel = (modelId: BedrockMantleResponsesModelId) =>
+    new OpenAIResponsesLanguageModel(modelId, {
+      provider: 'bedrock-mantle.responses',
+      url,
+      headers: getHeaders,
+      fetch: fetchFunction,
+    });
+
+  const provider = function (modelId: BedrockMantleChatModelId) {
+    if (new.target) {
+      throw new Error(
+        'The Bedrock Mantle model function cannot be called with the new keyword.',
+      );
+    }
+
+    return createChatModel(modelId);
+  };
+
+  provider.specificationVersion = 'v2' as const;
+  provider.languageModel = createChatModel;
+  provider.chat = createChatModel;
+  provider.responses = createResponsesModel;
+
+  provider.embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'textEmbeddingModel' });
+  };
+  provider.textEmbeddingModel = provider.embeddingModel;
+  provider.imageModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
+  };
+
+  return provider as BedrockMantleProvider;
+}
+
+/**
+ * Default Bedrock Mantle provider instance.
+ */
+export const bedrockMantle = createBedrockMantle();

--- a/packages/amazon-bedrock/src/mantle/index.ts
+++ b/packages/amazon-bedrock/src/mantle/index.ts
@@ -1,0 +1,6 @@
+export { bedrockMantle, createBedrockMantle } from './bedrock-mantle-provider';
+export type {
+  BedrockMantleProvider,
+  BedrockMantleProviderSettings,
+} from './bedrock-mantle-provider';
+export type { BedrockMantleModelId } from './bedrock-mantle-options';

--- a/packages/amazon-bedrock/tsconfig.json
+++ b/packages/amazon-bedrock/tsconfig.json
@@ -10,11 +10,15 @@
     "build",
     "node_modules",
     "tsup.config.ts",
-    "anthropic/index.d.ts"
+    "anthropic/index.d.ts",
+    "mantle/index.d.ts"
   ],
   "references": [
     {
       "path": "../anthropic"
+    },
+    {
+      "path": "../openai"
     },
     {
       "path": "../provider"

--- a/packages/amazon-bedrock/tsup.config.ts
+++ b/packages/amazon-bedrock/tsup.config.ts
@@ -14,6 +14,19 @@ export default defineConfig([
     },
   },
   {
+    entry: ['src/mantle/index.ts'],
+    outDir: 'dist/mantle',
+    format: ['cjs', 'esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+  {
     entry: ['src/anthropic/index.ts'],
     outDir: 'dist/anthropic',
     format: ['cjs', 'esm'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1369,6 +1369,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: workspace:*
         version: link:../anthropic
+      '@ai-sdk/openai':
+        specifier: workspace:*
+        version: link:../openai
       '@ai-sdk/provider':
         specifier: workspace:*
         version: link:../provider
@@ -6797,6 +6800,7 @@ packages:
   '@langchain/community@0.0.57':
     resolution: {integrity: sha512-tib4UJNkyA4TPNsTNChiBtZmThVJBr7X/iooSmKeCr+yUEha2Yxly3A4OAO95Vlpj4Q+od8HAfCbZih/1XqAMw==}
     engines: {node: '>=18'}
+    deprecated: This package has been deprecated. See https://github.com/langchain-ai/langchainjs-community/issues/61 for more info
     peerDependencies:
       '@aws-crypto/sha256-js': ^5.0.0
       '@aws-sdk/client-bedrock-agent-runtime': ^3.485.0
@@ -27203,7 +27207,7 @@ snapshots:
     dependencies:
       '@sentry/bundler-plugin-core': 5.1.1(encoding@0.1.13)
       uuid: 9.0.1
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -36596,7 +36600,7 @@ snapshots:
       neo-async: 2.6.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
 
   react@18.3.1:
     dependencies:
@@ -38244,6 +38248,15 @@ snapshots:
     optionalDependencies:
       esbuild: 0.25.9
 
+  terser-webpack-plugin@5.3.16(webpack@5.105.0):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.43.1
+      webpack: 5.105.0
+
   terser-webpack-plugin@5.3.16(webpack@5.97.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -38446,7 +38459,7 @@ snapshots:
       semver: 7.6.3
       source-map: 0.7.4
       typescript: 5.9.3
-      webpack: 5.105.0(esbuild@0.25.9)
+      webpack: 5.105.0
 
   ts-node@10.9.2(@types/node@20.17.24)(typescript@5.4.5):
     dependencies:
@@ -39786,6 +39799,38 @@ snapshots:
       webpack: 5.105.0(esbuild@0.25.9)
 
   webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.105.0:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.20.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(webpack@5.105.0)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   webpack@5.105.0(esbuild@0.25.9):
     dependencies:


### PR DESCRIPTION
## Background

Backports the Bedrock Mantle provider to the v2-spec (`ai@5`) package line, so
`@ai-sdk/amazon-bedrock@3.x` gains a `./mantle` export alongside the existing
`./anthropic` one.

Bedrock serves OpenAI GPT-5.x and xAI Grok models over an OpenAI-compatible
Responses API rather than Converse — the Mantle host
(`bedrock-mantle.{region}.api.aws`) for bare vendor IDs (`openai.*`, `xai.*`),
and `bedrock-runtime.{region}.amazonaws.com/openai/v1` for cross-region
inference profile IDs (`us.`, `eu.`, `global.` prefixes). On `main`/v6 this is
covered by `@ai-sdk/amazon-bedrock@4.x/mantle` (#14246, backported to
`release-v6.0` in #15752). The 3.x line has no equivalent, so v2-spec consumers
fall through to `createAmazonBedrock` (Converse), which cannot parse the
Responses-shaped reply — encrypted reasoning streams fail with
`AI_TypeValidationError`, and non-streaming calls fail earlier still.

## Changes

- add `src/mantle/` — `createBedrockMantle` / `bedrockMantle`, model id types,
  and tests. Ported from `release-v6.0` with `LanguageModelV3`/`ProviderV3`
  swapped for their V2 equivalents and `specificationVersion: 'v2'`.
- `./mantle` subpath export + `mantle/index.d.ts` re-export stub, mirroring the
  existing `./anthropic` layout; matching `tsup` entry and `tsconfig`
  reference/include.
- `createSigV4FetchFunction` takes an optional `service` argument (defaults to
  `'bedrock'`); Mantle signs against `bedrock-mantle`. v6's tests for this are
  ported alongside.
- adds `@ai-sdk/openai` as a dependency of `@ai-sdk/amazon-bedrock`. Mantle is a
  thin wrapper over `OpenAIChatLanguageModel` / `OpenAIResponsesLanguageModel`,
  so this mirrors the v6 package exactly.