### PR TITLE
feat(harness): add `credentialForwarding` setting to bridge backed harness adapters for granular control

### DIFF
--- a/.changeset/tasty-masks-jump.md
+++ b/.changeset/tasty-masks-jump.md
@@ -1,0 +1,11 @@
+---
+"@ai-sdk/harness-claude-code": patch
+"@ai-sdk/harness-deepagents": patch
+"@ai-sdk/harness-grok-build": patch
+"@ai-sdk/harness-opencode": patch
+"@ai-sdk/harness-codex": patch
+"@ai-sdk/harness-acp": patch
+"@ai-sdk/harness": patch
+---
+
+feat(harness): add `credentialForwarding` setting to bridge backed harness adapters for granular control

--- a/.github/konsistent.json
+++ b/.github/konsistent.json
@@ -266,6 +266,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "credentialForwarding": {},
                     "mintBridgeToken": {},
                     "port": { "type": "number" },
                     "portEndpoint": {},
@@ -297,6 +298,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "credentialForwarding": {},
                     "mintBridgeToken": {},
                     "port": { "type": "number" },
                     "portEndpoint": {},

--- a/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
+++ b/content/providers/02-ai-sdk-harnesses/01-claude-code.mdx
@@ -93,6 +93,14 @@ const harness = createClaudeCode({
 Settings:
 
 - `auth`: authentication mode: `auto`, `direct`, or `ai-gateway`.
+- `credentialForwarding`: optional synchronous or asynchronous callback that
+  customizes each credential immediately before the harness adapter forwards it
+  into a sandbox process. It receives the credential value that would otherwise
+  be forwarded (either the real credential or a masked value) and the
+  environment variable name used to expose it. This callback only controls the
+  value forwarded into the sandbox process. It does not restrict which
+  credentials the harness adapter can discover, read, or otherwise access in
+  the host process.
 - `mcpServers`: MCP server definitions keyed by server name.
 - `model`: Anthropic model id passed to the underlying Claude Code runtime.
 - `maxTurns`: maximum internal turns before yielding.

--- a/content/providers/02-ai-sdk-harnesses/02-codex.mdx
+++ b/content/providers/02-ai-sdk-harnesses/02-codex.mdx
@@ -89,6 +89,14 @@ const harness = createCodex({
 Settings:
 
 - `auth`: authentication mode: `auto`, `direct`, or `ai-gateway`.
+- `credentialForwarding`: optional synchronous or asynchronous callback that
+  customizes each credential immediately before the harness adapter forwards it
+  into a sandbox process. It receives the credential value that would otherwise
+  be forwarded (either the real credential or a masked value) and the
+  environment variable name used to expose it. This callback only controls the
+  value forwarded into the sandbox process. It does not restrict which
+  credentials the harness adapter can discover, read, or otherwise access in
+  the host process.
 - `codexConfig`: additional native Codex configuration. Values pass through as
   provided, so use the snake_case keys from Codex's `config.toml` reference.
   The adapter's managed values take precedence over conflicting entries.

--- a/content/providers/02-ai-sdk-harnesses/04-opencode.mdx
+++ b/content/providers/02-ai-sdk-harnesses/04-opencode.mdx
@@ -87,6 +87,14 @@ const harness = createOpenCode({
 Settings:
 
 - `auth`: authentication mode: `auto`, `anthropic`, `openai`, or `ai-gateway`.
+- `credentialForwarding`: optional synchronous or asynchronous callback that
+  customizes each credential immediately before the harness adapter forwards it
+  into a sandbox process. It receives the credential value that would otherwise
+  be forwarded (either the real credential or a masked value) and the
+  environment variable name used to expose it. This callback only controls the
+  value forwarded into the sandbox process. It does not restrict which
+  credentials the harness adapter can discover, read, or otherwise access in
+  the host process.
 - `mcpServers`: MCP server definitions keyed by server name.
 - `model`: OpenCode model id. Provider-prefixed values such as
   `anthropic/claude-sonnet-4-6` are passed through to OpenCode.

--- a/content/providers/02-ai-sdk-harnesses/05-deepagents.mdx
+++ b/content/providers/02-ai-sdk-harnesses/05-deepagents.mdx
@@ -87,6 +87,14 @@ const harness = createDeepAgents({
 Settings:
 
 - `auth`: authentication mode: `auto`, `anthropic`, or `ai-gateway`.
+- `credentialForwarding`: optional synchronous or asynchronous callback that
+  customizes each credential immediately before the harness adapter forwards it
+  into a sandbox process. It receives the credential value that would otherwise
+  be forwarded (either the real credential or a masked value) and the
+  environment variable name used to expose it. This callback only controls the
+  value forwarded into the sandbox process. It does not restrict which
+  credentials the harness adapter can discover, read, or otherwise access in
+  the host process.
 - `mcpServers`: MCP server definitions keyed by server name.
 - `model`: model id passed to the Deep Agents (LangChain) runtime. Through AI
   Gateway, use the `creator/model` slug (e.g. `anthropic/claude-sonnet-4-6`,

--- a/content/providers/02-ai-sdk-harnesses/06-acp.mdx
+++ b/content/providers/02-ai-sdk-harnesses/06-acp.mdx
@@ -73,6 +73,14 @@ try {
 - `credentialBrokering`: function that receives the effective runtime
   environment and returns additive outbound request transformations containing
   the real credential values.
+- `credentialForwarding`: optional synchronous or asynchronous callback that
+  customizes each credential immediately before the harness adapter forwards it
+  into a sandbox process. It receives the credential value that would otherwise
+  be forwarded (either the real credential or a masked value) and the
+  environment variable name used to expose it. This callback only controls the
+  value forwarded into the sandbox process. It does not restrict which
+  credentials the harness adapter can discover, read, or otherwise access in
+  the host process.
 - `env`: persistent environment values written at bootstrap.
 - `builtinTools`: optional native tool definitions for static typing and exact
   name matching.

--- a/content/providers/02-ai-sdk-harnesses/07-grok-build.mdx
+++ b/content/providers/02-ai-sdk-harnesses/07-grok-build.mdx
@@ -91,6 +91,14 @@ Settings:
 - `auth`: selects `auto`, `direct`, or `ai-gateway` authentication. The default
   is `auto`, which selects AI Gateway when Gateway credentials are present and
   direct xAI authentication otherwise.
+- `credentialForwarding`: optional synchronous or asynchronous callback that
+  customizes each credential immediately before the harness adapter forwards it
+  into a sandbox process. It receives the credential value that would otherwise
+  be forwarded (either the real credential or a masked value) and the
+  environment variable name used to expose it. This callback only controls the
+  value forwarded into the sandbox process. It does not restrict which
+  credentials the harness adapter can discover, read, or otherwise access in
+  the host process.
 - `model`: Grok model id selected through ACP. When omitted, Grok Build chooses
   its own default model.
 - `mcpServers`: MCP server definitions keyed by server name.

--- a/packages/harness-acp/src/acp-harness.test-d.ts
+++ b/packages/harness-acp/src/acp-harness.test-d.ts
@@ -119,4 +119,17 @@ describe('createACP built-in tool inference', () => {
       },
     });
   });
+
+  test('accepts asynchronous credential forwarding', () => {
+    createACP({
+      harnessId: 'credential-forwarding-acp',
+      source: {
+        type: 'npm-simple',
+        packageName: '@example/acp-agent',
+      },
+      executable: 'acp-agent',
+      credentialForwarding: async ({ credential, environmentVariableName }) =>
+        `${environmentVariableName}:${credential}`,
+    });
+  });
 });

--- a/packages/harness-acp/src/acp-harness.test.ts
+++ b/packages/harness-acp/src/acp-harness.test.ts
@@ -483,12 +483,20 @@ describe('createACP', () => {
       command: string;
       env: Record<string, string | undefined>;
     }> = [];
+    const credentialForwarding = vi.fn(
+      async ({
+        environmentVariableName,
+      }: {
+        environmentVariableName: string;
+      }) => `ephemeral-${environmentVariableName}`,
+    );
     const harness = createACP({
       harnessId: 'direct-brokered-acp',
       ...agentSettings,
       forwardEnv: ['PROVIDER_BASE_URL'],
       credentialEnv: ['PROVIDER_API_KEY'],
       credentialBrokering,
+      credentialForwarding,
       env: { STATIC_SETTING: 'literal-value' },
     });
 
@@ -519,9 +527,13 @@ describe('createACP', () => {
       },
     ]);
     expect(spawns[0]!.env).toMatchObject({
-      PROVIDER_API_KEY: 'PROVIDER_API_KEY',
+      PROVIDER_API_KEY: 'ephemeral-PROVIDER_API_KEY',
       PROVIDER_BASE_URL: 'https://provider.example/v1',
       STATIC_SETTING: 'literal-value',
+    });
+    expect(credentialForwarding).toHaveBeenCalledExactlyOnceWith({
+      credential: 'PROVIDER_API_KEY',
+      environmentVariableName: 'PROVIDER_API_KEY',
     });
     expect(JSON.stringify(spawns[0]!.env)).not.toContain('direct-secret');
 
@@ -547,6 +559,13 @@ describe('createACP', () => {
       command: string;
       env: Record<string, string | undefined>;
     }> = [];
+    const credentialForwarding = vi.fn(
+      async ({
+        environmentVariableName,
+      }: {
+        environmentVariableName: string;
+      }) => `ephemeral-${environmentVariableName}`,
+    );
     const harness = createACP({
       harnessId: 'gateway-brokered-acp',
       auth: 'ai-gateway',
@@ -554,6 +573,7 @@ describe('createACP', () => {
       forwardEnv: [],
       credentialEnv: ['PROVIDER_API_KEY'],
       credentialBrokering,
+      credentialForwarding,
       providerAuthentication: {
         gateway: {
           env: {
@@ -592,7 +612,8 @@ describe('createACP', () => {
         },
       },
     ]);
-    expect(spawns[0]!.env.PROVIDER_API_KEY).toBe('PROVIDER_API_KEY');
+    expect(spawns[0]!.env.PROVIDER_API_KEY).toBe('ephemeral-PROVIDER_API_KEY');
+    expect(spawns[0]!.env.PROVIDER_BASE_URL).toBe('https://gateway.example/v1');
     expect(spawns[0]!.env.AI_SDK_ACP_GATEWAY_API_KEY).toBeUndefined();
     expect(JSON.stringify(spawns[0]!.env)).not.toContain('gateway-secret');
     await expect(
@@ -603,12 +624,89 @@ describe('createACP', () => {
       success: true,
       value: {
         providerAuthentication: { type: 'ai-gateway' },
-        providerEnvironment: {
-          PROVIDER_API_KEY: 'PROVIDER_API_KEY',
-          PROVIDER_BASE_URL: 'https://gateway.example/v1',
+        providerEnvironment: {},
+      },
+    });
+    expect(credentialForwarding).toHaveBeenCalledExactlyOnceWith({
+      credential: 'PROVIDER_API_KEY',
+      environmentVariableName: 'PROVIDER_API_KEY',
+    });
+
+    await session.doDestroy();
+  });
+
+  it('uses the exposed environment variable name for brokered Gateway credentials', async () => {
+    vi.stubEnv('AI_GATEWAY_API_KEY', 'gateway-secret');
+    const addRequestTransformations = vi.fn(async () => {});
+    const credentialBrokering = vi.fn(
+      ({ env }: { env: Readonly<Record<string, string>> }) => [
+        {
+          match: { host: 'gateway.example' },
+          transform: {
+            headers: {
+              Authorization: `Bearer ${env.RUNTIME_PROVIDER_API_KEY}`,
+            },
+          },
+        },
+      ],
+    );
+    const credentialForwarding = vi.fn(
+      async ({ credential }: { credential: string }) => credential,
+    );
+    const spawns: Array<{
+      command: string;
+      env: Record<string, string | undefined>;
+    }> = [];
+    const harness = createACP({
+      harnessId: 'renamed-gateway-credential-acp',
+      auth: 'ai-gateway',
+      ...agentSettings,
+      forwardEnv: [],
+      credentialEnv: [],
+      credentialBrokering,
+      credentialForwarding,
+      providerAuthentication: {
+        gateway: {
+          env: {
+            RUNTIME_PROVIDER_API_KEY: { $source: 'gateway-api-key' },
+          },
         },
       },
     });
+
+    const session = await harness.doStart({
+      sessionId: 'session-1',
+      sandboxSession: fakeSandbox({
+        runs: [],
+        spawns,
+        stop: async () => {},
+        addRequestTransformations,
+      }),
+      sessionWorkDir: '/workspace/user-project',
+    });
+
+    expect(credentialBrokering).toHaveBeenCalledWith({
+      env: {
+        RUNTIME_PROVIDER_API_KEY: 'gateway-secret',
+      },
+    });
+    expect(addRequestTransformations).toHaveBeenCalledWith([
+      {
+        match: { host: 'gateway.example' },
+        transform: {
+          headers: { Authorization: 'Bearer gateway-secret' },
+        },
+      },
+    ]);
+    expect(credentialForwarding).toHaveBeenCalledExactlyOnceWith({
+      credential: 'RUNTIME_PROVIDER_API_KEY',
+      environmentVariableName: 'RUNTIME_PROVIDER_API_KEY',
+    });
+    expect(spawns[0]!.env.RUNTIME_PROVIDER_API_KEY).toBe(
+      'RUNTIME_PROVIDER_API_KEY',
+    );
+    expect(spawns[0]!.env.AI_SDK_ACP_GATEWAY_API_KEY).toBeUndefined();
+    expect(JSON.stringify(spawns[0]!.env)).not.toContain('gateway-secret');
 
     await session.doDestroy();
   });
@@ -642,6 +740,107 @@ describe('createACP', () => {
     expect(spawns[0]!.env.PROVIDER_API_KEY).toBe('legacy-secret');
 
     await session.doDestroy();
+  });
+
+  it('customizes direct and Gateway credentials under their sandbox environment names', async () => {
+    vi.stubEnv('PROVIDER_API_KEY', 'direct-secret');
+    vi.stubEnv('AI_GATEWAY_API_KEY', 'gateway-secret');
+    const credentialBrokering = vi.fn(() => []);
+    const credentialForwarding = vi.fn(
+      async ({ credential }: { credential: string }) =>
+        credential === 'gateway-secret'
+          ? 'ephemeral-gateway-credential'
+          : 'ephemeral-direct-credential',
+    );
+    const spawns: Array<{
+      command: string;
+      env: Record<string, string | undefined>;
+    }> = [];
+    const harness = createACP({
+      harnessId: 'custom-forwarding-acp',
+      auth: 'ai-gateway',
+      ...agentSettings,
+      forwardEnv: [],
+      credentialEnv: ['PROVIDER_API_KEY'],
+      credentialBrokering,
+      credentialForwarding,
+      providerAuthentication: {
+        gateway: {
+          env: {
+            RUNTIME_PROVIDER_API_KEY: { $source: 'gateway-api-key' },
+          },
+        },
+      },
+    });
+
+    const session = await harness.doStart({
+      sessionId: 'session-1',
+      sandboxSession: fakeSandbox({
+        runs: [],
+        spawns,
+        stop: async () => {},
+      }),
+      sessionWorkDir: '/workspace/user-project',
+    });
+
+    expect(credentialBrokering).not.toHaveBeenCalled();
+    expect(credentialForwarding).toHaveBeenNthCalledWith(1, {
+      credential: 'direct-secret',
+      environmentVariableName: 'PROVIDER_API_KEY',
+    });
+    expect(credentialForwarding).toHaveBeenNthCalledWith(2, {
+      credential: 'gateway-secret',
+      environmentVariableName: 'RUNTIME_PROVIDER_API_KEY',
+    });
+    expect(spawns[0]!.env.PROVIDER_API_KEY).toBe('ephemeral-direct-credential');
+    expect(spawns[0]!.env.RUNTIME_PROVIDER_API_KEY).toBe(
+      'ephemeral-gateway-credential',
+    );
+    expect(spawns[0]!.env.AI_SDK_ACP_GATEWAY_API_KEY).toBeUndefined();
+    await expect(
+      safeParseJSON({
+        text: spawns[0]!.env[ACP_BRIDGE_CONFIGURATION_ENV]!,
+      }),
+    ).resolves.toMatchObject({
+      success: true,
+      value: {
+        providerEnvironment: {},
+      },
+    });
+
+    await session.doDestroy();
+  });
+
+  it('aborts before spawning when credential forwarding fails', async () => {
+    vi.stubEnv('PROVIDER_API_KEY', 'direct-secret');
+    const error = new Error('credential forwarding failed');
+    const spawns: Array<{
+      command: string;
+      env: Record<string, string | undefined>;
+    }> = [];
+    const harness = createACP({
+      harnessId: 'failed-forwarding-acp',
+      ...agentSettings,
+      forwardEnv: [],
+      credentialEnv: ['PROVIDER_API_KEY'],
+      credentialBrokering: () => [],
+      credentialForwarding: async () => {
+        throw error;
+      },
+    });
+
+    await expect(
+      harness.doStart({
+        sessionId: 'session-1',
+        sandboxSession: fakeSandbox({
+          runs: [],
+          spawns,
+          stop: async () => {},
+        }),
+        sessionWorkDir: '/workspace/user-project',
+      }),
+    ).rejects.toBe(error);
+    expect(spawns).toEqual([]);
   });
 
   it('aborts before attach or spawn when credential brokering fails', async () => {

--- a/packages/harness-acp/src/acp-harness.ts
+++ b/packages/harness-acp/src/acp-harness.ts
@@ -40,6 +40,12 @@ export type ACPHarnessSettings<TBuiltinTools extends ToolSet = {}> = {
   readonly forwardEnv?: ACPV1Settings['forwardEnv'];
   readonly credentialEnv?: ACPV1Settings['credentialEnv'];
   readonly credentialBrokering?: ACPV1Settings['credentialBrokering'];
+  /**
+   * Customizes each credential value before it is forwarded into a sandbox
+   * process. This does not restrict which credentials the harness adapter can
+   * discover, read, or otherwise access in the host process.
+   */
+  readonly credentialForwarding?: ACPV1Settings['credentialForwarding'];
   readonly env?: ACPV1Settings['env'];
   readonly authentication?: ACPV1Settings['authentication'];
   readonly providerAuthentication?: ACPV1Settings['providerAuthentication'];

--- a/packages/harness-acp/src/v1/acp-v1-harness.ts
+++ b/packages/harness-acp/src/v1/acp-v1-harness.ts
@@ -14,6 +14,7 @@ import {
 } from '@ai-sdk/harness';
 import { HarnessBridgeCapabilityUnsupportedError } from '@ai-sdk/harness/bridge';
 import {
+  applyCredentialForwarding,
   createBridgeErrorHandler,
   createBridgeStartupError,
   classifyDiskLog,
@@ -82,6 +83,7 @@ import type {
   ACPOutputSchemaMapping,
   ACPPermissionModeMapping,
   ACPPermissionModeTarget,
+  ACPProfileValue,
   ACPSerializableValue,
   ACPV1Settings,
 } from './acp-v1-settings';
@@ -243,6 +245,22 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
       let sandboxProviderAuthenticationEnvironment =
         resolvedProviderAuthentication.env;
       let sandboxProviderEnvironment: Record<string, string> | undefined;
+      const credentialEnvironmentVariables = [
+        ...new Set([
+          ...(settings.credentialEnv ?? []),
+          'AI_GATEWAY_API_KEY',
+          'VERCEL_OIDC_TOKEN',
+        ]),
+      ];
+      const credentialForwardingEnvironmentVariables = [
+        ...new Set([
+          ...credentialEnvironmentVariables,
+          ...resolveACPProviderCredentialEnvironmentVariables({
+            providerAuthentication:
+              resolvedProviderAuthentication.providerAuthentication,
+          }),
+        ]),
+      ];
 
       if (
         settings.credentialBrokering != null &&
@@ -253,13 +271,6 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
           resolvedProviderAuthentication,
           clientApp,
         });
-        const credentialEnvironmentVariables = [
-          ...new Set([
-            ...(settings.credentialEnv ?? []),
-            'AI_GATEWAY_API_KEY',
-            'VERCEL_OIDC_TOKEN',
-          ]),
-        ];
         const requestTransformations = settings.credentialBrokering({
           env: {
             ...implementationEnvironment,
@@ -277,20 +288,33 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
         });
 
         /*
-         * Gateway profiles are resolved on the host twice: real values feed
-         * the transformation callback, while the bridge receives only a
-         * structurally equivalent environment with credential placeholders.
-         * Resolving the profile inside the sandbox would require serializing
-         * the Gateway credential into the bridge process environment.
+         * Each profile environment variable is resolved with its own name as
+         * the fake Gateway credential. This preserves profile transformations
+         * without exposing the real credential to the sandbox process.
          */
-        sandboxProviderEnvironment = maskSandboxCredentials({
-          environment: resolveProviderEnvironment({
-            resolvedProviderAuthentication,
-            clientApp,
-            gatewayApiKey: 'AI_GATEWAY_API_KEY',
-          }),
-          credentialEnvironmentVariables,
+        sandboxProviderEnvironment = resolveBrokeredProviderEnvironment({
+          resolvedProviderAuthentication,
+          clientApp,
         });
+      } else if (settings.credentialBrokering != null) {
+        warnCredentialBrokeringUnavailable();
+      }
+      if (
+        settings.credentialForwarding != null &&
+        sandboxProviderEnvironment == null &&
+        resolvedProviderAuthentication.providerAuthentication?.type ===
+          'ai-gateway'
+      ) {
+        sandboxProviderEnvironment = resolveProviderEnvironment({
+          resolvedProviderAuthentication,
+          clientApp,
+        });
+      }
+      if (sandboxProviderEnvironment != null) {
+        sandboxImplementationEnvironment = {
+          ...sandboxImplementationEnvironment,
+          ...sandboxProviderEnvironment,
+        };
         sandboxProviderAuthenticationEnvironment = Object.fromEntries(
           Object.entries(resolvedProviderAuthentication.env).filter(
             ([key]) =>
@@ -298,8 +322,6 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
               key !== 'AI_SDK_ACP_GATEWAY_BASE_URL',
           ),
         );
-      } else if (settings.credentialBrokering != null) {
-        warnCredentialBrokeringUnavailable();
       }
       const resolvedBridgeDir = posix.resolve(
         defaultWorkingDirectory,
@@ -521,6 +543,13 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
         }
       }
 
+      const forwardedImplementationEnvironment =
+        await applyCredentialForwarding({
+          environment: sandboxImplementationEnvironment,
+          credentialEnvironmentVariables:
+            credentialForwardingEnvironmentVariables,
+          credentialForwarding: settings.credentialForwarding,
+        });
       const port = resolveBridgePort({
         sandboxSession,
         override: portOverride,
@@ -549,12 +578,13 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
           ` --implementation-dir ${shellQuote(resolvedImplementationDir)}` +
           ` --bridge-type ${shellQuote(settings.harnessId)}`,
         env: {
-          ...sandboxImplementationEnvironment,
+          ...forwardedImplementationEnvironment,
           ...createACPBridgeEnvironment({
             authentication: settings.authentication,
             providerAuthentication:
               resolvedProviderAuthentication.providerAuthentication,
-            providerEnvironment: sandboxProviderEnvironment,
+            providerEnvironment:
+              sandboxProviderEnvironment == null ? undefined : {},
             sessionMeta: settings.session?.meta,
           }),
           ...sandboxProviderAuthenticationEnvironment,
@@ -722,13 +752,11 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
 function resolveProviderEnvironment({
   resolvedProviderAuthentication,
   clientApp,
-  gatewayApiKey,
 }: {
   resolvedProviderAuthentication: ReturnType<
     typeof resolveACPProviderAuthentication
   >;
   clientApp: ACPClientApp;
-  gatewayApiKey?: string;
 }): Record<string, string> {
   if (
     resolvedProviderAuthentication.providerAuthentication?.type !== 'ai-gateway'
@@ -739,12 +767,10 @@ function resolveProviderEnvironment({
     providerAuthentication:
       resolvedProviderAuthentication.providerAuthentication,
     gateway: {
-      apiKey:
-        gatewayApiKey ??
-        requireResolvedEnvironmentValue({
-          environment: resolvedProviderAuthentication.env,
-          name: 'AI_SDK_ACP_GATEWAY_API_KEY',
-        }),
+      apiKey: requireResolvedEnvironmentValue({
+        environment: resolvedProviderAuthentication.env,
+        name: 'AI_SDK_ACP_GATEWAY_API_KEY',
+      }),
       baseUrl: requireResolvedEnvironmentValue({
         environment: resolvedProviderAuthentication.env,
         name: 'AI_SDK_ACP_GATEWAY_BASE_URL',
@@ -753,6 +779,79 @@ function resolveProviderEnvironment({
       clientAppVersion: clientApp.version,
     },
   });
+}
+
+function resolveBrokeredProviderEnvironment({
+  resolvedProviderAuthentication,
+  clientApp,
+}: {
+  resolvedProviderAuthentication: ReturnType<
+    typeof resolveACPProviderAuthentication
+  >;
+  clientApp: ACPClientApp;
+}): Record<string, string> {
+  const providerAuthentication =
+    resolvedProviderAuthentication.providerAuthentication;
+  if (providerAuthentication?.type !== 'ai-gateway') return {};
+
+  const baseUrl = requireResolvedEnvironmentValue({
+    environment: resolvedProviderAuthentication.env,
+    name: 'AI_SDK_ACP_GATEWAY_BASE_URL',
+  });
+
+  return Object.fromEntries(
+    Object.entries(providerAuthentication.env).map(
+      ([environmentVariableName, value]) => {
+        const environment = resolveACPLaunchEnvironment({
+          providerAuthentication: {
+            type: 'ai-gateway',
+            env: { [environmentVariableName]: value },
+          },
+          gateway: {
+            apiKey: environmentVariableName,
+            baseUrl,
+            clientAppName: clientApp.name,
+            clientAppVersion: clientApp.version,
+          },
+        });
+        return [environmentVariableName, environment[environmentVariableName]!];
+      },
+    ),
+  );
+}
+
+function resolveACPProviderCredentialEnvironmentVariables({
+  providerAuthentication,
+}: {
+  providerAuthentication: ReturnType<
+    typeof resolveACPProviderAuthentication
+  >['providerAuthentication'];
+}): string[] {
+  if (providerAuthentication?.type !== 'ai-gateway') return [];
+
+  return Object.entries(providerAuthentication.env)
+    .filter(([, value]) => containsACPProviderCredential({ value }))
+    .map(([name]) => name);
+}
+
+function containsACPProviderCredential({
+  value,
+}: {
+  value: ACPProfileValue;
+}): boolean {
+  if (Array.isArray(value)) {
+    return value.some(item => containsACPProviderCredential({ value: item }));
+  }
+  if (value == null || typeof value !== 'object') return false;
+  if ('$source' in value) {
+    return (
+      value.$source === 'gateway-api-key' ||
+      value.$source === 'gateway-authorization'
+    );
+  }
+  return Object.values(value).some(item =>
+    containsACPProviderCredential({ value: item }),
+  );
 }
 
 function requireResolvedEnvironmentValue({

--- a/packages/harness-acp/src/v1/acp-v1-settings.ts
+++ b/packages/harness-acp/src/v1/acp-v1-settings.ts
@@ -1,4 +1,5 @@
 import type {
+  HarnessV1CredentialForwarding,
   HarnessV1PermissionMode,
   HarnessV1RequestTransformation,
 } from '@ai-sdk/harness';
@@ -125,6 +126,12 @@ export type ACPV1Settings = {
   readonly forwardEnv?: ReadonlyArray<string>;
   readonly credentialEnv?: ReadonlyArray<string>;
   readonly credentialBrokering?: ACPCredentialBrokering;
+  /**
+   * Customizes each credential value before it is forwarded into a sandbox
+   * process. This does not restrict which credentials the harness adapter can
+   * discover, read, or otherwise access in the host process.
+   */
+  readonly credentialForwarding?: HarnessV1CredentialForwarding;
   /**
    * Runtime environment values that are safe to persist in bootstrap and
    * lifecycle compatibility identity.

--- a/packages/harness-claude-code/src/claude-code-harness.test-d.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test-d.ts
@@ -65,4 +65,12 @@ describe('claudeCode ↔ HarnessAgent harness setting', () => {
       }),
     ).toExtend<HarnessAgentAdapter<any>>();
   });
+
+  test('createClaudeCode accepts asynchronous credential forwarding', () => {
+    expectTypeOf(
+      createClaudeCode({
+        credentialForwarding: async ({ credential }) => credential,
+      }),
+    ).toExtend<HarnessAgentAdapter<any>>();
+  });
 });

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -412,15 +412,27 @@ describe('createClaudeCode adapter', () => {
       sessionWorkDir: '/vercel/sandbox/claude-code-s1',
     });
 
-    expect(spawnEnvs.at(0)?.CLAUDE_AGENT_SDK_CLIENT_APP).toBe(
-      'ai-sdk/harness-claude-code/0.0.0-test',
-    );
+    await session.doPromptTurn({
+      prompt: 'Hello',
+      emit: () => {},
+    });
+
+    expect(sentMessages.at(-1)).toMatchObject({
+      type: 'start',
+      env: {
+        CLAUDE_AGENT_SDK_CLIENT_APP: 'ai-sdk/harness-claude-code/0.0.0-test',
+      },
+    });
     expect(spawnEnvs.at(0)?.BRIDGE_CHANNEL_TOKEN).toMatch(/^[a-f0-9]{64}$/);
     await session.doDestroy();
   });
 
   it('brokers credentials when the sandbox supports additive request transformations', async () => {
     const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const forwardedCredentials: Array<{
+      credential: string;
+      environmentVariableName: string;
+    }> = [];
     const addRequestTransformations = vi.fn(async () => {});
     const sandboxSession = fakeNetworkSandboxSessionForStartupSuccess({
       bridgePortUrl: 'ws://127.0.0.1:1',
@@ -436,12 +448,21 @@ describe('createClaudeCode adapter', () => {
           baseUrl: 'https://anthropic.example/v1',
         },
       },
+      credentialForwarding: async options => {
+        forwardedCredentials.push(options);
+        return `ephemeral-${options.environmentVariableName}`;
+      },
     });
 
     const session = await harness.doStart({
       sessionId: 's1',
       sandboxSession,
       sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+    });
+
+    await session.doPromptTurn({
+      prompt: 'Hello',
+      emit: () => {},
     });
 
     expect(addRequestTransformations).toHaveBeenCalledWith([
@@ -453,8 +474,116 @@ describe('createClaudeCode adapter', () => {
         transform: { headers: { 'x-api-key': 'anthropic-secret' } },
       },
     ]);
-    expect(spawnEnvs.at(0)?.ANTHROPIC_API_KEY).toBe('ANTHROPIC_API_KEY');
+    expect(forwardedCredentials).toEqual([
+      {
+        credential: 'ANTHROPIC_API_KEY',
+        environmentVariableName: 'ANTHROPIC_API_KEY',
+      },
+    ]);
+    expect(sentMessages.at(-1)).toMatchObject({
+      type: 'start',
+      env: { ANTHROPIC_API_KEY: 'ephemeral-ANTHROPIC_API_KEY' },
+    });
     expect(JSON.stringify(spawnEnvs.at(0))).not.toContain('anthropic-secret');
+
+    await session.doDestroy();
+  });
+
+  it('customizes real credentials when request transformations are unavailable', async () => {
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const forwardedCredentials: Array<{
+      credential: string;
+      environmentVariableName: string;
+    }> = [];
+    const harness = createClaudeCode({
+      auth: { anthropic: { apiKey: 'anthropic-secret' } },
+      credentialForwarding: options => {
+        forwardedCredentials.push(options);
+        return 'caller-managed-credential';
+      },
+    });
+
+    const session = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        spawnEnvs,
+        writes: [],
+        runs: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+    });
+
+    await session.doPromptTurn({
+      prompt: 'Hello',
+      emit: () => {},
+    });
+
+    expect(forwardedCredentials).toEqual([
+      {
+        credential: 'anthropic-secret',
+        environmentVariableName: 'ANTHROPIC_API_KEY',
+      },
+    ]);
+    expect(sentMessages.at(-1)).toMatchObject({
+      type: 'start',
+      env: { ANTHROPIC_API_KEY: 'caller-managed-credential' },
+    });
+    expect(JSON.stringify(spawnEnvs.at(0))).not.toContain('anthropic-secret');
+
+    await session.doDestroy();
+  });
+
+  it('customizes credentials forwarded through the Claude process environment', async () => {
+    const forwardedCredentials: Array<{
+      credential: string;
+      environmentVariableName: string;
+    }> = [];
+    const harness = createClaudeCode({
+      auth: { anthropic: { apiKey: 'bridge-secret' } },
+      env: {
+        ANTHROPIC_API_KEY: 'turn-api-key',
+        ANTHROPIC_AUTH_TOKEN: 'turn-auth-token',
+        NON_SECRET: 'preserved',
+      },
+      credentialForwarding: options => {
+        forwardedCredentials.push(options);
+        return `ephemeral-${options.credential}`;
+      },
+    });
+    const session = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        writes: [],
+        runs: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/claude-code-s1',
+    });
+
+    await session.doPromptTurn({
+      prompt: 'Hello',
+      emit: () => {},
+    });
+
+    expect(forwardedCredentials).toEqual([
+      {
+        credential: 'turn-api-key',
+        environmentVariableName: 'ANTHROPIC_API_KEY',
+      },
+      {
+        credential: 'turn-auth-token',
+        environmentVariableName: 'ANTHROPIC_AUTH_TOKEN',
+      },
+    ]);
+    expect(sentMessages.at(-1)).toMatchObject({
+      type: 'start',
+      env: {
+        ANTHROPIC_API_KEY: 'ephemeral-turn-api-key',
+        ANTHROPIC_AUTH_TOKEN: 'ephemeral-turn-auth-token',
+        NON_SECRET: 'preserved',
+      },
+    });
 
     await session.doDestroy();
   });

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -8,6 +8,7 @@ import {
   type HarnessV1BuiltinToolFiltering,
   type HarnessV1BuiltinTool,
   type HarnessV1ContinueTurnState,
+  type HarnessV1CredentialForwarding,
   type HarnessV1DebugConfig,
   type HarnessV1PermissionMode,
   type HarnessV1Prompt,
@@ -20,6 +21,7 @@ import {
   type HarnessV1StreamPart,
 } from '@ai-sdk/harness';
 import {
+  applyCredentialForwarding,
   classifyDiskLog,
   experimental_createBridgeUserMessageSubmitter,
   createBridgeErrorHandler,
@@ -74,6 +76,12 @@ const CLAUDE_CODE_CLIENT_APP = `ai-sdk/harness-claude-code/${VERSION}`;
 
 export type ClaudeCodeHarnessSettings = {
   readonly auth?: ClaudeCodeAuthOptions;
+  /**
+   * Customizes each credential value before it is forwarded into a sandbox
+   * process. This does not restrict which credentials the harness adapter can
+   * discover, read, or otherwise access in the host process.
+   */
+  readonly credentialForwarding?: HarnessV1CredentialForwarding;
   /**
    * MCP server definitions keyed by server name. Each definition uses the
    * underlying runtime's native MCP server configuration format.
@@ -845,17 +853,25 @@ export function createClaudeCode(
         settings.auth,
       );
       const resolvedAuthEnvironment = resolveClaudeCodeEnv(settings.auth);
-      let authEnv = resolvedAuthEnvironment;
-      let sandboxTurnEnvironment = settings.env;
+      let sandboxClaudeEnvironment = {
+        ...resolvedAuthEnvironment,
+        /*
+         * The Claude Agent SDK does not expose arbitrary model-request
+         * headers. It reads this environment variable and sends the value as
+         * `x-client-app`, while also appending `client-app/<value>` to
+         * `User-Agent`, so this is the attribution path for AI Gateway.
+         */
+        ...(resolvedAuthEnvironment.AI_GATEWAY_BASE_URL
+          ? { CLAUDE_AGENT_SDK_CLIENT_APP: CLAUDE_CODE_CLIENT_APP }
+          : {}),
+        ...settings.env,
+      };
       if (
         'addRequestTransformations' in sandboxSession &&
         sandboxSession.addRequestTransformations != null
       ) {
         const requestTransformations = createClaudeCodeRequestTransformations(
-          {
-            ...resolvedAuthEnvironment,
-            ...settings.env,
-          },
+          sandboxClaudeEnvironment,
           authenticationMode,
         );
         if (requestTransformations.length > 0) {
@@ -863,19 +879,20 @@ export function createClaudeCode(
             requestTransformations,
           );
         }
-        authEnv = maskSandboxCredentials({
-          environment: resolvedAuthEnvironment,
-          credentialEnvironmentVariables:
-            CLAUDE_CODE_CREDENTIAL_ENVIRONMENT_VARIABLES,
-        });
-        sandboxTurnEnvironment = maskSandboxCredentials({
-          environment: settings.env ?? {},
+        sandboxClaudeEnvironment = maskSandboxCredentials({
+          environment: sandboxClaudeEnvironment,
           credentialEnvironmentVariables:
             CLAUDE_CODE_CREDENTIAL_ENVIRONMENT_VARIABLES,
         });
       } else {
         warnCredentialBrokeringUnavailable();
       }
+      sandboxClaudeEnvironment = await applyCredentialForwarding({
+        environment: sandboxClaudeEnvironment,
+        credentialEnvironmentVariables:
+          CLAUDE_CODE_CREDENTIAL_ENVIRONMENT_VARIABLES,
+        credentialForwarding: settings.credentialForwarding,
+      });
       const bootstrapDir = posix.resolve(
         defaultWorkingDirectory,
         BOOTSTRAP_DIR,
@@ -961,7 +978,7 @@ export function createClaudeCode(
             proc: undefined,
             model: settings.model,
             maxTurns: settings.maxTurns,
-            env: sandboxTurnEnvironment,
+            env: sandboxClaudeEnvironment,
             thinking,
             effort: settings.effort,
             isResume: true,
@@ -1022,16 +1039,6 @@ export function createClaudeCode(
           ? randomBytes(32).toString('hex')
           : settings.mintBridgeToken(sandboxId!);
       const env = {
-        ...authEnv,
-        /*
-         * The Claude Agent SDK does not expose arbitrary model-request
-         * headers. It reads this environment variable and sends the value as
-         * `x-client-app`, while also appending `client-app/<value>` to
-         * `User-Agent`, so this is the attribution path for AI Gateway.
-         */
-        ...(authEnv.AI_GATEWAY_BASE_URL
-          ? { CLAUDE_AGENT_SDK_CLIENT_APP: CLAUDE_CODE_CLIENT_APP }
-          : {}),
         BRIDGE_CHANNEL_TOKEN: token,
         BRIDGE_WS_PORT: String(port),
         ...(sandboxHomeDir ? { HOME: sandboxHomeDir } : {}),
@@ -1141,7 +1148,7 @@ export function createClaudeCode(
         proc,
         model: settings.model,
         maxTurns: settings.maxTurns,
-        env: sandboxTurnEnvironment,
+        env: sandboxClaudeEnvironment,
         thinking,
         effort: settings.effort,
         isResume: respawnStrategy !== undefined,

--- a/packages/harness-codex/src/codex-harness.test.ts
+++ b/packages/harness-codex/src/codex-harness.test.ts
@@ -372,6 +372,10 @@ describe('createCodex adapter', () => {
 
   it('brokers credentials when the sandbox supports additive request transformations', async () => {
     const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const forwardedCredentials: Array<{
+      credential: string;
+      environmentVariableName: string;
+    }> = [];
     const addRequestTransformations = vi.fn(async () => {});
     const sandboxSession = fakeNetworkSandboxSessionForStartupSuccess({
       bridgePortUrl: 'ws://127.0.0.1:1',
@@ -387,6 +391,10 @@ describe('createCodex adapter', () => {
           apiKey: 'openai-secret',
           baseUrl: 'https://openai.example/v1',
         },
+      },
+      credentialForwarding: async options => {
+        forwardedCredentials.push(options);
+        return `ephemeral-${options.environmentVariableName}`;
       },
     });
 
@@ -407,7 +415,53 @@ describe('createCodex adapter', () => {
         },
       },
     ]);
-    expect(spawnEnvs.at(0)?.CODEX_API_KEY).toBe('CODEX_API_KEY');
+    expect(forwardedCredentials).toEqual([
+      {
+        credential: 'CODEX_API_KEY',
+        environmentVariableName: 'CODEX_API_KEY',
+      },
+    ]);
+    expect(spawnEnvs.at(0)?.CODEX_API_KEY).toBe('ephemeral-CODEX_API_KEY');
+    expect(JSON.stringify(spawnEnvs.at(0))).not.toContain('openai-secret');
+
+    await session.doDestroy();
+  });
+
+  it('customizes real credentials when request transformations are unavailable', async () => {
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const forwardedCredentials: Array<{
+      credential: string;
+      environmentVariableName: string;
+    }> = [];
+    const sandboxSession = fakeNetworkSandboxSessionForStartupSuccess({
+      bridgePortUrl: 'ws://127.0.0.1:1',
+      runs: [],
+      spawns: [],
+      spawnEnvs,
+      writes: [],
+    });
+    Object.assign(sandboxSession, { addRequestTransformations: undefined });
+    const harness = createCodex({
+      auth: { openai: { apiKey: 'openai-secret' } },
+      credentialForwarding: options => {
+        forwardedCredentials.push(options);
+        return 'caller-managed-credential';
+      },
+    });
+
+    const session = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession,
+      sessionWorkDir: '/vercel/sandbox/codex-s1',
+    });
+
+    expect(forwardedCredentials).toEqual([
+      {
+        credential: 'openai-secret',
+        environmentVariableName: 'CODEX_API_KEY',
+      },
+    ]);
+    expect(spawnEnvs.at(0)?.CODEX_API_KEY).toBe('caller-managed-credential');
     expect(JSON.stringify(spawnEnvs.at(0))).not.toContain('openai-secret');
 
     await session.doDestroy();

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -8,6 +8,7 @@ import {
   type HarnessV1DebugConfig,
   type HarnessV1BuiltinTool,
   type HarnessV1ContinueTurnState,
+  type HarnessV1CredentialForwarding,
   type HarnessV1Prompt,
   type HarnessV1PromptControl,
   type HarnessV1PortEndpoint,
@@ -19,6 +20,7 @@ import {
   type HarnessV1StreamPart,
 } from '@ai-sdk/harness';
 import {
+  applyCredentialForwarding,
   classifyDiskLog,
   createBridgeErrorHandler,
   createBridgeStartupError,
@@ -88,6 +90,12 @@ const CODEX_CLIENT_APP = `ai-sdk/harness-codex/${VERSION}`;
 
 export type CodexHarnessSettings = {
   readonly auth?: CodexAuthOptions;
+  /**
+   * Customizes each credential value before it is forwarded into a sandbox
+   * process. This does not restrict which credentials the harness adapter can
+   * discover, read, or otherwise access in the host process.
+   */
+  readonly credentialForwarding?: HarnessV1CredentialForwarding;
   /**
    * Additional configuration passed through to Codex as-is. Codex config keys
    * typically use snake_case and must be provided in that form. Values managed
@@ -402,6 +410,11 @@ export function createCodex(
         settings.mintBridgeToken == null
           ? randomBytes(32).toString('hex')
           : settings.mintBridgeToken(sandboxId!);
+      const forwardedAuthEnvironment = await applyCredentialForwarding({
+        environment: sandboxAuthEnvironment,
+        credentialEnvironmentVariables: CODEX_CREDENTIAL_ENVIRONMENT_VARIABLES,
+        credentialForwarding: settings.credentialForwarding,
+      });
       const codexSkillSetup =
         startOpts.skills && startOpts.skills.length > 0
           ? await writeCodexSkills({
@@ -411,7 +424,7 @@ export function createCodex(
             })
           : undefined;
       const env = {
-        ...sandboxAuthEnvironment,
+        ...forwardedAuthEnvironment,
         AI_SDK_HARNESS_CLIENT_APP: CODEX_CLIENT_APP,
         BRIDGE_CHANNEL_TOKEN: token,
         BRIDGE_WS_PORT: String(port),

--- a/packages/harness-deepagents/src/deepagents-harness.test.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.test.ts
@@ -253,6 +253,10 @@ describe('createDeepAgents', () => {
 
   it('brokers credentials when the sandbox supports additive request transformations', async () => {
     const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const forwardedCredentials: Array<{
+      credential: string;
+      environmentVariableName: string;
+    }> = [];
     const addRequestTransformations = vi.fn(async () => {});
     const sandboxSession = fakeSandboxSession({ spawnEnvs });
     Object.assign(sandboxSession, { addRequestTransformations });
@@ -262,6 +266,10 @@ describe('createDeepAgents', () => {
           apiKey: 'anthropic-secret',
           baseUrl: 'https://anthropic.example',
         },
+      },
+      credentialForwarding: async options => {
+        forwardedCredentials.push(options);
+        return `ephemeral-${options.environmentVariableName}`;
       },
     });
 
@@ -277,7 +285,49 @@ describe('createDeepAgents', () => {
         transform: { headers: { 'x-api-key': 'anthropic-secret' } },
       },
     ]);
-    expect(spawnEnvs.at(0)?.ANTHROPIC_API_KEY).toBe('ANTHROPIC_API_KEY');
+    expect(forwardedCredentials).toEqual([
+      {
+        credential: 'ANTHROPIC_API_KEY',
+        environmentVariableName: 'ANTHROPIC_API_KEY',
+      },
+    ]);
+    expect(spawnEnvs.at(0)?.ANTHROPIC_API_KEY).toBe(
+      'ephemeral-ANTHROPIC_API_KEY',
+    );
+    expect(JSON.stringify(spawnEnvs.at(0))).not.toContain('anthropic-secret');
+
+    await session.doDestroy();
+  });
+
+  it('customizes real credentials when request transformations are unavailable', async () => {
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const forwardedCredentials: Array<{
+      credential: string;
+      environmentVariableName: string;
+    }> = [];
+    const harness = createDeepAgents({
+      auth: { anthropic: { apiKey: 'anthropic-secret' } },
+      credentialForwarding: options => {
+        forwardedCredentials.push(options);
+        return 'caller-managed-credential';
+      },
+    });
+
+    const session = await harness.doStart({
+      sessionId: 'test-session',
+      sessionWorkDir: '/vercel/sandbox/deepagents-test-session',
+      sandboxSession: fakeSandboxSession({ spawnEnvs }),
+    } as unknown as Parameters<typeof harness.doStart>[0]);
+
+    expect(forwardedCredentials).toEqual([
+      {
+        credential: 'anthropic-secret',
+        environmentVariableName: 'ANTHROPIC_API_KEY',
+      },
+    ]);
+    expect(spawnEnvs.at(0)?.ANTHROPIC_API_KEY).toBe(
+      'caller-managed-credential',
+    );
     expect(JSON.stringify(spawnEnvs.at(0))).not.toContain('anthropic-secret');
 
     await session.doDestroy();

--- a/packages/harness-deepagents/src/deepagents-harness.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.ts
@@ -8,6 +8,7 @@ import {
   type HarnessV1BuiltinTool,
   type HarnessV1BuiltinToolFiltering,
   type HarnessV1ContinueTurnState,
+  type HarnessV1CredentialForwarding,
   type HarnessV1NetworkSandboxSession,
   type HarnessV1PermissionMode,
   type HarnessV1Prompt,
@@ -19,6 +20,7 @@ import {
   type HarnessV1StreamPart,
 } from '@ai-sdk/harness';
 import {
+  applyCredentialForwarding,
   markBridgeStarting,
   createBridgeErrorHandler,
   createBridgeStartupError,
@@ -85,6 +87,12 @@ const SKILLS_SOURCE_PATH = '/.agents/skills';
 
 export type DeepAgentsHarnessSettings = {
   readonly auth?: DeepAgentsAuthOptions;
+  /**
+   * Customizes each credential value before it is forwarded into a sandbox
+   * process. This does not restrict which credentials the harness adapter can
+   * discover, read, or otherwise access in the host process.
+   */
+  readonly credentialForwarding?: HarnessV1CredentialForwarding;
   /** Model id for the DeepAgents runtime, e.g. `claude-sonnet-4` (converted to `provider:model`). */
   readonly model?: string;
   /**
@@ -360,8 +368,14 @@ export function createDeepAgents(
         skillsPaths.push(homeSkillsRoot);
       }
 
+      const forwardedAuthEnvironment = await applyCredentialForwarding({
+        environment: sandboxAuthEnvironment,
+        credentialEnvironmentVariables:
+          DEEPAGENTS_CREDENTIAL_ENVIRONMENT_VARIABLES,
+        credentialForwarding: settings.credentialForwarding,
+      });
       const env = {
-        ...sandboxAuthEnvironment,
+        ...forwardedAuthEnvironment,
         AI_SDK_HARNESS_CLIENT_APP: DEEPAGENTS_CLIENT_APP,
         BRIDGE_CHANNEL_TOKEN: token,
         BRIDGE_WS_PORT: String(port),

--- a/packages/harness-grok-build/src/grok-build-harness.test-d.ts
+++ b/packages/harness-grok-build/src/grok-build-harness.test-d.ts
@@ -3,6 +3,7 @@ import { createGrokBuild } from './grok-build-harness';
 
 test('preserves Grok Build built-in tool types', () => {
   const harness = createGrokBuild({
+    credentialForwarding: async ({ credential }) => credential,
     mintBridgeToken: sandboxId => sandboxId,
   });
 

--- a/packages/harness-grok-build/src/grok-build-harness.test.ts
+++ b/packages/harness-grok-build/src/grok-build-harness.test.ts
@@ -164,9 +164,15 @@ describe('createGrokBuild', () => {
 
   it('forwards user-configurable settings', () => {
     const mintBridgeToken = (sandboxId: string) => `token-for-${sandboxId}`;
+    const credentialForwarding = async ({
+      credential,
+    }: {
+      credential: string;
+    }) => `ephemeral-${credential}`;
     const portEndpoint = { url: 'wss://sandbox.example/bridge' };
     createGrokBuild({
       auth: 'direct',
+      credentialForwarding,
       model: 'grok-code-fast-1',
       port: 4319,
       portEndpoint,
@@ -179,6 +185,7 @@ describe('createGrokBuild', () => {
 
     expect({
       auth: settings.auth,
+      credentialForwarding: settings.credentialForwarding,
       modelId: settings.modelId,
       port: settings.port,
       portEndpoint: settings.portEndpoint,
@@ -187,6 +194,7 @@ describe('createGrokBuild', () => {
       mintBridgeToken: settings.mintBridgeToken,
     }).toEqual({
       auth: 'direct',
+      credentialForwarding,
       modelId: 'grok-code-fast-1',
       port: 4319,
       portEndpoint,

--- a/packages/harness-grok-build/src/grok-build-harness.ts
+++ b/packages/harness-grok-build/src/grok-build-harness.ts
@@ -2,6 +2,7 @@ import {
   commonTool,
   type HarnessV1,
   type HarnessV1BuiltinTool,
+  type HarnessV1CredentialForwarding,
   type HarnessV1PortEndpoint,
 } from '@ai-sdk/harness';
 import { createCredentialRequestTransformation } from '@ai-sdk/harness/utils';
@@ -28,6 +29,12 @@ export type GrokBuildHarnessSettings = {
    * environment-based selection.
    */
   readonly auth?: ACPProviderAuthenticationMode;
+  /**
+   * Customizes each credential value before it is forwarded into a sandbox
+   * process. This does not restrict which credentials the harness adapter can
+   * discover, read, or otherwise access in the host process.
+   */
+  readonly credentialForwarding?: HarnessV1CredentialForwarding;
   /**
    * Grok model id selected through ACP. Unset preserves Grok Build's default.
    */
@@ -290,6 +297,7 @@ export function createGrokBuild(
 
   return createACP({
     auth: settings.auth,
+    credentialForwarding: settings.credentialForwarding,
     modelId: settings.model,
     port: settings.port,
     portEndpoint: settings.portEndpoint,

--- a/packages/harness-opencode/src/opencode-harness.test.ts
+++ b/packages/harness-opencode/src/opencode-harness.test.ts
@@ -336,6 +336,10 @@ describe('createOpenCode adapter', () => {
   it('brokers credentials when the sandbox supports additive request transformations', async () => {
     harnessUtilsMocks.waitForBridgeReady.mockResolvedValueOnce({ port: 4000 });
     const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const forwardedCredentials: Array<{
+      credential: string;
+      environmentVariableName: string;
+    }> = [];
     const addRequestTransformations = vi.fn(async () => {});
     const emptyStream = () =>
       new ReadableStream<Uint8Array>({
@@ -384,6 +388,10 @@ describe('createOpenCode adapter', () => {
           baseUrl: 'https://openai.example/v1',
         },
       },
+      credentialForwarding: async options => {
+        forwardedCredentials.push(options);
+        return `ephemeral-${options.environmentVariableName}`;
+      },
     });
 
     const session = await harness.doStart({
@@ -403,7 +411,85 @@ describe('createOpenCode adapter', () => {
         },
       },
     ]);
-    expect(spawnEnvs.at(0)?.OPENAI_API_KEY).toBe('OPENAI_API_KEY');
+    expect(forwardedCredentials).toEqual([
+      {
+        credential: 'OPENAI_API_KEY',
+        environmentVariableName: 'OPENAI_API_KEY',
+      },
+    ]);
+    expect(spawnEnvs.at(0)?.OPENAI_API_KEY).toBe('ephemeral-OPENAI_API_KEY');
+    expect(JSON.stringify(spawnEnvs.at(0))).not.toContain('openai-secret');
+
+    await session.doDetach();
+  });
+
+  it('customizes real credentials when request transformations are unavailable', async () => {
+    harnessUtilsMocks.waitForBridgeReady.mockResolvedValueOnce({ port: 4000 });
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const forwardedCredentials: Array<{
+      credential: string;
+      environmentVariableName: string;
+    }> = [];
+    const emptyStream = () =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      });
+    const sandbox = {
+      async run({ command }: { command: string }) {
+        return command === 'printf "%s" "$HOME"'
+          ? { exitCode: 0, stdout: '/home/vercel-sandbox', stderr: '' }
+          : { exitCode: 0, stdout: '', stderr: '' };
+      },
+      async readTextFile() {
+        return null;
+      },
+      async spawn({ env }: { env: Record<string, string | undefined> }) {
+        spawnEnvs.push(env);
+        return {
+          stdout: emptyStream(),
+          stderr: emptyStream(),
+          async wait() {},
+          async kill() {},
+        };
+      },
+    };
+    const sandboxSession = {
+      id: 'test-sandbox',
+      defaultWorkingDirectory: '/workspace',
+      restricted: () => sandbox,
+      ports: [4000] as ReadonlyArray<number>,
+      async getPortEndpoint() {
+        return { url: 'ws://sandbox.example' };
+      },
+      async getPortUrl() {
+        return 'ws://sandbox.example';
+      },
+      async stop() {},
+    } as unknown as HarnessV1NetworkSandboxSession;
+    const harness = createOpenCode({
+      provider: 'openai',
+      auth: { openai: { apiKey: 'openai-secret' } },
+      credentialForwarding: options => {
+        forwardedCredentials.push(options);
+        return 'caller-managed-credential';
+      },
+    });
+
+    const session = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession,
+      sessionWorkDir: '/workspace/project',
+    });
+
+    expect(forwardedCredentials).toEqual([
+      {
+        credential: 'openai-secret',
+        environmentVariableName: 'OPENAI_API_KEY',
+      },
+    ]);
+    expect(spawnEnvs.at(0)?.OPENAI_API_KEY).toBe('caller-managed-credential');
     expect(JSON.stringify(spawnEnvs.at(0))).not.toContain('openai-secret');
 
     await session.doDetach();

--- a/packages/harness-opencode/src/opencode-harness.ts
+++ b/packages/harness-opencode/src/opencode-harness.ts
@@ -8,6 +8,7 @@ import {
   type HarnessV1BuiltinTool,
   type HarnessV1BuiltinToolFiltering,
   type HarnessV1ContinueTurnState,
+  type HarnessV1CredentialForwarding,
   type HarnessV1DebugConfig,
   type HarnessV1NetworkSandboxSession,
   type HarnessV1PermissionMode,
@@ -20,6 +21,7 @@ import {
   type HarnessV1StreamPart,
 } from '@ai-sdk/harness';
 import {
+  applyCredentialForwarding,
   classifyDiskLog,
   experimental_createBridgeUserMessageSubmitter,
   createBridgeErrorHandler,
@@ -78,6 +80,12 @@ const OPENCODE_CLIENT_APP = `ai-sdk/harness-opencode/${VERSION}`;
 
 export type OpenCodeHarnessSettings = {
   readonly auth?: OpenCodeAuthOptions;
+  /**
+   * Customizes each credential value before it is forwarded into a sandbox
+   * process. This does not restrict which credentials the harness adapter can
+   * discover, read, or otherwise access in the host process.
+   */
+  readonly credentialForwarding?: HarnessV1CredentialForwarding;
   /**
    * MCP server definitions keyed by server name. Each definition uses the
    * underlying runtime's native MCP server configuration format.
@@ -426,8 +434,14 @@ export function createOpenCode(
               abortSignal: startOpts.abortSignal,
             })
           : undefined;
+      const forwardedAuthEnvironment = await applyCredentialForwarding({
+        environment: sandboxAuthEnvironment,
+        credentialEnvironmentVariables:
+          OPENCODE_CREDENTIAL_ENVIRONMENT_VARIABLES,
+        credentialForwarding: settings.credentialForwarding,
+      });
       const env = {
-        ...sandboxAuthEnvironment,
+        ...forwardedAuthEnvironment,
         AI_SDK_HARNESS_CLIENT_APP: OPENCODE_CLIENT_APP,
         BRIDGE_CHANNEL_TOKEN: token,
         BRIDGE_WS_PORT: String(port),

--- a/packages/harness/src/utils/credential-forwarding.test.ts
+++ b/packages/harness/src/utils/credential-forwarding.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { applyCredentialForwarding } from './credential-forwarding';
+
+describe('applyCredentialForwarding', () => {
+  it('preserves the environment when no callback is provided', async () => {
+    const environment = {
+      API_KEY: 'real-secret',
+      BASE_URL: 'https://api.example.com',
+    };
+
+    await expect(
+      applyCredentialForwarding({
+        environment,
+        credentialEnvironmentVariables: ['API_KEY'],
+        credentialForwarding: undefined,
+      }),
+    ).resolves.toEqual(environment);
+    expect(environment).toEqual({
+      API_KEY: 'real-secret',
+      BASE_URL: 'https://api.example.com',
+    });
+  });
+
+  it('forwards each present credential separately', async () => {
+    const credentialForwarding = vi.fn(
+      async ({
+        environmentVariableName,
+      }: {
+        environmentVariableName: string;
+      }) => `ephemeral-${environmentVariableName}`,
+    );
+
+    await expect(
+      applyCredentialForwarding({
+        environment: {
+          API_KEY: 'real-secret',
+          SECOND_API_KEY: 'SECOND_API_KEY',
+          BASE_URL: 'https://api.example.com',
+        },
+        credentialEnvironmentVariables: [
+          'API_KEY',
+          'SECOND_API_KEY',
+          'API_KEY',
+          'MISSING_API_KEY',
+        ],
+        credentialForwarding,
+      }),
+    ).resolves.toEqual({
+      API_KEY: 'ephemeral-API_KEY',
+      SECOND_API_KEY: 'ephemeral-SECOND_API_KEY',
+      BASE_URL: 'https://api.example.com',
+    });
+    expect(credentialForwarding).toHaveBeenNthCalledWith(1, {
+      credential: 'real-secret',
+      environmentVariableName: 'API_KEY',
+    });
+    expect(credentialForwarding).toHaveBeenNthCalledWith(2, {
+      credential: 'SECOND_API_KEY',
+      environmentVariableName: 'SECOND_API_KEY',
+    });
+    expect(credentialForwarding).toHaveBeenCalledTimes(2);
+  });
+
+  it('supports synchronous callbacks', async () => {
+    await expect(
+      applyCredentialForwarding({
+        environment: { API_KEY: 'real-secret' },
+        credentialEnvironmentVariables: ['API_KEY'],
+        credentialForwarding: ({ credential }) => `wrapped-${credential}`,
+      }),
+    ).resolves.toEqual({ API_KEY: 'wrapped-real-secret' });
+  });
+
+  it('propagates callback errors without using the original credential', async () => {
+    await expect(
+      applyCredentialForwarding({
+        environment: { API_KEY: 'real-secret' },
+        credentialEnvironmentVariables: ['API_KEY'],
+        credentialForwarding: async () => {
+          throw new Error('credential forwarding failed');
+        },
+      }),
+    ).rejects.toThrow('credential forwarding failed');
+  });
+});

--- a/packages/harness/src/utils/credential-forwarding.ts
+++ b/packages/harness/src/utils/credential-forwarding.ts
@@ -1,0 +1,28 @@
+import type { HarnessV1CredentialForwarding } from '../v1';
+
+export async function applyCredentialForwarding({
+  environment,
+  credentialEnvironmentVariables,
+  credentialForwarding,
+}: {
+  environment: Readonly<Record<string, string>>;
+  credentialEnvironmentVariables: ReadonlyArray<string>;
+  credentialForwarding: HarnessV1CredentialForwarding | undefined;
+}): Promise<Record<string, string>> {
+  const forwardedEnvironment = { ...environment };
+  if (credentialForwarding == null) return forwardedEnvironment;
+
+  for (const environmentVariableName of new Set(
+    credentialEnvironmentVariables,
+  )) {
+    const credential = forwardedEnvironment[environmentVariableName];
+    if (credential == null) continue;
+
+    forwardedEnvironment[environmentVariableName] = await credentialForwarding({
+      credential,
+      environmentVariableName,
+    });
+  }
+
+  return forwardedEnvironment;
+}

--- a/packages/harness/src/utils/index.ts
+++ b/packages/harness/src/utils/index.ts
@@ -12,6 +12,7 @@ export {
 } from './bridge-user-message-submitter';
 export { classifyDiskLog, type DiskLogRecoveryMode } from './classify-disk-log';
 export { getAiGatewayAuthFromEnv } from './ai-gateway-auth';
+export { applyCredentialForwarding } from './credential-forwarding';
 export {
   createCredentialRequestTransformation,
   maskSandboxCredentials,

--- a/packages/harness/src/v1/harness-v1-credential-forwarding.ts
+++ b/packages/harness/src/v1/harness-v1-credential-forwarding.ts
@@ -1,0 +1,17 @@
+/**
+ * Customizes a credential value immediately before a harness adapter forwards
+ * it into a sandbox process.
+ *
+ * This callback only controls the value exposed to sandbox processes. It does
+ * not restrict which credentials the harness adapter can discover, read, or
+ * otherwise access in the host process.
+ */
+export type HarnessV1CredentialForwarding = (options: {
+  /**
+   * The credential value that the adapter would otherwise forward (either the
+   * real credential or a masked value).
+   */
+  readonly credential: string;
+  /** The environment variable name used to expose the value in the sandbox. */
+  readonly environmentVariableName: string;
+}) => string | PromiseLike<string>;

--- a/packages/harness/src/v1/index.ts
+++ b/packages/harness/src/v1/index.ts
@@ -1,4 +1,5 @@
 export type { HarnessV1 } from './harness-v1';
+export type { HarnessV1CredentialForwarding } from './harness-v1-credential-forwarding';
 export type {
   HarnessV1Bootstrap,
   HarnessV1BootstrapCommand,


### PR DESCRIPTION
## Background

Applications that broker credentials outside `HarnessAgent` need control over the credential values forwarded into bridge-backed sandbox processes, including the ability to substitute ephemeral values.

## Summary

- Add an optional `credentialForwarding` callback that receives each real or masked credential and its final sandbox environment variable name.
- Apply the callback once per forwarded credential across bridge-backed harness adapters, including ACP profile-mapped credentials, while preserving existing behavior when omitted.
- Document the setting and enforce its presence in bridge-backed harness settings with konsistent.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
