### PR TITLE
fix(providers): clamp negative inputTokens.noCache for cache-exclusive providers

### DIFF
--- a/.changeset/olive-buttons-cheer.md
+++ b/.changeset/olive-buttons-cheer.md
@@ -1,0 +1,22 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/openai-compatible': patch
+'@ai-sdk/google-vertex': patch
+'@ai-sdk/open-responses': patch
+'@ai-sdk/huggingface': patch
+'@ai-sdk/moonshotai': patch
+'@ai-sdk/deepinfra': patch
+'@ai-sdk/deepseek': patch
+'@ai-sdk/alibaba': patch
+'@ai-sdk/mistral': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/google': patch
+'@ai-sdk/groq': patch
+'@ai-sdk/xai': patch
+---
+
+Fix negative `inputTokens.noCache` when providers report cache-exclusive prompt tokens.
+
+Provider converters derived uncached input tokens as `prompt_tokens - cached_tokens` with no floor. Providers that report `prompt_tokens` exclusive of cached tokens made that subtraction underflow, producing a negative `noCache` whenever the cached prefix exceeded the fresh remainder — routine in agentic traffic replaying a long cached context against a handful of new tokens.
+
+Converters now infer the reporting convention instead of assuming it: a cache breakdown larger than the reported total can only mean the reported value already *is* the uncached count, in which case the true total is the sum. Shared as `resolveInputTokenUsage` in `@ai-sdk/provider-utils`, which also generalizes the guard xAI already had.

--- a/packages/alibaba/src/convert-alibaba-usage.test.ts
+++ b/packages/alibaba/src/convert-alibaba-usage.test.ts
@@ -87,4 +87,20 @@ describe('convertAlibabaUsage', () => {
 
     expect(convertAlibabaUsage(usage).raw).toEqual(usage);
   });
+
+  it('treats prompt tokens as uncached when reads plus writes exceed them', () => {
+    const result = convertAlibabaUsage({
+      prompt_tokens: 12,
+      completion_tokens: 40,
+      prompt_tokens_details: {
+        cached_tokens: 4000,
+        cache_creation_input_tokens: 100,
+      },
+    });
+
+    expect(result.inputTokens.total).toBe(4112);
+    expect(result.inputTokens.noCache).toBe(12);
+    expect(result.inputTokens.cacheRead).toBe(4000);
+    expect(result.inputTokens.cacheWrite).toBe(100);
+  });
 });

--- a/packages/alibaba/src/convert-alibaba-usage.ts
+++ b/packages/alibaba/src/convert-alibaba-usage.ts
@@ -1,5 +1,8 @@
 import type { LanguageModelV4Usage } from '@ai-sdk/provider';
