### PR TITLE
fix(provider/moonshotai): align structured output schemas

### DIFF
--- a/.changeset/strict-kimis-shape.md
+++ b/.changeset/strict-kimis-shape.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+fix(provider/moonshotai): normalize structured output schemas and enable strict validation by default

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -92,6 +92,11 @@ unchanged.
 
 Native structured outputs are enabled for Moonshot models whose model ID starts with `kimi-`.
 
+Moonshot validates structured-output schemas strictly by default. The provider
+normalizes schemas to Moonshot's supported JSON Schema subset before sending
+them. Set the `strictJsonSchema` provider option to `false` to opt out of strict
+validation.
+
 For other Moonshot models, object generation falls back to JSON mode instead of schema-constrained decoding.
 
 For best reliability, it is strongly recommended to include your schema requirements in your prompt in addition to passing the schema through `Output`.
@@ -224,6 +229,11 @@ The following optional provider options are available for Moonshot AI language m
   - `'interleaved'`: Include reasoning between tool calls within a single turn
   - `'preserved'`: Keep all reasoning in history. For Kimi K2.6, this maps to
     `thinking.keep: 'all'`. Kimi K2.7 and K3 always preserve reasoning.
+
+- **strictJsonSchema** _boolean_
+
+  Whether to use strict JSON schema validation for structured outputs. Defaults
+  to `true`.
 
 ## Model Capabilities
 

--- a/examples/ai-functions/src/generate-text/moonshot/structured-outputs.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/structured-outputs.ts
@@ -1,4 +1,7 @@
-import { moonshotai } from '@ai-sdk/moonshotai';
+import {
+  moonshotai,
+  type MoonshotAILanguageModelOptions,
+} from '@ai-sdk/moonshotai';
 import { generateText, Output } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -12,6 +15,11 @@ run(async () => {
         traditions: z.array(z.string()),
       }),
     }),
+    providerOptions: {
+      moonshotai: {
+        strictJsonSchema: true,
+      } satisfies MoonshotAILanguageModelOptions,
+    },
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -525,16 +525,23 @@ describe('doGenerate', () => {
       prepareJsonFixtureResponse('moonshotai-text');
     });
 
-    it('should strip the $schema keyword from json schemas', async () => {
+    it('should normalize json schemas and enable strict mode by default', async () => {
       await provider.chatModel('kimi-k3').doGenerate({
         prompt: TEST_PROMPT,
         responseFormat: {
           type: 'json',
           name: 'recipe',
+          description: 'A recipe',
           schema: {
             $schema: 'http://json-schema.org/draft-07/schema#',
             type: 'object',
-            properties: { name: { type: 'string' } },
+            properties: {
+              name: { type: 'string' },
+              coordinates: {
+                type: 'array',
+                items: [{ type: 'number' }, { type: 'number' }],
+              },
+            },
           },
         },
       });
@@ -544,10 +551,40 @@ describe('doGenerate', () => {
         type: 'json_schema',
         json_schema: {
           name: 'recipe',
+          strict: true,
           schema: {
             type: 'object',
-            properties: { name: { type: 'string' } },
+            properties: {
+              name: { type: 'string' },
+              coordinates: {
+                type: 'array',
+                prefixItems: [{ type: 'number' }, { type: 'number' }],
+              },
+            },
           },
+        },
+      });
+    });
+
+    it('should allow strict json schema validation to be disabled', async () => {
+      await provider.chatModel('kimi-k3').doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: {
+          type: 'json',
+          schema: { type: 'object', properties: {} },
+        },
+        providerOptions: {
+          moonshotai: { strictJsonSchema: false },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.response_format).toStrictEqual({
+        type: 'json_schema',
+        json_schema: {
+          name: 'response',
+          strict: false,
+          schema: { type: 'object', properties: {} },
         },
       });
     });

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -46,6 +46,7 @@ import {
   type MoonshotAIChatModelId,
 } from './moonshotai-chat-options';
 import { prepareTools } from './moonshotai-prepare-tools';
+import { normalizeJsonSchemaForMFJS } from './normalize-json-schema-for-mfjs';
 
 export type MoonshotAIChatConfig = {
   provider: string;
@@ -413,10 +414,8 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
           type: 'json_schema',
           json_schema: {
             name: responseFormat.name ?? 'response',
-            schema: schemaWithoutDollarSchema,
-            ...(responseFormat.description != null && {
-              description: responseFormat.description,
-            }),
+            strict: moonshotOptions.strictJsonSchema ?? true,
+            schema: normalizeJsonSchemaForMFJS(schemaWithoutDollarSchema),
           },
         };
       } else {

--- a/packages/moonshotai/src/moonshotai-chat-options.test-d.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.test-d.ts
@@ -10,6 +10,7 @@ describe('MoonshotAILanguageModelOptions', () => {
         budgetTokens?: number;
       };
       reasoningHistory?: 'disabled' | 'interleaved' | 'preserved';
+      strictJsonSchema?: boolean;
       promptCacheKey?: string;
       safetyIdentifier?: string;
     }>();

--- a/packages/moonshotai/src/moonshotai-chat-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.ts
@@ -54,6 +54,12 @@ export const moonshotaiLanguageModelOptions = z.object({
   reasoningHistory: z.enum(['disabled', 'interleaved', 'preserved']).optional(),
 
   /**
+   * Whether to use strict JSON schema validation for structured outputs.
+   * Defaults to true.
+   */
+  strictJsonSchema: z.boolean().optional(),
+
+  /**
    * Used to cache responses for similar requests to optimize cache hit rates.
    * Typically a session or task id.
    */
@@ -82,6 +88,11 @@ export type MoonshotAILanguageModelOptions = {
   };
 
   reasoningHistory?: 'disabled' | 'interleaved' | 'preserved';
+  /**
+   * Whether to use strict JSON schema validation for structured outputs.
+   * Defaults to true.
+   */
+  strictJsonSchema?: boolean;
   promptCacheKey?: string;
   safetyIdentifier?: string;
 };


### PR DESCRIPTION
Fixes #19544

## Summary

- normalize response schemas through the existing Moonshot MFJS compatibility layer
- send the documented JSON schema shape with an explicit strict flag that defaults to true
- expose `strictJsonSchema` as a typed per-request opt-out and document it
- add request regression coverage, a type test, an example update, and a patch changeset

## Tests

- `pnpm --filter @ai-sdk/moonshotai... build`
- `pnpm --filter @ai-sdk/moonshotai test:node` — 110 passed
- `pnpm --filter @ai-sdk/moonshotai test:edge` — 110 passed
- `pnpm --filter @ai-sdk/moonshotai type-check`
- `pnpm type-check:full`
- `pnpm check`
- `git diff --check`

Rebased onto `main` after #19633 merged.
