### PR TITLE
fix(provider/moonshotai): align reasoning by model

### DIFF
--- a/.changeset/calm-kimis-think.md
+++ b/.changeset/calm-kimis-think.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+fix(provider/moonshotai): align thinking and reasoning options by model

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -93,8 +93,9 @@ For best reliability, it is strongly recommended to include your schema requirem
 
 ### Reasoning Models
 
-Kimi K3 always reasons. It currently supports only the `max` reasoning effort,
-which you can configure through provider options:
+Kimi K3 always reasons. It supports `low`, `high`, and `max` reasoning effort,
+which you can configure through provider options or the generic `reasoning`
+setting:
 
 ```ts
 import {
@@ -117,7 +118,9 @@ console.log(reasoningText);
 console.log(text);
 ```
 
-Moonshot AI offers thinking models like `kimi-k2-thinking` that generate intermediate reasoning tokens before their final response. The reasoning output is streamed through the standard AI SDK reasoning parts.
+Kimi K2.5 and K2.6 can enable or disable thinking. Kimi K2.7 always has
+thinking and preserved reasoning enabled. The reasoning output is streamed
+through the standard AI SDK reasoning parts.
 
 ```ts
 import {
@@ -127,11 +130,11 @@ import {
 import { generateText } from 'ai';
 
 const { text, reasoningText } = await generateText({
-  model: moonshotai('kimi-k2-thinking'),
+  model: moonshotai('kimi-k2.6'),
   providerOptions: {
     moonshotai: {
-      thinking: { type: 'enabled', budgetTokens: 2048 },
-      reasoningHistory: 'interleaved',
+      thinking: { type: 'enabled' },
+      reasoningHistory: 'preserved',
     } satisfies MoonshotAILanguageModelOptions,
   },
   prompt: 'How many "r"s are in the word "strawberry"?',
@@ -193,28 +196,29 @@ You can also pass a URL. Since Moonshot AI does not fetch external URLs, the AI 
 
 The following optional provider options are available for Moonshot AI language models:
 
-- **reasoningEffort** _'max'_
+- **reasoningEffort** _'low' | 'high' | 'max'_
 
-  Reasoning effort for Kimi K3. Currently, only `'max'` is supported.
+  Reasoning effort for Kimi K3.
 
 - **thinking** _object_
 
-  Configuration for thinking/reasoning models like Kimi K2 Thinking.
+  Configuration for Kimi K2.5 and K2.6. Kimi K2.7 accepts only `enabled`
+  because its thinking cannot be disabled. Kimi K3 does not accept this field.
   - **type** _'enabled' | 'disabled'_
 
     Whether to enable thinking mode
 
-  - **budgetTokens** _number_
-
-    Maximum number of tokens for thinking (minimum 1024)
+  The previously exposed `budgetTokens` option is deprecated because Moonshot
+  Chat Completions does not support thinking budgets. The provider omits it and
+  returns a warning.
 
 - **reasoningHistory** _'disabled' | 'interleaved' | 'preserved'_
 
   Controls how reasoning history is handled in multi-turn conversations:
   - `'disabled'`: Remove reasoning from history
   - `'interleaved'`: Include reasoning between tool calls within a single turn
-  - `'preserved'`: Keep all reasoning in history. Mapped to Moonshot's
-    `thinking.keep: 'all'` request field.
+  - `'preserved'`: Keep all reasoning in history. For Kimi K2.6, this maps to
+    `thinking.keep: 'all'`. Kimi K2.7 and K3 always preserve reasoning.
 
 ## Model Capabilities
 

--- a/examples/ai-functions/src/generate-text/moonshot/thinking.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/thinking.ts
@@ -13,9 +13,8 @@ run(async () => {
       moonshotai: {
         thinking: {
           type: 'enabled',
-          budgetTokens: 2048,
         },
-        reasoningHistory: 'interleaved',
+        reasoningHistory: 'preserved',
       } satisfies MoonshotAILanguageModelOptions,
     },
   });

--- a/examples/ai-functions/src/stream-text/moonshot/thinking.ts
+++ b/examples/ai-functions/src/stream-text/moonshot/thinking.ts
@@ -14,9 +14,8 @@ run(async () => {
       moonshotai: {
         thinking: {
           type: 'enabled',
-          budgetTokens: 2048,
         },
-        reasoningHistory: 'interleaved',
+        reasoningHistory: 'preserved',
       } satisfies MoonshotAILanguageModelOptions,
     },
   });

--- a/packages/moonshotai/README.md
+++ b/packages/moonshotai/README.md
@@ -52,9 +52,8 @@ const { text } = await generateText({
   moonshotai: {
     thinking: {
       type: 'enabled',
-      budgetTokens: 2048,
     },
-    reasoningHistory: 'interleaved',
+    reasoningHistory: 'preserved',
   },
 });
 ```

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -222,8 +222,8 @@ describe('doGenerate', () => {
       prepareJsonFixtureResponse('moonshotai-reasoning');
     });
 
