### PR TITLE
feat(harness): make `destroy` on `HarnessV1NetworkSandboxSession` mandatory

### DIFF
--- a/.changeset/famous-eyes-camp.md
+++ b/.changeset/famous-eyes-camp.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness": patch
+---
+
+feat(harness): make `destroy` on `HarnessV1NetworkSandboxSession` mandatory

--- a/architecture/sandbox-abstraction.md
+++ b/architecture/sandbox-abstraction.md
@@ -191,6 +191,10 @@ flowchart TD
 to connect to it. `getPortUrl()` remains available for compatibility but is
 deprecated because it drops those headers.
 
+`destroy()` stops the sandbox session before performing any additional cleanup,
+such as deleting the backing resource or freeing resources. Implementations
+with no additional cleanup can implement `destroy()` by calling `stop()`.
+
 `restricted()` is the boundary between infrastructure code and user/tool code.
 `HarnessAgent` owns the network sandbox session, while host-executed tools receive only the restricted basic session.
 

--- a/examples/ai-functions/src/sandbox/vercel-request-transformations.ts
+++ b/examples/ai-functions/src/sandbox/vercel-request-transformations.ts
@@ -54,6 +54,6 @@ run(async () => {
 
     console.log(result.stdout);
   } finally {
-    await session.destroy?.();
+    await session.destroy();
   }
 });

--- a/packages/harness-pi/src/pi-workspace-mirror.test.ts
+++ b/packages/harness-pi/src/pi-workspace-mirror.test.ts
@@ -158,7 +158,7 @@ describe('syncHostWorkspaceFromSandbox', () => {
         readFileSync(path.join(hostWorkDir, '.pi/group-100/SYSTEM.md'), 'utf8'),
       ).toBe('prompt 100');
     } finally {
-      await sandboxSession.destroy?.();
+      await sandboxSession.destroy();
     }
   }, 30_000);
 
@@ -202,7 +202,7 @@ describe('syncHostWorkspaceFromSandbox', () => {
         ),
       ).toBe('deep prompt');
     } finally {
-      await sandboxSession.destroy?.();
+      await sandboxSession.destroy();
     }
   }, 60_000);
 
@@ -259,7 +259,7 @@ describe('syncHostWorkspaceFromSandbox', () => {
         ),
       ).toBe('# Linked skill');
     } finally {
-      await sandboxSession.destroy?.();
+      await sandboxSession.destroy();
     }
   });
 
@@ -299,7 +299,7 @@ describe('syncHostWorkspaceFromSandbox', () => {
         ),
       ).toBe('# Project skill');
     } finally {
-      await sandboxSession.destroy?.();
+      await sandboxSession.destroy();
     }
   });
 
@@ -324,7 +324,7 @@ describe('syncHostWorkspaceFromSandbox', () => {
 
       expect(existsSync(path.join(hostWorkDir, '.pi'))).toBe(false);
     } finally {
-      await sandboxSession.destroy?.();
+      await sandboxSession.destroy();
     }
   });
 
@@ -353,7 +353,7 @@ describe('syncHostWorkspaceFromSandbox', () => {
         }),
       ).rejects.toThrow('symlink cycle');
     } finally {
-      await sandboxSession.destroy?.();
+      await sandboxSession.destroy();
     }
   });
 

