### PR TITLE
fix(gateway): report the served model id in streamed response-metadata

### DIFF
--- a/.changeset/quiet-moons-model.md
+++ b/.changeset/quiet-moons-model.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/gateway": patch
+---
+
+fix(gateway): report the served model id in streaming `response-metadata` instead of the upstream provider's model name
+
+The Gateway translates upstream provider responses, and the `response-metadata` frames it emits named the upstream provider's own model (e.g. Google's `gemini-3-flash-preview`) rather than the gateway model that was requested and served, so `streamText`'s `step.response.modelId` reported a stale, wrong model while every other record (`x-model-id` header, routing metadata) named the served one. The gateway language model now rewrites the streamed `response-metadata.modelId` to the `x-model-id` response header when present (it also survives fallback routing), falling back to the requested model id.

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -1390,6 +1390,100 @@ describe('GatewayLanguageModel', () => {
     });
   });
 
+  describe('response-metadata model id', () => {
+    it('should report the served model from the x-model-id header instead of the upstream provider model', async () => {
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        headers: { 'x-model-id': 'google/gemini-3.6-flash' },
+        chunks: [
+          `data: {"type":"stream-start","warnings":[]}\n\n`,
+          `data: {"type":"response-metadata","id":"test-id","modelId":"gemini-3-flash-preview"}\n\n`,
+          `data: {"type":"text-delta","textDelta":"Hello"}\n\n`,
+          `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
+        ],
+      };
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+      expect(chunks[1]).toMatchObject({
+        type: 'response-metadata',
+        id: 'test-id',
+        modelId: 'google/gemini-3.6-flash',
+      });
+    });
+
+    it('should match the x-model-id header case-insensitively', async () => {
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        headers: { 'X-Model-Id': 'google/gemini-3.6-flash' },
+        chunks: [
+          `data: {"type":"stream-start","warnings":[]}\n\n`,
+          `data: {"type":"response-metadata","id":"test-id","modelId":"gemini-3-flash-preview"}\n\n`,
+          `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
+        ],
+      };
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+      expect(chunks[1]).toMatchObject({
+        type: 'response-metadata',
+        modelId: 'google/gemini-3.6-flash',
+      });
+    });
+
+    it('should fall back to the requested model id when no x-model-id header is present', async () => {
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"stream-start","warnings":[]}\n\n`,
+          `data: {"type":"response-metadata","id":"test-id","modelId":"gemini-3-flash-preview"}\n\n`,
+          `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
+        ],
+      };
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+      expect(chunks[1]).toMatchObject({
+        type: 'response-metadata',
+        modelId: 'test-model',
+      });
+    });
+
+    it('should report the requested model id when the response-metadata chunk omits modelId', async () => {
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"stream-start","warnings":[]}\n\n`,
+          `data: {"type":"response-metadata","id":"test-id"}\n\n`,
+          `data: {"type":"finish","finishReason":"stop","usage":{"prompt_tokens":10,"completion_tokens":5}}\n\n`,
+        ],
+      };
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+      expect(chunks[1]).toMatchObject({
+        type: 'response-metadata',
+        modelId: 'test-model',
+      });
+    });
+  });
+
   describe('Provider Options', () => {
     function prepareJsonResponse({
       content = { type: 'text', text: '' },

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -142,6 +142,14 @@ export class GatewayLanguageModel implements LanguageModelV4 {
         fetch: this.config.fetch,
       });
 
+      // The Gateway translates upstream provider responses, and the
+      // `response-metadata` frames it emits name the upstream provider's own
+      // model (e.g. Google's `gemini-3-flash-preview`) rather than the gateway
+      // model that was requested and served. Surface the served model instead:
+      // the `x-model-id` response header is authoritative (it also survives
+      // fallback routing); the requested model id is the fallback.
+      const servedModelId =
+        readResponseHeader(responseHeaders, 'x-model-id') ?? this.modelId;
       return {
         stream: response.pipeThrough(
           new TransformStream<
@@ -163,12 +171,14 @@ export class GatewayLanguageModel implements LanguageModelV4 {
                   return; // Skip raw chunks if not requested
                 }
 
-                if (
-                  streamPart.type === 'response-metadata' &&
-                  streamPart.timestamp &&
-                  typeof streamPart.timestamp === 'string'
-                ) {
-                  streamPart.timestamp = new Date(streamPart.timestamp);
+                if (streamPart.type === 'response-metadata') {
+                  if (
+                    streamPart.timestamp &&
+                    typeof streamPart.timestamp === 'string'
+                  ) {
+                    streamPart.timestamp = new Date(streamPart.timestamp);
+                  }
+                  streamPart.modelId = servedModelId;
                 }
 
                 controller.enqueue(streamPart);
@@ -240,4 +250,20 @@ function maybeBase64EncodeFileData<T extends { type: string }>(data: T): T {
     }
   }
   return data;
+}
+
+function readResponseHeader(
+  headers: Record<string, string> | undefined,
+  name: string,
+): string | undefined {
+  if (headers == null) {
+    return undefined;
+  }
+  const lowerCaseName = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lowerCaseName) {
+      return value;
+    }
+  }
+  return undefined;
 }


### PR DESCRIPTION
Fixes #18118

## Problem

`streamText` through the Vercel AI Gateway reports a stale, wrong model in `step.response.modelId` / `step.model.modelId`: it names the **upstream provider's own model** (e.g. Google's `gemini-3-flash-preview`) instead of the gateway model that was requested and served (`google/gemini-3.6-flash`).

Every other record in the same response names the served model — the `x-model-id` response header, `providerMetadata.gateway.routing.canonicalSlug`, and the model attempt records — so only the surfaced `modelId` lies. The reporter's benchmark harness mislabeled five saved reports before anyone noticed.

## Root cause

The Gateway service translates upstream provider responses back into AI SDK stream parts, and the `response-metadata` frames it emits carry the upstream provider's model name. `GatewayLanguageModel.doStream` passed those frames through unmodified, and the `ai` package prefers `response-metadata.modelId` over the model instance's id when assembling `step.response`.

## Fix

In `GatewayLanguageModel.doStream`, rewrite the streamed `response-metadata.modelId` to the model the Gateway actually served:

1. Prefer the `x-model-id` response header (authoritative, and stays correct under fallback routing). Read case-insensitively.
2. Fall back to the requested model id (`gateway('google/gemini-3.6-flash')`) when the header is absent.

`generateText` is unaffected — it takes `modelId` from the model instance, which is already the requested gateway id. The raw upstream name remains available through `response.headers` and the routing provider metadata.

## Tests

Four new cases in `gateway-language-model.test.ts`:
- `x-model-id` header overrides an upstream model name in the frame
- header matching is case-insensitive
- absent header falls back to the requested model id
- a frame that omits `modelId` still reports the requested model id

Full `@ai-sdk/gateway` suite passes (513 tests), plus type-check, lint, and build.