### PR TITLE
feat(cerebras): add typed provider options

### DIFF
--- a/.changeset/calm-cerebras-options.md
+++ b/.changeset/calm-cerebras-options.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/cerebras': patch
+---
+
+feat(cerebras): add typed provider options and send `maxOutputTokens` as `max_completion_tokens` field

--- a/content/providers/01-ai-sdk-providers/40-cerebras.mdx
+++ b/content/providers/01-ai-sdk-providers/40-cerebras.mdx
@@ -118,9 +118,41 @@ See [AI SDK UI: Chatbot](/docs/ai-sdk-ui/chatbot#reasoning) for more details on 
 
 The following optional provider options are available for Cerebras language models:
 
-- **reasoningEffort** _'low' | 'medium' | 'high'_
+- **parallelToolCalls** _boolean_
 
-  Controls the depth of reasoning for GPT-OSS models. Defaults to `'medium'`.
+  Whether to enable parallel function calling during tool use. Defaults to `true`.
+
+- **logprobs** _boolean_
+
+  Whether to return log probabilities for generated tokens. Defaults to `false`.
+
+- **topLogprobs** _number_
+
+  Number of most likely tokens to return at each token position. Accepts values from `0` through `20`. Requires `logprobs` to be `true`.
+
+- **logitBias** _Record<string, number>_
+
+  Maps token IDs to bias values from `-100` through `100`.
+
+- **serviceTier** _'auto' | 'default' | 'flex' | 'priority'_
+
+  Controls request priority. Availability depends on your account and endpoint.
+
+- **reasoningEffort** _'none' | 'low' | 'medium' | 'high'_
+
+  Controls the amount of reasoning performed by supported models. Supported values and defaults depend on the model.
+
+- **reasoningFormat** _'none' | 'parsed' | 'text_parsed' | 'raw' | 'hidden'_
+
+  Controls how reasoning content appears in the response. Format support depends on the model.
+
+- **prediction** _{ type: 'content'; content: string | Array<{ type: 'text'; text: string }> }_
+
+  Supplies predicted output that can accelerate requests where most of the response is already known.
+
+- **promptCacheKey** _string_
+
+  Routes related requests to the same prompt cache. The value can contain up to 1024 characters and requires account-level enablement.
 
 - **user** _string_
 
@@ -129,6 +161,28 @@ The following optional provider options are available for Cerebras language mode
 - **strictJsonSchema** _boolean_
 
   Whether to use strict JSON schema validation. When `true`, the model uses constrained decoding to guarantee schema compliance. Defaults to `true`.
+
+For example:
+
+```ts
+import {
+  cerebras,
+  type CerebrasLanguageModelChatOptions,
+} from '@ai-sdk/cerebras';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: cerebras('gpt-oss-120b'),
+  prompt: 'Explain why the sky is blue.',
+  providerOptions: {
+    cerebras: {
+      reasoningEffort: 'low',
+      reasoningFormat: 'parsed',
+      promptCacheKey: 'conversation-123',
+    } satisfies CerebrasLanguageModelChatOptions,
+  },
+});
+```
 
 ## Model Capabilities
 

--- a/content/providers/01-ai-sdk-providers/40-cerebras.mdx
+++ b/content/providers/01-ai-sdk-providers/40-cerebras.mdx
@@ -130,7 +130,7 @@ The following optional provider options are available for Cerebras language mode
 
   Number of most likely tokens to return at each token position. Accepts values from `0` through `20`. Requires `logprobs` to be `true`.
 
-- **logitBias** _Record<string, number>_
+- **logitBias** _Record&lt;string, number&gt;_
 
   Maps token IDs to bias values from `-100` through `100`.
 
@@ -146,7 +146,7 @@ The following optional provider options are available for Cerebras language mode
 
   Controls how reasoning content appears in the response. Format support depends on the model.
 
-- **prediction** _{ type: 'content'; content: string | Array<{ type: 'text'; text: string }> }_
+- **prediction** _&#123; type: 'content'; content: string | Array&lt;&#123; type: 'text'; text: string &#125;&gt; &#125;_
 
   Supplies predicted output that can accelerate requests where most of the response is already known.
 

--- a/packages/cerebras/src/cerebras-chat-language-model-options.ts
+++ b/packages/cerebras/src/cerebras-chat-language-model-options.ts
@@ -1,3 +1,31 @@
+import { z } from 'zod/v4';
+
 export type { CerebrasChatModelId } from './cerebras-chat-options';
 
-export type CerebrasLanguageModelChatOptions = Record<string, never>;
+export const cerebrasLanguageModelChatOptions = z.object({
+  user: z.string().optional(),
+  strictJsonSchema: z.boolean().optional(),
+  parallelToolCalls: z.boolean().optional(),
+  logprobs: z.boolean().optional(),
+  topLogprobs: z.number().int().min(0).max(20).optional(),
+  logitBias: z.record(z.string(), z.number().min(-100).max(100)).optional(),
+  serviceTier: z.enum(['auto', 'default', 'flex', 'priority']).optional(),
+  reasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
+  reasoningFormat: z
+    .enum(['none', 'parsed', 'text_parsed', 'raw', 'hidden'])
+    .optional(),
+  prediction: z
+    .object({
+      type: z.literal('content'),
+      content: z.union([
+        z.string(),
+        z.array(z.object({ type: z.literal('text'), text: z.string() })),
+      ]),
+    })
+    .optional(),
+  promptCacheKey: z.string().max(1024).optional(),
+});
+
+export type CerebrasLanguageModelChatOptions = z.infer<
+  typeof cerebrasLanguageModelChatOptions
+>;

--- a/packages/cerebras/src/cerebras-chat-language-model.test.ts
+++ b/packages/cerebras/src/cerebras-chat-language-model.test.ts
@@ -3,8 +3,9 @@ import type {
   LanguageModelV4StreamPart,
 } from '@ai-sdk/provider';
 import fs from 'node:fs';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { createCerebras } from './cerebras-provider';
+import type { CerebrasLanguageModelChatOptions } from './index';
 
 const TEST_PROMPT: LanguageModelV4Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
@@ -57,6 +58,81 @@ function createStreamFixtureFetchMock(filename: string) {
 }
 
 describe('doGenerate', () => {
+  it('maps maxOutputTokens to max_completion_tokens', async () => {
+    const fetch = createJsonFixtureFetchMock(
+      'cerebras-structured-output-tools.1',
+    );
+    const model = createCerebras({ apiKey: 'test-api-key', fetch })(
+      'gpt-oss-120b',
+    );
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      maxOutputTokens: 64,
+    });
+
+    const requestBody = JSON.parse(fetch.mock.calls[0][1].body);
+    expect(requestBody).toMatchObject({ max_completion_tokens: 64 });
+    expect(requestBody).not.toHaveProperty('max_tokens');
+  });
+
+  it('maps Cerebras provider options to request fields', async () => {
+    const fetch = createJsonFixtureFetchMock(
+      'cerebras-structured-output-tools.1',
+    );
+    const model = createCerebras({ apiKey: 'test-api-key', fetch })(
+      'gpt-oss-120b',
+    );
+
+    const providerOptions = {
+      user: 'user-123',
+      strictJsonSchema: false,
+      parallelToolCalls: false,
+      logprobs: true,
+      topLogprobs: 2,
+      logitBias: { '42': 1 },
+      serviceTier: 'priority',
+      reasoningEffort: 'none',
+      reasoningFormat: 'parsed',
+      prediction: { type: 'content', content: 'expected' },
+      promptCacheKey: 'cache-key',
+    } satisfies CerebrasLanguageModelChatOptions;
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: { cerebras: providerOptions },
+    });
+
+    const requestBody = JSON.parse(fetch.mock.calls[0][1].body);
+    expect(requestBody).toMatchObject({
+      user: 'user-123',
+      parallel_tool_calls: false,
+      logprobs: true,
+      top_logprobs: 2,
+      logit_bias: { '42': 1 },
+      service_tier: 'priority',
+      reasoning_effort: 'none',
+      reasoning_format: 'parsed',
+      prediction: { type: 'content', content: 'expected' },
+      prompt_cache_key: 'cache-key',
+    });
+    expect(requestBody).not.toHaveProperty('parallelToolCalls');
+    expect(requestBody).not.toHaveProperty('reasoningFormat');
+    expect(requestBody).not.toHaveProperty('promptCacheKey');
+  });
+
+  it('exports the constrained Cerebras provider options type', () => {
+    expectTypeOf<
+      NonNullable<CerebrasLanguageModelChatOptions['serviceTier']>
+    >().toEqualTypeOf<'auto' | 'default' | 'flex' | 'priority'>();
+    expectTypeOf<
+      NonNullable<CerebrasLanguageModelChatOptions['reasoningEffort']>
+    >().toEqualTypeOf<'none' | 'low' | 'medium' | 'high'>();
+    expectTypeOf<
+      NonNullable<CerebrasLanguageModelChatOptions['reasoningFormat']>
+    >().toEqualTypeOf<'none' | 'parsed' | 'text_parsed' | 'raw' | 'hidden'>();
+  });
+
   describe('finish reason normalization', () => {
     it('preserves the captured first tool-call step', async () => {
       const fetch = createJsonFixtureFetchMock(

--- a/packages/cerebras/src/cerebras-provider.ts
+++ b/packages/cerebras/src/cerebras-provider.ts
@@ -37,8 +37,34 @@ const cerebrasErrorStructure: ProviderErrorStructure<CerebrasErrorData> = {
 function transformCerebrasRequestBody(
   args: Record<string, any>,
 ): Record<string, any> {
+  const {
+    max_tokens: maxTokens,
+    parallelToolCalls,
+    topLogprobs,
+    logitBias,
+    serviceTier,
+    reasoningFormat,
+    promptCacheKey,
+    ...restArgs
+  } = args;
+
   return {
-    ...args,
+    ...restArgs,
+    ...(maxTokens !== undefined && {
+      max_completion_tokens: maxTokens,
+    }),
+    ...(parallelToolCalls !== undefined && {
+      parallel_tool_calls: parallelToolCalls,
+    }),
+    ...(topLogprobs !== undefined && { top_logprobs: topLogprobs }),
+    ...(logitBias !== undefined && { logit_bias: logitBias }),
+    ...(serviceTier !== undefined && { service_tier: serviceTier }),
+    ...(reasoningFormat !== undefined && {
+      reasoning_format: reasoningFormat,
+    }),
+    ...(promptCacheKey !== undefined && {
+      prompt_cache_key: promptCacheKey,
+    }),
     messages: Array.isArray(args.messages)
       ? args.messages.map(message => {
           if (

--- a/packages/cerebras/src/index.ts
+++ b/packages/cerebras/src/index.ts
@@ -4,4 +4,5 @@ export type {
   CerebrasProviderSettings,
 } from './cerebras-provider';
 export type { CerebrasErrorData } from './cerebras-provider';
+export type { CerebrasLanguageModelChatOptions } from './cerebras-chat-language-model-options';
 export { VERSION } from './version';


### PR DESCRIPTION
## Background

[Cerebras Chat Completions](https://inference-docs.cerebras.ai/api-reference/chat-completions) documents various options that are supported by the Cerebras provider, but were untyped.  

## Summary

* added Cerebras api options as a zod schema and exported its type
* map `max_tokens` (openai compatible field name) to `max_completion_tokens` (cerebras documented field name) for `maxOutputTokens` option
  * `max_tokens` worked but cerebras didn't document it 

## End-to-End Verification

tested `generateText()` against Cerebras with various `providerOptions`

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

Fixes #19216 

Closes https://github.com/vercel/ai/pull/19208 (superseded)
Closes https://github.com/vercel/ai/pull/19219 (superseded)


