### PR TITLE
Backport: feat(provider/gateway): add Tako Search tool

### DIFF
--- a/.changeset/tako-gateway-tool.md
+++ b/.changeset/tako-gateway-tool.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat (provider/gateway): add Tako Search tool support

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -504,6 +504,112 @@ for await (const part of result.fullStream) {
 }
 ```
 
+#### Tako Search
+
+The Tako Search tool enables models to search the web and Tako's curated knowledge graph in a single call using [Tako's Search API](https://docs.tako.com/documentation/integrating-tako/search/overview). This tool is executed by the AI Gateway and returns token-efficient web excerpts, plus knowledge-graph results that carry structured data, premium source attribution, and an embed-ready visualization.
+
+```ts
+import { gateway, generateText } from 'ai';
+
+const result = await generateText({
+  model: 'openai/gpt-5.4-nano',
+  prompt: 'How has Nvidia quarterly revenue changed over the last two years?',
+  tools: {
+    tako_search: gateway.tools.takoSearch(),
+  },
+});
+
+console.log(result.text);
+console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+```
+
+Configure the search with effort, source selection, and localization defaults. These defaults override values the model includes in a tool call:
+
+```ts
+import { gateway, generateText } from 'ai';
+
+const result = await generateText({
+  model: 'openai/gpt-5.4-nano',
+  prompt: 'AMD vs. Nvidia headcount since 2013',
+  tools: {
+    tako_search: gateway.tools.takoSearch({
+      effort: 'fast',
+      sources: {
+        data: {
+          contentFormat: 'json_compact',
+          includeContents: true,
+          maxRows: 100,
+        },
+        web: {
+          count: 3,
+        },
+      },
+      countryCode: 'US',
+      locale: 'en-US',
+    }),
+  },
+});
+
+console.log(result.text);
+```
+
+The Tako Search tool supports these optional configuration options:
+
+- **effort** _'fast' | 'instant' | 'deep'_ - Search effort. `'fast'` is the balanced default, `'instant'` favors cached low-latency results, and `'deep'` broadens retrieval with reranking at higher cost and latency.
+- **sources** _object_ - Omit to search both curated Tako data and the live web. When set, only source keys present are searched.
+- **sources.web** _object_ - Configure web results:
+  - **count** _number_ - Maximum web results, 1-20.
+  - **category** _'finance' | 'news' | 'sports'_ - Restrict web results to one category.
+  - **includeDomains** / **excludeDomains** _string[]_ - Only return, or drop, results from these bare domains. Up to 20 each.
+  - **publishedAfter** / **publishedBefore** _string_ - Keep results published on or after, or on or before, this `YYYY-MM-DD` date.
+  - **snippetMaxChars** _number_ - Character cap on each result's text excerpt. Defaults to 4,000; maximum 20,000.
+  - **highlights** _boolean_ - Return query-relevant passages as each result's snippet instead of the opening text of the page. The snippet can hold multiple passages joined by `' ... '`, and a page with no highlight returns `snippet: null`. Defaults to `true` in the AI Gateway.
+  - **includeContents** _boolean_ - Inline each page's extracted full text in `content`. **articleContentMaxChars** caps it, defaulting to 30,000 characters (maximum 1,000,000).
+- **sources.data** _object_ - Configure data results:
+  - **count** _number_ - Maximum data results, 1-20. Defaults to 5.
+  - **includeContents** _boolean_ - Inline each card's underlying rows in `content.dataset` as typed, unit-labeled columns.
+  - **contentFormat** _'json_compact' | 'json_records' | 'csv' | 'card_json'_ - Serialization for inlined card data. Defaults to `'json_compact'`.
+  - **maxRows** _number_ - Row cap for inlined card data. Omit to use your account's default inline cap (20 rows on the standard plan); maximum 2,000.
+  - **nodeIds** _string[]_ - Data Graph node IDs to prioritize. Up to 20.
+  - **strict** _boolean_ - Only return cards matching `nodeIds`. Requires at least one `nodeIds` value.
+- **location** _object_ - End-user `{ latitude, longitude }` coordinates for localized results.
+- **countryCode** _string_ - ISO 3166-1 alpha-2 country code, such as `'US'`.
+- **locale** _string_ - BCP-47 locale, such as `'en-US'`.
+- **timezone** _string_ - IANA timezone, such as `'America/New_York'`.
+- **outputSettings** _object_ - Card rendering controls. `forceRefresh` is available only with `'instant'` effort.
+- **includeRelated** _number_ - Number of related search suggestions to include (1-20).
+
+For precise entity matching, quote a phrase in the query and optionally append a label: `"Tesla":PRODUCT price`. Tako treats the quoted phrase as one entity before searching.
+
+The tool works with both `generateText` and `streamText`:
+
+```ts
+import { gateway, streamText } from 'ai';
+
+const result = streamText({
+  model: 'openai/gpt-5.4-nano',
+  prompt: 'What is the latest US inflation rate?',
+  tools: {
+    tako_search: gateway.tools.takoSearch(),
+  },
+});
+
+for await (const part of result.fullStream) {
+  switch (part.type) {
+    case 'text-delta':
+      process.stdout.write(part.text);
+      break;
+    case 'tool-call':
+      console.log('\nTool call:', JSON.stringify(part, null, 2));
+      break;
+    case 'tool-result':
+      console.log('\nTool result:', JSON.stringify(part, null, 2));
+      break;
+  }
+}
+```
+
 #### Parallel Search
 
 The Parallel Search tool enables models to search the web using [Parallel AI's Search API](https://docs.parallel.ai/api-reference/search-beta/search). This tool is optimized for LLM consumption, returning relevant excerpts from web pages that can replace multiple keyword searches with a single call.

--- a/examples/ai-core/src/generate-text/gateway-tool-tako-search-params.ts
+++ b/examples/ai-core/src/generate-text/gateway-tool-tako-search-params.ts
@@ -1,0 +1,58 @@
+import { gateway, generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: 'openai/gpt-5-nano',
+    prompt: 'United States vs China inflation rate',
+    tools: {
+      tako_search: gateway.tools.takoSearch({
+        effort: 'fast',
+        sources: {
+          data: {
+            contentFormat: 'json_compact',
+            includeContents: true,
+            maxRows: 100,
+          },
+          web: {
+            count: 3,
+          },
+        },
+        countryCode: 'US',
+        locale: 'en-US',
+      }),
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Reasoning:', result.reasoning);
+  console.log();
+  console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+
+  for (const toolResult of result.toolResults) {
+    if (toolResult.dynamic) continue;
+
+    const { output } = toolResult;
+    if ('error' in output) continue;
+
+    for (const web of output.web_results ?? []) {
+      console.log(`[${web.citation_number}] ${web.source_name} - ${web.url}`);
+    }
+
+    for (const card of output.cards ?? []) {
+      const dataset = card.content?.dataset;
+      if (!dataset) continue;
+      console.log(
+        card.title,
+        dataset.columns.map(c => (c.unit ? `${c.name} (${c.unit})` : c.name)),
+        `${dataset.rows.length} of ${dataset.total_rows} rows`,
+      );
+    }
+  }
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/generate-text/gateway-tool-tako-search.ts
+++ b/examples/ai-core/src/generate-text/gateway-tool-tako-search.ts
@@ -1,0 +1,20 @@
+import { gateway, generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: 'openai/gpt-5-nano',
+    prompt:
+      "How has ChatGPT's web traffic trended this year, and what do analysts say about it?",
+    tools: {
+      tako_search: gateway.tools.takoSearch(),
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+  console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/gateway-tool-tako-search-params.ts
+++ b/examples/ai-core/src/stream-text/gateway-tool-tako-search-params.ts
@@ -1,0 +1,57 @@
+import { gateway, streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: 'openai/gpt-5-nano',
+    prompt:
+      'Who leads the Premier League, and how did the top teams do this weekend?',
+    tools: {
+      tako_search: gateway.tools.takoSearch({
+        effort: 'fast',
+        sources: {
+          data: { count: 3 },
+          web: {
+            category: 'news',
+            count: 5,
+            includeDomains: ['bbc.com', 'theguardian.com'],
+            publishedAfter: '2026-01-01',
+          },
+        },
+        countryCode: 'GB',
+      }),
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'reasoning-delta':
+        process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);
+        break;
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'tool-call':
+        console.log('\nTool call:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-result':
+        console.log('\nTool result:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-error':
+        console.log('\nTool error:', JSON.stringify(part, null, 2));
+        break;
+    }
+  }
+
+  console.log();
+  console.log('Tool calls:', JSON.stringify(await result.toolCalls, null, 2));
+  console.log(
+    'Tool results:',
+    JSON.stringify(await result.toolResults, null, 2),
+  );
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-core/src/stream-text/gateway-tool-tako-search.ts
+++ b/examples/ai-core/src/stream-text/gateway-tool-tako-search.ts
@@ -1,0 +1,35 @@
+import { gateway, streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: 'openai/gpt-5-nano',
+    prompt:
+      'Compare Nvidia and AMD employee counts since 2013 with source-grounded data.',
+    tools: {
+      tako_search: gateway.tools.takoSearch(),
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    switch (part.type) {
+      case 'reasoning-delta':
+        process.stdout.write(`\x1b[34m${part.text}\x1b[0m`);
+        break;
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'tool-call':
+        console.log('\nTool call:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-result':
+        console.log('\nTool result:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-error':
+        console.log('\nTool error:', JSON.stringify(part, null, 2));
+        break;
+    }
+  }
+}
+
+main().catch(console.error);

--- a/packages/gateway/src/gateway-tools.ts
+++ b/packages/gateway/src/gateway-tools.ts
@@ -1,5 +1,6 @@
 import { parallelSearch } from './tool/parallel-search';
 import { perplexitySearch } from './tool/perplexity-search';
+import { takoSearch } from './tool/tako-search';
 
 /**
  * Gateway-specific provider-defined tools.
@@ -23,4 +24,14 @@ export const gatewayTools = {
    * domain, language, date range, and recency filters.
    */
   perplexitySearch,
+
+  /**
+   * Search the web and Tako's curated knowledge graph in one call for
+   * token-efficient web excerpts and structured data results grounded in
+   * premium sources, each with an embed-ready visualization.
+   *
+   * Supports effort, per-source web and data controls, localization, and inline
+   * contents for agents that need to reason over underlying data.
+   */
+  takoSearch,
 };

--- a/packages/gateway/src/tool/tako-search.ts
+++ b/packages/gateway/src/tool/tako-search.ts
@@ -1,0 +1,583 @@
+import {
+  createProviderDefinedToolFactoryWithOutputSchema,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod';
+
+export type TakoSearchEffort = 'deep' | 'fast' | 'instant';
+
+export type TakoContentFormat =
+  | 'card_json'
+  | 'csv'
+  | 'json_compact'
+  | 'json_records';
+
+export interface TakoDataSourceConfig {
+  /** Maximum number of data cards to return (1-20). */
+  count?: number;
+  /** Inline underlying card data in the response. This can add a data charge. */
+  includeContents?: boolean;
+  /** Requested delivery mode for card data. Search cards are always inlined. */
+  mode?: 'inline' | 'url';
+  /** Serialization for inlined card data. */
+  contentFormat?: TakoContentFormat;
+  /** Maximum rows for inlined card data. The service clamps large values. */
+  maxRows?: number;
+  /** Data Graph node IDs to prioritize. */
+  nodeIds?: string[];
+  /** Return only cards matching nodeIds. Requires at least one node ID. */
+  strict?: boolean;
+}
+
+export interface TakoWebSourceConfig {
+  /** Maximum number of web results to return (1-20). */
+  count?: number;
+  /** Inline extracted web page text. This can add a data charge. */
+  includeContents?: boolean;
+  /** Optional web-result category filter. */
+  category?: 'finance' | 'news' | 'sports';
+  /** Only return results from these bare domains. */
+  includeDomains?: string[];
+  /** Exclude results from these bare domains. */
+  excludeDomains?: string[];
+  /** Maximum characters in each web-result snippet. */
+  snippetMaxChars?: number;
+  /** Include highlighted passages in web results. Defaults to true in AI Gateway. */
+  highlights?: boolean;
+  /** Maximum extracted characters per web page when including contents. */
+  articleContentMaxChars?: number;
+  /** Keep results published on or after this ISO date. */
+  publishedAfter?: string;
+  /** Keep results published on or before this ISO date. */
+  publishedBefore?: string;
+}
+
+export interface TakoSearchConfig {
+  /** Search effort. fast is the default balanced option. */
+  effort?: TakoSearchEffort;
+  /** Sources to search. Omit to search both curated data and the web. */
+  sources?: {
+    data?: TakoDataSourceConfig;
+    web?: TakoWebSourceConfig;
+  };
+  /** End-user coordinates for localized results. */
+  location?: {
+    latitude: number;
+    longitude: number;
+  };
+  /** ISO 3166-1 alpha-2 country code. */
+  countryCode?: string;
+  /** BCP-47 locale. */
+  locale?: string;
+  /** IANA timezone. */
+  timezone?: string;
+  /** Settings that control card rendering. */
+  outputSettings?: {
+    imageDarkMode?: boolean;
+    /** Instant-effort only. */
+    forceRefresh?: boolean;
+  };
+  /** Maximum related search suggestions to include (1-20). */
+  includeRelated?: number;
+}
+
+export interface TakoSearchInput {
+  query: string;
+  effort?: TakoSearchEffort;
+  sources?: {
+    data?: {
+      count?: number;
+      include_contents?: boolean;
+      mode?: 'inline' | 'url';
+      content_format?: TakoContentFormat;
+      max_rows?: number;
+      node_ids?: string[];
+      strict?: boolean;
+    };
+    web?: {
+      count?: number;
+      include_contents?: boolean;
+      category?: 'finance' | 'news' | 'sports';
+      include_domains?: string[];
+      exclude_domains?: string[];
+      snippet_max_chars?: number;
+      highlights?: boolean;
+      article_content_max_chars?: number;
+      published_after?: string;
+      published_before?: string;
+    };
+  };
+  location?: {
+    latitude: number;
+    longitude: number;
+  };
+  country_code?: string;
+  locale?: string;
+  timezone?: string;
+  output_settings?: {
+    image_dark_mode?: boolean;
+    force_refresh?: boolean;
+  };
+  include_related?: number;
+}
+
+export type TakoDatasetCell = boolean | number | string | null;
+
+export interface TakoResultContent {
+  content_format?: TakoContentFormat | null;
+  cost?: number;
+  data?: string | null;
+  records?: Array<Record<string, TakoDatasetCell>> | null;
+  dataset?: {
+    columns: Array<{
+      name: string;
+      type: 'boolean' | 'date' | 'datetime' | 'number' | 'string';
+      unit?: string | null;
+    }>;
+    rows: TakoDatasetCell[][];
+    total_rows: number;
+    truncated: boolean;
+    ref: string;
+    sources: Array<{
+      name: string;
+      index?: 'data' | 'web';
+    }>;
+    provenance?: 'query' | 'web_extraction';
+  } | null;
+  card_data?: Record<string, unknown> | null;
+  card_data_schema?: Record<string, unknown> | null;
+  url?: string | null;
+  expires_at?: string | null;
+  total_rows?: number | null;
+  truncated?: boolean;
+  export_pricing?: {
+    baseline_usd: number;
+    free_rows: number;
+    max_rows_ceiling: number;
+    row_cpm_usd: number;
+  } | null;
+  manifest?: Array<{
+    dtype?: 'boolean' | 'date' | 'datetime' | 'number' | 'string' | null;
+    entity?: string | null;
+    metric?: string | null;
+    name?: string | null;
+    unit?: string | null;
+  }> | null;
+}
+
+export interface TakoCard {
+  card_id?: string | null;
+  title?: string | null;
+  description?: string | null;
+  semantic_description?: string | null;
+  webpage_url?: string | null;
+  image_url?: string | null;
+  embed_url?: string | null;
+  sources?: Array<{
+    source_name?: string | null;
+    source_description?: string | null;
+    source_index: 'data' | 'web';
+    source_text?: string | null;
+    url?: string | null;
+  }> | null;
+  methodologies?: Array<{
+    methodology_name: string | null;
+    methodology_description: string | null;
+  }> | null;
+  source_indexes?: Array<'data' | 'web'> | null;
+  card_type?: string | null;
+  relevance?: 'High' | 'Low' | 'Medium' | null;
+  content?: TakoResultContent | null;
+  exportable?: boolean;
+  relevance_score?: number | null;
+  nodes?: Array<{
+    id: string;
+    type: 'entity' | 'metric';
+    name: string;
+    description?: string | null;
+  }> | null;
+  metric_definitions?: Array<{
+    name: string;
+    definition: string;
+  }> | null;
+  data_freshness?: {
+    coverage_end?: string | null;
+    data_as_of?: string | null;
+    last_updated?: string | null;
+  } | null;
+}
+
+export interface TakoWebResult {
+  title: string;
+  url: string;
+  snippet?: string | null;
+  source_name?: string | null;
+  publish_date?: string | null;
+  content?: TakoResultContent | null;
+  citation_number?: number | null;
+}
+
+export interface TakoSearchResponse {
+  request_id: string;
+  cards?: TakoCard[];
+  web_results?: TakoWebResult[];
+  usage?: {
+    total_cost_usd: number;
+    compute?: {
+      cost_usd: number;
+    } | null;
+    data?: {
+      cost_usd: number;
+      datasets: number;
+    } | null;
+  } | null;
+  related?: Array<Record<string, unknown>> | null;
+}
+
+export interface TakoSearchError {
+  error:
+    | 'api_error'
+    | 'configuration_error'
+    | 'execution_error'
+    | 'invalid_input'
+    | 'rate_limit'
+    | 'timeout'
+    | 'unknown_tool';
+  statusCode?: number;
+  message: string;
+}
+
+export type TakoSearchOutput = TakoSearchError | TakoSearchResponse;
+
+const takoDataSourceInputSchema = z.object({
+  count: z
+    .number()
+    .optional()
+    .describe('Maximum number of data cards to return (1-20).'),
+  include_contents: z
+    .boolean()
+    .optional()
+    .describe('Inline underlying card data. This can add a data charge.'),
+  mode: z
+    .enum(['inline', 'url'])
+    .optional()
+    .describe(
+      'Requested data delivery mode. Search card data is always inline.',
+    ),
+  content_format: z
+    .enum(['card_json', 'csv', 'json_compact', 'json_records'])
+    .optional()
+    .describe('Serialization for inlined card data.'),
+  max_rows: z
+    .number()
+    .optional()
+    .describe('Maximum rows for inlined card data.'),
+  node_ids: z
+    .array(z.string())
+    .optional()
+    .describe('Data Graph node IDs to prioritize. Maximum 20.'),
+  strict: z
+    .boolean()
+    .optional()
+    .describe(
+      'Only return cards matching node_ids. Requires a non-empty node_ids.',
+    ),
+});
+
+const takoWebSourceInputSchema = z.object({
+  count: z
+    .number()
+    .optional()
+    .describe('Maximum number of web results to return (1-20).'),
+  include_contents: z
+    .boolean()
+    .optional()
+    .describe('Inline extracted web page text. This can add a data charge.'),
+  category: z
+    .enum(['finance', 'news', 'sports'])
+    .optional()
+    .describe('Optional web-result category filter.'),
+  include_domains: z
+    .array(z.string())
+    .optional()
+    .describe('Only return results from these bare domains.'),
+  exclude_domains: z
+    .array(z.string())
+    .optional()
+    .describe('Exclude results from these bare domains.'),
+  snippet_max_chars: z
+    .number()
+    .optional()
+    .describe('Maximum characters in each web-result snippet.'),
+  highlights: z
+    .boolean()
+    .optional()
+    .describe(
+      'Include highlighted passages in web results. Defaults to true in AI Gateway.',
+    ),
+  article_content_max_chars: z
+    .number()
+    .optional()
+    .describe(
+      'Maximum extracted characters per web page when including contents.',
+    ),
+  published_after: z
+    .string()
+    .optional()
+    .describe('Keep results published on or after this ISO date (YYYY-MM-DD).'),
+  published_before: z
+    .string()
+    .optional()
+    .describe(
+      'Keep results published on or before this ISO date (YYYY-MM-DD).',
+    ),
+});
+
+const takoSearchInputSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      query: z
+        .string()
+        .describe(
+          'Natural-language search query. Include the entity, metric, and time period. Quote a phrase to force it to one entity, for example "Tesla":PRODUCT price.',
+        ),
+      effort: z
+        .enum(['deep', 'fast', 'instant'])
+        .optional()
+        .describe(
+          'Search effort. fast is the balanced default, instant favors cached results and low latency, and deep broadens retrieval with reranking at higher cost and latency.',
+        ),
+      sources: z
+        .object({
+          data: takoDataSourceInputSchema.optional(),
+          web: takoWebSourceInputSchema.optional(),
+        })
+        .optional()
+        .describe(
+          'Sources to search. Omit to search both curated data and the web. When provided, only keys present are searched.',
+        ),
+      location: z
+        .object({
+          latitude: z.number().describe('Latitude between -90 and 90.'),
+          longitude: z.number().describe('Longitude between -180 and 180.'),
+        })
+        .optional()
+        .describe('End-user coordinates for localized results.'),
+      country_code: z
+        .string()
+        .optional()
+        .describe("Two-letter ISO 3166-1 country code, such as 'US'."),
+      locale: z.string().optional().describe("BCP-47 locale, such as 'en-US'."),
+      timezone: z
+        .string()
+        .optional()
+        .describe("IANA timezone, such as 'America/New_York'."),
+      output_settings: z
+        .object({
+          image_dark_mode: z
+            .boolean()
+            .optional()
+            .describe('Render card preview images in dark mode.'),
+          force_refresh: z
+            .boolean()
+            .optional()
+            .describe(
+              'Instant-effort only. Request a refreshed instant result.',
+            ),
+        })
+        .optional()
+        .describe('Controls card rendering in the search response.'),
+      include_related: z
+        .number()
+        .optional()
+        .describe('Maximum related search suggestions to include (1-20).'),
+    }),
+  ),
+);
+
+const takoDatasetCellSchema = z
+  .union([z.boolean(), z.number(), z.string()])
+  .nullable();
+
+const takoResultContentSchema = z
+  .object({
+    content_format: z
+      .enum(['card_json', 'csv', 'json_compact', 'json_records'])
+      .nullish(),
+    cost: z.number().optional(),
+    data: z.string().nullish(),
+    records: z.array(z.record(z.string(), takoDatasetCellSchema)).nullish(),
+    dataset: z
+      .object({
+        columns: z.array(
+          z.object({
+            name: z.string(),
+            type: z.enum(['boolean', 'date', 'datetime', 'number', 'string']),
+            unit: z.string().nullish(),
+          }),
+        ),
+        rows: z.array(z.array(takoDatasetCellSchema)),
+        total_rows: z.number(),
+        truncated: z.boolean(),
+        ref: z.string(),
+        sources: z.array(
+          z.object({
+            name: z.string(),
+            index: z.enum(['data', 'web']).optional(),
+          }),
+        ),
+        provenance: z.enum(['query', 'web_extraction']).optional(),
+      })
+      .nullish(),
+    card_data: z.object({}).passthrough().nullish(),
+    card_data_schema: z.object({}).passthrough().nullish(),
+    url: z.string().nullish(),
+    expires_at: z.string().nullish(),
+    total_rows: z.number().nullish(),
+    truncated: z.boolean().optional(),
+    export_pricing: z
+      .object({
+        baseline_usd: z.number(),
+        free_rows: z.number(),
+        max_rows_ceiling: z.number(),
+        row_cpm_usd: z.number(),
+      })
+      .nullish(),
+    manifest: z
+      .array(
+        z.object({
+          dtype: z
+            .enum(['boolean', 'date', 'datetime', 'number', 'string'])
+            .nullish(),
+          entity: z.string().nullish(),
+          metric: z.string().nullish(),
+          name: z.string().nullish(),
+          unit: z.string().nullish(),
+        }),
+      )
+      .nullish(),
+  })
+  .passthrough();
+
+const takoCardSchema = z
+  .object({
+    card_id: z.string().nullish(),
+    title: z.string().nullish(),
+    description: z.string().nullish(),
+    semantic_description: z.string().nullish(),
+    webpage_url: z.string().nullish(),
+    image_url: z.string().nullish(),
+    embed_url: z.string().nullish(),
+    sources: z
+      .array(
+        z.object({
+          source_name: z.string().nullish(),
+          source_description: z.string().nullish(),
+          source_index: z.enum(['data', 'web']),
+          source_text: z.string().nullish(),
+          url: z.string().nullish(),
+        }),
+      )
+      .nullish(),
+    methodologies: z
+      .array(
+        z.object({
+          methodology_name: z.string().nullable(),
+          methodology_description: z.string().nullable(),
+        }),
+      )
+      .nullish(),
+    source_indexes: z.array(z.enum(['data', 'web'])).nullish(),
+    card_type: z.string().nullish(),
+    relevance: z.enum(['High', 'Low', 'Medium']).nullish(),
+    content: takoResultContentSchema.nullish(),
+    exportable: z.boolean().optional(),
+    relevance_score: z.number().nullish(),
+    nodes: z
+      .array(
+        z.object({
+          id: z.string(),
+          type: z.enum(['entity', 'metric']),
+          name: z.string(),
+          description: z.string().nullish(),
+        }),
+      )
+      .nullish(),
+    metric_definitions: z
+      .array(z.object({ name: z.string(), definition: z.string() }))
+      .nullish(),
+    data_freshness: z
+      .object({
+        coverage_end: z.string().nullish(),
+        data_as_of: z.string().nullish(),
+        last_updated: z.string().nullish(),
+      })
+      .nullish(),
+  })
+  .passthrough();
+
+const takoWebResultSchema = z
+  .object({
+    title: z.string(),
+    url: z.string(),
+    snippet: z.string().nullish(),
+    source_name: z.string().nullish(),
+    publish_date: z.string().nullish(),
+    content: takoResultContentSchema.nullish(),
+    citation_number: z.number().nullish(),
+  })
+  .passthrough();
+
+const takoSearchOutputSchema = lazySchema(() =>
+  zodSchema(
+    z.union([
+      z
+        .object({
+          request_id: z.string(),
+          cards: z.array(takoCardSchema).optional(),
+          web_results: z.array(takoWebResultSchema).optional(),
+          usage: z
+            .object({
+              total_cost_usd: z.number(),
+              compute: z.object({ cost_usd: z.number() }).nullish(),
+              data: z
+                .object({ cost_usd: z.number(), datasets: z.number() })
+                .nullish(),
+            })
+            .nullish(),
+          related: z.array(z.object({}).passthrough()).nullish(),
+        })
+        .passthrough(),
+      z.object({
+        error: z.enum([
+          'api_error',
+          'configuration_error',
+          'execution_error',
+          'invalid_input',
+          'rate_limit',
+          'timeout',
+          'unknown_tool',
+        ]),
+        statusCode: z.number().optional(),
+        message: z.string(),
+      }),
+    ]),
+  ),
+);
+
+export const takoSearchToolFactory =
+  createProviderDefinedToolFactoryWithOutputSchema<
+    TakoSearchInput,
+    TakoSearchOutput,
+    TakoSearchConfig
+  >({
+    id: 'gateway.tako_search',
+    name: 'tako_search',
+    inputSchema: takoSearchInputSchema,
+    outputSchema: takoSearchOutputSchema,
+  });
+
+export const takoSearch = (
+  config: TakoSearchConfig = {},
+): ReturnType<typeof takoSearchToolFactory> => takoSearchToolFactory(config);


### PR DESCRIPTION
Backport of #18963 to the release-v5.0 branch. FYI @shaper

## v5.0 adaptations (not a clean cherry-pick)

- Use `createProviderDefinedToolFactoryWithOutputSchema` with explicit `name: 'tako_search'` (main renamed it to `createProviderExecutedToolFactory`)
- Import `z` from `'zod'` (no `../zod` shim in the gateway package on v5.0)
- Use `result.fullStream` in docs and examples (main renamed it to `result.stream` after v5.0 branched)
- Examples placed in `examples/ai-core` with `gateway-tool-*` naming to match v5.0 conventions

## Verification

- `pnpm build` + `pnpm test` in `packages/gateway` pass (317 tests)
- `pnpm type-check:full` passes for all touched files (remaining failures are pre-existing `examples/next-*` React types issues)
- `examples/ai-core/src/stream-text/gateway-tool-tako-search-params.ts` verified end-to-end against the live gateway (`providerExecuted: true`)