### PR TITLE
chore(ai): bump bundle size limit to 615 KB

### DIFF
--- a/packages/ai/scripts/check-bundle-size.ts
+++ b/packages/ai/scripts/check-bundle-size.ts
@@ -3,7 +3,7 @@ import { writeFileSync, statSync } from 'fs';
 import { join } from 'path';
 
 // Bundle size limits in bytes
-const LIMIT = 610 * 1024;
+const LIMIT = 615 * 1024;
 
 interface BundleResult {
   size: number;


### PR DESCRIPTION
Unblocks #19295.

The Tako Search gateway tool backport pushes the `ai` package's browser bundle to 610.65 KB, marginally over the current 610 KB limit (`packages/ai/scripts/check-bundle-size.ts`).

On main this isn't an issue because zod imports were made tree-shakeable (#18304) and the runtime Zod 3 dependency was removed (#18378), bringing the limit down to 450 KB. Neither change is part of `release-v6.0`, where the gateway package's existing tools already pull in the full `z` namespace, so a small limit bump is the consistent fix (see prior bumps: #18352, #17526, #16116).

Once this lands on `release-v6.0`, rebasing #19295 should turn its Bundle Size Check green.