### PR TITLE
fix(provider/amazon-bedrock): transform stream exception events into Anthropic error format

### DIFF
--- a/.changeset/thin-hoops-repair.md
+++ b/.changeset/thin-hoops-repair.md
@@ -1,0 +1,16 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix (provider/amazon-bedrock): transform stream exception events into Anthropic error format
+
+Bedrock `invoke-with-response-stream` delivers mid-stream errors as event-stream
+exception frames whose payload is a JSON string (e.g.
+`{"message":"Bedrock is unable to process your request."}`). The Anthropic
+fetch shim forwarded that payload verbatim as the `error` member, producing
+`{"type":"error","error":"{\"message\":\"...\"}"}` — which fails the Anthropic
+stream chunk schema (`error` must be `{ type, message }`) and surfaces as
+`AI_TypeValidationError`, masking the actual Bedrock error and defeating
+error-type-based retry handling. Exception frames are now normalized the same
+way the non-streaming error branch already does, using the `:exception-type`
+header (e.g. `modelStreamErrorException`) as the error type.

--- a/.changeset/thin-hoops-repair.md
+++ b/.changeset/thin-hoops-repair.md
@@ -2,15 +2,4 @@
 "@ai-sdk/amazon-bedrock": patch
 ---
 
-fix (provider/amazon-bedrock): transform stream exception events into Anthropic error format
-
-Bedrock `invoke-with-response-stream` delivers mid-stream errors as event-stream
-exception frames whose payload is a JSON string (e.g.
-`{"message":"Bedrock is unable to process your request."}`). The Anthropic
-fetch shim forwarded that payload verbatim as the `error` member, producing
-`{"type":"error","error":"{\"message\":\"...\"}"}` — which fails the Anthropic
-stream chunk schema (`error` must be `{ type, message }`) and surfaces as
-`AI_TypeValidationError`, masking the actual Bedrock error and defeating
-error-type-based retry handling. Exception frames are now normalized the same
-way the non-streaming error branch already does, using the `:exception-type`
-header (e.g. `modelStreamErrorException`) as the error type.
+fix (provider/amazon-bedrock): transform stream exception events into the Anthropic error event shape so they no longer fail the stream chunk schema as `AI_TypeValidationError` and instead surface the Bedrock error message

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.test.ts
@@ -116,8 +116,6 @@ describe('createAmazonBedrockAnthropicFetch', () => {
     expect(text).toBe('data: [DONE]\n\n');
   });
 
