### PR TITLE
fix(provider/moonshotai): gate required tool choice

### DIFF
--- a/.changeset/brave-kimis-tool.md
+++ b/.changeset/brave-kimis-tool.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+Omit unsupported required tool choice requests for Kimi K2.6 and K2.7.

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -83,6 +83,10 @@ Moonshot V1 models support the standard `temperature`, `topP`,
 sampling parameters; the provider omits those settings for Kimi requests and
 returns an unsupported-setting warning when they are supplied.
 
+Kimi K3 supports the generic `required` tool choice. Kimi K2.6 and K2.7 do
+not; the provider omits `required` for those models and returns an unsupported
+setting warning. Other tool choice modes are unchanged.
+
 #### Structured Outputs
 
 Native structured outputs are enabled for Moonshot models whose model ID starts with `kimi-`.

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -139,6 +139,71 @@ describe('doGenerate', () => {
       });
     });
 
+    it.each([
+      { modelId: 'kimi-k2.6', modelFamily: 'kimi-k2.6' },
+      { modelId: 'kimi-k2.7-code', modelFamily: 'kimi-k2.7' },
+      { modelId: 'kimi-k2.7-code-highspeed', modelFamily: 'kimi-k2.7' },
+    ] as const)(
+      'should omit required tool choice and warn for $modelId',
+      async ({ modelId, modelFamily }) => {
+        const result = await provider.chatModel(modelId).doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'function',
+              name: 'getWeather',
+              description: 'Get the weather in a location',
+              inputSchema: {
+                type: 'object',
+                properties: { location: { type: 'string' } },
+                required: ['location'],
+              },
+            },
+          ],
+          toolChoice: { type: 'required' },
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody).not.toHaveProperty('tool_choice');
+        expect(requestBody.tools).toHaveLength(1);
+        expect(result.warnings).toStrictEqual([
+          {
+            type: 'unsupported',
+            feature: 'toolChoice',
+            details: `Required tool choice is not supported by ${modelFamily} models and has been omitted.`,
+          },
+        ]);
+      },
+    );
+
+    it.each(['kimi-k3', 'custom-model'] as const)(
+      'should preserve required tool choice for %s',
+      async modelId => {
+        const result = await provider.chatModel(modelId).doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'function',
+              name: 'getWeather',
+              description: 'Get the weather in a location',
+              inputSchema: {
+                type: 'object',
+                properties: { location: { type: 'string' } },
+                required: ['location'],
+              },
+            },
+          ],
+          toolChoice: { type: 'required' },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          model: modelId,
+          tool_choice: 'required',
+        });
+        expect(result.warnings).toStrictEqual([]);
+      },
+    );
+
     it('should extract text content, finish reason, and usage', async () => {
       const result = await provider.chatModel('kimi-k3').doGenerate({
         prompt: TEST_PROMPT,

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -167,13 +167,14 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
       });
     }
 
+    const modelFamily = getMoonshotAIModelFamily(this.modelId);
+
     const {
       tools: moonshotTools,
       toolChoice: moonshotToolChoice,
       toolWarnings,
-    } = prepareTools({ tools, toolChoice });
+    } = prepareTools({ modelFamily, tools, toolChoice });
 
-    const modelFamily = getMoonshotAIModelFamily(this.modelId);
     const requestedThinking = moonshotOptions.thinking;
     const requestedReasoningEffort = moonshotOptions.reasoningEffort;
     const preserveReasoning = moonshotOptions.reasoningHistory === 'preserved';

