### PR TITLE
feat(provider/deepseek): complete vision content parts

### DIFF
--- a/.changeset/wise-images-smile.md
+++ b/.changeset/wise-images-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/deepseek': patch
+---
+
+Add DeepSeek image detail and inline file-data content part support.

--- a/content/providers/01-ai-sdk-providers/30-deepseek.mdx
+++ b/content/providers/01-ai-sdk-providers/30-deepseek.mdx
@@ -224,6 +224,47 @@ The metrics include:
 
 ### File Uploads
 
+For inline images or image URLs, use file-part provider options to select the
+image processing detail. DeepSeek supports `low`, `high`, `original`, and
+`auto`:
+
+```ts highlight="2,13-17"
+import {
+  deepSeek,
+  type DeepSeekFilePartProviderOptions,
+} from '@ai-sdk/deepseek';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: deepSeek('deepseek-v4-flash-vision-exp'),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Describe this image.' },
+        {
+          type: 'file',
+          data: new URL('https://example.com/image.webp'),
+          mediaType: 'image/webp',
+          providerOptions: {
+            deepseek: {
+              imageDetail: 'low',
+            } satisfies DeepSeekFilePartProviderOptions,
+          },
+        },
+      ],
+    },
+  ],
+});
+```
+
+Set `fileData: true` on an inline image file part to use DeepSeek's
+`file_data` content-part representation. This preserves the file part's
+`filename`. `fileData` cannot be used with image URLs or `imageDetail`.
+
+DeepSeek accepts JPEG, PNG, GIF, and WebP image inputs. HTTP image URLs can be
+at most 8,192 characters.
+
 You can upload images using the [DeepSeek Files API](https://api-docs.deepseek.com/guides/files_api) and pass the returned provider reference to `deepseek-v4-flash-vision-exp`. This avoids sending the image bytes again in each request.
 
 ```ts

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
@@ -125,6 +125,164 @@ describe('convertToDeepSeekChatMessages', () => {
       `);
     });
 
