### PR TITLE
fix(sveltekit-openai): add initial system prompt to chat example

### DIFF
--- a/examples/sveltekit-openai/src/routes/api/chat/+server.ts
+++ b/examples/sveltekit-openai/src/routes/api/chat/+server.ts
@@ -18,7 +18,9 @@ export const POST = async ({ request }: { request: Request }) => {
 
   const result = streamText({
     model: openai('gpt-4o'),
-    messages: convertToModelMessages(messages),
+    system:
+      'You are a helpful assistant that can answer questions and use the available tools.',
+    messages: await convertToModelMessages(messages),
     stopWhen: isStepCount(5), // multi-steps for server-side tools
     tools: {
       // server-side tool with execute function:


### PR DESCRIPTION
## Summary

- Add an explicit system prompt to the SvelteKit OpenAI chat example.
- Await `convertToModelMessages`, which is asynchronous in the current API.

This makes the example show how to provide initial model instructions while keeping it compatible with the current AI SDK message conversion API.

Fixes #10220

## Validation

- `pnpm --filter @example/sveltekit-openai type-check`
- `pnpm --filter @example/sveltekit-openai build`
- `pnpm exec oxlint examples/sveltekit-openai/src/routes/api/chat/+server.ts`
- `pnpm exec oxfmt --check examples/sveltekit-openai/src/routes/api/chat/+server.ts`
- `git diff --check`

No changeset is included because this PR only updates an example application.