### PR TITLE
fix(harness): collect every tool approval in a step before pausing the turn

### DIFF
--- a/.changeset/lucky-doors-collect.md
+++ b/.changeset/lucky-doors-collect.md
@@ -1,0 +1,18 @@
+---
+'@ai-sdk/harness': patch
+'@ai-sdk/harness-pi': patch
+---
+
+fix (harness): collect every tool approval in a step before pausing the turn
+
+A model step that emits two host tool calls needing approval deadlocked: the turn
+paused after the first request and abandoned the reader, so the second `tool-call`
+was never read, never recorded in the step, and never surfaced as an approval
+request — while Pi's resume path refuses to rerun the turn until every dangling
+host tool call has a result.
+
+`tool-call` parts now carry an optional `stepToolCallCount`. When the runtime
+reports it, the turn keeps reading and enqueues an approval request for each call
+that needs one, pausing once with the whole step's requests surfaced. Runtimes that
+don't report it pause on the first call, as before. `@ai-sdk/harness-pi` reports it
+from `message_end`, which Pi commits before it starts executing any tool.

--- a/packages/harness-pi/src/pi-translate.test.ts
+++ b/packages/harness-pi/src/pi-translate.test.ts
@@ -176,6 +176,99 @@ describe('translatePiEvent', () => {
     expect(end.map(p => p.type)).toEqual(['tool-result', 'finish-step']);
   });
 