-    it('should send thinking with budget tokens', async () => {
-      await provider.chatModel('kimi-k2.6').doGenerate({
+    it('should omit unsupported budget tokens and warn', async () => {
+      const result = await provider.chatModel('kimi-k2.6').doGenerate({
         prompt: TEST_PROMPT,
         providerOptions: {
           moonshotai: {
@@ -235,8 +235,15 @@ describe('doGenerate', () => {
       const requestBody = await server.calls[0].requestBodyJson;
       expect(requestBody.thinking).toStrictEqual({
         type: 'enabled',
-        budget_tokens: 2048,
       });
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'deprecated',
+          setting: 'providerOptions.moonshotai.thinking.budgetTokens',
+          message:
+            'Moonshot Chat Completions does not support budget_tokens. Remove budgetTokens; the option has been omitted.',
+        },
+      ]);
     });
 
     it('should map reasoningHistory preserved to thinking.keep all', async () => {
@@ -327,8 +334,152 @@ describe('doGenerate', () => {
       expect(result.warnings).toEqual([
         {
           type: 'unsupported',
+          feature: 'reasoning "none"',
+          details: 'Kimi K3 reasoning cannot be disabled.',
+        },
+      ]);
+    });
+
+    it('should omit thinking for Kimi K3', async () => {
+      const result = await provider.chatModel('kimi-k3').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: {
+            thinking: { type: 'disabled' },
+            reasoningHistory: 'preserved',
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).not.toHaveProperty('thinking');
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'unsupported',
+          feature: 'thinking',
+          details:
+            'Kimi K3 always reasons and does not accept the thinking field. The option has been omitted.',
+        },
+      ]);
+    });
+
+    it.each(['kimi-k2.7-code', 'kimi-k2.7-code-highspeed'] as const)(
+      'should not disable thinking for %s',
+      async modelId => {
+        const result = await provider.chatModel(modelId).doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            moonshotai: { thinking: { type: 'disabled' } },
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+          'thinking',
+        );
+        expect(result.warnings).toStrictEqual([
+          {
+            type: 'unsupported',
+            feature: 'thinking.type "disabled"',
+            details: 'Kimi K2.7 thinking cannot be disabled.',
+          },
+        ]);
+      },
+    );
+
+    it('should rely on K2.7 preserved-thinking defaults', async () => {
+      const result = await provider.chatModel('kimi-k2.7-code').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: { reasoningHistory: 'preserved' },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'thinking',
+      );
+      expect(result.warnings).toStrictEqual([]);
+    });
+
+    it.each(['kimi-k2.5', 'kimi-k2.6'] as const)(
+      'should map generic reasoning to thinking for %s',
+      async modelId => {
+        await provider.chatModel(modelId).doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'low',
+        });
+        expect((await server.calls[0].requestBodyJson).thinking).toStrictEqual({
+          type: 'enabled',
+        });
+
+        await provider.chatModel(modelId).doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'none',
+        });
+        expect((await server.calls[1].requestBodyJson).thinking).toStrictEqual({
+          type: 'disabled',
+        });
+      },
+    );
+
+    it('should omit reasoning effort for K2 models and warn', async () => {
+      const result = await provider.chatModel('kimi-k2.6').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: { reasoningEffort: 'high' },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'reasoning_effort',
+      );
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'unsupported',
+          feature: 'reasoningEffort',
+          details:
+            'reasoningEffort is only supported by Kimi K3 and has been omitted for model "kimi-k2.6".',
+        },
+      ]);
+    });
+
+    it('should omit thinking and reasoning for Moonshot V1', async () => {
+      const result = await provider.chatModel('moonshot-v1-8k').doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'high',
+        providerOptions: {
+          moonshotai: {
+            reasoningEffort: 'high',
+            thinking: { type: 'enabled' },
+            reasoningHistory: 'preserved',
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).not.toHaveProperty('reasoning_effort');
+      expect(requestBody).not.toHaveProperty('thinking');
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'unsupported',
+          feature: 'reasoningEffort',
+          details:
+            'reasoningEffort is only supported by Kimi K3 and has been omitted for model "moonshot-v1-8k".',
+        },
+        {
+          type: 'unsupported',
+          feature: 'thinking',
+          details:
+            'thinking is not supported by model "moonshot-v1-8k" and has been omitted.',
+        },
+        {
+          type: 'unsupported',
+          feature: 'reasoning',
+          details: 'reasoning is not supported by model "moonshot-v1-8k".',
+        },
+        {
+          type: 'unsupported',
           feature:
-            'reasoning "none" (use providerOptions.moonshotai.thinking to control thinking)',
+            'reasoningHistory \'preserved\' is not supported by model "moonshot-v1-8k"',
         },
       ]);
     });

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -39,7 +39,7 @@ import {
   type MoonshotAIChatTokenUsage,
 } from './moonshotai-chat-api-types';
 import {
-  getModelThinkingKeepSupport,
+  getMoonshotAIModelFamily,
   isMoonshotAIKimiModel,
   moonshotaiLanguageModelOptions,
   type MoonshotAIChatModelId,
@@ -173,51 +173,180 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
       toolWarnings,
     } = prepareTools({ tools, toolChoice });
 
