### PR TITLE
fix (provider/amazon-bedrock): emit well-formed Anthropic error events for exception frames

### DIFF
--- a/.changeset/plenty-mirrors-share.md
+++ b/.changeset/plenty-mirrors-share.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+fix (provider/amazon-bedrock): emit well-formed Anthropic error events for eventstream exception frames
+
+The Anthropic surface converted exception frames with `JSON.stringify({ type: 'error', error: event.data })`, where `event.data` is already a JSON string. The resulting `{"type":"error","error":"<string>"}` fails the Anthropic error schema (`error` must be an object with `type` and `message`), so a retryable provider exception such as a transient Bedrock 500 surfaced as an `AI_TypeValidationError` instead of the provider error. Exception frames now emit the proper error event shape, unwrapping the message and carrying the eventstream's exception type through as the error type.

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.test.ts
@@ -148,7 +148,96 @@ describe('createAmazonBedrockAnthropicFetch', () => {
     const text = new TextDecoder().decode(value);
 
     expect(text).toBe(
-      `data: ${JSON.stringify({ type: 'error', error: errorData })}\n\n`,
+      `data: ${JSON.stringify({
+        type: 'error',
+        error: { type: 'ThrottlingException', message: 'Rate limit exceeded' },
+      })}\n\n`,
+    );
+  });
+
+  it('should emit the Anthropic error shape for exceptions without a type header', async () => {
+    const codec = new EventStreamCodec(toUtf8, fromUtf8);
+
+    const errorData = JSON.stringify({
+      message:
+        'The system encountered an unexpected error during processing. Try your request again.',
+    });
+    const amazonBedrockEvent = codec.encode({
+      headers: {
+        ':message-type': { type: 'string', value: 'exception' },
+      },
+      body: fromUtf8(errorData),
+    });
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(amazonBedrockEvent);
+        controller.close();
+      },
+    });
+
+    const mockResponse = createMockResponse(
+      stream,
+      'application/vnd.amazon.eventstream',
+    );
+    const baseFetch = createMockFetch(mockResponse);
+    const wrappedFetch = createAmazonBedrockAnthropicFetch(baseFetch);
+
+    const response = await wrappedFetch('https://example.com', {});
+    const reader = response.body!.getReader();
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+
+    expect(text).toBe(
+      `data: ${JSON.stringify({
+        type: 'error',
+        error: {
+          type: 'error',
+          message:
+            'The system encountered an unexpected error during processing. Try your request again.',
+        },
+      })}\n\n`,
+    );
+  });
+
+  it('should keep non-JSON exception data as the error message', async () => {
+    const codec = new EventStreamCodec(toUtf8, fromUtf8);
+
+    const amazonBedrockEvent = codec.encode({
+      headers: {
+        ':message-type': { type: 'string', value: 'exception' },
+        ':exception-type': { type: 'string', value: 'InternalServerException' },
+      },
+      body: fromUtf8('something went wrong'),
+    });
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(amazonBedrockEvent);
+        controller.close();
+      },
+    });
+
+    const mockResponse = createMockResponse(
+      stream,
+      'application/vnd.amazon.eventstream',
+    );
+    const baseFetch = createMockFetch(mockResponse);
+    const wrappedFetch = createAmazonBedrockAnthropicFetch(baseFetch);
+
+    const response = await wrappedFetch('https://example.com', {});
+    const reader = response.body!.getReader();
+    const { value } = await reader.read();
+    const text = new TextDecoder().decode(value);
+
+    expect(text).toBe(
+      `data: ${JSON.stringify({
+        type: 'error',
+        error: {
+          type: 'InternalServerException',
+          message: 'something went wrong',
+        },
+      })}\n\n`,
     );
   });
 

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
@@ -101,19 +101,14 @@ function transformAmazonBedrockEventStreamToSSE(
         // Unwrap the message and emit the Anthropic error event shape,
         // carrying the eventstream's exception type through as the error
         // type.
-        let message = event.data;
-        try {
-          const parsed: unknown = JSON.parse(event.data);
-          if (
-            parsed != null &&
-            typeof parsed === 'object' &&
-            typeof (parsed as { message?: unknown }).message === 'string'
-          ) {
-            message = (parsed as { message: string }).message;
-          }
-        } catch {
-          // not JSON; keep the raw string as the message
-        }
+        const parsed = await safeParseJSON({
+          text: event.data,
+          schema: amazonBedrockErrorSchema,
+        });
+        const message =
+          parsed.success && parsed.value.message
+            ? parsed.value.message
+            : event.data;
         controller.enqueue(
           textEncoder.encode(
             `data: ${JSON.stringify({

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
@@ -93,9 +93,33 @@ function transformAmazonBedrockEventStreamToSSE(
           controller.enqueue(textEncoder.encode('data: [DONE]\n\n'));
         }
       } else if (event.messageType === 'exception') {
+        // event.data is the exception body as a JSON string, for example
+        // '{"message":"..."}'. Embedding it verbatim produces
+        // {"type":"error","error":"<string>"}, which fails the Anthropic
+        // error schema (error must be an object with type and message) and
+        // surfaces as a TypeValidationError instead of the provider error.
+        // Unwrap the message and emit the Anthropic error event shape,
+        // carrying the eventstream's exception type through as the error
+        // type.
+        let message = event.data;
+        try {
+          const parsed: unknown = JSON.parse(event.data);
+          if (
+            parsed != null &&
+            typeof parsed === 'object' &&
+            typeof (parsed as { message?: unknown }).message === 'string'
+          ) {
+            message = (parsed as { message: string }).message;
+          }
+        } catch {
+          // not JSON; keep the raw string as the message
+        }
         controller.enqueue(
           textEncoder.encode(
-            `data: ${JSON.stringify({ type: 'error', error: event.data })}\n\n`,
+            `data: ${JSON.stringify({
+              type: 'error',
+              error: { type: event.exceptionType ?? 'error', message },
+            })}\n\n`,
           ),
         );
       }


### PR DESCRIPTION
## Background

Streaming through the Anthropic surface (`bedrock-runtime` with the Messages API), a transient Bedrock exception mid-stream surfaces as `AI_TypeValidationError: Type validation failed: ... expected object, received string` instead of a provider error. We hit this in production when a 13-step agent run died at step 13 on a retryable Bedrock internal error ("The system encountered an unexpected error during processing. Try your request again.").

The cause is in `transformAmazonBedrockEventStreamToSSE`: exception frames are converted with `JSON.stringify({ type: 'error', error: event.data })`, but `event.data` is already a JSON string, so the emitted SSE event is `{"type":"error","error":"<string>"}`. The Anthropic error schema requires `error` to be an object with `type` and `message`, so the SDK rejects the frame it produced itself, and a retryable provider fault becomes an opaque validation error that no retry logic classifies as retryable.

## Summary

- Exception frames now emit the Anthropic error event shape: the message is unwrapped from the JSON body (non-JSON data is kept verbatim as the message), and the eventstream's `:exception-type` header is carried through as the error type, falling back to `"error"` when the header is absent.
- Updated the existing exception test, which pinned the malformed output, and added two more cases: an exception without a type header, and non-JSON exception data.
- Added a patch changeset for `@ai-sdk/amazon-bedrock`.

## End-to-End Verification

Verified in production against `bedrock-runtime` with `global.anthropic.claude-opus-5`: with this change applied as a pnpm patch, Bedrock exception frames arrive as well-formed Anthropic error events and surface as typed provider errors rather than `AI_TypeValidationError`. All 473 package tests pass on both the node and edge configs.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)