### PR TITLE
fix(provider-utils): keep the leading dot when stripping a dotfile extension

### DIFF
--- a/.changeset/strip-file-extension-dotfile.md
+++ b/.changeset/strip-file-extension-dotfile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Fix `stripFileExtension` to keep the leading dot of a dotfile (e.g. `.env`, `.gitignore`) instead of returning an empty string. This prevents an empty document name being derived from a dotfile attachment.

--- a/packages/provider-utils/src/strip-file-extension.test.ts
+++ b/packages/provider-utils/src/strip-file-extension.test.ts
@@ -17,4 +17,13 @@ describe('stripFileExtension', () => {
   it('should strip a trailing dot', () => {
     expect(stripFileExtension('report.')).toBe('report');
   });
+
+  it('should keep the leading dot for a dotfile with no extension', () => {
+    expect(stripFileExtension('.env')).toBe('.env');
+    expect(stripFileExtension('.gitignore')).toBe('.gitignore');
+  });
+
+  it('should keep the leading dot when stripping a dotfile extension', () => {
+    expect(stripFileExtension('.hidden.txt')).toBe('.hidden');
+  });
 });

--- a/packages/provider-utils/src/strip-file-extension.ts
+++ b/packages/provider-utils/src/strip-file-extension.ts
@@ -5,9 +5,13 @@
  * - "report.pdf" -> "report"
  * - "archive.tar.gz" -> "archive"
  * - "filename" -> "filename"
+ * - ".env" -> ".env"
+ * - ".hidden.txt" -> ".hidden"
  */
 export function stripFileExtension(filename: string): string {
-  const firstDotIndex = filename.indexOf('.');
+  // Start the search at index 1 so a dotfile's leading dot (".env", ".gitignore")
+  // is not treated as an extension separator, which would strip the whole name.
+  const firstDotIndex = filename.indexOf('.', 1);
 
   return firstDotIndex === -1 ? filename : filename.slice(0, firstDotIndex);
 }


### PR DESCRIPTION
## Background

`stripFileExtension` treats a dotfile's leading dot as an extension separator, so it returns an empty string for names like `.env`, `.gitignore`, or `.bashrc`:

```ts
const firstDotIndex = filename.indexOf('.');            // 0 for ".env"
return firstDotIndex === -1 ? filename : filename.slice(0, firstDotIndex);  // ".env".slice(0,0) === ""
```

This reaches a real caller: `convert-to-amazon-bedrock-chat-messages.ts` derives the Bedrock document `name` from `stripFileExtension(part.filename)`. A user attaching a file named `.env` produces an **empty** document name, which the Bedrock Converse API rejects (document name must be non-empty).

## Summary

Start the dot search at index 1 so a leading dot is not treated as an extension separator:

```ts
const firstDotIndex = filename.indexOf('.', 1);
```

`.env` → `.env`, `.gitignore` → `.gitignore`, `.hidden.txt` → `.hidden`. All previously documented cases are unchanged (`report.pdf` → `report`, `archive.tar.gz` → `archive`, `report.` → `report`, `filename` → `filename`).

## End-to-End Verification

Added dotfile cases to the existing `strip-file-extension.test.ts`. Ran the real source before and after the change:

Before (`indexOf('.')`):

```
FAIL stripFileExtension(".env")        -> ""   (expect ".env")
FAIL stripFileExtension(".gitignore")  -> ""   (expect ".gitignore")
FAIL stripFileExtension(".hidden.txt") -> ""   (expect ".hidden")
ok   stripFileExtension("report.pdf")  -> "report"
3 FAILED
```

After (`indexOf('.', 1)`):

```
ok  .env -> .env    .gitignore -> .gitignore    .hidden.txt -> .hidden
ok  report.pdf -> report    archive.tar.gz -> archive    report. -> report    filename -> filename
ALL PASS
```

A `.changeset` entry (`@ai-sdk/provider-utils` patch) is included.

---

**Rendered before/after test run:**

![before/after test run](https://github.com/user-attachments/assets/ebe950ac-862c-46c0-8a2a-2b940c58b7af)
