### PR TITLE
[v5.0] fix: allow AI SDK packages to import in runtimes without global fetch

### DIFF
--- a/.changeset/calm-fetches-import.md
+++ b/.changeset/calm-fetches-import.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/provider-utils": patch
+---
+
+fix(provider-utils): allow imports in runtimes without a global fetch function

--- a/packages/provider-utils/src/safe-node-fetch.test.ts
+++ b/packages/provider-utils/src/safe-node-fetch.test.ts
@@ -8,6 +8,19 @@ import {
 
 type Address = { address: string; family: number };
 
+describe('module initialization', () => {
+  it('succeeds when the global fetch function is unavailable', async () => {
+    vi.resetModules();
+    vi.stubGlobal('fetch', undefined);
+
+    try {
+      await expect(import('./safe-node-fetch')).resolves.toBeDefined();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
 function createLookup(addresses: Address[]) {
   const lookup = vi.fn((_hostname, options, callback) => {
     callback(null, addresses);

--- a/packages/provider-utils/src/safe-node-fetch.ts
+++ b/packages/provider-utils/src/safe-node-fetch.ts
@@ -131,7 +131,11 @@ export async function getDefaultDownloadFetch(): Promise<FetchFunction> {
   return (safeNodeFetchPromise ??= createSafeNodeFetch());
 }
 
-function isNodeDefaultFetch(fetch: FetchFunction): boolean {
+function isNodeDefaultFetch(fetch: unknown): boolean {
+  if (typeof fetch !== 'function') {
+    return false;
+  }
+
   const source = Function.prototype.toString.call(fetch);
   return (
     source.includes('internal/deps/undici') ||


### PR DESCRIPTION
## Background

Backports #18535 to AI SDK v5. The provider-utils 3.x release line has the same module-evaluation crash reported in #19421 and reproduced in #19433.

## Summary

- guards Node default-fetch detection when global fetch is absent or non-callable
- preserves the existing safe-fetch path for callable Node fetch implementations
- adds the main-branch regression test and a patch changeset for provider-utils

## Testing

- pnpm --filter @ai-sdk/provider build
- pnpm --filter @ai-sdk/provider-utils build
- pnpm --filter @ai-sdk/provider-utils type-check
- pnpm --filter @ai-sdk/provider-utils test — 54 files and 454 tests passed in both Node and Edge
- fetch-less import smoke test passed against the built provider-utils package
- pnpm check
- pnpm type-check:full reports existing React type incompatibilities in examples; provider-utils type-check passes and no errors reference the changed files

## Related Issues

Addresses #19421

Backports #18535

Reproduction: #19433