### PR TITLE
feat(amazon-bedrock): type guardrail provider options

### DIFF
--- a/.changeset/moody-poets-invite.md
+++ b/.changeset/moody-poets-invite.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": minor
+---
+
+Add types for Amazon Bedrock guardrail configuration provider options.

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -261,23 +261,45 @@ const result = await generateText({
 
 ### Guardrails
 
-You can use the `bedrock` provider options to utilize [Amazon Bedrock Guardrails](https://aws.amazon.com/bedrock/guardrails/):
+You can use the `amazonBedrock` provider options to utilize [Amazon Bedrock Guardrails](https://aws.amazon.com/bedrock/guardrails/):
 
 ```ts
-import { type AmazonBedrockLanguageModelChatOptions } from '@ai-sdk/amazon-bedrock';
+import { amazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { generateText } from 'ai';
 
 const result = await generateText({
   model: amazonBedrock('anthropic.claude-3-sonnet-20240229-v1:0'),
   prompt: 'Write a story about space exploration.',
   providerOptions: {
-    bedrock: {
+    amazonBedrock: {
       guardrailConfig: {
         guardrailIdentifier: '1abcd2ef34gh',
         guardrailVersion: '1',
-        trace: 'enabled' as const,
+        trace: 'enabled',
+      },
+    },
+  },
+});
+```
+
+For streaming calls, you can also set the guardrail stream processing mode:
+
+```ts
+import { amazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { streamText } from 'ai';
+
+const result = streamText({
+  model: amazonBedrock('anthropic.claude-3-sonnet-20240229-v1:0'),
+  prompt: 'Write a story about space exploration.',
+  providerOptions: {
+    amazonBedrock: {
+      guardrailConfig: {
+        guardrailIdentifier: '1abcd2ef34gh',
+        guardrailVersion: '1',
+        trace: 'enabled',
         streamProcessingMode: 'async',
       },
-    } satisfies AmazonBedrockLanguageModelChatOptions,
+    },
   },
 });
 ```
@@ -285,7 +307,7 @@ const result = await generateText({
 Tracing information will be returned in the provider metadata if you have tracing enabled.
 
 ```ts
-if (result.providerMetadata?.bedrock.trace) {
+if (result.providerMetadata?.amazonBedrock.trace) {
   // ...
 }
 ```

--- a/examples/ai-functions/src/generate-text/amazon-bedrock/guardrails.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock/guardrails.ts
@@ -4,13 +4,13 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: amazonBedrock('anthropic.claude-3-haiku-20240307-v1:0'),
+    model: amazonBedrock('us.anthropic.claude-haiku-4-5-20251001-v1:0'),
     prompt:
       'Invent a new fake holiday and describe its traditions. ' +
       'You are a comedian and should insult the audience as much as possible.',
 
     providerOptions: {
-      bedrock: {
+      amazonBedrock: {
         guardrailConfig: {
           guardrailIdentifier: '<your-guardrail-identifier>',
           guardrailVersion: '1',

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.test.ts
@@ -4,6 +4,38 @@ import {
   type AmazonBedrockLanguageModelChatOptions,
 } from './amazon-bedrock-chat-language-model-options';
 describe('amazonBedrockLanguageModelChatOptions', () => {
+  describe('guardrailConfig', () => {
+    it('accepts valid guardrail config values', () => {
+      const result = amazonBedrockLanguageModelChatOptions.safeParse({
+        guardrailConfig: {
+          guardrailIdentifier: 'xxxxxxxx',
+          guardrailVersion: 'DRAFT',
+          trace: 'enabled_full',
+          streamProcessingMode: 'async',
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.guardrailConfig).toEqual({
+        guardrailIdentifier: 'xxxxxxxx',
+        guardrailVersion: 'DRAFT',
+        trace: 'enabled_full',
+        streamProcessingMode: 'async',
+      });
+    });
+
+    it('rejects invalid guardrail config enum values', () => {
+      const result = amazonBedrockLanguageModelChatOptions.safeParse({
+        guardrailConfig: {
+          trace: 'on',
+          streamProcessingMode: 'background',
+        },
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
   describe('serviceTier', () => {
     it('accepts valid service tier values', () => {
       const validValues = ['reserved', 'priority', 'default', 'flex'] as const;
@@ -34,9 +66,16 @@ describe('amazonBedrockLanguageModelChatOptions', () => {
   describe('type inference', () => {
     it('infers AmazonBedrockLanguageModelChatOptions type correctly', () => {
       const options: AmazonBedrockLanguageModelChatOptions = {
+        guardrailConfig: {
+          guardrailIdentifier: 'xxxxxxxx',
+          guardrailVersion: 'DRAFT',
+          trace: 'enabled',
+          streamProcessingMode: 'async',
+        },
         serviceTier: 'priority',
       };
 
+      expect(options.guardrailConfig?.streamProcessingMode).toBe('async');
       expect(options.serviceTier).toBe('priority');
     });
   });

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.ts
@@ -134,6 +134,20 @@ export const amazonBedrockLanguageModelChatOptions = z.object({
    */
   anthropicBeta: z.array(z.string()).optional(),
   /**
+   * Guardrail configuration for the request.
+   * `streamProcessingMode` only applies to streaming calls.
+   *
+   * @see https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-use-converse-api.html
+   */
+  guardrailConfig: z
+    .object({
+      guardrailIdentifier: z.string().optional(),
+      guardrailVersion: z.string().optional(),
+      trace: z.enum(['enabled', 'disabled', 'enabled_full']).optional(),
+      streamProcessingMode: z.enum(['sync', 'async']).optional(),
+    })
+    .optional(),
+  /**
    * Service tier for the request.
    * @see https://docs.aws.amazon.com/bedrock/latest/userguide/service-tiers-inference.html
    *


### PR DESCRIPTION
## Background

Amazon Bedrock guardrail configuration can already be passed through via `providerOptions.amazonBedrock.guardrailConfig`, but `AmazonBedrockLanguageModelChatOptions` did not include a typed schema for it.

This made valid guardrail options less convenient to use from TypeScript, especially for fields such as `trace` and `streamProcessingMode`.

## Summary

- Add `guardrailConfig` to `AmazonBedrockLanguageModelChatOptions`
- Add schema/type inference tests for guardrail provider options
- Update the Amazon Bedrock provider docs to use `providerOptions.amazonBedrock`

## End-to-End Verification

This can be run with AWS credentials and guardrail environment variables from `examples/ai-functions`:

```bash
pnpm tsx src/generate-text/amazon-bedrock/guardrails.ts
```

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

None.

## Related Issues

None.