### PR TITLE
docs: add Knowl to the agent memory providers

### DIFF
--- a/content/docs/03-agents/06-memory.mdx
+++ b/content/docs/03-agents/06-memory.mdx
@@ -295,7 +295,7 @@ try {
 
 Under the hood this is an MCP server, so you can also wire it with [`createMCPClient`](/docs/reference/ai-sdk-core/create-mcp-client) directly. The package adds project scoping, process lifecycle, and a launcher fix for Windows, where `npx` resolves to `npx.cmd` and cannot be spawned without a shell.
 
-**When to use memory providers**: these providers are a good fit when you want memory without building any storage infrastructure. The tradeoff is that the provider controls memory behavior, so you have less visibility into what gets stored and how it is retrieved. You also take on a dependency on an external service.
+**When to use memory providers**: these providers are a good fit when you want memory without building any storage infrastructure. The tradeoff is that the provider controls memory behavior, so you have less visibility into what gets stored and how it is retrieved. You also take on a dependency on an external service, except where the provider runs locally.
 
 ## Custom Tool
 

--- a/content/docs/03-agents/06-memory.mdx
+++ b/content/docs/03-agents/06-memory.mdx
@@ -256,6 +256,45 @@ Session memory supports two modes: **tool-driven** (the LLM decides when to read
 
 MongoDB memory works with any AI SDK model and embedding provider, with no vendor lock-in beyond MongoDB Atlas.
 
+### Knowl
+
+[Knowl](https://github.com/dat999zx/knowl) is a local-first memory engine for coding agents. It stores decisions, constraints and architecture as typed atoms in SQLite under your project, and resolves conflicts at write time: a fact whose subject and relation match one already stored retires the earlier record, so the stale value stops being a retrieval candidate rather than competing with its replacement. There is no hosted service and no API key.
+
+```bash
+pnpm add @knowl/ai-sdk
+```
+
+Knowl scopes memory to a project directory, so initialize one first:
+
+```bash
+npx -y @dat999zx/knowl init
+```
+
+```ts
+__PROVIDER_IMPORT__;
+import { knowlTools } from '@knowl/ai-sdk';
+import { ToolLoopAgent } from 'ai';
+
+const memory = await knowlTools({ projectRoot: '/srv/app' });
+
+try {
+  const agent = new ToolLoopAgent({
+    model: __MODEL__,
+    tools: memory.tools,
+  });
+
+  const result = await agent.generate({
+    prompt: 'Remember that my favorite editor is Neovim',
+  });
+} finally {
+  await memory.close();
+}
+```
+
+`projectRoot` selects which project's memory the agent reads and writes, so agents given different roots share nothing. The Knowl server runs as a child process, so call `memory.close()` when you are done, or create the client once at module scope and reuse it. Knowl works with any AI SDK provider.
+
+Under the hood this is an MCP server, so you can also wire it with [`createMCPClient`](/docs/reference/ai-sdk-core/create-mcp-client) directly. The package adds project scoping, process lifecycle, and a launcher fix for Windows, where `npx` resolves to `npx.cmd` and cannot be spawned without a shell.
+
 **When to use memory providers**: these providers are a good fit when you want memory without building any storage infrastructure. The tradeoff is that the provider controls memory behavior, so you have less visibility into what gets stored and how it is retrieved. You also take on a dependency on an external service.
 
 ## Custom Tool


### PR DESCRIPTION
Adds Knowl to the memory providers list in `content/docs/03-agents/06-memory.mdx`.

Knowl is a local-first memory engine for coding agents: typed knowledge atoms in SQLite under the project, with conflicts resolved at write time so a superseded fact stops being a retrieval candidate. It speaks MCP, and [`@knowl/ai-sdk`](https://www.npmjs.com/package/@knowl/ai-sdk) adapts its tools for the AI SDK.

Every provider currently on the page is a hosted service behind an API key, so this adds the first entry that runs entirely locally with no account. That is also why the second commit proposes a one-clause amendment to the closing paragraph, which currently tells readers they "take on a dependency on an external service" as a blanket statement about the whole section. It is a separate commit so you can take the entry and drop the amendment, or the reverse.

The entry follows the Supermemory and Hindsight shape, including the `__PROVIDER_IMPORT__` / `__MODEL__` placeholders and the standard Neovim prompt.

## Verification

Tested against the published server on Windows:

- 27 tools adapt through `createMCPClient`, each carrying an input schema
- project scoping verified by experiment rather than assumption: an atom written under one `projectRoot` is retrieved there and is correctly absent under another
- the client closes without leaving the child process behind

## One AI SDK bug found on the way, unrelated to this PR

Wiring `Experimental_StdioMCPTransport` to `npx` fails on Windows with `EINVAL`. `npx` resolves to `npx.cmd`, Node refuses to spawn `.cmd` files without `shell: true` since the fix for CVE-2024-27980, and `mcp-stdio` hardcodes `shell: false` (`dist/mcp-stdio/index.js`) with no override exposed on `StdioConfig`.

This affects any stdio MCP server launched via npx on Windows, not just this one. Our package works around it by routing through `cmd.exe /c`. Happy to open a separate issue with a minimal reproduction if that would be useful.

## Disclosure

I am a co-founder of Knowl.