+  it('reports the step tool-call count on every tool-call of the step', () => {
+    const state = createPiTranslatorState();
+    emit(
+      [
+        { type: 'turn_start' } as PiSessionEvent,
+        {
+          type: 'message_start',
+          message: { role: 'assistant', content: [] },
+        } as PiSessionEvent,
+        {
+          type: 'message_end',
+          message: {
+            role: 'assistant',
+            content: [
+              { type: 'toolCall', id: 'call-1', name: 'create_suite' },
+              { type: 'toolCall', id: 'call-2', name: 'create_suite' },
+            ],
+          },
+        } as PiSessionEvent,
+      ],
+      state,
+    );
+
+    const starts = emit(
+      [
+        {
+          type: 'tool_execution_start',
+          toolCallId: 'call-1',
+          toolName: 'create_suite',
+          args: { name: 'A' },
+        } as PiSessionEvent,
+        {
+          type: 'tool_execution_start',
+          toolCallId: 'call-2',
+          toolName: 'create_suite',
+          args: { name: 'B' },
+        } as PiSessionEvent,
+      ],
+      state,
+    );
+
+    expect(
+      starts.map(part =>
+        part.type === 'tool-call'
+          ? { toolCallId: part.toolCallId, count: part.stepToolCallCount }
+          : part.type,
+      ),
+    ).toEqual([
+      { toolCallId: 'call-1', count: 2 },
+      { toolCallId: 'call-2', count: 2 },
+    ]);
+  });
+
+  it('omits the step tool-call count when the step has no tool calls', () => {
+    const state = createPiTranslatorState();
+    emit(
+      [
+        { type: 'turn_start' } as PiSessionEvent,
+        {
+          type: 'message_start',
+          message: { role: 'assistant', content: [] },
+        } as PiSessionEvent,
+        {
+          type: 'message_end',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'k' }],
+          },
+        } as PiSessionEvent,
+      ],
+      state,
+    );
+
+    const start = translatePiEvent(
+      {
+        type: 'tool_execution_start',
+        toolCallId: 'orphan',
+        toolName: 'create_suite',
+        args: {},
+      } as PiSessionEvent,
+      state,
+    );
+
+    expect(start).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'orphan',
+        toolName: 'create_suite',
+        input: '{}',
+      },
+    ]);
+  });
+
   it('emits finish-step after a built-in approval request pauses the step', () => {
     const state = createPiTranslatorState();
     emit(

--- a/packages/harness-pi/src/pi-translate.ts
+++ b/packages/harness-pi/src/pi-translate.ts
@@ -30,6 +30,13 @@ export interface PiTranslatorState {
   observedToolNames: Map<string, string>;
   /** Tool ids requested by the current assistant message but not yet completed. */
   pendingStepToolCallIds: Set<string>;
+  /**
+   * How many tool calls the current assistant message requested. Known from
+   * `message_end`, which Pi emits before any `tool_execution_start`, and
+   * reported on every `tool-call` of the step so the host can collect all of
+   * the step's approvals before parking the turn for host input.
+   */
+  stepToolCallCount: number | undefined;
   /** Whether the current assistant message has opened a visible step. */
   stepOpen: boolean;
   /**
@@ -84,6 +91,7 @@ export function createPiTranslatorState(
     reasoningStarted: false,
     observedToolNames: new Map(),
     pendingStepToolCallIds: new Set(),
+    stepToolCallCount: undefined,
     stepOpen: false,
     hostToolResults: new Map(),
     dynamicToolCallIds: new Set(),
@@ -155,6 +163,7 @@ function finishStep(state: PiTranslatorState): HarnessV1StreamPart[] {
   if (!state.stepOpen || state.pendingStepToolCallIds.size > 0) return [];
   state.stepOpen = false;
   state.pendingStepToolCallIds.clear();
+  state.stepToolCallCount = undefined;
   return [
     {
       type: 'finish-step',
@@ -215,6 +224,7 @@ export function translatePiEvent(
       if (event.type === 'message_start') {
         state.stepOpen = true;
         state.pendingStepToolCallIds.clear();
+        state.stepToolCallCount = undefined;
       }
       state.streamedAssistantText = '';
       state.currentTextId = undefined;
@@ -308,11 +318,20 @@ export function translatePiEvent(
         state.currentReasoningId = undefined;
       }
       if (event.type === 'message_end') {
-        for (const toolCallId of extractPiToolCallIds(event.message)) {
+        const toolCallIds = extractPiToolCallIds(event.message);
+        for (const toolCallId of toolCallIds) {
           state.pendingStepToolCallIds.add(toolCallId);
         }
+        /*
+         * Pi commits the whole assistant message here, before it emits any
+         * `tool_execution_start`, so the step's tool-call count is known up
+         * front and can be reported on each `tool-call` below.
+         */
+        state.stepToolCallCount =
+          toolCallIds.length > 0 ? toolCallIds.length : undefined;
       } else {
         state.pendingStepToolCallIds.clear();
+        state.stepToolCallCount = undefined;
         parts.push(...finishStep(state));
       }
       return parts;
@@ -337,6 +356,9 @@ export function translatePiEvent(
           ...(wire !== native ? { nativeName: native } : {}),
           ...(providerExecuted ? { providerExecuted: true } : {}),
           ...(isMcpTool ? { dynamic: true } : {}),
+          ...(state.stepToolCallCount != null
+            ? { stepToolCallCount: state.stepToolCallCount }
+            : {}),
         } as HarnessV1StreamPart,
       ];
     }

--- a/packages/harness/src/agent/internal/run-prompt.test.ts
+++ b/packages/harness/src/agent/internal/run-prompt.test.ts
@@ -1196,6 +1196,125 @@ describe('runPrompt host tool generator results', () => {
     expect(stopBoundaryCalls).toBe(0);
   });
 
+  test('collects every approval in a step before pausing the turn', async () => {
+    const submitted: SubmittedResult[] = [];
+    const pending: unknown[] = [];
+    const weather = tool({
+      description: 'Get weather',
+      inputSchema: z.object({ city: z.string() }),
+      execute: async () => ({ temperature: 72 }),
+    });
+
+    const { result, done } = runPrompt({
+      harness,
+      session: fakeSession(
+        [
+          {
+            type: 'tool-call',
+            toolCallId: 'c1',
+            toolName: 'weather',
+            input: JSON.stringify({ city: 'SF' }),
+            stepToolCallCount: 2,
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'c2',
+            toolName: 'weather',
+            input: JSON.stringify({ city: 'NYC' }),
+            stepToolCallCount: 2,
+          },
+        ],
+        input => submitted.push(input),
+      ),
+      prompt: 'go',
+      instructions: undefined,
+      tools: { weather } as ToolSet,
+      toolSpecs: [],
+      sandboxSession,
+      sessionWorkDir: WORK_DIR,
+      runtimeContext: {} as never,
+      abortSignal: undefined,
+      toolApproval: { weather: 'user-approval' },
+      onPendingToolApproval: approval => pending.push(approval),
+    });
+
+    const parts: TextStreamPart<ToolSet>[] = [];
+    for await (const part of result.fullStream) parts.push(part);
+    await done;
+
+    expect(submitted).toEqual([]);
+    expect(await result.finishReason).toBe('tool-calls');
+    expect(
+      (pending as Array<{ toolCallId: string }>).map(
+        approval => approval.toolCallId,
+      ),
+    ).toEqual(['c1', 'c2']);
+    const approvalRequests = parts.filter(
+      part => part.type === 'tool-approval-request',
+    ) as Array<
+      Extract<TextStreamPart<ToolSet>, { type: 'tool-approval-request' }>
+    >;
+    expect(approvalRequests.map(request => request.toolCall.input)).toEqual([
+      { city: 'SF' },
+      { city: 'NYC' },
+    ]);
+    const steps = await result.steps;
+    expect(steps).toHaveLength(1);
+    expect(
+      steps[0]!.content.flatMap(part =>
+        part.type === 'tool-call' ? [part.toolCallId] : [],
+      ),
+    ).toEqual(['c1', 'c2']);
+  });
+
+  test('pauses on the first approval when the step tool-call count is unknown', async () => {
+    const pending: unknown[] = [];
+    const weather = tool({
+      description: 'Get weather',
+      inputSchema: z.object({ city: z.string() }),
+      execute: async () => ({ temperature: 72 }),
+    });
+
+    const { result, done } = runPrompt({
+      harness,
+      session: fakeSession([
+        {
+          type: 'tool-call',
+          toolCallId: 'c1',
+          toolName: 'weather',
+          input: JSON.stringify({ city: 'SF' }),
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'c2',
+          toolName: 'weather',
+          input: JSON.stringify({ city: 'NYC' }),
+        },
+      ]),
+      prompt: 'go',
+      instructions: undefined,
+      tools: { weather } as ToolSet,
+      toolSpecs: [],
+      sandboxSession,
+      sessionWorkDir: WORK_DIR,
+      runtimeContext: {} as never,
+      abortSignal: undefined,
+      toolApproval: { weather: 'user-approval' },
+      onPendingToolApproval: approval => pending.push(approval),
+    });
+
+    for await (const _part of result.fullStream) {
+      // drain
+    }
+    await done;
+
+    expect(
+      (pending as Array<{ toolCallId: string }>).map(
+        approval => approval.toolCallId,
+      ),
+    ).toEqual(['c1']);
+  });
+
   test('denies custom tools configured with denied approval status', async () => {
     const submitted: SubmittedResult[] = [];
     const weather = tool({

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -301,6 +301,23 @@ export function runPrompt<
     let stepText = '';
     let stepReasoning = '';
     let stepToolCalls: TurnContentPart[] = [];
+    /*
+     * A single step can emit several tool calls that each need host input
+     * (approval, or a result for a non-executable tool). Parking the turn on
+     * the first one would drop the rest: the reader is abandoned, so their
+     * `tool-call` events are never read, they never reach `stepToolCalls`, and
+     * no approval request is ever surfaced for them — while runtimes that
+     * resume by rerunning (Pi) refuse to restart the turn until every tool call
+     * in the step has a result, so the turn deadlocks.
+     *
+     * When the runtime declares the step's tool-call count, keep reading until
+     * every one of them has been processed and park once, with all of the
+     * step's requests enqueued. Runtimes that don't declare it park on the
+     * first call needing input, as before.
+     */
+    let stepToolCallCount: number | undefined;
+    let stepToolCallsSeen = 0;
+    let hostInputPauseRequested = false;
     const buildStepContent = (): TurnContentPart[] => {
       const parts: TurnContentPart[] = [];
       if (stepText) parts.push({ type: 'text', text: stepText });
@@ -312,6 +329,8 @@ export function runPrompt<
       stepText = '';
       stepReasoning = '';
       stepToolCalls = [];
+      stepToolCallCount = undefined;
+      stepToolCallsSeen = 0;
     };
     const zeroUsage: LanguageModelV4Usage = {
       inputTokens: {
@@ -367,6 +386,19 @@ export function runPrompt<
         usage: zeroUsage,
       });
       await result.finish();
+    };
+    /*
+     * Park the turn if host input is pending and the step has no further tool
+     * calls to emit. Returns whether the turn was parked, in which case the
+     * caller must return.
+     */
+    const parkIfHostInputPending = async (): Promise<boolean> => {
+      if (!hostInputPauseRequested) return false;
+      if (stepToolCallCount != null && stepToolCallsSeen < stepToolCallCount) {
+        return false;
+      }
+      await finishForHostInputPause({ completeCurrentStep: true });
+      return true;
     };
     const enqueueApprovalRequest = (approval: {
       approvalId: string;
@@ -652,6 +684,16 @@ export function runPrompt<
          * against the sandbox root, so the strip is display-only.
          */
         const displayValue = stripWorkDir(value, input.sessionWorkDir);
+        /*
+         * Tally before the replay skip below, so a step whose earlier tool
+         * calls are replayed (and skipped) still reaches its declared count.
+         */
+        if (value.type === 'tool-call') {
+          stepToolCallsSeen += 1;
+          if (value.stepToolCallCount != null) {
+            stepToolCallCount = value.stepToolCallCount;
+          }
+        }
         const settledHostInputReplay =
           (displayValue.type === 'tool-call' ||
             displayValue.type === 'tool-result' ||
@@ -823,6 +865,7 @@ export function runPrompt<
             );
             if (outcome === 'awaiting-tool-result') return;
             closingResumedStep = true;
+            if (await parkIfHostInputPending()) return;
             continue;
           }
 
@@ -831,8 +874,9 @@ export function runPrompt<
             approvalId: pendingApproval.approvalId,
             toolCall,
           });
-          await finishForHostInputPause({ completeCurrentStep: true });
-          return;
+          hostInputPauseRequested = true;
+          if (await parkIfHostInputPending()) return;
+          continue;
         }
 
         // Drive step boundaries.
@@ -843,6 +887,10 @@ export function runPrompt<
             usage: value.usage,
             providerMetadata: value.harnessMetadata,
           });
