### PR TITLE
docs(skills): improve provider package guide

### DIFF
--- a/skills/add-provider-package/SKILL.md
+++ b/skills/add-provider-package/SKILL.md
@@ -1,368 +1,208 @@
 ---
 name: add-provider-package
-description: Guide for adding new AI provider packages to the AI SDK. Use when creating a new @ai-sdk/<provider> package to integrate an AI service into the SDK.
+description: Guide for adding first-party AI provider packages to the AI SDK. Use when creating a provider package under packages/ to integrate an external AI service.
 metadata:
   internal: true
 ---
 
-## Adding a New Provider Package
+# Add a Provider Package
 
-This guide covers the process of creating a new `@ai-sdk/<provider>` package to integrate an AI service into the AI SDK.
+Add a complete first-party `@ai-sdk/<provider>` package that follows the current provider interfaces, repository conventions, security requirements, and release process.
 
-## First-Party vs Third-Party Providers
+## Read the Current Sources of Truth
 
-- **Third-party packages**: Any provider can create a third-party package. We're happy to link to it from our documentation.
-- **First-party `@ai-sdk/<provider>` packages**: If you prefer a first-party package, please create an issue first to discuss.
+Before implementing anything, read:
 
-## Reference Example
+- [Add new provider](../../contributing/add-new-provider.md) for current package and release requirements
+- [Provider development notes](../../contributing/providers.md) for naming, schemas, and workflow serialization
+- [Provider architecture](../../contributing/provider-architecture.md) for the provider abstraction
+- [Secure URL handling](../../contributing/secure-url-handling.md) when the provider fetches polling, image, audio, video, or other URLs
 
