### PR TITLE
feat(provider/deepseek): support V4 Flash Vision and Files API

### DIFF
--- a/.changeset/tidy-cats-see.md
+++ b/.changeset/tidy-cats-see.md
@@ -3,4 +3,4 @@
 '@ai-sdk/gateway': patch
 ---
 
-feat: add DeepSeek V4 Flash Vision Exp image input support
+feat: add DeepSeek V4 Flash Vision Exp image input and Files API support

--- a/.changeset/tidy-cats-see.md
+++ b/.changeset/tidy-cats-see.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/deepseek': patch
+'@ai-sdk/gateway': patch
+---
+
+feat: add DeepSeek V4 Flash Vision Exp image input support

--- a/content/providers/01-ai-sdk-providers/30-deepseek.mdx
+++ b/content/providers/01-ai-sdk-providers/30-deepseek.mdx
@@ -169,10 +169,11 @@ The metrics include:
 
 ## Model Capabilities
 
-| Model               | Text Generation | Object Generation | Image Input | Tool Usage | Tool Streaming |
-| ------------------- | --------------- | ----------------- | ----------- | ---------- | -------------- |
-| `deepseek-chat`     | <Check />       | <Check />         | <Cross />   | <Check />  | <Check />      |
-| `deepseek-reasoner` | <Check />       | <Check />         | <Cross />   | <Check />  | <Check />      |
+| Model                          | Text Generation | Object Generation | Image Input | Tool Usage | Tool Streaming |
+| ------------------------------ | --------------- | ----------------- | ----------- | ---------- | -------------- |
+| `deepseek-chat`                | <Check />       | <Check />         | <Cross />   | <Check />  | <Check />      |
+| `deepseek-reasoner`            | <Check />       | <Check />         | <Cross />   | <Check />  | <Check />      |
+| `deepseek-v4-flash-vision-exp` | <Check />       | <Check />         | <Check />   | <Check />  | <Check />      |
 
 <Note>
   Please see the [DeepSeek

--- a/content/providers/01-ai-sdk-providers/30-deepseek.mdx
+++ b/content/providers/01-ai-sdk-providers/30-deepseek.mdx
@@ -167,6 +167,46 @@ The metrics include:
   documentation](https://api-docs.deepseek.com/guides/kv_cache#checking-cache-hit-status).
 </Note>
 
+### File Uploads
+
+You can upload images using the [DeepSeek Files API](https://api-docs.deepseek.com/guides/files_api) and pass the returned provider reference to `deepseek-v4-flash-vision-exp`. This avoids sending the image bytes again in each request.
+
+```ts
+import { deepSeek, type DeepSeekFilesOptions } from '@ai-sdk/deepseek';
+import { generateText, uploadFile } from 'ai';
+import { readFile } from 'node:fs/promises';
+
+const { providerReference, mediaType } = await uploadFile({
+  api: deepSeek.files(),
+  data: await readFile('./image.png'),
+  filename: 'image.png',
+  providerOptions: {
+    deepseek: {
+      expiresAfter: 3600,
+    } satisfies DeepSeekFilesOptions,
+  },
+});
+
+const { text } = await generateText({
+  model: deepSeek('deepseek-v4-flash-vision-exp'),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Describe this image.' },
+        {
+          type: 'file',
+          mediaType: mediaType ?? 'image/png',
+          data: providerReference,
+        },
+      ],
+    },
+  ],
+});
+```
+
+The optional `expiresAfter` setting specifies the lifetime in seconds. DeepSeek accepts values from 3,600 seconds (one hour) through 2,592,000 seconds (30 days). Files are permanent when no expiration is specified.
+
 ## Model Capabilities
 
 | Model                          | Text Generation | Object Generation | Image Input | Tool Usage | Tool Streaming |

--- a/content/providers/01-ai-sdk-providers/index.mdx
+++ b/content/providers/01-ai-sdk-providers/index.mdx
@@ -71,6 +71,7 @@ Not all providers support all AI SDK features. Here's a quick comparison of the 
 | [Cohere](/providers/ai-sdk-providers/cohere)               | `command-a-reasoning-08-2025`                       | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Cohere](/providers/ai-sdk-providers/cohere)               | `command-r-plus`                                    | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Cohere](/providers/ai-sdk-providers/cohere)               | `command-r`                                         | <Cross />   | <Check />         | <Check />  | <Check />      |
