### PR TITLE
feat(xai): batch API support

### DIFF
--- a/.changeset/sharp-batches-grok.md
+++ b/.changeset/sharp-batches-grok.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat(xai): batch API support

--- a/content/providers/01-ai-sdk-providers/01-xai.mdx
+++ b/content/providers/01-ai-sdk-providers/01-xai.mdx
@@ -625,6 +625,66 @@ The following provider options are available:
   tools with client-side function tools in the same request.
 </Note>
 
+## Text Batches
+
+<Note type="warning">
+  Text batch support is experimental and the API may change in patch releases.
+</Note>
+
+The xAI provider supports asynchronous text generation through the
+[Batch API](https://docs.x.ai/developers/advanced-api-usage/batch-api). Use the
+experimental text batch APIs to start a batch, poll its status, and stream its
+results:
+
+```ts
+import { xai } from '@ai-sdk/xai';
+import {
+  experimental_getBatchResults as getBatchResults,
+  experimental_getBatchStatus as getBatchStatus,
+  experimental_startTextBatch as startTextBatch,
+} from 'ai';
+import { setTimeout } from 'node:timers/promises';
+
+const model = xai('grok-4.3');
+
+const batch = await startTextBatch({
+  model,
+  requests: [
+    { id: 'capital-france', prompt: 'What is the capital of France?' },
+    { id: 'capital-germany', prompt: 'What is the capital of Germany?' },
+  ],
+});
+
+let status = batch.status;
+while (status === 'pending') {
+  await setTimeout(60_000);
+  ({ status } = await getBatchStatus({ model, batch }));
+}
+
+for await (const item of getBatchResults({ model, batch })) {
+  if (item.status === 'succeeded') {
+    console.log(item.id, item.text);
+  } else {
+    console.error(item.id, item.error);
+  }
+}
+```
+
+`startTextBatch` returns a serializable batch reference. Persist this reference
+to check the batch status or retrieve its results from another process. Results
+can arrive in a different order from the input requests, so match each result by
+its `id`.
+
+Text batches are available through `xai(modelId)` and
+`xai.responses(modelId)`. The legacy `xai.chat(modelId)` models do not expose
+the batch APIs.
+
+<Note>
+  The xAI Batch API does not support per-batch webhooks. When you provide a
+  `webhookUrl`, the provider returns an unsupported warning and starts the batch
+  without a webhook.
+</Note>
+
 ## Model Capabilities
 
 | Model                         | Image Input | Object Generation | Tool Usage | Tool Streaming | Reasoning |

--- a/examples/ai-functions/src/start-text-batch/xai/basic.ts
+++ b/examples/ai-functions/src/start-text-batch/xai/basic.ts
@@ -1,0 +1,48 @@
+import { xai } from '@ai-sdk/xai';
+import {
+  experimental_getBatchResults as getBatchResults,
+  experimental_getBatchStatus as getBatchStatus,
+  experimental_startTextBatch as startTextBatch,
+} from 'ai';
+import { setTimeout } from 'node:timers/promises';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const model = xai('grok-4.6');
+
+  const batch = await startTextBatch({
+    model,
+    requests: [
+      {
+        id: 'capital-france',
+        prompt: 'What is the capital of France?',
+      },
+      {
+        id: 'capital-germany',
+        prompt: 'What is the capital of Germany?',
+      },
+    ],
+  });
+
+  print('Started batch:', batch);
+
+  while (true) {
+    const { status } = await getBatchStatus({ model, batch });
+    print('Batch status:', status);
+
+    if (status !== 'pending') {
+      break;
+    }
+
+    await setTimeout(10_000);
+  }
+
+  for await (const item of getBatchResults({ model, batch })) {
+    if (item.status === 'succeeded') {
+      print('Result:', { id: item.id, text: item.text });
+    } else {
+      print('Error:', { id: item.id, error: item.error });
+    }
+  }
+});

