### PR TITLE
fix(provider/xai): split responses text blocks interrupted by tool calls

### DIFF
--- a/.changeset/xai-responses-text-block-split.md
+++ b/.changeset/xai-responses-text-block-split.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(provider/xai): start a new text block when a tool call interrupts the streamed text in the responses API

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -2464,6 +2464,166 @@ describe('XaiResponsesLanguageModel', () => {
         expect(parts).toMatchSnapshot();
       });
 
+      it('should start a new text block when a provider tool call interrupts the text', async () => {
+        // xai streams one message output item for the whole response and interleaves the tool call
+        // items with its text deltas, instead of closing the message item and opening a new one
+        // after the tool call (event order captured from grok-4.6 with the web_search tool).
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_1',
+              object: 'response',
+              model: 'grok-4-fast-reasoning',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            item: {
+              type: 'message',
+              id: 'msg_1',
+              role: 'assistant',
+              status: 'in_progress',
+              content: [],
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.output_text.delta',
+            item_id: 'msg_1',
+            output_index: 0,
+            content_index: 0,
+            delta: 'Let me search. ',
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            item: {
+              type: 'web_search_call',
+              id: 'fc_1',
+              name: 'web_search',
+              call_id: '',
+              arguments: '{"query":"xai"}',
+              status: 'completed',
+            },
+            output_index: 1,
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'web_search_call',
+              id: 'fc_1',
+              name: 'web_search',
+              call_id: '',
+              arguments: '{"query":"xai"}',
+              status: 'completed',
+            },
+            output_index: 1,
+          }),
+          JSON.stringify({
+            type: 'response.output_text.delta',
+            item_id: 'msg_1',
+            output_index: 0,
+            content_index: 0,
+            delta: 'Found it.',
+          }),
+          JSON.stringify({
+            type: 'response.output_text.done',
+            item_id: 'msg_1',
+            output_index: 0,
+            content_index: 0,
+            text: 'Let me search. Found it.',
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'message',
+              id: 'msg_1',
+              role: 'assistant',
+              status: 'completed',
+              content: [
+                { type: 'output_text', text: 'Let me search. Found it.' },
+              ],
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.completed',
+            response: {
+              id: 'resp_1',
+              object: 'response',
+              model: 'grok-4-fast-reasoning',
+              output: [],
+              usage: {
+                input_tokens: 10,
+                output_tokens: 20,
+                total_tokens: 30,
+              },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'xai.web_search',
+              name: 'web_search',
+              args: {},
+            },
+          ],
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+
+        expect(
+          parts.filter(
+            part =>
+              part.type === 'text-start' ||
+              part.type === 'text-delta' ||
+              part.type === 'text-end' ||
+              part.type === 'tool-call',
+          ),
+        ).toMatchInlineSnapshot(`
+          [
+            {
+              "id": "text-msg_1",
+              "type": "text-start",
+            },
+            {
+              "delta": "Let me search. ",
+              "id": "text-msg_1",
+              "type": "text-delta",
+            },
+            {
+              "id": "text-msg_1",
+              "type": "text-end",
+            },
+            {
+              "input": "{"query":"xai"}",
+              "providerExecuted": true,
+              "toolCallId": "fc_1",
+              "toolName": "web_search",
+              "type": "tool-call",
+            },
+            {
+              "id": "text-msg_1-1",
+              "type": "text-start",
+            },
+            {
+              "delta": "Found it.",
+              "id": "text-msg_1-1",
+              "type": "text-delta",
+            },
+            {
+              "id": "text-msg_1-1",
+              "type": "text-end",
+            },
+          ]
+        `);
+      });
+
       it('should stream text deltas', async () => {
         prepareChunksFixtureResponse('xai-text-streaming.1');
 

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -591,8 +591,15 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
     let costInUsdTicks: number | undefined = undefined;
     let serviceTier: string | undefined = undefined;
     let isFirstChunk = true;
-    const contentBlocks: Record<string, { type: 'text' }> = {};
+    const contentBlocks: Record<string, { type: 'text'; ended: boolean }> = {};
     const seenToolCalls = new Set<string>();
+
+    // xai keeps a single message output item open for the whole response and interleaves tool call
+    // items with its text deltas, instead of closing the message and opening a new one after a tool
+    // call. The active text block is therefore closed whenever another output item starts, and the
+    // text that follows the tool call gets its own block id.
+    let activeTextBlockId: string | undefined = undefined;
+    const textBlockCounts: Record<string, number> = {};
 
     // Track ongoing function calls by output_index so we can stream
     // arguments via response.function_call_arguments.delta events.
@@ -607,6 +614,22 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
     > = {};
 
     const self = this;
+
+    const endActiveTextBlock = (
+      controller: TransformStreamDefaultController<LanguageModelV4StreamPart>,
+    ) => {
+      if (activeTextBlockId == null) {
+        return;
+      }
+
+      const block = contentBlocks[activeTextBlockId];
+      if (block != null && !block.ended) {
+        block.ended = true;
+        controller.enqueue({ type: 'text-end', id: activeTextBlockId });
+      }
+
+      activeTextBlockId = undefined;
+    };
 
     return {
       stream: response.pipeThrough(
@@ -717,19 +740,27 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
             }
 
             if (event.type === 'response.output_text.delta') {
-              const blockId = `text-${event.item_id}`;
+              if (activeTextBlockId == null) {
+                const blockIndex = textBlockCounts[event.item_id] ?? 0;
+                textBlockCounts[event.item_id] = blockIndex + 1;
+                activeTextBlockId =
+                  blockIndex === 0
+                    ? `text-${event.item_id}`
+                    : `text-${event.item_id}-${blockIndex}`;
 
-              if (contentBlocks[blockId] == null) {
-                contentBlocks[blockId] = { type: 'text' };
+                contentBlocks[activeTextBlockId] = {
+                  type: 'text',
+                  ended: false,
+                };
                 controller.enqueue({
                   type: 'text-start',
-                  id: blockId,
+                  id: activeTextBlockId,
                 });
               }
 
               controller.enqueue({
                 type: 'text-delta',
-                id: blockId,
+                id: activeTextBlockId,
                 delta: event.delta,
               });
 
@@ -861,6 +892,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
             ) {
               if (!seenToolCalls.has(event.item_id)) {
                 seenToolCalls.add(event.item_id);
+                endActiveTextBlock(controller);
 
                 const toolName = imageGenerationToolName ?? 'image_generation';
 
@@ -898,6 +930,13 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
               event.type === 'response.output_item.done'
             ) {
               const part = event.item;
+
+              // reasoning and tool call items are streamed while the message item stays open, so
+              // the text that came before them has to be closed here.
+              if (part.type !== 'message') {
+                endActiveTextBlock(controller);
+              }
+
               if (part.type === 'reasoning') {
                 if (event.type === 'response.output_item.done') {
                   const blockId = `reasoning-${part.id}`;
@@ -1147,7 +1186,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
 
                     // Only emit text if we haven't already streamed it via output_text.delta events
                     if (contentBlocks[blockId] == null) {
-                      contentBlocks[blockId] = { type: 'text' };
+                      contentBlocks[blockId] = { type: 'text', ended: false };
                       controller.enqueue({
                         type: 'text-start',
                         id: blockId,
@@ -1214,7 +1253,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
 
           flush(controller) {
             for (const [blockId, block] of Object.entries(contentBlocks)) {
-              if (block.type === 'text') {
+              if (block.type === 'text' && !block.ended) {
                 controller.enqueue({
                   type: 'text-end',
                   id: blockId,


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md

AI SDK maintenance is becoming increasingly automated. High-quality issues, reproductions,
failing tests, docs fixes, and focused clarifications are especially valuable. You do not
need to send a complete bug fix for your contribution to be appreciated or credited.
-->

## Background

With xAI's provider-executed tools (`webSearch`, `xSearch`, `codeExecution`, …) all assistant text of a
turn ends up in the **first** text part and every tool part is pushed behind it, even though the SSE order
is correct. A turn that streams "let me look this up" → search → "found X, searching again" → search →
"summary" is rendered as one text block followed by both tool calls, so the commentary is detached from the
tool calls it belongs to.

xAI's responses API keeps a **single** message output item open for the whole response and interleaves the
tool call items with that item's `response.output_text.delta` events, instead of closing the message item
and opening a new one after a tool call (which is what the OpenAI responses API does). Raw event order from
`grok-4.6` with `web_search` and text between the two searches:

```
response.output_item.added   item.id=msg_X  item.type=message              out=1
response.output_text.delta   item_id=msg_X                                 out=1 ci=0
response.output_item.added   item.id=ws_X_call-…-0  type=web_search_call    out=2
response.output_item.done    item.id=ws_X_call-…-0                         out=2
response.output_text.delta   item_id=msg_X                                 out=1 ci=0   <- same item
response.output_item.added   item.id=ws_X_call-…-1  type=web_search_call    out=3
response.output_item.done    item.id=ws_X_call-…-1                         out=3
response.output_text.delta   item_id=msg_X                                 out=1 ci=0   <- same item
response.output_text.done    item_id=msg_X                                 out=1 ci=0
response.output_item.done    item.id=msg_X  item.type=message              out=1
```

Because the text block id is derived from `event.item_id`, every delta of the turn maps to the block that
was started before the first tool call, and `text-end` is only emitted in `flush()`.

## Summary

- close the active text block when another output item starts (tool call or reasoning), so the text that
  follows a tool call is streamed as its own block
- keep `text-${item_id}` for the first block and use `text-${item_id}-${n}` for follow-up blocks, so ids
  only change where there previously was no separate block at all
- track an `ended` flag per content block, so a block closed early is neither ended a second time in
  `flush()` nor mistaken for "not streamed yet" by the `response.output_item.done` message branch (which
  would duplicate the whole text at the end of the stream)
- add a regression test that reproduces the interleaved event order above, plus a patch changeset

## End-to-End Verification

Ran `streamText` → `toUIMessageStream` → `readUIMessageStream` against the real xAI API with `grok-4.6` and
`xai.tools.webSearch({})`, asking two unrelated factual questions with one search each and instructing the
model to comment before and after every search.

Before, the resulting UI message parts were:

```
reasoning
text  "I am about to look up the height of Mount Fuji.The search result indicates Mount Fuji is 3,776
       meters tall. I am about to look up who wrote the novel Dune. …"     <- all segments merged
tool-webSearch (output-available)
tool-webSearch (output-available)
```

After:

```
reasoning
text  "I am about to look up the height of Mount Fuji."
tool-webSearch (output-available)
text  "The search confirms Mount Fuji stands 3,776 meters tall. I am about to look up who wrote the
       novel Dune."
tool-webSearch (output-available)
text  "The search shows Frank Herbert wrote Dune. Mount Fuji is 3,776.24 meters (12,389 feet) tall. …"
```

Also verified with a mixed tool set (provider-executed `webSearch` plus a client-side tool whose result is
submitted in a follow-up request) that the order stays correct across request boundaries.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

The reasoning path has the same shape (`reasoning-${item_id}`): if xAI ever emits reasoning deltas for an
item id whose block was already ended, the consumer would receive a delta for a closed block. No capture
shows that happening, so it is deliberately left out of this PR.