+| [DeepSeek](/providers/ai-sdk-providers/deepseek)           | `deepseek-v4-flash-vision-exp`                      | <Check />   | <Check />         | <Check />  | <Check />      |
 | [DeepSeek](/providers/ai-sdk-providers/deepseek)           | `deepseek-chat`                                     | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [DeepSeek](/providers/ai-sdk-providers/deepseek)           | `deepseek-reasoner`                                 | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Moonshot AI](/providers/ai-sdk-providers/moonshotai)      | `kimi-k2.5`                                         | <Check />   | <Check />         | <Check />  | <Check />      |

--- a/examples/ai-functions/src/generate-text/deepseek/deepseek-v4-flash-vision-exp-url.ts
+++ b/examples/ai-functions/src/generate-text/deepseek/deepseek-v4-flash-vision-exp-url.ts
@@ -16,7 +16,7 @@ run(async () => {
           {
             type: 'file',
             mediaType: 'image',
-            data: 'https://github.com/vercel/ai/blob/main/examples/ai-functions/data/comic-cat.png?raw=true',
+            data: 'https://cdn.deepseek.com/platform/favicon.png',
           },
         ],
       },

--- a/examples/ai-functions/src/generate-text/deepseek/deepseek-v4-flash-vision-exp-url.ts
+++ b/examples/ai-functions/src/generate-text/deepseek/deepseek-v4-flash-vision-exp-url.ts
@@ -1,0 +1,29 @@
+import { deepSeek } from '@ai-sdk/deepseek';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { text, usage, finishReason } = await generateText({
+    model: deepSeek('deepseek-v4-flash-vision-exp'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'What animal is depicted in this image? Answer with one word.',
+          },
+          {
+            type: 'file',
+            mediaType: 'image',
+            data: 'https://github.com/vercel/ai/blob/main/examples/ai-functions/data/comic-cat.png?raw=true',
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log(text);
+  console.log('Token usage:', usage);
+  console.log('Finish reason:', finishReason);
+});

--- a/examples/ai-functions/src/generate-text/deepseek/deepseek-v4-flash-vision-exp.ts
+++ b/examples/ai-functions/src/generate-text/deepseek/deepseek-v4-flash-vision-exp.ts
@@ -1,0 +1,30 @@
+import { deepSeek } from '@ai-sdk/deepseek';
+import { generateText } from 'ai';
+import fs from 'node:fs';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { text, usage, finishReason } = await generateText({
+    model: deepSeek('deepseek-v4-flash-vision-exp'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'What animal is depicted in this image? Answer with one word.',
+          },
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            data: fs.readFileSync('./data/comic-cat.png'),
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log(text);
+  console.log('Token usage:', usage);
+  console.log('Finish reason:', finishReason);
+});

--- a/examples/ai-functions/src/generate-text/gateway/deepseek-v4-flash-vision-exp.ts
+++ b/examples/ai-functions/src/generate-text/gateway/deepseek-v4-flash-vision-exp.ts
@@ -1,0 +1,29 @@
+import { generateText } from 'ai';
+import fs from 'node:fs';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { text, usage, finishReason } = await generateText({
+    model: 'deepseek/deepseek-v4-flash-vision-exp',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'What animal is depicted in this image? Answer with one word.',
+          },
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            data: fs.readFileSync('./data/comic-cat.png'),
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log(text);
+  console.log('Token usage:', usage);
+  console.log('Finish reason:', finishReason);
+});

