### PR TITLE
feat: batch completion webhooks via startTextBatch webhookUrl

### DIFF
--- a/.changeset/gateway-batch-webhooks.md
+++ b/.changeset/gateway-batch-webhooks.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/provider': patch
+'ai': patch
+'@ai-sdk/gateway': patch
+---
+
+feat: add batch completion webhooks. `experimental_startTextBatch` accepts a `webhook` factory (mirroring the video webhook flow), models signal support via `experimental_handleBatchWebhookOption`, and the gateway provider registers the URL through its batch `callbackUrl` contract.

--- a/.changeset/gateway-batch-webhooks.md
+++ b/.changeset/gateway-batch-webhooks.md
@@ -6,4 +6,4 @@
 'ai': patch
 ---
 
-feat: add batch completion webhooks. `experimental_startTextBatch` accepts a `webhookUrl`, and the gateway provider registers it through the batch `callbackUrl` contract. Direct Anthropic and OpenAI batch providers return an unsupported warning when the option is provided.
+feat: add batch completion webhooks. `experimental_startTextBatch` accepts a `webhookUrl`, and the gateway provider registers it through the batch `callbackUrl` contract and exports typed async-job metadata. Direct Anthropic and OpenAI batch providers return an unsupported warning when the option is provided.

--- a/.changeset/gateway-batch-webhooks.md
+++ b/.changeset/gateway-batch-webhooks.md
@@ -1,7 +1,9 @@
 ---
+'@ai-sdk/anthropic': patch
+'@ai-sdk/gateway': patch
+'@ai-sdk/openai': patch
 '@ai-sdk/provider': patch
 'ai': patch
-'@ai-sdk/gateway': patch
 ---
 
