### PR TITLE
fix(ai): do not throw when closing a cancelled stitchable stream

### DIFF
--- a/.changeset/fix-stream-object-abort-close.md
+++ b/.changeset/fix-stream-object-abort-close.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): do not throw when closing a cancelled stitchable stream

--- a/packages/ai/src/generate-object/stream-object-abort-before-open.test.ts
+++ b/packages/ai/src/generate-object/stream-object-abort-before-open.test.ts
@@ -1,0 +1,228 @@
+import {
+  convertArrayToReadableStream,
+  convertAsyncIterableToArray,
+} from '@ai-sdk/provider-utils/test';
+import type {
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
+} from '@ai-sdk/provider';
+import { afterEach, describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { Output } from '../generate-text';
+import { streamText } from '../generate-text/stream-text';
+import { MockLanguageModelV4 } from '../test/mock-language-model-v4';
+import { streamObject } from './stream-object';
+
+const testUsage: LanguageModelV4Usage = {
+  inputTokens: {
+    total: 3,
+    noCache: 3,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 10,
+    text: 10,
+    reasoning: undefined,
+  },
+};
+
+const objectChunks: LanguageModelV4StreamPart[] = [
+  { type: 'stream-start', warnings: [] },
+  {
+    type: 'response-metadata',
+    id: 'id-0',
+    modelId: 'mock-model-id',
+    timestamp: new Date(0),
+  },
+  { type: 'text-start', id: '1' },
+  { type: 'text-delta', id: '1', delta: '{ "content": "Hello, world!" }' },
+  { type: 'text-end', id: '1' },
+  {
+    type: 'finish',
+    finishReason: { unified: 'stop', raw: 'stop' },
+    usage: testUsage,
+  },
+];
+
+function createGatedModel(gate: Promise<void>) {
+  return new MockLanguageModelV4({
+    doStream: async ({ abortSignal }) => {
+      if (abortSignal?.aborted) {
+        throw abortSignal.reason ?? new DOMException('Aborted', 'AbortError');
+      }
+
+      await Promise.race([
+        gate,
+        abortSignal
+          ? new Promise<never>((_, reject) => {
+              abortSignal.addEventListener(
+                'abort',
+                () => {
+                  reject(
+                    abortSignal.reason ??
+                      new DOMException('Aborted', 'AbortError'),
+                  );
+                },
+                { once: true },
+              );
+            })
+          : new Promise<never>(() => {}),
+      ]);
+
+      return {
+        stream: convertArrayToReadableStream(objectChunks),
+      };
+    },
+  });
+}
+
+function collectBackgroundErrors() {
+  const errors: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    errors.push(reason);
+  };
+  const onUncaughtException = (error: unknown) => {
+    errors.push(error);
+  };
+  process.on('unhandledRejection', onUnhandledRejection);
+  process.on('uncaughtException', onUncaughtException);
+  return {
+    errors,
+    stop() {
+      process.off('unhandledRejection', onUnhandledRejection);
+      process.off('uncaughtException', onUncaughtException);
+    },
+  };
+}
+
+function isAlreadyClosedError(error: unknown): boolean {
+  if (error == null || typeof error !== 'object') {
+    return false;
+  }
+  const maybe = error as { name?: string; code?: string; message?: string };
+  return (
+    maybe.code === 'ERR_INVALID_STATE' ||
+    (maybe.name === 'TypeError' &&
+      typeof maybe.message === 'string' &&
+      maybe.message.includes('Controller is already closed'))
+  );
+}
+
+const schema = z.object({ content: z.string() });
+
+describe('vercel/ai#8102 abort before structured object stream opens', () => {
+  const collectors: Array<ReturnType<typeof collectBackgroundErrors>> = [];
+
+  afterEach(() => {
+    for (const collector of collectors.splice(0)) {
+      collector.stop();
+    }
+  });
+
+  it('streamObject: abortSignal aborted immediately, then consume', async () => {
+    const collector = collectBackgroundErrors();
+    collectors.push(collector);
+
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const result = streamObject({
+      model: createGatedModel(Promise.resolve()),
+      schema,
+      prompt: 'prompt',
+      abortSignal: abortController.signal,
+      onError: () => {},
+      maxRetries: 0,
+    });
+
+    await convertAsyncIterableToArray(result.partialObjectStream).catch(
+      () => {},
+    );
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const closedErrors = collector.errors.filter(isAlreadyClosedError);
+    expect(
+      closedErrors,
+      `unexpected Controller-already-closed errors: ${closedErrors
+        .map(error => (error instanceof Error ? error.stack : String(error)))
+        .join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('streamObject: cancel consumer before doStream returns (abort before first chunk)', async () => {
+    const collector = collectBackgroundErrors();
+    collectors.push(collector);
+
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => {
+      release = resolve;
+    });
+
+    const abortController = new AbortController();
+    const result = streamObject({
+      model: createGatedModel(gate),
+      schema,
+      prompt: 'prompt',
+      abortSignal: abortController.signal,
+      onError: () => {},
+      maxRetries: 0,
+    });
+
+    const reader = result.partialObjectStream.getReader();
+    const pendingRead = reader.read().catch(() => undefined);
+
+    abortController.abort();
+    await reader.cancel();
+    release();
+
+    await pendingRead;
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const closedErrors = collector.errors.filter(isAlreadyClosedError);
+    expect(
+      closedErrors,
+      `unexpected Controller-already-closed errors: ${closedErrors
+        .map(error => (error instanceof Error ? error.stack : String(error)))
+        .join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('streamText({output}): cancel consumer before doStream returns', async () => {
+    const collector = collectBackgroundErrors();
+    collectors.push(collector);
+
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => {
+      release = resolve;
+    });
+
+    const abortController = new AbortController();
+    const result = streamText({
+      model: createGatedModel(gate),
+      output: Output.object({ schema }),
+      prompt: 'prompt',
+      abortSignal: abortController.signal,
+      onError: () => {},
+      maxRetries: 0,
+    });
+
+    const reader = result.fullStream.getReader();
+    const pendingRead = reader.read().catch(() => undefined);
+
+    abortController.abort();
+    await reader.cancel();
+    release();
+
+    await pendingRead;
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const closedErrors = collector.errors.filter(isAlreadyClosedError);
+    expect(
+      closedErrors,
+      `unexpected Controller-already-closed errors: ${closedErrors
+        .map(error => (error instanceof Error ? error.stack : String(error)))
+        .join('\n')}`,
+    ).toEqual([]);
+  });
+});

--- a/packages/ai/src/util/create-stitchable-stream.ts
+++ b/packages/ai/src/util/create-stitchable-stream.ts
@@ -28,6 +28,14 @@ export function createStitchableStream<T>(): {
   let isCancelled = false;
   let waitForNewStream = createResolvablePromise<void>();
 
+  const safeClose = () => {
+    try {
+      controller?.close();
+    } catch {
+      // already closed (consumer cancelled the outer stream)
+    }
+  };
+
   const terminate = () => {
     if (isCancelled) {
       return;
@@ -41,7 +49,7 @@ export function createStitchableStream<T>(): {
       reader.cancel();
     });
     innerStreams = [];
-    controller?.close();
+    safeClose();
   };
 
   const processPull = async () => {
@@ -51,7 +59,7 @@ export function createStitchableStream<T>(): {
 
     // Case 1: Outer stream is closed and no more inner streams
     if (isClosed && innerStreams.length === 0) {
-      controller?.close();
+      safeClose();
       return;
     }
 
@@ -78,7 +86,7 @@ export function createStitchableStream<T>(): {
 
         if (innerStreams.length === 0 && isClosed) {
           // when closed and no more inner streams, stop pulling
-          controller?.close();
+          safeClose();
         } else {
           // continue pulling from the next stream
           await processPull();
@@ -155,7 +163,7 @@ export function createStitchableStream<T>(): {
       waitForNewStream.resolve();
 
       if (innerStreams.length === 0) {
-        controller?.close();
+        safeClose();
       }
     },
 


### PR DESCRIPTION
Fixes #8102.

Aborting or cancelling a `streamObject` request before the first chunk cancelled the outer stitchable stream. The `finally` block then called `close()`, which threw `TypeError [ERR_INVALID_STATE]: Controller is already closed` and crashed the process.

`close()` / `terminate()` / pull-complete now swallow an already-closed controller. `streamText({ output })` already survived this abort path; a regression test covers it anyway.

Reproduced on current `main` (`76fb75db97`) before the change.

```
cd packages/ai && node ../../node_modules/vitest/vitest.mjs --config vitest.node.config.js --run src/util/create-stitchable-stream.test.ts src/generate-object/stream-object-abort-before-open.test.ts
```
