### PR TITLE
fix(provider/moonshotai): gate sampling by model

### DIFF
--- a/.changeset/tidy-moons-sample.md
+++ b/.changeset/tidy-moons-sample.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+fix(provider/moonshotai): omit unsupported sampling settings for Kimi models

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -78,6 +78,11 @@ const model = moonshotai.languageModel('kimi-k3');
 Moonshot AI language models can be used in the `streamText` function
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
+Moonshot V1 models support the standard `temperature`, `topP`,
+`presencePenalty`, and `frequencyPenalty` settings. Kimi models use fixed
+sampling parameters; the provider omits those settings for Kimi requests and
+returns an unsupported-setting warning when they are supplied.
+
 #### Structured Outputs
 
 Native structured outputs are enabled for Moonshot models whose model ID starts with `kimi-`.

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -47,7 +47,7 @@ describe('doGenerate', () => {
     });
 
     it('should send correct request body', async () => {
-      await provider.chatModel('kimi-k3').doGenerate({
+      await provider.chatModel('moonshot-v1-8k').doGenerate({
         prompt: [
           { role: 'system', content: 'You are a helpful assistant.' },
           { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
@@ -68,11 +68,75 @@ describe('doGenerate', () => {
               "role": "user",
             },
           ],
-          "model": "kimi-k3",
+          "model": "moonshot-v1-8k",
           "temperature": 0.5,
           "top_p": 0.3,
         }
       `);
+    });
+
+    it.each([
+      'kimi-k2.5',
+      'kimi-k2.6',
+      'kimi-k2.7-code',
+      'kimi-k2.7-code-highspeed',
+      'kimi-k3',
+    ] as const)(
+      'should omit fixed sampling options and warn for %s',
+      async modelId => {
+        const result = await provider.chatModel(modelId).doGenerate({
+          prompt: TEST_PROMPT,
+          temperature: 0.2,
+          topP: 0.4,
+          frequencyPenalty: 0.5,
+          presencePenalty: 0.6,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: modelId,
+          messages: [{ role: 'user', content: 'Hello' }],
+        });
+        expect(result.warnings).toStrictEqual([
+          {
+            type: 'unsupported',
+            feature: 'temperature',
+            details: `temperature is fixed by model "${modelId}" and has been omitted.`,
+          },
+          {
+            type: 'unsupported',
+            feature: 'topP',
+            details: `topP is fixed by model "${modelId}" and has been omitted.`,
+          },
+          {
+            type: 'unsupported',
+            feature: 'frequencyPenalty',
+            details: `frequencyPenalty is fixed by model "${modelId}" and has been omitted.`,
+          },
+          {
+            type: 'unsupported',
+            feature: 'presencePenalty',
+            details: `presencePenalty is fixed by model "${modelId}" and has been omitted.`,
+          },
+        ]);
+      },
+    );
+
+    it('should preserve sampling options for custom model IDs', async () => {
+      await provider.chatModel('custom-model').doGenerate({
+        prompt: TEST_PROMPT,
+        temperature: 0.2,
+        topP: 0.4,
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.6,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        model: 'custom-model',
+        temperature: 0.2,
+        top_p: 0.4,
+        frequency_penalty: 0.5,
+        presence_penalty: 0.6,
+      });
     });
 
     it('should extract text content, finish reason, and usage', async () => {

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -40,6 +40,7 @@ import {
 } from './moonshotai-chat-api-types';
 import {
   getModelThinkingKeepSupport,
+  isMoonshotAIKimiModel,
   moonshotaiLanguageModelOptions,
   type MoonshotAIChatModelId,
 } from './moonshotai-chat-options';
@@ -135,6 +136,37 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
       allWarnings.push({ type: 'unsupported', feature: 'seed' });
     }
 
+    const supportsSamplingOptions = !isMoonshotAIKimiModel(this.modelId);
+
+    if (!supportsSamplingOptions && temperature != null) {
+      allWarnings.push({
+        type: 'unsupported',
+        feature: 'temperature',
+        details: `temperature is fixed by model "${this.modelId}" and has been omitted.`,
+      });
+    }
+    if (!supportsSamplingOptions && topP != null) {
+      allWarnings.push({
+        type: 'unsupported',
+        feature: 'topP',
+        details: `topP is fixed by model "${this.modelId}" and has been omitted.`,
+      });
+    }
+    if (!supportsSamplingOptions && frequencyPenalty != null) {
+      allWarnings.push({
+        type: 'unsupported',
+        feature: 'frequencyPenalty',
+        details: `frequencyPenalty is fixed by model "${this.modelId}" and has been omitted.`,
+      });
+    }
+    if (!supportsSamplingOptions && presencePenalty != null) {
+      allWarnings.push({
+        type: 'unsupported',
+        feature: 'presencePenalty',
+        details: `presencePenalty is fixed by model "${this.modelId}" and has been omitted.`,
+      });
+    }
+
     const {
       tools: moonshotTools,
       toolChoice: moonshotToolChoice,
@@ -219,10 +251,12 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
       args: {
         model: this.modelId,
         max_tokens: maxOutputTokens,
-        temperature,
-        top_p: topP,
-        frequency_penalty: frequencyPenalty,
-        presence_penalty: presencePenalty,
+        temperature: supportsSamplingOptions ? temperature : undefined,
+        top_p: supportsSamplingOptions ? topP : undefined,
+        frequency_penalty: supportsSamplingOptions
+          ? frequencyPenalty
+          : undefined,
+        presence_penalty: supportsSamplingOptions ? presencePenalty : undefined,
         response_format,
         stop: stopSequences,
         messages,

--- a/packages/moonshotai/src/moonshotai-chat-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.ts
@@ -11,6 +11,16 @@ export type MoonshotAIChatModelId =
   | 'kimi-k3'
   | (string & {});
 
+export function isMoonshotAIKimiModel(modelId: MoonshotAIChatModelId): boolean {
+  return (
+    modelId === 'kimi-k2.5' ||
+    modelId === 'kimi-k2.6' ||
+    modelId === 'kimi-k2.7-code' ||
+    modelId === 'kimi-k2.7-code-highspeed' ||
+    modelId === 'kimi-k3'
+  );
+}
+
 export const moonshotaiLanguageModelOptions = z.object({
   /**
    * Reasoning effort for Kimi K3.


### PR DESCRIPTION
## Summary

- omit `temperature`, `topP`, `frequencyPenalty`, and `presencePenalty` from official Kimi model requests
- return actionable unsupported-setting warnings for omitted values
- preserve sampling controls for Moonshot V1 and unknown/custom model IDs
- document model-specific sampling behavior

Fixes #19543

## Tests

- `pnpm --filter @ai-sdk/moonshotai test:node` (87 passed)
- `pnpm --filter @ai-sdk/moonshotai test:edge` (87 passed)
- `pnpm --filter @ai-sdk/moonshotai type-check`
- `pnpm type-check:full`
- `pnpm check`
