### PR TITLE
[v6.0] fix(provider/xai): report image moderation blocks

### DIFF
--- a/.changeset/wise-cats-imagine.md
+++ b/.changeset/wise-cats-imagine.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(provider/xai): report image moderation blocks as content policy errors

--- a/packages/xai/src/xai-image-model.test.ts
+++ b/packages/xai/src/xai-image-model.test.ts
@@ -289,6 +289,41 @@ describe('XaiImageModel', () => {
       expect(result.images[0]).toBe('dGVzdA==');
     });
 
+    it('should throw when an image is blocked by moderation', async () => {
+      // xAI documents that a moderated image sets `respect_moderation` to
+      // false and replaces the image with a placeholder:
+      // https://github.com/xai-org/xai-proto/blob/723dd2aa22d17be35617463837dc47cda008d90e/proto/xai/api/v1/image.proto#L148-L151
+      server.urls['https://api.example.com/images/generations'].response = {
+        type: 'json-value',
+        body: {
+          data: [
+            {
+              url: null,
+              b64_json: null,
+              respect_moderation: false,
+            },
+          ],
+        },
+      };
+
+      const model = createModel();
+
+      await expect(
+        model.doGenerate({
+          prompt,
+          files: undefined,
+          mask: undefined,
+          n: 1,
+          size: undefined,
+          aspectRatio: undefined,
+          seed: undefined,
+          providerOptions: {},
+        }),
+      ).rejects.toThrow(
+        'Image generation was blocked due to a content policy violation.',
+      );
+    });
+
     it('should pass headers', async () => {
       const model = createModel({
         headers: () => ({

--- a/packages/xai/src/xai-image-model.ts
+++ b/packages/xai/src/xai-image-model.ts
@@ -145,6 +145,12 @@ export class XaiImageModel implements ImageModelV3 {
       fetch: this.config.fetch,
     });
 
+    if (response.data.some(image => image.respect_moderation === false)) {
+      throw new Error(
+        'Image generation was blocked due to a content policy violation.',
+      );
+    }
+
     const hasAllBase64 = response.data.every(image => image.b64_json != null);
 
     const images = hasAllBase64
@@ -199,6 +205,7 @@ const xaiImageResponseSchema = z.object({
       url: z.string().nullish(),
       b64_json: z.string().nullish(),
       revised_prompt: z.string().nullish(),
+      respect_moderation: z.boolean().nullish(),
     }),
   ),
   usage: z


### PR DESCRIPTION
## Summary

Backport of #19185 to AI SDK 6.

- parse the xAI image response moderation marker
- throw a descriptive content-policy error before attempting to download a missing image URL
- include the deterministic regression test, documentation reference, and patch changeset

## Testing

- pnpm --filter @ai-sdk/xai test
- pnpm check
- pnpm type-check:full

## Version scope

AI SDK 5 is not included because it predates the dedicated XaiImageModel and routes image generation through the shared OpenAICompatibleImageModel. Applying this provider-specific response handling there would require an architectural change rather than a focused backport.