### PR TITLE
feat(tools-registry): add truthbear

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -586,4 +586,32 @@ console.log(result.text);`,
     websiteUrl: 'https://nitrosend.com',
     npmUrl: 'https://www.npmjs.com/package/@nitrosend/ai-sdk',
   },
+  {
+    slug: 'truthbear',
+    name: 'Truth Bear',
+    description:
+      'Truth Bear returns official-source records for AI agents: every record carries the official source URL, a record_hash you can recompute offline, a freshness stamp, and a did:key signature. The paid tool does not charge you here — it returns the live x402 payment challenge (network / asset / payTo / amount) so your own client can decide. Free tools (verify_citation, find_signal) need no wallet and no API key.',
+    packageName: 'truthbear-ai-sdk',
+    tags: ['data', 'verification', 'official-sources', 'x402'],
+    installCommand: {
+      pnpm: 'pnpm add truthbear-ai-sdk',
+      npm: 'npm install truthbear-ai-sdk',
+      yarn: 'yarn add truthbear-ai-sdk',
+      bun: 'bun add truthbear-ai-sdk',
+    },
+    codeExample: `import { generateText, isStepCount } from 'ai';
+import { truthBearTools } from 'truthbear-ai-sdk';
+
+const { text } = await generateText({
+  model: 'openai/gpt-5-mini',
+  prompt: 'Which Truth Bear signal lines cover US unemployment, and how fresh are they?',
+  tools: truthBearTools(),
+  stopWhen: isStepCount(3),
+});
+
+console.log(text);`,
+    docsUrl: 'https://github.com/CHANGCHINFU/truthbear-integrations#readme',
+    websiteUrl: 'https://truthbear.co',
+    npmUrl: 'https://www.npmjs.com/package/truthbear-ai-sdk',
+  },
 ];


### PR DESCRIPTION
Adds `truthbear-ai-sdk` to the tools registry.

**What it does.** Truth Bear returns official-source records for AI agents. Every record carries the official source URL, a `record_hash` that can be recomputed offline, a freshness stamp, and a `did:key` signature — so a model's citation can be checked rather than taken on trust.

**Two free tools, no key and no wallet:**
- `verify_citation` — given a `record_hash`, recompute it server-side and say whether it is a genuine record and what it attests to.
- `find_signal` — coverage and freshness manifest: which signal lines exist, how many entities each covers, how fresh they are.

**One paid tool, and it cannot charge you from this package.** `get_official_record` is priced per call over [x402](https://x402.org) (USDC on Base). This package has no wallet, reads no environment variable, and is given no way to accept a private key. If you pass your own payment-capable `fetch` (for example `wrapFetchWithPayment` from `x402-fetch`), the purchase completes through *your* client; if you do not, the tool returns the live payment challenge as data — network, asset, `payTo`, amount — and charges nothing. It never settles silently.

**Notes for review**
- The `codeExample` uses only the free tools, so it runs as-is with no wallet and no account.
- No prices are written into the package. They are read at runtime from the live HTTP 402 challenge, so the package cannot quote a stale price.
- Zero runtime dependencies (`ai` and `zod` are peers). MIT.
- Published from GitHub Actions with npm trusted publishing; `truthbear-ai-sdk@0.1.3` carries a [SLSA provenance attestation](https://www.npmjs.com/package/truthbear-ai-sdk).

**Checks run against this change**
- `oxfmt` with this repo's `.oxfmtrc.jsonc` — no changes to the file.
- `tsc --strict` — the entry type-checks against the `Tool` interface.

Source for the package: https://github.com/CHANGCHINFU/truthbear-integrations
