### PR TITLE
chore(cerebras): remove deprecated zai glm-4.7 model

### DIFF
--- a/.changeset/moody-knives-wink.md
+++ b/.changeset/moody-knives-wink.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/cerebras": patch
+---
+
+chore(cerebras): remove deprecated zai glm-4.7 model

--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -165,7 +165,6 @@ Here are the capabilities of popular models:
 | [DeepSeek](/providers/ai-sdk-providers/deepseek)   | `deepseek-chat`                             | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [DeepSeek](/providers/ai-sdk-providers/deepseek)   | `deepseek-reasoner`                         | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Cerebras](/providers/ai-sdk-providers/cerebras)   | `gpt-oss-120b`                              | <Cross />   | <Check />         | <Check />  | <Check />      |
-| [Cerebras](/providers/ai-sdk-providers/cerebras)   | `zai-glm-4.7`                               | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Cerebras](/providers/ai-sdk-providers/cerebras)   | `gemma-4-31b`                               | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Groq](/providers/ai-sdk-providers/groq)           | `meta-llama/llama-4-scout-17b-16e-instruct` | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Groq](/providers/ai-sdk-providers/groq)           | `llama-3.3-70b-versatile`                   | <Cross />   | <Check />         | <Check />  | <Check />      |

--- a/content/providers/01-ai-sdk-providers/40-cerebras.mdx
+++ b/content/providers/01-ai-sdk-providers/40-cerebras.mdx
@@ -85,7 +85,7 @@ const model = cerebras.chat('gpt-oss-120b');
 
 ### Reasoning Models
 
-Cerebras offers reasoning models including `gpt-oss-120b`, `zai-glm-4.7`, and `gemma-4-31b` that generate intermediate thinking tokens before their final response. The reasoning output is streamed through the standard AI SDK reasoning parts.
+Cerebras offers reasoning models including `gpt-oss-120b` and `gemma-4-31b` that generate intermediate thinking tokens before their final response. The reasoning output is streamed through the standard AI SDK reasoning parts.
 
 For `gpt-oss-120b`, you can control the reasoning depth using the `reasoningEffort` provider option:
 
@@ -189,5 +189,4 @@ const result = await generateText({
 | Model          | Image Input | Object Generation | Tool Usage | Tool Streaming | Reasoning |
 | -------------- | ----------- | ----------------- | ---------- | -------------- | --------- |
 | `gpt-oss-120b` | <Cross />   | <Check />         | <Check />  | <Check />      | <Check /> |
-| `zai-glm-4.7`  | <Cross />   | <Check />         | <Check />  | <Check />      | <Check /> |
 | `gemma-4-31b`  | <Check />   | <Check />         | <Check />  | <Check />      | <Check /> |

--- a/content/providers/01-ai-sdk-providers/index.mdx
+++ b/content/providers/01-ai-sdk-providers/index.mdx
@@ -99,7 +99,6 @@ Not all providers support all AI SDK features. Here's a quick comparison of the 
 | [DeepInfra](/providers/ai-sdk-providers/deepinfra)         | `deepseek-ai/DeepSeek-R1`                           | <Cross />   | <Cross />         | <Cross />  | <Cross />      |
 | [DeepInfra](/providers/ai-sdk-providers/deepinfra)         | `Qwen/QwQ-32B`                                      | <Cross />   | <Check />         | <Check />  | <Cross />      |
 | [Cerebras](/providers/ai-sdk-providers/cerebras)           | `gpt-oss-120b`                                      | <Cross />   | <Check />         | <Check />  | <Check />      |
-| [Cerebras](/providers/ai-sdk-providers/cerebras)           | `zai-glm-4.7`                                       | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Cerebras](/providers/ai-sdk-providers/cerebras)           | `gemma-4-31b`                                       | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Hugging Face](/providers/ai-sdk-providers/huggingface)    | `meta-llama/Llama-3.1-8B-Instruct`                  | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Hugging Face](/providers/ai-sdk-providers/huggingface)    | `moonshotai/Kimi-K2-Instruct`                       | <Cross />   | <Check />         | <Check />  | <Check />      |

--- a/examples/ai-functions/src/e2e/cerebras.test.ts
+++ b/examples/ai-functions/src/e2e/cerebras.test.ts
@@ -20,7 +20,6 @@ createFeatureTestSuite({
     invalidModel: provider.chat('no-such-model'),
     languageModels: [
       createChatModel('gpt-oss-120b'),
-      createChatModel('zai-glm-4.7'),
       createLanguageModelWithCapabilities(provider.chat('gemma-4-31b'), [
         'imageInput',
         'objectGeneration',

--- a/packages/cerebras/src/cerebras-chat-language-model.test.ts
+++ b/packages/cerebras/src/cerebras-chat-language-model.test.ts
@@ -139,7 +139,7 @@ describe('doGenerate', () => {
         'cerebras-structured-output-tools.1',
       );
       const model = createCerebras({ apiKey: 'test-api-key', fetch })(
-        'zai-glm-4.7',
+        'gpt-oss-120b',
       );
 
       const result = await model.doGenerate({
@@ -174,7 +174,7 @@ describe('doGenerate', () => {
         'cerebras-structured-output-tools.2',
       );
       const model = createCerebras({ apiKey: 'test-api-key', fetch })(
-        'zai-glm-4.7',
+        'gpt-oss-120b',
       );
 
       const result = await model.doGenerate({
@@ -207,7 +207,7 @@ describe('doGenerate', () => {
         'cerebras-structured-output-tools.2',
       );
       const model = createCerebras({ apiKey: 'test-api-key', fetch })(
-        'zai-glm-4.7',
+        'gpt-oss-120b',
       );
 
       const result = await model.doGenerate({ prompt: TEST_PROMPT });
@@ -247,7 +247,7 @@ describe('doStream', () => {
         'cererebras-structured-output-tools.1',
       );
       const model = createCerebras({ apiKey: 'test-api-key', fetch })(
-        'zai-glm-4.7',
+        'gpt-oss-120b',
       );
 
       const { stream } = await model.doStream({
@@ -304,7 +304,7 @@ describe('doStream', () => {
         'cererebras-structured-output-tools.1',
       );
       const model = createCerebras({ apiKey: 'test-api-key', fetch })(
-        'zai-glm-4.7',
+        'gpt-oss-120b',
       );
 
       const { stream } = await model.doStream({

--- a/packages/cerebras/src/cerebras-chat-options.ts
+++ b/packages/cerebras/src/cerebras-chat-options.ts
@@ -1,8 +1,4 @@
 // https://inference-docs.cerebras.ai/models/overview
 export type CerebrasChatModelId =
   // production
-  | 'gpt-oss-120b'
-  | 'gemma-4-31b'
-  // preview
-  | 'zai-glm-4.7'
-  | (string & {});
+  'gpt-oss-120b' | 'gemma-4-31b' | (string & {});


### PR DESCRIPTION
## Background

cerebras provider deprecated the GLM 4.7 model but our docs still listed it as valid model id

## Summary

remove model ID `zai/glm-4.7`

## End-to-End Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)