### PR TITLE
fix(harness): allow OpenCode and Grok Build install scripts

### DIFF
--- a/.changeset/clean-harness-builds.md
+++ b/.changeset/clean-harness-builds.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/harness-acp": patch
+"@ai-sdk/harness-grok-build": patch
+"@ai-sdk/harness-opencode": patch
+---
+
+Allow pinned OpenCode and Grok Build install scripts during pnpm 11 sandbox bootstrap.

--- a/content/providers/02-ai-sdk-harnesses/06-acp.mdx
+++ b/content/providers/02-ai-sdk-harnesses/06-acp.mdx
@@ -170,11 +170,18 @@ const source = {
   type: 'npm-locked',
   packageJson: packageJsonContents,
   pnpmLockYaml: pnpmLockYamlContents,
+  pnpmWorkspaceYaml: pnpmWorkspaceYamlContents,
 } as const;
 ```
 
 A locked source installs the supplied files with
-`pnpm install --frozen-lockfile`.
+`pnpm install --frozen-lockfile`. `pnpmWorkspaceYaml` is optional; provide it
+when the locked installation needs workspace-level pnpm configuration, such as
+an exact-version `allowBuilds` policy for a required dependency build script.
+
+The manifest, lockfile, and optional workspace configuration are persisted
+bootstrap artifacts and participate in lifecycle identity. Do not include
+credentials in these strings.
 
 An install command source runs a trusted Bash command inside the harness's
 deterministic bootstrap directory:

--- a/packages/harness-acp/src/acp-harness.test.ts
+++ b/packages/harness-acp/src/acp-harness.test.ts
@@ -1101,12 +1101,15 @@ describe('createACP', () => {
   });
 
   it('uses caller-provided artifacts for locked frozen acquisition', async () => {
+    const pnpmWorkspaceYaml =
+      "allowBuilds:\n  '@example/codex-acp@1.2.3': true\n";
     const harness = createACP({
       harnessId: 'codex-acp-locked',
       source: {
         type: 'npm-locked',
         packageJson: lockedPackageJson,
         pnpmLockYaml: lockedPnpmLockYaml,
+        pnpmWorkspaceYaml,
       },
       executable: 'codex-acp',
     });
@@ -1126,6 +1129,13 @@ describe('createACP', () => {
           '.harness-bootstrap/codex-acp-locked/implementation/pnpm-lock.yaml',
       )?.content,
     ).toBe(lockedPnpmLockYaml);
+    expect(
+      bootstrap.files.find(
+        file =>
+          file.path ===
+          '.harness-bootstrap/codex-acp-locked/implementation/pnpm-workspace.yaml',
+      )?.content,
+    ).toBe(pnpmWorkspaceYaml);
     expect(bootstrap.commands.map(command => command.command)).toContain(
       'pnpm --dir implementation install --frozen-lockfile --prod --store-dir ../.pnpm-store',
     );

--- a/packages/harness-acp/src/v1/acp-bootstrap.ts
+++ b/packages/harness-acp/src/v1/acp-bootstrap.ts
@@ -7,6 +7,7 @@ import {
   createImplementationManifest,
   getImplementationInstallScript,
   getImplementationLockfile,
+  getImplementationWorkspaceFile,
   type ACPImplementation,
 } from './implementation';
 
@@ -38,6 +39,9 @@ export function createACPBootstrap({
         implementation,
       });
       const implementationLock = getImplementationLockfile({
+        implementation,
+      });
+      const implementationWorkspace = getImplementationWorkspaceFile({
         implementation,
       });
       const implementationInstallScript = getImplementationInstallScript({
@@ -78,6 +82,14 @@ export function createACPBootstrap({
                 {
                   path: `${bootstrapDir}/implementation/pnpm-lock.yaml`,
                   content: implementationLock,
+                },
+              ]),
+          ...(implementationWorkspace == null
+            ? []
+            : [
+                {
+                  path: `${bootstrapDir}/implementation/pnpm-workspace.yaml`,
+                  content: implementationWorkspace,
                 },
               ]),
           ...(implementationInstallScript == null

--- a/packages/harness-acp/src/v1/acp-v1-settings.ts
+++ b/packages/harness-acp/src/v1/acp-v1-settings.ts
@@ -45,6 +45,8 @@ export type ACPNpmLockedSource = {
   readonly type: 'npm-locked';
   readonly packageJson: string;
   readonly pnpmLockYaml: string;
+  /** Optional pnpm workspace configuration required by the locked install. */
+  readonly pnpmWorkspaceYaml?: string;
 };
 
 export type ACPInstallCommandSource = {

--- a/packages/harness-acp/src/v1/implementation.test.ts
+++ b/packages/harness-acp/src/v1/implementation.test.ts
@@ -520,7 +520,7 @@ describe('ACP implementation', () => {
     ).not.toBe(baseIdentity);
   });
 
-  it('identifies locked manifest and lockfile content independently', () => {
+  it('identifies every locked acquisition artifact independently', () => {
     const lockedIdentity = identity({
       implementation: lockedImplementation,
     });
@@ -543,6 +543,18 @@ describe('ACP implementation', () => {
           source: {
             ...lockedImplementation.source,
             pnpmLockYaml: `${pnpmLockYaml}\n# changed\n`,
