### PR TITLE
[v5.0] fix: return array-backed mock language model results in configured order

### DIFF
--- a/.changeset/calm-mocks-replay.md
+++ b/.changeset/calm-mocks-replay.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Fix array-backed language model mocks to return configured results in order from the first call.

--- a/packages/ai/src/test/mock-language-model-v2.ts
+++ b/packages/ai/src/test/mock-language-model-v2.ts
@@ -44,7 +44,7 @@ export class MockLanguageModelV2 implements LanguageModelV2 {
       if (typeof doGenerate === 'function') {
         return doGenerate(options);
       } else if (Array.isArray(doGenerate)) {
-        return doGenerate[this.doGenerateCalls.length];
+        return doGenerate[this.doGenerateCalls.length - 1];
       } else {
         return doGenerate;
       }
@@ -55,7 +55,7 @@ export class MockLanguageModelV2 implements LanguageModelV2 {
       if (typeof doStream === 'function') {
         return doStream(options);
       } else if (Array.isArray(doStream)) {
-        return doStream[this.doStreamCalls.length];
+        return doStream[this.doStreamCalls.length - 1];
       } else {
         return doStream;
       }

--- a/packages/ai/src/test/mock-language-model.test.ts
+++ b/packages/ai/src/test/mock-language-model.test.ts
@@ -1,0 +1,46 @@
+import type { LanguageModelV2 } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { MockLanguageModelV2 } from './mock-language-model-v2';
+
+function generateResult(
+  text: string,
+): Awaited<ReturnType<LanguageModelV2['doGenerate']>> {
+  return {
+    content: [{ type: 'text', text }],
+    finishReason: 'stop',
+    usage: {
+      inputTokens: 1,
+      outputTokens: 1,
+      totalTokens: 2,
+    },
+    warnings: [],
+  };
+}
+
+function streamResult(): Awaited<ReturnType<LanguageModelV2['doStream']>> {
+  return { stream: new ReadableStream() };
+}
+
+describe('MockLanguageModelV2', () => {
+  it('returns array-backed generate results in order from the first entry', async () => {
+    const first = generateResult('first');
+    const second = generateResult('second');
+    const model = new MockLanguageModelV2({
+      doGenerate: [first, second],
+    });
+
+    await expect(model.doGenerate({} as never)).resolves.toBe(first);
+    await expect(model.doGenerate({} as never)).resolves.toBe(second);
+  });
+
+  it('returns array-backed stream results in order from the first entry', async () => {
+    const first = streamResult();
+    const second = streamResult();
+    const model = new MockLanguageModelV2({
+      doStream: [first, second],
+    });
+
+    await expect(model.doStream({} as never)).resolves.toBe(first);
+    await expect(model.doStream({} as never)).resolves.toBe(second);
+  });
+});


### PR DESCRIPTION
## Summary

- backport the `MockLanguageModelV2` array indexing fix from #19148
- return configured `doGenerate` and `doStream` results from the first entry
- add focused regression coverage for v5

## Testing

- `pnpm --filter ai exec vitest --config vitest.node.config.js --run src/test/mock-language-model.test.ts`
- `pnpm --filter ai exec vitest --config vitest.edge.config.js --run src/test/mock-language-model.test.ts`
- `pnpm exec ultracite check packages/ai/src/test/mock-language-model-v2.ts packages/ai/src/test/mock-language-model.test.ts .changeset/calm-mocks-replay.md`
- `pnpm --filter ai type-check`
- `pnpm type-check:full`

Backport of #19148.