### PR TITLE
fix(ai): invoke toUIMessageStream / createUIMessageStream onError only once per error

### DIFF
--- a/.changeset/on-error-once.md
+++ b/.changeset/on-error-once.md
@@ -1,0 +1,7 @@
+---
+"ai": patch
+---
+
+fix: invoke `toUIMessageStream` / `createUIMessageStream` `onError` only once per error
+
+When `onEnd`/`onFinish` or step callbacks forced `handleUIMessageStreamFinish` to process the stream, `processUIMessageStream` re-reported every `error` chunk even though the callback had already run when the chunk was produced — so `onError` fired twice per upstream error, the second time with a re-wrapped `new Error(errorText)` instead of the original error. Error chunks flowing through the finish handler are no longer re-reported; failures thrown from the step callbacks themselves still surface through `onError`.

--- a/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/create-ui-message-stream.test.ts
@@ -267,6 +267,29 @@ describe('createUIMessageStream', () => {
     `);
   });
 
+  it('should invoke onError only once per error when onEnd requires stream processing', async () => {
+    const onError = vi.fn(() => 'error-message');
+
+    const stream = createUIMessageStream({
+      execute: () => {
+        throw new Error('execute-error');
+      },
+      onError,
+      // forces handleUIMessageStreamFinish to run processUIMessageStream,
+      // which previously re-reported the error chunk
+      onEnd: () => {},
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toEqual([
+      { type: 'error', errorText: 'error-message' },
+    ]);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ message: 'execute-error' }),
+    );
+  });
+
   it('should add error parts when execute throws with promise', async () => {
     const stream = createUIMessageStream({
       execute: async () => {

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.test.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.test.ts
@@ -456,6 +456,59 @@ describe('handleUIMessageStreamFinish', () => {
     });
   });
 
+  describe('error reporting', () => {
+    it('should not invoke onError for error chunks when processing the stream', async () => {
+      const inputChunks: UIMessageChunk[] = [
+        { type: 'start', messageId: 'msg-123' },
+        { type: 'error', errorText: 'already reported upstream' },
+        { type: 'finish' },
+      ];
+
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream: createUIMessageStream(inputChunks),
+        messageId: 'msg-123',
+        originalMessages: [],
+        onError: mockErrorHandler,
+        // forces the processUIMessageStream path
+        onEnd: () => {},
+      });
+
+      expect(await convertReadableStreamToArray(resultStream)).toEqual(
+        inputChunks,
+      );
+      // the error chunk was already reported through the caller's onError
+      // when it was produced; re-reporting here would invoke it twice
+      expect(mockErrorHandler).not.toHaveBeenCalled();
+    });
+
+    it('should invoke onError when the step callback throws', async () => {
+      const resultStream = handleUIMessageStreamFinish<UIMessage>({
+        stream: createUIMessageStream([
+          { type: 'start', messageId: 'msg-123' },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'finish-step' },
+          { type: 'finish' },
+        ]),
+        messageId: 'msg-123',
+        originalMessages: [],
+        onError: mockErrorHandler,
+        onStepEnd: () => {
+          throw new Error('step-callback-error');
+        },
+      });
+
+      await convertReadableStreamToArray(resultStream);
+
+      expect(mockErrorHandler).toHaveBeenCalledTimes(1);
+      expect(mockErrorHandler).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ message: 'step-callback-error' }),
+      );
+    });
+  });
+
   describe('onStepFinish callback', () => {
     it('should call onStepEnd when finish-step chunk is encountered', async () => {
       const onStepEndCallback = vi.fn();

--- a/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
+++ b/packages/ai/src/ui-message-stream/handle-ui-message-stream-finish.ts
@@ -163,7 +163,14 @@ export function handleUIMessageStreamFinish<UI_MESSAGE extends UIMessage>({
   return processUIMessageStream<UI_MESSAGE>({
     stream: idInjectedStream,
     runUpdateMessageJob,
-    onError,
+    // Error chunks on this stream have already been through the caller's
+    // `onError`: `toUIMessageStream` and `createUIMessageStream` invoke it as
+    // an error → errorText transformer when they produce the chunk. Re-
+    // reporting the chunks here would call `onError` a second time per error
+    // (and with a re-wrapped `new Error(errorText)` instead of the original
+    // error). The `onError` above still surfaces failures thrown from the
+    // step callbacks themselves.
+    onError: () => {},
   }).pipeThrough(
     new TransformStream<
       InferUIMessageChunk<UI_MESSAGE>,

--- a/packages/ai/src/ui-message-stream/to-ui-message-stream.test.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-stream.test.ts
@@ -155,6 +155,35 @@ describe('toUIMessageStream', () => {
     expect(chunks).toEqual([{ type: 'error', errorText: 'handled: boom' }]);
   });
 
+  it('invokes onError only once per error when onEnd requires stream processing', async () => {
+    const onError = vi.fn(error => `handled: ${(error as Error).message}`);
+    const parts: TextStreamPart<{}>[] = [
+      { type: 'start' },
+      { type: 'error', error: new Error('boom') },
+    ];
+
+    const chunks = await convertReadableStreamToArray(
+      toUIMessageStream({
+        stream: convertArrayToReadableStream(parts),
+        tools: undefined,
+        onError,
+        // forces handleUIMessageStreamFinish to run processUIMessageStream,
+        // which previously re-reported the error chunk
+        onEnd: () => {},
+      }),
+    );
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ message: 'boom' }),
+    );
+    expect(chunks).toContainEqual({
+      type: 'error',
+      errorText: 'handled: boom',
+    });
+  });
+
   it('emits separate metadata chunks for non-lifecycle parts', async () => {
     type MetadataUIMessage = UIMessage<{ partType: string }>;
 


### PR DESCRIPTION
Fixes #14726

## Problem

A single `onError` passed to `result.toUIMessageStream({ onError })` (or `createUIMessageStream`) is invoked **twice** per upstream error whenever the finish handling processes the stream — i.e. whenever `onEnd`/`onFinish` or step callbacks are present. Without them, `handleUIMessageStreamFinish` early-returns and the callback fires once, which is why the bug is easy to miss.

Worse than the count: the second invocation receives a **re-wrapped `new Error(errorText)`** rather than the original error object, so consumers logging or classifying errors get a different value the second time.

## Root cause

`onError` in these APIs is an error → errorText *transformer*: both server-side producers invoke it when they create an error chunk —

- `toUIMessageStream` → `toUIMessageChunk`: `errorText: onError(part.error)`
- `createUIMessageStream`: `errorText: onError(error)` in every catch site

`handleUIMessageStreamFinish` then forwarded the same `onError` into `processUIMessageStream`, which reports error chunks again (`onError?.(new Error(chunk.errorText))`) → double invocation.

Client-side consumers of `processUIMessageStream` (`useChat`, `readUIMessageStream`) are unaffected: for them its `onError` is the single, intended error listener.

## Fix

In `handleUIMessageStreamFinish`, stop forwarding `onError` into `processUIMessageStream` — every error chunk on that stream was already reported at production time. The handler's own `onError` remains wired to step-callback failures (`callOnStepFinish`'s catch), which are genuinely new errors.

One behavioral note: a user writing `{ type: 'error', errorText }` into a `createUIMessageStream` writer directly no longer triggers an `onError` invocation when finish callbacks are present (previously it did, but only in that configuration — and with the re-wrapped error). The documented purpose of `onError` there is the errorText transformer.

## Tests

- `toUIMessageStream`: error part with `onEnd` present → `onError` called exactly once, with the original error object
- `createUIMessageStream`: `execute` throws with `onEnd` present → called exactly once, with the original error
- `handleUIMessageStreamFinish`: error chunks pass through without re-invoking `onError`; a throwing step callback still surfaces through `onError`

Full `ai` suite: 3449 passing (4 new). The one failure in `output-declaration.test.ts` reproduces identically on clean `main` (declaration emission flake in the full-suite run; passes in isolation both with and without this change).