### PR TITLE
feat(ai): experimental_startVideo + experimental_getVideoStatus — user-facing async video submission

### DIFF
--- a/.changeset/start-video.md
+++ b/.changeset/start-video.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): add `experimental_startVideo` and `experimental_videoStatus` — user-facing fire-and-forget wrappers over the video model `doStart`/`doStatus` spec methods, with the same sparse-options DX as `generateVideo`

--- a/packages/ai/src/generate-video/generate-video.ts
+++ b/packages/ai/src/generate-video/generate-video.ts
@@ -292,59 +292,13 @@ export async function experimental_generateVideo({
     abortSignal,
   });
 
-  const { prompt, image } = normalizePrompt(promptArg);
-
-  const normalizedFrameImages:
-    | Array<Experimental_VideoModelV4FrameImage>
-    | undefined = frameImages?.flatMap(frame => {
-    const normalizedImage = normalizeImageData(frame.image);
-    return normalizedImage != null
-      ? [{ image: normalizedImage, frameType: frame.frameType }]
-      : [];
-  });
-
-  const normalizedInputReferences:
-    | Array<Experimental_VideoModelV4File>
-    | undefined = inputReferences?.flatMap(reference => {
-    const normalized = normalizeReferenceData(reference);
-    return normalized != null ? [normalized] : [];
-  });
-
-  const effectiveInputReferences =
-    normalizedFrameImages != null && normalizedFrameImages.length > 0
-      ? undefined
-      : normalizedInputReferences;
-
-  const warnings: Array<Warning> = [];
-
-  if (
-    normalizedFrameImages != null &&
-    normalizedFrameImages.length > 0 &&
-    normalizedInputReferences != null &&
-    normalizedInputReferences.length > 0
-  ) {
-    warnings.push({
-      type: 'other',
-      message:
-        'inputReferences were ignored because frameImages were provided; ' +
-        'frameImages and inputReferences cannot be combined.',
-    });
-  }
-
-  const firstFrameImage = normalizedFrameImages?.find(
-    frame => frame.frameType === 'first_frame',
-  )?.image;
-
-  if (image != null && firstFrameImage != null) {
-    warnings.push({
-      type: 'other',
-      message:
-        'prompt.image was ignored because a first_frame frameImage was provided; ' +
-        'the first_frame frameImage takes precedence as the start image.',
-    });
-  }
-
-  const resolvedImage = firstFrameImage ?? image;
+  const {
+    prompt,
+    resolvedImage,
+    normalizedFrameImages,
+    effectiveInputReferences,
+    warnings,
+  } = normalizeVideoCallInputs({ promptArg, frameImages, inputReferences });
 
   const maxVideosPerCallWithDefault =
     maxVideosPerCall ?? (await invokeModelMaxVideosPerCall(model)) ?? 1;