+    it('should pass imageDetail to image URL content parts', async () => {
+      const result = await convertToDeepSeekChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                data: {
+                  type: 'url' as const,
+                  url: new URL('https://example.com/image.webp'),
+                },
+                mediaType: 'image/webp',
+                providerOptions: {
+                  deepseek: { imageDetail: 'low' },
+                },
+              },
+            ],
+          },
+        ],
+        responseFormat: undefined,
+        modelId: 'deepseek-v4-flash-vision-exp',
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image_url',
+              image_url: {
+                url: 'https://example.com/image.webp',
+                detail: 'low',
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should convert inline image data to file_data and preserve its filename', async () => {
+      const result = await convertToDeepSeekChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                data: {
+                  type: 'data' as const,
+                  data: new Uint8Array([0, 1, 2, 3]),
+                },
+                filename: 'sample.jpg',
+                mediaType: 'image/jpg',
+                providerOptions: {
+                  deepseek: { fileData: true },
+                },
+              },
+            ],
+          },
+        ],
+        responseFormat: undefined,
+        modelId: 'deepseek-v4-flash-vision-exp',
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              file_data: 'data:image/jpeg;base64,AAECAw==',
+              filename: 'sample.jpg',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should reject imageDetail together with fileData', async () => {
+      await expect(
+        convertToDeepSeekChatMessages({
+          prompt: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'file',
+                  data: {
+                    type: 'data' as const,
+                    data: new Uint8Array([0, 1, 2, 3]),
+                  },
+                  mediaType: 'image/png',
+                  providerOptions: {
+                    deepseek: { fileData: true, imageDetail: 'high' },
+                  },
+                },
+              ],
+            },
+          ],
+          responseFormat: undefined,
+          modelId: 'deepseek-v4-flash-vision-exp',
+        }),
+      ).rejects.toThrow(
+        'DeepSeek `imageDetail` cannot be combined with `fileData`.',
+      );
+    });
+
+    it('should reject image URLs longer than 8192 characters', async () => {
+      await expect(
+        convertToDeepSeekChatMessages({
+          prompt: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'file',
+                  data: {
+                    type: 'url' as const,
+                    url: new URL(`https://example.com/${'a'.repeat(8192)}`),
+                  },
+                  mediaType: 'image/png',
+                },
+              ],
+            },
+          ],
+          responseFormat: undefined,
+          modelId: 'deepseek-v4-flash-vision-exp',
+        }),
+      ).rejects.toThrow('DeepSeek image URLs must not exceed 8192 characters.');
+    });
+
+    it('should reject unsupported image formats', async () => {
+      await expect(
+        convertToDeepSeekChatMessages({
+          prompt: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'file',
+                  data: {
+                    type: 'data' as const,
+                    data: new Uint8Array([0, 1, 2, 3]),
+                  },
+                  mediaType: 'image/svg+xml',
+                },
+              ],
+            },
+          ],
+          responseFormat: undefined,
+          modelId: 'deepseek-v4-flash-vision-exp',
+        }),
+      ).rejects.toThrow(
+        'DeepSeek supports JPEG, PNG, GIF, and WebP image inputs.',
+      );
+    });
+
     it('should convert an image provider reference to a file content part', async () => {
       const result = await convertToDeepSeekChatMessages({
         prompt: [

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -16,7 +16,16 @@ import type {
   DeepSeekChatPrompt,
   DeepSeekContentPart,
 } from './deepseek-chat-api-types';
+import { deepseekFilePartProviderOptions } from './deepseek-file-part-options';
 import { deepseekAssistantMessageProviderOptions } from './deepseek-chat-language-model-options';
+
+const supportedImageMediaTypes = new Set([
+  'image/gif',
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+]);
 
 export async function convertToDeepSeekChatMessages({
   prompt,
@@ -130,6 +139,12 @@ export async function convertToDeepSeekChatMessages({
             part.type === 'file' &&
             getTopLevelMediaType(part.mediaType) === 'image'
           ) {
+            const filePartOptions = await parseProviderOptions({
+              provider: providerOptionsName,
+              providerOptions: part.providerOptions,
+              schema: deepseekFilePartProviderOptions,
+            });
+
             if (part.data.type === 'reference') {
               userContent.push({
                 type: 'file',
@@ -139,15 +154,77 @@ export async function convertToDeepSeekChatMessages({
                 }),
               });
             } else if (part.data.type === 'url' || part.data.type === 'data') {
-              userContent.push({
-                type: 'image_url',
-                image_url: {
-                  url:
-                    part.data.type === 'url'
-                      ? part.data.url.toString()
-                      : `data:${resolveFullMediaType({ part })};base64,${convertToBase64(part.data.data)}`,
-                },
-              });
+              const resolvedMediaType = resolveFullMediaType({ part });
+
+              if (!supportedImageMediaTypes.has(resolvedMediaType)) {
+                throw new UnsupportedFunctionalityError({
+                  functionality: `DeepSeek image media type ${resolvedMediaType}`,
+                  message:
+                    'DeepSeek supports JPEG, PNG, GIF, and WebP image inputs.',
+                });
+              }
+
+              if (part.data.type === 'url') {
+                const url = part.data.url.toString();
+
+                if (url.length > 8192) {
+                  throw new InvalidPromptError({
+                    prompt,
+                    message:
+                      'DeepSeek image URLs must not exceed 8192 characters.',
+                  });
+                }
+
+                if (filePartOptions?.fileData === true) {
+                  throw new InvalidPromptError({
+                    prompt,
+                    message:
+                      'DeepSeek `fileData` image parts require inline data, not a URL.',
+                  });
+                }
+
+                userContent.push({
+                  type: 'image_url',
+                  image_url: {
+                    url,
+                    ...(filePartOptions?.imageDetail != null && {
+                      detail: filePartOptions.imageDetail,
+                    }),
+                  },
+                });
+              } else {
+                const dataUrl = `data:${
+                  resolvedMediaType === 'image/jpg'
+                    ? 'image/jpeg'
+                    : resolvedMediaType
+                };base64,${convertToBase64(part.data.data)}`;
+
+                if (filePartOptions?.fileData === true) {
+                  if (filePartOptions.imageDetail != null) {
+                    throw new InvalidPromptError({
+                      prompt,
+                      message:
+                        'DeepSeek `imageDetail` cannot be combined with `fileData`.',
+                    });
+                  }
+
+                  userContent.push({
+                    type: 'file',
+                    file_data: dataUrl,
+                    ...(part.filename != null && { filename: part.filename }),
+                  });
+                } else {
+                  userContent.push({
+                    type: 'image_url',
+                    image_url: {
+                      url: dataUrl,
+                      ...(filePartOptions?.imageDetail != null && {
+                        detail: filePartOptions.imageDetail,
+                      }),
+                    },
+                  });
+                }
+              }
             } else {
               warnings.push({
                 type: 'unsupported',

--- a/packages/deepseek/src/chat/deepseek-chat-api-types.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-api-types.ts
@@ -31,13 +31,22 @@ export interface DeepSeekContentPartText {
 
 export interface DeepSeekContentPartImage {
   type: 'image_url';
-  image_url: { url: string };
+  image_url: {
+    url: string;
+    detail?: 'low' | 'high' | 'original' | 'auto';
+  };
 }
 
-export interface DeepSeekContentPartFile {
-  type: 'file';
-  file_id: string;
-}
+export type DeepSeekContentPartFile =
+  | {
+      type: 'file';
+      file_id: string;
+    }
+  | {
+      type: 'file';
+      file_data: string;
+      filename?: string;
+    };
 
 export interface DeepSeekAssistantMessage {
   role: 'assistant';

--- a/packages/deepseek/src/chat/deepseek-file-part-options.test-d.ts
+++ b/packages/deepseek/src/chat/deepseek-file-part-options.test-d.ts
@@ -1,0 +1,19 @@
+import { expectTypeOf, it } from 'vitest';
+import type { DeepSeekFilePartProviderOptions } from '../index';
+
+it('should type DeepSeek file part options', () => {
+  const options = {
+    imageDetail: 'original',
+  } satisfies DeepSeekFilePartProviderOptions;
+
+  expectTypeOf(options.imageDetail).toEqualTypeOf<'original'>();
+});
+
+it('should only accept true for fileData', () => {
+  const options = {
+    // @ts-expect-error - fileData only enables the alternate content part
+    fileData: false,
+  } satisfies DeepSeekFilePartProviderOptions;
+
+  expectTypeOf(options.fileData).toEqualTypeOf<false>();
+});

--- a/packages/deepseek/src/chat/deepseek-file-part-options.ts
+++ b/packages/deepseek/src/chat/deepseek-file-part-options.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod/v4';
+
+export const deepseekFilePartProviderOptions = z.object({
+  /**
+   * Controls how DeepSeek processes an image sent as an `image_url` part.
+   *
+   * @see https://api-docs.deepseek.com/api/create-chat-completion/
+   */
+  imageDetail: z.enum(['low', 'high', 'original', 'auto']).optional(),
+
+  /**
+   * Sends inline image data as a DeepSeek `file` part using `file_data`
+   * instead of an `image_url` data URL. When set, the file part's filename
+   * is preserved.
+   *
+   * This option only applies to inline image data. It cannot be combined
+   * with `imageDetail`.
+   */
+  fileData: z.literal(true).optional(),
+});
+
+export type DeepSeekFilePartProviderOptions = z.infer<
+  typeof deepseekFilePartProviderOptions
+>;

--- a/packages/deepseek/src/index.ts
+++ b/packages/deepseek/src/index.ts
@@ -18,4 +18,5 @@ export type {
   DeepSeekLanguageModelChatOptions as DeepSeekChatOptions,
 } from './chat/deepseek-chat-language-model-options';
 export type { DeepSeekErrorData } from './chat/deepseek-chat-api-types';
+export type { DeepSeekFilePartProviderOptions } from './chat/deepseek-file-part-options';
 export type { DeepSeekFilesOptions } from './files/deepseek-files-options';


### PR DESCRIPTION
## Background

DeepSeek's Chat Completions schema supports image processing detail and inline `file_data` content parts, but the provider only emitted `image_url.url` or an uploaded `file_id`.

## Summary

- add typed `imageDetail` support for `low`, `high`, `original`, and `auto`
- add an opt-in `fileData: true` representation for inline image bytes and preserve filenames
- validate the documented JPEG/PNG/GIF/WebP formats and 8,192-character HTTP URL limit
- keep the existing `image_url` behavior as the default

## Contributor Credit

Implemented by @gr2m with Codex.

## End-to-End Verification

- `pnpm --filter @ai-sdk/deepseek... build`
- `pnpm --filter @ai-sdk/deepseek test:node` — 76 tests passed
- `pnpm --filter @ai-sdk/deepseek test:edge` — 76 tests passed
- `pnpm --filter @ai-sdk/deepseek type-check`
- focused Ultracite check and `git diff --check`

## Checklist

- [x] Signed commit
- [x] Tests added/updated
- [x] Documentation updated
- [x] Patch changeset added
- [x] Self-reviewed

## Related Issues

Fixes #19384