### PR TITLE
feat(harness): sandbox-independent session export/import for harness sessions

### DIFF
--- a/.changeset/lucky-pears-export.md
+++ b/.changeset/lucky-pears-export.md
@@ -1,0 +1,8 @@
+---
+"@ai-sdk/harness": patch
+"@ai-sdk/harness-opencode": patch
+---
+
+feat(harness): add sandbox-independent session export/import via `doExportSession` / `importFrom`
+
+Session resume previously only worked while the originating sandbox still existed. This adds an optional `doExportSession()` method on `HarnessV1Session` that exports the complete conversation state as a host-persistable payload, and an `importFrom` option on `HarnessV1StartOptions` (and `HarnessAgent.createSession` / `session.exportSession()`) that reconstructs the exported conversation in a fresh sandbox. The OpenCode adapter implements both via OpenCode's `/sync/history` and `/sync/replay` APIs, preserving the native session id, tool activity, and compaction state.

--- a/packages/harness-opencode/src/bridge/index.ts
+++ b/packages/harness-opencode/src/bridge/index.ts
@@ -28,6 +28,11 @@ import {
 import { createEmitStreamEvent, stringValue } from './create-emit-stream-event';
 import { mapOpenCodeFinishReason } from './opencode-finish-step';
 import { prependOpenCodeBinToPath } from './opencode-path';
+import {
+  normalizeSyncHistory,
+  readReplaySessionId,
+  toReplayEvents,
+} from './opencode-sync';
 import { configureOpenCodeServerAuth } from './opencode-server-auth';
 import {
   addUsage,
@@ -135,7 +140,58 @@ await runBridge<StartMessage>({
   onStart: runTurn,
   onStop: () =>
     runtime.sessionId ? { openCodeSessionId: runtime.sessionId } : {},
+  onExportSession: exportSession,
 });
+
+/**
+ * Answer an `export-session` command with the OpenCode sync history of the
+ * current session. The runtime (and therefore the OpenCode server) only exists
+ * after the first turn, which the host mirrors by refusing to export before a
+ * session id is known.
+ */
+async function exportSession(): Promise<unknown> {
+  if (runtime.client == null || runtime.sessionId == null) {
+    throw new Error('The OpenCode bridge has no session to export yet.');
+  }
+  const history = await runtime.client.sync.history.list({ body: {} });
+  if (history.error) {
+    throw new Error(
+      `OpenCode sync history failed: ${formatError(history.error)}`,
+    );
+  }
+  return {
+    openCodeSessionId: runtime.sessionId,
+    syncEvents: normalizeSyncHistory(history.data),
+  };
+}
+
+/**
+ * Reconstruct an exported conversation by replaying its sync events into the
+ * fresh OpenCode server. Replay preserves the original session id, so the
+ * returned id re-locks the bridge onto the exported session.
+ */
+async function replaySyncEvents({
+  client,
+  start,
+}: {
+  client: OpenCodeClient;
+  start: StartMessage;
+}): Promise<string> {
+  const replayed = await client.sync.replay({
+    body_directory: workdir,
+    events: toReplayEvents(start.importEvents ?? []),
+  });
+  if (replayed.error) {
+    throw new Error(
+      `OpenCode sync replay failed: ${formatError(replayed.error)}`,
+    );
+  }
+  const sessionId = readReplaySessionId(replayed.data);
+  if (sessionId == null) {
+    throw new Error('OpenCode sync replay returned no session id.');
+  }
+  return sessionId;
+}
 
 async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   const emit: Emit = msg => turn.emit(msg as BridgeEvent);
@@ -529,6 +585,12 @@ async function ensureSession({
   emit: Emit;
 }): Promise<string> {
   if (runtime.sessionId) return runtime.sessionId;
+  if (start.importEvents && start.importEvents.length > 0) {
+    const sessionId = await replaySyncEvents({ client, start });
+    runtime.sessionId = sessionId;
+    emit({ type: 'bridge-thread', threadId: sessionId });
+    return sessionId;
+  }
   if (start.resumeSessionId) {
     const existing = await legacySessionGet({
       client,

--- a/packages/harness-opencode/src/bridge/opencode-sync.test.ts
+++ b/packages/harness-opencode/src/bridge/opencode-sync.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeSyncHistory,
+  readReplaySessionId,
+  toReplayEvents,
+} from './opencode-sync';
+
+const historyEvent = {
+  id: 'evt_1',
+  aggregate_id: 'ses_1',
+  seq: 1,
+  type: 'session.created',
+  data: { id: 'ses_1' },
+};
+
+describe('normalizeSyncHistory', () => {
+  it('passes through a bare event array', () => {
+    expect(normalizeSyncHistory([historyEvent])).toEqual([historyEvent]);
+  });
+
+  it('unwraps a wrapped { data } response', () => {
+    expect(normalizeSyncHistory({ data: [historyEvent] })).toEqual([
+      historyEvent,
+    ]);
+  });
+
+  it('returns an empty array for unexpected shapes', () => {
+    expect(normalizeSyncHistory(undefined)).toEqual([]);
+    expect(normalizeSyncHistory(null)).toEqual([]);
+    expect(normalizeSyncHistory({ data: 'nope' })).toEqual([]);
+    expect(normalizeSyncHistory('nope')).toEqual([]);
+  });
+});
+
+describe('toReplayEvents', () => {
+  it('renames aggregate_id to aggregateID for the replay request', () => {
+    expect(toReplayEvents([historyEvent])).toEqual([
+      {
+        id: 'evt_1',
+        aggregateID: 'ses_1',
+        seq: 1,
+        type: 'session.created',
+        data: { id: 'ses_1' },
+      },
+    ]);
+  });
+
+  it('defaults a missing data object to an empty record', () => {
+    const event = { ...historyEvent, data: undefined } as never;
+    expect(toReplayEvents([event])[0].data).toEqual({});
+  });
+});
+
+describe('readReplaySessionId', () => {
+  it('reads the sessionID field', () => {
+    expect(readReplaySessionId({ sessionID: 'ses_1' })).toBe('ses_1');
+  });
+
+  it('falls back to id', () => {
+    expect(readReplaySessionId({ id: 'ses_1' })).toBe('ses_1');
+  });
+
+  it('rejects empty and malformed values', () => {
+    expect(readReplaySessionId({ sessionID: '' })).toBeUndefined();
+    expect(readReplaySessionId({ sessionID: 42 })).toBeUndefined();
+    expect(readReplaySessionId(undefined)).toBeUndefined();
+  });
+});

--- a/packages/harness-opencode/src/bridge/opencode-sync.ts
+++ b/packages/harness-opencode/src/bridge/opencode-sync.ts
@@ -1,0 +1,55 @@
+import type { OpenCodeSyncEvent } from '../opencode-bridge-protocol';
+
+/**
+ * Sync helpers around OpenCode's `/sync` API: `POST /sync/history` exports the
+ * event log that makes up a session, `POST /sync/replay` reconstructs it in a
+ * fresh server. The wire shapes differ slightly (history returns
+ * `aggregate_id`, replay takes `aggregateID`), and the SDK response wrappers
+ * vary across versions, so the mapping/unwrapping lives here.
+ */
+
+/** Event shape accepted by `POST /sync/replay`. */
+export type OpenCodeReplayEvent = {
+  id: string;
+  aggregateID: string;
+  seq: number;
+  type: string;
+  data: Record<string, unknown>;
+};
+
+/** Unwrap a `/sync/history` response into its event array. */
+export function normalizeSyncHistory(data: unknown): OpenCodeSyncEvent[] {
+  if (Array.isArray(data)) return data as OpenCodeSyncEvent[];
+  if (
+    data != null &&
+    typeof data === 'object' &&
+    Array.isArray((data as { data?: unknown }).data)
+  ) {
+    return (data as { data: OpenCodeSyncEvent[] }).data;
+  }
+  return [];
+}
+
+/** Map exported history events to the `/sync/replay` request shape. */
+export function toReplayEvents(
+  events: ReadonlyArray<OpenCodeSyncEvent>,
+): OpenCodeReplayEvent[] {
+  return events.map(event => ({
+    id: event.id,
+    aggregateID: event.aggregate_id,
+    seq: event.seq,
+    type: event.type,
+    data: event.data ?? {},
+  }));
+}
+
+/** Read the session id from a `/sync/replay` response (`{ sessionID }`). */
+export function readReplaySessionId(data: unknown): string | undefined {
+  if (data == null || typeof data !== 'object') return undefined;
+  const record = data as { sessionID?: unknown; id?: unknown };
+  if (typeof record.sessionID === 'string' && record.sessionID.length > 0) {
+    return record.sessionID;
+  }
+  if (typeof record.id === 'string' && record.id.length > 0) return record.id;
+  return undefined;
+}

--- a/packages/harness-opencode/src/opencode-bridge-protocol.test.ts
+++ b/packages/harness-opencode/src/opencode-bridge-protocol.test.ts
@@ -62,5 +62,59 @@ describe('OpenCode bridge protocol', () => {
       toolCallId: 'tool-1',
       output: { ok: true },
     });
+    expect(inboundMessageSchema.parse({ type: 'export-session' })).toEqual({
+      type: 'export-session',
+    });
+  });
+
+  it('accepts importEvents on the start message', () => {
+    expect(
+      inboundMessageSchema.parse({
+        type: 'start',
+        prompt: 'hi',
+        importEvents: [
+          {
+            id: 'evt_1',
+            aggregate_id: 'ses_1',
+            seq: 1,
+            type: 'session.created',
+            data: { id: 'ses_1' },
+          },
+        ],
+      }),
+    ).toEqual({
+      type: 'start',
+      prompt: 'hi',
+      importEvents: [
+        {
+          id: 'evt_1',
+          aggregate_id: 'ses_1',
+          seq: 1,
+          type: 'session.created',
+          data: { id: 'ses_1' },
+        },
+      ],
+    });
+  });
+
+  it('validates bridge-export replies', () => {
+    expect(
+      outboundMessageSchema.parse({
+        type: 'bridge-export',
+        data: { openCodeSessionId: 'ses_1', syncEvents: [] },
+      }),
+    ).toEqual({
+      type: 'bridge-export',
+      data: { openCodeSessionId: 'ses_1', syncEvents: [] },
+    });
+    expect(
+      outboundMessageSchema.parse({
+        type: 'bridge-export',
+        error: { message: 'no session' },
+      }),
+    ).toEqual({
+      type: 'bridge-export',
+      error: { message: 'no session' },
+    });
   });
 });

--- a/packages/harness-opencode/src/opencode-bridge-protocol.ts
+++ b/packages/harness-opencode/src/opencode-bridge-protocol.ts
@@ -9,6 +9,21 @@ import { z } from 'zod/v4';
 export const outboundMessageSchema = harnessV1BridgeOutboundMessageSchema;
 export type OutboundMessage = z.infer<typeof outboundMessageSchema>;
 
+/**
+ * One OpenCode sync event as returned by `POST /sync/history`. Rounded to the
+ * fields `POST /sync/replay` needs (plus the `aggregate_id` → `aggregateID`
+ * rename the replay request requires).
+ */
+export const openCodeSyncEventSchema = z.looseObject({
+  id: z.string(),
+  aggregate_id: z.string(),
+  seq: z.number(),
+  type: z.string(),
+  data: z.record(z.string(), z.unknown()),
+});
+
+export type OpenCodeSyncEvent = z.infer<typeof openCodeSyncEventSchema>;
+
 export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
   operation: z.enum(['prompt', 'compact']).optional(),
   provider: z.string().optional(),
@@ -16,6 +31,13 @@ export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
   instructions: z.string().optional(),
   resumeSessionId: z.string().optional(),
   mcpServers: z.record(z.string(), z.unknown()).optional(),
+  /**
+   * One-shot: present only on the first `start` after
+   * `doStart({ importFrom })`. The bridge replays these events into the
+   * OpenCode server before resolving the session, reconstructing the exported
+   * conversation in this sandbox.
+   */
+  importEvents: z.array(openCodeSyncEventSchema).optional(),
 });
 
 export type StartMessage = z.infer<typeof startMessageSchema>;