-See https://github.com/vercel/ai/pull/8136/files for a complete example of adding a new provider.
+Use [PR #18595](https://github.com/vercel/ai/pull/18595/changes) as a recent end-to-end example, but choose the current provider package whose API shape and model types most closely resemble the new provider as the implementation reference.
 
-## Provider Architecture
+Third parties can publish provider packages outside this repository. A new first-party `@ai-sdk/<provider>` package requires prior discussion in an issue. Confirm that agreement exists before implementing the package.
 
-The AI SDK uses a layered provider architecture following the adapter pattern:
+## Discover the API Contract
 
-1. **Specifications** (`@ai-sdk/provider`): Defines interfaces like `LanguageModelV4`, `EmbeddingModelV4`, etc.
-2. **Utilities** (`@ai-sdk/provider-utils`): Shared code for implementing providers
-3. **Providers** (`@ai-sdk/<provider>`): Concrete implementations for each AI service
-4. **Core** (`ai`): High-level functions like `generateText`, `streamText`, `generateObject`
+Before designing model classes, look for an official, versioned OpenAPI or Swagger specification in the provider's documentation or repositories. Prefer first-party specifications and record the source URL plus its version, publication date, or commit in the implementation notes or pull request.
 
-## Step-by-Step Guide
+Use the specification and official documentation to identify:
 
-### 1. Create Package Structure
+- base URLs and authentication schemes
+- supported endpoints, model types, and capabilities
+- request parameters and response shapes
+- streaming transports and event formats
+- error response envelopes
+- asynchronous polling and download URL flows
 
-Create a new folder `packages/<provider>` with the following structure:
+Treat an OpenAPI specification as implementation evidence, not unquestioned truth. Specifications are often incomplete for server-sent events, streaming deltas, polymorphic content, tool calls, nullable fields, and errors. Do not add a generated client or generated production types by default. Implement minimal hand-written types and Zod schemas, then verify them against official documentation and captured API responses.
 
-```
+If no official specification exists, derive the contract from official documentation and real response fixtures, and note that limitation in the pull request.
+
+## Plan the Provider Shape
+
+Determine which AI SDK model interfaces the provider supports, such as `LanguageModelV4`, `EmbeddingModelV4`, `ImageModelV4`, `SpeechModelV4`, `TranscriptionModelV4`, `RerankingModelV4`, or `Experimental_VideoModelV4`.
+
+Before introducing a dependency, public API pattern, or new abstraction, read `contributing/decisions/README.md` and relevant accepted ADRs. Prefer existing provider utilities and implementation patterns.
+
+## Scaffold the Package
+
+Create `packages/<provider>/` by adapting a current, comparable provider package. A typical package contains:
+
+```text
 packages/<provider>/
 ├── src/
-│   ├── index.ts                  # Main exports
-│   ├── version.ts                # Package version
-│   ├── <provider>-provider.ts    # Provider implementation
+│   ├── index.ts
+│   ├── version.ts
+│   ├── <provider>-provider.ts
 │   ├── <provider>-provider.test.ts
-│   ├── <provider>-*-options.ts   # Model-specific options
-│   └── <provider>-*-model.ts     # Model implementations (e.g., language, embedding, image)
+│   ├── <provider>-<model-type>-model.ts
+│   ├── <provider>-<model-type>-model.test.ts
+│   └── <provider>-<model-type>-options.ts
+├── CHANGELOG.md
+├── README.md
 ├── package.json
 ├── tsconfig.json
 ├── tsconfig.build.json
 ├── tsup.config.ts
 ├── turbo.json
 ├── vitest.node.config.js
-├── vitest.edge.config.js
-└── README.md
+└── vitest.edge.config.js
 ```
 
-Do not create a `CHANGELOG.md` file. It will be auto-generated.
+Preserve current package conventions rather than recreating configuration from memory:
 
-### 2. Configure package.json
+- Set the repository package version to exactly `2.0.0`, with no prerelease suffix.
+- Create `CHANGELOG.md` with an initial `# @ai-sdk/<provider>` heading.
+- Use ESM output and the current `tsup` package-version injection pattern.
+- Extend `./node_modules/@vercel/ai-tsconfig/ts-library.json`, enable a composite project, and add package references for workspace dependencies.
+- Include the standard build, clean, type-check, Node test, and Edge test scripts.
+- Include the standard `files`, documentation prepack, repository, bugs, engines, and public provenance publishing metadata.
+- Use `workspace:*` for AI SDK workspace dependencies. Add `@ai-sdk/test-server` only when tests use it.
+- Support the repository's Zod 3 and Zod 4 peer dependency range and use `zod/v4` for new implementation schemas.
 
-Set up your `package.json` with:
+Run `pnpm update-references` after adding or changing workspace dependencies.
 
-- `"name": "@ai-sdk/<provider>"`
-- `"version": "0.0.0"` (initial version, will be updated by changeset)
-- `"type": "module"`
-- `"license": "Apache-2.0"`
-- `"sideEffects": false`
-- Dependencies on `@ai-sdk/provider` and `@ai-sdk/provider-utils` (use `workspace:*`)
-- Dev dependencies: `@ai-sdk/test-server`, `@types/node`, `@vercel/ai-tsconfig`, `tsup`, `typescript`, `zod`
-- `"engines": { "node": ">=22" }`
-- Peer dependency on `zod` (both v3 and v4): `"zod": "^3.25.76 || ^4.1.8"`
+## Implement the Provider Factory
 
-Example package entry point configuration:
+Follow the current provider factory pattern:
 
-```json
-{
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    "./package.json": "./package.json",
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    }
-  }
-}
+- Define a provider interface that extends `ProviderV4`.
+- Export `create<Provider>(settings)` and a default provider instance.
+- Make the provider callable when it has a meaningful default model type and comparable providers follow that pattern; otherwise return a provider object.
+- Set `provider.specificationVersion = 'v4'`.
+- Implement the fully specified factory methods required by `ProviderV4`, such as `languageModel`, `embeddingModel`, and `imageModel`.
+- Add short aliases such as `chat`, `embedding`, or `image` only when they improve the provider's API.
+- Throw `NoSuchModelError` from unsupported required model factories.
+- Support provider-appropriate settings such as `apiKey`, `baseURL`, `headers`, and a custom `fetch` implementation.
+- Load credentials with `loadApiKey` or the appropriate shared utility, normalize configurable base URLs, and include the package version in the user-agent suffix.
+- Export the provider factory, default instance, public option types, model ID types, and `VERSION` from `src/index.ts`.
+
+## Implement Model Classes
+
+Implement each supported model using the appropriate interface from `@ai-sdk/provider` and shared utilities from `@ai-sdk/provider-utils`.
+
+Provider option types and schemas must follow [the repository naming and export rules](../../contributing/providers.md#provider-specific-model-options-types). User-facing option fields should use `.optional()` unless `null` is meaningful. Response schemas should be minimal, tolerate unused provider fields, and use `.nullish()` where the API may omit or return `null`.
+
+All model classes must implement the workflow serialization contract described in [Provider development notes](../../contributing/providers.md#workflow-serialization):
+
+- make model configuration headers optional
+- add `WORKFLOW_SERIALIZE` and `WORKFLOW_DESERIALIZE` static methods
+- use `serializeModel`, `serializeModelOptions`, or the matching existing pattern
+- ensure authentication and other non-serializable functions can be restored from request options or the workflow environment
+
+## Handle Responses, Errors, and URLs Safely
+
+- Never use `JSON.parse` in production code. Use `parseJSON` or `safeParseJSON` from `@ai-sdk/provider-utils`.
+- Validate successful and failed responses with minimal schemas and shared response handlers such as `createJsonResponseHandler` and `createJsonErrorResponseHandler`.
+- Introduce a custom `AISDKError` subclass only when the package needs a new public SDK error type; ordinary provider HTTP failures should use the shared API error handling.
+- Set `validateUrl` explicitly on every `getFromApi` call.
+- Use `validateUrl: true` when the URL host or scheme comes from a provider response, and `false` when it is derived from a developer-configured base URL.
+- Use `trustedOrigin` for legitimate response URLs that may point to a configured private or self-hosted endpoint.
+- Use `credentialedOrigin` when credentials may be sent on the first hop, so they are withheld from off-origin URLs and redirects.
+
+Read [Secure URL handling](../../contributing/secure-url-handling.md) before implementing any polling or provider-supplied download URL flow.
+
+## Test Against the Real Contract
+
+Add focused tests for:
+
+- provider defaults, custom settings, factory aliases, and unsupported model types
+- request serialization and response parsing
+- streaming events, usage, finish reasons, warnings, tool calls, and provider metadata where supported
+- error response parsing and malformed responses
+- workflow serialization and deserialization
+- URL trust decisions for polling or downloads
+- both Node.js and Edge runtimes
+
+Use real provider responses as fixtures when practical. Read the [capture API response fixture skill](../capture-api-response-test-fixture/SKILL.md) before capturing them. Trim oversized fixtures only when doing so does not change their semantics.
+
+## Add Examples and Repository Integration
+
+Read the [AI Functions example skill](../develop-ai-functions-example/SKILL.md) before adding examples.
+
+For each supported model type, put the entry example at:
+
+```text
+examples/ai-functions/src/<function>/<provider>/basic.ts
 ```
 
-### 3. Create TypeScript Configurations
+Put additional examples in the same provider directory with descriptive `kebab-case.ts` names. Do not create flat provider files such as `src/generate-text/<provider>.ts`.
 
-**tsconfig.json**:
+Also update the relevant repository integration points:
 
-```json
-{
-  "extends": "@vercel/ai-tsconfig/base.json",
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
-}
-```
+- add `@ai-sdk/<provider>` to `examples/ai-functions/package.json`
+- add its project reference to `examples/ai-functions/tsconfig.json`
+- add required credentials to `examples/ai-functions/.env.example`
+- add credential names to the root `turbo.json` environment configuration when needed
+- run `pnpm update-references` to update root and package TypeScript references
 
-**tsconfig.build.json**:
+Run representative examples against the real API and confirm both non-streaming and streaming behavior when supported.
 
-```json
-{
-  "extends": "./tsconfig.json",
-  "exclude": [
-    "**/*.test.ts",
-    "**/*.test-d.ts",
-    "**/__snapshots__",
-    "**/__fixtures__"
-  ]
-}
-```
+## Add Package and Provider Documentation
 
-### 4. Configure Build Tool (tsup)
+- Write the package `README.md` with installation, authentication, configuration, supported models, and basic usage.
+- Add `content/providers/01-ai-sdk-providers/<last number + 10>-<provider>.mdx` with setup, model capabilities, provider options, and examples.
+- Configure the package's documentation prepack script to include that provider page.
 
-Create `tsup.config.ts`:
+## Prepare the Release
 
-```typescript
-import { defineConfig } from 'tsup';
+Create a major changeset for the new provider package. The repository package remains at plain `2.0.0`; do not add `-beta`, `-canary`, or another prerelease suffix.
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['cjs', 'esm'],
-  dts: true,
-  sourcemap: true,
-  clean: true,
-});
-```
+Before the first automated release, coordinate with the Vercel IT team to bootstrap an empty `@ai-sdk/<provider>` package on npm at `0.0.0` and configure its Trusted Publisher. Follow [Bootstrapping a new `@ai-sdk/*` package](../../contributing/releases.md#bootstrapping-a-new-ai-sdk-package). The temporary npm bootstrap version is separate from the repository package version.
 
-### 5. Configure Test Runners
+When `main` is in prerelease mode, do not backport the new package to a stable `vX.Y` branch.
 
-Create both `vitest.node.config.js` and `vitest.edge.config.js` (copy from existing provider like `anthropic`).
+## Verify the Complete Change
 
-### 6. Implement Provider
-
-**Provider implementation pattern**:
-
-```typescript
-// <provider>-provider.ts
-import { NoSuchModelError } from '@ai-sdk/provider';
-import { loadApiKey } from '@ai-sdk/provider-utils';
-
-export interface ProviderSettings {
-  apiKey?: string;
-  baseURL?: string;
-  // provider-specific settings
-}
-
-export class ProviderInstance {
-  readonly apiKey?: string;
-  readonly baseURL?: string;
-
-  constructor(options: ProviderSettings = {}) {
-    this.apiKey = options.apiKey;
-    this.baseURL = options.baseURL;
-  }
-
-  private get baseConfig() {
-    return {
-      apiKey: () =>
-        loadApiKey({
-          apiKey: this.apiKey,
-          environmentVariableName: 'PROVIDER_API_KEY',
-          description: 'Provider API key',
-        }),
-      baseURL: this.baseURL ?? 'https://api.provider.com',
-    };
-  }
-
-  languageModel(modelId: string) {
-    return new ProviderLanguageModel(modelId, this.baseConfig);
-  }
-
-  // Shorter alias
-  chat(modelId: string) {
-    return this.languageModel(modelId);
-  }
-}
-
-// Export default instance
-export const providerName = new ProviderInstance();
-```
-
-### 7. Implement Model Classes
-
-Each model type (language, embedding, image, etc.) should implement the appropriate interface from `@ai-sdk/provider`:
-
-- `LanguageModelV4` for text generation models
-- `EmbeddingModelV4` for embedding models
-- `ImageModelV4` for image generation models
-- etc.
-
-**Schema guidelines**:
-
-**Provider Options** (user-facing):
-
-- Use `.optional()` unless `null` is meaningful
-- Be as restrictive as possible for future flexibility
-
-**Response Schemas** (API responses):
-
-- Use `.nullish()` instead of `.optional()`
-- Keep minimal - only include properties you need
-- Allow flexibility for provider API changes
-
-### 8. Create README.md
-
-Include:
-
-- Brief description linking to documentation
-- Installation instructions
-- Basic usage example
-- Link to full documentation
-
-### 9. Write Tests
-
-- Unit tests for provider logic
-- API response parsing tests using fixtures in `__fixtures__` subdirectory
-- Both Node.js and Edge runtime tests
-
-See `capture-api-response-test-fixture` skill for capturing real API responses for testing.
-
-### 10. Add Examples
-
-Create examples in `examples/ai-functions/src/` for each model type the provider supports:
-
-- `generate-text/<provider>.ts` - Basic text generation
-- `stream-text/<provider>.ts` - Streaming text
-- `generate-object/<provider>.ts` - Structured output (if supported)
-- `stream-object/<provider>.ts` - Streaming structured output (if supported)
-- `embed/<provider>.ts` - Embeddings (if supported)
-- `generate-image/<provider>.ts` - Image generation (if supported)
-- etc.
-
-Add feature-specific examples as needed (e.g., `<provider>-tool-call.ts`, `<provider>-cache-control.ts`).
-
-### 11. Add Documentation
-
-Create documentation in `content/providers/01-ai-sdk-providers/<last number + 10>-<provider>.mdx`
-
-Include:
-
-- Setup instructions
-- Available models
-- Model capabilities
-- Provider-specific options
-- Usage examples
-- API configuration
-
-### 12. Create Changeset
-
-Run `pnpm changeset` and:
-
-- Select the new provider package
-- Choose `major` version (for new packages starting at 0.0.0)
-- Describe what the package provides
-
-### 13. Update References
-
-Run `pnpm update-references` from the workspace root to update tsconfig references.
-
-### 14. Build and Test
+Run, at minimum:
 
 ```bash
-# From workspace root
-pnpm build
-
-# From provider package
-cd packages/<provider>
-pnpm test              # Run all tests
-pnpm test:node         # Run Node.js tests
-pnpm test:edge         # Run Edge tests
-pnpm type-check        # Type checking
-
-# From workspace root
-pnpm type-check:full   # Full type check including examples
+pnpm --filter @ai-sdk/<provider> build
+pnpm --filter @ai-sdk/<provider> test
+pnpm --filter @ai-sdk/<provider> type-check
+pnpm type-check:full
+pnpm check
 ```
 
-### 15. Run Examples
+Also run the new examples with the required provider credentials. Run the root build when changes to shared packages or build configuration make it relevant.
 
-Test your examples:
+## Completion Checklist
 
-```bash
-cd examples/ai-functions
-pnpm tsx src/generate-text/<provider>.ts
-pnpm tsx src/stream-text/<provider>.ts
-```
-
-## Provider Method Naming
-
-- **Full names**: `languageModel(id)`, `imageModel(id)`, `embeddingModel(id)` (required)
-- **Short aliases**: `.chat(id)`, `.image(id)`, `.embedding(id)` (for DX)
-
-## File Naming Conventions
-
-- Source files: `kebab-case.ts`
-- Test files: `kebab-case.test.ts`
-- Type test files: `kebab-case.test-d.ts`
-- Provider classes: `<Provider>Provider`, `<Provider>LanguageModel`, etc.
-
-## Security Best Practices
-
-- Never use `JSON.parse` directly - use `parseJSON` or `safeParseJSON` from `@ai-sdk/provider-utils`
-- Load API keys securely using `loadApiKey` from `@ai-sdk/provider-utils`
-- Validate all API responses against schemas
-
-## Error Handling
-
-Errors should extend `AISDKError` from `@ai-sdk/provider` and use a marker pattern:
-
-```typescript
-import { AISDKError } from '@ai-sdk/provider';
-
-const name = 'AI_ProviderError';
-const marker = `vercel.ai.error.${name}`;
-const symbol = Symbol.for(marker);
-
-export class ProviderError extends AISDKError {
-  private readonly [symbol] = true;
-
-  constructor({ message, cause }: { message: string; cause?: unknown }) {
-    super({ name, message, cause });
-  }
-
-  static isInstance(error: unknown): error is ProviderError {
-    return AISDKError.hasMarker(error, marker);
-  }
-}
-```
-
-## Pre-release Mode
-
-If `main` is set up to publish `beta` releases, no further action is necessary. Just make sure not to backport it to the `vX.Y` stable branch since it will result in an npm version conflict once we exit pre-release mode on `main`.
-
-## Checklist
-
-- [ ] Package structure created in `packages/<provider>`
-- [ ] `package.json` configured with correct dependencies
-- [ ] TypeScript configs set up (`tsconfig.json`, `tsconfig.build.json`)
-- [ ] Build configuration (`tsup.config.ts`)
-- [ ] Test configurations (`vitest.node.config.js`, `vitest.edge.config.js`)
-- [ ] Provider implementation complete
-- [ ] Model classes implement appropriate interfaces
-- [ ] Unit tests written and passing
-- [ ] API response test fixtures captured
-- [ ] Examples created in `examples/ai-functions/src/`
-- [ ] Documentation added in `content/providers/01-ai-sdk-providers/`
-- [ ] README.md written
-- [ ] Major changeset created
-- [ ] `pnpm update-references` run
-- [ ] All tests passing (`pnpm test` from package)
-- [ ] Type checking passing (`pnpm type-check:full` from root)
-- [ ] Examples run successfully
-
-## Common Issues
-
-- **Missing tsconfig references**: Run `pnpm update-references` from workspace root
-- **Type errors in examples**: Run `pnpm type-check:full` to catch issues early
-- **Test failures**: Ensure both Node and Edge tests pass
-- **Build errors**: Check that `tsup.config.ts` is configured correctly
-
-## Related Documentation
-
-- [Provider Architecture](../../contributing/provider-architecture.md)
-- [Provider Development Notes](../../contributing/providers.md)
-- [Develop AI Functions Example](../develop-ai-functions-example/SKILL.md)
-- [Capture API Response Test Fixture](../capture-api-response-test-fixture/SKILL.md)
+- [ ] First-party package approved in an issue
+- [ ] Official OpenAPI specification reviewed, or its absence documented
+- [ ] API specification checked against documentation and real responses
+- [ ] Comparable current provider implementation selected
+- [ ] Repository package created at version `2.0.0`
+- [ ] Package, TypeScript, build, test, provenance, and documentation configuration added
+- [ ] Provider factory implements `ProviderV4`
+- [ ] Supported model classes and public option types implemented
+- [ ] Workflow serialization implemented for every model class
+- [ ] Response parsing, error handling, and URL fetching follow repository security rules
+- [ ] Node and Edge tests pass with representative response fixtures
+- [ ] Nested AI Functions examples added and run successfully
+- [ ] Example dependencies, TypeScript references, environment variables, and Turbo configuration updated
+- [ ] README and provider documentation added
+- [ ] Major changeset added
+- [ ] npm package and Trusted Publisher bootstrap coordinated
+- [ ] Package build, tests, full type check, and repository checks pass

--- a/skills/capture-api-response-test-fixture/SKILL.md
+++ b/skills/capture-api-response-test-fixture/SKILL.md
@@ -15,12 +15,12 @@ You can use our examples under `/examples/ai-functions` to generate test fixture
 
 #### generateText (doGenerate testing)
 
-For `generateText`, log the raw response output to the console and copy it into a new test fixture.
+For `generateText`, put the script under `src/generate-text/<provider>/`, log the raw response output to the console, and copy it into a new test fixture.
 
 ```ts
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
-import { run } from '../lib/run';
+import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
@@ -34,13 +34,13 @@ run(async () => {
 
 #### streamText (doStream testing)
 
-For `streamText`, you need to set `includeRawChunks` to `true` and use the special `saveRawChunks` helper. Run the script from the `/example/ai-functions` folder via `pnpm tsx src/stream-text/script-name.ts`. The result is then stored in the `/examples/ai-functions/output` folder. You can copy it to your fixtures folder and rename it.
+For `streamText`, you need to set `includeRawChunks` to `true` and use the special `saveRawChunks` helper. Put the script under the provider directory and run it from the `/examples/ai-functions` folder via `pnpm tsx src/stream-text/<provider>/<script-name>.ts`. The result is then stored in the `/examples/ai-functions/output` folder. You can copy it to your fixtures folder and rename it.
 
 ```ts
 import { openai } from '@ai-sdk/openai';
 import { streamText } from 'ai';
-import { run } from '../lib/run';
-import { saveRawChunks } from '../lib/save-raw-chunks';
+import { run } from '../../lib/run';
+import { saveRawChunks } from '../../lib/save-raw-chunks';
 
 run(async () => {
   const result = streamText({

--- a/skills/develop-ai-functions-example/SKILL.md
+++ b/skills/develop-ai-functions-example/SKILL.md
@@ -35,14 +35,16 @@ Examples are organized by AI SDK function in `examples/ai-functions/src/`:
 
 ## File Naming Convention
 
-Examples follow the pattern: `{provider}-{feature}.ts`
+Group examples by function and provider. Name the entry example `basic.ts` and use descriptive `kebab-case.ts` names for additional examples:
 
-| Pattern                                  | Example                                    | Description                |
-| ---------------------------------------- | ------------------------------------------ | -------------------------- |
-| `{provider}.ts`                          | `openai.ts`                                | Basic provider usage       |
-| `{provider}-{feature}.ts`                | `openai-tool-call.ts`                      | Specific feature           |
-| `{provider}-{sub-provider}.ts`           | `amazon-bedrock-anthropic.ts`              | Provider with sub-provider |
-| `{provider}-{sub-provider}-{feature}.ts` | `google-vertex-anthropic-cache-control.ts` | Sub-provider with feature  |
+| Pattern                                             | Example                                                | Description                |
+| --------------------------------------------------- | ------------------------------------------------------ | -------------------------- |
+| `<function>/<provider>/basic.ts`                    | `generate-text/openai/basic.ts`                        | Basic provider usage       |
+| `<function>/<provider>/<feature>.ts`                | `stream-text/openai/tool-call.ts`                      | Specific feature           |
+| `<function>/<provider>/<sub-provider>.ts`           | `stream-text/amazon-bedrock/anthropic.ts`              | Provider with sub-provider |
+| `<function>/<provider>/<sub-provider>-<feature>.ts` | `stream-text/google/vertex-anthropic-cache-control.ts` | Sub-provider with feature  |
+
+Do not create flat provider files such as `generate-text/openai.ts`.
 
 ## Example Structure
 
@@ -56,7 +58,7 @@ All examples use the `run()` wrapper from `lib/run.ts` which:
 ```typescript
 import { providerName } from '@ai-sdk/provider-name';
 import { generateText } from 'ai';
-import { run } from '../lib/run';
+import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
@@ -75,8 +77,8 @@ run(async () => {
 ```typescript
 import { providerName } from '@ai-sdk/provider-name';
 import { streamText } from 'ai';
-import { printFullStream } from '../lib/print-full-stream';
-import { run } from '../lib/run';
+import { printFullStream } from '../../lib/print-full-stream';
+import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
@@ -94,7 +96,7 @@ run(async () => {
 import { providerName } from '@ai-sdk/provider-name';
 import { generateText, tool } from 'ai';
 import { z } from 'zod';
-import { run } from '../lib/run';
+import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
@@ -123,7 +125,7 @@ run(async () => {
 import { providerName } from '@ai-sdk/provider-name';
 import { generateObject } from 'ai';
 import { z } from 'zod';
-import { run } from '../lib/run';
+import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateObject({
@@ -145,9 +147,9 @@ run(async () => {
 From the `examples/ai-functions` directory:
 
 ```bash
-pnpm tsx src/generate-text/openai.ts
-pnpm tsx src/stream-text/openai-tool-call.ts
-pnpm tsx src/agent/openai-generate.ts
+pnpm tsx src/generate-text/openai/basic.ts
+pnpm tsx src/stream-text/openai/tool-call.ts
+pnpm tsx src/agent/openai/generate.ts
 ```
 
 ## When to Write Examples


### PR DESCRIPTION
## Summary

- rewrite the add-provider-package skill around current repository and release conventions
- add official OpenAPI discovery guidance with live-response verification
- cover ProviderV4 factories, workflow serialization, secure URL handling, repository integration, and npm Trusted Publisher bootstrap
- align AI Functions example and fixture skills with the nested provider directory convention

## Validation

- `pnpm check`
- `quick_validate.py skills/add-provider-package`
- `quick_validate.py skills/develop-ai-functions-example`
- `quick_validate.py skills/capture-api-response-test-fixture`
- `git diff --check`

No changeset is needed because this only updates internal skill documentation.