-feat: add batch completion webhooks. `experimental_startTextBatch` accepts a `webhook` factory (mirroring the video webhook flow), models signal support via `experimental_handleBatchWebhookOption`, and the gateway provider registers the URL through its batch `callbackUrl` contract.
+feat: add batch completion webhooks. `experimental_startTextBatch` accepts a `webhookUrl`, and the gateway provider registers it through the batch `callbackUrl` contract. Direct Anthropic and OpenAI batch providers return an unsupported warning when the option is provided.

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -207,6 +207,51 @@ const { text } = await generateText({
 
 AI Gateway language models can also be used in the `streamText` function and support structured data generation with [`Output`](/docs/reference/ai-sdk-core/output) (see [AI SDK Core](/docs/ai-sdk-core)).
 
+## Text Batches
+
+<Note type="warning">
+  Text batch support is experimental and the API may change in patch releases.
+</Note>
+
+AI Gateway supports durable text batches through `experimental_startTextBatch`, `experimental_getBatchStatus`, and `experimental_getBatchResults`. See the [AI Gateway batch processing guide](https://vercel.com/docs/ai-gateway/models-and-providers/batch-processing) for supported models, limits, and the complete lifecycle.
+
+Pass a publicly reachable HTTPS `webhookUrl` when starting a batch to receive a terminal notification instead of polling. AI Gateway sends `batch.completed`, `batch.failed`, or `batch.cancelled`. The event contains terminal status information but not batch results. Completion webhooks are an AI Gateway capability; direct Anthropic and OpenAI batch providers return an unsupported warning when this option is provided.
+
+```ts filename="start-batch.ts"
+import { randomUUID } from 'node:crypto';
+import { experimental_startTextBatch as startTextBatch } from 'ai';
+
+// The receiver uses this token to look up the expected batch and signing
+// secret before trusting anything in the webhook body.
+const token = randomUUID();
+
+const batch = await startTextBatch({
+  model: 'anthropic/claude-haiku-4.5',
+  requests: [
+    { id: 'france', prompt: 'What is the capital of France?' },
+    { id: 'germany', prompt: 'What is the capital of Germany?' },
+  ],
+  webhookUrl: `https://example.com/api/batch-webhook?token=${token}`,
+});
+
+const asyncJob = batch.providerMetadata?.gateway?.asyncJob as
+  | { webhookSigningSecret?: string }
+  | undefined;
+
+if (asyncJob?.webhookSigningSecret == null) {
+  throw new Error('AI Gateway did not return a webhook signing secret.');
+}
+
+await saveBatchWebhook(token, {
+  batch,
+  signingSecret: asyncJob.webhookSigningSecret,
+});
+```
+
+The signing secret is returned only in the start response. Persist it and the complete `batch` reference before the process exits. The receiver must verify the `x-ai-gateway-signature` header against the raw request body before trusting the event. The header has the form `t=<unix seconds>,v1=<hex digest>`, where `v1` is the HMAC-SHA256 digest of `"<t>.<raw body>"`. Use a timing-safe comparison, reject stale timestamps, and reject events whose `data.jobId` does not match the persisted `batch.id`. Batch deliveries use the same signing format as AI Gateway video webhooks; see [verifying the delivery](https://vercel.com/docs/ai-gateway/modalities/video-generation#verifying-the-delivery) for a complete verification helper.
+
+AI Gateway expects a 2xx response within 10 seconds and retries failed deliveries. Retries carry the same `x-ai-gateway-idempotency-key` value (`<jobId>-<status>`), which receivers can use for deduplication. After verification, pass the persisted `batch` reference to `experimental_getBatchStatus` and `experimental_getBatchResults`. Delivery is best-effort, so periodically reconcile persisted batches by status as a fallback for a notification that exhausts its retries.
+
 ## Reranking Models
 
 You can create reranking models using the `rerankingModel` method on the provider instance:

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -219,38 +219,181 @@ Pass a publicly reachable HTTPS `webhookUrl` when starting a batch to receive a 
 
 ```ts filename="start-batch.ts"
 import { randomUUID } from 'node:crypto';
-import { experimental_startTextBatch as startTextBatch } from 'ai';
+import {
+  experimental_startTextBatch as startTextBatch,
+  type Experimental_TextBatchReference as TextBatchReference,
+  type GatewayProviderMetadata,
+} from 'ai';
 
 // The receiver uses this token to look up the expected batch and signing
 // secret before trusting anything in the webhook body.
 const token = randomUUID();
+const model = 'anthropic/claude-haiku-4.5' as const;
+
+// Reserve the token before starting so an early delivery finds a retryable
+// pending record rather than an unknown callback.
+await reserveBatchWebhook(token);
 
 const batch = await startTextBatch({
-  model: 'anthropic/claude-haiku-4.5',
+  model,
   requests: [
     { id: 'france', prompt: 'What is the capital of France?' },
     { id: 'germany', prompt: 'What is the capital of Germany?' },
   ],
+  providerOptions: {
+    gateway: { idempotencyKey: token },
+  },
   webhookUrl: `https://example.com/api/batch-webhook?token=${token}`,
 });
 
-const asyncJob = batch.providerMetadata?.gateway?.asyncJob as
-  | { webhookSigningSecret?: string }
+const gatewayMetadata = batch.providerMetadata?.gateway as
+  | GatewayProviderMetadata
   | undefined;
+const signingSecret = gatewayMetadata?.asyncJob?.webhookSigningSecret;
 
-if (asyncJob?.webhookSigningSecret == null) {
+if (typeof signingSecret !== 'string') {
   throw new Error('AI Gateway did not return a webhook signing secret.');
 }
 
-await saveBatchWebhook(token, {
-  batch,
-  signingSecret: asyncJob.webhookSigningSecret,
+// Keep sensitive provider metadata out of the receiver queue and logs.
+const batchReference = {
+  version: batch.version,
+  type: batch.type,
+  id: batch.id,
+  provider: batch.provider,
+  modelId: batch.modelId,
+} satisfies TextBatchReference;
+
+await completeBatchWebhookReservation(token, {
+  batch: batchReference,
+  model,
+  signingSecret,
 });
 ```
 
-The signing secret is returned only in the start response. Persist it and the complete `batch` reference before the process exits. The receiver must verify the `x-ai-gateway-signature` header against the raw request body before trusting the event. The header has the form `t=<unix seconds>,v1=<hex digest>`, where `v1` is the HMAC-SHA256 digest of `"<t>.<raw body>"`. Use a timing-safe comparison, reject stale timestamps, and reject events whose `data.jobId` does not match the persisted `batch.id`. Batch deliveries use the same signing format as AI Gateway video webhooks; see [verifying the delivery](https://vercel.com/docs/ai-gateway/modalities/video-generation#verifying-the-delivery) for a complete verification helper.
+The signing secret is returned only in the start response. Reserve the callback token before submitting the batch, then persist the secret, model, and minimal `batch` reference before the process exits. The stable `providerOptions.gateway.idempotencyKey` makes retrying an ambiguous start safe. Reuse the reserved token when retrying; do not generate a new one. Delete the reservation after a definitive start failure. While the reservation is still pending, the receiver should return a retryable response so an early delivery is sent again after setup completes.
 
-AI Gateway expects a 2xx response within 10 seconds and retries failed deliveries. Retries carry the same `x-ai-gateway-idempotency-key` value (`<jobId>-<status>`), which receivers can use for deduplication. After verification, pass the persisted `batch` reference to `experimental_getBatchStatus` and `experimental_getBatchResults`. Delivery is best-effort, so periodically reconcile persisted batches by status as a fallback for a notification that exhausts its retries.
+The receiver must verify the `x-ai-gateway-signature` header against a bounded raw request body before trusting the event:
+
+```ts filename="app/api/batch-webhook/route.ts"
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+const MAX_AGE_SECONDS = 5 * 60;
+const MAX_BODY_BYTES = 64 * 1024;
+
+export async function POST(request: Request) {
+  const token = new URL(request.url).searchParams.get('token');
+  if (token == null) return new Response(null, { status: 401 });
+
+  const record = await loadBatchWebhook(token);
+  if (record == null) return new Response(null, { status: 401 });
+  if (record.state !== 'ready') return new Response(null, { status: 503 });
+
+  const declaredLength = request.headers.get('content-length');
+  if (declaredLength != null && Number(declaredLength) > MAX_BODY_BYTES) {
+    return new Response(null, { status: 413 });
+  }
+
+  const rawBody = await readBodyWithLimit(request, MAX_BODY_BYTES);
+  if (rawBody == null) return new Response(null, { status: 413 });
+
+  const signature = request.headers.get('x-ai-gateway-signature');
+  if (
+    signature == null ||
+    !verifySignature({
+      header: signature,
+      rawBody,
+      secret: record.signingSecret,
+    })
+  ) {
+    return new Response(null, { status: 401 });
+  }
+
+  let event: { data?: { jobId?: string; status?: string } };
+  try {
+    event = JSON.parse(rawBody);
+  } catch {
+    return new Response(null, { status: 400 });
+  }
+
+  const jobId = event.data?.jobId;
+  const status = event.data?.status;
+  if (
+    jobId !== record.batch.id ||
+    (status !== 'cancelled' && status !== 'completed' && status !== 'failed')
+  ) {
+    return new Response(null, { status: 401 });
+  }
+
+  // The header is not signed, so require it to match the signed event body.
+  const deliveryId = `${jobId}-${status}`;
+  if (request.headers.get('x-ai-gateway-idempotency-key') !== deliveryId) {
+    return new Response(null, { status: 401 });
+  }
+
+  await enqueueBatchResultFetch({
+    batch: record.batch,
+    deliveryId,
+    model: record.model,
+  });
+
+  return new Response(null, { status: 204 });
+}
+
+async function readBodyWithLimit(request: Request, maxBytes: number) {
+  if (request.body == null) return '';
+
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  let body = '';
+  let size = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return body + decoder.decode();
+
+      size += value.byteLength;
+      if (size > maxBytes) {
+        await reader.cancel();
+        return undefined;
+      }
+
+      body += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function verifySignature({
+  header,
+  rawBody,
+  secret,
+}: {
+  header: string;
+  rawBody: string;
+  secret: string;
+}) {
+  const timestamp = header.match(/(?:^|,)t=(\d+)/)?.[1];
+  const digest = header.match(/(?:^|,)v1=([0-9a-f]{64})(?:,|$)/)?.[1];
+  if (timestamp == null || digest == null) return false;
+
+  const expected = createHmac('sha256', secret)
+    .update(`${timestamp}.${rawBody}`, 'utf8')
+    .digest('hex');
+  const provided = Buffer.from(digest, 'hex');
+  const computed = Buffer.from(expected, 'hex');
+  if (provided.length !== computed.length) return false;
+  if (!timingSafeEqual(provided, computed)) return false;
+
+  return Math.abs(Date.now() / 1000 - Number(timestamp)) <= MAX_AGE_SECONDS;
+}
+```
+
+The signature header has the form `t=<unix seconds>,v1=<hex digest>`, where `v1` is the HMAC-SHA256 digest of `"<t>.<raw body>"`. Verify a size-limited raw request body rather than a re-serialized object, use a timing-safe comparison, reject stale timestamps, and reject events whose `data.jobId` does not match the persisted `batch.id`.
+
+AI Gateway expects a 2xx response within 10 seconds and retries failed deliveries. It does not follow redirects, so the callback endpoint itself must return the 2xx response. Retries carry the same `x-ai-gateway-idempotency-key` value (`<jobId>-<status>`), which receivers can use for deduplication. After verification, pass the persisted model and `batch` reference to `experimental_getBatchStatus` and `experimental_getBatchResults`. Delivery is best-effort, so periodically reconcile persisted batches by status as a fallback for a notification that exhausts its retries.
 
 ## Reranking Models
 

--- a/packages/ai/src/batch/batch-types.test-d.ts
+++ b/packages/ai/src/batch/batch-types.test-d.ts
@@ -41,6 +41,9 @@ it('keeps batch start non-retrying', () => {
   expectTypeOf<StartTextBatchOptions['timeout']>().toEqualTypeOf<
     number | { totalMs?: number } | undefined
   >();
+  expectTypeOf<StartTextBatchOptions['webhookUrl']>().toEqualTypeOf<
+    string | undefined
+  >();
 });
 
 it('excludes Core orchestration and tool execution from batch items', () => {

--- a/packages/ai/src/batch/batch-types.test-d.ts
+++ b/packages/ai/src/batch/batch-types.test-d.ts
@@ -13,6 +13,7 @@ import {
   experimental_getBatchResults as getBatchResults,
   experimental_getBatchStatus as getBatchStatus,
   experimental_startTextBatch as startTextBatch,
+  type GatewayProviderMetadata,
   type Experimental_BatchError as BatchError,
   type Experimental_BatchLanguageModel as BatchLanguageModel,
   type Experimental_BatchOperationOptions as BatchOperationOptions,
@@ -27,6 +28,12 @@ import {
   type Experimental_TextBatchRequest as TextBatchRequest,
 } from '../index';
 import type { AsyncIterableStream } from '../util/async-iterable-stream';
+
+it('exposes typed Gateway async-job metadata', () => {
+  expectTypeOf<
+    NonNullable<GatewayProviderMetadata['asyncJob']>['webhookSigningSecret']
+  >().toEqualTypeOf<string | undefined>();
+});
 
 it('keeps text batch references as the current batch reference variant', () => {
   expectTypeOf<BatchReference>().toEqualTypeOf<TextBatchReference>();

--- a/packages/ai/src/batch/batch-types.ts
+++ b/packages/ai/src/batch/batch-types.ts
@@ -71,19 +71,19 @@ type BatchRequestOptions = {
 };
 
 /**
- * Webhook factory for batch completion notifications, mirroring the video
- * `webhook` option: invoked only when the model supports batch webhooks.
- */
-export type TextBatchWebhookFactory = () => PromiseLike<{ url: string }>;
-
-/**
  * Options for starting a text batch.
  */
 export type StartTextBatchOptions = {
   model: BatchLanguageModel;
   requests: ReadonlyArray<TextBatchRequest>;
   providerOptions?: ProviderOptions;
-  webhook?: TextBatchWebhookFactory;
+
+  /**
+   * URL that the provider should notify when the batch reaches a terminal
+   * state. Providers that do not support completion webhooks return an
+   * unsupported warning.
+   */
+  webhookUrl?: string;
 } & BatchRequestOptions;
 
 /**

--- a/packages/ai/src/batch/batch-types.ts
+++ b/packages/ai/src/batch/batch-types.ts
@@ -71,12 +71,19 @@ type BatchRequestOptions = {
 };
 
 /**
+ * Webhook factory for batch completion notifications, mirroring the video
+ * `webhook` option: invoked only when the model supports batch webhooks.
+ */
+export type TextBatchWebhookFactory = () => PromiseLike<{ url: string }>;
+
+/**
  * Options for starting a text batch.
  */
 export type StartTextBatchOptions = {
   model: BatchLanguageModel;
   requests: ReadonlyArray<TextBatchRequest>;
   providerOptions?: ProviderOptions;
+  webhook?: TextBatchWebhookFactory;
 } & BatchRequestOptions;
 
 /**

--- a/packages/ai/src/batch/batch.test.ts
+++ b/packages/ai/src/batch/batch.test.ts
@@ -171,48 +171,10 @@ describe('startTextBatch', () => {
     ).rejects.toBeInstanceOf(UnsupportedFunctionalityError);
   });
 
-  it('resolves the webhook factory through the model handler and forwards the webhook URL', async () => {
+  it('forwards the webhook URL to the batch model', async () => {
     const calls: Array<
       Parameters<BatchLanguageModelV4['experimental_doStartBatch']>[0]
     > = [];
-    const webhook = vi
-      .fn()
-      .mockResolvedValue({ url: 'https://example.com/batch-webhook' });
-    const model = Object.assign(
-      createMockBatchModel({
-        doStartBatch: async options => {
-          calls.push(options);
-          return { batchId: 'batch-123', status: 'pending', warnings: [] };
-        },
-      }),
-      {
-        experimental_handleBatchWebhookOption: async (options: {
-          webhook: () => PromiseLike<{ url: string }>;
-        }) => {
-          const { url } = await options.webhook();
-          return { webhookUrl: url };
-        },
-      },
-    );
-
-    const result = await startTextBatch({
-      model,
-      requests: [{ id: 'request-1', prompt: 'hello' }],
-      webhook,
-    });
-
-    expect(webhook).toHaveBeenCalledTimes(1);
-    expect(calls[0].webhookUrl).toBe('https://example.com/batch-webhook');
-    expect(result.warnings).toEqual([]);
-  });
-
-  it('warns without invoking the webhook factory when the model does not support webhooks', async () => {
-    const calls: Array<
-      Parameters<BatchLanguageModelV4['experimental_doStartBatch']>[0]
-    > = [];
-    const webhook = vi
-      .fn()
-      .mockResolvedValue({ url: 'https://example.com/batch-webhook' });
     const model = createMockBatchModel({
       doStartBatch: async options => {
         calls.push(options);
@@ -223,21 +185,11 @@ describe('startTextBatch', () => {
     const result = await startTextBatch({
       model,
       requests: [{ id: 'request-1', prompt: 'hello' }],
-      webhook,
+      webhookUrl: 'https://example.com/batch-webhook',
     });
 
-    expect(webhook).not.toHaveBeenCalled();
-    expect(calls[0].webhookUrl).toBeUndefined();
-    expect(result.warnings).toEqual([
-      {
-        warning: {
-          type: 'unsupported',
-          feature: 'webhook',
-          details:
-            'This model does not support batch webhooks. Poll the batch status instead.',
-        },
-      },
-    ]);
+    expect(calls[0].webhookUrl).toBe('https://example.com/batch-webhook');
+    expect(result.warnings).toEqual([]);
   });
 });
 

--- a/packages/ai/src/batch/batch.test.ts
+++ b/packages/ai/src/batch/batch.test.ts
@@ -170,6 +170,75 @@ describe('startTextBatch', () => {
       }),
     ).rejects.toBeInstanceOf(UnsupportedFunctionalityError);
   });
+
+  it('resolves the webhook factory through the model handler and forwards the webhook URL', async () => {
+    const calls: Array<
+      Parameters<BatchLanguageModelV4['experimental_doStartBatch']>[0]
+    > = [];
+    const webhook = vi
+      .fn()
+      .mockResolvedValue({ url: 'https://example.com/batch-webhook' });
+    const model = Object.assign(
+      createMockBatchModel({
+        doStartBatch: async options => {
+          calls.push(options);
+          return { batchId: 'batch-123', status: 'pending', warnings: [] };
+        },
+      }),
+      {
+        experimental_handleBatchWebhookOption: async (options: {
+          webhook: () => PromiseLike<{ url: string }>;
+        }) => {
+          const { url } = await options.webhook();
+          return { webhookUrl: url };
+        },
+      },
+    );
+
+    const result = await startTextBatch({
+      model,
+      requests: [{ id: 'request-1', prompt: 'hello' }],
+      webhook,
+    });
+
+    expect(webhook).toHaveBeenCalledTimes(1);
+    expect(calls[0].webhookUrl).toBe('https://example.com/batch-webhook');
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('warns without invoking the webhook factory when the model does not support webhooks', async () => {
+    const calls: Array<
+      Parameters<BatchLanguageModelV4['experimental_doStartBatch']>[0]
+    > = [];
+    const webhook = vi
+      .fn()
+      .mockResolvedValue({ url: 'https://example.com/batch-webhook' });
+    const model = createMockBatchModel({
+      doStartBatch: async options => {
+        calls.push(options);
+        return { batchId: 'batch-123', status: 'pending', warnings: [] };
+      },
+    });
+
+    const result = await startTextBatch({
+      model,
+      requests: [{ id: 'request-1', prompt: 'hello' }],
+      webhook,
+    });
+
+    expect(webhook).not.toHaveBeenCalled();
+    expect(calls[0].webhookUrl).toBeUndefined();
+    expect(result.warnings).toEqual([
+      {
+        warning: {
+          type: 'unsupported',
+          feature: 'webhook',
+          details:
+            'This model does not support batch webhooks. Poll the batch status instead.',
+        },
+      },
+    ]);
+  });
 });
 
 describe('getBatchStatus', () => {

--- a/packages/ai/src/batch/batch.ts
+++ b/packages/ai/src/batch/batch.ts
@@ -37,6 +37,7 @@ export async function startTextBatch({
   model: modelArg,
   requests,
   providerOptions,
+  webhook,
   abortSignal,
   headers,
   timeout,
@@ -44,6 +45,27 @@ export async function startTextBatch({
   validateRequests(requests);
 
   const model = resolveBatchLanguageModel(modelArg);
+
+  // Mirrors the video webhook flow: only invoke the user's factory when the
+  // model signals support, so ignored webhook endpoints are never created.
+  const earlyWarnings: StartTextBatchResult['warnings'][number][] = [];
+  let webhookUrl: string | undefined;
+  if (webhook != null) {
+    if (model.experimental_handleBatchWebhookOption != null) {
+      ({ webhookUrl } = await model.experimental_handleBatchWebhookOption({
+        webhook,
+      }));
+    } else {
+      earlyWarnings.push({
+        warning: {
+          type: 'unsupported',
+          feature: 'webhook',
+          details:
+            'This model does not support batch webhooks. Poll the batch status instead.',
+        },
+      });
+    }
+  }
   const operationAbortSignal = mergeAbortSignals(
     abortSignal,
     getTotalTimeoutMs(timeout),
@@ -81,8 +103,10 @@ export async function startTextBatch({
       providerOptions,
       abortSignal: operationAbortSignal,
       headers: headersWithUserAgent,
+      ...(webhookUrl != null && { webhookUrl }),
     });
-    const { batchId, warnings, ...status } = result;
+    const { batchId, warnings: startWarnings, ...status } = result;
+    const warnings = [...earlyWarnings, ...startWarnings];
 
     logWarnings({
       warnings: warnings.map(({ warning }) => warning),

--- a/packages/ai/src/batch/batch.ts
+++ b/packages/ai/src/batch/batch.ts
@@ -37,7 +37,7 @@ export async function startTextBatch({
   model: modelArg,
   requests,
   providerOptions,
-  webhook,
+  webhookUrl,
   abortSignal,
   headers,
   timeout,
@@ -45,27 +45,6 @@ export async function startTextBatch({
   validateRequests(requests);
 
   const model = resolveBatchLanguageModel(modelArg);
-
-  // Mirrors the video webhook flow: only invoke the user's factory when the
-  // model signals support, so ignored webhook endpoints are never created.
-  const earlyWarnings: StartTextBatchResult['warnings'][number][] = [];
-  let webhookUrl: string | undefined;
-  if (webhook != null) {
-    if (model.experimental_handleBatchWebhookOption != null) {
-      ({ webhookUrl } = await model.experimental_handleBatchWebhookOption({
-        webhook,
-      }));
-    } else {
-      earlyWarnings.push({
-        warning: {
-          type: 'unsupported',
-          feature: 'webhook',
-          details:
-            'This model does not support batch webhooks. Poll the batch status instead.',
-        },
-      });
-    }
-  }
   const operationAbortSignal = mergeAbortSignals(
     abortSignal,
     getTotalTimeoutMs(timeout),
@@ -105,8 +84,7 @@ export async function startTextBatch({
       headers: headersWithUserAgent,
       ...(webhookUrl != null && { webhookUrl }),
     });
-    const { batchId, warnings: startWarnings, ...status } = result;
-    const warnings = [...earlyWarnings, ...startWarnings];
+    const { batchId, warnings, ...status } = result;
 
     logWarnings({
       warnings: warnings.map(({ warning }) => warning),

--- a/packages/ai/src/batch/index.ts
+++ b/packages/ai/src/batch/index.ts
@@ -16,5 +16,4 @@ export type {
   TextBatchItemResult as Experimental_TextBatchItemResult,
   TextBatchReference as Experimental_TextBatchReference,
   TextBatchRequest as Experimental_TextBatchRequest,
-  TextBatchWebhookFactory as Experimental_TextBatchWebhookFactory,
 } from './batch-types';

--- a/packages/ai/src/batch/index.ts
+++ b/packages/ai/src/batch/index.ts
@@ -16,4 +16,5 @@ export type {
   TextBatchItemResult as Experimental_TextBatchItemResult,
   TextBatchReference as Experimental_TextBatchReference,
   TextBatchRequest as Experimental_TextBatchRequest,
+  TextBatchWebhookFactory as Experimental_TextBatchWebhookFactory,
 } from './batch-types';

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -2,7 +2,13 @@
 import './global';
 
 // re-exports:
-export { createGateway, gateway, type GatewayModelId } from '@ai-sdk/gateway';
+export {
+  createGateway,
+  gateway,
+  type GatewayAsyncJobMetadata,
+  type GatewayModelId,
+  type GatewayProviderMetadata,
+} from '@ai-sdk/gateway';
 export {
   asSchema,
   createIdGenerator,

--- a/packages/anthropic/src/anthropic-messages-batch.test.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.test.ts
@@ -147,6 +147,7 @@ describe('Anthropic Messages batch language model', () => {
         'Operation-Header': 'operation',
         'anthropic-beta': 'operation-header-beta',
       },
+      webhookUrl: 'https://example.com/batch-webhook',
     });
 
     expect(result).toMatchObject({
@@ -160,6 +161,14 @@ describe('Anthropic Messages batch language model', () => {
         failed: 0,
       },
       warnings: [
+        {
+          warning: {
+            type: 'unsupported',
+            feature: 'webhookUrl',
+            details:
+              'The Anthropic Message Batches API does not support completion webhooks.',
+          },
+        },
         {
           requestId: 'france',
           warning: { type: 'unsupported', feature: 'frequencyPenalty' },

--- a/packages/anthropic/src/anthropic-messages-batch.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.ts
@@ -145,6 +145,7 @@ export class AnthropicMessagesBatchLanguageModel
     providerOptions,
     headers,
     abortSignal,
+    webhookUrl,
   }: Parameters<
     BatchLanguageModelV4['experimental_doStartBatch']
   >[0]): Promise<BatchV4StartResult> {
@@ -161,7 +162,19 @@ export class AnthropicMessagesBatchLanguageModel
       custom_id: string;
       params: Record<string, unknown>;
     }> = [];
-    const batchWarnings: BatchV4StartResult['warnings'] = [];
+    const batchWarnings: BatchV4StartResult['warnings'] =
+      webhookUrl == null
+        ? []
+        : [
+            {
+              warning: {
+                type: 'unsupported',
+                feature: 'webhookUrl',
+                details:
+                  'The Anthropic Message Batches API does not support completion webhooks.',
+              },
+            },
+          ];
 
     for (const request of requests) {
       const requestBetas = await getAnthropicBatchProviderBetas({

--- a/packages/gateway/src/gateway-language-model-batch.test.ts
+++ b/packages/gateway/src/gateway-language-model-batch.test.ts
@@ -197,6 +197,67 @@ describe('GatewayBatchLanguageModel', () => {
       });
     });
 
+    it('should pass the webhook factory URL through experimental_handleBatchWebhookOption', async () => {
+      const result =
+        await createTestModel().experimental_handleBatchWebhookOption({
+          webhook: async () => ({ url: 'https://example.com/batch-webhook' }),
+        });
+
+      expect(result).toEqual({
+        webhookUrl: 'https://example.com/batch-webhook',
+      });
+    });
+
+    it('should send webhookUrl as the top-level callbackUrl body field', async () => {
+      prepareBatchStartResponse({
+        batchId: 'batch_abc123',
+        status: 'pending',
+        warnings: [],
+        providerMetadata: {
+          gateway: {
+            asyncJob: {
+              jobId: 'batch_abc123',
+              status: 'queued',
+              webhookSigningSecret: 'whsec_test',
+            },
+          },
+        },
+      });
+
+      const result = await createTestModel().experimental_doStartBatch({
+        requests: BATCH_PROMPT_REQUESTS,
+        webhookUrl: 'https://example.com/batch-webhook',
+      });
+
+      expect(await server.calls[0].requestBodyJson).toEqual({
+        callbackUrl: 'https://example.com/batch-webhook',
+        modelId: 'test-model',
+        requests: BATCH_PROMPT_REQUESTS,
+      });
+      // The webhook signing secret rides back on providerMetadata.
+      expect(result.providerMetadata).toEqual({
+        gateway: {
+          asyncJob: {
+            jobId: 'batch_abc123',
+            status: 'queued',
+            webhookSigningSecret: 'whsec_test',
+          },
+        },
+      });
+    });
+
+    it('should not send a callbackUrl body field when no webhookUrl is provided', async () => {
+      prepareBatchStartResponse();
+
+      await createTestModel().experimental_doStartBatch({
+        requests: BATCH_PROMPT_REQUESTS,
+      });
+
+      expect(
+        (await server.calls[0].requestBodyJson).callbackUrl,
+      ).toBeUndefined();
+    });
+
     it('should base64-encode Uint8Array file data in batch request prompts', async () => {
       prepareBatchStartResponse();
       const bytes = new Uint8Array([1, 2, 3, 4]);

--- a/packages/gateway/src/gateway-language-model-batch.test.ts
+++ b/packages/gateway/src/gateway-language-model-batch.test.ts
@@ -197,17 +197,6 @@ describe('GatewayBatchLanguageModel', () => {
       });
     });
 
-    it('should pass the webhook factory URL through experimental_handleBatchWebhookOption', async () => {
-      const result =
-        await createTestModel().experimental_handleBatchWebhookOption({
-          webhook: async () => ({ url: 'https://example.com/batch-webhook' }),
-        });
-
-      expect(result).toEqual({
-        webhookUrl: 'https://example.com/batch-webhook',
-      });
-    });
-
     it('should send webhookUrl as the top-level callbackUrl body field', async () => {
       prepareBatchStartResponse({
         batchId: 'batch_abc123',

--- a/packages/gateway/src/gateway-language-model-batch.ts
+++ b/packages/gateway/src/gateway-language-model-batch.ts
@@ -58,11 +58,23 @@ export class GatewayBatchLanguageModel
    * server-side, so status and results always route back through the
    * Gateway job.
    */
+  // The Gateway notifies the caller's URL on completion (`callbackUrl`), so
+  // the factory's URL passes straight through, mirroring the video model.
+  async experimental_handleBatchWebhookOption({
+    webhook,
+  }: {
+    webhook: () => PromiseLike<{ url: string }>;
+  }): Promise<{ webhookUrl: string }> {
+    const { url } = await webhook();
+    return { webhookUrl: url };
+  }
+
   async experimental_doStartBatch({
     requests,
     providerOptions,
     headers,
     abortSignal,
+    webhookUrl,
   }: BatchV4StartOptions<LanguageModelV4BatchRequest>): Promise<BatchV4StartResult> {
     const resolvedHeaders = this.config.headers
       ? await resolve(this.config.headers)
@@ -84,6 +96,7 @@ export class GatewayBatchLanguageModel
             : undefined,
         ),
         body: {
+          ...(webhookUrl != null && { callbackUrl: webhookUrl }),
           modelId: this.modelId,
           requests: requests.map(request => ({
             id: request.id,

--- a/packages/gateway/src/gateway-language-model-batch.ts
+++ b/packages/gateway/src/gateway-language-model-batch.ts
@@ -58,17 +58,6 @@ export class GatewayBatchLanguageModel
    * server-side, so status and results always route back through the
    * Gateway job.
    */
-  // The Gateway notifies the caller's URL on completion (`callbackUrl`), so
-  // the factory's URL passes straight through, mirroring the video model.
-  async experimental_handleBatchWebhookOption({
-    webhook,
-  }: {
-    webhook: () => PromiseLike<{ url: string }>;
-  }): Promise<{ webhookUrl: string }> {
-    const { url } = await webhook();
-    return { webhookUrl: url };
-  }
-
   async experimental_doStartBatch({
     requests,
     providerOptions,

--- a/packages/gateway/src/gateway-provider-metadata.ts
+++ b/packages/gateway/src/gateway-provider-metadata.ts
@@ -1,0 +1,27 @@
+import type { JSONValue } from '@ai-sdk/provider';
+
+/**
+ * Metadata for an asynchronous AI Gateway job.
+ */
+export type GatewayAsyncJobMetadata = {
+  readonly jobId: string;
+  readonly status: string;
+
+  /**
+   * Secret for verifying customer webhook deliveries. This is sensitive,
+   * start-response-only metadata and must not be logged or forwarded.
+   */
+  readonly webhookSigningSecret?: string;
+  readonly [key: string]: JSONValue | undefined;
+};
+
+/**
+ * Shape of the inner `providerMetadata.gateway` object returned by AI Gateway
+ * operations.
+ *
+ * Additional fields may be added without a package update.
+ */
+export type GatewayProviderMetadata = {
+  readonly asyncJob?: GatewayAsyncJobMetadata;
+  readonly [key: string]: JSONValue | undefined;
+};

--- a/packages/gateway/src/gateway-provider.test-d.ts
+++ b/packages/gateway/src/gateway-provider.test-d.ts
@@ -1,4 +1,14 @@
 import { createGateway } from './gateway-provider';
+import type { GatewayAsyncJobMetadata, GatewayProviderMetadata } from './index';
+
+const asyncJob = {
+  jobId: 'job_123',
+  status: 'queued',
+  webhookSigningSecret: 'whsec_123',
+} satisfies GatewayAsyncJobMetadata;
+
+const providerMetadata = { asyncJob } satisfies GatewayProviderMetadata;
+void providerMetadata;
 
 createGateway({ apiKey: 'vck_test-key' });
 createGateway({ apiKey: 'vca_test-token' });

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -42,6 +42,10 @@ export type {
   GatewayProviderSettings,
 } from './gateway-provider';
 export type {
+  GatewayAsyncJobMetadata,
+  GatewayProviderMetadata,
+} from './gateway-provider-metadata';
+export type {
   GatewayProviderOptions,
   /** @deprecated Use `GatewayProviderOptions` instead. */
   GatewayProviderOptions as GatewayLanguageModelOptions,

--- a/packages/openai/src/openai-responses-batch.test.ts
+++ b/packages/openai/src/openai-responses-batch.test.ts
@@ -149,6 +149,7 @@ describe('OpenAI batch language models', () => {
         },
       ],
       headers: { 'Operation-Header': 'operation' },
+      webhookUrl: 'https://example.com/batch-webhook',
     });
 
     expect(result).toEqual({
@@ -164,6 +165,14 @@ describe('OpenAI batch language models', () => {
       createdAt: '2023-11-14T22:13:20.000Z',
       expiresAt: '2023-11-15T22:13:20.000Z',
       warnings: [
+        {
+          warning: {
+            type: 'unsupported',
+            feature: 'webhookUrl',
+            details:
+              'The OpenAI Batch API does not support per-batch webhook URLs.',
+          },
+        },
         {
           requestId: 'germany',
           warning: { type: 'unsupported', feature: 'topK' },

--- a/packages/openai/src/openai-responses-batch.ts
+++ b/packages/openai/src/openai-responses-batch.ts
@@ -133,7 +133,19 @@ class OpenAIResponsesBatch {
     options: BatchV4StartOptions<OpenAIBatchRequest>,
   ): Promise<BatchV4StartResult> {
     const fileParts: string[] = [];
-    const warnings: BatchV4StartResult['warnings'] = [];
+    const warnings: BatchV4StartResult['warnings'] =
+      options.webhookUrl == null
+        ? []
+        : [
+            {
+              warning: {
+                type: 'unsupported',
+                feature: 'webhookUrl',
+                details:
+                  'The OpenAI Batch API does not support per-batch webhook URLs.',
+              },
+            },
+          ];
 
     for (const request of options.requests) {
       const preparedRequest = await this.options.prepareRequest(request);

--- a/packages/provider/src/batch/v4/batch-v4.ts
+++ b/packages/provider/src/batch/v4/batch-v4.ts
@@ -40,6 +40,11 @@ export type BatchV4StartOptions<REQUEST> = {
   readonly providerOptions?: SharedV4ProviderOptions;
   readonly abortSignal?: AbortSignal;
   readonly headers?: Record<string, string | undefined>;
+
+  /**
+   * URL the provider notifies when the batch reaches a terminal state.
+   */
+  readonly webhookUrl?: string;
 };
 
 /**
@@ -90,6 +95,14 @@ export type BatchV4ItemResult<RESULT> =
  * processing.
  */
 export type BatchModelV4<REQUEST, RESULT> = {
+  /**
+   * Webhook capability signal, mirroring the video model's `handleWebhookOption`:
+   * the SDK invokes the user's webhook factory only when this method is present.
+   */
+  experimental_handleBatchWebhookOption?: (options: {
+    webhook: () => PromiseLike<{ url: string }>;
+  }) => PromiseLike<{ webhookUrl: string }>;
+
   experimental_doStartBatch(
     options: BatchV4StartOptions<REQUEST>,
   ): PromiseLike<BatchV4StartResult>;

--- a/packages/provider/src/batch/v4/batch-v4.ts
+++ b/packages/provider/src/batch/v4/batch-v4.ts
@@ -43,6 +43,8 @@ export type BatchV4StartOptions<REQUEST> = {
 
   /**
    * URL the provider notifies when the batch reaches a terminal state.
+   * Providers that do not support completion webhooks should return an
+   * unsupported warning.
    */
   readonly webhookUrl?: string;
 };
@@ -95,14 +97,6 @@ export type BatchV4ItemResult<RESULT> =
  * processing.
  */
 export type BatchModelV4<REQUEST, RESULT> = {
-  /**
-   * Webhook capability signal, mirroring the video model's `handleWebhookOption`:
-   * the SDK invokes the user's webhook factory only when this method is present.
-   */
-  experimental_handleBatchWebhookOption?: (options: {
-    webhook: () => PromiseLike<{ url: string }>;
-  }) => PromiseLike<{ webhookUrl: string }>;
-
   experimental_doStartBatch(
     options: BatchV4StartOptions<REQUEST>,
   ): PromiseLike<BatchV4StartResult>;


### PR DESCRIPTION
## Background

The AI Gateway batch surface supports customer completion webhooks through a top-level `callbackUrl`. Signed terminal events are delivered after the job completes, fails, or is cancelled, and the signing secret is returned in `providerMetadata.gateway.asyncJob.webhookSigningSecret`.

The SDK batch protocol had no way to register a callback, so `experimental_startTextBatch` users could only poll.

## Summary

- **`@ai-sdk/provider`**: `BatchV4StartOptions` gains optional `webhookUrl`.
- **`ai`**: `experimental_startTextBatch` accepts `webhookUrl` and forwards it directly to `experimental_doStartBatch`, matching the detached `experimental_startVideo` API.
- **`@ai-sdk/gateway`**: maps `webhookUrl` to the top-level `callbackUrl` field on `POST {baseURL}/batch/start` and exports `GatewayProviderMetadata` / `GatewayAsyncJobMetadata` for typed access to the signing secret.
- **Direct providers**: Anthropic and OpenAI batch models return an unsupported warning when `webhookUrl` is supplied instead of silently dropping it.
- **Documentation**: the AI Gateway provider guide includes a crash-safe start flow and batch-specific receiver with bounded raw-body reads, HMAC verification, expected-job checks, signed-body-derived deduplication, fast 2xx handling, no-redirect guidance, and fallback reconciliation.

## Usage

```ts
const batch = await startTextBatch({
  model: "anthropic/claude-haiku-4.5",
  requests,
  webhookUrl: "https://example.com/batch-webhook",
});

const gatewayMetadata = batch.providerMetadata?.gateway as
  | GatewayProviderMetadata
  | undefined;
```

Reserve callback state before submission, use a stable Gateway idempotency key, and persist only the minimal batch reference plus the signing secret. Verify `x-ai-gateway-signature` against a bounded raw request body and confirm the delivered `data.jobId` matches the persisted batch ID before enqueueing result retrieval.

## Verification

- `packages/ai`: 7 batch tests
- `packages/gateway`: 26 batch model tests
- `packages/openai`: 24 batch tests
- `packages/anthropic`: 19 batch tests
- Gateway package build and declaration generation
- Package type checks passed for provider, ai, gateway, openai, and anthropic
- `pnpm type-check:full`
- `pnpm check`

## Notes

No Gateway service changes are needed. The `callbackUrl` field, signed delivery, and idempotent terminal event keys are already live server-side.