### PR TITLE
fix(baseten): enable structured outputs for chat models

### DIFF
--- a/.changeset/baseten-structured-outputs.md
+++ b/.changeset/baseten-structured-outputs.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/baseten': patch
+---
+
+fix(baseten): enable structured outputs so response_format json_schema is forwarded instead of degrading to json_object

--- a/packages/baseten/src/baseten-provider.ts
+++ b/packages/baseten/src/baseten-provider.ts
@@ -203,6 +203,7 @@ export function createBaseten(
           errorStructure: basetenErrorStructure,
           // Or stream_options.include_usage is omitted and streams report no usage.
           includeUsage: true,
+          supportsStructuredOutputs: true,
         });
       } else if (customURL.includes('/predict')) {
         throw new Error(
@@ -215,6 +216,7 @@ export function createBaseten(
       ...getCommonModelConfig('chat'),
       errorStructure: basetenErrorStructure,
       includeUsage: true,
+      supportsStructuredOutputs: true,
     });
   };
 

--- a/packages/baseten/src/baseten-provider.unit.test.ts
+++ b/packages/baseten/src/baseten-provider.unit.test.ts
@@ -176,6 +176,28 @@ describe('BasetenProvider', () => {
       });
     });
 
+    // Without this flag the openai-compatible chat model rewrites
+    // `response_format: json_schema` to `json_object`, silently discarding the
+    // schema, name, and strict flag with only a call warning.
+    describe('supportsStructuredOutputs', () => {
+      it('should be set for the default Model APIs path', () => {
+        createBaseten().chatModel('deepseek-ai/DeepSeek-V3-0324');
+
+        const config = OpenAICompatibleChatLanguageModelMock.mock.calls[0][1];
+        expect(config.supportsStructuredOutputs).toBe(true);
+      });
+
+      it('should be set for a dedicated /sync/v1 deployment', () => {
+        createBaseten({
+          modelURL:
+            'https://model-123.api.baseten.co/environments/production/sync/v1',
+        }).chatModel();
+
+        const config = OpenAICompatibleChatLanguageModelMock.mock.calls[0][1];
+        expect(config.supportsStructuredOutputs).toBe(true);
+      });
+    });
+
     // Baseten sends a bare string from the Model APIs but lets dedicated
     // deployments pass through their server's OpenAI-shaped object, so the
     // schema has to accept both. A failed parse degrades the message to the


### PR DESCRIPTION
## Background

Requests with `responseFormat: { type: 'json', schema }` are silently degraded for Baseten models: both chat model constructions (default Model APIs and dedicated `/sync/v1` deployments) omit `supportsStructuredOutputs`, which defaults to `false`, so the openai-compatible chat model rewrites the outbound body to `response_format: { type: 'json_object' }` — the schema, name, and strict flag are discarded and only a call warning is emitted.

Baseten supports structured outputs natively on both surfaces — "All Engine-Builder-LLM and BIS-LLM models support structured outputs with no extra configuration" (https://docs.baseten.co/inference/structured-outputs), with the code being "the same on both surfaces; only the base URL and model name differ."

This is the same defect #19025 fixed for Fireworks; cerebras and azure already set the flag.

## Gateway impact

Through Vercel AI Gateway with routing pinned to `only: ['baseten']`, an adversarial enum probe (schema `{ verdict: enum['alpha','beta'] }`, prompt demanding `"gamma"`) returns `"gamma"` — the schema never reaches Baseten's decoder. The same probe through `only: ['fireworks']` now returns an in-enum value since #19025 was deployed.

On a production fleet that overflows DeepSeek V4 Flash structured-output traffic to this route, ~32% of structured attempts failed client-side schema validation (~1.4k wasted generations in a single day, 2026-08-22), while schema-enforcing routes on the same traffic sit near zero. The Gateway response carries an empty `warnings` array in this case, so the degradation is invisible to callers.

## Summary

Set `supportsStructuredOutputs: true` on both Baseten chat model constructions (default Model APIs path and dedicated `/sync/v1` path), so `json_schema` response formats are forwarded to the Baseten API instead of degrading to plain JSON mode — same as fireworks (#19025), cerebras, and azure.

## Verification

- New unit tests asserting the flag on both construction paths
- `pnpm vitest run src/baseten-provider.unit.test.ts` — 42 passed
- `pnpm build` in `packages/baseten` — clean

## Related

- #19025 (identical fix for Fireworks, merged 2026-08-18 and observable in Gateway behavior since)
- Like #19025, this will need backports to `release-v6.0` and `release-v5.0` for the gateway's spec v3/v2 lines.