+          if (hostInputPauseRequested) {
+            await finishForHostInputPause({ completeCurrentStep: false });
+            return;
+          }
           if (input.stopConditions != null && input.stopConditions.length > 0) {
             pendingStopBoundary = {
               finishReason: value.finishReason,
@@ -882,6 +930,7 @@ export function runPrompt<
               output,
             });
             await telemetry.toolEnd(toolCall.toolCallId, { ok: true, output });
+            if (await parkIfHostInputPending()) return;
             continue;
           }
           const customToolApprovalDecision = resolveCustomToolApproval({
@@ -911,6 +960,7 @@ export function runPrompt<
               output,
             });
             await telemetry.toolEnd(toolCall.toolCallId, { ok: true, output });
+            if (await parkIfHostInputPending()) return;
             continue;
           }
           const pendingApproval =
@@ -947,6 +997,7 @@ export function runPrompt<
               );
               if (outcome === 'awaiting-tool-result') return;
               closingResumedStep = true;
+              if (await parkIfHostInputPending()) return;
               continue;
             }
             const pendingParsedToolCall = toolCallsByToolCallId.get(
@@ -962,13 +1013,15 @@ export function runPrompt<
               approvalId: pendingApproval.approvalId,
               toolCall: pendingParsedToolCall,
             });
