### PR TITLE
test(ai): preserve raw stream errors when onError throws

### DIFF
--- a/packages/ai/src/generate-object/stream-object.test.ts
+++ b/packages/ai/src/generate-object/stream-object.test.ts
@@ -998,9 +998,11 @@ describe('streamObject', () => {
         expect(onFinish).toHaveBeenCalledOnce();
       });
 
-      it('should reject pending result promises and invoke onError when the raw stream errors', async () => {
+      it('should preserve raw stream errors when onError throws', async () => {
         const error = new Error('test error');
-        const onError = vitest.fn();
+        const onError = vitest.fn(() => {
+          throw new Error('callback error');
+        });
         const result = streamObject({
           model: new MockLanguageModelV4({
             doStream: async () => ({


### PR DESCRIPTION
## Summary

- strengthen the `streamObject` raw provider-stream error regression test
- make `onError` throw and assert `fullStream` and result promises retain the original provider error
- cover the test gap identified while reviewing the v6 backport in #19206

Follow-up to #19187. This is test-only because the v7 implementation already dispatches the raw-stream callback through `notify()`.

## Testing

- `pnpm --dir packages/ai test:node src/generate-object/stream-object.test.ts`
- `pnpm --dir packages/ai test:edge src/generate-object/stream-object.test.ts`
- `pnpm type-check:full`
- `pnpm exec ultracite check packages/ai/src/generate-object/stream-object.test.ts`
- `git diff --check`