### PR TITLE
fix(workflow-harness): avoid suspending completed turns

### DIFF
--- a/.changeset/fuzzy-cats-rest.md
+++ b/.changeset/fuzzy-cats-rest.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow-harness': patch
+---
+
+Prevent time-slice timers from suspending harness turns that have already finished.

--- a/packages/workflow-harness/src/run-harness-agent-slice.test.ts
+++ b/packages/workflow-harness/src/run-harness-agent-slice.test.ts
@@ -312,7 +312,7 @@ describe('runHarnessAgentTimeSlice', () => {
   });
 
   test('completes the time slice: suspends at the budget and carries the cursor forward', async () => {
-    const session = fakeSession();
+    const session = fakeSession({ unfinishedTurn: true });
     const { result, closeForSuspend } = streamResult({
       chunks: [{ type: 'start' }, { type: 'text-delta', id: 't', delta: 'a' }],
       blockAfter: true,
@@ -348,6 +348,47 @@ describe('runHarnessAgentTimeSlice', () => {
     // It must also NOT close the output stream — the next slice keeps writing
     // to the same run stream; closing here would end the response mid-turn.
     expect(isClosed()).toBe(false);
+  });
+
+  test('finishes normally when the turn completes before its UI stream closes at the time-slice deadline', async () => {
+    vi.useFakeTimers();
+    try {
+      const session = fakeSession({ unfinishedTurn: false });
+      const { result, closeForSuspend: closeStream } = streamResult({
+        chunks: [{ type: 'start' }],
+        blockAfter: true,
+      });
+      const agent: HarnessWorkflowAgent = {
+        createSession: vi.fn(async () => session),
+        stream: vi.fn(async () => result),
+        continueStream: vi.fn(async () => result),
+      };
+
+      const { writable, isClosed } = collectingWritable();
+      const runPromise = runHarnessAgentTimeSlice({
+        agent,
+        state: createHarnessWorkflowState({
+          prompt: 'hi',
+          sessionId: 'ses_1',
+        }),
+        timeSliceSeconds: 1,
+        writable,
+      });
+
+      await vi.advanceTimersByTimeAsync(1000);
+      closeStream();
+
+      const next = await runPromise;
+      expect(next.status).toBe('finished');
+      expect(next.resumeFrom).toEqual(resumeState('detached'));
+      expect(session.suspendCalls).toBe(0);
+      expect(session.detachCalls).toBe(1);
+      expect(session.stopCalls).toBe(0);
+      expect(session.destroyCalls).toBe(0);
+      expect(isClosed()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test('mid-turn slice continues (no new prompt) and can finish', async () => {
@@ -390,7 +431,7 @@ describe('runHarnessAgentTimeSlice', () => {
   });
 
   test('continued slice reopens active parts and preserves aggregate token usage', async () => {
-    const firstSession = fakeSession();
+    const firstSession = fakeSession({ unfinishedTurn: true });
     const { result: firstResult, closeForSuspend } = streamResult({
       chunks: [
         { type: 'start' },
@@ -483,7 +524,7 @@ describe('runHarnessAgentTimeSlice', () => {
   });
 
   test('continued slice emits a pending tool input only once across the time-slice boundary', async () => {
-    const firstSession = fakeSession();
+    const firstSession = fakeSession({ unfinishedTurn: true });
     const { result: firstResult, closeForSuspend } = streamResult({
       chunks: [
         { type: 'start' },
@@ -696,7 +737,7 @@ describe('runHarnessAgentStep', () => {
 
 describe('runHarnessAgentSlice', () => {
   test('supports sliceTimeoutSeconds and maps ready_for_next_step to timed_out', async () => {
-    const session = fakeSession();
+    const session = fakeSession({ unfinishedTurn: true });
     const { result, closeForSuspend } = streamResult({
       chunks: [{ type: 'start' }],
       blockAfter: true,

--- a/packages/workflow-harness/src/run-harness-agent.ts
+++ b/packages/workflow-harness/src/run-harness-agent.ts
@@ -156,7 +156,9 @@ export async function runHarnessAgent(
     options.timeSliceSeconds == null
       ? undefined
       : setTimeout(() => {
-          suspendPromise = session.suspendTurn();
+          if (session.hasUnfinishedTurn()) {
+            suspendPromise = session.suspendTurn();
+          }
         }, options.timeSliceSeconds * 1000);
   (timer as { unref?: () => void } | undefined)?.unref?.();
 


### PR DESCRIPTION
## Background

A harness turn can complete just before its workflow time-slice deadline while the corresponding UI message stream is still closing. In that interval, the session has already transitioned its turn state to idle, but the time-slice timer remains active. The unconditional timer callback then calls `session.suspendTurn()`, which rejects because there is no unfinished turn to suspend and causes an otherwise successful workflow execution to fail.

## Summary

- Check `session.hasUnfinishedTurn()` in the time-slice timer before starting suspension.
- Add a deterministic regression test that fires the deadline after the turn becomes idle but before the UI stream closes, then verifies normal completion and session cleanup without a suspension call.
- Mark existing timeout fixtures as having unfinished turns so they model the session lifecycle explicitly.
- Add a patch changeset for `@ai-sdk/workflow-harness`.

The guard and `suspendTurn()` invocation run synchronously in the timer callback, so no additional state or coordination is needed. Direct invalid calls to `suspendTurn()` continue to reject as before.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #19419.