--- a/examples/ai-functions/src/upload-file/deepseek/image.ts
+++ b/examples/ai-functions/src/upload-file/deepseek/image.ts
@@ -1,0 +1,47 @@
+import { deepSeek, type DeepSeekFilesOptions } from '@ai-sdk/deepseek';
+import { generateText, uploadFile } from 'ai';
+import fs from 'node:fs';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { providerReference, mediaType, filename, providerMetadata } =
+    await uploadFile({
+      api: deepSeek.files(),
+      data: fs.readFileSync('./data/comic-cat.png'),
+      filename: 'comic-cat.png',
+      providerOptions: {
+        deepseek: {
+          expiresAfter: 3600,
+        } satisfies DeepSeekFilesOptions,
+      },
+    });
+
+  console.log('Provider reference:', providerReference);
+  console.log('Media type:', mediaType);
+  console.log('Filename:', filename);
+  console.log('Provider metadata:', providerMetadata);
+
+  const result = await generateText({
+    model: deepSeek('deepseek-v4-flash-vision-exp'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'What animal is depicted in this image? Answer with one word.',
+          },
+          {
+            type: 'file',
+            mediaType: mediaType ?? 'image/png',
+            data: providerReference,
+          },
+        ],
+      },
+    ],
+  });
+
+  console.log(result.text);
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+});

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
@@ -28,7 +28,7 @@ describe('convertToDeepSeekChatMessages', () => {
       `);
     });
 
-    it('should warn about unsupported file parts', async () => {
+    it('should convert image data to an image URL content part', async () => {
       const result = convertToDeepSeekChatMessages({
         prompt: [
           {
@@ -54,21 +54,73 @@ describe('convertToDeepSeekChatMessages', () => {
         {
           "messages": [
             {
-              "content": "Hello",
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+                {
+                  "image_url": {
+                    "url": "data:image/png;base64,AAECAw==",
+                  },
+                  "type": "image_url",
+                },
+              ],
               "role": "user",
             },
           ],
-          "warnings": [
-            {
-              "feature": "user message part type: file",
-              "type": "unsupported",
-            },
-          ],
+          "warnings": [],
         }
       `);
     });
 
-    it('should accept top-level-only mediaType without error and not read it (category D)', async () => {
+    it('should convert an image URL to an image URL content part', async () => {
+      const result = convertToDeepSeekChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Hello' },
+              {
+                type: 'file',
+                data: {
+                  type: 'url' as const,
+                  url: new URL('https://example.com/image.png'),
+                },
+                mediaType: 'image/png',
+              },
+            ],
+          },
+        ],
+        responseFormat: undefined,
+        modelId: 'deepseek-chat',
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+                {
+                  "image_url": {
+                    "url": "https://example.com/image.png",
+                  },
+                  "type": "image_url",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "warnings": [],
+        }
+      `);
+    });
+
+    it('should warn about unsupported non-image file parts', async () => {
       const result = convertToDeepSeekChatMessages({
         prompt: [
           {
@@ -81,7 +133,7 @@ describe('convertToDeepSeekChatMessages', () => {
                   type: 'data' as const,
                   data: Buffer.from([0, 1, 2, 3]).toString('base64'),
                 },
-                mediaType: 'image',
+                mediaType: 'application/pdf',
               },
             ],
           },
@@ -90,9 +142,22 @@ describe('convertToDeepSeekChatMessages', () => {
         modelId: 'deepseek-chat',
       });
 
-      expect(result.messages).toEqual([{ role: 'user', content: 'Hello' }]);
-      expect(JSON.stringify(result.messages)).not.toContain('image');
-      expect(JSON.stringify(result.messages)).not.toContain('mediaType');
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": "Hello",
+              "role": "user",
+            },
+          ],
+          "warnings": [
+            {
+              "feature": "user message part type: file",
+              "type": "unsupported",
+            },
+          ],
+        }
+      `);
     });
   });
 

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
@@ -1,5 +1,6 @@
-import { convertToDeepSeekChatMessages } from './convert-to-deepseek-chat-messages';
+import { NoSuchProviderReferenceError } from '@ai-sdk/provider';
 import { describe, it, expect } from 'vitest';
