### PR TITLE
fix(deepinfra): enable structured outputs to forward response_format json_schema

### DIFF
--- a/.changeset/deepinfra-structured-outputs.md
+++ b/.changeset/deepinfra-structured-outputs.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/deepinfra': patch
+---
+
+fix(deepinfra): enable structured outputs to forward response_format json_schema

--- a/examples/ai-functions/src/generate-text/deepinfra/output-object.ts
+++ b/examples/ai-functions/src/generate-text/deepinfra/output-object.ts
@@ -1,0 +1,30 @@
+import { deepInfra } from '@ai-sdk/deepinfra';
+import { generateText, Output } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: deepInfra('deepseek-ai/DeepSeek-V3'),
+    output: Output.object({
+      schema: z.object({
+        recipe: z.object({
+          name: z.string(),
+          ingredients: z.array(
+            z.object({
+              name: z.string(),
+              amount: z.string(),
+            }),
+          ),
+          steps: z.array(z.string()),
+        }),
+      }),
+    }),
+    prompt: 'Generate a lasagna recipe.',
+  });
+
+  console.log(JSON.stringify(result.output, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+});

--- a/examples/ai-functions/src/stream-text/deepinfra/output-object.ts
+++ b/examples/ai-functions/src/stream-text/deepinfra/output-object.ts
@@ -1,0 +1,33 @@
+import { deepInfra } from '@ai-sdk/deepinfra';
+import { Output, streamText } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: deepInfra('deepseek-ai/DeepSeek-V3'),
+    output: Output.object({
+      schema: z.object({
+        characters: z.array(
+          z.object({
+            name: z.string(),
+            class: z
+              .string()
+              .describe('Character class, e.g. warrior, mage, or thief.'),
+            description: z.string(),
+          }),
+        ),
+      }),
+    }),
+    prompt:
+      'Generate 3 character descriptions for a fantasy role playing game.',
+  });
+
+  for await (const partialOutput of result.partialOutputStream) {
+    console.clear();
+    console.log(partialOutput);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+});

--- a/packages/deepinfra/src/deepinfra-chat-language-model.ts
+++ b/packages/deepinfra/src/deepinfra-chat-language-model.ts
@@ -15,6 +15,7 @@ type DeepInfraChatConfig = {
   url: (options: { path: string; modelId?: string }) => string;
   headers?: () => Record<string, string | undefined>;
   fetch?: FetchFunction;
+  supportsStructuredOutputs?: boolean;
 };
 
 export class DeepInfraChatLanguageModel extends OpenAICompatibleChatLanguageModel {

--- a/packages/deepinfra/src/deepinfra-provider.test.ts
+++ b/packages/deepinfra/src/deepinfra-provider.test.ts
@@ -112,6 +112,14 @@ describe('DeepInfraProvider', () => {
         }),
       );
     });
+
+    it('should set supportsStructuredOutputs so response_format json_schema is forwarded', () => {
+      const provider = createDeepInfra();
+      provider.chatModel('test-model');
+
+      const config = DeepInfraChatLanguageModelMock.mock.calls[0][1];
+      expect(config.supportsStructuredOutputs).toBe(true);
+    });
   });
 
   describe('completionModel', () => {

--- a/packages/deepinfra/src/deepinfra-provider.ts
+++ b/packages/deepinfra/src/deepinfra-provider.ts
@@ -118,10 +118,10 @@ export function createDeepInfra(
   });
 
   const createChatModel = (modelId: DeepInfraChatModelId) => {
-    return new DeepInfraChatLanguageModel(
-      modelId,
-      getCommonModelConfig('chat'),
-    );
+    return new DeepInfraChatLanguageModel(modelId, {
+      ...getCommonModelConfig('chat'),
+      supportsStructuredOutputs: true,
+    });
   };
 
   const createCompletionModel = (modelId: DeepInfraCompletionModelId) =>


### PR DESCRIPTION
## Background

supersedes https://github.com/vercel/ai/pull/19314

the deepinfra provider allows generating structured outputs but AI SDK didn't have this enabled natively

## Summary

enable `supportStructuredOutputs` flag for deepinfra

## End-to-End Verification

verified by running the example
- `examples/ai-functions/src/generate-text/deepinfra/output-object.ts`
- `examples/ai-functions/src/stream-text/deepinfra/output-object.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

Closes #19314

Co-authored-by: Gaurav Arora <whoarora@gmail.com>