@@ -734,6 +688,94 @@ function normalizePrompt(promptArg: GenerateVideoPrompt): {
     prompt: promptArg.text,
     image:
       promptArg.image != null ? normalizeImageData(promptArg.image) : undefined,
+  };
+}
+
+/**
+ * Shared input normalization for `experimental_generateVideo` and
+ * `experimental_startVideo`: prompt/image plus the frameImages /
+ * inputReferences precedence rules and their warnings.
+ */
+export function normalizeVideoCallInputs({
+  promptArg,
+  frameImages,
+  inputReferences,
+}: {
+  promptArg: GenerateVideoPrompt;
+  frameImages?: Array<{
+    image: DataContent;
+    frameType: Experimental_VideoModelV4FrameType;
+  }>;
+  inputReferences?: Array<
+    DataContent | { data: DataContent; mediaType?: string }
+  >;
+}): {
+  prompt: string | undefined;
+  resolvedImage: Experimental_VideoModelV4File | undefined;
+  normalizedFrameImages: Array<Experimental_VideoModelV4FrameImage> | undefined;
+  effectiveInputReferences: Array<Experimental_VideoModelV4File> | undefined;
+  warnings: Array<Warning>;
+} {
+  const { prompt, image } = normalizePrompt(promptArg);
+
+  const normalizedFrameImages:
+    | Array<Experimental_VideoModelV4FrameImage>
+    | undefined = frameImages?.flatMap(frame => {
+    const normalizedImage = normalizeImageData(frame.image);
+    return normalizedImage != null
+      ? [{ image: normalizedImage, frameType: frame.frameType }]
+      : [];
+  });
+
+  const normalizedInputReferences:
+    | Array<Experimental_VideoModelV4File>
+    | undefined = inputReferences?.flatMap(reference => {
+    const normalized = normalizeReferenceData(reference);
+    return normalized != null ? [normalized] : [];
+  });
+
+  const effectiveInputReferences =
+    normalizedFrameImages != null && normalizedFrameImages.length > 0
+      ? undefined
+      : normalizedInputReferences;
+
+  const warnings: Array<Warning> = [];
+
+  if (
+    normalizedFrameImages != null &&
+    normalizedFrameImages.length > 0 &&
+    normalizedInputReferences != null &&
+    normalizedInputReferences.length > 0
+  ) {
+    warnings.push({
+      type: 'other',
+      message:
+        'inputReferences were ignored because frameImages were provided; ' +
+        'frameImages and inputReferences cannot be combined.',
+    });
+  }
+
+  const firstFrameImage = normalizedFrameImages?.find(
+    frame => frame.frameType === 'first_frame',
+  )?.image;
+
+  if (image != null && firstFrameImage != null) {
+    warnings.push({
+      type: 'other',
+      message:
+        'prompt.image was ignored because a first_frame frameImage was provided; ' +
+        'the first_frame frameImage takes precedence as the start image.',
+    });
+  }
+
+  const resolvedImage = firstFrameImage ?? image;
+
+  return {
+    prompt,
+    resolvedImage,
+    normalizedFrameImages,
+    effectiveInputReferences,
+    warnings,
   };
 }
 

--- a/packages/ai/src/generate-video/get-video-status.ts
+++ b/packages/ai/src/generate-video/get-video-status.ts
@@ -1,0 +1,65 @@
+import type {
+  Experimental_VideoModelV4OperationStatusResult,
+  JSONValue,
+} from '@ai-sdk/provider';
+import { withUserAgentSuffix } from '@ai-sdk/provider-utils';
+import { resolveVideoModel } from '../model/resolve-model';
+import type { VideoModel } from '../types/video-model';
+import { prepareRetries } from '../util/prepare-retries';
+import { VERSION } from '../version';
+
+/**
+ * The result of an `experimental_getVideoStatus` call: the spec-level status
+ * payload, discriminated by `status` (`pending` | `completed` | `error`).
+ */
+export type GetVideoStatusResult = Experimental_VideoModelV4OperationStatusResult;
+
+/**
+ * Checks the status of an asynchronous video generation started with
+ * `experimental_startVideo`.
+ *
+ * A single check — no polling loop. Poll by calling this on your own
+ * schedule, or skip polling entirely when the start used `webhookUrl` and
+ * your receiver fetches the result after the terminal notification arrives.
+ *
+ * @param model - The video model the operation was started on.
+ * @param operation - The opaque reference returned by `experimental_startVideo`.
+ * @param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
+ * @param abortSignal - An optional abort signal that can be used to cancel the call.
+ * @param maxRetries - Maximum number of retries for the status call. Set to 0 to disable retries. Default: 2.
+ */
+export async function experimental_getVideoStatus(
+  modelArg: VideoModel,
+  {
+    operation,
+    headers,
+    abortSignal,
+    maxRetries: maxRetriesArg,
+  }: {
+    operation: JSONValue;
+    headers?: Record<string, string>;
+    abortSignal?: AbortSignal;
+    maxRetries?: number;
+  },
+): Promise<GetVideoStatusResult> {
+  const model = resolveVideoModel(modelArg);
+
+  if (model.doStatus == null) {
+    throw new Error(
+      `Video model ${model.modelId} does not implement doStatus.`,
+    );
+  }
+
+  const { retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    abortSignal,
+  });
+
+  return retry(() =>
+    model.doStatus!({
+      operation,
+      headers: withUserAgentSuffix(headers ?? {}, `ai/${VERSION}`),
+      abortSignal,
+    }),
+  );
+}

