### PR TITLE
fix(xai): preserve legacy runtime identity

### DIFF
--- a/.changeset/old-taxis-smile.md
+++ b/.changeset/old-taxis-smile.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/spacexai': patch
+'@ai-sdk/xai': patch
+---
+
+fix(xai): preserve legacy runtime identifiers and user agent

--- a/.changeset/old-taxis-smile.md
+++ b/.changeset/old-taxis-smile.md
@@ -1,6 +1,0 @@
----
-'@ai-sdk/spacexai': patch
-'@ai-sdk/xai': patch
----
-
-fix(xai): preserve legacy runtime identifiers and user agent

--- a/packages/spacexai/internal.d.ts
+++ b/packages/spacexai/internal.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/internal';

--- a/packages/spacexai/package.json
+++ b/packages/spacexai/package.json
@@ -15,7 +15,8 @@
     "!src/**/__snapshots__",
     "!src/**/__fixtures__",
     "CHANGELOG.md",
-    "README.md"
+    "README.md",
+    "internal.d.ts"
   ],
   "directories": {
     "doc": "./docs"
@@ -39,6 +40,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./internal": {
+      "types": "./dist/internal/index.d.ts",
+      "import": "./dist/internal/index.js",
+      "default": "./dist/internal/index.js"
     }
   },
   "dependencies": {

--- a/packages/spacexai/src/internal/index.ts
+++ b/packages/spacexai/src/internal/index.ts
@@ -1,0 +1,4 @@
+export {
+  createSpaceXAIProvider,
+  type SpaceXAIProviderConfig,
+} from '../spacexai-provider';

--- a/packages/spacexai/src/spacexai-provider.ts
+++ b/packages/spacexai/src/spacexai-provider.ts
@@ -144,9 +144,19 @@ export interface SpaceXAIProviderSettings {
 /** @deprecated Use `SpaceXAIProviderSettings` instead. */
 export type XaiProviderSettings = SpaceXAIProviderSettings;
 
-export function createSpaceXAI(
-  options: SpaceXAIProviderSettings = {},
-): SpaceXAIProvider {
+export interface SpaceXAIProviderConfig {
+  options?: SpaceXAIProviderSettings;
+  providerName: string;
+  tools: typeof spacexaiTools;
+  userAgent: string;
+}
+
+export function createSpaceXAIProvider({
+  options = {},
+  providerName,
+  tools,
+  userAgent,
+}: SpaceXAIProviderConfig): SpaceXAIProvider {
   const baseURL = withoutTrailingSlash(
     options.baseURL ?? 'https://api.x.ai/v1',
   );
@@ -160,12 +170,12 @@ export function createSpaceXAI(
         })}`,
         ...options.headers,
       },
-      `ai-sdk/spacexai/${VERSION}`,
+      userAgent,
     );
 
   const createChatLanguageModel = (modelId: SpaceXAIChatModelId) => {
     return new SpaceXAIChatLanguageModel(modelId, {
-      provider: 'spacexai.chat',
+      provider: `${providerName}.chat`,
       baseURL,
       headers: getHeaders,
       generateId,
@@ -175,7 +185,7 @@ export function createSpaceXAI(
 
   const createResponsesLanguageModel = (modelId: SpaceXAIResponsesModelId) => {
     return new SpaceXAIResponsesLanguageModel(modelId, {
-      provider: 'spacexai.responses',
+      provider: `${providerName}.responses`,
       baseURL,
       headers: getHeaders,
       generateId,
@@ -185,7 +195,7 @@ export function createSpaceXAI(
 
   const createImageModel = (modelId: SpaceXAIImageModelId) => {
     return new SpaceXAIImageModel(modelId, {
-      provider: 'spacexai.image',
+      provider: `${providerName}.image`,
       baseURL,
       headers: getHeaders,
       fetch: options.fetch,
@@ -194,7 +204,7 @@ export function createSpaceXAI(
 
   const createVideoModel = (modelId: SpaceXAIVideoModelId) => {
     return new SpaceXAIVideoModel(modelId, {
-      provider: 'spacexai.video',
+      provider: `${providerName}.video`,
       baseURL,
       headers: getHeaders,
       fetch: options.fetch,
@@ -203,7 +213,7 @@ export function createSpaceXAI(
 
   const createRealtimeModel = (modelId: string) => {
     return new SpaceXAIRealtimeModel(modelId, {
-      provider: 'spacexai.realtime',
+      provider: `${providerName}.realtime`,
       baseURL: baseURL ?? 'https://api.x.ai/v1',
       headers: getHeaders,
       fetch: options.fetch,
@@ -212,7 +222,7 @@ export function createSpaceXAI(
 
   const createSpeechModel = () => {
     return new SpaceXAISpeechModel('', {
-      provider: 'spacexai.speech',
+      provider: `${providerName}.speech`,
       baseURL,
       headers: getHeaders,
       fetch: options.fetch,
@@ -221,7 +231,7 @@ export function createSpaceXAI(
 
   const createTranscriptionModel = () => {
     return new SpaceXAITranscriptionModel('', {
-      provider: 'spacexai.transcription',
+      provider: `${providerName}.transcription`,
       baseURL,
       headers: getHeaders,
       fetch: options.fetch,
@@ -250,7 +260,7 @@ export function createSpaceXAI(
 
   const createFiles = () =>
     new SpaceXAIFiles({
-      provider: 'spacexai.files',
+      provider: `${providerName}.files`,
       baseURL,
       headers: getHeaders,
       fetch: options.fetch,
@@ -277,9 +287,20 @@ export function createSpaceXAI(
   provider.transcriptionModel = createTranscriptionModel;
   provider.transcription = createTranscriptionModel;
   provider.files = createFiles;
-  provider.tools = spacexaiTools;
+  provider.tools = tools;
 
   return provider;
+}
+
+export function createSpaceXAI(
+  options: SpaceXAIProviderSettings = {},
+): SpaceXAIProvider {
+  return createSpaceXAIProvider({
+    options,
+    providerName: 'spacexai',
+    tools: spacexaiTools,
+    userAgent: `ai-sdk/spacexai/${VERSION}`,
+  });
 }
 
 /** @deprecated Use `createSpaceXAI` instead. */

--- a/packages/spacexai/tsup.config.ts
+++ b/packages/spacexai/tsup.config.ts
@@ -13,4 +13,17 @@ export default defineConfig([
       ),
     },
   },
+  {
+    entry: ['src/internal/index.ts'],
+    outDir: 'dist/internal',
+    format: ['esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
 ]);

--- a/packages/xai/src/index.test.ts
+++ b/packages/xai/src/index.test.ts
@@ -1,14 +1,108 @@
 import { describe, expect, it } from 'vitest';
-import { createSpaceXAI, createXai, spacexai, xai } from './index';
+import {
+  codeExecution,
+  createSpaceXAI,
+  createXai,
+  imageGeneration,
+  mcpServer,
+  spacexai,
+  spacexaiTools,
+  VERSION,
+  viewImage,
+  viewXVideo,
+  webSearch,
+  xai,
+  xaiTools,
+  xSearch,
+} from './index';
 
 describe('@ai-sdk/xai', () => {
-  it('re-exports the spacexai provider', () => {
-    expect(typeof createSpaceXAI).toBe('function');
-    expect(typeof spacexai).toBe('function');
+  it('preserves the legacy provider identifiers', () => {
+    const provider = createXai({ apiKey: 'test-api-key' });
+
+    expect({
+      responses: provider('grok-4').provider,
+      chat: provider.chat('grok-4').provider,
+      image: provider.image('grok-imagine-image').provider,
+      video: provider.video('grok-imagine-video').provider,
+      realtime: provider.experimental_realtime('grok-voice').provider,
+      speech: provider.speech().provider,
+      transcription: provider.transcription().provider,
+      files: provider.files().provider,
+    }).toEqual({
+      responses: 'xai.responses',
+      chat: 'xai.chat',
+      image: 'xai.image',
+      video: 'xai.video',
+      realtime: 'xai.realtime',
+      speech: 'xai.speech',
+      transcription: 'xai.transcription',
+      files: 'xai.files',
+    });
   });
 
-  it('re-exports deprecated xai aliases', () => {
-    expect(createXai).toBe(createSpaceXAI);
-    expect(xai).toBe(spacexai);
+  it('preserves the legacy provider-defined tool identifiers', () => {
+    expect({
+      codeExecution: codeExecution().id,
+      fileSearch: xaiTools.fileSearch({ vectorStoreIds: ['store-1'] }).id,
+      imageGeneration: imageGeneration().id,
+      mcpServer: mcpServer({ serverUrl: 'https://mcp.example.com' }).id,
+      viewImage: viewImage().id,
+      viewXVideo: viewXVideo().id,
+      webSearch: webSearch().id,
+      xSearch: xSearch().id,
+    }).toEqual({
+      codeExecution: 'xai.code_execution',
+      fileSearch: 'xai.file_search',
+      imageGeneration: 'xai.image_generation',
+      mcpServer: 'xai.mcp',
+      viewImage: 'xai.view_image',
+      viewXVideo: 'xai.view_x_video',
+      webSearch: 'xai.web_search',
+      xSearch: 'xai.x_search',
+    });
+  });
+
+  it('preserves the legacy package user-agent', async () => {
+    let requestHeaders: Headers | undefined;
+    const provider = createXai({
+      apiKey: 'test-api-key',
+      fetch: async (
+        _url: Parameters<typeof globalThis.fetch>[0],
+        init?: Parameters<typeof globalThis.fetch>[1],
+      ) => {
+        requestHeaders = new Headers(init?.headers);
+        return new Response(
+          JSON.stringify({ data: [{ b64_json: 'dGVzdA==' }] }),
+          {
+            headers: { 'content-type': 'application/json' },
+            status: 200,
+          },
+        );
+      },
+    });
+
+    await provider.image('grok-imagine-image').doGenerate({
+      prompt: 'A test image',
+      files: undefined,
+      mask: undefined,
+      n: 1,
+      size: undefined,
+      aspectRatio: undefined,
+      seed: undefined,
+      providerOptions: {},
+    });
+
+    expect(requestHeaders?.get('user-agent')).toContain(
+      `ai-sdk/xai/${VERSION}`,
+    );
+    expect(requestHeaders?.get('user-agent')).not.toContain('ai-sdk/spacexai/');
+  });
+
+  it('keeps the new spacexai exports on the new identity', () => {
+    expect(createSpaceXAI).not.toBe(createXai);
+    expect(xai).not.toBe(spacexai);
+    expect(spacexai('grok-4').provider).toBe('spacexai.responses');
+    expect(spacexaiTools.webSearch().id).toBe('spacexai.web_search');
   });
 });

--- a/packages/xai/src/index.ts
+++ b/packages/xai/src/index.ts
@@ -1,1 +1,80 @@
+import {
+  codeExecution as spacexaiCodeExecution,
+  imageGeneration as spacexaiImageGeneration,
+  mcpServer as spacexaiMcpServer,
+  spacexaiTools,
+  type XaiProvider,
+  type XaiProviderSettings,
+  viewImage as spacexaiViewImage,
+  viewXVideo as spacexaiViewXVideo,
+  webSearch as spacexaiWebSearch,
+  xSearch as spacexaiXSearch,
+} from '@ai-sdk/spacexai';
+import { createSpaceXAIProvider } from '@ai-sdk/spacexai/internal';
+import { VERSION } from './version';
+
 export * from '@ai-sdk/spacexai';
+
+function withProviderId<
+  ARGS extends unknown[],
+  RESULT extends { id: `${string}.${string}` },
+>(
+  toolFactory: (...args: ARGS) => RESULT,
+  id: `${string}.${string}`,
+): (...args: ARGS) => RESULT {
+  return (...args) => ({ ...toolFactory(...args), id });
+}
+
+export const codeExecution: typeof spacexaiCodeExecution = withProviderId(
+  spacexaiCodeExecution,
+  'xai.code_execution',
+);
+const fileSearch = withProviderId(spacexaiTools.fileSearch, 'xai.file_search');
+export const imageGeneration: typeof spacexaiImageGeneration = withProviderId(
+  spacexaiImageGeneration,
+  'xai.image_generation',
+);
+export const mcpServer: typeof spacexaiMcpServer = withProviderId(
+  spacexaiMcpServer,
+  'xai.mcp',
+);
+export const viewImage: typeof spacexaiViewImage = withProviderId(
+  spacexaiViewImage,
+  'xai.view_image',
+);
+export const viewXVideo: typeof spacexaiViewXVideo = withProviderId(
+  spacexaiViewXVideo,
+  'xai.view_x_video',
+);
+export const webSearch: typeof spacexaiWebSearch = withProviderId(
+  spacexaiWebSearch,
+  'xai.web_search',
+);
+export const xSearch: typeof spacexaiXSearch = withProviderId(
+  spacexaiXSearch,
+  'xai.x_search',
+);
+
+export const xaiTools: typeof spacexaiTools = {
+  codeExecution,
+  fileSearch,
+  imageGeneration,
+  mcpServer,
+  viewImage,
+  viewXVideo,
+  webSearch,
+  xSearch,
+};
+
+export function createXai(options: XaiProviderSettings = {}): XaiProvider {
+  return createSpaceXAIProvider({
+    options,
+    providerName: 'xai',
+    tools: xaiTools,
+    userAgent: `ai-sdk/xai/${VERSION}`,
+  });
+}
+
+export const xai = createXai();
+
+export { VERSION };

--- a/packages/xai/src/version.ts
+++ b/packages/xai/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/xai/tsup.config.ts
+++ b/packages/xai/tsup.config.ts
@@ -6,5 +6,11 @@ export default defineConfig([
     format: ['esm'],
     dts: true,
     sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
   },
 ]);


### PR DESCRIPTION
## Summary

- preserve legacy xai model and provider identifiers for consumers of @ai-sdk/xai
- preserve legacy xai provider-defined tool identifiers
- restore the @ai-sdk/xai package version and user-agent while leaving @ai-sdk/spacexai unchanged
- add Node and Edge regression coverage for both identities

Stacked on #18947.

## Testing

- pnpm --filter @ai-sdk/xai test:node
- pnpm --filter @ai-sdk/xai test:edge
- pnpm --filter @ai-sdk/spacexai test:node
- pnpm --filter @ai-sdk/spacexai test:edge
- pnpm type-check:full
- pnpm check
- pnpm --filter @ai-sdk/spacexai build
- pnpm --filter @ai-sdk/xai build