### PR TITLE
fix(mcp): support shell option in stdio and extract error response bo…

### DIFF
--- a/.changeset/mcp-transport-error-and-shell-options.md
+++ b/.changeset/mcp-transport-error-and-shell-options.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+fix(mcp): support shell option in stdio transport and extract response body in SSE transport errors

--- a/packages/mcp/src/tool/mcp-sse-transport.test.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.test.ts
@@ -72,7 +72,17 @@ describe('SseMCPTransport', () => {
       body: 'Internal Server Error',
     };
 
-    await expect(transport.start()).rejects.toThrow();
+    let caughtError: MCPClientError | undefined;
+    try {
+      await transport.start();
+    } catch (error) {
+      caughtError = error as MCPClientError;
+    }
+
+    expect(caughtError).toBeInstanceOf(MCPClientError);
+    expect(caughtError?.statusCode).toBe(500);
+    expect(caughtError?.url).toBe('http://localhost:3000/sse');
+    expect(caughtError?.responseBody).toBe('Internal Server Error');
   });
 
   it('should handle valid JSON-RPC messages', async () => {

--- a/packages/mcp/src/tool/mcp-sse-transport.ts
+++ b/packages/mcp/src/tool/mcp-sse-transport.ts
@@ -130,7 +130,8 @@ export class SseMCPTransport implements MCPTransport {
           }
 
           if (!response.ok || !response.body) {
-            let errorMessage = `MCP SSE Transport Error: ${response.status} ${response.statusText}`;
+            const text = await response.text().catch(() => null);
+            let errorMessage = `MCP SSE Transport Error: ${response.status} ${response.statusText}${text ? `: ${text}` : ''}`;
 
             if (response.status === 405) {
               errorMessage +=
@@ -139,6 +140,9 @@ export class SseMCPTransport implements MCPTransport {
 
             const error = new MCPClientError({
               message: errorMessage,
+              statusCode: response.status,
+              url: this.url.href,
+              responseBody: text ?? undefined,
             });
             this.onerror?.(error);
             return reject(error);

--- a/packages/mcp/src/tool/mcp-stdio/create-child-process.test.ts
+++ b/packages/mcp/src/tool/mcp-stdio/create-child-process.test.ts
@@ -96,6 +96,16 @@ describe('createChildProcess', () => {
     childProcessWithStderr.kill();
   });
 
+  it('should spawn a child process with custom shell option', async () => {
+    const childProcessWithShell = createChildProcess(
+      { command: process.execPath, shell: true },
+      new AbortController().signal,
+    );
+
+    expect(childProcessWithShell.pid).toBeDefined();
+    childProcessWithShell.kill();
+  });
+
   it.runIf(process.platform === 'win32')(
     'should spawn npx on Windows',
     async () => {

--- a/packages/mcp/src/tool/mcp-stdio/create-child-process.ts
+++ b/packages/mcp/src/tool/mcp-stdio/create-child-process.ts
@@ -19,7 +19,7 @@ export function createChildProcess(
   return spawn(config.command, config.args ?? [], {
     env: getEnvironment(config.env),
     stdio: ['pipe', 'pipe', config.stderr ?? 'inherit'],
-    shell: false,
+    shell: config.shell ?? false,
     signal,
     windowsHide: globalThis.process.platform === 'win32' && isElectron(),
     cwd: config.cwd,

--- a/packages/mcp/src/tool/mcp-stdio/mcp-stdio-transport.ts
+++ b/packages/mcp/src/tool/mcp-stdio/mcp-stdio-transport.ts
@@ -11,6 +11,7 @@ export interface StdioConfig {
   env?: Record<string, string>;
   stderr?: IOType | Stream | number;
   cwd?: string;
+  shell?: boolean | string;
 }
 
 export class StdioMCPTransport implements MCPTransport {


### PR DESCRIPTION
## Background

1. In `@ai-sdk/mcp`, `createChildProcess` had `shell: false` hardcoded without exposing a `shell` configuration in `StdioConfig`. This prevented running command shims and custom shell wrappers in environments requiring shell execution (such as Windows `npx` shims and `.cmd` tools).
2. During SSE connection initialization in `SseMCPTransport.start()`, when a server returned a non-2xx HTTP response (e.g. `401`, `403`, `404`, `500`), the response body was discarded and `statusCode`, `url`, and `responseBody` were not populated on `MCPClientError`.

## Summary

- Added `shell?: boolean | string` to `StdioConfig` and forwarded it to `spawn` in `createChildProcess`.
- Updated `SseMCPTransport.start()` to extract the response text body and attach `statusCode`, `url`, and `responseBody` to `MCPClientError`.
- Added unit tests in `create-child-process.test.ts` and `mcp-sse-transport.test.ts`.
- Added patch changeset for `@ai-sdk/mcp`.

## End-to-End Verification

- Ran vitest unit test suite across `@ai-sdk/mcp`: 12/12 test files passed, 287/287 tests passed.
- Verified lint rules via `oxlint`: 0 warnings, 0 errors.
- Verified formatting via `oxfmt`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