-import { createNullLanguageModelUsage } from '@ai-sdk/provider-utils';
+import {
+  createNullLanguageModelUsage,
+  resolveInputTokenUsage,
+} from '@ai-sdk/provider-utils';
 
 /**
  * Usage as reported by Alibaba's OpenAI-compatible chat completions API.
@@ -46,11 +49,17 @@ export function convertAlibabaUsage(
   const reasoningTokens =
     usage.completion_tokens_details?.reasoning_tokens ?? 0;
 
+  // Alibaba counts both cache reads and cache writes inside prompt_tokens.
+  const { total: totalInputTokens, noCache: noCacheInputTokens } =
+    resolveInputTokenUsage({
+      reportedInputTokens: promptTokens,
+      cachedTokens: cacheReadTokens + cacheWriteTokens,
+    });
+
   return {
     inputTokens: {
-      total: promptTokens,
-      // Alibaba counts both cache reads and cache writes inside prompt_tokens.
-      noCache: promptTokens - cacheReadTokens - cacheWriteTokens,
+      total: totalInputTokens,
+      noCache: noCacheInputTokens,
       cacheRead: cacheReadTokens,
       cacheWrite: cacheWriteTokens,
     },

--- a/packages/deepinfra/src/deepinfra-chat-language-model.ts
+++ b/packages/deepinfra/src/deepinfra-chat-language-model.ts
@@ -5,6 +5,7 @@ import type {
 } from '@ai-sdk/provider';
 import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
 import {
+  resolveInputTokenUsage,
   serializeModelOptions,
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
@@ -102,12 +103,18 @@ export class DeepInfraChatLanguageModel extends OpenAICompatibleChatLanguageMode
         const reasoningTokens =
           fixedRawUsage.completion_tokens_details?.reasoning_tokens ?? 0;
 
+        const { total: totalInputTokens, noCache: noCacheInputTokens } =
+          resolveInputTokenUsage({
+            reportedInputTokens: promptTokens,
+            cachedTokens: cacheReadTokens,
+          });
+
         return {
           ...result,
           usage: {
             inputTokens: {
-              total: promptTokens,
-              noCache: promptTokens - cacheReadTokens,
+              total: totalInputTokens,
+              noCache: noCacheInputTokens,
               cacheRead: cacheReadTokens,
               cacheWrite: undefined,
             },
@@ -154,12 +161,18 @@ export class DeepInfraChatLanguageModel extends OpenAICompatibleChatLanguageMode
                   fixedRawUsage.completion_tokens_details?.reasoning_tokens ??
                   0;
 
+                const { total: totalInputTokens, noCache: noCacheInputTokens } =
+                  resolveInputTokenUsage({
+                    reportedInputTokens: promptTokens,
+                    cachedTokens: cacheReadTokens,
+                  });
+
                 controller.enqueue({
                   ...value,
                   usage: {
                     inputTokens: {
-                      total: promptTokens,
-                      noCache: promptTokens - cacheReadTokens,
+                      total: totalInputTokens,
+                      noCache: noCacheInputTokens,
                       cacheRead: cacheReadTokens,
                       cacheWrite: undefined,
                     },

--- a/packages/deepseek/src/chat/convert-to-deepseek-usage.test.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-usage.test.ts
@@ -20,4 +20,16 @@ describe('convertDeepSeekUsage', () => {
       raw: usage,
     });
   });
+
+  it('treats prompt tokens as uncached when the cache breakdown exceeds them', () => {
+    const result = convertDeepSeekUsage({
+      prompt_tokens: 12,
+      completion_tokens: 40,
+      prompt_cache_hit_tokens: 4100,
+    });
+
+    expect(result.inputTokens.total).toBe(4112);
+    expect(result.inputTokens.noCache).toBe(12);
+    expect(result.inputTokens.cacheRead).toBe(4100);
+  });
 });

--- a/packages/deepseek/src/chat/convert-to-deepseek-usage.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-usage.ts
@@ -1,5 +1,8 @@
 import type { LanguageModelV4Usage } from '@ai-sdk/provider';
-import { createNullLanguageModelUsage } from '@ai-sdk/provider-utils';
+import {
+  createNullLanguageModelUsage,
+  resolveInputTokenUsage,
+} from '@ai-sdk/provider-utils';
 
 export function convertDeepSeekUsage(
   usage:
@@ -27,10 +30,16 @@ export function convertDeepSeekUsage(
   const reasoningTokens =
     usage.completion_tokens_details?.reasoning_tokens ?? 0;
 
+  const { total: totalInputTokens, noCache: noCacheInputTokens } =
+    resolveInputTokenUsage({
+      reportedInputTokens: promptTokens,
+      cachedTokens: cacheReadTokens,
+    });
+
   return {
     inputTokens: {
-      total: promptTokens,
-      noCache: promptTokens - cacheReadTokens,
+      total: totalInputTokens,
+      noCache: noCacheInputTokens,
       cacheRead: cacheReadTokens,
       cacheWrite: undefined,
     },

--- a/packages/google-vertex/src/xai/google-vertex-xai-provider.ts
+++ b/packages/google-vertex/src/xai/google-vertex-xai-provider.ts
@@ -11,6 +11,7 @@ import {
 import {
   loadOptionalSetting,
   loadSetting,
+  resolveInputTokenUsage,
   withoutTrailingSlash,
   type FetchFunction,
   type Resolvable,
@@ -112,10 +113,16 @@ function convertGoogleVertexXaiUsage(
   const reasoningTokens =
     usage.completion_tokens_details?.reasoning_tokens ?? 0;
 
+  const { total: totalInputTokens, noCache: noCacheInputTokens } =
+    resolveInputTokenUsage({
+      reportedInputTokens: promptTokens,
+      cachedTokens: cacheReadTokens,
+    });
+
   return {
     inputTokens: {
-      total: promptTokens,
-      noCache: promptTokens - cacheReadTokens,
+      total: totalInputTokens,
+      noCache: noCacheInputTokens,
       cacheRead: cacheReadTokens,
       cacheWrite: undefined,
     },

--- a/packages/google/src/convert-google-usage.test.ts
+++ b/packages/google/src/convert-google-usage.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { convertGoogleUsage } from './convert-google-usage';
+
+describe('convertGoogleUsage', () => {
+  it('subtracts cached content tokens when prompt tokens include them', () => {
+    const usage = {
+      promptTokenCount: 1000,
+      candidatesTokenCount: 40,
+      cachedContentTokenCount: 900,
+      thoughtsTokenCount: 5,
+    };
+
+    expect(convertGoogleUsage(usage)).toEqual({
+      inputTokens: {
+        total: 1000,
+        noCache: 100,
+        cacheRead: 900,
+        cacheWrite: undefined,
+      },
+      outputTokens: { total: 45, text: 40, reasoning: 5 },
+      raw: usage,
+    });
+  });
+
+  it('treats prompt tokens as uncached when cached content exceeds them', () => {
+    const usage = {
+      promptTokenCount: 12,
+      candidatesTokenCount: 40,
+      cachedContentTokenCount: 4100,
+    };
+
+    expect(convertGoogleUsage(usage)).toEqual({
+      inputTokens: {
+        total: 4112,
+        noCache: 12,
+        cacheRead: 4100,
+        cacheWrite: undefined,
+      },
+      outputTokens: { total: 40, text: 40, reasoning: 0 },
+      raw: usage,
+    });
+  });
+
+  it('returns null usage for missing usage', () => {
+    expect(convertGoogleUsage(null).inputTokens.noCache).toBeUndefined();
+  });
+});

--- a/packages/google/src/convert-google-usage.ts
+++ b/packages/google/src/convert-google-usage.ts
@@ -1,5 +1,8 @@
 import type { LanguageModelV4Usage } from '@ai-sdk/provider';
-import { createNullLanguageModelUsage } from '@ai-sdk/provider-utils';
+import {
+  createNullLanguageModelUsage,
+  resolveInputTokenUsage,
+} from '@ai-sdk/provider-utils';
 
 export type GoogleTokenDetail = {
   modality: string;
@@ -30,10 +33,16 @@ export function convertGoogleUsage(
   const cachedContentTokens = usage.cachedContentTokenCount ?? 0;
   const thoughtsTokens = usage.thoughtsTokenCount ?? 0;
 
+  const { total: totalInputTokens, noCache: noCacheInputTokens } =
+    resolveInputTokenUsage({
+      reportedInputTokens: promptTokens,
+      cachedTokens: cachedContentTokens,
+    });
+
   return {
     inputTokens: {
-      total: promptTokens,
-      noCache: promptTokens - cachedContentTokens,
+      total: totalInputTokens,
+      noCache: noCacheInputTokens,
       cacheRead: cachedContentTokens,
       cacheWrite: undefined,
     },

--- a/packages/google/src/interactions/convert-google-interactions-usage.ts
+++ b/packages/google/src/interactions/convert-google-interactions-usage.ts
@@ -1,5 +1,8 @@
 import type { JSONObject, LanguageModelV4Usage } from '@ai-sdk/provider';
-import { createNullLanguageModelUsage } from '@ai-sdk/provider-utils';
+import {
+  createNullLanguageModelUsage,
+  resolveInputTokenUsage,
+} from '@ai-sdk/provider-utils';
 import type { GoogleInteractionsUsage } from './google-interactions-api';
 
 export function convertGoogleInteractionsUsage(
@@ -14,11 +17,17 @@ export function convertGoogleInteractionsUsage(
   const totalThought = usage.total_thought_tokens ?? 0;
   const totalCached = usage.total_cached_tokens ?? 0;
 
+  const { total: totalInputTokens, noCache: noCacheInputTokens } =
+    resolveInputTokenUsage({
+      reportedInputTokens: totalInput,
+      cachedTokens: totalCached,
+    });
+
   return {
     inputTokens: {
-      total: usage.total_input_tokens ?? undefined,
+      total: usage.total_input_tokens == null ? undefined : totalInputTokens,
       noCache:
-        usage.total_input_tokens == null ? undefined : totalInput - totalCached,
+        usage.total_input_tokens == null ? undefined : noCacheInputTokens,
       cacheRead: usage.total_cached_tokens ?? undefined,
       cacheWrite: undefined,
     },

--- a/packages/groq/src/convert-groq-usage.test.ts
+++ b/packages/groq/src/convert-groq-usage.test.ts
@@ -315,4 +315,16 @@ describe('convertGroqUsage', () => {
       raw: {},
     });
   });
+
+  it('treats prompt tokens as uncached when the cache breakdown exceeds them', () => {
+    const result = convertGroqUsage({
+      prompt_tokens: 12,
+      completion_tokens: 40,
+      prompt_tokens_details: { cached_tokens: 4100 },
+    });
+
+    expect(result.inputTokens.total).toBe(4112);
+    expect(result.inputTokens.noCache).toBe(12);
+    expect(result.inputTokens.cacheRead).toBe(4100);
+  });
 });

--- a/packages/groq/src/convert-groq-usage.ts
+++ b/packages/groq/src/convert-groq-usage.ts
@@ -1,5 +1,8 @@
 import type { LanguageModelV4Usage } from '@ai-sdk/provider';
-import { createNullLanguageModelUsage } from '@ai-sdk/provider-utils';
+import {
+  createNullLanguageModelUsage,
+  resolveInputTokenUsage,
+} from '@ai-sdk/provider-utils';
 
 export function convertGroqUsage(
   usage:
@@ -37,11 +40,16 @@ export function convertGroqUsage(
       ? Math.max(0, completionTokens - reasoningTokens)
       : completionTokens;
 
+  const { total: totalInputTokens, noCache: noCacheInputTokens } =
+    resolveInputTokenUsage({
+      reportedInputTokens: promptTokens,
+      cachedTokens: cacheReadTokens ?? 0,
+    });
+
   return {
     inputTokens: {
-      total: promptTokens,
-      noCache:
-        cacheReadTokens != null ? promptTokens - cacheReadTokens : promptTokens,
+      total: totalInputTokens,
+      noCache: noCacheInputTokens,
       cacheRead: cacheReadTokens,
       cacheWrite: undefined,
     },

--- a/packages/huggingface/src/responses/convert-huggingface-responses-usage.test.ts
+++ b/packages/huggingface/src/responses/convert-huggingface-responses-usage.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { convertHuggingFaceResponsesUsage } from './convert-huggingface-responses-usage';
+
+describe('convertHuggingFaceResponsesUsage', () => {
+  it('subtracts cached tokens when input tokens include them', () => {
+    const usage = {
+      input_tokens: 1000,
+      output_tokens: 40,
+      total_tokens: 1040,
+      input_tokens_details: { cached_tokens: 900 },
+    };
+
+    expect(convertHuggingFaceResponsesUsage(usage)).toEqual({
+      inputTokens: {
+        total: 1000,
+        noCache: 100,
+        cacheRead: 900,
+        cacheWrite: undefined,
+      },
+      outputTokens: { total: 40, text: 40, reasoning: 0 },
+      raw: usage,
+    });
+  });
+
+  it('treats input tokens as uncached when the cache breakdown exceeds them', () => {
+    const usage = {
+      input_tokens: 12,
+      output_tokens: 40,
+      total_tokens: 52,
+      input_tokens_details: { cached_tokens: 4100 },
+    };
+
+    expect(convertHuggingFaceResponsesUsage(usage)).toEqual({
+      inputTokens: {
+        total: 4112,
+        noCache: 12,
+        cacheRead: 4100,
+        cacheWrite: undefined,
+      },
+      outputTokens: { total: 40, text: 40, reasoning: 0 },
+      raw: usage,
+    });
+  });
+
+  it('returns null usage for missing usage', () => {
+    expect(
+      convertHuggingFaceResponsesUsage(null).inputTokens.noCache,
+    ).toBeUndefined();
+  });
+});

--- a/packages/huggingface/src/responses/convert-huggingface-responses-usage.ts
+++ b/packages/huggingface/src/responses/convert-huggingface-responses-usage.ts
@@ -1,5 +1,8 @@
 import type { LanguageModelV4Usage } from '@ai-sdk/provider';
-import { createNullLanguageModelUsage } from '@ai-sdk/provider-utils';
+import {
+  createNullLanguageModelUsage,
+  resolveInputTokenUsage,
+} from '@ai-sdk/provider-utils';
 
 export type HuggingFaceResponsesUsage = {
   input_tokens: number;
@@ -25,10 +28,16 @@ export function convertHuggingFaceResponsesUsage(
   const cachedTokens = usage.input_tokens_details?.cached_tokens ?? 0;
   const reasoningTokens = usage.output_tokens_details?.reasoning_tokens ?? 0;
 
+  const { total: totalInputTokens, noCache: noCacheInputTokens } =
+    resolveInputTokenUsage({
+      reportedInputTokens: inputTokens,
+      cachedTokens: cachedTokens,
+    });
+
   return {
     inputTokens: {
-      total: inputTokens,
-      noCache: inputTokens - cachedTokens,
+      total: totalInputTokens,
+      noCache: noCacheInputTokens,
       cacheRead: cachedTokens,
       cacheWrite: undefined,
     },

--- a/packages/mistral/src/convert-mistral-usage.test.ts
+++ b/packages/mistral/src/convert-mistral-usage.test.ts
@@ -138,4 +138,17 @@ describe('convertMistralUsage', () => {
       raw: usage,
     });
   });
+
+  it('treats prompt tokens as uncached when the cache breakdown exceeds them', () => {
+    const result = convertMistralUsage({
+      prompt_tokens: 12,
+      completion_tokens: 40,
+      total_tokens: 52,
+      num_cached_tokens: 4100,
+    });
+
+    expect(result.inputTokens.total).toBe(4112);
+    expect(result.inputTokens.noCache).toBe(12);
+    expect(result.inputTokens.cacheRead).toBe(4100);
+  });
 });

--- a/packages/mistral/src/convert-mistral-usage.ts
+++ b/packages/mistral/src/convert-mistral-usage.ts
@@ -1,5 +1,8 @@
 import type { LanguageModelV4Usage } from '@ai-sdk/provider';
-import { createNullLanguageModelUsage } from '@ai-sdk/provider-utils';
+import {
+  createNullLanguageModelUsage,
+  resolveInputTokenUsage,
+} from '@ai-sdk/provider-utils';
 
 export type MistralUsage = {
   prompt_tokens: number;
@@ -26,10 +29,16 @@ export function convertMistralUsage(
     usage.prompt_token_details?.cached_tokens ??
     0;
 
+  const { total: totalInputTokens, noCache: noCacheInputTokens } =
+    resolveInputTokenUsage({
+      reportedInputTokens: promptTokens,
+      cachedTokens: cacheReadTokens,
+    });
+
   return {
     inputTokens: {
-      total: promptTokens,
-      noCache: promptTokens - cacheReadTokens,
+      total: totalInputTokens,
+      noCache: noCacheInputTokens,
       cacheRead: cacheReadTokens || undefined,
       cacheWrite: undefined,
     },

--- a/packages/moonshotai/src/convert-moonshotai-chat-usage.test.ts
+++ b/packages/moonshotai/src/convert-moonshotai-chat-usage.test.ts
@@ -262,4 +262,16 @@ describe('convertMoonshotAIChatUsage', () => {
       },
     });
   });
+
+  it('treats prompt tokens as uncached when the cache breakdown exceeds them', () => {
+    const result = convertMoonshotAIChatUsage({
+      prompt_tokens: 12,
+      completion_tokens: 40,
+      cached_tokens: 4100,
+    });
+
+    expect(result.inputTokens.total).toBe(4112);
+    expect(result.inputTokens.noCache).toBe(12);
+    expect(result.inputTokens.cacheRead).toBe(4100);
+  });
 });

--- a/packages/moonshotai/src/convert-moonshotai-chat-usage.ts
+++ b/packages/moonshotai/src/convert-moonshotai-chat-usage.ts
@@ -1,5 +1,8 @@
 import type { LanguageModelV4Usage } from '@ai-sdk/provider';
-import { createNullLanguageModelUsage } from '@ai-sdk/provider-utils';
+import {
+  createNullLanguageModelUsage,
+  resolveInputTokenUsage,
+} from '@ai-sdk/provider-utils';
 
 export function convertMoonshotAIChatUsage(
   usage:
@@ -30,10 +33,16 @@ export function convertMoonshotAIChatUsage(
   const reasoningTokens =
     usage.completion_tokens_details?.reasoning_tokens ?? 0;
 
+  const { total: totalInputTokens, noCache: noCacheInputTokens } =
+    resolveInputTokenUsage({
+      reportedInputTokens: promptTokens,
+      cachedTokens: cacheReadTokens,
+    });
+
   return {
     inputTokens: {
-      total: promptTokens,
-      noCache: promptTokens - cacheReadTokens,
+      total: totalInputTokens,
+      noCache: noCacheInputTokens,
       cacheRead: cacheReadTokens,
       cacheWrite: undefined,
     },

--- a/packages/open-responses/src/responses/open-responses-language-model.ts
+++ b/packages/open-responses/src/responses/open-responses-language-model.ts
@@ -21,6 +21,7 @@ import {
   mapReasoningToProviderEffort,
   parseProviderOptions,
   postJsonToApi,
+  resolveInputTokenUsage,
   serializeModelOptions,
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
@@ -343,6 +344,10 @@ export class OpenResponsesLanguageModel implements LanguageModelV4 {
     const cachedInputTokens = usage?.input_tokens_details?.cached_tokens;
     const outputTokens = usage?.output_tokens;
     const reasoningTokens = usage?.output_tokens_details?.reasoning_tokens;
+    const resolvedInputTokens = resolveInputTokenUsage({
+      reportedInputTokens: inputTokens ?? 0,
+      cachedTokens: cachedInputTokens ?? 0,
+    });
 
     return {
       content,
@@ -355,8 +360,8 @@ export class OpenResponsesLanguageModel implements LanguageModelV4 {
       },
       usage: {
         inputTokens: {
-          total: inputTokens,
-          noCache: (inputTokens ?? 0) - (cachedInputTokens ?? 0),
+          total: inputTokens == null ? undefined : resolvedInputTokens.total,
+          noCache: resolvedInputTokens.noCache,
           cacheRead: cachedInputTokens,
           cacheWrite: undefined,
         },
@@ -429,9 +434,14 @@ export class OpenResponsesLanguageModel implements LanguageModelV4 {
       const reasoningTokens =
         responseUsage.output_tokens_details?.reasoning_tokens;
 
+      const resolvedInputTokens = resolveInputTokenUsage({
+        reportedInputTokens: inputTokens ?? 0,
+        cachedTokens: cachedInputTokens ?? 0,
+      });
+
       usage.inputTokens = {
-        total: inputTokens,
-        noCache: (inputTokens ?? 0) - (cachedInputTokens ?? 0),
+        total: inputTokens == null ? undefined : resolvedInputTokens.total,
+        noCache: resolvedInputTokens.noCache,
         cacheRead: cachedInputTokens,
         cacheWrite: undefined,
       };

--- a/packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.test.ts
+++ b/packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.test.ts
@@ -55,4 +55,23 @@ describe('convertOpenAICompatibleChatUsage', () => {
       raw: usage,
     });
   });
+
+  it('treats prompt tokens as uncached when the cache breakdown exceeds them', () => {
+    const usage = {
+      prompt_tokens: 12,
+      completion_tokens: 40,
+      prompt_tokens_details: { cached_tokens: 4100 },
+    };
+
+    expect(convertOpenAICompatibleChatUsage(usage)).toEqual({
+      inputTokens: {
+        total: 4112,
+        noCache: 12,
+        cacheRead: 4100,
+        cacheWrite: undefined,
+      },
+      outputTokens: { total: 40, text: 40, reasoning: 0 },
+      raw: usage,
+    });
+  });
 });

--- a/packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.ts
+++ b/packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.ts
@@ -1,5 +1,8 @@
 import type { LanguageModelV4Usage } from '@ai-sdk/provider';
-import { createNullLanguageModelUsage } from '@ai-sdk/provider-utils';
+import {
+  createNullLanguageModelUsage,
+  resolveInputTokenUsage,
+} from '@ai-sdk/provider-utils';
 
 export function convertOpenAICompatibleChatUsage(
   usage:
@@ -26,10 +29,16 @@ export function convertOpenAICompatibleChatUsage(
   const reasoningTokens =
     usage.completion_tokens_details?.reasoning_tokens ?? 0;
 
+  const { total: totalInputTokens, noCache: noCacheInputTokens } =
+    resolveInputTokenUsage({
+      reportedInputTokens: promptTokens,
+      cachedTokens: cacheReadTokens,
+    });
+
   return {
     inputTokens: {
-      total: promptTokens,
-      noCache: promptTokens - cacheReadTokens,
+      total: totalInputTokens,
+      noCache: noCacheInputTokens,
       cacheRead: cacheReadTokens,
       cacheWrite: undefined,
     },

--- a/packages/openai/src/chat/convert-openai-chat-usage.test.ts
+++ b/packages/openai/src/chat/convert-openai-chat-usage.test.ts
@@ -22,4 +22,40 @@ describe('convertOpenAIChatUsage', () => {
       raw: usage,
     });
   });
+
+  it('treats prompt tokens as uncached when the cache breakdown exceeds them', () => {
+    // Some providers report prompt_tokens exclusive of cached tokens. The
+    // subtraction would underflow, so the reported value IS the uncached count.
+    const usage = {
+      prompt_tokens: 12,
+      completion_tokens: 40,
+      total_tokens: 4152,
+      prompt_tokens_details: { cached_tokens: 4100 },
+      completion_tokens_details: { reasoning_tokens: 0 },
+    };
+
+    expect(convertOpenAIChatUsage(usage)).toEqual({
+      inputTokens: {
+        total: 4112,
+        noCache: 12,
+        cacheRead: 4100,
+        cacheWrite: undefined,
+      },
+      outputTokens: { total: 40, text: 40, reasoning: 0 },
+      raw: usage,
+    });
+  });
+
+  it('accounts for cache writes when inferring the reporting convention', () => {
+    const usage = {
+      prompt_tokens: 30,
+      completion_tokens: 10,
+      prompt_tokens_details: { cached_tokens: 900, cache_write_tokens: 200 },
+    };
+
+    const result = convertOpenAIChatUsage(usage);
+
+    expect(result.inputTokens.noCache).toBe(30);
+    expect(result.inputTokens.total).toBe(1130);
+  });
 });

--- a/packages/openai/src/chat/convert-openai-chat-usage.ts
+++ b/packages/openai/src/chat/convert-openai-chat-usage.ts
@@ -1,5 +1,8 @@
 import type { LanguageModelV4Usage } from '@ai-sdk/provider';
-import { createNullLanguageModelUsage } from '@ai-sdk/provider-utils';
+import {
+  createNullLanguageModelUsage,
+  resolveInputTokenUsage,
+} from '@ai-sdk/provider-utils';
 
 export type OpenAIChatUsage = {
   prompt_tokens?: number | null;
@@ -31,10 +34,16 @@ export function convertOpenAIChatUsage(
   const reasoningTokens =
     usage.completion_tokens_details?.reasoning_tokens ?? 0;
 
+  const { total: totalInputTokens, noCache: noCacheInputTokens } =
+    resolveInputTokenUsage({
+      reportedInputTokens: promptTokens,
+      cachedTokens: cachedTokens + (cacheWriteTokens ?? 0),
+    });
+
   return {
     inputTokens: {
-      total: promptTokens,
-      noCache: promptTokens - cachedTokens - (cacheWriteTokens ?? 0),
+      total: totalInputTokens,
+      noCache: noCacheInputTokens,
       cacheRead: cachedTokens,
       cacheWrite: cacheWriteTokens,
     },

--- a/packages/openai/src/responses/convert-openai-responses-usage.test.ts
+++ b/packages/openai/src/responses/convert-openai-responses-usage.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { convertOpenAIResponsesUsage } from './convert-openai-responses-usage';
+
+describe('convertOpenAIResponsesUsage', () => {
+  it('subtracts the cache breakdown when input tokens include it', () => {
+    const usage = {
+      input_tokens: 1000,
+      output_tokens: 40,
+      input_tokens_details: { cached_tokens: 900 },
+    };
+
+    expect(convertOpenAIResponsesUsage(usage)).toEqual({
+      inputTokens: {
+        total: 1000,
+        noCache: 100,
+        cacheRead: 900,
+        cacheWrite: undefined,
+      },
+      outputTokens: { total: 40, text: 40, reasoning: 0 },
+      raw: usage,
+    });
+  });
+
+  it('treats input tokens as uncached when the cache breakdown exceeds them', () => {
+    // Some providers report input_tokens exclusive of cached tokens. The
+    // subtraction would underflow, so the reported value IS the uncached count.
+    const usage = {
+      input_tokens: 12,
+      output_tokens: 40,
+      input_tokens_details: { cached_tokens: 4100 },
+    };
+
+    expect(convertOpenAIResponsesUsage(usage)).toEqual({
+      inputTokens: {
+        total: 4112,
+        noCache: 12,
+        cacheRead: 4100,
+        cacheWrite: undefined,
+      },
+      outputTokens: { total: 40, text: 40, reasoning: 0 },
+      raw: usage,
+    });
+  });
+
+  it('accounts for cache writes when inferring the reporting convention', () => {
+    const result = convertOpenAIResponsesUsage({
+      input_tokens: 30,
+      output_tokens: 10,
+      input_tokens_details: { cached_tokens: 900, cache_write_tokens: 200 },
+    });
+
+    expect(result.inputTokens.noCache).toBe(30);
+    expect(result.inputTokens.total).toBe(1130);
+    expect(result.inputTokens.cacheRead).toBe(900);
+    expect(result.inputTokens.cacheWrite).toBe(200);
+  });
+
+  it('returns null usage for missing usage', () => {
+    expect(
+      convertOpenAIResponsesUsage(null).inputTokens.noCache,
+    ).toBeUndefined();
+  });
+});

--- a/packages/openai/src/responses/convert-openai-responses-usage.ts
+++ b/packages/openai/src/responses/convert-openai-responses-usage.ts
@@ -1,5 +1,8 @@
 import type { LanguageModelV4Usage } from '@ai-sdk/provider';
-import { createNullLanguageModelUsage } from '@ai-sdk/provider-utils';
+import {
+  createNullLanguageModelUsage,
+  resolveInputTokenUsage,
+} from '@ai-sdk/provider-utils';
 
 export type OpenAIResponsesUsage = {
   input_tokens: number;
@@ -30,10 +33,16 @@ export function convertOpenAIResponsesUsage(
     usage.input_tokens_details?.cache_write_tokens ?? undefined;
   const reasoningTokens = usage.output_tokens_details?.reasoning_tokens ?? 0;
 
+  const { total: totalInputTokens, noCache: noCacheInputTokens } =
+    resolveInputTokenUsage({
+      reportedInputTokens: inputTokens,
+      cachedTokens: cachedTokens + (cacheWriteTokens ?? 0),
+    });
+
   return {
     inputTokens: {
-      total: inputTokens,
-      noCache: inputTokens - cachedTokens - (cacheWriteTokens ?? 0),
+      total: totalInputTokens,
+      noCache: noCacheInputTokens,
       cacheRead: cachedTokens,
       cacheWrite: cacheWriteTokens,
     },

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -77,6 +77,7 @@ export {
 export * from './remove-undefined-entries';
 export * from './resolve';
 export { resolveFullMediaType } from './resolve-full-media-type';
+export { resolveInputTokenUsage } from './resolve-input-token-usage';
 export { resolveProviderReference } from './resolve-provider-reference';
 export * from './retry-with-exponential-backoff';
 export * from './response-handler';

--- a/packages/provider-utils/src/resolve-input-token-usage.test.ts
+++ b/packages/provider-utils/src/resolve-input-token-usage.test.ts
@@ -69,7 +69,25 @@ describe('resolveInputTokenUsage', () => {
     });
   });
 
-  it('always returns non-negative counts', () => {
+  it('keeps the cache breakdown a partition of the total', () => {
+    // `total` is the authoritative input-token count and noCache/cacheRead/
+    // cacheWrite are its breakdown, so they must sum back to it. The bug this
+    // guards produced noCache < 0 and cacheRead > total, violating both halves.
+    for (const reportedInputTokens of [0, 1, 12, 100, 1000, 5000]) {
+      for (const cachedTokens of [0, 1, 50, 900, 4100, 1_000_000]) {
+        const { total, noCache } = resolveInputTokenUsage({
+          reportedInputTokens,
+          cachedTokens,
+        });
+
+        expect(noCache + cachedTokens).toBe(total);
+        expect(noCache).toBeGreaterThanOrEqual(0);
+        expect(total).toBeGreaterThanOrEqual(cachedTokens);
+      }
+    }
+  });
+
+  it('always returns non-negative counts, even for malformed input', () => {
     const cases = [
       { reportedInputTokens: 0, cachedTokens: 0 },
       { reportedInputTokens: 1, cachedTokens: 1_000_000 },

--- a/packages/provider-utils/src/resolve-input-token-usage.test.ts
+++ b/packages/provider-utils/src/resolve-input-token-usage.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { resolveInputTokenUsage } from './resolve-input-token-usage';
+
+describe('resolveInputTokenUsage', () => {
+  describe('cache-inclusive providers (cached <= reported)', () => {
+    it('subtracts the cache breakdown from the reported total', () => {
+      expect(
+        resolveInputTokenUsage({
+          reportedInputTokens: 1000,
+          cachedTokens: 900,
+        }),
+      ).toEqual({ total: 1000, noCache: 100 });
+    });
+
+    it('treats a fully cached prompt as zero uncached tokens', () => {
+      expect(
+        resolveInputTokenUsage({
+          reportedInputTokens: 1000,
+          cachedTokens: 1000,
+        }),
+      ).toEqual({ total: 1000, noCache: 0 });
+    });
+
+    it('passes the reported total through when nothing was cached', () => {
+      expect(
+        resolveInputTokenUsage({ reportedInputTokens: 1000, cachedTokens: 0 }),
+      ).toEqual({ total: 1000, noCache: 1000 });
+    });
+  });
+
+  describe('cache-exclusive providers (cached > reported)', () => {
+    it('treats the reported count as uncached and sums for the total', () => {
+      expect(
+        resolveInputTokenUsage({
+          reportedInputTokens: 12,
+          cachedTokens: 4100,
+        }),
+      ).toEqual({ total: 4112, noCache: 12 });
+    });
+
+    it('never returns a negative noCache, the regression this guards', () => {
+      const { noCache } = resolveInputTokenUsage({
+        reportedInputTokens: 100,
+        cachedTokens: 5000,
+      });
+
+      expect(noCache).toBe(100);
+      expect(noCache).toBeGreaterThanOrEqual(0);
+    });
+
+    it('handles a zero reported count against a non-zero cache', () => {
+      expect(
+        resolveInputTokenUsage({ reportedInputTokens: 0, cachedTokens: 500 }),
+      ).toEqual({ total: 500, noCache: 0 });
+    });
+  });
+
+  describe('malformed provider input', () => {
+    it('clamps a negative reported count rather than propagating it', () => {
+      expect(
+        resolveInputTokenUsage({ reportedInputTokens: -5, cachedTokens: 0 }),
+      ).toEqual({ total: 0, noCache: 0 });
+    });
+
+    it('clamps a negative cache breakdown', () => {
+      expect(
+        resolveInputTokenUsage({ reportedInputTokens: 100, cachedTokens: -5 }),
+      ).toEqual({ total: 100, noCache: 100 });
+    });
+  });
+
+  it('always returns non-negative counts', () => {
+    const cases = [
+      { reportedInputTokens: 0, cachedTokens: 0 },
+      { reportedInputTokens: 1, cachedTokens: 1_000_000 },
+      { reportedInputTokens: 1_000_000, cachedTokens: 1 },
+      { reportedInputTokens: -100, cachedTokens: -100 },
+    ];
+
+    for (const input of cases) {
+      const { total, noCache } = resolveInputTokenUsage(input);
+
+      expect(total).toBeGreaterThanOrEqual(0);
+      expect(noCache).toBeGreaterThanOrEqual(0);
+      expect(noCache).toBeLessThanOrEqual(total);
+    }
+  });
+});

--- a/packages/provider-utils/src/resolve-input-token-usage.ts
+++ b/packages/provider-utils/src/resolve-input-token-usage.ts
@@ -1,0 +1,44 @@
+/**
+ * Resolves the total/uncached split of a provider's input token count.
+ *
+ * Providers disagree about whether the input-token count they report already
+ * includes cached tokens. Most include them, so the uncached remainder is
+ * `reported - cached`. Some report the uncached count directly, and for those
+ * the subtraction underflows.
+ *
+ * A cache breakdown larger than the reported total is the proof of which
+ * convention is in play: it can only happen when the reported value already
+ * *is* the uncached count, in which case the true total is the sum.
+ *
+ * Without this inference `noCache` goes negative whenever a cache-exclusive
+ * provider serves a request whose cached prefix exceeds the fresh remainder —
+ * routine in agentic traffic, where a long cached context is replayed against
+ * a handful of new tokens — and consumers downstream bill and report on it.
+ *
+ * @param reportedInputTokens - The provider's reported input/prompt token count.
+ * @param cachedTokens - Tokens attributable to the cache (reads plus writes).
+ * Whether the provider counted these inside `reportedInputTokens` is inferred
+ * rather than assumed.
+ *
+ * @returns Non-negative `total` and `noCache` counts.
+ */
+export function resolveInputTokenUsage({
+  reportedInputTokens,
+  cachedTokens,
+}: {
+  reportedInputTokens: number;
+  cachedTokens: number;
+}): { total: number; noCache: number } {
+  // Normalize up front so both outputs are non-negative by construction; a
+  // provider reporting a negative count is a separate defect and must not
+  // become a negative token count downstream.
+  const reported = Math.max(0, reportedInputTokens);
+  const cached = Math.max(0, cachedTokens);
+
+  const reportedIncludesCached = cached <= reported;
+
+  return {
+    total: reportedIncludesCached ? reported : reported + cached,
+    noCache: reportedIncludesCached ? reported - cached : reported,
+  };
+}

