### PR TITLE
fix(mcp): reject private OAuth endpoints before sending credentials

### DIFF
--- a/.changeset/rare-bees-smell.md
+++ b/.changeset/rare-bees-smell.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+fix(mcp): reject private OAuth endpoints before sending credentials

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -1026,6 +1026,91 @@ describe('exchangeAuthorization', () => {
     client_name: 'Test Client',
   };
 
+  it('rejects private token endpoints before sending OAuth credentials', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      Response.json({
+        access_token: 'attacker-token',
+        token_type: 'Bearer',
+      }),
+    );
+
+    await expect(
+      exchangeAuthorization('https://attacker.example', {
+        metadata: {
+          ...validMetadata,
+          issuer: 'https://attacker.example',
+          authorization_endpoint: 'https://honest.example/authorize',
+          token_endpoint: 'http://169.254.169.254/latest/token',
+          token_endpoint_auth_methods_supported: ['client_secret_post'],
+        },
+        clientInformation: validClientInfo,
+        authorizationCode: 'real-code',
+        codeVerifier: 'real-verifier',
+        redirectUri: 'http://localhost:3000/callback',
+        fetchFn,
+      }),
+    ).rejects.toThrow(
+      'OAuth endpoint URL is not allowed: http://169.254.169.254/latest/token',
+    );
+
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('rejects https link-local token endpoints before sending OAuth credentials', async () => {
+    const fetchFn = vi.fn();
+
+    await expect(
+      exchangeAuthorization('https://attacker.example', {
+        metadata: {
+          ...validMetadata,
+          token_endpoint: 'https://169.254.169.254/latest/token',
+        },
+        clientInformation: validClientInfo,
+        authorizationCode: 'real-code',
+        codeVerifier: 'real-verifier',
+        redirectUri: 'http://localhost:3000/callback',
+        fetchFn,
+      }),
+    ).rejects.toThrow(
+      'OAuth endpoint URL is not allowed: https://169.254.169.254/latest/token',
+    );
+
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('allows loopback token endpoints used by local MCP OAuth', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      Response.json({
+        access_token: 'local-token',
+        token_type: 'Bearer',
+      }),
+    );
+
+    await expect(
+      exchangeAuthorization('http://localhost:4000', {
+        metadata: {
+          ...validMetadata,
+          issuer: 'http://localhost:4000',
+          authorization_endpoint: 'http://localhost:4000/authorize',
+          token_endpoint: 'http://localhost:4000/token',
+        },
+        clientInformation: validClientInfo,
+        authorizationCode: 'code123',
+        codeVerifier: 'verifier123',
+        redirectUri: 'http://localhost:3000/callback',
+        fetchFn,
+      }),
+    ).resolves.toEqual({
+      access_token: 'local-token',
+      token_type: 'Bearer',
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url.href).toBe('http://localhost:4000/token');
+    expect(init.redirect).toBe('error');
+  });
+
   it('exchanges code for tokens', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -1045,6 +1130,7 @@ describe('exchangeAuthorization', () => {
     const [fetchUrl, fetchOptions] = mockFetch.mock.calls[0];
     expect(fetchUrl.href).toBe('https://auth.example.com/token');
     expect(fetchOptions.method).toBe('POST');
+    expect(fetchOptions.redirect).toBe('error');
     expect(fetchOptions.headers.get('Content-Type')).toBe(
       'application/x-www-form-urlencoded',
     );
@@ -1301,6 +1387,7 @@ describe('refreshAuthorization', () => {
       }),
       expect.objectContaining({
         method: 'POST',
+        redirect: 'error',
         headers: new Headers({
           'Content-Type': 'application/x-www-form-urlencoded',
           Accept: 'application/json',
@@ -1475,6 +1562,26 @@ describe('refreshAuthorization', () => {
     expect(body.get('client_id')).toBe('set-by-async-provider');
     expect(body.get('client_secret')).toBe('secret-by-async-provider');
   });
+
+  it('rejects private token endpoints before sending the refresh token', async () => {
+    const fetchFn = vi.fn();
+
+    await expect(
+      refreshAuthorization('https://attacker.example', {
+        metadata: {
+          ...validMetadata,
+          token_endpoint: 'http://169.254.169.254/latest/token',
+        },
+        clientInformation: validClientInfo,
+        refreshToken: 'real-refresh-token',
+        fetchFn,
+      }),
+    ).rejects.toThrow(
+      'OAuth endpoint URL is not allowed: http://169.254.169.254/latest/token',
+    );
+
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
 });
 
 describe('registerClient', () => {
@@ -1509,6 +1616,7 @@ describe('registerClient', () => {
       }),
       expect.objectContaining({
         method: 'POST',
+        redirect: 'error',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -1607,6 +1715,28 @@ describe('registerClient', () => {
         clientMetadata: validClientMetadata,
       }),
     ).rejects.toThrow('Dynamic client registration failed');
+  });
+
+  it('rejects private registration endpoints before sending client metadata', async () => {
+    const fetchFn = vi.fn();
+
+    await expect(
+      registerClient('https://attacker.example', {
+        metadata: {
+          issuer: 'https://attacker.example',
+          authorization_endpoint: 'https://attacker.example/authorize',
+          token_endpoint: 'https://attacker.example/token',
+          registration_endpoint: 'http://169.254.169.254/latest/register',
+          response_types_supported: ['code'],
+        } as AuthorizationServerMetadata,
+        clientMetadata: validClientMetadata,
+        fetchFn,
+      }),
+    ).rejects.toThrow(
+      'OAuth endpoint URL is not allowed: http://169.254.169.254/latest/register',
+    );
+
+    expect(fetchFn).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -27,7 +27,11 @@ import {
   resourceUrlStripSlash,
 } from '../util/oauth-util';
 import { LATEST_PROTOCOL_VERSION } from './types';
-import { parseJSON, type FetchFunction } from '@ai-sdk/provider-utils';
+import {
+  parseJSON,
+  validateDownloadUrl,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
 export type AuthResult = 'AUTHORIZED' | 'REDIRECT';
 
 export interface OAuthAuthorizationServerInformation {
@@ -121,6 +125,45 @@ export class UnauthorizedError extends Error {
 
 function normalizeUrl(url: string | URL): string {
   return new URL(url).href;
+}
+
+/** Allow loopback HTTP(S) for local MCP OAuth (RFC 8252 §7.3, RFC 6761 §6.3). */
+function isOAuthLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/\.+$/, '');
+  return (
+    normalized === 'localhost' ||
+    normalized.endsWith('.localhost') ||
+    normalized === '127.0.0.1' ||
+    normalized === '[::1]' ||
+    normalized === '::1'
+  );
+}
+
+/**
+ * Guards metadata-derived token/registration URLs before credentials are sent.
+ * Loopback is allowed for local OAuth; every other target uses the shared
+ * download URL guard (http(s) only, no private/link-local IPs).
+ *
+ * Credential POSTs use `redirect: 'error'` instead of
+ * `fetchWithValidatedRedirects`, which is GET-only and would follow hops with
+ * the authorization code, PKCE verifier, and client secret still attached.
+ */
+function assertSafeOAuthEndpoint(endpointUrl: URL): void {
+  if (
+    (endpointUrl.protocol === 'http:' || endpointUrl.protocol === 'https:') &&
+    isOAuthLoopbackHost(endpointUrl.hostname)
+  ) {
+    return;
+  }
+
+  try {
+    validateDownloadUrl(endpointUrl.href);
+  } catch (error) {
+    throw new MCPClientOAuthError({
+      message: `OAuth endpoint URL is not allowed: ${endpointUrl.href}`,
+      cause: error,
+    });
+  }
 }
 
 function validateAuthorizationResponseIssuer({
@@ -896,6 +939,7 @@ export async function exchangeAuthorization(
   const tokenUrl = metadata?.token_endpoint
     ? new URL(metadata.token_endpoint)
     : new URL('/token', authorizationServerUrl);
+  assertSafeOAuthEndpoint(tokenUrl);
 
   if (
     metadata?.grant_types_supported &&
@@ -943,6 +987,7 @@ export async function exchangeAuthorization(
     method: 'POST',
     headers,
     body: params,
+    redirect: 'error',
   });
 
   if (!response.ok) {
@@ -999,6 +1044,7 @@ export async function refreshAuthorization(
   } else {
     tokenUrl = new URL('/token', authorizationServerUrl);
   }
+  assertSafeOAuthEndpoint(tokenUrl);
 
   const headers = new Headers({
     'Content-Type': 'application/x-www-form-urlencoded',
@@ -1035,6 +1081,7 @@ export async function refreshAuthorization(
     method: 'POST',
     headers,
     body: params,
+    redirect: 'error',
   });
   if (!response.ok) {
     throw await parseErrorResponse(response);
@@ -1074,6 +1121,7 @@ export async function registerClient(
   } else {
     registrationUrl = new URL('/register', authorizationServerUrl);
   }
+  assertSafeOAuthEndpoint(registrationUrl);
 
   const applicationType =
     clientMetadata.application_type ??
@@ -1087,6 +1135,7 @@ export async function registerClient(
       ...clientMetadata,
       application_type: applicationType,
     }),
+    redirect: 'error',
   });
 
   if (!response.ok) {
@@ -1101,10 +1150,7 @@ function inferOAuthApplicationType(redirectUris: string[]): 'native' | 'web' {
     const url = new URL(redirectUri);
     return (
       ((url.protocol === 'http:' || url.protocol === 'https:') &&
-        (url.hostname === 'localhost' ||
-          url.hostname.endsWith('.localhost') ||
-          url.hostname === '127.0.0.1' ||
-          url.hostname === '[::1]')) ||
+        isOAuthLoopbackHost(url.hostname)) ||
       (url.protocol !== 'http:' && url.protocol !== 'https:')
     );
   };


### PR DESCRIPTION
## Background

When an MCP server does OAuth, it sends back metadata that includes a `token_endpoint` URL. The client trusted that URL and POSTed secrets to it. the check on the URL wasn't a strong one and a malicious server could point `token_endpoint` there, steal those secrets and replay them for the user’s tokens.

## Summary

the client now checks the endpoint:

- only http / https
- no private / link-local IPs
- localhost still allowed

## End-to-End Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)