-            await finishForHostInputPause({ completeCurrentStep: true });
-            return;
+            hostInputPauseRequested = true;
+            if (await parkIfHostInputPending()) return;
+            continue;
           }
           if (!isExecutableTool(activeTools[toolCall.toolName])) {
             recordPendingToolResult({ toolCall });
-            await finishForHostInputPause({ completeCurrentStep: true });
-            return;
+            hostInputPauseRequested = true;
+            if (await parkIfHostInputPending()) return;
+            continue;
           }
           startHostToolExecution(
             (async () => {
@@ -1019,6 +1072,8 @@ export function runPrompt<
             })(),
           );
         }
+
+        if (await parkIfHostInputPending()) return;
       }
       await waitForOutstandingHostToolExecutions();
       const isTurnSuspending = input.isTurnSuspending?.() === true;

--- a/packages/harness/src/v1/harness-v1-stream-part.ts
+++ b/packages/harness/src/v1/harness-v1-stream-part.ts
@@ -70,6 +70,19 @@ export type HarnessV1StreamPart =
   // `true` for runtime-executed builtins, false/undefined for host tools.
   | (LanguageModelV4ToolCall & {
       nativeName?: string;
+      /**
+       * How many tool calls the runtime emits for the step this call belongs
+       * to. Lets the host collect every approval in a step before parking the
+       * turn for host input, instead of parking on the first one and dropping
+       * the rest.
+       *
+       * Adapters that know the step's tool-call set before emitting the first
+       * `tool-call` (e.g. Pi, whose `message_end` carries the whole assistant
+       * message) should set it on every `tool-call` of the step. Adapters that
+       * discover tool calls incrementally omit it, and the host parks on the
+       * first call needing input.
+       */
+      stepToolCallCount?: number;
     })
   | LanguageModelV4ToolApprovalRequest
   | LanguageModelV4ToolResult
