### PR TITLE
fix: handle empty string tool call IDs in xai, mistral, and cohere doGenerate

### DIFF
--- a/.changeset/three-tools-generate.md
+++ b/.changeset/three-tools-generate.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/xai': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/cohere': patch
+---
+
+fix: handle empty string tool call IDs

--- a/packages/cohere/src/cohere-chat-language-model.test.ts
+++ b/packages/cohere/src/cohere-chat-language-model.test.ts
@@ -104,6 +104,33 @@ describe('doGenerate', () => {
       prepareJsonFixtureResponse('cohere-tool-call');
     });
 
+    it('should generate an ID when the tool call ID is empty', async () => {
+      const body = JSON.parse(
+        fs.readFileSync('src/__fixtures__/cohere-tool-call.json', 'utf8'),
+      );
+      body.message.tool_calls[0].id = '';
+      server.urls['https://api.cohere.com/v2/chat'].response = {
+        type: 'json-value',
+        body,
+      };
+
+      const testProvider = createCohere({
+        apiKey: 'test-api-key',
+        generateId: vi.fn().mockReturnValue('test-id'),
+      });
+
+      const { content } = await testProvider('command-r-plus').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(content).toContainEqual({
+        type: 'tool-call',
+        toolCallId: 'test-id',
+        toolName: 'weather',
+        input: '{"location":"San Francisco"}',
+      });
+    });
+
     it('should extract tool calls', async () => {
       const result = await model.doGenerate({
         tools: [

--- a/packages/cohere/src/cohere-chat-language-model.ts
+++ b/packages/cohere/src/cohere-chat-language-model.ts
@@ -220,7 +220,7 @@ export class CohereChatLanguageModel implements LanguageModelV4 {
     for (const toolCall of response.message.tool_calls ?? []) {
       content.push({
         type: 'tool-call' as const,
-        toolCallId: toolCall.id,
+        toolCallId: toolCall.id || this.config.generateId(),
         toolName: toolCall.function.name,
         // Cohere sometimes returns `null` for tool call arguments for tools
         // defined as having no arguments.

--- a/packages/mistral/src/mistral-chat-language-model.test.ts
+++ b/packages/mistral/src/mistral-chat-language-model.test.ts
@@ -91,6 +91,33 @@ describe('doGenerate', () => {
 
       expect(result).toMatchSnapshot();
     });
+
+    it('should generate an ID when the tool call ID is empty', async () => {
+      const body = JSON.parse(
+        fs.readFileSync('src/__fixtures__/mistral-tool-call.json', 'utf8'),
+      );
+      body.choices[0].message.tool_calls[0].id = '';
+      server.urls[CHAT_COMPLETIONS_URL].response = {
+        type: 'json-value',
+        body,
+      };
+
+      const testProvider = createMistral({
+        apiKey: 'test-api-key',
+        generateId: () => 'test-id',
+      });
+
+      const result = await testProvider
+        .chat('mistral-small-latest')
+        .doGenerate({ prompt: TEST_PROMPT });
+
+      expect(result.content).toContainEqual({
+        type: 'tool-call',
+        toolCallId: 'test-id',
+        toolName: 'weather',
+        input: '{"location": "San Francisco"}',
+      });
+    });
   });
 
   describe('reasoning', () => {

--- a/packages/mistral/src/mistral-chat-language-model.ts
+++ b/packages/mistral/src/mistral-chat-language-model.ts
@@ -282,7 +282,7 @@ export class MistralChatLanguageModel implements LanguageModelV4 {
       for (const toolCall of choice.message.tool_calls) {
         content.push({
           type: 'tool-call',
-          toolCallId: toolCall.id,
+          toolCallId: toolCall.id || this.generateId(),
           toolName: toolCall.function.name,
           input: toolCall.function.arguments!,
         });

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -88,6 +88,26 @@ describe('XaiChatLanguageModel', () => {
         const result = await model.doGenerate({ prompt: TEST_PROMPT });
         expect(result).toMatchSnapshot();
       });
+
+      it('should generate an ID when the tool call ID is empty', async () => {
+        const body = JSON.parse(
+          fs.readFileSync('src/__fixtures__/xai-tool-call.json', 'utf8'),
+        );
+        body.choices[0].message.tool_calls[0].id = '';
+        server.urls['https://api.x.ai/v1/chat/completions'].response = {
+          type: 'json-value',
+          body,
+        };
+
+        const result = await model.doGenerate({ prompt: TEST_PROMPT });
+
+        expect(result.content).toContainEqual({
+          type: 'tool-call',
+          toolCallId: 'test-id',
+          toolName: 'weather',
+          input: '{"location":"San Francisco"}',
+        });
+      });
     });
 
     it('should extract usage', async () => {

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -319,7 +319,7 @@ export class XaiChatLanguageModel implements LanguageModelV4 {
       for (const toolCall of choice.message.tool_calls) {
         content.push({
           type: 'tool-call',
-          toolCallId: toolCall.id,
+          toolCallId: toolCall.id || this.config.generateId(),
           toolName: toolCall.function.name,
           input: toolCall.function.arguments,
         });


### PR DESCRIPTION
## Background

#19091 fixed #7834 by falling back to a generated ID when a provider returns an empty string tool call ID, across eight provider packages. Three siblings were missed: the `doGenerate` tool call mappings in `@ai-sdk/xai`, `@ai-sdk/mistral`, and `@ai-sdk/cohere` still emit the raw ID. Each response schema types the ID as `z.string()`, which validates `''`, so empty IDs flow through to `toolCallId` unchanged.

## Summary

Applies the same `toolCall.id || generateId()` fallback from #19091 to the three remaining `doGenerate` sites, and mirrors its regression test in each package (empty-string ID in the response, generated ID expected in the tool call content). Adds one patch changeset covering the three packages.

Deliberately out of scope: the xai (line 609) and cohere (line 361) streaming paths also emit raw IDs with no fallback (mistral's streaming goes through `StreamingToolCallTracker` and is covered). Happy to address those in this PR or a follow-up, whichever you prefer.

## End-to-End Verification

Served each package's tool call fixture with an empty string `id` through the test server: before the change `doGenerate` returned `toolCallId: ""`, after it returns the generated ID. Full node and edge suites pass for all three packages (xai 434, mistral 111, cohere 76 in both environments); `pnpm check` and `type-check` clean.