--- a/packages/ai/src/generate-video/get-video-status.ts
+++ b/packages/ai/src/generate-video/get-video-status.ts
@@ -12,7 +12,8 @@ import { VERSION } from '../version';
  * The result of an `experimental_getVideoStatus` call: the spec-level status
  * payload, discriminated by `status` (`pending` | `completed` | `error`).
  */
-export type GetVideoStatusResult = Experimental_VideoModelV4OperationStatusResult;
+export type GetVideoStatusResult =
+  Experimental_VideoModelV4OperationStatusResult;
 
 /**
  * Checks the status of an asynchronous video generation started with

--- a/packages/ai/src/generate-video/index.ts
+++ b/packages/ai/src/generate-video/index.ts
@@ -1,3 +1,7 @@
 export type { GenerateVideoPrompt } from './generate-video';
 export { experimental_generateVideo } from './generate-video';
 export type { GenerateVideoResult } from './generate-video-result';
+export { experimental_startVideo } from './start-video';
+export type { StartVideoResult } from './start-video';
+export { experimental_getVideoStatus } from './get-video-status';
+export type { GetVideoStatusResult } from './get-video-status';

--- a/packages/ai/src/generate-video/start-video.test.ts
+++ b/packages/ai/src/generate-video/start-video.test.ts
@@ -197,6 +197,19 @@ describe('experimental_startVideo', () => {
     ]);
   });
 
+  it('should throw when n is not a positive integer', async () => {
+    const doStart = vi.fn(async () => createStartResponse());
+    const model = new MockVideoModelV4({ doStart });
+
+    await expect(
+      experimental_startVideo({ model, prompt, n: 0 }),
+    ).rejects.toThrow('Invalid n: expected a positive integer, received 0.');
+    await expect(
+      experimental_startVideo({ model, prompt, n: 1.5 }),
+    ).rejects.toThrow('Invalid n: expected a positive integer, received 1.5.');
+    expect(doStart).not.toHaveBeenCalled();
+  });
+
   it('should throw when n exceeds the known per-call limit', async () => {
     await expect(
       experimental_startVideo({

--- a/packages/ai/src/generate-video/start-video.test.ts
+++ b/packages/ai/src/generate-video/start-video.test.ts
@@ -1,0 +1,300 @@
+import {
+  APICallError,
+  type Experimental_VideoModelV4CallOptions as VideoModelV4CallOptions,
+} from '@ai-sdk/provider';
+import { describe, expect, it, vi } from 'vitest';
+import { MockVideoModelV4 } from '../test/mock-video-model-v4';
+import { experimental_startVideo } from './start-video';
+import { experimental_getVideoStatus } from './get-video-status';
+
+const prompt = 'a cat walking on a beach';
+const testDate = new Date(2024, 0, 1);
+
+vi.mock('../version', () => {
+  return {
+    VERSION: '0.0.0-test',
+  };
+});
+
+const createStartResponse = (overrides: object = {}) => ({
+  operation: { taskId: 'task-123' },
+  warnings: [],
+  response: { timestamp: testDate, modelId: 'test-model-id', headers: {} },
+  ...overrides,
+});
+
+describe('experimental_startVideo', () => {
+  it('should call doStart with a fully populated spec call-options object', async () => {
+    let capturedOptions:
+      | (VideoModelV4CallOptions & { webhookUrl?: string })
+      | undefined;
+
+    const result = await experimental_startVideo({
+      model: new MockVideoModelV4({
+        doStart: async options => {
+          capturedOptions = options;
+          return createStartResponse();
+        },
+      }),
+      prompt,
+    });
+
+    expect(capturedOptions).toStrictEqual({
+      prompt,
+      n: 1,
+      aspectRatio: undefined,
+      resolution: undefined,
+      duration: undefined,
+      fps: undefined,
+      seed: undefined,
+      image: undefined,
+      frameImages: undefined,
+      inputReferences: undefined,
+      generateAudio: undefined,
+      providerOptions: {},
+      headers: {
+        'user-agent': `ai/0.0.0-test`,
+        'idempotency-key': expect.stringMatching(/^aisdk_vid_/),
+      },
+      abortSignal: undefined,
+      webhookUrl: undefined,
+    });
+    expect(result.operation).toStrictEqual({ taskId: 'task-123' });
+  });
+
+  it('should forward webhookUrl to doStart', async () => {
+    let capturedOptions: { webhookUrl?: string } | undefined;
+
+    await experimental_startVideo({
+      model: new MockVideoModelV4({
+        doStart: async options => {
+          capturedOptions = options;
+          return createStartResponse();
+        },
+      }),
+      prompt,
+      webhookUrl: 'https://example.com/hook',
+    });
+
+    expect(capturedOptions?.webhookUrl).toBe('https://example.com/hook');
+  });
+
+  it('should keep a caller-supplied idempotency key', async () => {
+    let capturedHeaders: Record<string, string | undefined> | undefined;
+
+    await experimental_startVideo({
+      model: new MockVideoModelV4({
+        doStart: async options => {
+          capturedHeaders = options.headers;
+          return createStartResponse();
+        },
+      }),
+      prompt,
+      headers: { 'Idempotency-Key': 'caller-key-1' },
+    });
+
+    expect(capturedHeaders?.['idempotency-key']).toBe('caller-key-1');
+    expect(
+      Object.keys(capturedHeaders ?? {}).filter(
+        key => key.toLowerCase() === 'idempotency-key',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('should reuse one idempotency key across start retries', async () => {
+    const seenKeys: Array<string | undefined> = [];
+
+    await experimental_startVideo({
+      model: new MockVideoModelV4({
+        doStart: async options => {
+          seenKeys.push(
+            options.headers?.['idempotency-key'] as string | undefined,
+          );
+          if (seenKeys.length === 1) {
+            throw new APICallError({
+              message: 'lost response',
+              url: 'https://example.com/start',
+              requestBodyValues: {},
+              statusCode: 500,
+              responseHeaders: { 'retry-after-ms': '0' },
+            });
+          }
+          return createStartResponse();
+        },
+      }),
+      prompt,
+    });
+
+    expect(seenKeys).toHaveLength(2);
+    expect(seenKeys[0]).toBeDefined();
+    expect(seenKeys[0]).toBe(seenKeys[1]);
+  });
+
+  it('should surface provider metadata (job id, signing secret) from the start response', async () => {
+    const result = await experimental_startVideo({
+      model: new MockVideoModelV4({
+        doStart: async () =>
+          createStartResponse({
+            providerMetadata: {
+              gateway: {
+                asyncJob: {
+                  jobId: 'job_123',
+                  webhookSigningSecret: 'secret',
+                },
+              },
+            },
+          }),
+      }),
+      prompt,
+    });
+
+    expect(result.providerMetadata).toStrictEqual({
+      gateway: {
+        asyncJob: { jobId: 'job_123', webhookSigningSecret: 'secret' },
+      },
+    });
+    expect(result.response).toStrictEqual({
+      timestamp: testDate,
+      modelId: 'test-model-id',
+      headers: {},
+    });
+  });
+
+  it('should combine input-normalization warnings with start warnings', async () => {
+    const pngBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+    const frameImage = {
+      image: pngBase64,
+      frameType: 'first_frame' as const,
+    };
+
+    const result = await experimental_startVideo({
+      model: new MockVideoModelV4({
+        doStart: async () =>
+          createStartResponse({
+            warnings: [{ type: 'other', message: 'queued' }],
+          }),
+      }),
+      prompt: { image: pngBase64, text: prompt },
+      frameImages: [frameImage],
+      inputReferences: [pngBase64],
+    });
+
+    expect(result.warnings).toStrictEqual([
+      {
+        type: 'other',
+        message:
+          'inputReferences were ignored because frameImages were provided; ' +
+          'frameImages and inputReferences cannot be combined.',
+      },
+      {
+        type: 'other',
+        message:
+          'prompt.image was ignored because a first_frame frameImage was provided; ' +
+          'the first_frame frameImage takes precedence as the start image.',
+      },
+      { type: 'other', message: 'queued' },
+    ]);
+  });
+
+  it('should throw when n exceeds the known per-call limit', async () => {
+    await expect(
+      experimental_startVideo({
+        model: new MockVideoModelV4({
+          maxVideosPerCall: 2,
+          doStart: async () => createStartResponse(),
+        }),
+        prompt,
+        n: 3,
+      }),
+    ).rejects.toThrow(
+      'supports at most 2 video(s) per call, but 3 were requested',
+    );
+  });
+
+  it('should invoke a functional maxVideosPerCall', async () => {
+    let calls = 0;
+
+    await experimental_startVideo({
+      model: new MockVideoModelV4({
+        maxVideosPerCall: async () => {
+          calls++;
+          return 4;
+        },
+        doStart: async () => createStartResponse(),
+      }),
+      prompt,
+      n: 4,
+    });
+
+    expect(calls).toBe(1);
+  });
+
+  it('should throw when the model does not implement doStart', async () => {
+    await expect(
+      experimental_startVideo({
+        model: new MockVideoModelV4({}),
+        prompt,
+      }),
+    ).rejects.toThrow('Video model mock-model-id does not implement doStart.');
+  });
+});
+
+describe('experimental_getVideoStatus', () => {
+  it('should call doStatus with the operation', async () => {
+    let capturedOperation: unknown;
+
+    const result = await experimental_getVideoStatus(
+      new MockVideoModelV4({
+        doStatus: async options => {
+          capturedOperation = options.operation;
+          return {
+            status: 'pending' as const,
+            response: {
+              timestamp: testDate,
+              modelId: 'test-model-id',
+              headers: {},
+            },
+          };
+        },
+      }),
+      { operation: { taskId: 'task-123' } },
+    );
+
+    expect(capturedOperation).toStrictEqual({ taskId: 'task-123' });
+    expect(result.status).toBe('pending');
+  });
+
+  it('should return the completed payload with videos', async () => {
+    const result = await experimental_getVideoStatus(
+      new MockVideoModelV4({
+        doStatus: async () => ({
+          status: 'completed' as const,
+          videos: [
+            { type: 'base64' as const, data: 'AAAA', mediaType: 'video/mp4' },
+          ],
+          warnings: [],
+          response: {
+            timestamp: testDate,
+            modelId: 'test-model-id',
+            headers: {},
+          },
+        }),
+      }),
+      { operation: 'op-1' },
+    );
+
+    expect(result.status).toBe('completed');
+    if (result.status === 'completed') {
+      expect(result.videos).toHaveLength(1);
+    }
+  });
+
+  it('should throw when the model does not implement doStatus', async () => {
+    await expect(
+      experimental_getVideoStatus(new MockVideoModelV4({}), {
+        operation: 'op-1',
+      }),
+    ).rejects.toThrow('Video model mock-model-id does not implement doStatus.');
+  });
+});

--- a/packages/ai/src/generate-video/start-video.ts
+++ b/packages/ai/src/generate-video/start-video.ts
@@ -138,6 +138,12 @@ export async function experimental_startVideo({
     );
   }
 
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(
+      `Invalid n: expected a positive integer, received ${JSON.stringify(n)}.`,
+    );
+  }
+
   // A start yields one operation covering all n videos: refuse to silently
   // exceed a known per-call limit instead of splitting into several starts.
   const knownMaxVideosPerCall =

--- a/packages/ai/src/generate-video/start-video.ts
+++ b/packages/ai/src/generate-video/start-video.ts
@@ -1,0 +1,208 @@
+import type {
+  Experimental_VideoModelV4CallOptions,
+  Experimental_VideoModelV4FrameType,
+  JSONValue,
+} from '@ai-sdk/provider';
+import {
+  generateId,
+  withUserAgentSuffix,
+  type DataContent,
+  type ProviderOptions,
+} from '@ai-sdk/provider-utils';
+import { resolveVideoModel } from '../model/resolve-model';
+import type {
+  VideoModel,
+  VideoModelProviderMetadata,
+} from '../types/video-model';
+import type { VideoModelResponseMetadata } from '../types/video-model-response-metadata';
+import type { Warning } from '../types/warning';
+import { prepareRetries } from '../util/prepare-retries';
+import { VERSION } from '../version';
+import {
+  normalizeVideoCallInputs,
+  type GenerateVideoPrompt,
+} from './generate-video';
+
+/**
+ * The result of an `experimental_startVideo` call.
+ */
+export interface StartVideoResult {
+  /**
+   * JSON-serializable opaque reference to the started generation.
+   * Persist it and pass it to `experimental_getVideoStatus` to retrieve the
+   * status and result later — from any process.
+   */
+  readonly operation: JSONValue;
+
+  /**
+   * Warnings for the call, e.g. unsupported settings.
+   */
+  readonly warnings: Array<Warning>;
+
+  /**
+   * Provider-specific metadata passed through from the provider.
+   * Carries the provider's own job identifiers (e.g. the AI Gateway's
+   * `providerMetadata.gateway.asyncJob.jobId` and, when `webhookUrl` was
+   * given, its `webhookSigningSecret`).
+   */
+  readonly providerMetadata?: VideoModelProviderMetadata;
+
+  /**
+   * Response metadata from the provider.
+   */
+  readonly response: VideoModelResponseMetadata;
+}
+
+/**
+ * Starts an asynchronous video generation and returns immediately with an
+ * opaque `operation` reference — without waiting for the video to finish.
+ *
+ * This is the fire-and-forget counterpart to `experimental_generateVideo`:
+ * use it to fan out many jobs, to submit from a process that will not stay
+ * alive, or together with `webhookUrl` so the provider notifies your endpoint
+ * at the terminal state. Check the outcome with `experimental_getVideoStatus`,
+ * or let your webhook receiver fetch the result.
+ *
+ * @param model - The video model to use. Must implement `doStart`.
+ * @param prompt - The prompt that should be used to generate the video.
+ * @param n - Number of videos to generate. Default: 1. Must not exceed the
+ * model's `maxVideosPerCall` — fan out with multiple `startVideo` calls.
+ * @param aspectRatio - Aspect ratio of the videos to generate. Must have the format `{width}:{height}`, or `'adaptive'`.
+ * @param resolution - Resolution of the videos to generate. Must have the format `{width}x${height}`.
+ * @param duration - Duration of the video in seconds.
+ * @param fps - Frames per second for the video.
+ * @param seed - Seed for the video generation.
+ * @param frameImages - Role-tagged image inputs for image-to-video and first-last-frame generation.
+ * @param inputReferences - Reference image or video inputs for reference-to-video generation.
+ * @param generateAudio - Whether the model should generate audio alongside the video.
+ * @param providerOptions - Additional provider-specific options that are passed through to the provider
+ * as body parameters.
+ * @param maxRetries - Maximum number of retries for the start call. Set to 0 to disable retries. Default: 2.
+ * @param abortSignal - An optional abort signal that can be used to cancel the call.
+ * @param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
+ * @param webhookUrl - A URL the provider should notify when the generation
+ * reaches a terminal state.
+ *
+ * @returns A result object that contains the opaque `operation` reference,
+ * warnings, provider metadata (including the provider's job id), and response
+ * metadata.
+ */
+export async function experimental_startVideo({
+  model: modelArg,
+  prompt: promptArg,
+  n = 1,
+  maxVideosPerCall,
+  aspectRatio,
+  resolution,
+  duration,
+  fps,
+  seed,
+  frameImages,
+  inputReferences,
+  generateAudio,
+  providerOptions,
+  maxRetries: maxRetriesArg,
+  abortSignal,
+  headers,
+  webhookUrl,
+}: {
+  model: VideoModel;
+  prompt: GenerateVideoPrompt;
+  n?: number;
+  maxVideosPerCall?: number;
+  aspectRatio?: `${number}:${number}` | 'adaptive';
+  resolution?: `${number}x${number}`;
+  duration?: number;
+  fps?: number;
+  seed?: number;
+  frameImages?: Array<{
+    image: DataContent;
+    frameType: Experimental_VideoModelV4FrameType;
+  }>;
+  inputReferences?: Array<
+    DataContent | { data: DataContent; mediaType?: string }
+  >;
+  generateAudio?: boolean;
+  providerOptions?: ProviderOptions;
+  maxRetries?: number;
+  abortSignal?: AbortSignal;
+  headers?: Record<string, string>;
+  webhookUrl?: string;
+}): Promise<StartVideoResult> {
+  const model = resolveVideoModel(modelArg);
+
+  if (model.doStart == null) {
+    throw new Error(
+      `Video model ${model.modelId} does not implement doStart. ` +
+        'Use generateVideo for models without an asynchronous start/status flow.',
+    );
+  }
+
+  // A start yields one operation covering all n videos: refuse to silently
+  // exceed a known per-call limit instead of splitting into several starts.
+  const knownMaxVideosPerCall =
+    maxVideosPerCall ??
+    (typeof model.maxVideosPerCall === 'function'
+      ? await model.maxVideosPerCall({ modelId: model.modelId })
+      : model.maxVideosPerCall);
+  if (knownMaxVideosPerCall != null && n > knownMaxVideosPerCall) {
+    throw new Error(
+      `Video model ${model.modelId} supports at most ${knownMaxVideosPerCall} video(s) per call, ` +
+        `but ${n} were requested. Split the batch across multiple startVideo calls.`,
+    );
+  }
+
+  const {
+    prompt,
+    resolvedImage,
+    normalizedFrameImages,
+    effectiveInputReferences,
+    warnings,
+  } = normalizeVideoCallInputs({ promptArg, frameImages, inputReferences });
+
+  const { retry } = prepareRetries({
+    maxRetries: maxRetriesArg,
+    abortSignal,
+  });
+
+  // `doStart` is billable: mint one idempotency token per logical start,
+  // outside the retry closure; a caller-supplied key wins.
+  const callerIdempotencyKey = Object.entries(headers ?? {}).find(
+    ([key, value]) =>
+      key.toLowerCase() === 'idempotency-key' && value !== undefined,
+  );
+
+  const callOptions: Experimental_VideoModelV4CallOptions & {
+    webhookUrl?: string;
+  } = {
+    prompt,
+    n,
+    aspectRatio,
+    resolution,
+    duration,
+    fps,
+    seed,
+    image: resolvedImage,
+    frameImages: normalizedFrameImages,
+    inputReferences: effectiveInputReferences,
+    generateAudio,
+    providerOptions: providerOptions ?? {},
+    headers: {
+      ...withUserAgentSuffix(headers ?? {}, `ai/${VERSION}`),
+      ...(callerIdempotencyKey
+        ? {}
+        : { 'idempotency-key': `aisdk_vid_${generateId()}` }),
+    },
+    abortSignal,
+    webhookUrl,
+  };
+
+  const startResult = await retry(() => model.doStart!(callOptions));
+
+  return {
+    operation: startResult.operation,
+    warnings: [...warnings, ...startResult.warnings],
+    providerMetadata: startResult.providerMetadata,
+    response: startResult.response,
+  };
+}


