### PR TITLE
docs: update security reporting instructions

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,6 +4,6 @@ If you believe you have found a security vulnerability in the AI SDK, we encoura
 
 We will investigate all legitimate reports and do our best to quickly fix the problem.
 
-Email `security@vercel.com` to disclose any security vulnerabilities.
+Report security vulnerabilities through the [Vercel Open Source HackerOne program](https://hackerone.com/vercel-open-source).
 
 https://vercel.com/security


### PR DESCRIPTION
## Background

The security policy currently directs vulnerability reports to an unmonitored email address. The supported disclosure channel for AI SDK is Vercel's Open Source HackerOne program.

## Summary

- replace the security email instructions with a direct link to the Vercel Open Source HackerOne program

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run pnpm changeset in the project root)
- [x] I have reviewed this pull request (self-review)