### PR TITLE
fix(deepinfra): enable structured outputs for chat models

### DIFF
--- a/.changeset/deepinfra-structured-outputs.md
+++ b/.changeset/deepinfra-structured-outputs.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/deepinfra': patch
+---
+
+fix(deepinfra): enable structured outputs so response_format json_schema is forwarded instead of degrading to json_object

--- a/packages/deepinfra/src/deepinfra-chat-language-model.ts
+++ b/packages/deepinfra/src/deepinfra-chat-language-model.ts
@@ -15,6 +15,7 @@ type DeepInfraChatConfig = {
   url: (options: { path: string; modelId?: string }) => string;
   headers?: () => Record<string, string | undefined>;
   fetch?: FetchFunction;
+  supportsStructuredOutputs?: boolean;
 };
 
 export class DeepInfraChatLanguageModel extends OpenAICompatibleChatLanguageModel {

--- a/packages/deepinfra/src/deepinfra-provider.test.ts
+++ b/packages/deepinfra/src/deepinfra-provider.test.ts
@@ -112,6 +112,14 @@ describe('DeepInfraProvider', () => {
         }),
       );
     });
+
+    it('should set supportsStructuredOutputs so response_format json_schema is forwarded', () => {
+      const provider = createDeepInfra();
+      provider.chatModel('test-model');
+
+      const config = DeepInfraChatLanguageModelMock.mock.calls[0][1];
+      expect(config.supportsStructuredOutputs).toBe(true);
+    });
   });
 
   describe('completionModel', () => {

--- a/packages/deepinfra/src/deepinfra-provider.ts
+++ b/packages/deepinfra/src/deepinfra-provider.ts
@@ -118,10 +118,10 @@ export function createDeepInfra(
   });
 
   const createChatModel = (modelId: DeepInfraChatModelId) => {
-    return new DeepInfraChatLanguageModel(
-      modelId,
-      getCommonModelConfig('chat'),
-    );
+    return new DeepInfraChatLanguageModel(modelId, {
+      ...getCommonModelConfig('chat'),
+      supportsStructuredOutputs: true,
+    });
   };
 
   const createCompletionModel = (modelId: DeepInfraCompletionModelId) =>


### PR DESCRIPTION
## Background

Requests with `responseFormat: { type: 'json', schema }` are silently degraded for DeepInfra models: the provider constructs its chat model without `supportsStructuredOutputs`, which defaults to `false`, so the openai-compatible chat model rewrites the outbound body to `response_format: { type: 'json_object' }` — the schema, name, and strict flag are discarded and only a call warning is emitted.

DeepInfra supports structured outputs natively — "The model is constrained to produce only values that match your schema" (https://docs.deepinfra.com/chat/structured-outputs), across the models listed under https://deepinfra.com/models?q=json, which includes the DeepSeek V4 line (e.g. `DeepSeek-V4-Flash-0731`).

This is the same defect #19025 fixed for Fireworks; cerebras and azure already set the flag.

## Gateway impact

Through Vercel AI Gateway with routing pinned to `only: ['deepinfra']`, an adversarial enum probe (schema `{ verdict: enum['alpha','beta'] }`, prompt demanding `"gamma"`) returns `"gamma"` — the schema never reaches DeepInfra's decoder. The same probe through `only: ['fireworks']` now returns an in-enum value since #19025 was deployed.

On a production fleet that overflows DeepSeek V4 Flash structured-output traffic to this route, ~22% of structured attempts failed client-side schema validation (~5.7k wasted generations in a single day, 2026-08-22), while schema-enforcing routes on the same traffic sit near zero. The Gateway response carries an empty `warnings` array in this case, so the degradation is invisible to callers.

## Summary

Set `supportsStructuredOutputs: true` on the DeepInfra chat model config (construction site in `deepinfra-provider.ts`, plus the field on `DeepInfraChatConfig`), so `json_schema` response formats are forwarded to the DeepInfra API instead of degrading to plain JSON mode — same as fireworks (#19025), cerebras, and azure.

## Verification

- New unit test asserting the flag is passed to `DeepInfraChatLanguageModel`
- `pnpm vitest run src/deepinfra-provider.test.ts` — 10 passed
- `pnpm build` in `packages/deepinfra` — clean

## Related

- #19025 (identical fix for Fireworks, merged 2026-08-18 and observable in Gateway behavior since)
- Like #19025, this will need backports to `release-v6.0` and `release-v5.0` for the gateway's spec v3/v2 lines.

