### PR TITLE
docs: update examples to use `instructions` instead of deprecated `system`

### DIFF
--- a/content/cookbook/00-guides/01-rag-chatbot.mdx
+++ b/content/cookbook/00-guides/01-rag-chatbot.mdx
@@ -539,7 +539,7 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: 'openai/gpt-4o',
-    system: `You are a helpful assistant. Check your knowledge base before answering any questions.
+    instructions: `You are a helpful assistant. Check your knowledge base before answering any questions.
     Only respond to questions using information from tool calls.
     if no relevant information is found in the tool calls, respond, "Sorry, I don't know."`,
     messages: await convertToModelMessages(messages),
@@ -585,7 +585,7 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: 'openai/gpt-4o',
-    system: `You are a helpful assistant. Check your knowledge base before answering any questions.
+    instructions: `You are a helpful assistant. Check your knowledge base before answering any questions.
     Only respond to questions using information from tool calls.
     if no relevant information is found in the tool calls, respond, "Sorry, I don't know."`,
     messages: await convertToModelMessages(messages),
@@ -718,7 +718,7 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: 'openai/gpt-4o',
-    system: `You are a helpful assistant. Check your knowledge base before answering any questions.
+    instructions: `You are a helpful assistant. Check your knowledge base before answering any questions.
     Only respond to questions using information from tool calls.
     if no relevant information is found in the tool calls, respond, "Sorry, I don't know."`,
     messages: await convertToModelMessages(messages),
@@ -835,7 +835,7 @@ export async function POST(req: Request) {
     model: 'openai/gpt-4o',
     messages: await convertToModelMessages(messages),
     stopWhen: isStepCount(5),
-    system: `You are a helpful assistant. Check your knowledge base before answering any questions.
+    instructions: `You are a helpful assistant. Check your knowledge base before answering any questions.
     Only respond to questions using information from tool calls.
     if no relevant information is found in the tool calls, respond, "Sorry, I don't know."`,
     tools: {

--- a/content/cookbook/00-guides/03-slackbot.mdx
+++ b/content/cookbook/00-guides/03-slackbot.mdx
@@ -327,7 +327,7 @@ export const generateResponse = async (
 ) => {
   const { text } = await generateText({
     model: __MODEL__,
-    system: `You are a Slack bot assistant. Keep your responses concise and to the point.
+    instructions: `You are a Slack bot assistant. Keep your responses concise and to the point.
     - Do not tag users.
     - Current date is: ${new Date().toISOString().split('T')[0]}`,
     messages,
@@ -360,7 +360,7 @@ export const generateResponse = async (
 ) => {
   const { text } = await generateText({
     model: __MODEL__,
-    system: `You are a Slack bot assistant. Keep your responses concise and to the point.
+    instructions: `You are a Slack bot assistant. Keep your responses concise and to the point.
     - Do not tag users.
     - Current date is: ${new Date().toISOString().split('T')[0]}
     - Always include sources in your final response if you use web search.`,

--- a/content/cookbook/00-guides/04-natural-language-postgres.mdx
+++ b/content/cookbook/00-guides/04-natural-language-postgres.mdx
@@ -273,7 +273,7 @@ export const generateQuery = async (input: string) => {
   try {
     const result = await generateText({
       model: 'openai/gpt-4o',
-      system: `You are a SQL (postgres) ...`, // SYSTEM PROMPT AS ABOVE - OMITTED FOR BREVITY
+      instructions: `You are a SQL (postgres) ...`, // SYSTEM PROMPT AS ABOVE - OMITTED FOR BREVITY
       prompt: `Generate the query necessary to retrieve the data the user wants: ${input}`,
       output: Output.object({
         schema: z.object({
@@ -390,7 +390,7 @@ export const explainQuery = async (input: string, sqlQuery: string) => {
   try {
     const result = await generateText({
       model: 'openai/gpt-4o',
-      system: `You are a SQL (postgres) expert. ...`, // SYSTEM PROMPT AS ABOVE - OMITTED FOR BREVITY
+      instructions: `You are a SQL (postgres) expert. ...`, // SYSTEM PROMPT AS ABOVE - OMITTED FOR BREVITY
       prompt: `Explain the SQL query you generated to retrieve the data the user wanted. Assume the user is not an expert in SQL. Break down the query into steps. Be concise.
 
       User Query:
@@ -437,7 +437,7 @@ export const explainQuery = async (input: string, sqlQuery: string) => {
   try {
     const result = await generateText({
       model: 'openai/gpt-4o',
-      system: `You are a SQL (postgres) expert. ...`, // SYSTEM PROMPT AS ABOVE - OMITTED FOR BREVITY
+      instructions: `You are a SQL (postgres) expert. ...`, // SYSTEM PROMPT AS ABOVE - OMITTED FOR BREVITY
       prompt: `Explain the SQL query you generated to retrieve the data the user wanted. Assume the user is not an expert in SQL. Break down the query into steps. Be concise.
 
       User Query:
@@ -590,7 +590,7 @@ export const generateChartConfig = async (
   try {
     const { output: config } = await generateText({
       model: 'openai/gpt-4o',
-      system: 'You are a data visualization expert.',
+      instructions: 'You are a data visualization expert.',
       prompt: `Given the following data from a SQL query result, generate the chart config that best visualises the data and answers the users query.
       For multiple groups use multi-lines.
 

--- a/content/cookbook/00-guides/21-llama-3_1.mdx
+++ b/content/cookbook/00-guides/21-llama-3_1.mdx
@@ -173,7 +173,7 @@ const problem =
 
 const { text: answer } = await generateText({
   model: deepInfra('meta-llama/Meta-Llama-3.1-70B-Instruct'),
-  system:
+  instructions:
     'You are solving math problems. Reason step by step. Use the calculator when necessary.',
   prompt: problem,
   tools: {

--- a/content/cookbook/01-next/10-generate-text.mdx
+++ b/content/cookbook/01-next/10-generate-text.mdx
@@ -65,7 +65,7 @@ export async function POST(req: Request) {
 
   const { text } = await generateText({
     model: 'openai/gpt-4o',
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     prompt,
   });
 

--- a/content/cookbook/01-next/11-generate-text-with-chat-prompt.mdx
+++ b/content/cookbook/01-next/11-generate-text-with-chat-prompt.mdx
@@ -97,7 +97,7 @@ export async function POST(req: Request) {
 
   const { responseMessages } = await generateText({
     model: 'openai/gpt-4o',
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     messages,
   });
 

--- a/content/cookbook/01-next/20-stream-text.mdx
+++ b/content/cookbook/01-next/20-stream-text.mdx
@@ -58,7 +58,7 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: 'openai/gpt-4o',
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     prompt,
   });
 

--- a/content/cookbook/01-next/21-stream-text-with-chat-prompt.mdx
+++ b/content/cookbook/01-next/21-stream-text-with-chat-prompt.mdx
@@ -91,7 +91,7 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: 'openai/gpt-4o',
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     messages: await convertToModelMessages(messages),
   });
 

--- a/content/cookbook/01-next/24-stream-text-multistep.mdx
+++ b/content/cookbook/01-next/24-stream-text-multistep.mdx
@@ -34,7 +34,7 @@ export async function POST(req: Request) {
       // step 1 example: forced tool call
       const result1 = streamText({
         model: 'openai/gpt-4o-mini',
-        system: 'Extract the user goal from the conversation.',
+        instructions: 'Extract the user goal from the conversation.',
         messages,
         toolChoice: 'required', // force the model to call a tool
         tools: {
@@ -57,7 +57,7 @@ export async function POST(req: Request) {
       const result2 = streamText({
         // different system prompt, different model, no tools:
         model: 'openai/gpt-4o',
-        system:
+        instructions:
           'You are a helpful assistant with a different system prompt. Repeat the extract user goal in your answer.',
         // continue the workflow stream with the messages from the previous step:
         messages: [

--- a/content/cookbook/01-next/25-markdown-chatbot-with-memoization.mdx
+++ b/content/cookbook/01-next/25-markdown-chatbot-with-memoization.mdx
@@ -37,7 +37,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    system:
+    instructions:
       'You are a helpful assistant. Respond to the user in Markdown format.',
     model: 'openai/gpt-4o',
     messages: await convertToModelMessages(messages),

--- a/content/cookbook/01-next/30-generate-object.mdx
+++ b/content/cookbook/01-next/30-generate-object.mdx
@@ -94,7 +94,7 @@ export async function POST(req: Request) {
 
   const result = await generateText({
     model: 'openai/gpt-4o',
-    system: 'You generate three notifications for a messages app.',
+    instructions: 'You generate three notifications for a messages app.',
     prompt,
     output: Output.object({
       schema: z.object({

--- a/content/cookbook/01-next/70-call-tools.mdx
+++ b/content/cookbook/01-next/70-call-tools.mdx
@@ -138,7 +138,7 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: 'openai/gpt-4o',
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     messages: await convertToModelMessages(messages),
     stopWhen: isStepCount(5),
     tools,

--- a/content/cookbook/01-next/72-call-tools-multiple-steps.mdx
+++ b/content/cookbook/01-next/72-call-tools-multiple-steps.mdx
@@ -131,7 +131,7 @@ export async function POST(req: Request) {
 
   const result = streamText({
     model: 'openai/gpt-4o',
-    system: 'You are a helpful assistant.',
+    instructions: 'You are a helpful assistant.',
     messages: await convertToModelMessages(messages),
     stopWhen: isStepCount(5),
     tools,

--- a/content/cookbook/01-next/75-human-in-the-loop.mdx
+++ b/content/cookbook/01-next/75-human-in-the-loop.mdx
@@ -337,7 +337,7 @@ When a user denies a tool execution, the model receives the denial and can respo
 const result = streamText({
   model: openai('gpt-4o'),
   messages,
-  system:
+  instructions:
     'When a tool execution is not approved by the user, do not retry it. ' +
     'Inform the user that the action was not performed.',
   tools: {

--- a/content/cookbook/05-node/11-generate-text-with-chat-prompt.mdx
+++ b/content/cookbook/05-node/11-generate-text-with-chat-prompt.mdx
@@ -16,7 +16,7 @@ import { generateText } from 'ai';
 const result = await generateText({
   model: 'openai/gpt-4o',
   maxOutputTokens: 1024,
-  system: 'You are a helpful chatbot.',
+  instructions: 'You are a helpful chatbot.',
   messages: [
     {
       role: 'user',

--- a/content/cookbook/05-node/21-stream-text-with-chat-prompt.mdx
+++ b/content/cookbook/05-node/21-stream-text-with-chat-prompt.mdx
@@ -17,7 +17,7 @@ import { streamText } from 'ai';
 const result = streamText({
   model: 'openai/gpt-4o',
   maxOutputTokens: 1024,
-  system: 'You are a helpful chatbot.',
+  instructions: 'You are a helpful chatbot.',
   messages: [
     {
       role: 'user',

--- a/content/cookbook/20-rsc/11-generate-text-with-chat-prompt.mdx
+++ b/content/cookbook/20-rsc/11-generate-text-with-chat-prompt.mdx
@@ -96,7 +96,7 @@ export async function continueConversation(history: Message[]) {
 
   const { text } = await generateText({
     model: 'openai/gpt-5.4',
-    system: 'You are a friendly assistant!',
+    instructions: 'You are a friendly assistant!',
     messages: history,
   });
 

--- a/content/cookbook/20-rsc/21-stream-text-with-chat-prompt.mdx
+++ b/content/cookbook/20-rsc/21-stream-text-with-chat-prompt.mdx
@@ -109,7 +109,7 @@ export async function continueConversation(history: Message[]) {
   (async () => {
     const { textStream } = streamText({
       model: 'openai/gpt-5.4',
-      system:
+      instructions:
         "You are a dude that doesn't drop character until the DVD commentary.",
       messages: history,
     });

--- a/content/cookbook/20-rsc/30-generate-object.mdx
+++ b/content/cookbook/20-rsc/30-generate-object.mdx
@@ -93,7 +93,7 @@ export async function getNotifications(input: string) {
 
   const { output: notifications } = await generateText({
     model: 'openai/gpt-5.4',
-    system: 'You generate three notifications for a messages app.',
+    instructions: 'You generate three notifications for a messages app.',
     prompt: input,
     output: Output.object({
       schema: z.object({

--- a/content/cookbook/20-rsc/40-stream-object.mdx
+++ b/content/cookbook/20-rsc/40-stream-object.mdx
@@ -102,7 +102,7 @@ export async function generate(input: string) {
   (async () => {
     const { partialOutputStream } = streamText({
       model: 'openai/gpt-5.4',
-      system: 'You generate three notifications for a messages app.',
+      instructions: 'You generate three notifications for a messages app.',
       prompt: input,
       output: Output.object({
         schema: z.object({

--- a/content/cookbook/20-rsc/50-call-tools.mdx
+++ b/content/cookbook/20-rsc/50-call-tools.mdx
@@ -100,7 +100,7 @@ export async function continueConversation(history: Message[]) {
 
   const { text, toolResults } = await generateText({
     model: 'openai/gpt-5.4',
-    system: 'You are a friendly assistant!',
+    instructions: 'You are a friendly assistant!',
     messages: history,
     tools: {
       celsiusToFahrenheit: {

--- a/content/cookbook/20-rsc/51-call-tools-in-parallel.mdx
+++ b/content/cookbook/20-rsc/51-call-tools-in-parallel.mdx
@@ -106,7 +106,7 @@ export async function continueConversation(history: Message[]) {
 
   const { text, toolResults } = await generateText({
     model: 'openai/gpt-5.4',
-    system: 'You are a friendly weather assistant!',
+    instructions: 'You are a friendly weather assistant!',
     messages: history,
     tools: {
       getWeather: {

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -1110,7 +1110,7 @@ import { generateText } from 'ai';
 
 const result = await generateText({
   model: anthropic('claude-sonnet-4-6'),
-  system:
+  instructions:
     'You have access to an `advisor` tool backed by a stronger reviewer model.',
   prompt:
     'Build a concurrent worker pool in Go with graceful shutdown. Outline the design first.',

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -1467,7 +1467,7 @@ Function tools work the same way as on the standard provider:
 
 ```ts
 import { google } from '@ai-sdk/google';
-import { generateText, stepCountIs, tool } from 'ai';
+import { generateText, isStepCount, tool } from 'ai';
 import { z } from 'zod';
 
 const weatherTool = tool({
@@ -1479,7 +1479,7 @@ const weatherTool = tool({
 const { text, toolCalls } = await generateText({
   model: google.interactions('gemini-3.7-flash'),
   tools: { getWeather: weatherTool },
-  stopWhen: stepCountIs(5),
+  stopWhen: isStepCount(5),
   prompt: 'What is the weather in San Francisco right now?',
 });
 ```
@@ -1804,7 +1804,7 @@ import { generateText } from 'ai';
 
 const { text } = await generateText({
   model: google('gemma-3-27b-it'),
-  system: 'You are a helpful assistant that responds concisely.',
+  instructions: 'You are a helpful assistant that responds concisely.',
   prompt: 'What is machine learning?',
 });
 ```


### PR DESCRIPTION
## Background

AI SDK 7 renamed the top-level `system` call option to `instructions` (kept only as a deprecated fallback), and `stepCountIs` to `isStepCount`. The core docs under `content/docs` were updated for the release, but the sweep missed the cookbook and some provider pages — 24 code examples across 22 live pages still teach the deprecated `system:` syntax to newcomers. See #19174 for the full audit.

## Summary

Updated all remaining top-level `system:` call options to `instructions:` in:

- `content/cookbook/01-next/` (10 files)
- `content/cookbook/05-node/` (2 files)
- `content/cookbook/20-rsc/` (6 files)
- `content/cookbook/00-guides/` (4 files: RAG chatbot, Slackbot, natural-language Postgres, Llama 3.1)
- `content/providers/01-ai-sdk-providers/05-anthropic.mdx`
- `content/providers/01-ai-sdk-providers/15-google.mdx`

Also updated the last non-migration-guide use of `stepCountIs` → `isStepCount` in the Google provider page, including its import.

Intentionally untouched: migration guides (they document historical syntax) and vendor-maintained pages (`content/providers/05-community-providers/`, `content/providers/03-observability/maxim.mdx`) — flagged in the issue instead. Prose references to "system prompt"/"system message" as a concept were left as-is, since `role: 'system'` messages still exist.

24 files changed, 34 substitutions, no prose or structural changes.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

The vendor-maintained community-provider and observability pages listed in #19174 also use the deprecated `system:` option — pending maintainer guidance on whether those should be updated too.

## Related Issues

Fixes #19174 