@@ -267,6 +280,7 @@ export const harnessV1ToolCallPartSchema = z.object({
   dynamic: z.boolean().optional(),
   providerMetadata: harnessV1ProviderMetadataSchema.optional(),
   nativeName: z.string().optional(),
+  stepToolCallCount: z.number().int().positive().optional(),
 });
 
 export const harnessV1ToolApprovalRequestPartSchema = z.object({


### PR DESCRIPTION
Fixes #19302.

## The deadlock

When one model step emits two host tool calls that both need approval, the turn hangs forever and the second approval is never surfaced, so nothing in the UI can unstick it.

`runPrompt` enqueues the approval request for the first such call, parks the turn and `return`s — abandoning the reader. The step's remaining `tool-call` parts are never read, so they never land in `stepToolCalls` and no approval request is ever created for them. The runtime's own journal is unaffected: Pi commits the assistant message with **both** `toolCall` blocks and `stopReason: "toolUse"`.

On resume, `findDanglingHostToolCalls` walks that journal and returns both calls, and `deferRerunUntilHostToolResults` arms a barrier that reruns only once every awaited call has a result. Approving call #1 clears it and leaves `awaiting = {call_2}` — a call the host was never told about, so no card exists, so no result can ever arrive. `startRerun()` is never called.

The barrier itself is fine, and it does not require all approvals in a single pause: `pi-session.test.ts` shows it re-arming across successive `doContinueTurn` calls with only the still-dangling calls, so serial progress works. But that only helps if the host eventually *learns* about call #2 — and the early `return` in `run-prompt.ts` is exactly what prevents it. That is the bug being fixed here.

Every other part of this contract is already plural — `getPendingToolApprovals()` returns a `Map` that `run-prompt.ts` iterates, `continueTurn`/`continueStream` take `toolApprovalContinuations` as an array, and `findDanglingHostToolCalls` iterates every unresolved `toolCall` block. Only the pause site is singular, and a host has no API to ask for the rest.

## The fix

`tool-call` parts carry a new optional `stepToolCallCount`. When the runtime reports it, `runPrompt` latches the pause request instead of returning, keeps reading, enqueues a request for every call in the step that needs host input, and parks once with all of them surfaced. A `finish-step` while a pause is latched parks too, keeping the runtime's real `finishReason`/`usage`.

Runtimes that omit the field park on the first call needing input, exactly as today, so the protocol change is additive and the `harness-pi` barrier needs no change.

`@ai-sdk/harness-pi` reports the count from `message_end`. That is sound because Pi dispatches a step's tool calls through `executeToolCallsParallel`, which emits `tool_execution_start` for every call while only pushing thunks — the host tools' `execute` runs at the trailing `Promise.all`. So `message_end` precedes every `tool-call`, and both `tool-call` parts are in the harness's stream before anything blocks:

```
message_end            (assistant message: both toolCall blocks)
tool_execution_start   -> harness `tool-call` #1
tool_execution_start   -> harness `tool-call` #2
Promise.all begins     -> both execute() pend on approval
```

## Tests

- `run-prompt.test.ts`: a step with two approval-needing calls and `stepToolCallCount: 2` surfaces both pending approvals, applies both approval inputs, and records one step whose content holds both tool calls. Verified to fail on unmodified `run-prompt.ts` (pending approvals came back as `['c1']`).
- `run-prompt.test.ts`: without the count, the turn still pauses on the first approval.
- `pi-translate.test.ts`: the count is reported on every `tool-call` of a step, and omitted for steps with no tool calls.

`packages/harness` (265 node / 242 edge) and `packages/harness-pi` (169) pass; the one `pi-auth.test.ts` failure in `harness-pi` is pre-existing on a clean tree. Both packages typecheck via `tsc --build`.
