### PR TITLE
fix(mcp): support stdio command shims on Windows

### DIFF
--- a/.changeset/nice-rice-remember.md
+++ b/.changeset/nice-rice-remember.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+fix(mcp): support spawning command shims such as `npx` on Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,38 @@ jobs:
           SKIP_RSC_E2E: '1'
         run: pnpm test:ci
 
+  test_mcp_windows:
+    name: 'Test MCP (Windows)'
+    runs-on: windows-latest
+    needs: build-packages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download package build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: package-build-artifacts
+
+      - name: Extract package build artifacts
+        run: tar -xzf package-build-artifacts.tgz
+
+      - name: Run MCP tests
+        working-directory: packages/mcp
+        run: pnpm test:node
+
   test_rsc_e2e:
     name: 'Test RSC e2e'
     runs-on: ubuntu-latest
@@ -550,6 +582,7 @@ jobs:
         build-packages,
         test_node_versions,
         test_matrix,
+        test_mcp_windows,
         test_rsc_e2e,
         test_ai_matrix,
         test_codemod_matrix,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -44,10 +44,12 @@
   "dependencies": {
     "@ai-sdk/provider": "workspace:*",
     "@ai-sdk/provider-utils": "workspace:*",
+    "cross-spawn": "^7.0.6",
     "pkce-challenge": "^5.0.1"
   },
   "devDependencies": {
     "@ai-sdk/test-server": "workspace:*",
+    "@types/cross-spawn": "^6.0.6",
     "@types/node": "22.19.19",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8.5.1",

--- a/packages/mcp/src/tool/mcp-stdio/__fixtures__/exit.cmd
+++ b/packages/mcp/src/tool/mcp-stdio/__fixtures__/exit.cmd
@@ -1,0 +1,2 @@
+@echo off
+exit /b 0

--- a/packages/mcp/src/tool/mcp-stdio/create-child-process.test.ts
+++ b/packages/mcp/src/tool/mcp-stdio/create-child-process.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { once } from 'node:events';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import * as getEnvironmentModule from './get-environment';
 import os from 'node:os';
 
@@ -91,4 +95,69 @@ describe('createChildProcess', () => {
     expect(childProcessWithStderr.stderr).toBeDefined();
     childProcessWithStderr.kill();
   });
+
+  it.runIf(process.platform === 'win32')(
+    'should spawn npx on Windows',
+    async () => {
+      const childProcess = createChildProcess(
+        {
+          command: 'npx',
+          args: ['--version'],
+          env: { PATH: process.env.PATH! },
+          stderr: 'pipe',
+        },
+        new AbortController().signal,
+      );
+      const stdout: Buffer[] = [];
+      childProcess.stdout?.on('data', chunk => stdout.push(chunk));
+
+      const [exitCode] = await once(childProcess, 'close');
+
+      expect(exitCode).toBe(0);
+      expect(Buffer.concat(stdout).toString().trim()).toMatch(/^\d+\.\d+\.\d+/);
+    },
+  );
+
+  it.runIf(process.platform === 'win32')(
+    'should escape command shim arguments on Windows',
+    async () => {
+      const cwd = mkdtempSync(join(os.tmpdir(), 'ai-sdk-mcp-'));
+      const markerPath = join(cwd, 'injected.txt');
+
+      try {
+        const childProcess = createChildProcess(
+          {
+            command: fileURLToPath(
+              new URL('./__fixtures__/exit.cmd', import.meta.url),
+            ),
+            args: [`safe & type nul > "${markerPath}"`],
+            cwd,
+            stderr: 'pipe',
+          },
+          new AbortController().signal,
+        );
+
+        const [exitCode] = await once(childProcess, 'close');
+
+        expect(exitCode).toBe(0);
+        expect(existsSync(markerPath)).toBe(false);
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform === 'win32')(
+    'should reject line breaks in arguments on Windows',
+    () => {
+      expect(() =>
+        createChildProcess(
+          { command: 'npx', args: ['safe\r\necho unsafe'] },
+          new AbortController().signal,
+        ),
+      ).toThrow(
+        'Stdio MCP commands and arguments must not contain line breaks on Windows.',
+      );
+    },
+  );
 });

--- a/packages/mcp/src/tool/mcp-stdio/create-child-process.ts
+++ b/packages/mcp/src/tool/mcp-stdio/create-child-process.ts
@@ -1,4 +1,5 @@
-import { spawn, type ChildProcess } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+import spawn from 'cross-spawn';
 import { getEnvironment } from './get-environment';
 import type { StdioConfig } from './mcp-stdio-transport';
 
@@ -6,6 +7,15 @@ export function createChildProcess(
   config: StdioConfig,
   signal: AbortSignal,
 ): ChildProcess {
+  if (
+    globalThis.process.platform === 'win32' &&
+    [config.command, ...(config.args ?? [])].some(value => /[\r\n]/.test(value))
+  ) {
+    throw new TypeError(
+      'Stdio MCP commands and arguments must not contain line breaks on Windows.',
+    );
+  }
+
   return spawn(config.command, config.args ?? [], {
     env: getEnvironment(config.env),
     stdio: ['pipe', 'pipe', config.stderr ?? 'inherit'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3311,6 +3311,9 @@ importers:
       '@ai-sdk/provider-utils':
         specifier: workspace:*
         version: link:../provider-utils
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       pkce-challenge:
         specifier: ^5.0.1
         version: 5.0.1
@@ -3318,6 +3321,9 @@ importers:
       '@ai-sdk/test-server':
         specifier: workspace:*
         version: link:../test-server
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
       '@types/node':
         specifier: 22.19.19
         version: 22.19.19
@@ -13745,6 +13751,9 @@ packages:
 
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
+  '@types/cross-spawn@6.0.6':
+    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -35950,6 +35959,10 @@ snapshots:
   '@types/cookie@0.6.0': {}
 
   '@types/cookiejar@2.1.5': {}
+
+  '@types/cross-spawn@6.0.6':
+    dependencies:
+      '@types/node': 22.19.19
 
   '@types/d3-array@3.2.2': {}
 


### PR DESCRIPTION
## Background

`Experimental_StdioMCPTransport` currently uses Node.js `spawn` with `shell: false`. On Windows, npm command shims such as `npx.cmd` cannot be launched directly, so configuring `command: "npx"` fails with `ENOENT` and configuring `command: "npx.cmd"` fails with `EINVAL`.

## Changes

- use `cross-spawn` to resolve and invoke Windows command shims while preserving `shell: false`
- reject CR/LF in Windows commands and arguments before the command-shell fallback
- add Windows-only regression coverage for `npx`, metacharacter escaping, and line-break rejection
- run the MCP Node test suite on Windows in CI
- add a patch changeset for `@ai-sdk/mcp`

## Verification

- `pnpm check`
- `pnpm --filter @ai-sdk/mcp type-check`
- `pnpm --filter @ai-sdk/mcp test:node` (283 passed, 3 Windows-only tests skipped locally)
- `pnpm type-check:full` reaches unrelated existing diagnostics in `examples/nuxt-openai`; the MCP package type check passes

Fixes #19157