### PR TITLE
fix: use del-cli in clean scripts so package builds work on Windows

### DIFF
--- a/.changeset/clean-windows-scripts.md
+++ b/.changeset/clean-windows-scripts.md
@@ -1,0 +1,10 @@
+---
+"@ai-sdk/test-server": patch
+"@ai-sdk/mcp": patch
+"@ai-sdk/huggingface": patch
+"@ai-sdk/baseten": patch
+---
+
+fix: use `del-cli` in `clean` scripts so package builds work on Windows
+
+Four packages still ran `rm -rf` in their `clean` script, which fails on Windows PowerShell/CMD and broke `pnpm build` / `pnpm test` there. They now use the cross-platform `del-cli` (already a root devDependency) like every other package.

--- a/packages/baseten/package.json
+++ b/packages/baseten/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
     "build:watch": "pnpm clean && tsup --watch",
-    "clean": "rm -rf dist docs *.tsbuildinfo",
+    "clean": "del-cli dist docs *.tsbuildinfo",
     "prepack": "mkdir -p docs && cp ../../content/providers/01-ai-sdk-providers/170-baseten.mdx ./docs/",
     "postpack": "del-cli docs",
     "type-check": "tsc --build",

--- a/packages/huggingface/package.json
+++ b/packages/huggingface/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
     "build:watch": "pnpm clean && tsup --watch",
-    "clean": "rm -rf dist docs *.tsbuildinfo",
+    "clean": "del-cli dist docs *.tsbuildinfo",
     "prepack": "mkdir -p docs && cp ../../content/providers/01-ai-sdk-providers/170-huggingface.mdx ./docs/",
     "postpack": "del-cli docs",
     "type-check": "tsc --build",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
     "build:watch": "pnpm clean && tsup --watch",
-    "clean": "rm -rf dist *.tsbuildinfo",
+    "clean": "del-cli dist *.tsbuildinfo",
     "type-check": "tsc --build",
     "test": "pnpm test:node && pnpm test:edge",
     "test:update": "pnpm test:node -u",

--- a/packages/test-server/package.json
+++ b/packages/test-server/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
     "build:watch": "pnpm clean && tsup --watch",
-    "clean": "rm -rf dist *.tsbuildinfo",
+    "clean": "del-cli dist *.tsbuildinfo",
     "type-check": "tsc --build",
     "test": "pnpm test:node && pnpm test:edge",
     "test:update": "pnpm test:node -u",


### PR DESCRIPTION
Fixes #17951

## Problem

`pnpm build` / `pnpm test` fail on Windows because four packages still run `rm -rf` in their `clean` script, and PowerShell/CMD have no native `rm`:

```
'rm' is not recognized as an internal or external command, operable program or batch file.
```

Every other package in the repo already uses the cross-platform `del-cli`.

## Fix

Switch the `clean` script of the four remaining packages to `del-cli` with the same paths the old `rm -rf` removed:

- `@ai-sdk/test-server`: `del-cli dist *.tsbuildinfo`
- `@ai-sdk/mcp`: `del-cli dist *.tsbuildinfo`
- `@ai-sdk/huggingface`: `del-cli dist docs *.tsbuildinfo`
- `@ai-sdk/baseten`: `del-cli dist docs *.tsbuildinfo`

No dependency changes are needed — `del-cli@^5.1.0` is already a workspace root devDependency, which is how the other packages consume it.

## Verification

Ran `pnpm clean` followed by `pnpm build` in all four packages — clean succeeds via `del-cli` and builds regenerate their output.