### PR TITLE
fix(harness-pi): fix incorrect grep use

### DIFF
--- a/.changeset/clever-cups-drive.md
+++ b/.changeset/clever-cups-drive.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-pi": patch
+---
+
+fix(harness-pi): fix incorrect grep use

--- a/packages/harness-pi/src/pi-remote-ops.test.ts
+++ b/packages/harness-pi/src/pi-remote-ops.test.ts
@@ -289,7 +289,8 @@ describe('createPiRemoteOps.grepFiles', () => {
     const cmd =
       env.runCalls.find(call => call.command.includes('grep '))?.command ?? '';
     expect(cmd).toContain('grep');
-    expect(cmd).toContain('-R');
+    expect(cmd).toContain('-r');
+    expect(cmd).not.toContain('-R');
     expect(cmd).toContain('-i');
     expect(cmd).toContain('-F');
     expect(cmd).toContain('-C');

--- a/packages/harness-pi/src/pi-remote-ops.ts
+++ b/packages/harness-pi/src/pi-remote-ops.ts
@@ -320,7 +320,7 @@ export function createPiRemoteOps(options: PiRemoteOpsOptions): PiRemoteOps {
         ? resolvedPath
         : relativeTarget;
     const flags = [
-      '-R',
+      '-r',
       '-n',
       '--binary-files=without-match',
       ...(input.ignoreCase ? ['-i'] : []),


### PR DESCRIPTION
## Background

Pi's recursive grep used `grep -R`, which follows symlinks discovered during directory traversal. This could bypass the harness's readable-path containment and expose files outside the permitted roots.

## Summary

- Use `grep -r` so recursive searches skip nested symlinks while preserving explicit, prevalidated targets.
- Update the grep command regression test to reject `-R`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
