### PR TITLE
feat(cerebras): expose provider options

### DIFF
--- a/.changeset/bright-cerebras-options.md
+++ b/.changeset/bright-cerebras-options.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cerebras': patch
+---
+
+Expose typed Cerebras provider options for exact output limits, reasoning, log probabilities, and tool calls.

--- a/packages/cerebras/src/cerebras-chat-language-model-options.ts
+++ b/packages/cerebras/src/cerebras-chat-language-model-options.ts
@@ -1,3 +1,38 @@
+import type { OpenAICompatibleLanguageModelChatOptions } from '@ai-sdk/openai-compatible';
+
 export type { CerebrasChatModelId } from './cerebras-chat-options';
 
-export type CerebrasLanguageModelChatOptions = Record<string, never>;
+export type CerebrasLanguageModelChatOptions = Omit<
+  OpenAICompatibleLanguageModelChatOptions,
+  'reasoningEffort'
+> & {
+  /** Exact Cerebras output limit, including reasoning tokens. */
+  max_completion_tokens?: number;
+
+  /** Whether to allow parallel function calls. */
+  parallel_tool_calls?: boolean;
+
+  /** Whether to return output-token log probabilities. */
+  logprobs?: boolean;
+
+  /** Number of most likely tokens to return at each position. */
+  top_logprobs?: number;
+
+  /** Token-ID to logit-bias mapping. */
+  logit_bias?: Record<string, number>;
+
+  /** Cerebras service tier for the request. */
+  service_tier?: 'auto' | 'default' | 'flex' | 'priority';
+
+  /** Reasoning effort, including disabling optional reasoning. */
+  reasoningEffort?: 'none' | 'low' | 'medium' | 'high';
+
+  /** Format used to return reasoning content. */
+  reasoning_format?: 'none' | 'parsed' | 'text_parsed' | 'raw' | 'hidden';
+
+  /** A predicted output used to accelerate regeneration workloads. */
+  prediction?: Record<string, unknown>;
+
+  /** Stable identifier for prompt-cache routing. */
+  prompt_cache_key?: string;
+};

--- a/packages/cerebras/src/cerebras-chat-language-model.test.ts
+++ b/packages/cerebras/src/cerebras-chat-language-model.test.ts
@@ -5,11 +5,32 @@ import type {
 import fs from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 import { createCerebras } from './cerebras-provider';
+import type { CerebrasLanguageModelChatOptions } from './cerebras-chat-language-model-options';
 
 const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 ];
 const JSON_RESPONSE_FORMAT = { type: 'json' as const };
+
+it('exposes Cerebras request options', () => {
+  const options: CerebrasLanguageModelChatOptions = {
+    max_completion_tokens: 64,
+    parallel_tool_calls: false,
+    logprobs: true,
+    top_logprobs: 2,
+    logit_bias: { '42': 1 },
+    service_tier: 'priority',
+    reasoningEffort: 'none',
+    reasoning_format: 'parsed',
+    prediction: { type: 'content', content: 'expected' },
+    prompt_cache_key: 'cache-key',
+  };
+
+  expect(options).toMatchObject({
+    max_completion_tokens: 64,
+    reasoningEffort: 'none',
+  });
+});
 
 async function convertStreamToArray(
   stream: ReadableStream<LanguageModelV4StreamPart>,

--- a/packages/cerebras/src/index.ts
+++ b/packages/cerebras/src/index.ts
@@ -4,4 +4,5 @@ export type {
   CerebrasProviderSettings,
 } from './cerebras-provider';
 export type { CerebrasErrorData } from './cerebras-provider';
+export type { CerebrasLanguageModelChatOptions } from './cerebras-chat-language-model-options';
 export { VERSION } from './version';


### PR DESCRIPTION
## Summary

- replace the empty Cerebras provider-options type with typed request options
- cover exact output limits, optional reasoning, log probabilities, parallel tool calls, service tier, prediction, and prompt-cache routing
- export the public options type and add a patch changeset

## Validation

- Cerebras package typecheck passed
- Oxfmt check passed
- the focused Vitest runner currently hits an existing workspace ESM configuration error before test collection

Closes #19216