### PR TITLE
fix(example): set SvelteKit Vercel runtime

### DIFF
--- a/examples/sveltekit-openai/svelte.config.js
+++ b/examples/sveltekit-openai/svelte.config.js
@@ -8,7 +8,7 @@ const config = {
   preprocess: vitePreprocess(),
 
   kit: {
-    adapter: adapter(),
+    adapter: adapter({ runtime: 'nodejs24.x' }),
   },
 };
 


### PR DESCRIPTION
## Summary

- configure the SvelteKit example to emit Node.js 24 Vercel functions
- allow the example build to run when the repository selects Node.js 26

## Tests

- `pn --filter @example/sveltekit-openai build` under Node.js 26.5.0
- `pn check`
- `pn exec turbo build --concurrency 16 --output-logs=errors-only` passes the SvelteKit task, then fails in the unrelated `@example/next-openai` task because the local environment provides an empty `baseURL`