### PR TITLE
feat(alibaba): support wan3 all-in-one video generation

### DIFF
--- a/.changeset/alibaba-wan3-video.md
+++ b/.changeset/alibaba-wan3-video.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/alibaba': patch
+---
+
+feat(provider/alibaba): support wan3 all-in-one video generation

--- a/examples/ai-functions/src/generate-video/alibaba/wan3.0-first-last-frame.ts
+++ b/examples/ai-functions/src/generate-video/alibaba/wan3.0-first-last-frame.ts
@@ -1,0 +1,41 @@
+import { alibaba, type AlibabaVideoModelOptions } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+// wan3 is the first Wan model with a real last_frame slot. Both frames go
+// into input.media; older Wan models warn and drop last_frame.
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating first-to-last-frame video with wan3.0-video...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan3.0-video'),
+        prompt:
+          'The scene starts on the opening frame and ends on the closing frame',
+        resolution: '1280x720',
+        duration: 5,
+        frameImages: [
+          {
+            frameType: 'first_frame',
+            image:
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+          },
+          {
+            frameType: 'last_frame',
+            image:
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-dog.png',
+          },
+        ],
+        providerOptions: {
+          alibaba: {
+            ratio: 'adaptive',
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/alibaba/wan3.0-i2v.ts
+++ b/examples/ai-functions/src/generate-video/alibaba/wan3.0-i2v.ts
@@ -1,0 +1,33 @@
+import { alibaba, type AlibabaVideoModelOptions } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+// wan3 has no -i2v id. A start image on the request becomes input.media
+// first_frame and switches the generation into image-to-video.
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating image-to-video with wan3.0-video...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan3.0-video'),
+        prompt: {
+          image:
+            'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+          text: 'The cat slowly turns its head and blinks',
+        },
+        resolution: '1280x720',
+        duration: 5,
+        generateAudio: true,
+        providerOptions: {
+          alibaba: {
+            ratio: 'adaptive',
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/alibaba/wan3.0-r2v.ts
+++ b/examples/ai-functions/src/generate-video/alibaba/wan3.0-r2v.ts
@@ -1,0 +1,32 @@
+import { alibaba, type AlibabaVideoModelOptions } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+// wan3 has no -r2v id. inputReferences become input.media reference_image /
+// reference_video items, referenced in the prompt as Image 1, Image 2, etc.
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating reference-to-video with wan3.0-video...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan3.0-video'),
+        prompt: 'Image 1 and Image 2 have a conversation in a cozy cafe',
+        resolution: '1920x1080',
+        duration: 6,
+        inputReferences: [
+          'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+          'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-dog.png',
+        ],
+        providerOptions: {
+          alibaba: {
+            ratio: '16:9',
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/alibaba/wan3.0-reference-voice.ts
+++ b/examples/ai-functions/src/generate-video/alibaba/wan3.0-reference-voice.ts
@@ -1,0 +1,43 @@
+import { alibaba, type AlibabaVideoModelOptions } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+// referenceVoice sets a character's voice from an audio clip (wav/mp3).
+// It does not determine the spoken content, which comes from the prompt.
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating reference-to-video with voice references (wan3.0-video)...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan3.0-video'),
+        prompt:
+          'Image 1 and Video 1 stand side by side and introduce themselves to the camera',
+        resolution: '1920x1080',
+        duration: 6,
+        providerOptions: {
+          alibaba: {
+            media: [
+              {
+                type: 'reference_image',
+                url: 'https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20260408/sjuytr/wan-r2v-object-girl.jpg',
+                referenceVoice:
+                  'https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20260408/gbqewz/wan-r2v-girl-voice.mp3',
+              },
+              {
+                type: 'reference_video',
+                url: 'https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20260129/qigswt/wan-r2v-role2.mp4',
+                referenceVoice:
+                  'https://help-static-aliyun-doc.aliyuncs.com/file-manage-files/zh-CN/20260408/isllrq/wan-r2v-boy-voice.mp3',
+              },
+            ],
+            ratio: '16:9',
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/alibaba/wan3.0-t2v.ts
+++ b/examples/ai-functions/src/generate-video/alibaba/wan3.0-t2v.ts
@@ -1,0 +1,29 @@
+import { alibaba, type AlibabaVideoModelOptions } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating text-to-video with wan3.0-video...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan3.0-video'),
+        prompt:
+          'A chicken flying into the sunset in the style of 90s anime. ' +
+          'The camera slowly pans up as the sky turns gold.',
+        resolution: '1920x1080',
+        aspectRatio: '16:9',
+        duration: 5,
+        generateAudio: true,
+        providerOptions: {
+          alibaba: {
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/examples/ai-functions/src/generate-video/alibaba/wan3.0-video.ts
+++ b/examples/ai-functions/src/generate-video/alibaba/wan3.0-video.ts
@@ -1,0 +1,43 @@
+import { alibaba, type AlibabaVideoModelOptions } from '@ai-sdk/alibaba';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+// wan3 serves every mode from one model id, so the media on the request — not a
+// `-i2v`/`-r2v` suffix — decides what gets generated. This one combines both
+// frames with references, and lets the model pick the duration (`-1`).
+run(async () => {
+  const { video } = await withSpinner(
+    'Generating video with wan3.0-video...',
+    () =>
+      generateVideo({
+        model: alibaba.video('wan3.0-video'),
+        prompt:
+          'Image 1 walks toward Image 2 across a cozy cafe, ending on the closing frame',
+        resolution: '1920x1080',
+        duration: -1, // smart duration: the model picks, up to 30s
+        generateAudio: true,
+        frameImages: [
+          {
+            frameType: 'first_frame',
+            image:
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+          },
+          {
+            frameType: 'last_frame',
+            image:
+              'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-dog.png',
+          },
+        ],
+        providerOptions: {
+          alibaba: {
+            ratio: 'adaptive',
+            pollTimeoutMs: 600000, // 10 minutes
+          } satisfies AlibabaVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos([video]);
+});

--- a/packages/alibaba/src/alibaba-video-model-options.ts
+++ b/packages/alibaba/src/alibaba-video-model-options.ts
@@ -16,8 +16,8 @@ export type AlibabaVideoModelOptions = {
   /** Whether to add watermark to generated video. Defaults to false. */
   watermark?: boolean | null;
   /**
-   * Enable audio generation (for wan2.6 I2V/R2V models;
-   * wan2.7 models always generate audio).
+   * Enable audio generation (wan2.6 I2V/R2V and wan3 models;
+   * wan2.7 models always generate audio). Defaults to true on wan3.
    */
   audio?: boolean | null;
   /**
@@ -27,22 +27,34 @@ export type AlibabaVideoModelOptions = {
    */
   referenceUrls?: string[] | null;
   /**
-   * Explicit media array for reference-to-video mode (wan2.7 models).
-   * Overrides the automatic mapping from `inputReferences` and `frameImages`.
+   * Explicit media array (wan2.7 and wan3 models). Overrides the automatic
+   * mapping from `inputReferences` and `frameImages`.
    * Use `Image 1`, `Video 1`, etc. in prompts to reference media items
-   * (images and videos are counted separately, in array order).
+   * (images, videos, and audio are counted separately, in array order).
+   *
+   * `reference_audio`, `file`, and `link` are wan3-only and have no top-level
+   * call option, so they can only be passed here. wan3 also rejects mixing
+   * `reference_*`/`file`/`link` with `first_frame`/`last_frame`.
    */
   media?: Array<{
-    type: 'reference_image' | 'reference_video' | 'first_frame';
+    type:
+      | 'reference_image'
+      | 'reference_video'
+      | 'reference_audio'
+      | 'first_frame'
+      | 'last_frame'
+      | 'file'
+      | 'link';
     /** Public URL, or a `data:{mime};base64,{data}` URI for images. */
     url: string;
     /** URL to an audio file used as voice reference for this media item. */
     referenceVoice?: string | null;
   }> | null;
   /**
-   * Aspect ratio (wan2.7 text-to-video and reference-to-video models).
+   * Aspect ratio (wan2.7 text-to-video and reference-to-video models, and
+   * every wan3 generation). `adaptive` is wan3-only, and is its default.
    */
-  ratio?: '16:9' | '9:16' | '1:1' | '4:3' | '3:4' | null;
+  ratio?: 'adaptive' | '16:9' | '9:16' | '1:1' | '4:3' | '3:4' | null;
   /** Polling interval in milliseconds. Defaults to 5000 (5 seconds). */
   pollIntervalMs?: number | null;
   /** Maximum wait time in milliseconds for video generation. Defaults to 600000 (10 minutes). */
@@ -63,13 +75,23 @@ export const alibabaVideoModelOptionsSchema = lazySchema(() =>
       media: z
         .array(
           z.object({
-            type: z.enum(['reference_image', 'reference_video', 'first_frame']),
+            type: z.enum([
+              'reference_image',
+              'reference_video',
+              'reference_audio',
+              'first_frame',
+              'last_frame',
+              'file',
+              'link',
+            ]),
             url: z.string(),
             referenceVoice: z.string().nullish(),
           }),
         )
         .nullish(),
-      ratio: z.enum(['16:9', '9:16', '1:1', '4:3', '3:4']).nullish(),
+      ratio: z
+        .enum(['adaptive', '16:9', '9:16', '1:1', '4:3', '3:4'])
+        .nullish(),
       pollIntervalMs: z.number().positive().nullish(),
       pollTimeoutMs: z.number().positive().nullish(),
     }),

--- a/packages/alibaba/src/alibaba-video-model.test.ts
+++ b/packages/alibaba/src/alibaba-video-model.test.ts
@@ -1214,7 +1214,7 @@ describe('AlibabaVideoModel', () => {
 
       expect(result.status).toBe('completed');
       if (result.status === 'completed') {
-        expect(result.providerMetadata.alibaba.usage).toStrictEqual({
+        expect(result.providerMetadata?.alibaba.usage).toStrictEqual({
           duration: 12,
           outputVideoDuration: 8,
           inputVideoDuration: 4,

--- a/packages/alibaba/src/alibaba-video-model.test.ts
+++ b/packages/alibaba/src/alibaba-video-model.test.ts
@@ -550,6 +550,349 @@ describe('AlibabaVideoModel', () => {
           }),
         );
       });
+
+      it('should prefer frameImages first_frame over the legacy image option', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        await model.doStart({
+          ...defaultOptions,
+          image: { type: 'url', url: 'https://example.com/legacy.jpg' },
+          frameImages: [
+            {
+              frameType: 'first_frame',
+              image: { type: 'url', url: 'https://example.com/first.jpg' },
+            },
+          ],
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.input).toMatchObject({
+          media: [
+            { type: 'first_frame', url: 'https://example.com/first.jpg' },
+          ],
+        });
+      });
+
+      it('should send last_frame alone without warning', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        const result = await model.doStart({
+          ...defaultOptions,
+          frameImages: [
+            {
+              frameType: 'last_frame',
+              image: { type: 'url', url: 'https://example.com/last.jpg' },
+            },
+          ],
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.input).toMatchObject({
+          media: [{ type: 'last_frame', url: 'https://example.com/last.jpg' }],
+        });
+        expect(result.warnings).not.toContainEqual(
+          expect.objectContaining({ feature: 'frameImages' }),
+        );
+      });
+
+      it('should combine inputReferences with first and last frames', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        const result = await model.doStart({
+          ...defaultOptions,
+          inputReferences: [
+            { type: 'url', url: 'https://example.com/character.png' },
+            { type: 'url', url: 'https://example.com/role.mp4' },
+          ],
+          frameImages: [
+            {
+              frameType: 'first_frame',
+              image: { type: 'url', url: 'https://example.com/first.jpg' },
+            },
+            {
+              frameType: 'last_frame',
+              image: { type: 'url', url: 'https://example.com/last.jpg' },
+            },
+          ],
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.input).toMatchObject({
+          media: [
+            {
+              type: 'reference_image',
+              url: 'https://example.com/character.png',
+            },
+            { type: 'reference_video', url: 'https://example.com/role.mp4' },
+            { type: 'first_frame', url: 'https://example.com/first.jpg' },
+            { type: 'last_frame', url: 'https://example.com/last.jpg' },
+          ],
+        });
+        expect(result.warnings).not.toContainEqual(
+          expect.objectContaining({ feature: 'frameImages' }),
+        );
+        expect(result.warnings).not.toContainEqual(
+          expect.objectContaining({ feature: 'inputReferences' }),
+        );
+      });
+
+      it.each([
+        ['1280x720', '720P'],
+        ['1920x1080', '1080P'],
+        ['720x1280', '720P'],
+        ['832x480', '480P'],
+      ] as const)(
+        'should map resolution %s to %s',
+        async (resolution, tier) => {
+          const model = createModel({ modelId: 'wan3.0-video' });
+
+          const result = await model.doStart({
+            ...defaultOptions,
+            resolution,
+          });
+
+          const body = await server.calls[0].requestBodyJson;
+          expect(body.parameters).toMatchObject({ resolution: tier });
+          expect(body.parameters).not.toHaveProperty('size');
+          expect(result.warnings).not.toContainEqual(
+            expect.objectContaining({ feature: 'resolution' }),
+          );
+        },
+      );
+
+      it('should derive a supported ratio from the resolution', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        await model.doStart({
+          ...defaultOptions,
+          resolution: '720x1280',
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.parameters).toMatchObject({
+          resolution: '720P',
+          ratio: '9:16',
+        });
+      });
+
+      it('should map aspectRatio, including adaptive, without warning', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        const result = await model.doStart({
+          ...defaultOptions,
+          aspectRatio: 'adaptive',
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.parameters).toMatchObject({ ratio: 'adaptive' });
+        expect(result.warnings).not.toContainEqual(
+          expect.objectContaining({ feature: 'aspectRatio' }),
+        );
+      });
+
+      it('should prefer providerOptions.alibaba.ratio over aspectRatio', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        await model.doStart({
+          ...defaultOptions,
+          aspectRatio: '9:16',
+          providerOptions: { alibaba: { ratio: '1:1' } },
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.parameters).toMatchObject({ ratio: '1:1' });
+      });
+
+      it('should let generateAudio override the legacy audio option', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        const result = await model.doStart({
+          ...defaultOptions,
+          generateAudio: false,
+          providerOptions: { alibaba: { audio: true } },
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.parameters).toMatchObject({ audio: false });
+        expect(result.warnings).not.toContainEqual(
+          expect.objectContaining({ feature: 'generateAudio' }),
+        );
+      });
+
+      it('should send the legacy audio option when generateAudio is omitted', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        await model.doStart({
+          ...defaultOptions,
+          providerOptions: { alibaba: { audio: false } },
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.parameters).toMatchObject({ audio: false });
+      });
+
+      it('should still send audio_url, prompt rewrite, watermark, and seed', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        await model.doStart({
+          ...defaultOptions,
+          seed: 42,
+          duration: 8,
+          providerOptions: {
+            alibaba: {
+              audioUrl: 'https://example.com/soundtrack.mp3',
+              negativePrompt: 'blurry, low quality',
+              promptExtend: false,
+              watermark: true,
+            },
+          },
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body).toMatchObject({
+          input: {
+            prompt,
+            audio_url: 'https://example.com/soundtrack.mp3',
+            negative_prompt: 'blurry, low quality',
+          },
+          parameters: {
+            seed: 42,
+            duration: 8,
+            prompt_extend: false,
+            watermark: true,
+          },
+        });
+      });
+
+      it('should send file images as data URIs for frames and references', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+        const imageData = new Uint8Array([137, 80, 78, 71]);
+
+        await model.doStart({
+          ...defaultOptions,
+          inputReferences: [
+            { type: 'file', data: imageData, mediaType: 'image/png' },
+          ],
+          frameImages: [
+            {
+              frameType: 'first_frame',
+              image: {
+                type: 'file',
+                data: imageData,
+                mediaType: 'image/png',
+              },
+            },
+          ],
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.input).toMatchObject({
+          media: [
+            {
+              type: 'reference_image',
+              url: 'data:image/png;base64,iVBORw==',
+            },
+            {
+              type: 'first_frame',
+              url: 'data:image/png;base64,iVBORw==',
+            },
+          ],
+        });
+      });
+
+      it('should warn and skip non-URL video references', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        const result = await model.doStart({
+          ...defaultOptions,
+          inputReferences: [
+            {
+              type: 'file',
+              data: new Uint8Array([0, 0, 0, 24]),
+              mediaType: 'video/mp4',
+            },
+          ],
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.input).not.toHaveProperty('media');
+        expect(result.warnings).toContainEqual(
+          expect.objectContaining({
+            type: 'unsupported',
+            feature: 'inputReferences',
+          }),
+        );
+      });
+
+      it('should use providerOptions.alibaba.media as an override', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        await model.doStart({
+          ...defaultOptions,
+          inputReferences: [
+            { type: 'url', url: 'https://example.com/ignored.png' },
+          ],
+          frameImages: [
+            {
+              frameType: 'first_frame',
+              image: {
+                type: 'url',
+                url: 'https://example.com/ignored-first.jpg',
+              },
+            },
+          ],
+          providerOptions: {
+            alibaba: {
+              media: [
+                {
+                  type: 'reference_video',
+                  url: 'https://example.com/character.mp4',
+                  referenceVoice: 'https://example.com/voice.mp3',
+                },
+                {
+                  type: 'last_frame',
+                  url: 'https://example.com/closing.png',
+                },
+              ],
+            },
+          },
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.input).toMatchObject({
+          media: [
+            {
+              type: 'reference_video',
+              url: 'https://example.com/character.mp4',
+              reference_voice: 'https://example.com/voice.mp3',
+            },
+            { type: 'last_frame', url: 'https://example.com/closing.png' },
+          ],
+        });
+      });
+
+      it('should still warn about unsupported fps and n > 1', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        const result = await model.doStart({
+          ...defaultOptions,
+          fps: 24,
+          n: 3,
+        });
+
+        expect(result.warnings).toContainEqual(
+          expect.objectContaining({
+            type: 'unsupported',
+            feature: 'fps',
+          }),
+        );
+        expect(result.warnings).toContainEqual(
+          expect.objectContaining({
+            type: 'unsupported',
+            feature: 'n',
+          }),
+        );
+      });
     });
 
     describe('warnings', () => {

--- a/packages/alibaba/src/alibaba-video-model.test.ts
+++ b/packages/alibaba/src/alibaba-video-model.test.ts
@@ -366,6 +366,192 @@ describe('AlibabaVideoModel', () => {
       });
     });
 
+    describe('wan3 (all-in-one)', () => {
+      // wan3 ships one id for every mode, so the request's own media — not the
+      // model id — decides text- vs image- vs reference-to-video.
+      it('should send a bare prompt with no media for text-to-video', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        await model.doStart({ ...defaultOptions });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body).toMatchObject({
+          model: 'wan3.0-video',
+          input: { prompt },
+        });
+        expect(body.input).not.toHaveProperty('media');
+        expect(body.input).not.toHaveProperty('img_url');
+      });
+
+      it('should carry the start image in input.media instead of img_url', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        await model.doStart({
+          ...defaultOptions,
+          image: { type: 'url', url: 'https://example.com/first.jpg' },
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.input).toMatchObject({
+          media: [
+            { type: 'first_frame', url: 'https://example.com/first.jpg' },
+          ],
+        });
+        expect(body.input).not.toHaveProperty('img_url');
+      });
+
+      it('should send both frame images without warning', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        const result = await model.doStart({
+          ...defaultOptions,
+          frameImages: [
+            {
+              frameType: 'first_frame',
+              image: { type: 'url', url: 'https://example.com/first.jpg' },
+            },
+            {
+              frameType: 'last_frame',
+              image: { type: 'url', url: 'https://example.com/last.jpg' },
+            },
+          ],
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.input).toMatchObject({
+          media: [
+            { type: 'first_frame', url: 'https://example.com/first.jpg' },
+            { type: 'last_frame', url: 'https://example.com/last.jpg' },
+          ],
+        });
+        expect(result.warnings).not.toContainEqual(
+          expect.objectContaining({ feature: 'frameImages' }),
+        );
+      });
+
+      it('should map inputReferences to media without a dedicated r2v id', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        const result = await model.doStart({
+          ...defaultOptions,
+          inputReferences: [
+            { type: 'url', url: 'https://example.com/ref.jpg' },
+            { type: 'url', url: 'https://example.com/ref.mp4' },
+          ],
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.input).toMatchObject({
+          media: [
+            { type: 'reference_image', url: 'https://example.com/ref.jpg' },
+            { type: 'reference_video', url: 'https://example.com/ref.mp4' },
+          ],
+        });
+        expect(result.warnings).not.toContainEqual(
+          expect.objectContaining({ feature: 'inputReferences' }),
+        );
+      });
+
+      it('should send resolution tiers, including 480P', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        const result = await model.doStart({
+          ...defaultOptions,
+          resolution: '832x480',
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body).toMatchObject({ parameters: { resolution: '480P' } });
+        expect(result.warnings).not.toContainEqual(
+          expect.objectContaining({ feature: 'resolution' }),
+        );
+      });
+
+      it('should warn on a resolution outside the three tiers', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        const result = await model.doStart({
+          ...defaultOptions,
+          resolution: '3840x2160',
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.parameters).not.toHaveProperty('resolution');
+        expect(result.warnings).toContainEqual(
+          expect.objectContaining({
+            type: 'unsupported',
+            feature: 'resolution',
+          }),
+        );
+      });
+
+      it('should send the audio toggle, adaptive ratio, and smart duration', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        const result = await model.doStart({
+          ...defaultOptions,
+          generateAudio: false,
+          duration: -1,
+          providerOptions: { alibaba: { ratio: 'adaptive' } },
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body).toMatchObject({
+          parameters: { audio: false, ratio: 'adaptive', duration: -1 },
+        });
+        expect(result.warnings).not.toContainEqual(
+          expect.objectContaining({ feature: 'generateAudio' }),
+        );
+      });
+
+      it('should pass through wan3-only media types from providerOptions', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        await model.doStart({
+          ...defaultOptions,
+          providerOptions: {
+            alibaba: {
+              media: [
+                {
+                  type: 'reference_audio',
+                  url: 'https://example.com/voice.mp3',
+                },
+                { type: 'file', url: 'https://example.com/deck.pdf' },
+                { type: 'link', url: 'https://example.com/article' },
+              ],
+            },
+          },
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.input).toMatchObject({
+          media: [
+            { type: 'reference_audio', url: 'https://example.com/voice.mp3' },
+            { type: 'file', url: 'https://example.com/deck.pdf' },
+            { type: 'link', url: 'https://example.com/article' },
+          ],
+        });
+      });
+
+      it('should warn about shotType, which wan3 dropped', async () => {
+        const model = createModel({ modelId: 'wan3.0-video' });
+
+        const result = await model.doStart({
+          ...defaultOptions,
+          providerOptions: { alibaba: { shotType: 'multi' } },
+        });
+
+        const body = await server.calls[0].requestBodyJson;
+        expect(body.parameters).not.toHaveProperty('shot_type');
+        expect(result.warnings).toContainEqual(
+          expect.objectContaining({
+            type: 'unsupported',
+            feature: 'shotType',
+          }),
+        );
+      });
+    });
+
     describe('warnings', () => {
       it('should warn about unsupported aspectRatio', async () => {
         const model = createModel();
@@ -658,6 +844,49 @@ describe('AlibabaVideoModel', () => {
           },
         });
       }
+    });
+
+    it('should surface wan3 usage facts when the task reports them', async () => {
+      server.urls[TASK_URL].response = {
+        type: 'json-value',
+        body: {
+          ...succeededTaskResponse,
+          usage: {
+            duration: 12,
+            output_video_duration: 8,
+            input_video_duration: 4,
+            fps: 24,
+            SR: 720,
+            size: '1280x720',
+            ratio: '16:9',
+          },
+        },
+      };
+
+      const model = createModel({ modelId: 'wan3.0-video' });
+
+      const result = await model.doStatus({
+        operation: { taskId: 'task-abc-123' },
+      });
+
+      expect(result.status).toBe('completed');
+      if (result.status === 'completed') {
+        expect(result.providerMetadata.alibaba.usage).toStrictEqual({
+          duration: 12,
+          outputVideoDuration: 8,
+          inputVideoDuration: 4,
+          fps: 24,
+          resolution: 720,
+          size: '1280x720',
+          ratio: '16:9',
+        });
+      }
+
+      // Reset
+      server.urls[TASK_URL].response = {
+        type: 'json-value',
+        body: succeededTaskResponse,
+      };
     });
 
     it('should include timestamp, modelId, and headers in response', async () => {

--- a/packages/alibaba/src/alibaba-video-model.ts
+++ b/packages/alibaba/src/alibaba-video-model.ts
@@ -79,8 +79,12 @@ const alibabaVideoTaskStatusSchema = z.object({
     .object({
       duration: z.number().nullish(),
       output_video_duration: z.number().nullish(),
+      // wan3 splits the total: input video counts toward its 30s ceiling.
+      input_video_duration: z.number().nullish(),
+      fps: z.number().nullish(),
       SR: z.number().nullish(),
       size: z.string().nullish(),
+      ratio: z.string().nullish(),
     })
     .nullish(),
   request_id: z.string().nullish(),
@@ -90,17 +94,29 @@ type AlibabaVideoTaskStatusResponse = z.infer<
   typeof alibabaVideoTaskStatusSchema
 >;
 
+// Only meaningful for ids that name their mode (wan2.6/wan2.7). wan3 ships a
+// single all-in-one id, so its mode comes from the media the request carries.
 function detectMode(modelId: string): 't2v' | 'i2v' | 'r2v' {
   if (modelId.includes('-i2v')) return 'i2v';
   if (modelId.includes('-r2v')) return 'r2v';
   return 't2v';
 }
 
-// wan2.7 models use a different protocol than earlier wan models:
-// resolution tiers + ratio instead of size, input.media instead of
-// input.reference_urls (R2V), and no shot_type or audio parameters.
-function isWan27Model(modelId: string): boolean {
-  return modelId.startsWith('wan2.7');
+/**
+ * Request protocol, selected by model id:
+ * - `legacy` (wan2.6 and earlier): `parameters.size`, `input.img_url`, and
+ *   `input.reference_urls`.
+ * - `wan27`: resolution tiers and `ratio` instead of `size`, `input.media`
+ *   instead of `input.reference_urls`, no `shot_type`, audio always on.
+ * - `wan3`: like `wan27`, plus a real `last_frame` slot, an `audio` toggle,
+ *   a 480P tier, and one id covering every mode.
+ */
+type AlibabaVideoProtocol = 'legacy' | 'wan27' | 'wan3';
+
+function detectProtocol(modelId: string): AlibabaVideoProtocol {
+  if (modelId.startsWith('wan3')) return 'wan3';
+  if (modelId.startsWith('wan2.7')) return 'wan27';
+  return 'legacy';
 }
 
 // Maps SDK "WIDTHxHEIGHT" resolutions to Alibaba resolution tiers.
@@ -159,6 +175,13 @@ function getFirstFrameImage(
     ?.image;
 }
 
+function getLastFrameImage(
+  options: VideoModelV4CallOptions,
+): VideoModelV4File | undefined {
+  return options.frameImages?.find(frame => frame.frameType === 'last_frame')
+    ?.image;
+}
+
 function resolveStartImage(
   options: VideoModelV4CallOptions,
 ): VideoModelV4File | undefined {
@@ -169,11 +192,13 @@ function isVideoUrl(url: string): boolean {
   return /\.(mp4|mov)([?#]|$)/i.test(url);
 }
 
-// Builds the wan2.7 input.media array from inputReferences and frameImages.
+// Builds the input.media array (wan2.7 and wan3) from inputReferences plus the
+// frame images the caller resolved for this protocol.
 function resolveMedia(
   options: VideoModelV4CallOptions,
   alibabaOptions: AlibabaVideoModelOptions | undefined,
   warnings: SharedV4Warning[],
+  frames: { first?: VideoModelV4File; last?: VideoModelV4File },
 ): Array<Record<string, unknown>> | undefined {
   if (alibabaOptions?.media != null && alibabaOptions.media.length > 0) {
     return alibabaOptions.media.map(item => ({
@@ -209,11 +234,17 @@ function resolveMedia(
     }
   }
 
-  const firstFrame = getFirstFrameImage(options);
-  if (firstFrame != null) {
+  if (frames.first != null) {
     media.push({
       type: 'first_frame',
-      url: convertImageModelFileToDataUri(firstFrame),
+      url: convertImageModelFileToDataUri(frames.first),
+    });
+  }
+
+  if (frames.last != null) {
+    media.push({
+      type: 'last_frame',
+      url: convertImageModelFileToDataUri(frames.last),
     });
   }
 
@@ -298,20 +329,37 @@ export class AlibabaVideoModel implements VideoModelV4 {
     }
 
     const startImage = resolveStartImage(options);
-    const wan27 = isWan27Model(this.modelId);
-    // wan2.7 T2V and R2V take an explicit aspect ratio (I2V follows the input image)
-    const supportsRatio = wan27 && mode !== 'i2v';
+    const protocol = detectProtocol(this.modelId);
+    const wan27 = protocol === 'wan27';
+    const wan3 = protocol === 'wan3';
+    // Resolution tiers and input.media replaced size/img_url from wan2.7 on.
+    const tieredProtocol = wan27 || wan3;
+    // wan2.7 T2V and R2V take an explicit aspect ratio (I2V follows the input
+    // image); wan3 serves every mode from one id, so it always takes one.
+    const supportsRatio = wan3 || (wan27 && mode !== 'i2v');
 
-    // Handle image input for I2V mode
-    if (mode === 'i2v' && startImage != null) {
+    // Handle image input for I2V mode (wan3 carries frames in input.media)
+    if (!wan3 && mode === 'i2v' && startImage != null) {
       input.img_url = fileToImageString(startImage);
     }
 
-    // Handle references for R2V mode
-    if (mode === 'r2v') {
+    if (wan3) {
+      // The media the request carries decides whether this is text-, image-,
+      // or reference-to-video, so there is no mode to read off the id. A bare
+      // prompt stays text-to-video.
+      const media = resolveMedia(options, alibabaOptions, warnings, {
+        first: startImage,
+        last: getLastFrameImage(options),
+      });
+      if (media != null) {
+        input.media = media;
+      }
+    } else if (mode === 'r2v') {
       if (wan27) {
         // wan2.7: input.media
-        const media = resolveMedia(options, alibabaOptions, warnings);
+        const media = resolveMedia(options, alibabaOptions, warnings, {
+          first: getFirstFrameImage(options),
+        });
         if (media != null) {
           input.media = media;
         }
@@ -328,11 +376,10 @@ export class AlibabaVideoModel implements VideoModelV4 {
       }
     }
 
-    const lastFrame = options.frameImages?.find(
-      frame => frame.frameType === 'last_frame',
-    )?.image;
+    const lastFrame = getLastFrameImage(options);
 
-    if (lastFrame != null) {
+    // wan3 has a real closing-frame slot, filled in input.media above.
+    if (lastFrame != null && !wan3) {
       warnings.push({
         type: 'unsupported',
         feature: 'frameImages',
@@ -345,7 +392,8 @@ export class AlibabaVideoModel implements VideoModelV4 {
     if (
       options.inputReferences != null &&
       options.inputReferences.length > 0 &&
-      mode !== 'r2v'
+      mode !== 'r2v' &&
+      !wan3
     ) {
       warnings.push({
         type: 'unsupported',
@@ -369,17 +417,22 @@ export class AlibabaVideoModel implements VideoModelV4 {
 
     // Resolution / Size mapping
     if (options.resolution != null) {
-      if (mode === 'i2v' || wan27) {
-        // I2V and wan2.7 models use "720P" / "1080P" format
+      if (mode === 'i2v' || tieredProtocol) {
+        // I2V, wan2.7, and wan3 use the "720P" / "1080P" tier format
         const resolutionTier =
           resolutionTierMap[options.resolution] || options.resolution;
-        if (wan27 && resolutionTier !== '720P' && resolutionTier !== '1080P') {
+        // wan3 adds a 480P tier to wan2.7's two.
+        const supportedTiers = wan3
+          ? ['480P', '720P', '1080P']
+          : ['720P', '1080P'];
+        if (tieredProtocol && !supportedTiers.includes(resolutionTier)) {
           warnings.push({
             type: 'unsupported',
             feature: 'resolution',
             details:
-              'wan2.7 models only support 720P and 1080P ' +
-              `resolutions. The resolution "${options.resolution}" was ignored.`,
+              `${wan3 ? 'wan3' : 'wan2.7'} models only support the ` +
+              `${supportedTiers.join(', ')} resolution tiers. ` +
+              `The resolution "${options.resolution}" was ignored.`,
           });
         } else {
           parameters.resolution = resolutionTier;
@@ -409,14 +462,14 @@ export class AlibabaVideoModel implements VideoModelV4 {
       parameters.prompt_extend = alibabaOptions.promptExtend;
     }
     if (alibabaOptions?.shotType != null) {
-      if (wan27) {
+      if (tieredProtocol) {
         // wan2.7 removed shot_type; shot structure is described in the prompt
         warnings.push({
           type: 'unsupported',
           feature: 'shotType',
           details:
-            'wan2.7 models do not support the shotType option. ' +
-            'Describe the shot structure in the prompt instead.',
+            `${wan3 ? 'wan3' : 'wan2.7'} models do not support the shotType ` +
+            'option. Describe the shot structure in the prompt instead.',
         });
       } else {
         parameters.shot_type = alibabaOptions.shotType;
@@ -525,6 +578,20 @@ export class AlibabaVideoModel implements VideoModelV4 {
                     statusResponse.usage.output_video_duration,
                   resolution: statusResponse.usage.SR,
                   size: statusResponse.usage.size,
+                  // wan3-only. Spread rather than set to undefined so the
+                  // metadata shape for older wan models is unchanged.
+                  ...(statusResponse.usage.input_video_duration != null
+                    ? {
+                        inputVideoDuration:
+                          statusResponse.usage.input_video_duration,
+                      }
+                    : {}),
+                  ...(statusResponse.usage.fps != null
+                    ? { fps: statusResponse.usage.fps }
+                    : {}),
+                  ...(statusResponse.usage.ratio != null
+                    ? { ratio: statusResponse.usage.ratio }
+                    : {}),
                 },
               }
             : {}),

--- a/packages/alibaba/src/alibaba-video-settings.ts
+++ b/packages/alibaba/src/alibaba-video-settings.ts
@@ -13,4 +13,6 @@ export type AlibabaVideoModelId =
   | 'wan2.6-r2v-flash'
   | 'wan2.7-r2v'
   | 'wan2.7-r2v-2026-06-12'
+  // All-in-One (one id serves text-, image-, and reference-to-video)
+  | 'wan3.0-video'
   | (string & {});


### PR DESCRIPTION
Wan3 (wan3.0-video) is one model id that serves text-to-video, image-to-video (first and last frame), and reference-to-video. The existing provider derived both the wire protocol and the generation mode from substrings of the model id (isWan27Model, detectMode), so wan3 fell through both checks: it was classified t2v and sent the legacy wan2.6 shape — parameters.size instead of the resolution tier, no ratio, and input.media never built, silently dropping every reference image and video.

This splits protocol detection from mode detection. detectProtocol returns legacy / wan27 / wan3; mode detection stays for the ids that actually name their mode. wan3 builds input.media from whatever the request carries, so a bare prompt is text-to-video, a start image is image-to-video, and references are reference-to-video — with no id suffix involved.

Also for wan3: last_frame is a real slot rather than an ignored-with-warning option, the 480P tier is accepted alongside 720P/1080P, the audio boolean is forwarded (wan2.7 suppresses it because audio is always on there), and shot_type warns as it does on wan2.7. reference_audio, file, and link have no top-level call option, so they're reachable through providerOptions.alibaba.media, whose type enum is extended; ratio gains wan3's adaptive default.

doStatus now parses and surfaces wan3's extra usage facts — input_video_duration, fps, ratio — as providerMetadata.alibaba.usage. These are spread conditionally, so metadata for wan2.x is unchanged. input_video_duration matters downstream: wan3 counts input video toward its 30s ceiling, and consumers billing on duration need the output figure separated from the total.

wan2.6/wan2.7 request shaping is untouched.