+          },
+        },
+      }),
+    ).not.toBe(lockedIdentity);
+    expect(
+      identity({
+        implementation: {
+          ...lockedImplementation,
+          source: {
+            ...lockedImplementation.source,
+            pnpmWorkspaceYaml:
+              "allowBuilds:\n  '@example/acp-agent@1.2.3': true\n",
           },
         },
       }),

--- a/packages/harness-acp/src/v1/implementation.ts
+++ b/packages/harness-acp/src/v1/implementation.ts
@@ -60,6 +60,9 @@ export function validateACPV1Implementation(
     if (source.pnpmLockYaml.length === 0) {
       throw new Error('ACP source.pnpmLockYaml must not be empty.');
     }
+    if (source.pnpmWorkspaceYaml?.length === 0) {
+      throw new Error('ACP source.pnpmWorkspaceYaml must not be empty.');
+    }
   } else if (source.type === 'npm-simple') {
     validateNpmSimpleSource({ source });
   } else if (source.command.trim().length === 0) {
@@ -133,6 +136,15 @@ export function getImplementationLockfile({
   return source.type === 'npm-locked' ? source.pnpmLockYaml : undefined;
 }
 
+export function getImplementationWorkspaceFile({
+  implementation,
+}: {
+  implementation: ACPImplementation;
+}): string | undefined {
+  const { source } = implementation;
+  return source.type === 'npm-locked' ? source.pnpmWorkspaceYaml : undefined;
+}
+
 export function createImplementationDescriptor({
   implementation,
 }: {
@@ -177,6 +189,7 @@ export function createImplementationIdentity({
           type: source.type,
           packageJson: source.packageJson,
           pnpmLockYaml: source.pnpmLockYaml,
+          pnpmWorkspaceYaml: source.pnpmWorkspaceYaml,
         }
       : source.type === 'npm-simple'
         ? {

--- a/packages/harness-grok-build/src/bridge/pnpm-workspace.yaml
+++ b/packages/harness-grok-build/src/bridge/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  '@xai-official/grok@0.2.111': true

--- a/packages/harness-grok-build/src/grok-build-harness.test.ts
+++ b/packages/harness-grok-build/src/grok-build-harness.test.ts
@@ -27,9 +27,13 @@ describe('createGrokBuild', () => {
       ...settings.source,
       packageJson: JSON.parse(settings.source.packageJson),
       pnpmLockYaml: '<pnpm-lock.yaml>',
+      pnpmWorkspaceYaml: '<pnpm-workspace.yaml>',
     };
     expect(settings.source.pnpmLockYaml).toContain(
       "'@xai-official/grok@0.2.111'",
+    );
+    expect(settings.source.pnpmWorkspaceYaml).toBe(
+      "allowBuilds:\n  '@xai-official/grok@0.2.111': true\n",
     );
 
     expect({
@@ -136,6 +140,7 @@ describe('createGrokBuild', () => {
             "version": "0.0.0",
           },
           "pnpmLockYaml": "<pnpm-lock.yaml>",
+          "pnpmWorkspaceYaml": "<pnpm-workspace.yaml>",
           "type": "npm-locked",
         },
         "version": "v1",

--- a/packages/harness-grok-build/src/grok-build-harness.ts
+++ b/packages/harness-grok-build/src/grok-build-harness.ts
@@ -15,12 +15,15 @@ import { VERSION } from './version';
 
 declare const __GROK_BUILD_IMPLEMENTATION_PACKAGE_JSON__: string;
 declare const __GROK_BUILD_IMPLEMENTATION_PNPM_LOCK_YAML__: string;
+declare const __GROK_BUILD_IMPLEMENTATION_PNPM_WORKSPACE_YAML__: string;
 
 const GROK_BUILD_CLIENT_APP = `ai-sdk/harness-grok-build/${VERSION}`;
 const GROK_BUILD_IMPLEMENTATION_PACKAGE_JSON =
   __GROK_BUILD_IMPLEMENTATION_PACKAGE_JSON__;
 const GROK_BUILD_IMPLEMENTATION_PNPM_LOCK =
   __GROK_BUILD_IMPLEMENTATION_PNPM_LOCK_YAML__;
+const GROK_BUILD_IMPLEMENTATION_PNPM_WORKSPACE =
+  __GROK_BUILD_IMPLEMENTATION_PNPM_WORKSPACE_YAML__;
 
 export type GrokBuildHarnessSettings = {
   /**
@@ -311,6 +314,7 @@ export function createGrokBuild(
       type: 'npm-locked',
       packageJson: GROK_BUILD_IMPLEMENTATION_PACKAGE_JSON,
       pnpmLockYaml: GROK_BUILD_IMPLEMENTATION_PNPM_LOCK,
+      pnpmWorkspaceYaml: GROK_BUILD_IMPLEMENTATION_PNPM_WORKSPACE,
     },
     executable: 'grok',
     args: ['agent', 'stdio'],

--- a/packages/harness-grok-build/tsup.config.ts
+++ b/packages/harness-grok-build/tsup.config.ts
@@ -14,6 +14,11 @@ const implementationPnpmLockYaml = JSON.stringify(
     new URL('./src/bridge/pnpm-lock.yaml', import.meta.url),
   ).toString(),
 );
+const implementationPnpmWorkspaceYaml = JSON.stringify(
+  readFileSync(
+    new URL('./src/bridge/pnpm-workspace.yaml', import.meta.url),
+  ).toString(),
+);
 
 export default defineConfig({
   entry: { index: 'src/index.ts' },
@@ -25,5 +30,7 @@ export default defineConfig({
     __PACKAGE_VERSION__: packageVersion,
     __GROK_BUILD_IMPLEMENTATION_PACKAGE_JSON__: implementationPackageJson,
     __GROK_BUILD_IMPLEMENTATION_PNPM_LOCK_YAML__: implementationPnpmLockYaml,
+    __GROK_BUILD_IMPLEMENTATION_PNPM_WORKSPACE_YAML__:
+      implementationPnpmWorkspaceYaml,
   },
 });

--- a/packages/harness-grok-build/vitest.node.config.js
+++ b/packages/harness-grok-build/vitest.node.config.js
@@ -11,11 +11,18 @@ const implementationPnpmLockYaml = JSON.stringify(
     new URL('./src/bridge/pnpm-lock.yaml', import.meta.url),
   ).toString(),
 );
+const implementationPnpmWorkspaceYaml = JSON.stringify(
+  readFileSync(
+    new URL('./src/bridge/pnpm-workspace.yaml', import.meta.url),
+  ).toString(),
+);
 
 export default defineConfig({
   define: {
     __GROK_BUILD_IMPLEMENTATION_PACKAGE_JSON__: implementationPackageJson,
     __GROK_BUILD_IMPLEMENTATION_PNPM_LOCK_YAML__: implementationPnpmLockYaml,
+    __GROK_BUILD_IMPLEMENTATION_PNPM_WORKSPACE_YAML__:
+      implementationPnpmWorkspaceYaml,
   },
   test: {
     environment: 'node',

--- a/packages/harness-opencode/package.json
+++ b/packages/harness-opencode/package.json
@@ -21,7 +21,7 @@
     "build": "pnpm clean && tsup --tsconfig tsconfig.build.json && pnpm copy-bridge-assets",
     "build:watch": "pnpm clean && tsup --watch",
     "clean": "del-cli dist *.tsbuildinfo",
-    "copy-bridge-assets": "node -e \"import('node:fs/promises').then(async fs => { await fs.copyFile('src/bridge/package.json', 'dist/bridge/package.json'); await fs.copyFile('src/bridge/pnpm-lock.yaml', 'dist/bridge/pnpm-lock.yaml'); })\"",
+    "copy-bridge-assets": "node -e \"import('node:fs/promises').then(async fs => { await fs.copyFile('src/bridge/package.json', 'dist/bridge/package.json'); await fs.copyFile('src/bridge/pnpm-lock.yaml', 'dist/bridge/pnpm-lock.yaml'); await fs.copyFile('src/bridge/pnpm-workspace.yaml', 'dist/bridge/pnpm-workspace.yaml'); })\"",
     "type-check": "tsc --build",
     "test": "pnpm test:node",
     "test:watch": "vitest --config vitest.node.config.js",

--- a/packages/harness-opencode/src/bridge/pnpm-workspace.yaml
+++ b/packages/harness-opencode/src/bridge/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  'opencode-ai@1.18.3': true

--- a/packages/harness-opencode/src/opencode-bootstrap.ts
+++ b/packages/harness-opencode/src/opencode-bootstrap.ts
@@ -36,8 +36,7 @@ export async function getOpenCodeBootstrap(): Promise<HarnessV1Bootstrap> {
         command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
       },
       {
-        command:
-          'node node_modules/opencode-ai/postinstall.mjs && ./node_modules/.bin/opencode --version',
+        command: './node_modules/.bin/opencode --version',
       },
     ],
   };

--- a/packages/harness-opencode/src/opencode-bootstrap.ts
+++ b/packages/harness-opencode/src/opencode-bootstrap.ts
@@ -8,9 +8,10 @@ let cachedBootstrap: HarnessV1Bootstrap | undefined;
 
 export async function getOpenCodeBootstrap(): Promise<HarnessV1Bootstrap> {
   if (cachedBootstrap != null) return cachedBootstrap;
-  const [pkg, lock, bridge, hostToolMcp] = await Promise.all([
+  const [pkg, lock, workspace, bridge, hostToolMcp] = await Promise.all([
     readBridgeAsset('package.json'),
     readBridgeAsset('pnpm-lock.yaml'),
+    readBridgeAsset('pnpm-workspace.yaml'),
     readBridgeAsset('index.mjs'),
     readBridgeAsset('host-tool-mcp.mjs'),
   ]);
@@ -20,6 +21,10 @@ export async function getOpenCodeBootstrap(): Promise<HarnessV1Bootstrap> {
     files: [
       { path: `${OPENCODE_BOOTSTRAP_DIR}/package.json`, content: pkg },
       { path: `${OPENCODE_BOOTSTRAP_DIR}/pnpm-lock.yaml`, content: lock },
+      {
+        path: `${OPENCODE_BOOTSTRAP_DIR}/pnpm-workspace.yaml`,
+        content: workspace,
+      },
       { path: `${OPENCODE_BOOTSTRAP_DIR}/bridge.mjs`, content: bridge },
       {
         path: `${OPENCODE_BOOTSTRAP_DIR}/host-tool-mcp.mjs`,

--- a/packages/harness-opencode/src/opencode-harness.test.ts
+++ b/packages/harness-opencode/src/opencode-harness.test.ts
@@ -706,10 +706,15 @@ describe('createOpenCode adapter', () => {
         '.harness-bootstrap/opencode/host-tool-mcp.mjs',
         '.harness-bootstrap/opencode/package.json',
         '.harness-bootstrap/opencode/pnpm-lock.yaml',
+        '.harness-bootstrap/opencode/pnpm-workspace.yaml',
       ]);
       for (const file of recipe.files) {
         expect(file.content.length).toBeGreaterThan(0);
       }
+      expect(
+        recipe.files.find(file => file.path.endsWith('pnpm-workspace.yaml'))
+          ?.content,
+      ).toBe("allowBuilds:\n  'opencode-ai@1.18.3': true\n");
     });
 
     it('runs the OpenCode CLI postinstall during bootstrap', async () => {

--- a/packages/harness-opencode/src/opencode-harness.test.ts
+++ b/packages/harness-opencode/src/opencode-harness.test.ts
@@ -717,15 +717,14 @@ describe('createOpenCode adapter', () => {
       ).toBe("allowBuilds:\n  'opencode-ai@1.18.3': true\n");
     });
 
-    it('runs the OpenCode CLI postinstall during bootstrap', async () => {
+    it('allows the pinned OpenCode build and verifies the installed CLI', async () => {
       const harness = createOpenCode();
       const recipe = await harness.getBootstrap!();
       expect(recipe.commands[0]).toEqual({
         command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store',
       });
       expect(recipe.commands).toContainEqual({
-        command:
-          'node node_modules/opencode-ai/postinstall.mjs && ./node_modules/.bin/opencode --version',
+        command: './node_modules/.bin/opencode --version',
       });
     });
 


### PR DESCRIPTION
## Background

pnpm 11 rejects dependency build scripts unless they are explicitly allowed. The pinned `opencode-ai@1.18.3` and `@xai-official/grok@0.2.111` CLIs require postinstall scripts, so their sandbox bootstrap fails with `ERR_PNPM_IGNORED_BUILDS` before either harness can start.

## Summary

- add exact-version `allowBuilds` policies to the OpenCode and Grok Build bootstrap artifacts
- let ACP `npm-locked` sources carry an optional `pnpmWorkspaceYaml` artifact
- include the ACP workspace artifact in implementation identity so policy changes invalidate incompatible lifecycle state
- document locked-source workspace configuration and persisted-artifact behavior
- publish patch changesets for `@ai-sdk/harness-acp`, `@ai-sdk/harness-grok-build`, and `@ai-sdk/harness-opencode`

## End-to-End Verification

- installed the pinned OpenCode bridge dependencies from a clean temporary directory with pnpm 11.0.0; `opencode-ai` postinstall completed
- installed the pinned Grok Build implementation dependencies from a clean temporary directory with pnpm 11.0.0; `@xai-official/grok` postinstall completed

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