--- a/packages/moonshotai/src/moonshotai-prepare-tools.test.ts
+++ b/packages/moonshotai/src/moonshotai-prepare-tools.test.ts
@@ -1,0 +1,67 @@
+import type { LanguageModelV4CallOptions } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { prepareTools } from './moonshotai-prepare-tools';
+
+const tools: NonNullable<LanguageModelV4CallOptions['tools']> = [
+  {
+    type: 'function',
+    name: 'getWeather',
+    description: 'Get the weather in a location',
+    inputSchema: {
+      type: 'object',
+      properties: { location: { type: 'string' } },
+      required: ['location'],
+    },
+  },
+];
+
+describe('prepareTools', () => {
+  it.each(['kimi-k2.6', 'kimi-k2.7'] as const)(
+    'omits required tool choice for %s',
+    modelFamily => {
+      const result = prepareTools({
+        modelFamily,
+        tools,
+        toolChoice: { type: 'required' },
+      });
+
+      expect(result.toolChoice).toBeUndefined();
+      expect(result.tools).toHaveLength(1);
+      expect(result.toolWarnings).toStrictEqual([
+        {
+          type: 'unsupported',
+          feature: 'toolChoice',
+          details: `Required tool choice is not supported by ${modelFamily} models and has been omitted.`,
+        },
+      ]);
+    },
+  );
+
+  it.each(['kimi-k3', 'unknown'] as const)(
+    'preserves required tool choice for %s',
+    modelFamily => {
+      const result = prepareTools({
+        modelFamily,
+        tools,
+        toolChoice: { type: 'required' },
+      });
+
+      expect(result.toolChoice).toBe('required');
+      expect(result.toolWarnings).toStrictEqual([]);
+    },
+  );
+
+  it.each(['auto', 'none'] as const)(
+    'preserves %s tool choice for Kimi K2.6',
+    type => {
+      const result = prepareTools({
+        modelFamily: 'kimi-k2.6',
+        tools,
+        toolChoice: { type },
+      });
+
+      expect(result.toolChoice).toBe(type);
+      expect(result.toolWarnings).toStrictEqual([]);
+    },
+  );
+});

--- a/packages/moonshotai/src/moonshotai-prepare-tools.ts
+++ b/packages/moonshotai/src/moonshotai-prepare-tools.ts
@@ -3,12 +3,15 @@ import {
   type LanguageModelV4CallOptions,
   type SharedV4Warning,
 } from '@ai-sdk/provider';
+import type { MoonshotAIModelFamily } from './moonshotai-chat-options';
 import { normalizeJsonSchemaForMFJS } from './normalize-json-schema-for-mfjs';
 
 export function prepareTools({
+  modelFamily,
   tools,
   toolChoice,
 }: {
+  modelFamily: MoonshotAIModelFamily;
   tools: LanguageModelV4CallOptions['tools'];
   toolChoice?: LanguageModelV4CallOptions['toolChoice'];
 }): {
@@ -78,7 +81,20 @@ export function prepareTools({
   switch (type) {
     case 'auto':
     case 'none':
+      return { tools: moonshotTools, toolChoice: type, toolWarnings };
     case 'required':
+      if (modelFamily === 'kimi-k2.6' || modelFamily === 'kimi-k2.7') {
+        toolWarnings.push({
+          type: 'unsupported',
+          feature: 'toolChoice',
+          details: `Required tool choice is not supported by ${modelFamily} models and has been omitted.`,
+        });
+        return {
+          tools: moonshotTools,
+          toolChoice: undefined,
+          toolWarnings,
+        };
+      }
       return { tools: moonshotTools, toolChoice: type, toolWarnings };
     case 'tool':
       return {


### PR DESCRIPTION
## Summary

- omit `tool_choice: "required"` for Kimi K2.6 and K2.7, which reject that documented wire value
- return an actionable unsupported-setting warning while preserving the tool definitions
- keep Kimi K3, custom model IDs, and other tool-choice modes unchanged
- add request-level and tool-preparation regression tests, documentation, and a patch changeset

## Verification

- `pnpm --filter @ai-sdk/moonshotai test:node` (106 tests)
- `pnpm --filter @ai-sdk/moonshotai test:edge` (106 tests)
- `pnpm --filter @ai-sdk/moonshotai type-check`
- `pnpm type-check:full`
- `pnpm check`

## Dependency

This PR is temporarily based on #19582 because it uses the model-family helper introduced there. It will be retargeted to `main` after #19582 merges.

Fixes #19553
