### PR TITLE
fix(baseten): enable structured outputs so response_format json_schema is forwarded

### DIFF
--- a/.changeset/baseten-structured-outputs.md
+++ b/.changeset/baseten-structured-outputs.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/baseten': patch
+---
+
+fix(baseten): enable structured outputs so response_format json_schema is forwarded

--- a/examples/ai-functions/src/generate-text/baseten/output-object.ts
+++ b/examples/ai-functions/src/generate-text/baseten/output-object.ts
@@ -1,0 +1,30 @@
+import { baseten } from '@ai-sdk/baseten';
+import { generateText, Output } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: baseten('zai-org/GLM-5.2'),
+    output: Output.object({
+      schema: z.object({
+        recipe: z.object({
+          name: z.string(),
+          ingredients: z.array(
+            z.object({
+              name: z.string(),
+              amount: z.string(),
+            }),
+          ),
+          steps: z.array(z.string()),
+        }),
+      }),
+    }),
+    prompt: 'Generate a lasagna recipe.',
+  });
+
+  console.log(JSON.stringify(result.output?.recipe, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+});

--- a/examples/ai-functions/src/stream-text/baseten/output-object.ts
+++ b/examples/ai-functions/src/stream-text/baseten/output-object.ts
@@ -1,0 +1,33 @@
+import { baseten } from '@ai-sdk/baseten';
+import { Output, streamText } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: baseten('zai-org/GLM-5.2'),
+    output: Output.object({
+      schema: z.object({
+        characters: z.array(
+          z.object({
+            name: z.string(),
+            class: z
+              .string()
+              .describe('Character class, e.g. warrior, mage, or thief.'),
+            description: z.string(),
+          }),
+        ),
+      }),
+    }),
+    prompt:
+      'Generate 3 character descriptions for a fantasy role playing game.',
+  });
+
+  for await (const partialOutput of result.partialOutputStream) {
+    console.clear();
+    console.log(partialOutput);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+});

--- a/packages/baseten/src/baseten-provider.ts
+++ b/packages/baseten/src/baseten-provider.ts
@@ -203,6 +203,7 @@ export function createBaseten(
           errorStructure: basetenErrorStructure,
           // Or stream_options.include_usage is omitted and streams report no usage.
           includeUsage: true,
+          supportsStructuredOutputs: true,
         });
       } else if (customURL.includes('/predict')) {
         throw new Error(
@@ -215,6 +216,7 @@ export function createBaseten(
       ...getCommonModelConfig('chat'),
       errorStructure: basetenErrorStructure,
       includeUsage: true,
+      supportsStructuredOutputs: true,
     });
   };
 

--- a/packages/baseten/src/baseten-provider.unit.test.ts
+++ b/packages/baseten/src/baseten-provider.unit.test.ts
@@ -176,6 +176,28 @@ describe('BasetenProvider', () => {
       });
     });
 
+    // Without this flag the openai-compatible chat model rewrites
+    // `response_format: json_schema` to `json_object`, silently discarding the
+    // schema, name, and strict flag with only a call warning.
+    describe('supportsStructuredOutputs', () => {
+      it('should be set for the default Model APIs path', () => {
+        createBaseten().chatModel('deepseek-ai/DeepSeek-V3-0324');
+
+        const config = OpenAICompatibleChatLanguageModelMock.mock.calls[0][1];
+        expect(config.supportsStructuredOutputs).toBe(true);
+      });
+
+      it('should be set for a dedicated /sync/v1 deployment', () => {
+        createBaseten({
+          modelURL:
+            'https://model-123.api.baseten.co/environments/production/sync/v1',
+        }).chatModel();
+
+        const config = OpenAICompatibleChatLanguageModelMock.mock.calls[0][1];
+        expect(config.supportsStructuredOutputs).toBe(true);
+      });
+    });
+
     // Baseten sends a bare string from the Model APIs but lets dedicated
     // deployments pass through their server's OpenAI-shaped object, so the
     // schema has to accept both. A failed parse degrades the message to the


### PR DESCRIPTION
## Background

supersedes #19315 

the baseten provider allows generating structured outputs but AI SDK didn't have this enabled natively

## Summary

enable `supportStructuredOutputs` flag for baseten

## End-to-End Verification

verified by running the example

- `examples/ai-functions/src/generate-text/deepinfra/output-object.ts`
- `examples/ai-functions/src/stream-text/deepinfra/output-object.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

<!--
Feel free to mention things not covered by this PR that can be done in future PRs.
Remove the section if it's not needed.
 -->

## Related Issues

closes #19315 

Co-authored-by: Gaurav Arora <whoarora@gmail.com>