### PR TITLE
fix(sandbox-vercel): support @vercel/sandbox v3

### DIFF
--- a/.changeset/green-rivers-smile.md
+++ b/.changeset/green-rivers-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/sandbox-vercel': patch
+---
+
+Add support for `@vercel/sandbox` v3 while preserving the adapter's existing Node 24 runtime default.

--- a/examples/ai-e2e-next/package.json
+++ b/examples/ai-e2e-next/package.json
@@ -38,7 +38,7 @@
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@valibot/to-json-schema": "^1.7.0",
     "@vercel/blob": "^0.26.0",
-    "@vercel/sandbox": "^2.0.1",
+    "@vercel/sandbox": "^3.0.0",
     "ai": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -77,7 +77,7 @@
     "@opentelemetry/sdk-trace-node": "^2.7.1",
     "@standard-schema/spec": "1.1.0",
     "@valibot/to-json-schema": "^1.7.0",
-    "@vercel/sandbox": "^2.0.1",
+    "@vercel/sandbox": "^3.0.0",
     "ai": "workspace:*",
     "arktype": "2.1.28",
     "dotenv": "16.4.5",

--- a/examples/harness-e2e-next/package.json
+++ b/examples/harness-e2e-next/package.json
@@ -27,7 +27,7 @@
     "@cline/agents": "^0.0.72",
     "@cline/core": "^0.0.72",
     "@earendil-works/pi-coding-agent": "^0.80.10",
-    "@vercel/sandbox": "^2.0.1",
+    "@vercel/sandbox": "^3.0.0",
     "@xai-official/grok": "0.2.111",
     "ai": "workspace:*",
     "clsx": "^2.1.1",

--- a/examples/harness-e2e-tui/package.json
+++ b/examples/harness-e2e-tui/package.json
@@ -16,7 +16,7 @@
     "@ai-sdk/sandbox-vercel": "workspace:*",
     "@ai-sdk/tui": "workspace:*",
     "@earendil-works/pi-coding-agent": "^0.80.10",
-    "@vercel/sandbox": "^2.0.1",
+    "@vercel/sandbox": "^3.0.0",
     "ai": "workspace:*",
     "dotenv": "16.4.5",
     "zod": "3.25.76"

--- a/packages/sandbox-vercel/README.md
+++ b/packages/sandbox-vercel/README.md
@@ -14,6 +14,10 @@ npm i @ai-sdk/sandbox-vercel
 
 The factory is synchronous. The returned provider is stable; the actual `@vercel/sandbox` `Sandbox` is created on demand inside `provider.createSession()`.
 