+import { convertToDeepSeekChatMessages } from './convert-to-deepseek-chat-messages';
 
 describe('convertToDeepSeekChatMessages', () => {
   describe('user messages', () => {
@@ -118,6 +119,77 @@ describe('convertToDeepSeekChatMessages', () => {
           "warnings": [],
         }
       `);
+    });
+
+    it('should convert an image provider reference to a file content part', () => {
+      const result = convertToDeepSeekChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Hello' },
+              {
+                type: 'file',
+                data: {
+                  type: 'reference',
+                  reference: {
+                    deepseek: 'file-api-deepseek',
+                    openai: 'file-openai',
+                  },
+                },
+                mediaType: 'image/png',
+              },
+            ],
+          },
+        ],
+        responseFormat: undefined,
+        modelId: 'deepseek-v4-flash-vision-exp',
+      });
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "messages": [
+            {
+              "content": [
+                {
+                  "text": "Hello",
+                  "type": "text",
+                },
+                {
+                  "file_id": "file-api-deepseek",
+                  "type": "file",
+                },
+              ],
+              "role": "user",
+            },
+          ],
+          "warnings": [],
+        }
+      `);
+    });
+
+    it('should throw when an image reference has no DeepSeek identifier', () => {
+      expect(() =>
+        convertToDeepSeekChatMessages({
+          prompt: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'file',
+                  data: {
+                    type: 'reference',
+                    reference: { openai: 'file-openai' },
+                  },
+                  mediaType: 'image/png',
+                },
+              ],
+            },
+          ],
+          responseFormat: undefined,
+          modelId: 'deepseek-v4-flash-vision-exp',
+        }),
+      ).toThrow(NoSuchProviderReferenceError);
     });
 
     it('should warn about unsupported non-image file parts', async () => {

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -7,6 +7,7 @@ import {
   convertToBase64,
   getTopLevelMediaType,
   resolveFullMediaType,
+  resolveProviderReference,
 } from '@ai-sdk/provider-utils';
 import type {
   DeepSeekChatPrompt,
@@ -76,7 +77,9 @@ export function convertToDeepSeekChatMessages({
         const hasImagePart = content.some(
           part =>
             part.type === 'file' &&
-            (part.data.type === 'url' || part.data.type === 'data') &&
+            (part.data.type === 'reference' ||
+              part.data.type === 'url' ||
+              part.data.type === 'data') &&
             getTopLevelMediaType(part.mediaType) === 'image',
         );
 
@@ -103,18 +106,32 @@ export function convertToDeepSeekChatMessages({
             userContent.push({ type: 'text', text: part.text });
           } else if (
             part.type === 'file' &&
-            (part.data.type === 'url' || part.data.type === 'data') &&
             getTopLevelMediaType(part.mediaType) === 'image'
           ) {
-            userContent.push({
-              type: 'image_url',
-              image_url: {
-                url:
-                  part.data.type === 'url'
-                    ? part.data.url.toString()
-                    : `data:${resolveFullMediaType({ part })};base64,${convertToBase64(part.data.data)}`,
-              },
-            });
+            if (part.data.type === 'reference') {
+              userContent.push({
+                type: 'file',
+                file_id: resolveProviderReference({
+                  reference: part.data.reference,
+                  provider: 'deepseek',
+                }),
+              });
+            } else if (part.data.type === 'url' || part.data.type === 'data') {
+              userContent.push({
+                type: 'image_url',
+                image_url: {
+                  url:
+                    part.data.type === 'url'
+                      ? part.data.url.toString()
+                      : `data:${resolveFullMediaType({ part })};base64,${convertToBase64(part.data.data)}`,
+                },
+              });
+            } else {
+              warnings.push({
+                type: 'unsupported',
+                feature: `user message part type: ${part.type}`,
+              });
+            }
           } else {
             warnings.push({
               type: 'unsupported',

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -3,7 +3,15 @@ import type {
   LanguageModelV4Prompt,
   SharedV4Warning,
 } from '@ai-sdk/provider';
-import type { DeepSeekChatPrompt } from './deepseek-chat-api-types';
+import {
+  convertToBase64,
+  getTopLevelMediaType,
+  resolveFullMediaType,
+} from '@ai-sdk/provider-utils';
+import type {
+  DeepSeekChatPrompt,
+  DeepSeekContentPart,
+} from './deepseek-chat-api-types';
 
 export function convertToDeepSeekChatMessages({
   prompt,
@@ -65,10 +73,48 @@ export function convertToDeepSeekChatMessages({
       }
 
       case 'user': {
-        let userContent = '';
+        const hasImagePart = content.some(
+          part =>
+            part.type === 'file' &&
+            (part.data.type === 'url' || part.data.type === 'data') &&
+            getTopLevelMediaType(part.mediaType) === 'image',
+        );
+
+        if (!hasImagePart) {
+          let userContent = '';
+          for (const part of content) {
+            if (part.type === 'text') {
+              userContent += part.text;
+            } else {
+              warnings.push({
+                type: 'unsupported',
+                feature: `user message part type: ${part.type}`,
+              });
+            }
+          }
+
+          messages.push({ role: 'user', content: userContent });
+          break;
+        }
+
+        const userContent: Array<DeepSeekContentPart> = [];
         for (const part of content) {
           if (part.type === 'text') {
-            userContent += part.text;
+            userContent.push({ type: 'text', text: part.text });
+          } else if (
+            part.type === 'file' &&
+            (part.data.type === 'url' || part.data.type === 'data') &&
+            getTopLevelMediaType(part.mediaType) === 'image'
+          ) {
+            userContent.push({
+              type: 'image_url',
+              image_url: {
+                url:
+                  part.data.type === 'url'
+                    ? part.data.url.toString()
+                    : `data:${resolveFullMediaType({ part })};base64,${convertToBase64(part.data.data)}`,
+              },
+            });
           } else {
             warnings.push({
               type: 'unsupported',

--- a/packages/deepseek/src/chat/deepseek-chat-api-types.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-api-types.ts
@@ -21,7 +21,8 @@ export interface DeepSeekUserMessage {
 
 export type DeepSeekContentPart =
   | DeepSeekContentPartText
-  | DeepSeekContentPartImage;
+  | DeepSeekContentPartImage
+  | DeepSeekContentPartFile;
 
 export interface DeepSeekContentPartText {
   type: 'text';
@@ -31,6 +32,11 @@ export interface DeepSeekContentPartText {
 export interface DeepSeekContentPartImage {
   type: 'image_url';
   image_url: { url: string };
+}
+
+export interface DeepSeekContentPartFile {
+  type: 'file';
+  file_id: string;
 }
 
 export interface DeepSeekAssistantMessage {

--- a/packages/deepseek/src/chat/deepseek-chat-api-types.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-api-types.ts
@@ -16,7 +16,21 @@ export interface DeepSeekSystemMessage {
 
 export interface DeepSeekUserMessage {
   role: 'user';
-  content: string;
+  content: string | Array<DeepSeekContentPart>;
+}
+
+export type DeepSeekContentPart =
+  | DeepSeekContentPartText
+  | DeepSeekContentPartImage;
+
+export interface DeepSeekContentPartText {
+  type: 'text';
+  text: string;
+}
+
+export interface DeepSeekContentPartImage {
+  type: 'image_url';
+  image_url: { url: string };
 }
 
 export interface DeepSeekAssistantMessage {

--- a/packages/deepseek/src/chat/deepseek-chat-language-model-options.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model-options.ts
@@ -4,6 +4,7 @@ import { z } from 'zod/v4';
 export type DeepSeekChatModelId =
   | 'deepseek-chat'
   | 'deepseek-reasoner'
+  | 'deepseek-v4-flash-vision-exp'
   | (string & {});
 
 export const deepseekLanguageModelChatOptions = z.object({

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.test.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.test.ts
@@ -20,6 +20,14 @@ const server = createTestServer({
 });
 
 describe('DeepSeekChatLanguageModel', () => {
+  describe('supportedUrls', () => {
+    it('should natively support HTTP image URLs', () => {
+      expect(provider.chat('deepseek-chat').supportedUrls).toEqual({
+        'image/*': [/^https?:\/\/.*$/],
+      });
+    });
+  });
+
   describe('doGenerate', () => {
     function prepareJsonFixtureResponse(filename: string) {
       server.urls['https://api.deepseek.com/chat/completions'].response = {

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.ts
@@ -57,7 +57,10 @@ export class DeepSeekChatLanguageModel implements LanguageModelV4 {
   readonly specificationVersion = 'v4';
 
   readonly modelId: DeepSeekChatModelId;
-  readonly supportedUrls = {};
+
+  readonly supportedUrls = {
+    'image/*': [/^https?:\/\/.*$/],
+  };
 
   private readonly config: DeepSeekChatConfig;
   private readonly failedResponseHandler: ResponseHandler<APICallError>;

--- a/packages/deepseek/src/deepseek-provider.ts
+++ b/packages/deepseek/src/deepseek-provider.ts
@@ -1,4 +1,5 @@
 import {
+  type FilesV4,
   NoSuchModelError,
   type LanguageModelV4,
   type ProviderV4,
@@ -11,6 +12,7 @@ import {
 } from '@ai-sdk/provider-utils';
 import type { DeepSeekChatModelId } from './chat/deepseek-chat-language-model-options';
 import { DeepSeekChatLanguageModel } from './chat/deepseek-chat-language-model';
+import { DeepSeekFiles } from './files/deepseek-files';
 import { VERSION } from './version';
 
 export interface DeepSeekProviderSettings {
@@ -53,6 +55,11 @@ export interface DeepSeekProvider extends ProviderV4 {
   chat(modelId: DeepSeekChatModelId): LanguageModelV4;
 
   /**
+   * Creates a DeepSeek files interface for uploading images.
+   */
+  files(): FilesV4;
+
+  /**
    * @deprecated Use `embeddingModel` instead.
    */
   textEmbeddingModel(modelId: string): never;
@@ -61,9 +68,9 @@ export interface DeepSeekProvider extends ProviderV4 {
 export function createDeepSeek(
   options: DeepSeekProviderSettings = {},
 ): DeepSeekProvider {
-  const baseURL = withoutTrailingSlash(
-    options.baseURL ?? 'https://api.deepseek.com',
-  );
+  const baseURL =
+    withoutTrailingSlash(options.baseURL ?? 'https://api.deepseek.com') ??
+    'https://api.deepseek.com';
 
   const getHeaders = () =>
     withUserAgentSuffix(
@@ -87,12 +94,21 @@ export function createDeepSeek(
     });
   };
 
+  const createFiles = () =>
+    new DeepSeekFiles({
+      provider: 'deepseek.files',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
   const provider = (modelId: DeepSeekChatModelId) =>
     createLanguageModel(modelId);
 
   provider.specificationVersion = 'v4' as const;
   provider.languageModel = createLanguageModel;
   provider.chat = createLanguageModel;
+  provider.files = createFiles;
 
   provider.embeddingModel = (modelId: string) => {
     throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });

--- a/packages/deepseek/src/files/deepseek-files-api.ts
+++ b/packages/deepseek/src/files/deepseek-files-api.ts
@@ -1,0 +1,16 @@
+import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export const deepSeekFilesResponseSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      id: z.string(),
+      object: z.string().nullish(),
+      bytes: z.number().nullish(),
+      created_at: z.number().nullish(),
+      filename: z.string().nullish(),
+      purpose: z.string().nullish(),
+      expires_at: z.number().nullish(),
+    }),
+  ),
+);

--- a/packages/deepseek/src/files/deepseek-files-options.ts
+++ b/packages/deepseek/src/files/deepseek-files-options.ts
@@ -1,0 +1,22 @@
+import {
+  lazySchema,
+  zodSchema,
+  type InferSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+export const deepSeekFilesOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      /**
+       * Number of seconds after creation before the file expires.
+       * Must be between 1 hour and 30 days.
+       */
+      expiresAfter: z.number().int().min(3600).max(2592000).optional(),
+    }),
+  ),
+);
+
+export type DeepSeekFilesOptions = InferSchema<
+  typeof deepSeekFilesOptionsSchema
+>;

--- a/packages/deepseek/src/files/deepseek-files.test.ts
+++ b/packages/deepseek/src/files/deepseek-files.test.ts
@@ -1,0 +1,174 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { createDeepSeek } from '../deepseek-provider';
+
+vi.mock('../version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const server = createTestServer({
+  'https://api.deepseek.com/files': {},
+});
+
+function prepareFileResponse({
+  id = 'file-api-abc123',
+  expiresAt = null,
+}: {
+  id?: string;
+  expiresAt?: number | null;
+} = {}) {
+  server.urls['https://api.deepseek.com/files'].response = {
+    type: 'json-value',
+    body: {
+      id,
+      object: 'file',
+      bytes: 1024,
+      created_at: 1700000000,
+      filename: 'comic-cat.png',
+      purpose: 'user_data',
+      expires_at: expiresAt,
+    },
+  };
+}
+
+describe('DeepSeek Files - uploadFile', () => {
+  it('should upload an image with the user_data purpose', async () => {
+    prepareFileResponse();
+
+    const files = createDeepSeek({ apiKey: 'test-api-key' }).files();
+
+    await files.uploadFile({
+      data: { type: 'data', data: new Uint8Array([1, 2, 3]) },
+      mediaType: 'image/png',
+      filename: 'comic-cat.png',
+    });
+
+    const multipart = await server.calls[0].requestBodyMultipart;
+    expect(multipart).toMatchObject({ purpose: 'user_data' });
+    expect(multipart!.file).toBeDefined();
+  });
+
+  it('should return a DeepSeek provider reference and response metadata', async () => {
+    prepareFileResponse({
+      id: 'file-api-xyz789',
+      expiresAt: 1700003600,
+    });
+
+    const files = createDeepSeek({ apiKey: 'test-api-key' }).files();
+
+    const result = await files.uploadFile({
+      data: { type: 'data', data: new Uint8Array([1, 2, 3]) },
+      mediaType: 'image/png',
+      filename: 'comic-cat.png',
+    });
+
+    expect(result).toEqual({
+      warnings: [],
+      providerReference: { deepseek: 'file-api-xyz789' },
+      filename: 'comic-cat.png',
+      mediaType: 'image/png',
+      providerMetadata: {
+        deepseek: {
+          filename: 'comic-cat.png',
+          purpose: 'user_data',
+          bytes: 1024,
+          createdAt: 1700000000,
+          expiresAt: 1700003600,
+        },
+      },
+    });
+  });
+
+  it('should pass expires_after as bracketed multipart fields', async () => {
+    prepareFileResponse();
+
+    const files = createDeepSeek({ apiKey: 'test-api-key' }).files();
+
+    await files.uploadFile({
+      data: { type: 'data', data: new Uint8Array([1, 2, 3]) },
+      mediaType: 'image/png',
+      providerOptions: {
+        deepseek: { expiresAfter: 3600 },
+      },
+    });
+
+    const multipart = await server.calls[0].requestBodyMultipart;
+    expect(multipart).toMatchObject({
+      'expires_after[anchor]': 'created_at',
+      'expires_after[seconds]': '3600',
+    });
+    expect(multipart).not.toHaveProperty('expires_after');
+  });
+
+  it('should omit expires_after fields when no expiry is requested', async () => {
+    prepareFileResponse();
+
+    const files = createDeepSeek({ apiKey: 'test-api-key' }).files();
+
+    await files.uploadFile({
+      data: { type: 'data', data: new Uint8Array([1, 2, 3]) },
+      mediaType: 'image/png',
+    });
+
+    const multipart = await server.calls[0].requestBodyMultipart;
+    expect(multipart).not.toHaveProperty('expires_after[anchor]');
+    expect(multipart).not.toHaveProperty('expires_after[seconds]');
+  });
+
+  it('should reject an expiry outside the supported range', async () => {
+    prepareFileResponse();
+
+    const files = createDeepSeek({ apiKey: 'test-api-key' }).files();
+
+    await expect(
+      files.uploadFile({
+        data: { type: 'data', data: new Uint8Array([1, 2, 3]) },
+        mediaType: 'image/png',
+        providerOptions: {
+          deepseek: { expiresAfter: 3599 },
+        },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('should pass authentication and custom headers', async () => {
+    prepareFileResponse();
+
+    const files = createDeepSeek({
+      apiKey: 'test-api-key',
+      headers: { 'Custom-Header': 'custom-value' },
+    }).files();
+
+    await files.uploadFile({
+      data: { type: 'data', data: new Uint8Array([1, 2, 3]) },
+      mediaType: 'image/png',
+    });
+
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      authorization: 'Bearer test-api-key',
+      'custom-header': 'custom-value',
+    });
+  });
+
+  it('should handle base64-encoded data', async () => {
+    prepareFileResponse();
+
+    const files = createDeepSeek({ apiKey: 'test-api-key' }).files();
+
+    const result = await files.uploadFile({
+      data: { type: 'data', data: btoa('image bytes') },
+      mediaType: 'image/png',
+    });
+
+    expect(result.providerReference).toEqual({
+      deepseek: 'file-api-abc123',
+    });
+  });
+
+  it('should expose the v4 files interface', () => {
+    const files = createDeepSeek({ apiKey: 'test-api-key' }).files();
+
+    expect(files.specificationVersion).toBe('v4');
+    expect(files.provider).toBe('deepseek.files');
+  });
+});

--- a/packages/deepseek/src/files/deepseek-files.ts
+++ b/packages/deepseek/src/files/deepseek-files.ts
@@ -1,0 +1,109 @@
+import type {
+  FilesV4,
+  FilesV4UploadFileCallOptions,
+  FilesV4UploadFileResult,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertInlineFileDataToUint8Array,
+  createJsonErrorResponseHandler,
+  createJsonResponseHandler,
+  parseProviderOptions,
+  postFormDataToApi,
+  type FetchFunction,
+  type InferSchema,
+} from '@ai-sdk/provider-utils';
+import { deepSeekErrorSchema } from '../chat/deepseek-chat-api-types';
+import { deepSeekFilesResponseSchema } from './deepseek-files-api';
+import {
+  deepSeekFilesOptionsSchema,
+  type DeepSeekFilesOptions,
+} from './deepseek-files-options';
+
+interface DeepSeekFilesConfig {
+  provider: string;
+  baseURL: string;
+  headers: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+}
+
+const deepSeekFailedResponseHandler = createJsonErrorResponseHandler({
+  errorSchema: deepSeekErrorSchema,
+  errorToMessage: (error: InferSchema<typeof deepSeekErrorSchema>) =>
+    error.error.message,
+});
+
+export class DeepSeekFiles implements FilesV4 {
+  readonly specificationVersion = 'v4';
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(private readonly config: DeepSeekFilesConfig) {}
+
+  async uploadFile({
+    data,
+    mediaType,
+    filename,
+    providerOptions,
+  }: FilesV4UploadFileCallOptions): Promise<FilesV4UploadFileResult> {
+    const deepSeekOptions = (await parseProviderOptions({
+      provider: 'deepseek',
+      providerOptions,
+      schema: deepSeekFilesOptionsSchema,
+    })) as DeepSeekFilesOptions | undefined;
+
+    const fileBytes = convertInlineFileDataToUint8Array(data);
+    const blob = new Blob([fileBytes], { type: mediaType });
+
+    const formData = new FormData();
+    if (filename != null) {
+      formData.append('file', blob, filename);
+    } else {
+      formData.append('file', blob);
+    }
+    formData.append('purpose', 'user_data');
+
+    if (deepSeekOptions?.expiresAfter != null) {
+      formData.append('expires_after[anchor]', 'created_at');
+      formData.append(
+        'expires_after[seconds]',
+        String(deepSeekOptions.expiresAfter),
+      );
+    }
+
+    const { value: response } = await postFormDataToApi({
+      url: `${this.config.baseURL}/files`,
+      headers: combineHeaders(this.config.headers()),
+      formData,
+      failedResponseHandler: deepSeekFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        deepSeekFilesResponseSchema,
+      ),
+      fetch: this.config.fetch,
+    });
+
+    return {
+      warnings: [],
+      providerReference: { deepseek: response.id },
+      ...((response.filename ?? filename)
+        ? { filename: response.filename ?? filename }
+        : {}),
+      ...(mediaType != null ? { mediaType } : {}),
+      providerMetadata: {
+        deepseek: {
+          ...(response.filename != null ? { filename: response.filename } : {}),
+          ...(response.purpose != null ? { purpose: response.purpose } : {}),
+          ...(response.bytes != null ? { bytes: response.bytes } : {}),
+          ...(response.created_at != null
+            ? { createdAt: response.created_at }
+            : {}),
+          ...(response.expires_at != null
+            ? { expiresAt: response.expires_at }
+            : {}),
+        },
+      },
+    };
+  }
+}

--- a/packages/deepseek/src/index.ts
+++ b/packages/deepseek/src/index.ts
@@ -17,3 +17,4 @@ export type {
   DeepSeekLanguageModelChatOptions as DeepSeekChatOptions,
 } from './chat/deepseek-chat-language-model-options';
 export type { DeepSeekErrorData } from './chat/deepseek-chat-api-types';
+export type { DeepSeekFilesOptions } from './files/deepseek-files-options';

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -59,6 +59,7 @@ export type GatewayModelId =
   | 'deepseek/deepseek-v3.2-thinking'
   | 'deepseek/deepseek-v4-flash'
   | 'deepseek/deepseek-v4-flash-0731'
+  | 'deepseek/deepseek-v4-flash-vision-exp'
   | 'deepseek/deepseek-v4-pro'
   | 'deepseek/deepseek-v4-pro-0813'
   | 'google/gemini-2.5-flash'


### PR DESCRIPTION
## Background

DeepSeek V4 Flash Vision Exp accepts image inputs and Files API references, but the DeepSeek provider flattened user content to text and reported file parts as unsupported. The model was also missing from the AI Gateway model ID registry.

## Summary

- serialize inline image bytes as data URLs and forward image URLs in DeepSeek chat messages
- add `deepSeek.files()` for multipart image uploads with `purpose=user_data` and optional expiration
- serialize uploaded DeepSeek provider references as `{ type: "file", file_id }` content blocks
- preserve the existing string payload for prompts without supported image parts
- add the direct DeepSeek and AI Gateway model IDs
- add direct-provider, Gateway, and file-upload examples, regression tests, capability documentation, and patch changesets

## End-to-End Verification

- Inline image example: DeepSeek returned `Cat` with finish reason `stop`.
- Files API example: uploaded `comic-cat.png`, received a `file-api-…` provider reference with a one-hour expiration, passed that reference to `deepseek-v4-flash-vision-exp`, and received `Cat` with finish reason `stop`.

## Validation

- `pnpm --filter @ai-sdk/deepseek test`
- `pnpm --filter @ai-sdk/deepseek type-check`
- `pnpm --filter @ai-sdk/deepseek build`
- `pnpm check`
- `pnpm type-check:full`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