--- a/packages/harness/src/agent/harness-agent-session.ts
+++ b/packages/harness/src/agent/harness-agent-session.ts
@@ -462,8 +462,8 @@ export class HarnessAgentSession {
   }
 
   /**
-   * Stop the runtime and discard resumability. A harness-owned sandbox is
-   * destroyed when supported; otherwise it is stopped.
+   * Stop the runtime and discard resumability. A harness-owned network
+   * sandbox is stopped and destroyed through its `destroy()` method.
    */
   async destroy(): Promise<void> {
     if (this.sessionState !== 'active') return;
@@ -474,10 +474,8 @@ export class HarnessAgentSession {
       await Promise.resolve(session.doDestroy()).catch(() => {});
     }
     if (!this.ownsSandboxLifecycle) return;
-    if ('stop' in sandboxSession) {
-      await Promise.resolve(
-        sandboxSession.destroy?.() ?? sandboxSession.stop(),
-      ).catch(() => {});
+    if ('destroy' in sandboxSession) {
+      await Promise.resolve(sandboxSession.destroy()).catch(() => {});
     }
   }
 

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -2720,17 +2720,6 @@ describe('HarnessAgent', () => {
     expect(sandboxDestroy).toHaveBeenCalledTimes(1);
   });
 
-  test('session.destroy() falls back to stopping the sandbox when destroy is unsupported', async () => {
-    const { session, sandboxStop, sandboxDestroy } = makeLifecycleSession({
-      sandboxSessionOverrides: { destroy: undefined },
-    });
-
-    await session.destroy();
-
-    expect(sandboxStop).toHaveBeenCalledTimes(1);
-    expect(sandboxDestroy).not.toHaveBeenCalled();
-  });
-
   test('session.compact() forwards to the harness session doCompact, then throws once ended', async () => {
     const { harness, doCompact } = mockHarness({ script: () => [] });
     const agent = new HarnessAgent({ harness, sandbox: makeSandboxProvider() });

--- a/packages/harness/src/v1/harness-v1-network-sandbox-session.test-d.ts
+++ b/packages/harness/src/v1/harness-v1-network-sandbox-session.test-d.ts
@@ -23,7 +23,7 @@ test('restricted() returns the bare sandbox session surface', () => {
   >().toEqualTypeOf<SandboxSession>();
 });
 
-test('network sandbox session exposes port resolution and stop as required', () => {
+test('network sandbox session exposes port resolution and lifecycle as required', () => {
   expectTypeOf<HarnessV1NetworkSandboxSession['ports']>().toEqualTypeOf<
     ReadonlyArray<number>
   >();
@@ -37,6 +37,7 @@ test('network sandbox session exposes port resolution and stop as required', () 
     HarnessV1NetworkSandboxSession['getPortUrl']
   >().not.toBeUndefined();
   expectTypeOf<HarnessV1NetworkSandboxSession['stop']>().not.toBeUndefined();
+  expectTypeOf<HarnessV1NetworkSandboxSession['destroy']>().not.toBeUndefined();
 });
 
 test('setNetworkPolicy is optional on the network sandbox session', () => {

--- a/packages/harness/src/v1/harness-v1-network-sandbox-session.ts
+++ b/packages/harness/src/v1/harness-v1-network-sandbox-session.ts
@@ -71,11 +71,13 @@ export interface HarnessV1NetworkSandboxSession extends SandboxSession {
   readonly stop: () => PromiseLike<void>;
 
   /**
-   * Destroy/delete the sandbox resource when supported. Optional because some
-   * providers only have a stop/dispose concept. Implementations must handle
-   * both a still-running sandbox and a previously stopped sandbox.
+   * Stop the sandbox session, then perform any additional cleanup necessary
+   * to destroy it, such as deleting its backing resource or freeing resources.
+   * Implementations with no cleanup beyond stopping may delegate to `stop()`.
+   * Implementations must handle both a still-running sandbox and a previously
+   * stopped sandbox.
    */
-  readonly destroy?: () => PromiseLike<void>;
+  readonly destroy: () => PromiseLike<void>;
 
   /**
    * Update the sandbox's outbound network policy. Optional — implementations

--- a/packages/sandbox-just-bash/src/just-bash-network-sandbox-session.test.ts
+++ b/packages/sandbox-just-bash/src/just-bash-network-sandbox-session.test.ts
@@ -1,6 +1,6 @@
 import { HarnessCapabilityUnsupportedError } from '@ai-sdk/harness';
 import { Sandbox } from 'just-bash';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { JustBashNetworkSandboxSession } from './just-bash-network-sandbox-session';
 
 describe('JustBashNetworkSandboxSession', () => {
@@ -23,5 +23,13 @@ describe('JustBashNetworkSandboxSession', () => {
     await expect(
       sandbox.getPortUrl({ port: 4319, protocol: 'ws' }),
     ).rejects.toBeInstanceOf(HarnessCapabilityUnsupportedError);
+  });
+
+  it('delegates destroy to stop', async () => {
+    const stop = vi.spyOn(sandbox, 'stop');
+
+    await sandbox.destroy();
+
+    expect(stop).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/sandbox-vercel/src/vercel-sandbox.test.ts
+++ b/packages/sandbox-vercel/src/vercel-sandbox.test.ts
@@ -134,7 +134,7 @@ describe('createVercelSandbox (wrap existing)', () => {
 
   it('destroy is a no-op (caller owns lifecycle)', async () => {
     const { sandbox, spies } = makeMockSandbox();
-    await (await createVercelSandbox({ sandbox }).createSession()).destroy?.();
+    await (await createVercelSandbox({ sandbox }).createSession()).destroy();
     expect(spies.stop).not.toHaveBeenCalled();
     expect(spies.delete).not.toHaveBeenCalled();
   });
@@ -532,13 +532,22 @@ describe('createVercelSandbox (create from scratch)', () => {
     expect(createMock.mock.calls[0][0]).toMatchObject({ timeout: 60_000 });
   });
 
-  it('destroy stops and deletes owned sandboxes', async () => {
-    const { sandbox, spies } = makeMockSandbox();
+  it('destroy stops before deleting owned sandboxes', async () => {
+    const calls: string[] = [];
+    const { sandbox, spies } = makeMockSandbox({
+      stop: vi.fn(async () => {
+        calls.push('stop');
+      }),
+      delete: vi.fn(async () => {
+        calls.push('delete');
+      }),
+    });
     createMock.mockResolvedValueOnce(sandbox);
 
     const handle = await createVercelSandbox({}).createSession();
-    await handle.destroy?.();
+    await handle.destroy();
 
+    expect(calls).toEqual(['stop', 'delete']);
     expect(spies.stop).toHaveBeenCalledTimes(1);
     expect(spies.delete).toHaveBeenCalledTimes(1);
   });
@@ -552,7 +561,7 @@ describe('createVercelSandbox (create from scratch)', () => {
     createMock.mockResolvedValueOnce(sandbox);
 
     const handle = await createVercelSandbox({}).createSession();
-    await handle.destroy?.();
+    await handle.destroy();
 
     expect(spies.stop).toHaveBeenCalledTimes(1);
     expect(spies.delete).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Background

Network sandbox cleanup had two paths because `destroy()` was optional, forcing callers to fall back to `stop()` instead of relying on one terminal cleanup contract.

There is really no point for this method to be optional.

## Summary

- Require `destroy()` on `HarnessV1NetworkSandboxSession`.
- Define `destroy()` to stop the session before releasing or deleting resources; implementations without additional cleanup can delegate to `stop()`.
- Remove the `HarnessAgentSession` fallback and update sandbox lifecycle tests and call sites.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