+When neither `runtime` nor `image` is provided, the adapter uses the legacy
+`node24` runtime on both Vercel Sandbox v2 and v3. Pass `image` explicitly to
+opt into a v3 managed image such as `vercel/sandbox/universal`.
+
 ```ts
 import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
 

--- a/packages/sandbox-vercel/package.json
+++ b/packages/sandbox-vercel/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@ai-sdk/harness": "workspace:*",
     "@ai-sdk/provider-utils": "workspace:*",
-    "@vercel/sandbox": "^2.0.1"
+    "@vercel/sandbox": "^2.0.1 || ^3.0.0"
   },
   "devDependencies": {
     "@types/node": "22.19.19",

--- a/packages/sandbox-vercel/src/vercel-network-policy-manager.ts
+++ b/packages/sandbox-vercel/src/vercel-network-policy-manager.ts
@@ -650,51 +650,7 @@ function cloneNetworkAccessPolicy(
 }
 
 function cloneNetworkPolicy(policy: NetworkPolicy): NetworkPolicy {
-  if (policy === 'allow-all' || policy === 'deny-all') {
-    return policy;
-  }
-  return {
-    ...(policy.allow == null
-      ? {}
-      : Array.isArray(policy.allow)
-        ? { allow: [...policy.allow] }
-        : {
-            allow: Object.fromEntries(
-              Object.entries(policy.allow).map(([host, rules]) => [
-                host,
-                rules.map(rule => ({
-                  ...(rule.match == null
-                    ? {}
-                    : { match: cloneMatch(rule.match) }),
-                  ...(rule.transform == null
-                    ? {}
-                    : {
-                        transform: rule.transform.map(transform => ({
-                          ...(transform.headers == null
-                            ? {}
-                            : { headers: { ...transform.headers } }),
-                        })),
-                      }),
-                  ...(rule.forwardURL == null
-                    ? {}
-                    : { forwardURL: rule.forwardURL }),
-                })),
-              ]),
-            ),
-          }),
-    ...(policy.subnets == null
-      ? {}
-      : {
-          subnets: {
-            ...(policy.subnets.allow == null
-              ? {}
-              : { allow: [...policy.subnets.allow] }),
-            ...(policy.subnets.deny == null
-              ? {}
-              : { deny: [...policy.subnets.deny] }),
-          },
-        }),
-  };
+  return structuredClone(policy);
 }
 
 function cloneMatch(

--- a/packages/sandbox-vercel/src/vercel-sandbox.test.ts
+++ b/packages/sandbox-vercel/src/vercel-sandbox.test.ts
@@ -511,7 +511,7 @@ describe('createVercelSandbox (create from scratch)', () => {
     expect(error).toBe(cause);
   });
 
-  it('applies a 30 minute default timeout when none is provided', async () => {
+  it('preserves the Node 24 runtime and 30 minute timeout defaults', async () => {
     const { sandbox } = makeMockSandbox();
     createMock.mockResolvedValueOnce(sandbox);
 
@@ -519,8 +519,61 @@ describe('createVercelSandbox (create from scratch)', () => {
 
     expect(createMock).toHaveBeenCalledTimes(1);
     expect(createMock.mock.calls[0][0]).toMatchObject({
+      runtime: 'node24',
       timeout: 30 * 60 * 1_000,
     });
+  });
+
+  it('does not add the legacy runtime when an image is provided', async () => {
+    const { sandbox } = makeMockSandbox();
+    createMock.mockResolvedValueOnce(sandbox);
+
+    await createVercelSandbox({
+      image: 'vercel/sandbox/universal',
+    }).createSession();
+
+    expect(createMock.mock.calls[0][0]).toMatchObject({
+      image: 'vercel/sandbox/universal',
+    });
+    expect(createMock.mock.calls[0][0]).not.toHaveProperty('runtime');
+  });
+
+  it('uses an image for a template without forwarding it to snapshot forks', async () => {
+    const { sandbox: template } = makeMockSandbox();
+    const { sandbox: fork } = makeMockSandbox();
+    Object.assign(template, { currentSnapshotId: 'snap_123' });
+    getOrCreateMock.mockResolvedValueOnce(template);
+    createMock.mockResolvedValueOnce(fork);
+
+    await createVercelSandbox({
+      image: 'vercel/sandbox/universal',
+    }).createSession({
+      identity: 'template-test',
+      onFirstCreate: async () => {},
+    });
+
+    expect(getOrCreateMock.mock.calls[0][0]).toMatchObject({
+      image: 'vercel/sandbox/universal',
+    });
+    expect(createMock.mock.calls[0][0]).toMatchObject({
+      source: { type: 'snapshot', snapshotId: 'snap_123' },
+    });
+    expect(createMock.mock.calls[0][0]).not.toHaveProperty('image');
+    expect(createMock.mock.calls[0][0]).not.toHaveProperty('runtime');
+  });
+
+  it('does not add the legacy runtime when restoring a snapshot', async () => {
+    const { sandbox } = makeMockSandbox();
+    createMock.mockResolvedValueOnce(sandbox);
+
+    await createVercelSandbox({
+      source: { type: 'snapshot', snapshotId: 'snap_123' },
+    }).createSession();
+
+    expect(createMock.mock.calls[0][0]).toMatchObject({
+      source: { type: 'snapshot', snapshotId: 'snap_123' },
+    });
+    expect(createMock.mock.calls[0][0]).not.toHaveProperty('runtime');
   });
 
   it('respects an explicitly provided timeout', async () => {

--- a/packages/sandbox-vercel/src/vercel-sandbox.ts
+++ b/packages/sandbox-vercel/src/vercel-sandbox.ts
@@ -63,6 +63,7 @@ export type VercelSandboxSettings =
  * too short for multi-step workflows — the VM expires between steps.
  */
 const DEFAULT_SANDBOX_TIMEOUT_MS = 30 * 60 * 1_000;
+const DEFAULT_SANDBOX_RUNTIME = 'node24';
 
 const VERCEL_PROVIDER_ID = 'vercel-sandbox';
 const TEMPLATE_NAME_PREFIX = 'ai-sdk-harness';
@@ -72,6 +73,18 @@ const SNAPSHOT_POLL_TIMEOUT_MS = 30_000;
 
 function sessionSandboxName(sessionId: string): string {
   return `${SESSION_NAME_PREFIX}-${sessionId}`;
+}
+
+function hasExplicitSandboxEnvironment(params: object): boolean {
+  return (
+    ('runtime' in params && params.runtime != null) ||
+    ('image' in params && params.image != null) ||
+    ('source' in params &&
+      typeof params.source === 'object' &&
+      params.source != null &&
+      'type' in params.source &&
+      params.source.type === 'snapshot')
+  );
 }
 
 export function createVercelSandbox(
@@ -120,10 +133,16 @@ export class VercelSandboxProvider implements HarnessV1SandboxProvider {
       name: explicitName,
       ...createParams
     } = settings;
-    const baseParams: BaseCreateSandboxParams = {
+    // Sandbox v3 changed its implicit default from the Node 24 runtime to the
+    // Universal managed image. Keep this adapter's existing default stable while
+    // allowing callers to opt into managed images explicitly.
+    const baseParams = {
+      ...(hasExplicitSandboxEnvironment(createParams)
+        ? {}
+        : { runtime: DEFAULT_SANDBOX_RUNTIME }),
       ...createParams,
       timeout: createParams.timeout ?? DEFAULT_SANDBOX_TIMEOUT_MS,
-    };
+    } as BaseCreateSandboxParams;
 
     const identity = options?.identity;
     const onFirstCreate = options?.onFirstCreate;
@@ -202,6 +221,7 @@ export class VercelSandboxProvider implements HarnessV1SandboxProvider {
 
     const {
       runtime: _ignoredRuntime,
+      image: _ignoredImage,
       source: _ignoredSource,
       persistent: _ignoredPersistent,
       ...forkParams

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,8 +237,8 @@ importers:
         specifier: ^0.26.0
         version: 0.26.0
       '@vercel/sandbox':
-        specifier: ^2.0.1
-        version: 2.1.1
+        specifier: ^3.0.0
+        version: 3.1.0
       ai:
         specifier: workspace:*
         version: link:../../packages/ai
@@ -529,8 +529,8 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0(valibot@1.1.0(typescript@5.8.3))
       '@vercel/sandbox':
-        specifier: ^2.0.1
-        version: 2.1.1
+        specifier: ^3.0.0
+        version: 3.1.0
       ai:
         specifier: workspace:*
         version: link:../../packages/ai
@@ -770,8 +770,8 @@ importers:
         specifier: ^0.80.10
         version: 0.80.10(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.21.3)(zod@3.25.76)
       '@vercel/sandbox':
-        specifier: ^2.0.1
-        version: 2.1.1
+        specifier: ^3.0.0
+        version: 3.1.0
       '@xai-official/grok':
         specifier: 0.2.111
         version: 0.2.111
@@ -858,8 +858,8 @@ importers:
         specifier: ^0.80.10
         version: 0.80.10(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.21.3)(zod@3.25.76)
       '@vercel/sandbox':
-        specifier: ^2.0.1
-        version: 2.1.1
+        specifier: ^3.0.0
+        version: 3.1.0
       ai:
         specifier: workspace:*
         version: link:../../packages/ai
@@ -3961,8 +3961,8 @@ importers:
         specifier: workspace:*
         version: link:../provider-utils
       '@vercel/sandbox':
-        specifier: ^2.0.1
-        version: 2.1.1
+        specifier: ^2.0.1 || ^3.0.0
+        version: 3.1.0
     devDependencies:
       '@types/node':
         specifier: 22.19.19
@@ -14142,6 +14142,9 @@ packages:
 
   '@vercel/sandbox@2.1.1':
     resolution: {integrity: sha512-gKhW+YlvU15Qxya7jQKByB+sqA1dWat5zx/rvxT52E3Ryg9MAIXgqD5wd1d+CoJDbdHL26gIOcksTZY5sFpplA==}
+
+  '@vercel/sandbox@3.1.0':
+    resolution: {integrity: sha512-z124E4rsmNpwGtTnLImiYzEXk972bWniQyhlvkEt35UtwKTdfBAFXcNG2OvqYqwzAsdQaP3B7teQ2pqA9B5Viw==}
 
   '@vimeo/player@2.29.0':
     resolution: {integrity: sha512-9JjvjeqUndb9otCCFd0/+2ESsLk7VkDE6sxOBy9iy2ukezuQbplVRi+g9g59yAurKofbmTi/KcKxBGO/22zWRw==}
@@ -36521,6 +36524,24 @@ snapshots:
       undici: 7.27.1
       xdg-app-paths: 5.1.0
       zod: 3.24.4
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  '@vercel/sandbox@3.1.0':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jose: 6.2.3
+      jsonlines: 0.1.1
+      lru-cache: 10.4.3
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.29.0
+      xdg-app-paths: 5.1.0
+      zod: 4.4.3
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a


### PR DESCRIPTION
## Summary

- Support `@vercel/sandbox` v2 and v3, and upgrade the repository examples to v3.
- Preserve the existing `node24` runtime when callers omit both `runtime` and `image`.
- Allow callers to opt into v3 managed images with the existing `image` setting.
- Let snapshot restores and template forks inherit their environment without conflicting `runtime` or `image` fields.
- Use `structuredClone` for network policies so v3’s mutually exclusive rule variants remain intact.

## Upgrade behavior

- Calls without `runtime` or `image` continue using the Node 24 runtime and require no code changes.
- Existing lockfiles may continue resolving `@vercel/sandbox` v2.
- Consumers already using Sandbox v3 can remove dependency overrides after upgrading this adapter.
- Fresh installs resolve v3 while retaining the adapter’s previous default environment.
- Managed images are opt-in.