### PR TITLE
feat(gateway): handleWebhookOption on the video model

### DIFF
--- a/.changeset/gateway-video-webhook-option.md
+++ b/.changeset/gateway-video-webhook-option.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(gateway): implement `handleWebhookOption` on the video model so `generateVideo({ webhook })` registers the factory URL as the gateway's `callbackUrl` and awaits delivery instead of falling back to polling

--- a/packages/gateway/src/gateway-video-model.test.ts
+++ b/packages/gateway/src/gateway-video-model.test.ts
@@ -1,5 +1,5 @@
 import type { Experimental_VideoModelV4 } from '@ai-sdk/provider';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { GatewayVideoModel } from './gateway-video-model';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import type { GatewayConfig } from './gateway-config';
@@ -1180,6 +1180,25 @@ describe('GatewayVideoModel', () => {
     });
   });
 
+  describe('handleWebhookOption', () => {
+    it('should pass the factory URL and received promise straight through', async () => {
+      const received = Promise.resolve({
+        headers: { 'x-ai-gateway-signature': 't=1,v1=abc' },
+        body: { type: 'video.generation.completed' },
+      });
+      const webhook = vi.fn(async () => ({
+        url: 'https://example.com/hook',
+        received,
+      }));
+
+      const result = await createTestModel().handleWebhookOption!({ webhook });
+
+      expect(webhook).toHaveBeenCalledOnce();
+      expect(result.webhookUrl).toBe('https://example.com/hook');
+      expect(result.received).toBe(received);
+    });
+  });
+
   describe('doStart', () => {
     const baseCallOptions = {
       prompt: 'A beautiful sunset over mountains',
@@ -1439,9 +1458,5 @@ describe('GatewayVideoModel', () => {
       ).rejects.toThrow();
     });
 
-    it('does not implement handleWebhookOption (polling-only gateway)', () => {
-      const model: Experimental_VideoModelV4 = createTestModel();
-      expect(model.handleWebhookOption).toBeUndefined();
-    });
   });
 });

--- a/packages/gateway/src/gateway-video-model.test.ts
+++ b/packages/gateway/src/gateway-video-model.test.ts
@@ -1457,6 +1457,5 @@ describe('GatewayVideoModel', () => {
         createTestModel().doStatus({ operation: { gatewayJobId: 'job_123' } }),
       ).rejects.toThrow();
     });
-
   });
 });

--- a/packages/gateway/src/gateway-video-model.ts
+++ b/packages/gateway/src/gateway-video-model.ts
@@ -6,6 +6,7 @@ import {
   type Experimental_VideoModelV4File as VideoModelV4File,
   type Experimental_VideoModelV4OperationStartResult as VideoModelV4OperationStartResult,
   type Experimental_VideoModelV4OperationStatusResult as VideoModelV4OperationStatusResult,
+  type Experimental_VideoModelV4OperationWebhook as VideoModelV4OperationWebhook,
   type Experimental_VideoModelV4VideoData as VideoModelV4VideoData,
   type JSONValue,
   type SharedV4ProviderMetadata,
@@ -171,15 +172,22 @@ export class GatewayVideoModel implements VideoModelV4 {
     }
   }
 
-  // `handleWebhookOption` is intentionally NOT implemented. The Gateway's
-  // async video jobs are polling-first: it does not expose a provider->SDK
-  // webhook completion channel. If this method were present, `generateVideo`
-  // would forward a webhook URL and await a notification that never arrives.
-  // `doStart` still forwards the spec's `webhookUrl` — as the Gateway's
-  // `callbackUrl` wire field (its completion-webhook contract; unknown body
-  // keys are stripped server-side). Enabling webhooks later requires adding
-  // `handleWebhookOption` here plus handling the Gateway's HMAC-signed
-  // delivery format; the wire field is already the right one.
+  // The Gateway notifies the caller's URL on completion (`doStart` maps it to
+  // `callbackUrl`), so the factory's URL and `received` pass straight through.
+  async handleWebhookOption({
+    webhook,
+  }: {
+    webhook: () => PromiseLike<{
+      url: string;
+      received: PromiseLike<VideoModelV4OperationWebhook>;
+    }>;
+  }): Promise<{
+    webhookUrl: string;
+    received: PromiseLike<VideoModelV4OperationWebhook>;
+  }> {
+    const { url, received } = await webhook();
+    return { webhookUrl: url, received };
+  }
 
   async doStart(
     options: VideoModelV4CallOptions & {


### PR DESCRIPTION
## What

Implements `handleWebhookOption` on the gateway v4 video model so `experimental_generateVideo({ webhook })` works end to end against the AI Gateway:

1. The factory's URL is handed to `doStart` as `webhookUrl`, which already maps onto the gateway's `callbackUrl` wire field (the completion-webhook contract).
2. The factory's `received` promise passes straight through, so the SDK awaits the delivery instead of warning (`unsupported: webhook`) and falling back to polling.
3. On `received` resolving, the SDK's existing flow does one `doStatus` to fetch the result — matching the gateway's thin webhook payload (no video bytes).

Note: the gateway's delivery is HMAC-signed (`x-ai-gateway-signature: t=...,v1=...`); verification stays the receiver's responsibility (typically inside the factory's `received` promise). The previous comment on this method described it as intentionally unimplemented because the URL would be registered but never notified — that is no longer true: the gateway's async video jobs do deliver to `callbackUrl` at the terminal state.

## Test plan

- New unit test: URL + `received` pass-through.
- Removed the now-obsolete `does not implement handleWebhookOption` assertion.
- `pnpm vitest run src/gateway-video-model.test.ts` → 48 passed.
- Verified live against production from the ai-gateway examples repo (`examples/typescript/async-video/customer-webhook.ts`): webhook.site receiver, `klingai/kling-v2.5-turbo-t2v` completed in ~85s, `video.generation.completed` delivered with the stable idempotency key, HMAC signature verified, `generateVideo` resolved with the video.