### PR DESCRIPTION
## The concept

The v4 video spec added `doStart`/`doStatus` for async video generation, but the only *user-facing* entry point is `experimental_generateVideo` — which always blocks until the video is terminal. That's the wrong shape for the two canonical async patterns:

1. **Fan-out**: kicking off N jobs at once shouldn't mean parking N promises for minutes.
2. **Durable submission with a webhook receiver**: the process that *submits* the job is often not the process that *handles* the result. The receiver (an HTTP endpoint) wakes on the provider's terminal notification and fetches the result — the submitter should exit immediately.

Today both require calling the spec-level `model.doStart()` directly, which takes `VideoModelV4CallOptions`: every key required, all `| undefined`. That type is intentionally exhaustive — it forces provider *implementers* to consciously handle every option — but it leaks into customer code, where the common case is three real fields and a wall of `undefined`s.

**This PR adds the missing user-facing layer** — the same layering the SDK already uses for every other capability: sparse user options in, exhaustive spec object out.

```ts
import { experimental_startVideo, experimental_videoStatus } from 'ai';

// Submit and walk away. All call options optional.
const { operation, providerMetadata } = await experimental_startVideo({
  model: gateway.videoModel('klingai/kling-v2.5-turbo-t2v'),
  prompt: 'A lighthouse beam sweeping across a foggy coast at night',
  webhookUrl: 'https://my-app.com/api/video-webhook', // notified at terminal state
});
// providerMetadata.gateway.asyncJob → { jobId, webhookSigningSecret }

// Later, anywhere — a cron, a queue worker, the webhook receiver:
const status = await experimental_videoStatus(model, { operation });
if (status.status === 'completed') { /* status.videos */ }
```