--- a/examples/ai-functions/src/start-text-batch/xai/basic.ts
+++ b/examples/ai-functions/src/start-text-batch/xai/basic.ts
@@ -9,7 +9,7 @@ import { print } from '../../lib/print';
 import { run } from '../../lib/run';
 
 run(async () => {
-  const model = xai('grok-4.6');
+  const model = xai('grok-4.3');
 
   const batch = await startTextBatch({
     model,

--- a/packages/xai/src/__snapshots__/xai-chat-language-model.test.ts.snap
+++ b/packages/xai/src/__snapshots__/xai-chat-language-model.test.ts.snap
@@ -111,6 +111,7 @@ Response: I'll go with "Hello" as it's a common greeting and keeps it simple.",
         "reasoning_tokens": 228,
         "rejected_prediction_tokens": 0,
       },
+      "cost_in_usd_ticks": 1176500,
       "prompt_tokens": 12,
       "prompt_tokens_details": {
         "audio_tokens": 0,
@@ -252,6 +253,7 @@ I should call this function to advance the user's request.",
         "reasoning_tokens": 189,
         "rejected_prediction_tokens": 0,
       },
+      "cost_in_usd_ticks": 1399000,
       "prompt_tokens": 291,
       "prompt_tokens_details": {
         "audio_tokens": 0,
@@ -350,6 +352,7 @@ exports[`XaiChatLanguageModel > doStream > text > should stream text content 1`]
           "reasoning_tokens": 290,
           "rejected_prediction_tokens": 0,
         },
+        "cost_in_usd_ticks": 1466250,
         "prompt_tokens": 12,
         "prompt_tokens_details": {
           "audio_tokens": 0,
@@ -455,6 +458,7 @@ exports[`XaiChatLanguageModel > doStream > tool call > should stream tool call c
           "reasoning_tokens": 196,
           "rejected_prediction_tokens": 0,
         },
+        "cost_in_usd_ticks": 1330500,
         "prompt_tokens": 291,
         "prompt_tokens_details": {
           "audio_tokens": 0,

--- a/packages/xai/src/responses/xai-responses-batch.test.ts
+++ b/packages/xai/src/responses/xai-responses-batch.test.ts
@@ -74,7 +74,7 @@ function chatResultBody(text: string) {
     id: 'response_123',
     object: 'chat.completion',
     created: 1_700_000_000,
-    model: 'grok-4.6',
+    model: 'grok-4.3',
     choices: [
       {
         index: 0,
@@ -110,33 +110,6 @@ function successfulResult(id: string, text: string) {
   };
 }
 
-function responsesResultBody(text: string) {
-  return {
-    id: 'resp_123',
-    object: 'response',
-    created_at: 1_700_000_000,
-    model: 'grok-4.6',
-    output: [
-      {
-        type: 'message',
-        role: 'assistant',
-        id: 'msg_123',
-        status: 'completed',
-        content: [{ type: 'output_text', text, annotations: [] }],
-      },
-    ],
-    usage: {
-      input_tokens: 10,
-      output_tokens: 3,
-      input_tokens_details: { cached_tokens: 2 },
-      output_tokens_details: { reasoning_tokens: 1 },
-      cost_in_usd_ticks: 123,
-    },
-    status: 'completed',
-    service_tier: 'default',
-  };
-}
-
 describe('xAI Responses batch language model', () => {
   it('uploads prepared JSONL requests and creates a file-backed batch', async () => {
     server.urls[urls.files].response = {
@@ -158,7 +131,7 @@ describe('xAI Responses batch language model', () => {
     const model = createXai({
       apiKey: 'test-api-key',
       headers: { 'Provider-Header': 'provider' },
-    }).responses('grok-4.6');
+    }).responses('grok-4.3');
 
     const result = await model.experimental_doStartBatch({
       requests: [
@@ -213,7 +186,7 @@ describe('xAI Responses batch language model', () => {
         method: 'POST',
         url: '/v1/responses',
         body: {
-          model: 'grok-4.6',
+          model: 'grok-4.3',
           input: [
             {
               role: 'user',
@@ -232,7 +205,7 @@ describe('xAI Responses batch language model', () => {
         method: 'POST',
         url: '/v1/responses',
         body: {
-          model: 'grok-4.6',
+          model: 'grok-4.3',
           input: [
             {
               role: 'user',
@@ -275,7 +248,7 @@ describe('xAI Responses batch language model', () => {
         },
       }),
     };
-    const model = createXai({ apiKey: 'test-api-key' })('grok-4.6');
+    const model = createXai({ apiKey: 'test-api-key' })('grok-4.3');
 
     await expect(
       model.experimental_doGetBatchStatus({ batchId: 'batch_123' }),
@@ -309,7 +282,7 @@ describe('xAI Responses batch language model', () => {
         },
       }),
     };
-    const model = createXai({ apiKey: 'test-api-key' })('grok-4.6');
+    const model = createXai({ apiKey: 'test-api-key' })('grok-4.3');
 
     const status = await model.experimental_doGetBatchStatus({
       batchId: 'batch_123',
@@ -332,7 +305,7 @@ describe('xAI Responses batch language model', () => {
         },
       }),
     };
-    const model = createXai({ apiKey: 'test-api-key' })('grok-4.6');
+    const model = createXai({ apiKey: 'test-api-key' })('grok-4.3');
 
     await expect(
       model.experimental_doGetBatchResults({ batchId: 'batch_123' }),
@@ -378,7 +351,7 @@ describe('xAI Responses batch language model', () => {
               pagination_token: null,
             },
           };
-    const model = createXai({ apiKey: 'test-api-key' })('grok-4.6');
+    const model = createXai({ apiKey: 'test-api-key' })('grok-4.3');
 
     const stream = await model.experimental_doGetBatchResults({
       batchId: 'batch_123',
@@ -404,7 +377,9 @@ describe('xAI Responses batch language model', () => {
             inputTokens: { total: 10, noCache: 8, cacheRead: 2 },
             outputTokens: { total: 4, text: 3, reasoning: 1 },
           },
-          providerMetadata: { xai: { serviceTier: 'default' } },
+          providerMetadata: {
+            xai: { costInUsdTicks: 123, serviceTier: 'default' },
+          },
         },
       },
       {
@@ -471,18 +446,12 @@ describe('xAI Responses batch language model', () => {
               },
             },
           },
-          {
-            batch_request_id: 'responses',
-            batch_result: {
-              response: { responses: responsesResultBody('Madrid') },
-            },
-          },
           successfulResult('valid', 'Berlin'),
         ],
         pagination_token: null,
       },
     };
-    const model = createXai({ apiKey: 'test-api-key' })('grok-4.6');
+    const model = createXai({ apiKey: 'test-api-key' })('grok-4.3');
 
     const stream = await model.experimental_doGetBatchResults({
       batchId: 'batch_123',
@@ -501,16 +470,6 @@ describe('xAI Responses batch language model', () => {
         error: { code: 'unsupported_content' },
       },
       {
-        id: 'responses',
-        status: 'succeeded',
-        result: {
-          content: [{ type: 'text', text: 'Madrid' }],
-          providerMetadata: {
-            xai: { costInUsdTicks: 123, serviceTier: 'default' },
-          },
-        },
-      },
-      {
         id: 'valid',
         status: 'succeeded',
         result: {
@@ -523,6 +482,9 @@ describe('xAI Responses batch language model', () => {
               url: 'https://example.com/source',
             },
           ],
+          providerMetadata: {
+            xai: { costInUsdTicks: 123, serviceTier: 'default' },
+          },
         },
       },
     ]);
@@ -532,8 +494,8 @@ describe('xAI Responses batch language model', () => {
     const provider = createXai({ apiKey: 'test-api-key' });
 
     for (const model of [
-      provider('grok-4.6'),
-      provider.responses('grok-4.6'),
+      provider('grok-4.3'),
+      provider.responses('grok-4.3'),
     ]) {
       expect(model.experimental_doStartBatch).toBeTypeOf('function');
       expect(model.experimental_doGetBatchStatus).toBeTypeOf('function');
@@ -541,17 +503,17 @@ describe('xAI Responses batch language model', () => {
     }
 
     expect(
-      (provider.chat('grok-4.6') as any).experimental_doStartBatch,
+      (provider.chat('grok-4.3') as any).experimental_doStartBatch,
     ).toBeUndefined();
     expect(
-      (new XaiResponsesLanguageModel('grok-4.6', config) as any)
+      (new XaiResponsesLanguageModel('grok-4.3', config) as any)
         .experimental_doStartBatch,
     ).toBeUndefined();
   });
 
   it('preserves batch support when workflow deserializes a model', () => {
     const model = XaiResponsesBatchLanguageModel[WORKFLOW_DESERIALIZE]({
-      modelId: 'grok-4.6',
+      modelId: 'grok-4.3',
       config,
     });
 

--- a/packages/xai/src/responses/xai-responses-batch.test.ts
+++ b/packages/xai/src/responses/xai-responses-batch.test.ts
@@ -1,0 +1,560 @@
+import { WORKFLOW_DESERIALIZE } from '@ai-sdk/provider-utils';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { createXai } from '../xai-provider';
+import { XaiResponsesBatchLanguageModel } from './xai-responses-batch';
+import { XaiResponsesLanguageModel } from './xai-responses-language-model';
+
+vi.mock('../version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const urls = {
+  files: 'https://api.x.ai/v1/files',
+  batches: 'https://api.x.ai/v1/batches',
+  batch: 'https://api.x.ai/v1/batches/batch_123',
+  results: 'https://api.x.ai/v1/batches/batch_123/results',
+  resultsPage1: 'https://api.x.ai/v1/batches/batch_123/results?limit=1000',
+  resultsPage2:
+    'https://api.x.ai/v1/batches/batch_123/results?limit=1000&pagination_token=next%2Fpage',
+} as const;
+
+const server = createTestServer({
+  [urls.files]: {},
+  [urls.batches]: {},
+  [urls.batch]: {},
+  [urls.results]: {},
+});
+
+const config = {
+  provider: 'xai.responses',
+  baseURL: 'https://api.x.ai/v1',
+  headers: () => ({ Authorization: 'Bearer test-api-key' }),
+  generateId: () => 'generated-id',
+};
+
+function request(prompt: string, options: { topK?: number } = {}) {
+  return {
+    options: {
+      prompt: [
+        {
+          role: 'user' as const,
+          content: [{ type: 'text' as const, text: prompt }],
+        },
+      ],
+      ...options,
+    },
+  };
+}
+
+function batchResponse(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    batch_id: 'batch_123',
+    name: 'ai-sdk-text-batch',
+    create_time: '2026-08-25T12:00:00Z',
+    expire_time: '2099-08-26T12:00:00Z',
+    cancel_time: null,
+    cancel_by_xai_message: null,
+    state: {
+      num_requests: 2,
+      num_pending: 0,
+      num_success: 2,
+      num_error: 0,
+      num_cancelled: 0,
+    },
+    ...overrides,
+  };
+}
+
+function chatResultBody(text: string) {
+  return {
+    id: 'response_123',
+    object: 'chat.completion',
+    created: 1_700_000_000,
+    model: 'grok-4.6',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: text,
+          reasoning_content: 'Reasoning',
+          tool_calls: null,
+        },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: {
+      prompt_tokens: 10,
+      completion_tokens: 3,
+      total_tokens: 14,
+      prompt_tokens_details: { cached_tokens: 2 },
+      completion_tokens_details: { reasoning_tokens: 1 },
+      cost_in_usd_ticks: 123,
+    },
+    citations: ['https://example.com/source'],
+    service_tier: 'default',
+  };
+}
+
+function successfulResult(id: string, text: string) {
+  return {
+    batch_request_id: id,
+    batch_result: {
+      response: { chat_get_completion: chatResultBody(text) },
+      error: { code: 0, message: '' },
+    },
+  };
+}
+
+function responsesResultBody(text: string) {
+  return {
+    id: 'resp_123',
+    object: 'response',
+    created_at: 1_700_000_000,
+    model: 'grok-4.6',
+    output: [
+      {
+        type: 'message',
+        role: 'assistant',
+        id: 'msg_123',
+        status: 'completed',
+        content: [{ type: 'output_text', text, annotations: [] }],
+      },
+    ],
+    usage: {
+      input_tokens: 10,
+      output_tokens: 3,
+      input_tokens_details: { cached_tokens: 2 },
+      output_tokens_details: { reasoning_tokens: 1 },
+      cost_in_usd_ticks: 123,
+    },
+    status: 'completed',
+    service_tier: 'default',
+  };
+}
+
+describe('xAI Responses batch language model', () => {
+  it('uploads prepared JSONL requests and creates a file-backed batch', async () => {
+    server.urls[urls.files].response = {
+      type: 'json-value',
+      body: { id: 'file_123', filename: 'batch.jsonl' },
+    };
+    server.urls[urls.batches].response = {
+      type: 'json-value',
+      body: batchResponse({
+        state: {
+          num_requests: 2,
+          num_pending: 2,
+          num_success: 0,
+          num_error: 0,
+          num_cancelled: 0,
+        },
+      }),
+    };
+    const model = createXai({
+      apiKey: 'test-api-key',
+      headers: { 'Provider-Header': 'provider' },
+    }).responses('grok-4.6');
+
+    const result = await model.experimental_doStartBatch({
+      requests: [
+        { id: 'france', ...request('What is the capital of France?') },
+        {
+          id: 'germany',
+          ...request('What is the capital of Germany?', { topK: 10 }),
+        },
+      ],
+      headers: { 'Operation-Header': 'operation' },
+      webhookUrl: 'https://example.com/batch-webhook',
+    });
+
+    expect(result).toEqual({
+      batchId: 'batch_123',
+      status: 'pending',
+      requestCounts: {
+        total: 2,
+        pending: 2,
+        completed: 0,
+        failed: 0,
+      },
+      createdAt: '2026-08-25T12:00:00Z',
+      expiresAt: '2099-08-26T12:00:00Z',
+      warnings: [
+        {
+          warning: {
+            type: 'unsupported',
+            feature: 'webhookUrl',
+            details:
+              'The xAI Batch API does not support per-batch webhook URLs.',
+          },
+        },
+        {
+          requestId: 'germany',
+          warning: { type: 'unsupported', feature: 'topK' },
+        },
+      ],
+    });
+
+    const multipart = await server.calls[0].requestBodyMultipart;
+    const file = multipart?.file as File;
+    expect(file.name).toBe('batch.jsonl');
+    expect(file.type).toBe('application/jsonl');
+    const lines = (await file.text())
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line));
+    expect(lines).toEqual([
+      {
+        custom_id: 'france',
+        method: 'POST',
+        url: '/v1/responses',
+        body: {
+          model: 'grok-4.6',
+          input: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'input_text',
+                  text: 'What is the capital of France?',
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        custom_id: 'germany',
+        method: 'POST',
+        url: '/v1/responses',
+        body: {
+          model: 'grok-4.6',
+          input: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'input_text',
+                  text: 'What is the capital of Germany?',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+    expect(await server.calls[1].requestBodyJson).toEqual({
+      name: 'ai-sdk-text-batch',
+      input_file_id: 'file_123',
+    });
+    for (const call of server.calls) {
+      expect(call.requestHeaders).toMatchObject({
+        authorization: 'Bearer test-api-key',
+        'provider-header': 'provider',
+        'operation-header': 'operation',
+      });
+    }
+  });
+
+  it('maps xAI state counters and cancellation metadata', async () => {
+    server.urls[urls.batch].response = {
+      type: 'json-value',
+      body: batchResponse({
+        cancel_time: '2026-08-25T12:30:00Z',
+        cancel_by_xai_message: 'Cancelled by user.',
+        state: {
+          num_requests: 4,
+          num_pending: 0,
+          num_success: 2,
+          num_error: 1,
+          num_cancelled: 1,
+        },
+      }),
+    };
+    const model = createXai({ apiKey: 'test-api-key' })('grok-4.6');
+
+    await expect(
+      model.experimental_doGetBatchStatus({ batchId: 'batch_123' }),
+    ).resolves.toEqual({
+      status: 'failed',
+      requestCounts: {
+        total: 4,
+        pending: 0,
+        completed: 2,
+        failed: 2,
+      },
+      error: {
+        message: 'Cancelled by user.',
+        code: 'batch_cancelled',
+      },
+      createdAt: '2026-08-25T12:00:00Z',
+      expiresAt: '2099-08-26T12:00:00Z',
+    });
+  });
+
+  it('omits inconsistent request counts', async () => {
+    server.urls[urls.batch].response = {
+      type: 'json-value',
+      body: batchResponse({
+        state: {
+          num_requests: 2,
+          num_pending: 1,
+          num_success: 2,
+          num_error: 0,
+          num_cancelled: 0,
+        },
+      }),
+    };
+    const model = createXai({ apiKey: 'test-api-key' })('grok-4.6');
+
+    const status = await model.experimental_doGetBatchStatus({
+      batchId: 'batch_123',
+    });
+
+    expect(status).toMatchObject({ status: 'pending' });
+    expect(status.requestCounts).toBeUndefined();
+  });
+
+  it('rejects result retrieval while the batch is pending', async () => {
+    server.urls[urls.batch].response = {
+      type: 'json-value',
+      body: batchResponse({
+        state: {
+          num_requests: 2,
+          num_pending: 1,
+          num_success: 1,
+          num_error: 0,
+          num_cancelled: 0,
+        },
+      }),
+    };
+    const model = createXai({ apiKey: 'test-api-key' })('grok-4.6');
+
+    await expect(
+      model.experimental_doGetBatchResults({ batchId: 'batch_123' }),
+    ).rejects.toMatchObject({
+      name: 'AI_InvalidArgumentError',
+      argument: 'batchId',
+      message: 'xAI batch "batch_123" is not complete.',
+    });
+  });
+
+  it('paginates and converts successful and failed results', async () => {
+    server.urls[urls.batch].response = {
+      type: 'json-value',
+      body: batchResponse(),
+    };
+    server.urls[urls.results].response = ({ callNumber }) =>
+      callNumber === 1
+        ? {
+            type: 'json-value',
+            body: {
+              results: [successfulResult('france', 'Paris')],
+              pagination_token: 'next/page',
+            },
+          }
+        : {
+            type: 'json-value',
+            body: {
+              results: [
+                {
+                  batch_request_id: 'failed',
+                  batch_result: {
+                    error: { code: 3, message: 'Invalid request.' },
+                  },
+                  error_message: 'Invalid request.',
+                },
+                {
+                  batch_request_id: 'cancelled',
+                  batch_result: {
+                    error: { code: 1, message: 'Cancelled.' },
+                  },
+                },
+              ],
+              pagination_token: null,
+            },
+          };
+    const model = createXai({ apiKey: 'test-api-key' })('grok-4.6');
+
+    const stream = await model.experimental_doGetBatchResults({
+      batchId: 'batch_123',
+    });
+    const results = await convertReadableStreamToArray(stream);
+
+    expect(results).toMatchObject([
+      {
+        id: 'france',
+        status: 'succeeded',
+        result: {
+          content: [
+            { type: 'text', text: 'Paris' },
+            { type: 'reasoning', text: 'Reasoning' },
+            {
+              type: 'source',
+              sourceType: 'url',
+              url: 'https://example.com/source',
+            },
+          ],
+          finishReason: { unified: 'stop', raw: 'stop' },
+          usage: {
+            inputTokens: { total: 10, noCache: 8, cacheRead: 2 },
+            outputTokens: { total: 4, text: 3, reasoning: 1 },
+          },
+          providerMetadata: { xai: { serviceTier: 'default' } },
+        },
+      },
+      {
+        id: 'failed',
+        status: 'failed',
+        error: { message: 'Invalid request.', code: '3' },
+      },
+      {
+        id: 'cancelled',
+        status: 'cancelled',
+        error: { message: 'Cancelled.', code: '1' },
+      },
+    ]);
+    expect(server.calls.map(call => call.requestUrl)).toEqual([
+      urls.batch,
+      urls.resultsPage1,
+      urls.resultsPage2,
+    ]);
+  });
+
+  it('fails invalid and unsupported items without stopping later results', async () => {
+    server.urls[urls.batch].response = {
+      type: 'json-value',
+      body: batchResponse(),
+    };
+    server.urls[urls.results].response = {
+      type: 'json-value',
+      body: {
+        results: [
+          {
+            batch_request_id: 'invalid',
+            batch_result: {
+              response: { chat_get_completion: { choices: 42 } },
+            },
+          },
+          {
+            batch_request_id: 'tool-call',
+            batch_result: {
+              response: {
+                chat_get_completion: {
+                  ...chatResultBody(''),
+                  choices: [
+                    {
+                      index: 0,
+                      message: {
+                        role: 'assistant',
+                        content: null,
+                        reasoning_content: null,
+                        tool_calls: [
+                          {
+                            id: 'call_1',
+                            type: 'function',
+                            function: {
+                              name: 'weather',
+                              arguments: '{}',
+                            },
+                          },
+                        ],
+                      },
+                      finish_reason: 'tool_calls',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          {
+            batch_request_id: 'responses',
+            batch_result: {
+              response: { responses: responsesResultBody('Madrid') },
+            },
+          },
+          successfulResult('valid', 'Berlin'),
+        ],
+        pagination_token: null,
+      },
+    };
+    const model = createXai({ apiKey: 'test-api-key' })('grok-4.6');
+
+    const stream = await model.experimental_doGetBatchResults({
+      batchId: 'batch_123',
+    });
+    const results = await convertReadableStreamToArray(stream);
+
+    expect(results).toMatchObject([
+      {
+        id: 'invalid',
+        status: 'failed',
+        error: { code: 'invalid_response' },
+      },
+      {
+        id: 'tool-call',
+        status: 'failed',
+        error: { code: 'unsupported_content' },
+      },
+      {
+        id: 'responses',
+        status: 'succeeded',
+        result: {
+          content: [{ type: 'text', text: 'Madrid' }],
+          providerMetadata: {
+            xai: { costInUsdTicks: 123, serviceTier: 'default' },
+          },
+        },
+      },
+      {
+        id: 'valid',
+        status: 'succeeded',
+        result: {
+          content: [
+            { type: 'text', text: 'Berlin' },
+            { type: 'reasoning', text: 'Reasoning' },
+            {
+              type: 'source',
+              sourceType: 'url',
+              url: 'https://example.com/source',
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('only exposes batch support on xAI Responses models', () => {
+    const provider = createXai({ apiKey: 'test-api-key' });
+
+    for (const model of [
+      provider('grok-4.6'),
+      provider.responses('grok-4.6'),
+    ]) {
+      expect(model.experimental_doStartBatch).toBeTypeOf('function');
+      expect(model.experimental_doGetBatchStatus).toBeTypeOf('function');
+      expect(model.experimental_doGetBatchResults).toBeTypeOf('function');
+    }
+
+    expect(
+      (provider.chat('grok-4.6') as any).experimental_doStartBatch,
+    ).toBeUndefined();
+    expect(
+      (new XaiResponsesLanguageModel('grok-4.6', config) as any)
+        .experimental_doStartBatch,
+    ).toBeUndefined();
+  });
+
+  it('preserves batch support when workflow deserializes a model', () => {
+    const model = XaiResponsesBatchLanguageModel[WORKFLOW_DESERIALIZE]({
+      modelId: 'grok-4.6',
+      config,
+    });
+
+    expect(model.experimental_doStartBatch).toBeTypeOf('function');
+  });
+});

--- a/packages/xai/src/responses/xai-responses-batch.ts
+++ b/packages/xai/src/responses/xai-responses-batch.ts
@@ -1,0 +1,663 @@
+import {
+  InvalidArgumentError,
+  type Experimental_BatchLanguageModelV4 as BatchLanguageModelV4,
+  type Experimental_BatchV4Error as BatchV4Error,
+  type Experimental_BatchV4ItemResult as BatchV4ItemResult,
+  type Experimental_BatchV4OperationOptions as BatchV4OperationOptions,
+  type Experimental_BatchV4StartOptions as BatchV4StartOptions,
+  type Experimental_BatchV4StartResult as BatchV4StartResult,
+  type Experimental_BatchV4Status as BatchV4Status,
+  type LanguageModelV4Content,
+  type LanguageModelV4GenerateResult,
+  type SharedV4ProviderMetadata,
+  type SharedV4Warning,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertAsyncIteratorToReadableStream,
+  createJsonResponseHandler,
+  createNullLanguageModelUsage,
+  getFromApi,
+  lazySchema,
+  normalizeBatchRequestCounts,
+  postFormDataToApi,
+  postJsonToApi,
+  safeValidateTypes,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+  zodSchema,
+  type InferSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { convertXaiChatUsage } from '../convert-xai-chat-usage';
+import { getResponseMetadata } from '../get-response-metadata';
+import { mapXaiFinishReason } from '../map-xai-finish-reason';
+import {
+  xaiChatResponseSchema,
+  type XaiChatResponse,
+} from '../xai-chat-language-model';
+import { xaiFailedResponseHandler } from '../xai-error';
+import { xaiFilesResponseSchema } from '../files/xai-files-api';
+import { convertXaiResponsesUsage } from './convert-xai-responses-usage';
+import { mapXaiResponsesFinishReason } from './map-xai-responses-finish-reason';
+import {
+  xaiResponsesResponseSchema,
+  type XaiResponsesResponse,
+} from './xai-responses-api';
+import {
+  XaiResponsesLanguageModel,
+  type XaiResponsesConfig,
+} from './xai-responses-language-model';
+import type { XaiResponsesModelId } from './xai-responses-language-model-options';
+
+const xaiBatchEndpoint = '/v1/responses';
+const xaiBatchName = 'ai-sdk-text-batch';
+const xaiBatchResultsPageSize = 1000;
+
+type XaiBatchRequest = Parameters<
+  BatchLanguageModelV4['experimental_doStartBatch']
+>[0]['requests'][number];
+
+type XaiBatchPreparedRequest = {
+  body: unknown;
+  warnings: SharedV4Warning[];
+};
+
+type XaiBatchResponseConversion =
+  | { success: true; result: LanguageModelV4GenerateResult }
+  | { success: false; error: BatchV4Error };
+
+const xaiBatchResponseSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      batch_id: z.string(),
+      name: z.string().nullish(),
+      create_time: z.string().nullish(),
+      expire_time: z.string().nullish(),
+      cancel_time: z.string().nullish(),
+      cancel_by_xai_message: z.string().nullish(),
+      state: z
+        .object({
+          num_requests: z.number().nullish(),
+          num_pending: z.number().nullish(),
+          num_success: z.number().nullish(),
+          num_error: z.number().nullish(),
+          num_cancelled: z.number().nullish(),
+        })
+        .nullish(),
+    }),
+  ),
+);
+
+type XaiBatchResponse = InferSchema<typeof xaiBatchResponseSchema>;
+
+const xaiBatchErrorSchema = z.object({
+  code: z.union([z.string(), z.number()]).nullish(),
+  message: z.string().nullish(),
+});
+
+const xaiBatchResultSchema = z.object({
+  batch_request_id: z.string(),
+  batch_result: z
+    .object({
+      response: z
+        .object({
+          chat_get_completion: z.unknown().nullish(),
+          responses: z.unknown().nullish(),
+        })
+        .nullish(),
+      error: xaiBatchErrorSchema.nullish(),
+    })
+    .nullish(),
+  error_message: z.string().nullish(),
+});
+
+type XaiBatchResult = z.infer<typeof xaiBatchResultSchema>;
+
+const xaiBatchResultsPageSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      results: z.array(xaiBatchResultSchema),
+      pagination_token: z.string().nullish(),
+    }),
+  ),
+);
+
+class XaiResponsesBatch {
+  constructor(
+    private readonly options: {
+      config: XaiResponsesConfig;
+      prepareRequest: (
+        request: XaiBatchRequest,
+      ) => PromiseLike<XaiBatchPreparedRequest>;
+    },
+  ) {}
+
+  async startBatch(
+    options: BatchV4StartOptions<XaiBatchRequest>,
+  ): Promise<BatchV4StartResult> {
+    const fileParts: string[] = [];
+    const warnings: BatchV4StartResult['warnings'] =
+      options.webhookUrl == null
+        ? []
+        : [
+            {
+              warning: {
+                type: 'unsupported',
+                feature: 'webhookUrl',
+                details:
+                  'The xAI Batch API does not support per-batch webhook URLs.',
+              },
+            },
+          ];
+
+    for (const request of options.requests) {
+      const preparedRequest = await this.options.prepareRequest(request);
+
+      fileParts.push(
+        JSON.stringify({
+          custom_id: request.id,
+          method: 'POST',
+          url: xaiBatchEndpoint,
+          body: preparedRequest.body,
+        }),
+        '\n',
+      );
+
+      for (const warning of preparedRequest.warnings) {
+        warnings.push({ requestId: request.id, warning });
+      }
+    }
+
+    const filename = 'batch.jsonl';
+    const file = new Blob(fileParts, { type: 'application/jsonl' });
+    fileParts.length = 0;
+    const formData = new FormData();
+    formData.append('file', file, filename);
+
+    const headers = combineHeaders(
+      this.options.config.headers?.(),
+      options.headers,
+    );
+
+    const { value: uploadedFile } = await postFormDataToApi({
+      url: this.getUrl('/files'),
+      headers,
+      formData,
+      failedResponseHandler: xaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        xaiFilesResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.options.config.fetch,
+    });
+
+    const { value: batch } = await postJsonToApi({
+      url: this.getUrl('/batches'),
+      headers,
+      body: {
+        name: xaiBatchName,
+        input_file_id: uploadedFile.id,
+      },
+      failedResponseHandler: xaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        xaiBatchResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.options.config.fetch,
+    });
+
+    return {
+      batchId: batch.batch_id,
+      ...convertXaiBatchStatus(batch),
+      warnings,
+    };
+  }
+
+  async getBatchStatus(
+    options: BatchV4OperationOptions,
+  ): Promise<BatchV4Status> {
+    return convertXaiBatchStatus(await this.retrieveBatch(options));
+  }
+
+  async getBatchResults(
+    options: BatchV4OperationOptions,
+  ): Promise<ReadableStream<BatchV4ItemResult<LanguageModelV4GenerateResult>>> {
+    const batch = await this.retrieveBatch(options);
+    if (convertXaiBatchStatus(batch).status === 'pending') {
+      throw new InvalidArgumentError({
+        argument: 'batchId',
+        message: `xAI batch "${options.batchId}" is not complete.`,
+      });
+    }
+
+    return convertAsyncIteratorToReadableStream(
+      this.iterateBatchResults(options),
+    );
+  }
+
+  private async retrieveBatch(
+    options: BatchV4OperationOptions,
+  ): Promise<XaiBatchResponse> {
+    const { value: batch } = await getFromApi({
+      url: this.getUrl(`/batches/${encodeURIComponent(options.batchId)}`),
+      headers: combineHeaders(this.options.config.headers?.(), options.headers),
+      failedResponseHandler: xaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        xaiBatchResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.options.config.fetch,
+      validateUrl: false,
+    });
+
+    return batch;
+  }
+
+  private async *iterateBatchResults(
+    options: BatchV4OperationOptions,
+  ): AsyncGenerator<BatchV4ItemResult<LanguageModelV4GenerateResult>> {
+    let paginationToken: string | undefined;
+
+    do {
+      const query = new URLSearchParams({
+        limit: String(xaiBatchResultsPageSize),
+      });
+      if (paginationToken != null) {
+        query.set('pagination_token', paginationToken);
+      }
+
+      const { value: page } = await getFromApi({
+        url: this.getUrl(
+          `/batches/${encodeURIComponent(options.batchId)}/results?${query}`,
+        ),
+        headers: combineHeaders(
+          this.options.config.headers?.(),
+          options.headers,
+        ),
+        failedResponseHandler: xaiFailedResponseHandler,
+        successfulResponseHandler: createJsonResponseHandler(
+          xaiBatchResultsPageSchema,
+        ),
+        abortSignal: options.abortSignal,
+        fetch: this.options.config.fetch,
+        validateUrl: false,
+      });
+
+      for (const result of page.results) {
+        yield await this.convertBatchResult(result);
+      }
+
+      paginationToken = page.pagination_token ?? undefined;
+    } while (paginationToken != null);
+  }
+
+  private async convertBatchResult(
+    result: XaiBatchResult,
+  ): Promise<BatchV4ItemResult<LanguageModelV4GenerateResult>> {
+    const error = result.batch_result?.error;
+    if (
+      (result.error_message?.length ?? 0) > 0 ||
+      (error?.code != null && error.code !== 0 && error.code !== '0') ||
+      (error?.code == null && (error?.message?.length ?? 0) > 0)
+    ) {
+      const convertedError = convertXaiBatchError(result);
+      return {
+        id: result.batch_request_id,
+        status: isXaiCancellationError(error?.code) ? 'cancelled' : 'failed',
+        error: convertedError,
+      };
+    }
+
+    const response = result.batch_result?.response;
+    if (response?.responses != null) {
+      const validation = await safeValidateTypes({
+        value: response.responses,
+        schema: xaiResponsesResponseSchema,
+      });
+      if (!validation.success) {
+        return invalidXaiBatchResult(result.batch_request_id);
+      }
+
+      const conversion = convertXaiResponsesBatchResponse(validation.value);
+      return conversion.success
+        ? {
+            id: result.batch_request_id,
+            status: 'succeeded',
+            result: conversion.result,
+          }
+        : {
+            id: result.batch_request_id,
+            status: 'failed',
+            error: conversion.error,
+          };
+    }
+
+    if (response?.chat_get_completion != null) {
+      const validation = await safeValidateTypes({
+        value: response.chat_get_completion,
+        schema: xaiChatResponseSchema,
+      });
+      if (!validation.success) {
+        return invalidXaiBatchResult(result.batch_request_id);
+      }
+
+      const conversion = convertXaiChatBatchResponse(validation.value);
+      return conversion.success
+        ? {
+            id: result.batch_request_id,
+            status: 'succeeded',
+            result: conversion.result,
+          }
+        : {
+            id: result.batch_request_id,
+            status: 'failed',
+            error: conversion.error,
+          };
+    }
+
+    return invalidXaiBatchResult(result.batch_request_id);
+  }
+
+  private getUrl(path: string) {
+    return `${this.options.config.baseURL ?? 'https://api.x.ai/v1'}${path}`;
+  }
+}
+
+export class XaiResponsesBatchLanguageModel
+  extends XaiResponsesLanguageModel
+  implements BatchLanguageModelV4
+{
+  private readonly batch: XaiResponsesBatch;
+
+  static [WORKFLOW_SERIALIZE](model: XaiResponsesLanguageModel) {
+    return XaiResponsesLanguageModel[WORKFLOW_SERIALIZE](model);
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: XaiResponsesModelId;
+    config: XaiResponsesConfig;
+  }) {
+    return new XaiResponsesBatchLanguageModel(options.modelId, options.config);
+  }
+
+  constructor(modelId: XaiResponsesModelId, config: XaiResponsesConfig) {
+    super(modelId, config);
+    this.batch = new XaiResponsesBatch({
+      config,
+      prepareRequest: async request => {
+        const { args: body, warnings } = await this.getArgs(request.options);
+        return { body, warnings };
+      },
+    });
+  }
+
+  experimental_doStartBatch(
+    options: Parameters<BatchLanguageModelV4['experimental_doStartBatch']>[0],
+  ) {
+    return this.batch.startBatch(options);
+  }
+
+  experimental_doGetBatchStatus(options: BatchV4OperationOptions) {
+    return this.batch.getBatchStatus(options);
+  }
+
+  experimental_doGetBatchResults(options: BatchV4OperationOptions) {
+    return this.batch.getBatchResults(options);
+  }
+}
+
+function convertXaiBatchStatus(batch: XaiBatchResponse): BatchV4Status {
+  const requestCounts = normalizeBatchRequestCounts({
+    total: batch.state?.num_requests,
+    pending: batch.state?.num_pending,
+    completed: batch.state?.num_success,
+    failed:
+      batch.state?.num_error != null && batch.state?.num_cancelled != null
+        ? batch.state.num_error + batch.state.num_cancelled
+        : undefined,
+  });
+  const isCancelled =
+    batch.cancel_time != null || batch.cancel_by_xai_message != null;
+  const isExpired = isPastDate(batch.expire_time);
+  const status: BatchV4Status['status'] =
+    isCancelled || isExpired
+      ? 'failed'
+      : requestCounts != null &&
+          requestCounts.total > 0 &&
+          requestCounts.pending === 0
+        ? 'completed'
+        : 'pending';
+
+  return {
+    status,
+    ...(requestCounts != null ? { requestCounts } : {}),
+    ...(isCancelled
+      ? {
+          error: {
+            message:
+              batch.cancel_by_xai_message ??
+              `xAI batch "${batch.batch_id}" was cancelled.`,
+            code: 'batch_cancelled',
+          },
+        }
+      : isExpired
+        ? {
+            error: {
+              message: `xAI batch "${batch.batch_id}" expired.`,
+              code: 'batch_expired',
+            },
+          }
+        : {}),
+    ...(batch.create_time != null ? { createdAt: batch.create_time } : {}),
+    ...(batch.expire_time != null ? { expiresAt: batch.expire_time } : {}),
+  };
+}
+
+function isPastDate(value: string | null | undefined) {
+  if (value == null) {
+    return false;
+  }
+  const timestamp = Date.parse(value);
+  return !Number.isNaN(timestamp) && timestamp <= Date.now();
+}
+
+function convertXaiBatchError(result: XaiBatchResult): BatchV4Error {
+  const error = result.batch_result?.error;
+  return {
+    message:
+      result.error_message || error?.message || 'xAI batch request failed.',
+    ...(error?.code != null && error.code !== 0 && error.code !== '0'
+      ? { code: String(error.code) }
+      : {}),
+  };
+}
+
+function isXaiCancellationError(code: string | number | null | undefined) {
+  const normalizedCode = String(code).toLowerCase();
+  return (
+    code === 1 ||
+    normalizedCode === '1' ||
+    normalizedCode === 'cancelled' ||
+    normalizedCode === 'batch_cancelled'
+  );
+}
+
+function invalidXaiBatchResult(
+  id: string,
+): BatchV4ItemResult<LanguageModelV4GenerateResult> {
+  return {
+    id,
+    status: 'failed',
+    error: {
+      message: 'xAI returned an invalid Responses batch result.',
+      code: 'invalid_response',
+    },
+  };
+}
+
+function convertXaiResponsesBatchResponse(
+  response: XaiResponsesResponse,
+): XaiBatchResponseConversion {
+  const content: LanguageModelV4Content[] = [];
+
+  for (const part of response.output) {
+    if (part.type === 'message') {
+      for (const contentPart of part.content) {
+        if (contentPart.text) {
+          content.push({ type: 'text', text: contentPart.text });
+        }
+        for (const annotation of contentPart.annotations ?? []) {
+          if (annotation.type === 'url_citation' && 'url' in annotation) {
+            content.push({
+              type: 'source',
+              sourceType: 'url',
+              id: annotation.url,
+              url: annotation.url,
+              title: annotation.title ?? annotation.url,
+            });
+          }
+        }
+      }
+      continue;
+    }
+
+    if (part.type === 'reasoning') {
+      const text = (
+        part.summary.length > 0 ? part.summary : (part.content ?? [])
+      )
+        .map(item => item.text)
+        .filter(Boolean)
+        .join('');
+      if (text || part.encrypted_content) {
+        content.push({
+          type: 'reasoning',
+          text,
+          providerMetadata: {
+            xai: {
+              ...(part.encrypted_content != null
+                ? { reasoningEncryptedContent: part.encrypted_content }
+                : {}),
+              itemId: part.id,
+            },
+          },
+        });
+      }
+      continue;
+    }
+
+    return unsupportedXaiBatchContent(part.type);
+  }
+
+  return {
+    success: true,
+    result: {
+      content,
+      finishReason: {
+        unified: mapXaiResponsesFinishReason(response.status),
+        raw: response.status,
+      },
+      usage: response.usage
+        ? convertXaiResponsesUsage(response.usage)
+        : createNullLanguageModelUsage(),
+      response: getResponseMetadata(response),
+      warnings: [],
+      ...((response.usage?.cost_in_usd_ticks != null ||
+        response.service_tier != null) && {
+        providerMetadata: {
+          xai: {
+            ...(response.usage?.cost_in_usd_ticks != null
+              ? { costInUsdTicks: response.usage.cost_in_usd_ticks }
+              : {}),
+            ...(response.service_tier != null
+              ? { serviceTier: response.service_tier }
+              : {}),
+          },
+        } satisfies SharedV4ProviderMetadata,
+      }),
+    },
+  };
+}
+
+function convertXaiChatBatchResponse(
+  response: XaiChatResponse,
+): XaiBatchResponseConversion {
+  if (response.error != null) {
+    return {
+      success: false,
+      error: {
+        message: response.error,
+        ...(response.code != null ? { code: response.code } : {}),
+      },
+    };
+  }
+
+  const choice = response.choices?.[0];
+  if (choice == null) {
+    return {
+      success: false,
+      error: {
+        message: 'xAI returned a batch response without any choices.',
+        code: 'invalid_response',
+      },
+    };
+  }
+
+  if (choice.message.tool_calls?.length) {
+    return unsupportedXaiBatchContent('tool_calls');
+  }
+
+  const content: LanguageModelV4Content[] = [];
+  if (choice.message.content) {
+    content.push({ type: 'text', text: choice.message.content });
+  }
+  if (choice.message.reasoning_content) {
+    content.push({
+      type: 'reasoning',
+      text: choice.message.reasoning_content,
+    });
+  }
+  for (const url of response.citations ?? []) {
+    content.push({
+      type: 'source',
+      sourceType: 'url',
+      id: url,
+      url,
+    });
+  }
+
+  return {
+    success: true,
+    result: {
+      content,
+      finishReason: {
+        unified: mapXaiFinishReason(choice.finish_reason),
+        raw: choice.finish_reason ?? undefined,
+      },
+      usage: response.usage
+        ? convertXaiChatUsage(response.usage)
+        : createNullLanguageModelUsage(),
+      response: getResponseMetadata(response),
+      warnings: [],
+      ...(response.service_tier != null && {
+        providerMetadata: {
+          xai: {
+            serviceTier: response.service_tier,
+          },
+        } satisfies SharedV4ProviderMetadata,
+      }),
+    },
+  };
+}
+
+function unsupportedXaiBatchContent(type: string): XaiBatchResponseConversion {
+  return {
+    success: false,
+    error: {
+      message:
+        `xAI returned "${type}" content, but tool content is not supported ` +
+        'in AI SDK text batches.',
+      code: 'unsupported_content',
+    },
+  };
+}

--- a/packages/xai/src/responses/xai-responses-batch.ts
+++ b/packages/xai/src/responses/xai-responses-batch.ts
@@ -302,6 +302,8 @@ class XaiResponsesBatch {
       };
     }
 
+    // xAI returns text batch results in chat completion format, including for
+    // requests submitted to the Responses API endpoint.
     const response = result.batch_result?.response;
     if (response?.chat_get_completion != null) {
       const validation = await safeValidateTypes({

--- a/packages/xai/src/responses/xai-responses-batch.ts
+++ b/packages/xai/src/responses/xai-responses-batch.ts
@@ -38,12 +38,6 @@ import {
 } from '../xai-chat-language-model';
 import { xaiFailedResponseHandler } from '../xai-error';
 import { xaiFilesResponseSchema } from '../files/xai-files-api';
-import { convertXaiResponsesUsage } from './convert-xai-responses-usage';
-import { mapXaiResponsesFinishReason } from './map-xai-responses-finish-reason';
-import {
-  xaiResponsesResponseSchema,
-  type XaiResponsesResponse,
-} from './xai-responses-api';
 import {
   XaiResponsesLanguageModel,
   type XaiResponsesConfig,
@@ -103,7 +97,6 @@ const xaiBatchResultSchema = z.object({
       response: z
         .object({
           chat_get_completion: z.unknown().nullish(),
-          responses: z.unknown().nullish(),
         })
         .nullish(),
       error: xaiBatchErrorSchema.nullish(),
@@ -310,29 +303,6 @@ class XaiResponsesBatch {
     }
 
     const response = result.batch_result?.response;
-    if (response?.responses != null) {
-      const validation = await safeValidateTypes({
-        value: response.responses,
-        schema: xaiResponsesResponseSchema,
-      });
-      if (!validation.success) {
-        return invalidXaiBatchResult(result.batch_request_id);
-      }
-
-      const conversion = convertXaiResponsesBatchResponse(validation.value);
-      return conversion.success
-        ? {
-            id: result.batch_request_id,
-            status: 'succeeded',
-            result: conversion.result,
-          }
-        : {
-            id: result.batch_request_id,
-            status: 'failed',
-            error: conversion.error,
-          };
-    }
-
     if (response?.chat_get_completion != null) {
       const validation = await safeValidateTypes({
         value: response.chat_get_completion,
@@ -496,89 +466,6 @@ function invalidXaiBatchResult(
   };
 }
 
-function convertXaiResponsesBatchResponse(
-  response: XaiResponsesResponse,
-): XaiBatchResponseConversion {
-  const content: LanguageModelV4Content[] = [];
-
-  for (const part of response.output) {
-    if (part.type === 'message') {
-      for (const contentPart of part.content) {
-        if (contentPart.text) {
-          content.push({ type: 'text', text: contentPart.text });
-        }
-        for (const annotation of contentPart.annotations ?? []) {
-          if (annotation.type === 'url_citation' && 'url' in annotation) {
-            content.push({
-              type: 'source',
-              sourceType: 'url',
-              id: annotation.url,
-              url: annotation.url,
-              title: annotation.title ?? annotation.url,
-            });
-          }
-        }
-      }
-      continue;
-    }
-
-    if (part.type === 'reasoning') {
-      const text = (
-        part.summary.length > 0 ? part.summary : (part.content ?? [])
-      )
-        .map(item => item.text)
-        .filter(Boolean)
-        .join('');
-      if (text || part.encrypted_content) {
-        content.push({
-          type: 'reasoning',
-          text,
-          providerMetadata: {
-            xai: {
-              ...(part.encrypted_content != null
-                ? { reasoningEncryptedContent: part.encrypted_content }
-                : {}),
-              itemId: part.id,
-            },
-          },
-        });
-      }
-      continue;
-    }
-
-    return unsupportedXaiBatchContent(part.type);
-  }
-
-  return {
-    success: true,
-    result: {
-      content,
-      finishReason: {
-        unified: mapXaiResponsesFinishReason(response.status),
-        raw: response.status,
-      },
-      usage: response.usage
-        ? convertXaiResponsesUsage(response.usage)
-        : createNullLanguageModelUsage(),
-      response: getResponseMetadata(response),
-      warnings: [],
-      ...((response.usage?.cost_in_usd_ticks != null ||
-        response.service_tier != null) && {
-        providerMetadata: {
-          xai: {
-            ...(response.usage?.cost_in_usd_ticks != null
-              ? { costInUsdTicks: response.usage.cost_in_usd_ticks }
-              : {}),
-            ...(response.service_tier != null
-              ? { serviceTier: response.service_tier }
-              : {}),
-          },
-        } satisfies SharedV4ProviderMetadata,
-      }),
-    },
-  };
-}
-
 function convertXaiChatBatchResponse(
   response: XaiChatResponse,
 ): XaiBatchResponseConversion {
@@ -639,10 +526,16 @@ function convertXaiChatBatchResponse(
         : createNullLanguageModelUsage(),
       response: getResponseMetadata(response),
       warnings: [],
-      ...(response.service_tier != null && {
+      ...((response.usage?.cost_in_usd_ticks != null ||
+        response.service_tier != null) && {
         providerMetadata: {
           xai: {
-            serviceTier: response.service_tier,
+            ...(response.usage?.cost_in_usd_ticks != null
+              ? { costInUsdTicks: response.usage.cost_in_usd_ticks }
+              : {}),
+            ...(response.service_tier != null
+              ? { serviceTier: response.service_tier }
+              : {}),
           },
         } satisfies SharedV4ProviderMetadata,
       }),

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -41,7 +41,7 @@ import {
 } from './xai-responses-language-model-options';
 import { prepareResponsesTools } from './xai-responses-prepare-tools';
 
-type XaiResponsesConfig = {
+export type XaiResponsesConfig = {
   provider: string;
   baseURL: string | undefined;
   headers?: () => Record<string, string | undefined>;
@@ -88,7 +88,7 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
     'text/*': [/^https?:\/\/.*$/],
   };
 
-  private async getArgs({
+  protected async getArgs({
     prompt,
     maxOutputTokens,
     temperature,

--- a/packages/xai/src/xai-chat-language-model.test.ts
+++ b/packages/xai/src/xai-chat-language-model.test.ts
@@ -118,6 +118,7 @@ describe('XaiChatLanguageModel', () => {
               "reasoning_tokens": 228,
               "rejected_prediction_tokens": 0,
             },
+            "cost_in_usd_ticks": 1176500,
             "prompt_tokens": 12,
             "prompt_tokens_details": {
               "audio_tokens": 0,
@@ -1644,6 +1645,7 @@ describe('XaiChatLanguageModel', () => {
               "reasoning_tokens": 228,
               "rejected_prediction_tokens": 0,
             },
+            "cost_in_usd_ticks": 1176500,
             "prompt_tokens": 12,
             "prompt_tokens_details": {
               "audio_tokens": 0,

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -676,6 +676,7 @@ const xaiUsageSchema = z.object({
   prompt_tokens: z.number(),
   completion_tokens: z.number(),
   total_tokens: z.number(),
+  cost_in_usd_ticks: z.number().nullish(),
   prompt_tokens_details: z
     .object({
       text_tokens: z.number().nullish(),

--- a/packages/xai/src/xai-chat-language-model.ts
+++ b/packages/xai/src/xai-chat-language-model.ts
@@ -696,7 +696,7 @@ const xaiUsageSchema = z.object({
 
 export type XaiChatUsage = z.infer<typeof xaiUsageSchema>;
 
-const xaiChatResponseSchema = z.object({
+export const xaiChatResponseSchema = z.object({
   id: z.string().nullish(),
   created: z.number().nullish(),
   model: z.string().nullish(),
@@ -732,6 +732,8 @@ const xaiChatResponseSchema = z.object({
   code: z.string().nullish(),
   error: z.string().nullish(),
 });
+
+export type XaiChatResponse = z.infer<typeof xaiChatResponseSchema>;
 
 const xaiChatChunkSchema = z.object({
   id: z.string().nullish(),

--- a/packages/xai/src/xai-provider.test-d.ts
+++ b/packages/xai/src/xai-provider.test-d.ts
@@ -1,0 +1,16 @@
+import type {
+  Experimental_BatchLanguageModelV4 as BatchLanguageModelV4,
+  LanguageModelV4,
+} from '@ai-sdk/provider';
+import { expectTypeOf, it } from 'vitest';
+import { xai } from './index';
+
+it('types only xAI Responses models with their batch capability', () => {
+  expectTypeOf(xai('grok-4.6')).toMatchTypeOf<BatchLanguageModelV4>();
+  expectTypeOf(
+    xai.languageModel('grok-4.6'),
+  ).toMatchTypeOf<BatchLanguageModelV4>();
+  expectTypeOf(xai.responses('grok-4.6')).toMatchTypeOf<BatchLanguageModelV4>();
+  expectTypeOf(xai.chat('grok-4.6')).toEqualTypeOf<LanguageModelV4>();
+  expectTypeOf(xai.chat('grok-4.6')).not.toMatchTypeOf<BatchLanguageModelV4>();
+});

--- a/packages/xai/src/xai-provider.ts
+++ b/packages/xai/src/xai-provider.ts
@@ -2,6 +2,7 @@ import {
   type Experimental_RealtimeFactoryV4 as RealtimeFactoryV4,
   type Experimental_RealtimeFactoryV4GetTokenOptions as RealtimeFactoryV4GetTokenOptions,
   type Experimental_VideoModelV4,
+  type Experimental_BatchLanguageModelV4 as BatchLanguageModelV4,
   type FilesV4,
   type ImageModelV4,
   type LanguageModelV4,
@@ -22,7 +23,7 @@ import { XaiChatLanguageModel } from './xai-chat-language-model';
 import type { XaiChatModelId } from './xai-chat-language-model-options';
 import { XaiImageModel } from './xai-image-model';
 import type { XaiImageModelId } from './xai-image-settings';
-import { XaiResponsesLanguageModel } from './responses/xai-responses-language-model';
+import { XaiResponsesBatchLanguageModel } from './responses/xai-responses-batch';
 import type { XaiResponsesModelId } from './responses/xai-responses-language-model-options';
 import { XaiRealtimeModel } from './realtime/xai-realtime-model';
 import { xaiTools } from './tool';
@@ -34,12 +35,12 @@ import { XaiSpeechModel } from './xai-speech-model';
 import { XaiTranscriptionModel } from './xai-transcription-model';
 
 export interface XaiProvider extends ProviderV4 {
-  (modelId: XaiResponsesModelId): LanguageModelV4;
+  (modelId: XaiResponsesModelId): BatchLanguageModelV4;
 
   /**
    * Creates an Xai language model for text generation.
    */
-  languageModel(modelId: XaiResponsesModelId): LanguageModelV4;
+  languageModel(modelId: XaiResponsesModelId): BatchLanguageModelV4;
 
   /**
    * Creates an Xai chat model for text generation.
@@ -49,7 +50,7 @@ export interface XaiProvider extends ProviderV4 {
   /**
    * Creates an Xai responses model for text generation.
    */
-  responses: (modelId: XaiResponsesModelId) => LanguageModelV4;
+  responses: (modelId: XaiResponsesModelId) => BatchLanguageModelV4;
 
   /**
    * Creates an Xai image model for image generation.
@@ -166,7 +167,7 @@ export function createXai(options: XaiProviderSettings = {}): XaiProvider {
   };
 
   const createResponsesLanguageModel = (modelId: XaiResponsesModelId) => {
-    return new XaiResponsesLanguageModel(modelId, {
+    return new XaiResponsesBatchLanguageModel(modelId, {
       provider: 'xai.responses',
       baseURL,
       headers: getHeaders,


### PR DESCRIPTION
## Background

xAI has a [Batch API](https://docs.x.ai/developers/advanced-api-usage/batch-api) for processing large numbers of requests asynchronously. AI SDK already supports its experimental text batch APIs in several providers, but `@ai-sdk/xai` did not implement them.

## Summary

Added Batch API support to the xAI provider.

- Exposes batch support through `xai(modelId)` and `xai.responses(modelId)`.
- Prepares each request through the existing Responses API implementation.
- Uploads requests as JSONL through the xAI Files API and starts a file-backed batch.

## End-to-End Verification

Ran the xAI batch example against the live API with `grok-4.3`. The batch uploaded successfully, completed, and returned the expected results for both request IDs.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Add fast-fail validation across batch providers for models that do not support batch processing.