-  // Sends one exception frame through the wrapped fetch and returns the
-  // decoded SSE text.
   async function transformExceptionFrame({
     exceptionType,
     body,
@@ -157,10 +155,6 @@ describe('createAmazonBedrockAnthropicFetch', () => {
   }
 
   it('should transform exception messages into Anthropic error event format', async () => {
-    // Bedrock delivers mid-stream errors as exception frames whose payload is
-    // {"message":"..."} (e.g. "Bedrock is unable to process your request.").
-    // Forwarding the payload string un-parsed fails the Anthropic stream
-    // chunk schema, which requires error to be a { type, message } object.
     const text = await transformExceptionFrame({
       exceptionType: 'modelStreamErrorException',
       body: JSON.stringify({

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.test.ts
@@ -116,16 +116,24 @@ describe('createAmazonBedrockAnthropicFetch', () => {
     expect(text).toBe('data: [DONE]\n\n');
   });
 
-  it('should transform exception messages into Anthropic error event format', async () => {
+  // Sends one exception frame through the wrapped fetch and returns the
+  // decoded SSE text.
+  async function transformExceptionFrame({
+    exceptionType,
+    body,
+  }: {
+    exceptionType?: string;
+    body: string;
+  }): Promise<string> {
     const codec = new EventStreamCodec(toUtf8, fromUtf8);
-
-    const errorData = JSON.stringify({ message: 'Rate limit exceeded' });
     const amazonBedrockEvent = codec.encode({
       headers: {
         ':message-type': { type: 'string', value: 'exception' },
-        ':exception-type': { type: 'string', value: 'ThrottlingException' },
+        ...(exceptionType != null && {
+          ':exception-type': { type: 'string', value: exceptionType },
+        }),
       },
-      body: fromUtf8(errorData),
+      body: fromUtf8(body),
     });
 
     const stream = new ReadableStream({
@@ -139,152 +147,63 @@ describe('createAmazonBedrockAnthropicFetch', () => {
       stream,
       'application/vnd.amazon.eventstream',
     );
-    const baseFetch = createMockFetch(mockResponse);
-    const wrappedFetch = createAmazonBedrockAnthropicFetch(baseFetch);
+    const wrappedFetch = createAmazonBedrockAnthropicFetch(
+      createMockFetch(mockResponse),
+    );
 
     const response = await wrappedFetch('https://example.com', {});
-    const reader = response.body!.getReader();
-    const { value } = await reader.read();
-    const text = new TextDecoder().decode(value);
+    const { value } = await response.body!.getReader().read();
+    return new TextDecoder().decode(value);
+  }
+
+  it('should transform exception messages into Anthropic error event format', async () => {
+    // Bedrock delivers mid-stream errors as exception frames whose payload is
+    // {"message":"..."} (e.g. "Bedrock is unable to process your request.").
+    // Forwarding the payload string un-parsed fails the Anthropic stream
+    // chunk schema, which requires error to be a { type, message } object.
+    const text = await transformExceptionFrame({
+      exceptionType: 'modelStreamErrorException',
+      body: JSON.stringify({
+        message: 'Bedrock is unable to process your request.',
+      }),
+    });
 
     expect(text).toBe(
       `data: ${JSON.stringify({
         type: 'error',
-        error: { type: 'ThrottlingException', message: 'Rate limit exceeded' },
+        error: {
+          type: 'modelStreamErrorException',
+          message: 'Bedrock is unable to process your request.',
+        },
       })}\n\n`,
     );
   });
 
-  it('should parse exception events so the Anthropic stream chunk schema accepts them', async () => {
-    const codec = new EventStreamCodec(toUtf8, fromUtf8);
-
-    // Exact payload observed from bedrock-runtime invoke-with-response-stream
-    // during a model error: the exception body is a JSON string with only a
-    // `message` field. Emitting it un-parsed produces
-    // {"type":"error","error":"{\"message\":\"...\"}"} which fails the
-    // Anthropic chunk schema (error must be an object) and surfaces as
-    // AI_TypeValidationError instead of the Bedrock error message.
-    const errorData = JSON.stringify({
-      message: 'Bedrock is unable to process your request.',
-    });
-    const amazonBedrockEvent = codec.encode({
-      headers: {
-        ':message-type': { type: 'string', value: 'exception' },
-        ':exception-type': {
-          type: 'string',
-          value: 'modelStreamErrorException',
-        },
-      },
-      body: fromUtf8(errorData),
-    });
-
-    const stream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(amazonBedrockEvent);
-        controller.close();
-      },
-    });
-
-    const mockResponse = createMockResponse(
-      stream,
-      'application/vnd.amazon.eventstream',
-    );
-    const baseFetch = createMockFetch(mockResponse);
-    const wrappedFetch = createAmazonBedrockAnthropicFetch(baseFetch);
-
-    const response = await wrappedFetch('https://example.com', {});
-    const reader = response.body!.getReader();
-    const { value } = await reader.read();
-    const text = new TextDecoder().decode(value);
-
-    const event = JSON.parse(text.replace(/^data: /, ''));
-    expect(event).toEqual({
-      type: 'error',
-      error: {
-        type: 'modelStreamErrorException',
-        message: 'Bedrock is unable to process your request.',
-      },
-    });
-    // the error member must be an object to satisfy the Anthropic
-    // stream chunk schema: z.object({ type: z.string(), message: z.string() })
-    expect(typeof event.error).toBe('object');
-  });
-
   it('should use raw exception data as message when it has no message field', async () => {
-    const codec = new EventStreamCodec(toUtf8, fromUtf8);
-
     const errorData = JSON.stringify({ code: 'InternalFailure' });
-    const amazonBedrockEvent = codec.encode({
-      headers: {
-        ':message-type': { type: 'string', value: 'exception' },
-        ':exception-type': {
-          type: 'string',
-          value: 'internalServerException',
-        },
-      },
-      body: fromUtf8(errorData),
+
+    const text = await transformExceptionFrame({
+      exceptionType: 'internalServerException',
+      body: errorData,
     });
 
-    const stream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(amazonBedrockEvent);
-        controller.close();
-      },
-    });
-
-    const mockResponse = createMockResponse(
-      stream,
-      'application/vnd.amazon.eventstream',
+    expect(text).toBe(
+      `data: ${JSON.stringify({
+        type: 'error',
+        error: { type: 'internalServerException', message: errorData },
+      })}\n\n`,
     );
-    const baseFetch = createMockFetch(mockResponse);
-    const wrappedFetch = createAmazonBedrockAnthropicFetch(baseFetch);
-
-    const response = await wrappedFetch('https://example.com', {});
-    const reader = response.body!.getReader();
-    const { value } = await reader.read();
-    const text = new TextDecoder().decode(value);
-
-    const event = JSON.parse(text.replace(/^data: /, ''));
-    expect(event.error).toEqual({
-      type: 'internalServerException',
-      message: errorData,
-    });
   });
 
-  it('should fall back to type "error" when the exception has no :exception-type header', async () => {
-    const codec = new EventStreamCodec(toUtf8, fromUtf8);
+  it('should fall back to type "error" and raw text for a non-JSON exception without :exception-type header', async () => {
+    const text = await transformExceptionFrame({ body: 'not valid json' });
 
-    const amazonBedrockEvent = codec.encode({
-      headers: {
-        ':message-type': { type: 'string', value: 'exception' },
-      },
-      body: fromUtf8('not valid json'),
-    });
-
-    const stream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(amazonBedrockEvent);
-        controller.close();
-      },
-    });
-
-    const mockResponse = createMockResponse(
-      stream,
-      'application/vnd.amazon.eventstream',
+    expect(text).toBe(
+      `data: ${JSON.stringify({
+        type: 'error',
+        error: { type: 'error', message: 'not valid json' },
+      })}\n\n`,
     );
-    const baseFetch = createMockFetch(mockResponse);
-    const wrappedFetch = createAmazonBedrockAnthropicFetch(baseFetch);
-
-    const response = await wrappedFetch('https://example.com', {});
-    const reader = response.body!.getReader();
-    const { value } = await reader.read();
-    const text = new TextDecoder().decode(value);
-
-    const event = JSON.parse(text.replace(/^data: /, ''));
-    expect(event.error).toEqual({
-      type: 'error',
-      message: 'not valid json',
-    });
   });
 
   it('should handle multiple events in sequence', async () => {

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.test.ts
@@ -116,7 +116,7 @@ describe('createAmazonBedrockAnthropicFetch', () => {
     expect(text).toBe('data: [DONE]\n\n');
   });
 
-  it('should handle exception messages', async () => {
+  it('should transform exception messages into Anthropic error event format', async () => {
     const codec = new EventStreamCodec(toUtf8, fromUtf8);
 
     const errorData = JSON.stringify({ message: 'Rate limit exceeded' });
@@ -148,8 +148,143 @@ describe('createAmazonBedrockAnthropicFetch', () => {
     const text = new TextDecoder().decode(value);
 
     expect(text).toBe(
-      `data: ${JSON.stringify({ type: 'error', error: errorData })}\n\n`,
+      `data: ${JSON.stringify({
+        type: 'error',
+        error: { type: 'ThrottlingException', message: 'Rate limit exceeded' },
+      })}\n\n`,
     );
+  });
+
+  it('should parse exception events so the Anthropic stream chunk schema accepts them', async () => {
+    const codec = new EventStreamCodec(toUtf8, fromUtf8);
+
+    // Exact payload observed from bedrock-runtime invoke-with-response-stream
+    // during a model error: the exception body is a JSON string with only a
+    // `message` field. Emitting it un-parsed produces
+    // {"type":"error","error":"{\"message\":\"...\"}"} which fails the
+    // Anthropic chunk schema (error must be an object) and surfaces as
+    // AI_TypeValidationError instead of the Bedrock error message.
+    const errorData = JSON.stringify({
+      message: 'Bedrock is unable to process your request.',
+    });
+    const amazonBedrockEvent = codec.encode({
+      headers: {
+        ':message-type': { type: 'string', value: 'exception' },
+        ':exception-type': {
+          type: 'string',
+          value: 'modelStreamErrorException',
+        },
+      },
+      body: fromUtf8(errorData),
+    });
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(amazonBedrockEvent);
+        controller.close();
+      },
+    });
+
+    const mockResponse = createMockResponse(
+      stream,
+      'application/vnd.amazon.eventstream',
+    );
+    const baseFetch = createMockFetch(mockResponse);
+    const wrappedFetch = createAmazonBedrockAnthropicFetch(baseFetch);
+
+    const response = await wrappedFetch('https://example.com', {});
+    const reader = response.body!.getReader();
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+
+    const event = JSON.parse(text.replace(/^data: /, ''));
+    expect(event).toEqual({
+      type: 'error',
+      error: {
+        type: 'modelStreamErrorException',
+        message: 'Bedrock is unable to process your request.',
+      },
+    });
+    // the error member must be an object to satisfy the Anthropic
+    // stream chunk schema: z.object({ type: z.string(), message: z.string() })
+    expect(typeof event.error).toBe('object');
+  });
+
+  it('should use raw exception data as message when it has no message field', async () => {
+    const codec = new EventStreamCodec(toUtf8, fromUtf8);
+
+    const errorData = JSON.stringify({ code: 'InternalFailure' });
+    const amazonBedrockEvent = codec.encode({
+      headers: {
+        ':message-type': { type: 'string', value: 'exception' },
+        ':exception-type': {
+          type: 'string',
+          value: 'internalServerException',
+        },
+      },
+      body: fromUtf8(errorData),
+    });
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(amazonBedrockEvent);
+        controller.close();
+      },
+    });
+
+    const mockResponse = createMockResponse(
+      stream,
+      'application/vnd.amazon.eventstream',
+    );
+    const baseFetch = createMockFetch(mockResponse);
+    const wrappedFetch = createAmazonBedrockAnthropicFetch(baseFetch);
+
+    const response = await wrappedFetch('https://example.com', {});
+    const reader = response.body!.getReader();
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+
+    const event = JSON.parse(text.replace(/^data: /, ''));
+    expect(event.error).toEqual({
+      type: 'internalServerException',
+      message: errorData,
+    });
+  });
+
+  it('should fall back to type "error" when the exception has no :exception-type header', async () => {
+    const codec = new EventStreamCodec(toUtf8, fromUtf8);
+
+    const amazonBedrockEvent = codec.encode({
+      headers: {
+        ':message-type': { type: 'string', value: 'exception' },
+      },
+      body: fromUtf8('not valid json'),
+    });
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(amazonBedrockEvent);
+        controller.close();
+      },
+    });
+
+    const mockResponse = createMockResponse(
+      stream,
+      'application/vnd.amazon.eventstream',
+    );
+    const baseFetch = createMockFetch(mockResponse);
+    const wrappedFetch = createAmazonBedrockAnthropicFetch(baseFetch);
+
+    const response = await wrappedFetch('https://example.com', {});
+    const reader = response.body!.getReader();
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+
+    const event = JSON.parse(text.replace(/^data: /, ''));
+    expect(event.error).toEqual({
+      type: 'error',
+      message: 'not valid json',
+    });
   });
 
   it('should handle multiple events in sequence', async () => {

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
@@ -10,9 +10,6 @@ const amazonBedrockErrorSchema = z.looseObject({
   message: z.string().optional(),
 });
 
-// Transform a Bedrock error payload into the Anthropic error shape
-// ({ type, message }) so downstream Anthropic handlers and the stream
-// chunk schema can process it.
 async function toAnthropicErrorPayload(
   text: string,
   type = 'error',
@@ -103,8 +100,6 @@ function transformAmazonBedrockEventStreamToSSE(
           controller.enqueue(textEncoder.encode('data: [DONE]\n\n'));
         }
       } else if (event.messageType === 'exception') {
-        // Emitting the raw payload string would fail the Anthropic chunk
-        // schema; normalize to the Anthropic error event shape instead.
         controller.enqueue(
           textEncoder.encode(
             `data: ${JSON.stringify({

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
@@ -10,6 +10,24 @@ const amazonBedrockErrorSchema = z.looseObject({
   message: z.string().optional(),
 });
 
+// Transform a Bedrock error payload into the Anthropic error shape
+// ({ type, message }) so downstream Anthropic handlers and the stream
+// chunk schema can process it.
+async function toAnthropicErrorPayload(
+  text: string,
+  type = 'error',
+): Promise<{ type: string; message: string }> {
+  const parsed = await safeParseJSON({
+    text,
+    schema: amazonBedrockErrorSchema,
+  });
+
+  const message =
+    parsed.success && parsed.value.message ? parsed.value.message : text;
+
+  return { type, message };
+}
+
 export function createAmazonBedrockAnthropicFetch(
   baseFetch: FetchFunction,
 ): FetchFunction {
@@ -20,17 +38,9 @@ export function createAmazonBedrockAnthropicFetch(
     // so that anthropicFailedResponseHandler can extract the message.
     if (!response.ok) {
       const text = await response.text();
-      const parsed = await safeParseJSON({
-        text,
-        schema: amazonBedrockErrorSchema,
-      });
-
-      const message =
-        parsed.success && parsed.value.message ? parsed.value.message : text;
-
       const anthropicError = JSON.stringify({
         type: 'error',
-        error: { type: 'error', message },
+        error: await toAnthropicErrorPayload(text),
       });
 
       return new Response(anthropicError, {
@@ -93,26 +103,16 @@ function transformAmazonBedrockEventStreamToSSE(
           controller.enqueue(textEncoder.encode('data: [DONE]\n\n'));
         }
       } else if (event.messageType === 'exception') {
-        // Transform Bedrock stream exceptions into Anthropic error event format
-        // ({ type, message } object), mirroring the non-streaming error branch
-        // above. Emitting the raw payload string fails the Anthropic chunk
-        // schema and surfaces as a type validation error instead of the
-        // actual Bedrock error message.
-        const parsed = await safeParseJSON({
-          text: event.data,
-          schema: amazonBedrockErrorSchema,
-        });
-
-        const message =
-          parsed.success && parsed.value.message
-            ? parsed.value.message
-            : event.data;
-
+        // Emitting the raw payload string would fail the Anthropic chunk
+        // schema; normalize to the Anthropic error event shape instead.
         controller.enqueue(
           textEncoder.encode(
             `data: ${JSON.stringify({
               type: 'error',
-              error: { type: event.exceptionType ?? 'error', message },
+              error: await toAnthropicErrorPayload(
+                event.data,
+                event.exceptionType,
+              ),
             })}\n\n`,
           ),
         );

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
@@ -93,9 +93,27 @@ function transformAmazonBedrockEventStreamToSSE(
           controller.enqueue(textEncoder.encode('data: [DONE]\n\n'));
         }
       } else if (event.messageType === 'exception') {
+        // Transform Bedrock stream exceptions into Anthropic error event format
+        // ({ type, message } object), mirroring the non-streaming error branch
+        // above. Emitting the raw payload string fails the Anthropic chunk
+        // schema and surfaces as a type validation error instead of the
+        // actual Bedrock error message.
+        const parsed = await safeParseJSON({
+          text: event.data,
+          schema: amazonBedrockErrorSchema,
+        });
+
+        const message =
+          parsed.success && parsed.value.message
+            ? parsed.value.message
+            : event.data;
+
         controller.enqueue(
           textEncoder.encode(
-            `data: ${JSON.stringify({ type: 'error', error: event.data })}\n\n`,
+            `data: ${JSON.stringify({
+              type: 'error',
+              error: { type: event.exceptionType ?? 'error', message },
+            })}\n\n`,
           ),
         );
       }


### PR DESCRIPTION
## Background

When Bedrock fails mid-stream (`InvokeModelWithResponseStream`), it sends an exception frame whose body is a JSON string like `{"message":"Bedrock is unable to process your request."}`. The Anthropic fetch shim forwards that string as-is:

```
data: {"type":"error","error":"{\"message\":\"Bedrock is unable to process your request.\"}"}
```

The Anthropic chunk schema expects `error` to be an object (`{ type, message }`), so every mid-stream Bedrock error blows up as `AI_TypeValidationError` and the real error message is lost. We hit this in production. The non-streaming error branch in the same file already normalizes Bedrock errors correctly; the stream branch doesn't.

Refs: [InvokeModelWithResponseStream exception members](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModelWithResponseStream.html), [Anthropic streaming error events](https://platform.claude.com/docs/en/build-with-claude/streaming).


## End-to-End Verification

Replayed a real encoded Bedrock exception frame (`@smithy/eventstream-codec`, `:exception-type: modelStreamErrorException`) through `createBedrockAnthropic(...).doStream()` with a stubbed fetch. Before: the same `AI_TypeValidationError` we saw in production. After: a normal error carrying Bedrock's message.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)


## Related Issues

Related error class: #9852
