### PR TITLE
docs: fix broken relative links to CONTRIBUTING.md in tool registry guide

### DIFF
--- a/contributing/add-new-tool-to-registry.md
+++ b/contributing/add-new-tool-to-registry.md
@@ -14,7 +14,7 @@ Before submitting your tool, ensure you have:
 
 1. **Fork and clone the repository**
 
-   Follow the setup instructions in the main [CONTRIBUTING.md](../../CONTRIBUTING.md)
+   Follow the setup instructions in the main [CONTRIBUTING.md](../CONTRIBUTING.md)
 
 2. **Add your tool entry**
 
@@ -88,6 +88,6 @@ Before submitting your tool, ensure you have:
 
 If you have questions about adding your tool to the registry:
 
-- Check the main [CONTRIBUTING.md](../../CONTRIBUTING.md) guide
+- Check the main [CONTRIBUTING.md](../CONTRIBUTING.md) guide
 - Review existing tool entries in `registry.ts` for examples
 - Open an issue on [GitHub](https://github.com/vercel/ai/issues)


### PR DESCRIPTION
## What
Fix two broken relative links to the root `CONTRIBUTING.md` in `contributing/add-new-tool-to-registry.md`. Both pointed to `../../CONTRIBUTING.md`, which resolves above the repository root and 404s on GitHub.

## Why
The file lives in `contributing/`, so `../CONTRIBUTING.md` correctly reaches the root `CONTRIBUTING.md`, while `../../` overshoots to the repository's parent directory. `CONTRIBUTING.md` exists only at the repo root (there is no `contributing/CONTRIBUTING.md`).

## How verified
- Confirmed `CONTRIBUTING.md` exists only at the repository root.
- Confirmed there is no `contributing/CONTRIBUTING.md`.
- Docs-only change; no changeset required per CONTRIBUTING.md.