### PR TITLE
feat(harness-acp): support `title` and `toolUseKind` for ACP tools

### DIFF
--- a/.changeset/large-dolls-enjoy.md
+++ b/.changeset/large-dolls-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-acp": patch
+---
+
+feat(harness-acp): support `title` and `toolUseKind` for ACP tools

--- a/packages/harness-acp/src/acp-harness.test.ts
+++ b/packages/harness-acp/src/acp-harness.test.ts
@@ -962,13 +962,17 @@ describe('createACP', () => {
     expect(harness.builtinTools.bash.nativeName).toBe('shell');
   });
 
-  it('serializes built-in names and input schemas across the bridge', () => {
+  it('serializes built-in matching fields and input schemas across the bridge', () => {
     const builtinTools = {
-      bash: commonTool('bash', {
-        nativeName: 'shell',
-        description: 'Execute a command',
-        inputSchema: z.object({ command: z.string() }),
-      }),
+      bash: {
+        ...commonTool('bash', {
+          nativeName: 'shell',
+          toolUseKind: 'bash',
+          description: 'Execute a command',
+          inputSchema: z.object({ command: z.string() }),
+        }),
+        title: 'Terminal',
+      },
     };
 
     expect(serializeBuiltinTools({ builtinTools })).toMatchInlineSnapshot(`
@@ -988,7 +992,9 @@ describe('createACP', () => {
             "type": "object",
           },
           "nativeName": "shell",
+          "title": "Terminal",
           "toolName": "bash",
+          "toolUseKind": "bash",
         },
       ]
     `);

--- a/packages/harness-acp/src/v1/acp-v1-bridge-protocol.ts
+++ b/packages/harness-acp/src/v1/acp-v1-bridge-protocol.ts
@@ -33,6 +33,18 @@ export type ACPBuiltinToolMapping = {
   readonly nativeName?: HarnessV1BuiltinTool['nativeName'];
 
   /**
+   * Stable prefix of the display title emitted by an ACP implementation.
+   * Used only when the implementation omits a programmatic tool name.
+   */
+  readonly title?: HarnessV1BuiltinTool['title'];
+
+  /**
+   * Broad capability category used to compare a built-in with the ACP tool
+   * kind when resolving unnamed calls.
+   */
+  readonly toolUseKind?: HarnessV1BuiltinTool['toolUseKind'];
+
+  /**
    * JSON Schema used to identify tool calls when an ACP implementation does
    * not provide a programmatic tool name. It is optional because built-in
    * definitions are allowed to omit their input schema.
@@ -43,6 +55,8 @@ export type ACPBuiltinToolMapping = {
 const builtinToolSchema: z.ZodType<ACPBuiltinToolMapping> = z.object({
   toolName: z.string(),
   nativeName: z.string().optional(),
+  title: z.string().optional(),
+  toolUseKind: z.enum(['readonly', 'edit', 'bash']).optional(),
   inputSchema: z.json().optional(),
 });
 

--- a/packages/harness-acp/src/v1/acp-v1-harness.ts
+++ b/packages/harness-acp/src/v1/acp-v1-harness.ts
@@ -1583,6 +1583,22 @@ export function serializeBuiltinTools({
       typeof tool.nativeName === 'string'
         ? tool.nativeName
         : undefined;
+    const title =
+      tool != null &&
+      typeof tool === 'object' &&
+      'title' in tool &&
+      typeof tool.title === 'string'
+        ? tool.title
+        : undefined;
+    const toolUseKind =
+      tool != null &&
+      typeof tool === 'object' &&
+      'toolUseKind' in tool &&
+      (tool.toolUseKind === 'readonly' ||
+        tool.toolUseKind === 'edit' ||
+        tool.toolUseKind === 'bash')
+        ? tool.toolUseKind
+        : undefined;
     let inputSchema: ACPBuiltinToolMapping['inputSchema'];
     if (
       tool != null &&
@@ -1599,6 +1615,8 @@ export function serializeBuiltinTools({
     return {
       toolName,
       ...(nativeName == null ? {} : { nativeName }),
+      ...(title == null ? {} : { title }),
+      ...(toolUseKind == null ? {} : { toolUseKind }),
       ...(inputSchema == null ? {} : { inputSchema }),
     };
   });

--- a/packages/harness-acp/src/v1/bridge/host-tool-correlation.test.ts
+++ b/packages/harness-acp/src/v1/bridge/host-tool-correlation.test.ts
@@ -67,6 +67,36 @@ describe('createHostToolCorrelation', () => {
     expect(raw).toHaveLength(1);
   });
 
+  it('matches Cursor MCP updates by provider, tool, and nested args', () => {
+    const { correlation, semantic, raw } = setup();
+    register({
+      correlation,
+      token: 'cursor-token',
+      toolName: 'weather',
+      input: { city: 'Lima' },
+      order: 1,
+    });
+    const rawUpdate = {
+      sessionUpdate: 'tool_call',
+      toolCallId: 'cursor-mcp-call',
+      title: 'ai-sdk-harness-tools: weather',
+      kind: 'other',
+      status: 'completed',
+      rawInput: {
+        providerIdentifier: 'ai-sdk-harness-tools',
+        toolName: 'weather',
+        args: { city: 'Lima' },
+      },
+    } as const;
+    correlation.update({
+      message: update(rawUpdate),
+      rawUpdate,
+    });
+
+    expect(semantic).toEqual([]);
+    expect(raw).toEqual([rawUpdate]);
+  });
+
   it('uses an exact result token as the strongest correlation evidence', () => {
     const { correlation, semantic, raw } = setup();
     const rawUpdate = {

--- a/packages/harness-acp/src/v1/bridge/index.ts
+++ b/packages/harness-acp/src/v1/bridge/index.ts
@@ -38,7 +38,10 @@ import {
   type HostToolRelay,
   type HostToolRelayTurn,
 } from './host-tool-relay';
-import { refreshHostToolCatalog } from './refresh-host-tool-catalog';
+import {
+  promptAndRefreshInitialHostToolCatalog,
+  refreshHostToolCatalog,
+} from './refresh-host-tool-catalog';
 import { createACPPermissionController } from './permission-controller';
 import { configureACPPermissionMode } from './permission-mode';
 import {
@@ -130,8 +133,12 @@ await runBridge<StartMessage>({
 });
 
 async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
+  let initialHostToolCatalogRefreshRequired: boolean;
   try {
-    await ensureSession({ start, turn });
+    ({ initialHostToolCatalogRefreshRequired } = await ensureSession({
+      start,
+      turn,
+    }));
   } catch (error) {
     if (HarnessBridgeCapabilityUnsupportedError.isInstance(error)) throw error;
     throw createACPBridgeError({
@@ -148,6 +155,10 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     throw new Error(
       'ACP session initialization did not start stderr monitoring.',
     );
+  }
+  const activeHostToolRelay = hostToolRelay;
+  if (activeHostToolRelay == null) {
+    throw new Error('The host tool MCP relay is unavailable.');
   }
   if (start.recoveryMode?.type === 'lossy-rerun') {
     const marker = {
@@ -260,15 +271,35 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     removeCorrelationInvocation:
       emitStreamEvent.removeHostToolCorrelationInvocation,
   };
-  hostToolRelay?.bindTurn({ turn: relayTurn });
+  activeHostToolRelay.bindTurn({ turn: relayTurn });
   try {
     const promptMeta = createOutputSchemaPromptMeta({ start });
-    void promptActiveSession({
-      session: activeSession,
-      agent: connection!.agent,
-      prompt: start.prompt,
-      meta: promptMeta,
-    });
+    const startPrompt = () =>
+      promptActiveSession({
+        session: activeSession,
+        agent: connection!.agent,
+        prompt: start.prompt,
+        meta: promptMeta,
+      });
+    if (initialHostToolCatalogRefreshRequired) {
+      try {
+        await promptAndRefreshInitialHostToolCatalog({
+          startPrompt,
+          relay: activeHostToolRelay,
+          tools: start.tools ?? [],
+          harnessId: bridgeType,
+          timeoutMs: CATALOG_REFRESH_TIMEOUT_MS,
+        });
+      } catch (error) {
+        if (HarnessBridgeCapabilityUnsupportedError.isInstance(error)) {
+          catalogRefreshError = error;
+        }
+        sessionConfigurationFailure = { error };
+        throw error;
+      }
+    } else {
+      void startPrompt();
+    }
     if (turn.abortSignal.aborted) {
       await cancel();
     } else {
@@ -316,7 +347,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   } finally {
     permissionController.cancelAll();
     activePermissionController = undefined;
-    hostToolRelay?.unbindTurn({ turn: relayTurn });
+    activeHostToolRelay.unbindTurn({ turn: relayTurn });
   }
 }
 
@@ -326,7 +357,7 @@ async function ensureSession({
 }: {
   start: StartMessage;
   turn: BridgeTurn;
-}): Promise<void> {
+}): Promise<{ initialHostToolCatalogRefreshRequired: boolean }> {
   if (sessionConfigurationFailure != null) {
     throw sessionConfigurationFailure.error;
   }
@@ -364,7 +395,7 @@ async function ensureSession({
       }
       throw error;
     }
-    return;
+    return { initialHostToolCatalogRefreshRequired: false };
   }
 
   const clientApp = resolveClientApp();
@@ -558,12 +589,6 @@ async function ensureSession({
       .start();
   }
   try {
-    await refreshHostToolCatalog({
-      relay: hostToolRelay,
-      tools,
-      harnessId: bridgeType,
-      timeoutMs: CATALOG_REFRESH_TIMEOUT_MS,
-    });
     if (start.permissionModeMapping != null) {
       await configureACPPermissionMode({
         agent: connection.agent,
@@ -588,6 +613,7 @@ async function ensureSession({
     sessionId: createdSession.sessionId,
   });
   sessionConfigurationFingerprint = fingerprint;
+  return { initialHostToolCatalogRefreshRequired: tools.length > 0 };
 }
 
 function createExternalMcpServers({

--- a/packages/harness-acp/src/v1/bridge/refresh-host-tool-catalog.test.ts
+++ b/packages/harness-acp/src/v1/bridge/refresh-host-tool-catalog.test.ts
@@ -1,8 +1,36 @@
 import { HarnessBridgeCapabilityUnsupportedError } from '@ai-sdk/harness/bridge';
 import { describe, expect, it, vi } from 'vitest';
-import { refreshHostToolCatalog } from './refresh-host-tool-catalog';
+import {
+  promptAndRefreshInitialHostToolCatalog,
+  refreshHostToolCatalog,
+} from './refresh-host-tool-catalog';
 
 describe('refreshHostToolCatalog', () => {
+  it('starts the initial prompt before waiting for lazy MCP discovery', async () => {
+    let promptStarted = false;
+    const startPrompt = vi.fn(async () => {
+      promptStarted = true;
+    });
+    const waitForCatalogRefresh = vi.fn(async () => promptStarted);
+
+    await promptAndRefreshInitialHostToolCatalog({
+      startPrompt,
+      relay: {
+        updateCatalog: () => ({ changed: false, revision: 1 }),
+        waitForCatalogRefresh,
+      },
+      tools: [{ name: 'weather', inputSchema: { type: 'object' } }],
+      harnessId: 'lazy-acp',
+      timeoutMs: 100,
+    });
+
+    expect(startPrompt).toHaveBeenCalledOnce();
+    expect(waitForCatalogRefresh).toHaveBeenCalledWith({
+      revision: 1,
+      timeoutMs: 100,
+    });
+  });
+
   it('waits when a non-empty catalog is unchanged but may not be loaded', async () => {
     const waitForCatalogRefresh = vi.fn(async () => true);
 

--- a/packages/harness-acp/src/v1/bridge/refresh-host-tool-catalog.ts
+++ b/packages/harness-acp/src/v1/bridge/refresh-host-tool-catalog.ts
@@ -2,6 +2,34 @@ import type { HarnessV1BridgeToolWire } from '@ai-sdk/harness';
 import { HarnessBridgeCapabilityUnsupportedError } from '@ai-sdk/harness/bridge';
 import type { HostToolRelay } from './host-tool-relay';
 
+/*
+ * Some ACP agents start session MCP servers only after receiving the first
+ * prompt. Starting that prompt before waiting lets those agents discover the
+ * initial catalog, while the relay's revision checks still reject stale or
+ * unknown tool invocations.
+ */
+export async function promptAndRefreshInitialHostToolCatalog({
+  startPrompt,
+  relay,
+  tools,
+  harnessId,
+  timeoutMs,
+}: {
+  startPrompt: () => Promise<unknown>;
+  relay: Pick<HostToolRelay, 'updateCatalog' | 'waitForCatalogRefresh'>;
+  tools: ReadonlyArray<HarnessV1BridgeToolWire>;
+  harnessId: string;
+  timeoutMs: number;
+}): Promise<void> {
+  void startPrompt();
+  await refreshHostToolCatalog({
+    relay,
+    tools,
+    harnessId,
+    timeoutMs,
+  });
+}
+
 export async function refreshHostToolCatalog({
   relay,
   tools,

--- a/packages/harness-acp/src/v1/bridge/stream-translator.test.ts
+++ b/packages/harness-acp/src/v1/bridge/stream-translator.test.ts
@@ -449,6 +449,87 @@ describe('createACPStreamTranslator', () => {
     `);
   });
 
+  it('matches an unnamed built-in by the longest compatible title prefix', () => {
+    const events: HarnessV1StreamPart[] = [];
+    const translator = createACPStreamTranslator({
+      emit: event => events.push(event),
+      builtinTools: [
+        {
+          toolName: 'read',
+          title: 'Read',
+          toolUseKind: 'readonly',
+        },
+        {
+          toolName: 'readLints',
+          title: 'Read Lints',
+          toolUseKind: 'readonly',
+        },
+        {
+          toolName: 'edit',
+          title: 'Read Lints',
+          toolUseKind: 'edit',
+        },
+      ],
+    });
+
+    translator.update({
+      sessionUpdate: 'tool_call',
+      toolCallId: 'call-cursor-lints',
+      title: 'Read Lints `src/index.ts`',
+      kind: 'read',
+      status: 'completed',
+      rawInput: { paths: ['src/index.ts'] },
+    });
+
+    expect(toolEvents({ events })).toMatchInlineSnapshot(`
+      [
+        {
+          "input": "{\"paths\":[\"src/index.ts\"]}",
+          "providerExecuted": true,
+          "toolCallId": "call-cursor-lints",
+          "toolName": "readLints",
+          "type": "tool-call",
+        },
+        {
+          "result": {},
+          "toolCallId": "call-cursor-lints",
+          "toolName": "readLints",
+          "type": "tool-result",
+        },
+      ]
+    `);
+  });
+
+  it('keeps equally specific title matches dynamic', () => {
+    const events: HarnessV1StreamPart[] = [];
+    const translator = createACPStreamTranslator({
+      emit: event => events.push(event),
+      builtinTools: [
+        { toolName: 'first', title: 'Operation' },
+        { toolName: 'second', title: 'Operation' },
+      ],
+    });
+
+    translator.update({
+      sessionUpdate: 'tool_call',
+      toolCallId: 'call-cursor-ambiguous',
+      title: 'Operation detail',
+      kind: 'other',
+      status: 'completed',
+      rawInput: {},
+    });
+
+    expect(toolEvents({ events })[0]).toMatchInlineSnapshot(`
+      {
+        "input": "{}",
+        "providerExecuted": true,
+        "toolCallId": "call-cursor-ambiguous",
+        "toolName": "acp_tool_call-cursor-ambiguous",
+        "type": "tool-call",
+      }
+    `);
+  });
+
   it('uses literal schema properties to distinguish anonymous ACP tools', () => {
     const events: HarnessV1StreamPart[] = [];
     const translator = createACPStreamTranslator({

--- a/packages/harness-acp/src/v1/bridge/stream-translator.ts
+++ b/packages/harness-acp/src/v1/bridge/stream-translator.ts
@@ -206,6 +206,11 @@ export function createACPStreamTranslator({
       const builtin = resolveBuiltinTool({
         programmaticName,
         metadata: state.values._meta,
+        title: getStringProperty({
+          value: state.values,
+          property: 'title',
+        }),
+        kind: isACPToolKind(state.values.kind) ? state.values.kind : undefined,
         rawInput: state.values.rawInput,
         builtinTools,
         builtinToolsByName,
@@ -478,12 +483,16 @@ function addBuiltinToolMatch({
 function resolveBuiltinTool({
   programmaticName,
   metadata,
+  title,
+  kind,
   rawInput,
   builtinTools,
   builtinToolsByName,
 }: {
   programmaticName: string | undefined;
   metadata: unknown;
+  title: string | undefined;
+  kind: ACPToolKind | undefined;
   rawInput: unknown;
   builtinTools: ReadonlyArray<ACPBuiltinToolMapping>;
   builtinToolsByName: ReadonlyMap<string, ACPBuiltinToolMapping>;
@@ -502,10 +511,66 @@ function resolveBuiltinTool({
       : undefined;
   }
 
+  const titleMatch = findBuiltinToolByTitle({
+    title,
+    kind,
+    builtinTools,
+  });
+  if (titleMatch != null) return titleMatch;
+
   const schemaMatches = builtinTools.filter(tool =>
     matchesBuiltinToolInput({ rawInput, inputSchema: tool.inputSchema }),
   );
   return schemaMatches.length === 1 ? schemaMatches[0] : undefined;
+}
+
+function findBuiltinToolByTitle({
+  title,
+  kind,
+  builtinTools,
+}: {
+  title: string | undefined;
+  kind: ACPToolKind | undefined;
+  builtinTools: ReadonlyArray<ACPBuiltinToolMapping>;
+}): ACPBuiltinToolMapping | undefined {
+  if (title == null) return undefined;
+  const matches = builtinTools.filter(
+    tool =>
+      tool.title != null &&
+      title.startsWith(tool.title) &&
+      isCompatibleToolKind({ toolUseKind: tool.toolUseKind, kind }),
+  );
+  if (matches.length === 0) return undefined;
+  const longestPrefixLength = Math.max(
+    ...matches.map(tool => tool.title!.length),
+  );
+  const longestMatches = matches.filter(
+    tool => tool.title!.length === longestPrefixLength,
+  );
+  return longestMatches.length === 1 ? longestMatches[0] : undefined;
+}
+
+function isCompatibleToolKind({
+  toolUseKind,
+  kind,
+}: {
+  toolUseKind: ACPBuiltinToolMapping['toolUseKind'];
+  kind: ACPToolKind | undefined;
+}): boolean {
+  if (toolUseKind == null || kind == null) return true;
+  switch (toolUseKind) {
+    case 'readonly':
+      return (
+        kind === 'read' ||
+        kind === 'search' ||
+        kind === 'fetch' ||
+        kind === 'think'
+      );
+    case 'edit':
+      return kind === 'edit' || kind === 'delete' || kind === 'move';
+    case 'bash':
+      return kind === 'execute';
+  }
 }
 
 function findBuiltinToolsInMetadata({


### PR DESCRIPTION
## Background

Some ACP implementations, including Cursor, rely on standard ACP `title` and `toolUseKind` metadata when built-in tool calls omit a programmatic name. Because these are ACP protocol fields rather than implementation-specific extensions, support belongs in the central ACP meta-adapter.

## Summary

- Carry built-in `title` and `toolUseKind` metadata through the ACP bridge.
- Resolve unnamed built-in calls using the longest compatible title prefix and ACP tool kind, while preserving dynamic calls when matches remain ambiguous.
- Start the initial prompt before waiting for lazy MCP catalog discovery and correlate nested Cursor MCP inputs.
- Add regression coverage for serialization, matching, catalog refresh, and host-tool correlation.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

This will unblock implementation of a Cursor harness adapter.
