### PR TITLE
[v6.0] fix(mcp): support stdio command shims on Windows

### DIFF
--- a/.changeset/nice-rice-remember.md
+++ b/.changeset/nice-rice-remember.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+fix(mcp): support spawning command shims such as `npx` on Windows

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -45,10 +45,12 @@
   "dependencies": {
     "@ai-sdk/provider": "workspace:*",
     "@ai-sdk/provider-utils": "workspace:*",
+    "cross-spawn": "^7.0.6",
     "pkce-challenge": "^5.0.0"
   },
   "devDependencies": {
     "@ai-sdk/test-server": "workspace:*",
+    "@types/cross-spawn": "^6.0.6",
     "@types/node": "20.17.24",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8",

--- a/packages/mcp/src/tool/mcp-stdio/__fixtures__/exit.cmd
+++ b/packages/mcp/src/tool/mcp-stdio/__fixtures__/exit.cmd
@@ -1,0 +1,2 @@
+@echo off
+exit /b 0

--- a/packages/mcp/src/tool/mcp-stdio/create-child-process.test.ts
+++ b/packages/mcp/src/tool/mcp-stdio/create-child-process.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { once } from 'node:events';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import * as getEnvironmentModule from './get-environment';
 import os from 'node:os';
 
@@ -91,4 +95,69 @@ describe('createChildProcess', () => {
     expect(childProcessWithStderr.stderr).toBeDefined();
     childProcessWithStderr.kill();
   });
+
+  it.runIf(process.platform === 'win32')(
+    'should spawn npx on Windows',
+    async () => {
+      const childProcess = createChildProcess(
+        {
+          command: 'npx',
+          args: ['--version'],
+          env: { PATH: process.env.PATH! },
+          stderr: 'pipe',
+        },
+        new AbortController().signal,
+      );
+      const stdout: Buffer[] = [];
+      childProcess.stdout?.on('data', chunk => stdout.push(chunk));
+
+      const [exitCode] = await once(childProcess, 'close');
+
+      expect(exitCode).toBe(0);
+      expect(Buffer.concat(stdout).toString().trim()).toMatch(/^\d+\.\d+\.\d+/);
+    },
+  );
+
+  it.runIf(process.platform === 'win32')(
+    'should escape command shim arguments on Windows',
+    async () => {
+      const cwd = mkdtempSync(join(os.tmpdir(), 'ai-sdk-mcp-'));
+      const markerPath = join(cwd, 'injected.txt');
+
+      try {
+        const childProcess = createChildProcess(
+          {
+            command: fileURLToPath(
+              new URL('./__fixtures__/exit.cmd', import.meta.url),
+            ),
+            args: [`safe & type nul > "${markerPath}"`],
+            cwd,
+            stderr: 'pipe',
+          },
+          new AbortController().signal,
+        );
+
+        const [exitCode] = await once(childProcess, 'close');
+
+        expect(exitCode).toBe(0);
+        expect(existsSync(markerPath)).toBe(false);
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform === 'win32')(
+    'should reject line breaks in arguments on Windows',
+    () => {
+      expect(() =>
+        createChildProcess(
+          { command: 'npx', args: ['safe\r\necho unsafe'] },
+          new AbortController().signal,
+        ),
+      ).toThrow(
+        'Stdio MCP commands and arguments must not contain line breaks on Windows.',
+      );
+    },
+  );
 });

--- a/packages/mcp/src/tool/mcp-stdio/create-child-process.ts
+++ b/packages/mcp/src/tool/mcp-stdio/create-child-process.ts
@@ -1,4 +1,5 @@
-import { spawn, type ChildProcess } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+import spawn from 'cross-spawn';
 import { getEnvironment } from './get-environment';
 import type { StdioConfig } from './mcp-stdio-transport';
 
@@ -6,6 +7,15 @@ export function createChildProcess(
   config: StdioConfig,
   signal: AbortSignal,
 ): ChildProcess {
+  if (
+    globalThis.process.platform === 'win32' &&
+    [config.command, ...(config.args ?? [])].some(value => /[\r\n]/.test(value))
+  ) {
+    throw new TypeError(
+      'Stdio MCP commands and arguments must not contain line breaks on Windows.',
+    );
+  }
+
   return spawn(config.command, config.args ?? [], {
     env: getEnvironment(config.env),
     stdio: ['pipe', 'pipe', config.stderr ?? 'inherit'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2509,6 +2509,9 @@ importers:
       '@ai-sdk/provider-utils':
         specifier: workspace:*
         version: link:../provider-utils
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       pkce-challenge:
         specifier: ^5.0.0
         version: 5.0.1
@@ -2516,6 +2519,9 @@ importers:
       '@ai-sdk/test-server':
         specifier: workspace:*
         version: link:../test-server
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
       '@types/node':
         specifier: 20.17.24
         version: 20.17.24
@@ -10723,6 +10729,9 @@ packages:
 
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
+  '@types/cross-spawn@6.0.6':
+    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -29275,6 +29284,10 @@ snapshots:
   '@types/cookie@0.6.0': {}
 
   '@types/cookiejar@2.1.5': {}
+
+  '@types/cross-spawn@6.0.6':
+    dependencies:
+      '@types/node': 22.19.19
 
   '@types/d3-array@3.2.2': {}
 


### PR DESCRIPTION
Manual backport of #19286 to `release-v6.0`.

The main-only CI workflow change is intentionally omitted. The Windows regression job on #19286 passes; this PR carries the implementation, regression tests, dependency updates, lockfile changes, and patch changeset.

## Verification

- `pnpm exec turbo build --filter=@ai-sdk/mcp`
- `pnpm --filter @ai-sdk/mcp type-check`
- `pnpm --filter @ai-sdk/mcp test:node` (245 passed, 3 Windows-only tests skipped locally)
- targeted Ultracite check