### PR TITLE
fix(tools-registry): correct Nitrosend API key URL

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -582,7 +582,7 @@ const result = await withNitrosendTools({}, async ({ tools }) => {
 
 console.log(result.text);`,
     docsUrl: 'https://docs.nitrosend.com/integrations/vercel-ai-sdk',
-    apiKeyUrl: 'https://app.nitrosend.com/settings/api-keys',
+    apiKeyUrl: 'https://app.nitrosend.com/my/settings/api-keys',
     websiteUrl: 'https://nitrosend.com',
     npmUrl: 'https://www.npmjs.com/package/@nitrosend/ai-sdk',
   },


### PR DESCRIPTION
## Summary

Corrects the Nitrosend tools-registry API-key destination by adding the missing /my dashboard namespace.

The canonical destination is https://app.nitrosend.com/my/settings/api-keys as settled in https://github.com/nitrosend/nitrosend/issues/562.

## Validation

- git diff --check
- compared against the Nitrosend app route contract and documentation update

No package code, API surface, or changeset is involved.