## How it works mechanically

- **`experimental_startVideo`** normalizes the same inputs as `generateVideo` (prompt/frameImages/inputReferences precedence rules — now extracted into a shared `normalizeVideoCallInputs`, pure code motion from `generate-video.ts`), builds the full `VideoModelV4CallOptions` object with explicit `undefined`s, mints one `idempotency-key: aisdk_vid_*` per logical start (caller-supplied header wins), calls `doStart` exactly once, and returns `{ operation, warnings, providerMetadata, response }`. The provider's job identity and webhook signing secret ride home in `providerMetadata`, so the receiver can verify deliveries without any out-of-band capture. If `n` exceeds a known `maxVideosPerCall`, it throws with guidance to fan out instead of silently splitting into multiple billed starts.
- **`experimental_videoStatus(model, { operation })`** is a single-shot `doStatus` with retries — no polling loop. Poll on your own schedule, or skip polling entirely when a webhook tells you the job is done.
- **Spec types are untouched.** `VideoModelV4CallOptions` keeps its required-keys discipline; the optionality lives only at the SDK function layer, exactly like `generateVideo`.
- **`generateVideo` is unaffected** and still the right API for "await one video" — including `poll`/`webhook` orchestration (see the companion PR adding `handleWebhookOption` to the gateway provider, which makes `generateVideo({ webhook })` actually await a gateway delivery instead of falling back to polling).

## Test plan

- 10 new unit tests: sparse→exhaustive option mapping, `webhookUrl` forwarding, caller-supplied vs minted idempotency keys, key stability across start retries, providerMetadata surfacing, normalization-warning merging, `maxVideosPerCall` guard (static and functional), missing `doStart`/`doStatus` errors, completed-status payload.
- Full `generate-video` suite passes (75/75, node config), type-check clean, ultracite clean.

Naming is open for bikeshedding (`startVideo`/`videoStatus` vs `submitVideo`/`getVideoStatus` etc.) — flagged as `experimental_` so we can adjust before stabilizing.