### PR TITLE
Isolate onChunk and onError throws in streamText

### DIFF
--- a/.changeset/quiet-streams-hold.md
+++ b/.changeset/quiet-streams-hold.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Isolate `onChunk` and `onError` throws in `streamText` so they do not break the stream or hide the original provider error.

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -10218,6 +10218,49 @@ describe('streamText', () => {
       expect(onStepFinish).toHaveBeenCalledOnce();
       expect(onFinish).toHaveBeenCalledOnce();
     });
+
+    it('should isolate onChunk throws from the stream', async () => {
+      const onFinish = vi.fn();
+
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'Hello' },
+            { type: 'text-end', id: '1' },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+            },
+          ]),
+        }),
+        prompt: 'test-input',
+        onChunk() {
+          throw new Error('chunk callback failed');
+        },
+        onFinish,
+      });
+
+      const [textChunks, parts, steps] = await Promise.all([
+        convertAsyncIterableToArray(result.textStream),
+        convertAsyncIterableToArray(result.fullStream),
+        result.steps,
+      ]);
+
+      expect(textChunks).toStrictEqual(['Hello']);
+      expect(parts.map(part => part.type)).toStrictEqual([
+        'start',
+        'start-step',
+        'text-start',
+        'text-delta',
+        'text-end',
+        'finish-step',
+        'finish',
+      ]);
+      expect(steps).toHaveLength(1);
+      expect(onFinish).toHaveBeenCalled();
+    });
   });
 
   describe('options.onError', () => {
@@ -10275,6 +10318,77 @@ describe('streamText', () => {
       await expect(resultObject.steps).resolves.toHaveLength(1);
       expect(onStepFinish).toHaveBeenCalledOnce();
       expect(onFinish).toHaveBeenCalledOnce();
+    });
+
+    it('should isolate onError throws from the stream and preserve the provider error', async () => {
+      const onFinish = vi.fn();
+      const providerError = new Error('provider api failure');
+
+      const result = streamText({
+        model: createTestModel({
+          stream: convertArrayToReadableStream([
+            {
+              type: 'response-metadata',
+              id: 'id-0',
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            { type: 'text-start', id: '1' },
+            { type: 'text-delta', id: '1', delta: 'Hello' },
+            { type: 'error', error: providerError },
+            {
+              type: 'finish',
+              finishReason: { unified: 'error', raw: undefined },
+              usage: testUsage,
+            },
+          ]),
+        }),
+        prompt: 'test-input',
+        onError() {
+          throw new Error('my rethrow');
+        },
+        onFinish,
+      });
+
+      const [textChunks, parts, steps] = await Promise.all([
+        convertAsyncIterableToArray(result.textStream),
+        convertAsyncIterableToArray(result.fullStream),
+        result.steps,
+      ]);
+
+      expect(textChunks).toStrictEqual(['Hello']);
+      expect(parts.filter(part => part.type === 'error')).toStrictEqual([
+        { type: 'error', error: providerError },
+      ]);
+      expect(steps).toHaveLength(1);
+      expect(steps[0].finishReason).toBe('error');
+      expect(onFinish).toHaveBeenCalled();
+    });
+
+    it('should not reject result promises with an onError throw when doStream fails', async () => {
+      const providerError = new Error('provider api failure');
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => {
+            throw providerError;
+          },
+        }),
+        prompt: 'test-input',
+        onError() {
+          throw new Error('my rethrow');
+        },
+      });
+
+      const parts = await convertAsyncIterableToArray(result.fullStream);
+
+      expect(parts.filter(part => part.type === 'error')).toStrictEqual([
+        { type: 'error', error: providerError },
+      ]);
+
+      await expect(result.steps).rejects.toThrow(
+        'No output generated. Check the stream for errors.',
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Throwing from `streamText`'s `onChunk` or `onError` rejected the event-processor `TransformStream`. Downstream consumers then saw the callback error instead of the provider error, and `onFinish` never ran.
- Route both callbacks through `notify()`, the same isolation used by `onStart` / `onFinish` / `onStepFinish`. The original provider error still flows on the stream.
- Fixes #19161

## Test plan

- [x] RED then GREEN: `onChunk` throw does not reject the stream
- [x] RED then GREEN: `onError` throw preserves the provider error and still runs `onFinish`
- [x] RED then GREEN: result promises keep the original `doStream` failure, not the callback throw
- [x] `packages/ai/src/generate-text/stream-text.test.ts` — 418 passed on node and edge