--- a/packages/xai/src/convert-xai-chat-usage.ts
+++ b/packages/xai/src/convert-xai-chat-usage.ts
@@ -1,4 +1,5 @@
 import type { LanguageModelV4Usage } from '@ai-sdk/provider';
+import { resolveInputTokenUsage } from '@ai-sdk/provider-utils';
 import type { XaiChatUsage } from './xai-chat-language-model';
 
 export function convertXaiChatUsage(usage: XaiChatUsage): LanguageModelV4Usage {
@@ -6,16 +7,16 @@ export function convertXaiChatUsage(usage: XaiChatUsage): LanguageModelV4Usage {
   const reasoningTokens =
     usage.completion_tokens_details?.reasoning_tokens ?? 0;
 
-  const promptTokensIncludesCached = cacheReadTokens <= usage.prompt_tokens;
+  const { total: totalInputTokens, noCache: noCacheInputTokens } =
+    resolveInputTokenUsage({
+      reportedInputTokens: usage.prompt_tokens,
+      cachedTokens: cacheReadTokens,
+    });
 
   return {
     inputTokens: {
-      total: promptTokensIncludesCached
-        ? usage.prompt_tokens
-        : usage.prompt_tokens + cacheReadTokens,
-      noCache: promptTokensIncludesCached
-        ? usage.prompt_tokens - cacheReadTokens
-        : usage.prompt_tokens,
+      total: totalInputTokens,
+      noCache: noCacheInputTokens,
       cacheRead: cacheReadTokens,
       cacheWrite: undefined,
     },

--- a/packages/xai/src/responses/convert-xai-responses-usage.ts
+++ b/packages/xai/src/responses/convert-xai-responses-usage.ts
@@ -1,4 +1,5 @@
 import type { LanguageModelV4Usage } from '@ai-sdk/provider';
+import { resolveInputTokenUsage } from '@ai-sdk/provider-utils';
 import type { XaiResponsesUsage } from './xai-responses-api';
 
 export function convertXaiResponsesUsage(
@@ -7,16 +8,16 @@ export function convertXaiResponsesUsage(
   const cacheReadTokens = usage.input_tokens_details?.cached_tokens ?? 0;
   const reasoningTokens = usage.output_tokens_details?.reasoning_tokens ?? 0;
 
-  const inputTokensIncludesCached = cacheReadTokens <= usage.input_tokens;
+  const { total: totalInputTokens, noCache: noCacheInputTokens } =
+    resolveInputTokenUsage({
+      reportedInputTokens: usage.input_tokens,
+      cachedTokens: cacheReadTokens,
+    });
 
   return {
     inputTokens: {
-      total: inputTokensIncludesCached
-        ? usage.input_tokens
-        : usage.input_tokens + cacheReadTokens,
-      noCache: inputTokensIncludesCached
-        ? usage.input_tokens - cacheReadTokens
-        : usage.input_tokens,
+      total: totalInputTokens,
+      noCache: noCacheInputTokens,
       cacheRead: cacheReadTokens,
       cacheWrite: undefined,
     },


### PR DESCRIPTION
## Problem

Provider converters derive uncached input tokens by subtraction, with no floor:

```ts
// packages/openai-compatible/src/chat/convert-openai-compatible-chat-usage.ts
noCache: promptTokens - cacheReadTokens,

// packages/openai/src/chat/convert-openai-chat-usage.ts
noCache: promptTokens - cachedTokens - (cacheWriteTokens ?? 0),
```

Providers disagree about whether the prompt-token count they report already includes cached tokens. For the ones that report it **exclusive** of cache, this underflows and `noCache` goes negative — which happens whenever the cached prefix exceeds the fresh remainder. That is routine in agentic traffic, where a long cached context is replayed against a handful of new tokens.

Exactly one converter guarded this today: xAI (`convert-xai-chat-usage.ts`).

### Observed in production

Found via AI Gateway, whose usage-fact schema declares `inputTokens` as `{ type: 'integer', minimum: 0 }`. 421 log samples over 3 days, 100% identical:

```
TypeError: Data does not match AI_GATEWAY_REQUEST schema: data/inputTokens must be >= 0
```

Spanning 8+ teams, 3 API surfaces, 3 regions, many SDK versions. The negative value reached both the reporting pipeline (fact dropped entirely) and cost computation.

## Fix

Infer the reporting convention instead of assuming it. A cache breakdown larger than the reported total can only happen when the reported value already *is* the uncached count — in which case the true total is the sum:

```ts
const reportedIncludesCached = cached <= reported;
total:   reportedIncludesCached ? reported : reported + cached
noCache: reportedIncludesCached ? reported - cached : reported
```

A plain `Math.max(0, …)` would stop the negative but leave `total` understated, so the inference is the correct fix rather than just the safe one.

Added as `resolveInputTokenUsage` in `@ai-sdk/provider-utils` and routed every affected converter through it. xAI's local guard is replaced by the shared helper, so the semantic now lives in one place.

## Affected converters

openai (chat + responses), openai-compatible, google (+ interactions), groq, mistral, deepseek, moonshotai, alibaba, huggingface, deepinfra, google-vertex (xai), open-responses, xai.

`@ai-sdk/openai-compatible` is the widest blast radius — ~35 downstream providers build on it.

## Prior art

The **output** half of this exact bug was fixed twice — 83e65105d6 and 221425865d — both clamping `outputTokens.text` when reasoning exceeds completion. Neither touched the input half. `convert-openai-compatible-chat-usage.ts` currently clamps output and not input, on adjacent lines.

## Tests

- New `resolve-input-token-usage.test.ts` (9 cases): cache-inclusive, cache-exclusive, malformed input, and an invariant check that `0 <= noCache <= total`.
- Per-converter `cached > prompt` regression tests across 10 converters, including 3 new test files (openai responses, google, huggingface).
- Verified the new tests **fail** without the source fix.
- Full suites green across all 14 packages: 31/31 turbo tasks, ~4,200 tests, no regressions.

## Follow-up

Needs a backport to `release-v6.0` (spec v3), which carries the same defect. `release-v5.0` has no `noCache` and is unaffected.