-    // Thinking is configured through explicit provider options only.
-    const thinking = moonshotOptions.thinking;
+    const modelFamily = getMoonshotAIModelFamily(this.modelId);
+    const requestedThinking = moonshotOptions.thinking;
+    const requestedReasoningEffort = moonshotOptions.reasoningEffort;
+    const preserveReasoning = moonshotOptions.reasoningHistory === 'preserved';
 
-    // Moonshot has no reasoning_history field; the API silently ignores it
-    // (verified against the live API). Preserved Thinking maps to
-    // thinking.keep, which only accepts 'all' and only on some models
-    // (verified: k2.6, k2.7-code, k3 accept it; k2.5 rejects it). Other
-    // reasoningHistory values use the server default.
-    let keep: 'all' | undefined;
-    if (moonshotOptions.reasoningHistory === 'preserved') {
-      if (getModelThinkingKeepSupport(this.modelId)) {
-        keep = 'all';
-      } else {
-        allWarnings.push({
-          type: 'unsupported',
-          feature: `reasoningHistory 'preserved' is not supported by model "${this.modelId}"`,
-        });
-      }
-    }
-
-    // Map the generic reasoning call option to Moonshot's reasoning_effort
-    // (explicit provider options win). 'none' cannot disable Moonshot
-    // thinking from here; use thinking: { type: 'disabled' } instead.
-    if (reasoning === 'none') {
+    if (requestedThinking?.budgetTokens != null) {
       allWarnings.push({
-        type: 'unsupported',
-        feature:
-          'reasoning "none" (use providerOptions.moonshotai.thinking to control thinking)',
+        type: 'deprecated',
+        setting: 'providerOptions.moonshotai.thinking.budgetTokens',
+        message:
+          'Moonshot Chat Completions does not support budget_tokens. Remove budgetTokens; the option has been omitted.',
       });
     }
-    const reasoningEffort =
-      moonshotOptions.reasoningEffort ??
-      (isCustomReasoning(reasoning) && reasoning !== 'none'
-        ? mapReasoningToProviderEffort({
-            reasoning,
-            effortMap: {
-              minimal: 'low',
-              low: 'low',
-              medium: 'high',
-              high: 'high',
-              xhigh: 'max',
-            },
-            warnings: allWarnings,
-          })
-        : undefined);
+
+    let thinking: { type: 'enabled' | 'disabled'; keep?: 'all' } | undefined;
+    let reasoningEffort: 'low' | 'high' | 'max' | undefined;
+
+    const warnUnsupportedReasoningEffort = () => {
+      if (requestedReasoningEffort != null) {
+        allWarnings.push({
+          type: 'unsupported',
+          feature: 'reasoningEffort',
+          details: `reasoningEffort is only supported by Kimi K3 and has been omitted for model "${this.modelId}".`,
+        });
+      }
+    };
+
+    switch (modelFamily) {
+      case 'kimi-k3': {
+        if (requestedThinking != null) {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: 'thinking',
+            details:
+              'Kimi K3 always reasons and does not accept the thinking field. The option has been omitted.',
+          });
+        }
+        if (reasoning === 'none') {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: 'reasoning "none"',
+            details: 'Kimi K3 reasoning cannot be disabled.',
+          });
+        }
+        reasoningEffort =
+          requestedReasoningEffort ??
+          (isCustomReasoning(reasoning) && reasoning !== 'none'
+            ? mapReasoningToProviderEffort({
+                reasoning,
+                effortMap: {
+                  minimal: 'low',
+                  low: 'low',
+                  medium: 'high',
+                  high: 'high',
+                  xhigh: 'max',
+                },
+                warnings: allWarnings,
+              })
+            : undefined);
+        break;
+      }
+      case 'kimi-k2.7': {
+        warnUnsupportedReasoningEffort();
+        if (requestedThinking?.type === 'disabled' || reasoning === 'none') {
+          allWarnings.push({
+            type: 'unsupported',
+            feature:
+              requestedThinking?.type === 'disabled'
+                ? 'thinking.type "disabled"'
+                : 'reasoning "none"',
+            details: 'Kimi K2.7 thinking cannot be disabled.',
+          });
+        } else if (requestedThinking?.type === 'enabled') {
+          thinking = { type: 'enabled' };
+        }
+        break;
+      }
+      case 'kimi-k2.6': {
+        warnUnsupportedReasoningEffort();
+        const thinkingType =
+          requestedThinking?.type ??
+          (isCustomReasoning(reasoning)
+            ? reasoning === 'none'
+              ? 'disabled'
+              : 'enabled'
+            : undefined);
+        if (thinkingType != null || preserveReasoning) {
+          thinking = {
+            type: thinkingType ?? 'enabled',
+            ...(preserveReasoning ? { keep: 'all' as const } : {}),
+          };
+        }
+        break;
+      }
+      case 'kimi-k2.5': {
+        warnUnsupportedReasoningEffort();
+        const thinkingType =
+          requestedThinking?.type ??
+          (isCustomReasoning(reasoning)
+            ? reasoning === 'none'
+              ? 'disabled'
+              : 'enabled'
+            : undefined);
+        if (thinkingType != null) {
+          thinking = { type: thinkingType };
+        }
+        if (preserveReasoning) {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: `reasoningHistory 'preserved' is not supported by model "${this.modelId}"`,
+          });
+        }
+        break;
+      }
+      case 'moonshot-v1': {
+        warnUnsupportedReasoningEffort();
+        if (requestedThinking != null) {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: 'thinking',
+            details: `thinking is not supported by model "${this.modelId}" and has been omitted.`,
+          });
+        }
+        if (isCustomReasoning(reasoning) && reasoning !== 'none') {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: 'reasoning',
+            details: `reasoning is not supported by model "${this.modelId}".`,
+          });
+        }
+        if (preserveReasoning) {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: `reasoningHistory 'preserved' is not supported by model "${this.modelId}"`,
+          });
+        }
+        break;
+      }
+      case 'unknown': {
+        if (reasoning === 'none') {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: 'reasoning "none"',
+            details:
+              'Use providerOptions.moonshotai.thinking to control thinking on custom models.',
+          });
+        }
+        reasoningEffort =
+          requestedReasoningEffort ??
+          (isCustomReasoning(reasoning) && reasoning !== 'none'
+            ? mapReasoningToProviderEffort({
+                reasoning,
+                effortMap: {
+                  minimal: 'low',
+                  low: 'low',
+                  medium: 'high',
+                  high: 'high',
+                  xhigh: 'max',
+                },
+                warnings: allWarnings,
+              })
+            : undefined);
+        if (requestedThinking?.type != null) {
+          thinking = { type: requestedThinking.type };
+        }
+        if (preserveReasoning) {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: `reasoningHistory 'preserved' is not supported by model "${this.modelId}"`,
+          });
+        }
+        break;
+      }
+    }
 
     let response_format: Record<string, unknown> | undefined;
     if (responseFormat?.type === 'json') {
@@ -262,17 +391,7 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
         messages,
         tools: moonshotTools,
         tool_choice: moonshotToolChoice,
-        ...(thinking != null || keep != null
-          ? {
-              thinking: {
-                ...(thinking?.type != null && { type: thinking.type }),
-                ...(thinking?.budgetTokens !== undefined && {
-                  budget_tokens: thinking.budgetTokens,
-                }),
-                ...(keep != null && { keep }),
-              },
-            }
-          : {}),
+        ...(thinking != null ? { thinking } : {}),
         ...(reasoningEffort != null && {
           reasoning_effort: reasoningEffort,
         }),

--- a/packages/moonshotai/src/moonshotai-chat-options.test-d.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.test-d.ts
@@ -1,0 +1,17 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { MoonshotAILanguageModelOptions } from './index';
+
+describe('MoonshotAILanguageModelOptions', () => {
+  it('only exposes official thinking and reasoning effort fields', () => {
+    expectTypeOf<MoonshotAILanguageModelOptions>().toEqualTypeOf<{
+      reasoningEffort?: 'low' | 'high' | 'max';
+      thinking?: {
+        type?: 'enabled' | 'disabled';
+        budgetTokens?: number;
+      };
+      reasoningHistory?: 'disabled' | 'interleaved' | 'preserved';
+      promptCacheKey?: string;
+      safetyIdentifier?: string;
+    }>();
+  });
+});

--- a/packages/moonshotai/src/moonshotai-chat-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.ts
@@ -12,13 +12,28 @@ export type MoonshotAIChatModelId =
   | (string & {});
 
 export function isMoonshotAIKimiModel(modelId: MoonshotAIChatModelId): boolean {
-  return (
-    modelId === 'kimi-k2.5' ||
-    modelId === 'kimi-k2.6' ||
-    modelId === 'kimi-k2.7-code' ||
-    modelId === 'kimi-k2.7-code-highspeed' ||
-    modelId === 'kimi-k3'
-  );
+  return getMoonshotAIModelFamily(modelId).startsWith('kimi-');
+}
+
+export type MoonshotAIModelFamily =
+  | 'kimi-k2.5'
+  | 'kimi-k2.6'
+  | 'kimi-k2.7'
+  | 'kimi-k3'
+  | 'moonshot-v1'
+  | 'unknown';
+
+export function getMoonshotAIModelFamily(
+  modelId: MoonshotAIChatModelId,
+): MoonshotAIModelFamily {
+  if (modelId === 'kimi-k2.5') return 'kimi-k2.5';
+  if (modelId === 'kimi-k2.6') return 'kimi-k2.6';
+  if (modelId === 'kimi-k2.7-code' || modelId === 'kimi-k2.7-code-highspeed') {
+    return 'kimi-k2.7';
+  }
+  if (modelId === 'kimi-k3') return 'kimi-k3';
+  if (modelId.startsWith('moonshot-v1-')) return 'moonshot-v1';
+  return 'unknown';
 }
 
 export const moonshotaiLanguageModelOptions = z.object({
@@ -30,6 +45,8 @@ export const moonshotaiLanguageModelOptions = z.object({
   thinking: z
     .object({
       type: z.enum(['enabled', 'disabled']).optional(),
+      // Accepted at runtime so existing callers receive a migration warning.
+      // This field is intentionally excluded from the public type below.
       budgetTokens: z.number().int().min(1024).optional(),
     })
     .optional(),
@@ -49,21 +66,22 @@ export const moonshotaiLanguageModelOptions = z.object({
   safetyIdentifier: z.string().optional(),
 });
 
-export type MoonshotAILanguageModelOptions = z.infer<
-  typeof moonshotaiLanguageModelOptions
->;
+export type MoonshotAILanguageModelOptions = {
+  /** Reasoning effort for Kimi K3. */
+  reasoningEffort?: 'low' | 'high' | 'max';
 
-/**
- * Whether the model accepts `thinking.keep` (Preserved Thinking). Verified
- * against the live API: kimi-k2.6, kimi-k2.7-code(+highspeed), and kimi-k3
- * accept `keep: 'all'`; other models reject it with a 400.
- */
-export function getModelThinkingKeepSupport(
-  modelId: MoonshotAIChatModelId,
-): boolean {
-  return (
-    modelId === 'kimi-k2.6' ||
-    modelId === 'kimi-k3' ||
-    modelId.startsWith('kimi-k2.7-code')
-  );
-}
+  /** Controls thinking on Kimi K2.5 and K2.6. K2.7 is always enabled. */
+  thinking?: {
+    type?: 'enabled' | 'disabled';
+
+    /**
+     * @deprecated Moonshot Chat Completions does not support thinking budgets.
+     * This value is ignored with a warning.
+     */
+    budgetTokens?: number;
+  };
+
+  reasoningHistory?: 'disabled' | 'interleaved' | 'preserved';
+  promptCacheKey?: string;
+  safetyIdentifier?: string;
+};


### PR DESCRIPTION
## Summary

- align `thinking` requests with the official K3, K2.7, K2.6, K2.5, and Moonshot V1 model behaviors
- map generic reasoning controls only where the selected model supports them
- preserve the deprecated `budgetTokens` option for compatibility while warning and omitting the unsupported wire field
- update tests, type tests, documentation, examples, and release notes

## Verification

- `pnpm --filter @ai-sdk/moonshotai test:node` (95 tests)
- `pnpm --filter @ai-sdk/moonshotai test:edge` (95 tests)
- `pnpm --filter @ai-sdk/moonshotai type-check`
- `pnpm type-check:full`
- `pnpm check`

Fixes #19554