--- a/packages/harness-opencode/src/opencode-harness.test.ts
+++ b/packages/harness-opencode/src/opencode-harness.test.ts
@@ -688,6 +688,202 @@ describe('createOpenCode adapter', () => {
     await session.doDestroy();
   });
 
+  describe('session export/import', () => {
+    function createSandboxSession() {
+      const emptyStream = () =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        });
+      const sandbox = {
+        async run({ command }: { command: string }) {
+          return command === 'printf "%s" "$HOME"'
+            ? { exitCode: 0, stdout: '/home/vercel-sandbox', stderr: '' }
+            : { exitCode: 0, stdout: '', stderr: '' };
+        },
+        async readTextFile() {
+          return null;
+        },
+        async spawn() {
+          return {
+            stdout: emptyStream(),
+            stderr: emptyStream(),
+            async wait() {},
+            async kill() {},
+          };
+        },
+      };
+      return {
+        id: 'test-sandbox',
+        defaultWorkingDirectory: '/workspace',
+        restricted: () => sandbox,
+        ports: [4000] as ReadonlyArray<number>,
+        async getPortEndpoint() {
+          return { url: 'ws://sandbox.example' };
+        },
+        async getPortUrl() {
+          return 'ws://sandbox.example';
+        },
+        async stop() {},
+      } as unknown as HarnessV1NetworkSandboxSession;
+    }
+
+    const syncEvents = [
+      {
+        id: 'evt_1',
+        aggregate_id: 'ses_1',
+        seq: 1,
+        type: 'session.created',
+        data: { id: 'ses_1' },
+      },
+      {
+        id: 'evt_2',
+        aggregate_id: 'ses_1',
+        seq: 2,
+        type: 'message.updated',
+        data: { id: 'msg_1' },
+      },
+    ];
+
+    beforeEach(() => {
+      harnessUtilsMocks.channels.length = 0;
+      harnessUtilsMocks.waitForBridgeReady.mockReset();
+      harnessUtilsMocks.waitForBridgeReady.mockResolvedValue({ port: 4000 });
+    });
+
+    it('exports the session via export-session and shapes the payload', async () => {
+      const session = await createOpenCode().doStart({
+        sessionId: 's1',
+        sandboxSession: createSandboxSession(),
+        sessionWorkDir: '/workspace/project',
+      });
+      const channel = harnessUtilsMocks.channels.at(-1)!;
+      channel.emit('bridge-thread', {
+        type: 'bridge-thread',
+        threadId: 'ses_1',
+      });
+
+      const pending = session.doExportSession!();
+      expect(channel.sent).toContainEqual({ type: 'export-session' });
+      channel.emit('bridge-export', {
+        type: 'bridge-export',
+        data: { openCodeSessionId: 'ses_1', syncEvents },
+      });
+      await expect(pending).resolves.toEqual({
+        type: 'session-export',
+        harnessId: 'opencode',
+        specificationVersion: 'harness-v1',
+        data: { openCodeSessionId: 'ses_1', syncEvents },
+      });
+
+      await session.doDestroy();
+    });
+
+    it('surfaces bridge export errors', async () => {
+      const session = await createOpenCode().doStart({
+        sessionId: 's1',
+        sandboxSession: createSandboxSession(),
+        sessionWorkDir: '/workspace/project',
+      });
+      const channel = harnessUtilsMocks.channels.at(-1)!;
+      channel.emit('bridge-thread', {
+        type: 'bridge-thread',
+        threadId: 'ses_1',
+      });
+
+      const pending = session.doExportSession!();
+      channel.emit('bridge-export', {
+        type: 'bridge-export',
+        error: { message: 'The OpenCode bridge has no session to export yet.' },
+      });
+      await expect(pending).rejects.toThrow(
+        'OpenCode session export failed: The OpenCode bridge has no session to export yet.',
+      );
+
+      await session.doDestroy();
+    });
+
+    it('refuses to export before a turn has established a session', async () => {
+      const session = await createOpenCode().doStart({
+        sessionId: 's1',
+        sandboxSession: createSandboxSession(),
+        sessionWorkDir: '/workspace/project',
+      });
+      await expect(session.doExportSession!()).rejects.toThrow(
+        'has no OpenCode session to export yet',
+      );
+      await session.doDestroy();
+    });
+
+    it('seeds the first start with importEvents and the exported session id', async () => {
+      const session = await createOpenCode().doStart({
+        sessionId: 's1',
+        sandboxSession: createSandboxSession(),
+        sessionWorkDir: '/workspace/project',
+        importFrom: {
+          type: 'session-export',
+          harnessId: 'opencode',
+          specificationVersion: 'harness-v1',
+          data: { openCodeSessionId: 'ses_1', syncEvents },
+        },
+      });
+      expect(session.isResume).toBe(true);
+      const channel = harnessUtilsMocks.channels.at(-1)!;
+
+      await session.doPromptTurn({ prompt: 'recall', emit: () => {} });
+      expect(channel.sent.at(-1)).toMatchObject({
+        type: 'start',
+        prompt: 'recall',
+        resumeSessionId: 'ses_1',
+        importEvents: syncEvents,
+      });
+
+      await session.doPromptTurn({ prompt: 'again', emit: () => {} });
+      expect(channel.sent.at(-1)).toMatchObject({
+        type: 'start',
+        prompt: 'again',
+      });
+      expect(
+        (channel.sent.at(-1) as { importEvents?: unknown }).importEvents,
+      ).toBeUndefined();
+
+      await session.doDestroy();
+    });
+
+    it('refuses exports produced by other harnesses', async () => {
+      await expect(
+        createOpenCode().doStart({
+          sessionId: 's1',
+          sandboxSession: createSandboxSession(),
+          sessionWorkDir: '/workspace/project',
+          importFrom: {
+            type: 'session-export',
+            harnessId: 'claude-code',
+            specificationVersion: 'harness-v1',
+            data: {},
+          },
+        }),
+      ).rejects.toBeInstanceOf(HarnessCapabilityUnsupportedError);
+    });
+
+    it('refuses malformed export payloads', async () => {
+      await expect(
+        createOpenCode().doStart({
+          sessionId: 's1',
+          sandboxSession: createSandboxSession(),
+          sessionWorkDir: '/workspace/project',
+          importFrom: {
+            type: 'session-export',
+            harnessId: 'opencode',
+            specificationVersion: 'harness-v1',
+            data: { openCodeSessionId: 'ses_1' },
+          },
+        }),
+      ).rejects.toThrow('malformed session export payload');
+    });
+  });
+
   describe('getBootstrap', () => {
     it('returns a recipe with the expected harnessId and bootstrapDir', async () => {
       const harness = createOpenCode();

--- a/packages/harness-opencode/src/opencode-harness.ts
+++ b/packages/harness-opencode/src/opencode-harness.ts
@@ -16,6 +16,7 @@ import {
   type HarnessV1PortEndpoint,
   type HarnessV1ResumeSessionState,
   type HarnessV1Session,
+  type HarnessV1SessionExport,
   type HarnessV1Skill,
   type HarnessV1StreamPart,
 } from '@ai-sdk/harness';
@@ -58,8 +59,10 @@ import {
   type OpenCodeAuthOptions,
 } from './opencode-auth';
 import {
+  openCodeSyncEventSchema,
   outboundMessageSchema,
   type InboundMessage,
+  type OpenCodeSyncEvent,
   type OutboundMessage,
 } from './opencode-bridge-protocol';
 import { VERSION } from './version';
@@ -220,6 +223,11 @@ const openCodeResumeStateSchema = z.object({
   bridge: openCodeBridgeCoordsSchema.optional(),
 });
 
+const openCodeSessionExportDataSchema = z.object({
+  openCodeSessionId: z.string().optional(),
+  syncEvents: z.array(openCodeSyncEventSchema).optional(),
+});
+
 type OpenCodeBridgeCoords = z.infer<typeof openCodeBridgeCoordsSchema>;
 
 export function createOpenCode(
@@ -315,6 +323,33 @@ export function createOpenCode(
           : undefined;
       const coords = resumeData?.bridge;
 
+      const importFrom = startOpts.importFrom;
+      let importSessionId: string | undefined;
+      let importEvents: ReadonlyArray<OpenCodeSyncEvent> | undefined;
+      if (importFrom != null) {
+        if (importFrom.harnessId !== 'opencode') {
+          throw new HarnessCapabilityUnsupportedError({
+            harnessId: 'opencode',
+            message: `The OpenCode harness cannot import a session export produced by harness '${importFrom.harnessId}'.`,
+          });
+        }
+        const parsed = openCodeSessionExportDataSchema.safeParse(
+          importFrom.data,
+        );
+        if (
+          !parsed.success ||
+          parsed.data.syncEvents == null ||
+          parsed.data.syncEvents.length === 0
+        ) {
+          throw new Error(
+            'The OpenCode harness received a malformed session export payload.',
+          );
+        }
+        importSessionId = parsed.data.openCodeSessionId;
+        importEvents = parsed.data.syncEvents;
+      }
+      const isImport = importEvents != null;
+
       const workDir = startOpts.sessionWorkDir;
       const sessionDataDir = `${defaultWorkingDirectory}/.agent-runs/${startOpts.sessionId}`;
       const bridgeStateDir = `${sessionDataDir}/bridge`;
@@ -382,6 +417,7 @@ export function createOpenCode(
             permissionMode: startOpts.permissionMode,
             builtinToolFiltering: startOpts.builtinToolFiltering,
             supportsUserMessageResponses: () => supportsUserMessageResponses,
+            importEvents: undefined,
           });
         } catch {}
       }
@@ -531,9 +567,10 @@ export function createOpenCode(
         provider: settings.provider,
         reasoningVariant: settings.reasoningVariant,
         mcpServers: settings.mcpServers,
-        openCodeSessionId: resumeSessionId,
-        isResume: respawnStrategy !== undefined,
-        seedResumeSessionOnFirstPrompt: respawnStrategy !== undefined,
+        openCodeSessionId: resumeSessionId ?? importSessionId,
+        isResume: respawnStrategy !== undefined || isImport,
+        seedResumeSessionOnFirstPrompt:
+          respawnStrategy !== undefined || isImport,
         rerunContinue: respawnStrategy === 'rerun',
         bridgePort: boundPort,
         bridgeToken: token,
@@ -542,6 +579,7 @@ export function createOpenCode(
         permissionMode: startOpts.permissionMode,
         builtinToolFiltering: startOpts.builtinToolFiltering,
         supportsUserMessageResponses: () => supportsUserMessageResponses,
+        importEvents,
       });
     },
   };
@@ -769,6 +807,7 @@ function createSession({
   permissionMode,
   builtinToolFiltering,
   supportsUserMessageResponses,
+  importEvents,
 }: {
   sessionId: string;
   channel: OpenCodeChannel;
@@ -788,6 +827,7 @@ function createSession({
   permissionMode: HarnessV1PermissionMode | undefined;
   builtinToolFiltering: HarnessV1BuiltinToolFiltering | undefined;
   supportsUserMessageResponses: () => boolean;
+  importEvents: ReadonlyArray<OpenCodeSyncEvent> | undefined;
 }): HarnessV1Session {
   let stopped = false;
   let stopPromise: Promise<void> | undefined;
@@ -795,6 +835,9 @@ function createSession({
   let pendingResumeSessionId = seedResumeSessionOnFirstPrompt
     ? openCodeSessionId
     : undefined;
+  // One-shot: rides only the first `start` message, which replays the exported
+  // conversation into the fresh OpenCode server before the session resolves.
+  let pendingImportEvents = importEvents;
   let activeTurn = false;
   const pendingCompactionParts: HarnessV1StreamPart[] = [];
 
@@ -960,6 +1003,14 @@ function createSession({
     ...(debug ? { debug } : {}),
   });
 
+  const takePendingImportEvents = ():
+    | ReadonlyArray<OpenCodeSyncEvent>
+    | undefined => {
+    const events = pendingImportEvents;
+    pendingImportEvents = undefined;
+    return events;
+  };
+
   return {
     sessionId,
     isResume,
@@ -979,6 +1030,7 @@ function createSession({
         emit: promptOpts.emit,
         abortSignal: promptOpts.abortSignal,
       });
+      const importEventsForStart = takePendingImportEvents();
       channel.send({
         type: 'start',
         operation: 'prompt',
@@ -993,6 +1045,9 @@ function createSession({
           : { responseFormat: promptOpts.responseFormat }),
         ...(promptOpts.instructions
           ? { instructions: promptOpts.instructions }
+          : {}),
+        ...(importEventsForStart
+          ? { importEvents: [...importEventsForStart] }
           : {}),
         ...startBase(),
       });
@@ -1015,6 +1070,7 @@ function createSession({
         abortSignal: continueOpts.abortSignal,
       });
       if (rerunContinue) {
+        const importEventsForStart = takePendingImportEvents();
         channel.send({
           type: 'start',
           operation: 'prompt',
@@ -1029,6 +1085,9 @@ function createSession({
             : { responseFormat: continueOpts.responseFormat }),
           ...(continueOpts.instructions
             ? { instructions: continueOpts.instructions }
+            : {}),
+          ...(importEventsForStart
+            ? { importEvents: [...importEventsForStart] }
             : {}),
           ...startBase(),
         });
@@ -1059,6 +1118,7 @@ function createSession({
         debug,
         mcpServers,
         resumeSessionId: latestOpenCodeSessionId,
+        importEvents: takePendingImportEvents(),
         onCompaction: part => pendingCompactionParts.push(part),
       });
     },
@@ -1205,6 +1265,73 @@ function createSession({
       };
       return payload;
     },
+    doExportSession: async (): Promise<HarnessV1SessionExport> => {
+      if (stopped) {
+        throw new Error(
+          `OpenCode session ${sessionId} is already stopped; cannot export.`,
+        );
+      }
+      if (activeTurn) {
+        throw new Error(
+          `OpenCode session ${sessionId} cannot export during an active turn.`,
+        );
+      }
+      if (latestOpenCodeSessionId == null) {
+        throw new Error(
+          `OpenCode session ${sessionId} has no OpenCode session to export yet; run a prompt turn first.`,
+        );
+      }
+      const reply = await new Promise<{
+        data?: unknown;
+        error?: { message: string };
+      }>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          unsub();
+          reject(
+            new Error(
+              `OpenCode session ${sessionId} did not reply to export-session within 30s.`,
+            ),
+          );
+        }, 30_000);
+        timer.unref?.();
+        const unsub = channel.on('bridge-export', msg => {
+          clearTimeout(timer);
+          unsub();
+          resolve(msg);
+        });
+        try {
+          channel.send({ type: 'export-session' });
+        } catch (err) {
+          clearTimeout(timer);
+          unsub();
+          reject(err);
+        }
+      });
+      if (reply.error != null) {
+        throw new Error(
+          `OpenCode session export failed: ${reply.error.message}`,
+        );
+      }
+      const parsed = openCodeSessionExportDataSchema.safeParse(reply.data);
+      if (
+        !parsed.success ||
+        parsed.data.openCodeSessionId == null ||
+        parsed.data.syncEvents == null
+      ) {
+        throw new Error(
+          'The OpenCode bridge returned a malformed session export payload.',
+        );
+      }
+      return {
+        type: 'session-export',
+        harnessId: 'opencode',
+        specificationVersion: 'harness-v1',
+        data: {
+          openCodeSessionId: parsed.data.openCodeSessionId,
+          syncEvents: parsed.data.syncEvents,
+        } as HarnessV1SessionExport['data'],
+      };
+    },
   };
 }
 
@@ -1216,6 +1343,7 @@ async function runCompactOperation({
   debug,
   mcpServers,
   resumeSessionId,
+  importEvents,
   onCompaction,
 }: {
   channel: OpenCodeChannel;
@@ -1225,6 +1353,7 @@ async function runCompactOperation({
   debug: HarnessV1DebugConfig | undefined;
   mcpServers: Record<string, unknown> | undefined;
   resumeSessionId: string | undefined;
+  importEvents: ReadonlyArray<OpenCodeSyncEvent> | undefined;
   onCompaction: (part: HarnessV1StreamPart) => void;
 }): Promise<void> {
   let pendingResolve: (() => void) | undefined;
@@ -1254,6 +1383,9 @@ async function runCompactOperation({
     ...(mcpServers == null ? {} : { mcpServers }),
     ...(permissionMode ? { permissionMode } : {}),
     ...(resumeSessionId ? { resumeSessionId } : {}),
+    ...(importEvents && importEvents.length > 0
+      ? { importEvents: [...importEvents] }
+      : {}),
     ...(debug ? { debug } : {}),
   });
   await done;

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -98,7 +98,7 @@ const agent = new HarnessAgent({
 });
 ```
 
-Use `session.detach()` to park a bridge-backed session for later attach, `session.stop()` to save state and stop the sandbox, or `session.destroy()` to clean up without keeping resume state. Bridge-backed adapters such as Claude Code, Codex, OpenCode, and DeepAgents require a network sandbox session that exposes ports — `@ai-sdk/sandbox-vercel` is the supported choice today. `@ai-sdk/sandbox-just-bash` is suitable only for host-runtime or otherwise non-bridge flows, such as Pi.
+Use `session.detach()` to park a bridge-backed session for later attach, `session.stop()` to save state and stop the sandbox, or `session.destroy()` to clean up without keeping resume state. `session.exportSession()` (supported by the OpenCode adapter) snapshots the full conversation as a payload that survives the sandbox — later `agent.createSession({ sessionId, importFrom })` reconstructs it in a fresh sandbox after the original is gone. Bridge-backed adapters such as Claude Code, Codex, OpenCode, and DeepAgents require a network sandbox session that exposes ports — `@ai-sdk/sandbox-vercel` is the supported choice today. `@ai-sdk/sandbox-just-bash` is suitable only for host-runtime or otherwise non-bridge flows, such as Pi.
 
 `sandbox` is an optional `HarnessV1SandboxProvider`. When omitted, pass a `HarnessV1NetworkSandboxSession` to every `agent.createSession({ sandboxSession })` call. Use `sandboxConfig` for agent specific sandbox configuration that works independently from the sandbox provider that is used:
 
@@ -133,6 +133,12 @@ formats carry a caller-provided JSON Schema plus optional name and description;
 the adapter must enforce the schema and emit the resulting JSON through normal
 text parts. If the runtime cannot honor the format, throw
 `HarnessCapabilityUnsupportedError` before starting the turn.
+
+Adapters that can snapshot the runtime's native conversation state expose an
+optional `doExportSession()` on the session; the host persists the returned
+`HarnessV1SessionExport` beyond the sandbox's lifetime and replays it with
+`doStart({ importFrom })` in a fresh sandbox. Absence of the method signals the
+adapter does not support it.
 
 Bootstrap recipe paths may be absolute or relative. Relative `bootstrapDir` and
 file paths are resolved against `sandboxSession.defaultWorkingDirectory`.

--- a/packages/harness/src/agent/harness-agent-session.ts
+++ b/packages/harness/src/agent/harness-agent-session.ts
@@ -25,11 +25,15 @@ import type {
   HarnessAgentPendingToolResult,
   HarnessAgentPrompt,
   HarnessAgentResumeSessionState,
+  HarnessAgentSessionExport,
   HarnessAgentToolSpec,
 } from './harness-agent-types';
 import type { HarnessAgentToolApprovalContinuation } from './harness-agent-tool-approval-continuation';
 import type { HarnessAgentToolResultContinuation } from './harness-agent-tool-result-continuation';
-import { validateLifecycleStateData } from './internal/lifecycle-state-validation';
+import {
+  validateLifecycleStateData,
+  validateSessionExportData,
+} from './internal/lifecycle-state-validation';
 import { runPrompt } from './internal/run-prompt';
 import { getRestrictedSandboxSession } from '../utils/get-restricted-sandbox-session';
 
@@ -107,8 +111,8 @@ export class HarnessAgentSession {
     | undefined;
 
   /**
-   * Whether this session was created from `resumeFrom` or `continueFrom`.
-   * Captured at construction so it survives lifecycle cleanup.
+   * Whether this session was created from `resumeFrom`, `continueFrom`, or
+   * `importFrom`. Captured at construction so it survives lifecycle cleanup.
    */
   readonly isResume: boolean;
 
@@ -393,6 +397,37 @@ export class HarnessAgentSession {
     }
 
     await control.submitUserMessage(text);
+  }
+
+  /**
+   * Export the complete conversation state as a payload that survives the
+   * sandbox, for a later `agent.createSession({ sessionId, importFrom })` in a
+   * fresh sandbox. Non-destructive: the session stays active afterwards.
+   *
+   * Throws `HarnessCapabilityUnsupportedError` when the harness adapter does
+   * not implement `doExportSession`, and when a turn is currently active.
+   */
+  async exportSession(): Promise<HarnessAgentSessionExport> {
+    if (this.sessionState !== 'active' || this.underlyingSession == null) {
+      throw new Error(
+        `Harness session ${this.sessionId} is not active and cannot be exported.`,
+      );
+    }
+    if (this.underlyingSession.doExportSession == null) {
+      throw new HarnessCapabilityUnsupportedError({
+        harnessId: this.harness.harnessId,
+        message: `Harness '${this.harness.harnessId}' does not support session export.`,
+      });
+    }
+    if (this.turnState !== 'idle') {
+      throw new Error(
+        `Harness session ${this.sessionId} cannot export during an active turn.`,
+      );
+    }
+    return validateSessionExportData({
+      harness: this.harness,
+      state: await this.underlyingSession.doExportSession(),
+    });
   }
 
   /**

--- a/packages/harness/src/agent/harness-agent-types.ts
+++ b/packages/harness/src/agent/harness-agent-types.ts
@@ -16,6 +16,7 @@ import type {
   HarnessV1PromptTurnOptions,
   HarnessV1ResumeSessionState,
   HarnessV1Session,
+  HarnessV1SessionExport,
   HarnessV1Skill,
   HarnessV1StartOptions,
   HarnessV1StreamPart,
@@ -45,6 +46,7 @@ export type HarnessAgentToolSpec = HarnessV1ToolSpec;
 export type HarnessAgentLifecycleState = HarnessV1LifecycleState;
 export type HarnessAgentResumeSessionState = HarnessV1ResumeSessionState;
 export type HarnessAgentContinueTurnState = HarnessV1ContinueTurnState;
+export type HarnessAgentSessionExport = HarnessV1SessionExport;
 export type HarnessAgentPendingToolApproval = HarnessV1PendingToolApproval;
 export type HarnessAgentPendingToolResult = HarnessV1PendingToolResult;
 

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -8,6 +8,7 @@ import type {
   HarnessV1PromptTurnOptions,
   HarnessV1ResumeSessionState,
   HarnessV1SandboxProvider,
+  HarnessV1SessionExport,
   HarnessV1Session,
   HarnessV1StreamPart,
   HarnessV1ToolSpec,
@@ -46,6 +47,7 @@ function mockHarness(options: {
   onPromptTurn?: (options: HarnessV1PromptTurnOptions) => void;
   promptDone?: (options: HarnessV1PromptTurnOptions) => Promise<void>;
   supportsSteering?: boolean;
+  sessionExport?: () => HarnessV1SessionExport;
   onSuspendTurn?: () => void | Promise<void>;
   continueScript?: (
     submitToolResult: (input: {
@@ -70,6 +72,7 @@ function mockHarness(options: {
   doStop: ReturnType<typeof vi.fn>;
   doDestroy: ReturnType<typeof vi.fn>;
   doCompact: ReturnType<typeof vi.fn>;
+  doExportSession: ReturnType<typeof vi.fn>;
 } {
   const prompts: HarnessV1PromptTurnOptions['prompt'][] = [];
   const toolResults: { toolCallId: string; output: unknown }[] = [];
@@ -95,6 +98,16 @@ function mockHarness(options: {
   const doDestroy = vi.fn(async () => {});
   const doCompact = vi.fn(async (_customInstructions?: string) => {});
   const doDetach = vi.fn(async () => resumeState);
+  const doExportSession = vi.fn(async () =>
+    options.sessionExport
+      ? options.sessionExport()
+      : {
+          type: 'session-export' as const,
+          harnessId: 'mock',
+          specificationVersion: 'harness-v1' as const,
+          data: {},
+        },
+  );
   const doSuspendTurn = vi.fn(async () => {
     await options.onSuspendTurn?.();
     return continueState;
@@ -168,6 +181,7 @@ function mockHarness(options: {
     doDestroy,
     doContinueTurn,
     doSuspendTurn,
+    ...(options.sessionExport ? { doExportSession } : {}),
   };
 
   return {
@@ -193,6 +207,7 @@ function mockHarness(options: {
     doDetach,
     doContinueTurn,
     doSuspendTurn,
+    doExportSession,
     doStop,
     doDestroy,
     doCompact,
@@ -1977,6 +1992,116 @@ describe('HarnessAgent', () => {
         } as HarnessV1ResumeSessionState,
       }),
     ).rejects.toThrow(/cannot contain pending tool results/);
+  });
+
+  test('exportSession() returns the adapter export and keeps the session usable', async () => {
+    const sessionExport: HarnessV1SessionExport = {
+      type: 'session-export',
+      harnessId: 'mock',
+      specificationVersion: 'harness-v1',
+      data: { events: [] },
+    };
+    const { harness, doExportSession } = mockHarness({
+      script: () => [],
+      sessionExport: () => sessionExport,
+    });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession({ sessionId: 's1' });
+
+    await expect(session.exportSession()).resolves.toEqual(sessionExport);
+    expect(doExportSession).toHaveBeenCalledTimes(1);
+    // Non-destructive: the session remains active.
+    await expect(session.exportSession()).resolves.toEqual(sessionExport);
+
+    await session.destroy();
+    await expect(session.exportSession()).rejects.toThrow(/cannot be exported/);
+  });
+
+  test('exportSession() throws HarnessCapabilityUnsupportedError when the adapter omits doExportSession', async () => {
+    const { harness } = mockHarness({ script: () => [] });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+    const session = await agent.createSession({ sessionId: 's1' });
+
+    await expect(session.exportSession()).rejects.toBeInstanceOf(
+      HarnessCapabilityUnsupportedError,
+    );
+    await session.destroy();
+  });
+
+  test('createSession({ importFrom }) hands the export to a fresh-sandbox doStart', async () => {
+    const sessionExport: HarnessV1SessionExport = {
+      type: 'session-export',
+      harnessId: 'mock',
+      specificationVersion: 'harness-v1',
+      data: { events: [] },
+    };
+    const startOptions: Array<Parameters<HarnessV1['doStart']>[0]> = [];
+    const { harness } = mockHarness({
+      script: () => [],
+      sessionExport: () => sessionExport,
+      onDoStart: opts => startOptions.push(opts),
+    });
+    const sandboxSession = makeSandboxSession();
+    const createSession = vi.fn(async () => sandboxSession);
+    const resumeSession = vi.fn(async () => sandboxSession);
+    const agent = new HarnessAgent({
+      harness,
+      sandbox: {
+        specificationVersion: 'harness-sandbox-v1',
+        providerId: 'mock-sandbox',
+        createSession,
+        resumeSession,
+      },
+    });
+
+    const session = await agent.createSession({
+      sessionId: 's1',
+      importFrom: sessionExport,
+    });
+
+    expect(startOptions.at(0)?.importFrom).toEqual(sessionExport);
+    expect(createSession).toHaveBeenCalledTimes(1);
+    expect(resumeSession).not.toHaveBeenCalled();
+
+    await session.destroy();
+  });
+
+  test('createSession() rejects importFrom combined with resumeFrom', async () => {
+    const { harness } = mockHarness({ script: () => [] });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+
+    await expect(
+      agent.createSession({
+        importFrom: {
+          type: 'session-export',
+          harnessId: 'mock',
+          specificationVersion: 'harness-v1',
+          data: {},
+        },
+        resumeFrom: {
+          type: 'resume-session',
+          harnessId: 'mock',
+          specificationVersion: 'harness-v1',
+          data: {},
+        },
+      }),
+    ).rejects.toThrow(/cannot be combined with `resumeFrom`/);
+  });
+
+  test('createSession() rejects exports produced by another harness', async () => {
+    const { harness } = mockHarness({ script: () => [] });
+    const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });
+
+    await expect(
+      agent.createSession({
+        importFrom: {
+          type: 'session-export',
+          harnessId: 'other-harness',
+          specificationVersion: 'harness-v1',
+          data: {},
+        },
+      }),
+    ).rejects.toThrow(/produced by harness 'other-harness'/);
   });
 
   test('host-side tools are executed and the result is submitted back', async () => {

--- a/packages/harness/src/agent/harness-agent.ts
+++ b/packages/harness/src/agent/harness-agent.ts
@@ -38,6 +38,7 @@ import type {
   HarnessAgentPermissionMode,
   HarnessAgentPrompt,
   HarnessAgentResumeSessionState,
+  HarnessAgentSessionExport,
   HarnessAgentToolSpec,
 } from './harness-agent-types';
 import {
@@ -59,7 +60,10 @@ import {
   validateSandboxBootstrapSettings,
 } from './internal/sandbox-bootstrap';
 import { buildObservability } from './internal/resolve-observability';
-import { validateLifecycleStateData } from './internal/lifecycle-state-validation';
+import {
+  validateLifecycleStateData,
+  validateSessionExportData,
+} from './internal/lifecycle-state-validation';
 import {
   permissionModeNeedsBuiltinSupport,
   resolvePermissionMode,
@@ -104,7 +108,10 @@ export interface HarnessAgentCallExtensions {
  *    harness's `lifecycleStateSchema` before handing it to the adapter.
  *    `createSession({ sessionId, continueFrom })` resumes from state returned
  *    by `session.suspendTurn()` before `continueStream()` /
- *    `continueGenerate()`.
+ *    `continueGenerate()`. `createSession({ sessionId, importFrom })`
+ *    reconstructs a conversation from `session.exportSession()` state in a
+ *    fresh sandbox — sandbox-independent, for when the original sandbox no
+ *    longer exists.
  *  - **Host tool execution.** User tools passed in `settings.tools` are
  *    executed on the host whenever the underlying runtime calls them;
  *    the result is fed back to the harness via `submitToolResult`.
@@ -238,6 +245,13 @@ export class HarnessAgent<
      */
     continueFrom?: HarnessAgentContinueTurnState;
     /**
+     * Export payload returned by a prior `session.exportSession()`. Reconstructs
+     * the exported conversation in a fresh sandbox — unlike `resumeFrom`, it does
+     * not require the original sandbox to still exist. Mutually exclusive with
+     * `resumeFrom` and `continueFrom`.
+     */
+    importFrom?: HarnessAgentSessionExport;
+    /**
      * Existing sandbox session to run the harness in. When provided, the
      * caller retains ownership of the sandbox lifecycle.
      */
@@ -247,6 +261,7 @@ export class HarnessAgent<
     const sessionId = options?.sessionId ?? generateId();
     const resumeFrom = options?.resumeFrom;
     const continueFrom = options?.continueFrom;
+    const importFrom = options?.importFrom;
     const providedSandboxSession = options?.sandboxSession;
     const abortSignal = options?.abortSignal;
     const harness = this.settings.harness;
@@ -258,6 +273,16 @@ export class HarnessAgent<
         'HarnessAgent.createSession: pass either `resumeFrom` or `continueFrom`, not both.',
       );
     }
+    if (importFrom != null && (resumeFrom != null || continueFrom != null)) {
+      throw new Error(
+        'HarnessAgent.createSession: `importFrom` targets a fresh sandbox and cannot be combined with `resumeFrom` or `continueFrom`.',
+      );
+    }
+
+    const validatedImportFrom =
+      importFrom == null
+        ? undefined
+        : validateSessionExportData({ harness, state: importFrom });
 
     let validatedResumeFrom: HarnessAgentResumeSessionState | undefined;
     if (resumeFrom != null) {
@@ -435,6 +460,7 @@ export class HarnessAgent<
         skills: this.settings.skills,
         resumeFrom: validatedResumeFrom,
         continueFrom: effectiveContinueFrom,
+        importFrom: validatedImportFrom,
         permissionMode: this.permissionMode,
         builtinToolFiltering: this.builtinToolFiltering,
         abortSignal,

--- a/packages/harness/src/agent/internal/lifecycle-state-validation.ts
+++ b/packages/harness/src/agent/internal/lifecycle-state-validation.ts
@@ -1,6 +1,10 @@
 import { safeValidateTypes } from '@ai-sdk/provider-utils';
 import { HarnessError } from '../../errors/harness-error';
-import type { HarnessV1, HarnessV1LifecycleState } from '../../v1';
+import type {
+  HarnessV1,
+  HarnessV1LifecycleState,
+  HarnessV1SessionExport,
+} from '../../v1';
 
 /**
  * Validate a lifecycle state against the harness's contract:
@@ -105,4 +109,34 @@ export async function validateLifecycleStateData<
       ? { pendingToolResults: state.pendingToolResults }
       : {}),
   } as STATE;
+}
+
+/**
+ * Validate a session export against the harness's contract: `type` must be
+ * `'session-export'`, `specificationVersion` must be `'harness-v1'`, and
+ * `harnessId` must match the harness that will import it. The adapter owns the
+ * export `data` shape, so — unlike lifecycle state — no schema is applied here;
+ * the adapter re-validates `data` in `doStart({ importFrom })`.
+ */
+export function validateSessionExportData(input: {
+  harness: HarnessV1;
+  state: HarnessV1SessionExport;
+}): HarnessV1SessionExport {
+  const { harness, state } = input;
+  if (state.type !== 'session-export') {
+    throw new HarnessError({
+      message: `Session export has unexpected type '${state.type}'; expected 'session-export'.`,
+    });
+  }
+  if (state.specificationVersion !== 'harness-v1') {
+    throw new HarnessError({
+      message: `Session export has unexpected specificationVersion '${state.specificationVersion}'; expected 'harness-v1'.`,
+    });
+  }
+  if (state.harnessId !== harness.harnessId) {
+    throw new HarnessError({
+      message: `Session export was produced by harness '${state.harnessId}' but this agent uses '${harness.harnessId}'.`,
+    });
+  }
+  return state;
 }

--- a/packages/harness/src/bridge/index.test.ts
+++ b/packages/harness/src/bridge/index.test.ts
@@ -13,9 +13,11 @@ afterEach(async () => {
 async function startBridge({
   onStart,
   onStop,
+  onExportSession,
 }: {
   onStart: (start: { type: 'start' }, turn: BridgeTurn) => Promise<void>;
   onStop?: () => unknown;
+  onExportSession?: () => unknown;
 }): Promise<BridgeHandle> {
   const handle = await runBridge<{ type: 'start' }>({
     bridgeType: 'test',
@@ -24,6 +26,7 @@ async function startBridge({
     token: TOKEN,
     onStart,
     ...(onStop ? { onStop } : {}),
+    ...(onExportSession ? { onExportSession } : {}),
     // Never call process.exit from a test.
     onExit: () => {},
   });
@@ -597,5 +600,78 @@ describe('runBridge', () => {
       expect(onDestroy).toHaveBeenCalledTimes(1);
       expect(exited).toBe(true);
     });
+  });
+
+  it('answers export-session with the onExportSession payload', async () => {
+    const handle = await startBridge({
+      onStart: async (_start, turn) => turn.emit({ type: 'finish' }),
+      onExportSession: async () => ({ openCodeSessionId: 'ses_1' }),
+    });
+
+    const client = await connect(handle.port);
+    await client.waitFor(f => f.type === 'bridge-hello');
+    client.send({ type: 'export-session' });
+
+    const reply = await client.waitFor(f => f.type === 'bridge-export');
+    expect(reply.data).toEqual({ openCodeSessionId: 'ses_1' });
+    expect(reply.error).toBeUndefined();
+  });
+
+  it('replies with an error when the bridge has no export support', async () => {
+    const handle = await startBridge({
+      onStart: async (_start, turn) => turn.emit({ type: 'finish' }),
+    });
+
+    const client = await connect(handle.port);
+    await client.waitFor(f => f.type === 'bridge-hello');
+    client.send({ type: 'export-session' });
+
+    const reply = await client.waitFor(f => f.type === 'bridge-export');
+    expect(reply.data).toBeUndefined();
+    expect(reply.error).toEqual({
+      message: 'The test bridge does not support session export.',
+    });
+  });
+
+  it('replies with an error when onExportSession throws', async () => {
+    const handle = await startBridge({
+      onStart: async (_start, turn) => turn.emit({ type: 'finish' }),
+      onExportSession: async () => {
+        throw new Error('no session yet');
+      },
+    });
+
+    const client = await connect(handle.port);
+    await client.waitFor(f => f.type === 'bridge-hello');
+    client.send({ type: 'export-session' });
+
+    const reply = await client.waitFor(f => f.type === 'bridge-export');
+    expect(reply.data).toBeUndefined();
+    expect(reply.error).toEqual({ message: 'no session yet' });
+  });
+
+  it('does not claim the event stream for export-session', async () => {
+    const handle = await startBridge({
+      onStart: async (_start, turn) => turn.emit({ type: 'finish' }),
+      onExportSession: async () => ({ openCodeSessionId: 'ses_1' }),
+    });
+
+    const a = await connect(handle.port);
+    await a.waitFor(f => f.type === 'bridge-hello');
+    a.send({ type: 'start' });
+    await a.waitFor(f => f.type === 'finish'); // A owns the stream
+
+    const b = await connect(handle.port);
+    await b.waitFor(f => f.type === 'bridge-hello');
+    b.send({ type: 'export-session' });
+    const reply = await b.waitFor(f => f.type === 'bridge-export');
+    expect(reply.data).toEqual({ openCodeSessionId: 'ses_1' });
+
+    // A still owns the stream: the next turn's events go to it, not to B.
+    a.send({ type: 'start' });
+    await a.waitFor(
+      f => f.type === 'finish' && typeof f.seq === 'number' && f.seq > 1,
+    );
+    expect(b.frames.some(f => f.type === 'finish')).toBe(false);
   });
 });

--- a/packages/harness/src/bridge/index.ts
+++ b/packages/harness/src/bridge/index.ts
@@ -301,6 +301,12 @@ export interface RunBridgeOptions<TStart extends { type: 'start' }> {
    */
   onStop?(): unknown | Promise<unknown>;
   /**
+   * Produce the adapter-defined session export payload for `export-session`.
+   * The reply is a `bridge-export` control frame answered on the requesting
+   * socket. When omitted, the bridge replies with an error instead.
+   */
+  onExportSession?(): unknown | Promise<unknown>;
+  /**
    * Perform adapter-defined destruction before the bridge exits.
    */
   onDestroy?(): void | Promise<void>;
@@ -334,7 +340,8 @@ type InboundControl =
   | { type: 'abort' }
   | { type: 'stop' }
   | { type: 'destroy' }
-  | { type: 'resume'; lastSeenEventId: number };
+  | { type: 'resume'; lastSeenEventId: number }
+  | { type: 'export-session' };
 
 const WS_OPEN = 1;
 
@@ -354,7 +361,14 @@ export interface BridgeHandle {
 export async function runBridge<TStart extends { type: 'start' }>(
   options: RunBridgeOptions<TStart>,
 ): Promise<BridgeHandle> {
-  const { bridgeType, bridgeStateDir, onStart, onStop, onDestroy } = options;
+  const {
+    bridgeType,
+    bridgeStateDir,
+    onStart,
+    onStop,
+    onExportSession,
+    onDestroy,
+  } = options;
   const expectedToken = options.token ?? procEnv.BRIDGE_CHANNEL_TOKEN ?? '';
   const bridgeWsPort =
     options.port ?? parseInt(procEnv.BRIDGE_WS_PORT ?? '0', 10);
@@ -796,6 +810,29 @@ export async function runBridge<TStart extends { type: 'start' }>(
         const data = (await onStop?.()) ?? {};
         sendControl(ws, { type: 'bridge-stop', data });
         drainThenExit(ws, 1000, 'stop');
+        return;
+      }
+      case 'export-session': {
+        // Control frame: reply only to the requester, never claim the event
+        // stream or disturb an idle/active bridge.
+        if (onExportSession == null) {
+          sendControl(ws, {
+            type: 'bridge-export',
+            error: {
+              message: `The ${bridgeType} bridge does not support session export.`,
+            },
+          });
+          return;
+        }
+        try {
+          const data = await onExportSession();
+          sendControl(ws, { type: 'bridge-export', data });
+        } catch (err) {
+          sendControl(ws, {
+            type: 'bridge-export',
+            error: { message: formatBridgeError(err).message },
+          });
+        }
         return;
       }
     }

--- a/packages/harness/src/v1/harness-v1-bridge-protocol.ts
+++ b/packages/harness/src/v1/harness-v1-bridge-protocol.ts
@@ -157,6 +157,17 @@ export const harnessV1BridgeStopSchema = z.object({
 });
 
 /**
+ * The bridge's reply to an inbound `export-session`: either the
+ * adapter-specific payload the host serializes into a session export, or an
+ * error when the bridge cannot export (unsupported, or export failed).
+ */
+export const harnessV1BridgeExportSchema = z.object({
+  type: z.literal('bridge-export'),
+  data: z.unknown().optional(),
+  error: z.object({ message: z.string() }).optional(),
+});
+
+/**
  * A resume coordinate the bridge proactively announces (e.g. Codex's thread id)
  * so the host can cache it for a later resume without waiting for `stop`.
  */
@@ -225,6 +236,7 @@ export const harnessV1BridgeOutboundMessageSchema = z.discriminatedUnion(
     harnessV1BridgeHelloSchema,
     experimental_harnessV1BridgeUserMessageResponseSchema,
     harnessV1BridgeStopSchema,
+    harnessV1BridgeExportSchema,
     harnessV1BridgeThreadSchema,
     harnessV1BridgeSandboxLogSchema,
     harnessV1BridgeDebugEventSchema,
@@ -335,6 +347,16 @@ export const harnessV1BridgeStopInboundSchema = z.object({
 });
 
 /**
+ * Ask the bridge to export the complete session state as a payload that
+ * survives the sandbox. The bridge replies with `bridge-export` — a control
+ * frame answered on the requesting socket, so it neither claims the event
+ * stream nor disturbs an idle bridge.
+ */
+export const harnessV1BridgeExportSessionInboundSchema = z.object({
+  type: z.literal('export-session'),
+});
+
+/**
  * The inbound command members shared by every bridge adapter. Spread these
  * alongside the adapter's own `start` schema to build the final inbound union:
  * `z.discriminatedUnion('type', [adapterStartSchema, ...harnessV1BridgeInboundCommandSchemas])`.
@@ -347,6 +369,7 @@ export const harnessV1BridgeInboundCommandSchemas = [
   harnessV1BridgeDestroyInboundSchema,
   harnessV1BridgeResumeInboundSchema,
   harnessV1BridgeStopInboundSchema,
+  harnessV1BridgeExportSessionInboundSchema,
 ] as const;
 
 /**

--- a/packages/harness/src/v1/harness-v1-lifecycle-state.ts
+++ b/packages/harness/src/v1/harness-v1-lifecycle-state.ts
@@ -72,6 +72,20 @@ export type HarnessV1ContinueTurnState = HarnessV1LifecycleStateBase & {
   readonly pendingToolResults?: readonly HarnessV1PendingToolResult[];
 };
 
+/**
+ * Opaque payload returned by `HarnessV1Session.doExportSession` and accepted by
+ * a future `HarnessV1.doStart({ importFrom })` to reconstruct the exported
+ * conversation in a fresh sandbox.
+ *
+ * Unlike the lifecycle states, an export is not tied to the lifetime of the
+ * sandbox that produced it: the host may persist it as JSON indefinitely and
+ * replay it after the original sandbox is gone (snapshot expiry, garbage
+ * collection, or an invalidating template change).
+ */
+export type HarnessV1SessionExport = HarnessV1LifecycleStateBase & {
+  readonly type: 'session-export';
+};
+
 export type HarnessV1LifecycleState =
   | HarnessV1ResumeSessionState
   | HarnessV1ContinueTurnState;

--- a/packages/harness/src/v1/harness-v1-session.ts
+++ b/packages/harness/src/v1/harness-v1-session.ts
@@ -8,6 +8,7 @@ import type { HarnessV1ResponseFormat } from './harness-v1-response-format';
 import type {
   HarnessV1ContinueTurnState,
   HarnessV1ResumeSessionState,
+  HarnessV1SessionExport,
 } from './harness-v1-lifecycle-state';
 import type { HarnessV1Skill } from './harness-v1-skill';
 import type { HarnessV1StreamPart } from './harness-v1-stream-part';
@@ -48,6 +49,15 @@ export type HarnessV1StartOptions = {
    * in a shape ready for `doContinueTurn` rather than for a fresh prompt.
    */
   readonly continueFrom?: HarnessV1ContinueTurnState;
+
+  /**
+   * Optional export payload returned by a prior session's `doExportSession`.
+   * When provided, the adapter reconstructs the exported conversation in this
+   * sandbox before accepting a new prompt. Unlike `resumeFrom`, the payload is
+   * not tied to the lifetime of the sandbox that produced it, so it can be
+   * replayed into a fresh sandbox after the original one is gone.
+   */
+  readonly importFrom?: HarnessV1SessionExport;
 
   /**
    * Approval policy for built-in adapter-native tool use. Custom host-executed
@@ -197,8 +207,8 @@ export type HarnessV1Session = {
   readonly sessionId: string;
 
   /**
-   * Whether this session was created from `resumeFrom` or `continueFrom`. Fresh
-   * sessions report `false`; resumed sessions report `true`.
+   * Whether this session was created from `resumeFrom`, `continueFrom`, or
+   * `importFrom`. Fresh sessions report `false`; resumed sessions report `true`.
    */
   readonly isResume: boolean;
 
@@ -273,6 +283,18 @@ export type HarnessV1Session = {
    * session handoff. Required on every adapter.
    */
   doSuspendTurn(): PromiseLike<HarnessV1ContinueTurnState>;
+
+  /**
+   * Export the complete conversation state as a payload the host can persist
+   * beyond the lifetime of the sandbox, and later reconstruct with
+   * `HarnessV1.doStart({ importFrom })` in a fresh sandbox.
+   *
+   * Optional — adapters that cannot produce a sandbox-independent export omit
+   * the method, and that absence is the capability signal. Only valid between
+   * turns. Unlike `doDetach`, exporting is non-destructive: the session stays
+   * usable and the underlying runtime keeps running.
+   */
+  doExportSession?(): PromiseLike<HarnessV1SessionExport>;
 
   /**
    * Detach from the underlying runtime without tearing it down, returning a

--- a/packages/harness/src/v1/index.ts
+++ b/packages/harness/src/v1/index.ts
@@ -39,6 +39,7 @@ export type {
   HarnessV1PendingToolApproval,
   HarnessV1PendingToolResult,
   HarnessV1ResumeSessionState,
+  HarnessV1SessionExport,
 } from './harness-v1-lifecycle-state';
 export type {
   HarnessV1NetworkPolicy,


### PR DESCRIPTION
Fixes #18939

## Problem

`HarnessV1ResumeSessionState` only works while the originating sandbox still exists. When the sandbox is lost (snapshot expiry, provider garbage collection, or an invalidating template change), the conversation becomes unrecoverable — a returning user silently loses the whole thread. There was no seam in the v1 contract for a host that persists its own transcript to hand state back to the harness, because the resume payload is opaque and sandbox-bound, and the contract states prior turns are never replayed across it.

## Solution

A capability pair on the harness contract, mirroring the issue's proposal:

- **`HarnessV1SessionExport`** — a new opaque, host-persistable payload (`type: 'session-export'`) that is *not* tied to sandbox lifetime.
- **`HarnessV1Session.doExportSession?()`** — optional method; export is non-destructive (the session stays usable) and only valid between turns. Absence of the method is the capability signal, following the contract's documented convention that optional features are signalled by method presence rather than a static capabilities flag.
- **`HarnessV1StartOptions.importFrom`** — reconstructs an exported conversation before the first prompt.

Mirrored on the `HarnessAgent` surface as `session.exportSession()` and `createSession({ sessionId, importFrom })`, with the same harness-id validation as `resumeFrom`/`continueFrom` (mutually exclusive with them; import targets a fresh sandbox, so it never routes through `sandboxProvider.resumeSession`).

### OpenCode adapter implementation

Uses OpenCode's native sync API, verified in the issue's spike to preserve role boundaries, tool calls/results, compaction state, and the original session id exactly:

- `doExportSession()` sends a new `export-session` bridge command; the bridge calls `POST /sync/history` and replies with a `bridge-export` control frame carrying `{ openCodeSessionId, syncEvents }`.
- `doStart({ importFrom })` seeds the first `start` message with `importEvents` plus the exported `resumeSessionId`; the bridge replays them through `POST /sync/replay` in the fresh OpenCode server before resolving the session (`ensureSession`).

Transport-wise, `export-session` is served as a control frame — it replies on the requesting socket only and never claims the bridge's event stream, so an idle or actively-streaming bridge is undisturbed.

### Notes for reviewers

- I followed the contract's existing capability convention (optional method presence) rather than adding a `supportsSessionExport` boolean as the issue sketched — happy to add the flag too if you prefer an adapter-level signal available before `doStart`.
- The sync-event wire shapes differ slightly between the two endpoints (`aggregate_id` on export vs `aggregateID` on replay); the mapping lives in `packages/harness-opencode/src/bridge/opencode-sync.ts` with unit tests.
- The bridge's sandbox-pinned `@opencode-ai/sdk` 1.18.3 already ships the sync API, so no lockfile change was needed.

## Tests

- `runBridge` export-session round-trip: payload reply, unsupported reply, hook-throws reply, and event-stream ownership preserved.
- OpenCode adapter: `doExportSession` round-trip and error surfacing, refusal before a session exists, one-shot `importEvents` seeding on the first start (absent on the second), foreign-harness and malformed-export rejection.
- `HarnessAgent`: `exportSession()` passthrough + capability error + post-destroy refusal, `importFrom` reaching `doStart` on the fresh-sandbox path, mutual-exclusion and harness-id validation.
- Sync helpers: history unwrapping, `aggregate_id` → `aggregateID` mapping, replay session-id reading.
- Full suites pass: `@ai-sdk/harness` (272 tests), `@ai-sdk/harness-opencode` (84 tests); type-check, lint, and builds pass for both packages and all downstream harness adapters.