### PR TITLE
fix(provider/moonshotai): validate media MIME types

### DIFF
--- a/.changeset/brave-kimis-tool.md
+++ b/.changeset/brave-kimis-tool.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+Omit unsupported required tool choice requests for Kimi K2.6 and K2.7.

--- a/.changeset/calm-kimis-think.md
+++ b/.changeset/calm-kimis-think.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+fix(provider/moonshotai): align thinking and reasoning options by model

--- a/.changeset/strict-kimis-shape.md
+++ b/.changeset/strict-kimis-shape.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+fix(provider/moonshotai): normalize structured output schemas and enable strict validation by default

--- a/.changeset/tidy-kimis-watch.md
+++ b/.changeset/tidy-kimis-watch.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+fix(provider/moonshotai): reject unsupported image and video media types locally

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -159,6 +159,10 @@ See [AI SDK UI: Chatbot](/docs/ai-sdk-ui/chatbot#reasoning) for more details on 
 
 Kimi K3, Kimi K2.7 Code, Kimi K2.6, and Kimi K2.5 support video input. Pass the video as a `file` content part with a video media type:
 
+Supported image media types are JPEG, PNG, GIF, WebP, BMP, HEIC, and HEIF.
+Supported video media types are MP4, MPEG, MOV, AVI, FLV, MPG, WebM, WMV, and
+3GPP. Other image and video media types, including SVG, are rejected locally.
+
 ```ts
 import { moonshotai } from '@ai-sdk/moonshotai';
 import { generateText } from 'ai';

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -91,6 +91,11 @@ setting warning. Other tool choice modes are unchanged.
 
 Native structured outputs are enabled for Moonshot models whose model ID starts with `kimi-`.
 
+Moonshot validates structured-output schemas strictly by default. The provider
+normalizes schemas to Moonshot's supported JSON Schema subset before sending
+them. Set the `strictJsonSchema` provider option to `false` to opt out of strict
+validation.
+
 For other Moonshot models, object generation falls back to JSON mode instead of schema-constrained decoding.
 
 For best reliability, it is strongly recommended to include your schema requirements in your prompt in addition to passing the schema through `Output`.
@@ -223,6 +228,11 @@ The following optional provider options are available for Moonshot AI language m
   - `'interleaved'`: Include reasoning between tool calls within a single turn
   - `'preserved'`: Keep all reasoning in history. For Kimi K2.6, this maps to
     `thinking.keep: 'all'`. Kimi K2.7 and K3 always preserve reasoning.
+
+- **strictJsonSchema** _boolean_
+
+  Whether to use strict JSON schema validation for structured outputs. Defaults
+  to `true`.
 
 ## Model Capabilities
 

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -83,6 +83,10 @@ Moonshot V1 models support the standard `temperature`, `topP`,
 sampling parameters; the provider omits those settings for Kimi requests and
 returns an unsupported-setting warning when they are supplied.
 
+Kimi K3 supports the generic `required` tool choice. Kimi K2.6 and K2.7 do
+not; the provider omits `required` for those models and returns an unsupported
+setting warning. Other tool choice modes are unchanged.
+
 #### Structured Outputs
 
 Native structured outputs are enabled for Moonshot models whose model ID starts with `kimi-`.

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -93,8 +93,9 @@ For best reliability, it is strongly recommended to include your schema requirem
 
 ### Reasoning Models
 
-Kimi K3 always reasons. It currently supports only the `max` reasoning effort,
-which you can configure through provider options:
+Kimi K3 always reasons. It supports `low`, `high`, and `max` reasoning effort,
+which you can configure through provider options or the generic `reasoning`
+setting:
 
 ```ts
 import {
@@ -117,7 +118,9 @@ console.log(reasoningText);
 console.log(text);
 ```
 
-Moonshot AI offers thinking models like `kimi-k2-thinking` that generate intermediate reasoning tokens before their final response. The reasoning output is streamed through the standard AI SDK reasoning parts.
+Kimi K2.5 and K2.6 can enable or disable thinking. Kimi K2.7 always has
+thinking and preserved reasoning enabled. The reasoning output is streamed
+through the standard AI SDK reasoning parts.
 
 ```ts
 import {
@@ -127,11 +130,11 @@ import {
 import { generateText } from 'ai';
 
 const { text, reasoningText } = await generateText({
-  model: moonshotai('kimi-k2-thinking'),
+  model: moonshotai('kimi-k2.6'),
   providerOptions: {
     moonshotai: {
-      thinking: { type: 'enabled', budgetTokens: 2048 },
-      reasoningHistory: 'interleaved',
+      thinking: { type: 'enabled' },
+      reasoningHistory: 'preserved',
     } satisfies MoonshotAILanguageModelOptions,
   },
   prompt: 'How many "r"s are in the word "strawberry"?',
@@ -193,28 +196,29 @@ You can also pass a URL. Since Moonshot AI does not fetch external URLs, the AI 
 
 The following optional provider options are available for Moonshot AI language models:
 
-- **reasoningEffort** _'max'_
+- **reasoningEffort** _'low' | 'high' | 'max'_
 
-  Reasoning effort for Kimi K3. Currently, only `'max'` is supported.
+  Reasoning effort for Kimi K3.
 
 - **thinking** _object_
 
-  Configuration for thinking/reasoning models like Kimi K2 Thinking.
+  Configuration for Kimi K2.5 and K2.6. Kimi K2.7 accepts only `enabled`
+  because its thinking cannot be disabled. Kimi K3 does not accept this field.
   - **type** _'enabled' | 'disabled'_
 
     Whether to enable thinking mode
 
-  - **budgetTokens** _number_
-
-    Maximum number of tokens for thinking (minimum 1024)
+  The previously exposed `budgetTokens` option is deprecated because Moonshot
+  Chat Completions does not support thinking budgets. The provider omits it and
+  returns a warning.
 
 - **reasoningHistory** _'disabled' | 'interleaved' | 'preserved'_
 
   Controls how reasoning history is handled in multi-turn conversations:
   - `'disabled'`: Remove reasoning from history
   - `'interleaved'`: Include reasoning between tool calls within a single turn
-  - `'preserved'`: Keep all reasoning in history. Mapped to Moonshot's
-    `thinking.keep: 'all'` request field.
+  - `'preserved'`: Keep all reasoning in history. For Kimi K2.6, this maps to
+    `thinking.keep: 'all'`. Kimi K2.7 and K3 always preserve reasoning.
 
 ## Model Capabilities
 

--- a/examples/ai-functions/src/generate-text/moonshot/structured-outputs.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/structured-outputs.ts
@@ -1,4 +1,7 @@
-import { moonshotai } from '@ai-sdk/moonshotai';
+import {
+  moonshotai,
+  type MoonshotAILanguageModelOptions,
+} from '@ai-sdk/moonshotai';
 import { generateText, Output } from 'ai';
 import { z } from 'zod';
 import { run } from '../../lib/run';
@@ -12,6 +15,11 @@ run(async () => {
         traditions: z.array(z.string()),
       }),
     }),
+    providerOptions: {
+      moonshotai: {
+        strictJsonSchema: true,
+      } satisfies MoonshotAILanguageModelOptions,
+    },
     prompt: 'Invent a new holiday and describe its traditions.',
   });
 

--- a/examples/ai-functions/src/generate-text/moonshot/thinking.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/thinking.ts
@@ -13,9 +13,8 @@ run(async () => {
       moonshotai: {
         thinking: {
           type: 'enabled',
-          budgetTokens: 2048,
         },
-        reasoningHistory: 'interleaved',
+        reasoningHistory: 'preserved',
       } satisfies MoonshotAILanguageModelOptions,
     },
   });

--- a/examples/ai-functions/src/stream-text/moonshot/thinking.ts
+++ b/examples/ai-functions/src/stream-text/moonshot/thinking.ts
@@ -14,9 +14,8 @@ run(async () => {
       moonshotai: {
         thinking: {
           type: 'enabled',
-          budgetTokens: 2048,
         },
-        reasoningHistory: 'interleaved',
+        reasoningHistory: 'preserved',
       } satisfies MoonshotAILanguageModelOptions,
     },
   });

--- a/packages/moonshotai/README.md
+++ b/packages/moonshotai/README.md
@@ -52,9 +52,8 @@ const { text } = await generateText({
   moonshotai: {
     thinking: {
       type: 'enabled',
-      budgetTokens: 2048,
     },
-    reasoningHistory: 'interleaved',
+    reasoningHistory: 'preserved',
   },
 });
 ```

--- a/packages/moonshotai/src/convert-to-moonshotai-chat-messages.test.ts
+++ b/packages/moonshotai/src/convert-to-moonshotai-chat-messages.test.ts
@@ -39,6 +39,41 @@ describe('user messages', () => {
     ]);
   });
 
+  it.each([
+    'image/jpeg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+    'image/bmp',
+    'image/heic',
+    'image/heif',
+  ])('should accept the supported image media type %s', mediaType => {
+    const result = convertToMoonshotAIChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: { type: 'data' as const, data: new Uint8Array([0, 1]) },
+            mediaType,
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: `data:${mediaType};base64,AAE=` },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('should pass through image URLs', () => {
     const result = convertToMoonshotAIChatMessages([
       {
@@ -92,6 +127,43 @@ describe('user messages', () => {
           {
             type: 'video_url',
             video_url: { url: 'data:video/mp4;base64,AAECAw==' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it.each([
+    'video/mp4',
+    'video/mpeg',
+    'video/mov',
+    'video/avi',
+    'video/x-flv',
+    'video/mpg',
+    'video/webm',
+    'video/wmv',
+    'video/3gpp',
+  ])('should accept the supported video media type %s', mediaType => {
+    const result = convertToMoonshotAIChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: { type: 'data' as const, data: new Uint8Array([0, 1]) },
+            mediaType,
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'video_url',
+            video_url: { url: `data:${mediaType};base64,AAE=` },
           },
         ],
       },
@@ -198,6 +270,48 @@ describe('user messages', () => {
         },
       ]),
     ).toThrow("'file part media type audio/mp3' functionality not supported");
+  });
+
+  it('should throw for unsupported image media types', () => {
+    expect(() =>
+      convertToMoonshotAIChatMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: {
+                type: 'data' as const,
+                data: new Uint8Array([0, 1, 2, 3]),
+              },
+              mediaType: 'image/svg+xml',
+            },
+          ],
+        },
+      ]),
+    ).toThrow(
+      "'file part media type image/svg+xml' functionality not supported",
+    );
+  });
+
+  it('should throw for unsupported video media types', () => {
+    expect(() =>
+      convertToMoonshotAIChatMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: {
+                type: 'data' as const,
+                data: new Uint8Array([0, 1, 2, 3]),
+              },
+              mediaType: 'video/ogg',
+            },
+          ],
+        },
+      ]),
+    ).toThrow("'file part media type video/ogg' functionality not supported");
   });
 
   it('should throw for PDF file parts (rejected by the API)', () => {

--- a/packages/moonshotai/src/convert-to-moonshotai-chat-messages.ts
+++ b/packages/moonshotai/src/convert-to-moonshotai-chat-messages.ts
@@ -11,6 +11,28 @@ import {
 
 import type { MoonshotAIMessages } from './moonshotai-chat-api-types';
 
+const supportedImageMediaTypes = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/bmp',
+  'image/heic',
+  'image/heif',
+]);
+
+const supportedVideoMediaTypes = new Set([
+  'video/mp4',
+  'video/mpeg',
+  'video/mov',
+  'video/avi',
+  'video/x-flv',
+  'video/mpg',
+  'video/webm',
+  'video/wmv',
+  'video/3gpp',
+]);
+
 // Moonshot AI chat completions accepts text, image_url, and video_url content
 // parts only. Anything else (audio, PDF, other file types) throws here rather
 // than being rejected by the API with a 400.
@@ -58,25 +80,53 @@ export function convertToMoonshotAIChatMessages(
                     const topLevel = getTopLevelMediaType(part.mediaType);
 
                     if (topLevel === 'image') {
+                      const mediaType =
+                        part.data.type === 'url' && part.mediaType === 'image/*'
+                          ? undefined
+                          : resolveFullMediaType({ part });
+
+                      if (
+                        mediaType != null &&
+                        !supportedImageMediaTypes.has(mediaType)
+                      ) {
+                        throw new UnsupportedFunctionalityError({
+                          functionality: `file part media type ${mediaType}`,
+                        });
+                      }
+
                       return {
                         type: 'image_url' as const,
                         image_url: {
                           url:
                             part.data.type === 'url'
                               ? part.data.url.toString()
-                              : `data:${resolveFullMediaType({ part })};base64,${convertToBase64(part.data.data)}`,
+                              : `data:${mediaType};base64,${convertToBase64(part.data.data)}`,
                         },
                       };
                     }
 
                     if (topLevel === 'video') {
+                      const mediaType =
+                        part.data.type === 'url' && part.mediaType === 'video/*'
+                          ? undefined
+                          : resolveFullMediaType({ part });
+
+                      if (
+                        mediaType != null &&
+                        !supportedVideoMediaTypes.has(mediaType)
+                      ) {
+                        throw new UnsupportedFunctionalityError({
+                          functionality: `file part media type ${mediaType}`,
+                        });
+                      }
+
                       return {
                         type: 'video_url' as const,
                         video_url: {
                           url:
                             part.data.type === 'url'
                               ? part.data.url.toString()
-                              : `data:${resolveFullMediaType({ part })};base64,${convertToBase64(part.data.data)}`,
+                              : `data:${mediaType};base64,${convertToBase64(part.data.data)}`,
                         },
                       };
                     }

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -222,8 +222,8 @@ describe('doGenerate', () => {
       prepareJsonFixtureResponse('moonshotai-reasoning');
     });
 
-    it('should send thinking with budget tokens', async () => {
-      await provider.chatModel('kimi-k2.6').doGenerate({
+    it('should omit unsupported budget tokens and warn', async () => {
+      const result = await provider.chatModel('kimi-k2.6').doGenerate({
         prompt: TEST_PROMPT,
         providerOptions: {
           moonshotai: {
@@ -235,8 +235,15 @@ describe('doGenerate', () => {
       const requestBody = await server.calls[0].requestBodyJson;
       expect(requestBody.thinking).toStrictEqual({
         type: 'enabled',
-        budget_tokens: 2048,
       });
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'deprecated',
+          setting: 'providerOptions.moonshotai.thinking.budgetTokens',
+          message:
+            'Moonshot Chat Completions does not support budget_tokens. Remove budgetTokens; the option has been omitted.',
+        },
+      ]);
     });
 
     it('should map reasoningHistory preserved to thinking.keep all', async () => {
@@ -327,8 +334,152 @@ describe('doGenerate', () => {
       expect(result.warnings).toEqual([
         {
           type: 'unsupported',
+          feature: 'reasoning "none"',
+          details: 'Kimi K3 reasoning cannot be disabled.',
+        },
+      ]);
+    });
+
+    it('should omit thinking for Kimi K3', async () => {
+      const result = await provider.chatModel('kimi-k3').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: {
+            thinking: { type: 'disabled' },
+            reasoningHistory: 'preserved',
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).not.toHaveProperty('thinking');
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'unsupported',
+          feature: 'thinking',
+          details:
+            'Kimi K3 always reasons and does not accept the thinking field. The option has been omitted.',
+        },
+      ]);
+    });
+
+    it.each(['kimi-k2.7-code', 'kimi-k2.7-code-highspeed'] as const)(
+      'should not disable thinking for %s',
+      async modelId => {
+        const result = await provider.chatModel(modelId).doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            moonshotai: { thinking: { type: 'disabled' } },
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+          'thinking',
+        );
+        expect(result.warnings).toStrictEqual([
+          {
+            type: 'unsupported',
+            feature: 'thinking.type "disabled"',
+            details: 'Kimi K2.7 thinking cannot be disabled.',
+          },
+        ]);
+      },
+    );
+
+    it('should rely on K2.7 preserved-thinking defaults', async () => {
+      const result = await provider.chatModel('kimi-k2.7-code').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: { reasoningHistory: 'preserved' },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'thinking',
+      );
+      expect(result.warnings).toStrictEqual([]);
+    });
+
+    it.each(['kimi-k2.5', 'kimi-k2.6'] as const)(
+      'should map generic reasoning to thinking for %s',
+      async modelId => {
+        await provider.chatModel(modelId).doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'low',
+        });
+        expect((await server.calls[0].requestBodyJson).thinking).toStrictEqual({
+          type: 'enabled',
+        });
+
+        await provider.chatModel(modelId).doGenerate({
+          prompt: TEST_PROMPT,
+          reasoning: 'none',
+        });
+        expect((await server.calls[1].requestBodyJson).thinking).toStrictEqual({
+          type: 'disabled',
+        });
+      },
+    );
+
+    it('should omit reasoning effort for K2 models and warn', async () => {
+      const result = await provider.chatModel('kimi-k2.6').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: { reasoningEffort: 'high' },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'reasoning_effort',
+      );
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'unsupported',
+          feature: 'reasoningEffort',
+          details:
+            'reasoningEffort is only supported by Kimi K3 and has been omitted for model "kimi-k2.6".',
+        },
+      ]);
+    });
+
+    it('should omit thinking and reasoning for Moonshot V1', async () => {
+      const result = await provider.chatModel('moonshot-v1-8k').doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'high',
+        providerOptions: {
+          moonshotai: {
+            reasoningEffort: 'high',
+            thinking: { type: 'enabled' },
+            reasoningHistory: 'preserved',
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).not.toHaveProperty('reasoning_effort');
+      expect(requestBody).not.toHaveProperty('thinking');
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'unsupported',
+          feature: 'reasoningEffort',
+          details:
+            'reasoningEffort is only supported by Kimi K3 and has been omitted for model "moonshot-v1-8k".',
+        },
+        {
+          type: 'unsupported',
+          feature: 'thinking',
+          details:
+            'thinking is not supported by model "moonshot-v1-8k" and has been omitted.',
+        },
+        {
+          type: 'unsupported',
+          feature: 'reasoning',
+          details: 'reasoning is not supported by model "moonshot-v1-8k".',
+        },
+        {
+          type: 'unsupported',
           feature:
-            'reasoning "none" (use providerOptions.moonshotai.thinking to control thinking)',
+            'reasoningHistory \'preserved\' is not supported by model "moonshot-v1-8k"',
         },
       ]);
     });

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -139,6 +139,71 @@ describe('doGenerate', () => {
       });
     });
 
+    it.each([
+      { modelId: 'kimi-k2.6', modelFamily: 'kimi-k2.6' },
+      { modelId: 'kimi-k2.7-code', modelFamily: 'kimi-k2.7' },
+      { modelId: 'kimi-k2.7-code-highspeed', modelFamily: 'kimi-k2.7' },
+    ] as const)(
+      'should omit required tool choice and warn for $modelId',
+      async ({ modelId, modelFamily }) => {
+        const result = await provider.chatModel(modelId).doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'function',
+              name: 'getWeather',
+              description: 'Get the weather in a location',
+              inputSchema: {
+                type: 'object',
+                properties: { location: { type: 'string' } },
+                required: ['location'],
+              },
+            },
+          ],
+          toolChoice: { type: 'required' },
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        expect(requestBody).not.toHaveProperty('tool_choice');
+        expect(requestBody.tools).toHaveLength(1);
+        expect(result.warnings).toStrictEqual([
+          {
+            type: 'unsupported',
+            feature: 'toolChoice',
+            details: `Required tool choice is not supported by ${modelFamily} models and has been omitted.`,
+          },
+        ]);
+      },
+    );
+
+    it.each(['kimi-k3', 'custom-model'] as const)(
+      'should preserve required tool choice for %s',
+      async modelId => {
+        const result = await provider.chatModel(modelId).doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'function',
+              name: 'getWeather',
+              description: 'Get the weather in a location',
+              inputSchema: {
+                type: 'object',
+                properties: { location: { type: 'string' } },
+                required: ['location'],
+              },
+            },
+          ],
+          toolChoice: { type: 'required' },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          model: modelId,
+          tool_choice: 'required',
+        });
+        expect(result.warnings).toStrictEqual([]);
+      },
+    );
+
     it('should extract text content, finish reason, and usage', async () => {
       const result = await provider.chatModel('kimi-k3').doGenerate({
         prompt: TEST_PROMPT,

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -589,16 +589,23 @@ describe('doGenerate', () => {
       prepareJsonFixtureResponse('moonshotai-text');
     });
 
-    it('should strip the $schema keyword from json schemas', async () => {
+    it('should normalize json schemas and enable strict mode by default', async () => {
       await provider.chatModel('kimi-k3').doGenerate({
         prompt: TEST_PROMPT,
         responseFormat: {
           type: 'json',
           name: 'recipe',
+          description: 'A recipe',
           schema: {
             $schema: 'http://json-schema.org/draft-07/schema#',
             type: 'object',
-            properties: { name: { type: 'string' } },
+            properties: {
+              name: { type: 'string' },
+              coordinates: {
+                type: 'array',
+                items: [{ type: 'number' }, { type: 'number' }],
+              },
+            },
           },
         },
       });
@@ -608,10 +615,40 @@ describe('doGenerate', () => {
         type: 'json_schema',
         json_schema: {
           name: 'recipe',
+          strict: true,
           schema: {
             type: 'object',
-            properties: { name: { type: 'string' } },
+            properties: {
+              name: { type: 'string' },
+              coordinates: {
+                type: 'array',
+                prefixItems: [{ type: 'number' }, { type: 'number' }],
+              },
+            },
           },
+        },
+      });
+    });
+
+    it('should allow strict json schema validation to be disabled', async () => {
+      await provider.chatModel('kimi-k3').doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: {
+          type: 'json',
+          schema: { type: 'object', properties: {} },
+        },
+        providerOptions: {
+          moonshotai: { strictJsonSchema: false },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.response_format).toStrictEqual({
+        type: 'json_schema',
+        json_schema: {
+          name: 'response',
+          strict: false,
+          schema: { type: 'object', properties: {} },
         },
       });
     });

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -39,7 +39,7 @@ import {
   type MoonshotAIChatTokenUsage,
 } from './moonshotai-chat-api-types';
 import {
-  getModelThinkingKeepSupport,
+  getMoonshotAIModelFamily,
   isMoonshotAIKimiModel,
   moonshotaiLanguageModelOptions,
   type MoonshotAIChatModelId,
@@ -173,51 +173,180 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
       toolWarnings,
     } = prepareTools({ tools, toolChoice });
 
-    // Thinking is configured through explicit provider options only.
-    const thinking = moonshotOptions.thinking;
+    const modelFamily = getMoonshotAIModelFamily(this.modelId);
+    const requestedThinking = moonshotOptions.thinking;
+    const requestedReasoningEffort = moonshotOptions.reasoningEffort;
+    const preserveReasoning = moonshotOptions.reasoningHistory === 'preserved';
 
-    // Moonshot has no reasoning_history field; the API silently ignores it
-    // (verified against the live API). Preserved Thinking maps to
-    // thinking.keep, which only accepts 'all' and only on some models
-    // (verified: k2.6, k2.7-code, k3 accept it; k2.5 rejects it). Other
-    // reasoningHistory values use the server default.
-    let keep: 'all' | undefined;
-    if (moonshotOptions.reasoningHistory === 'preserved') {
-      if (getModelThinkingKeepSupport(this.modelId)) {
-        keep = 'all';
-      } else {
-        allWarnings.push({
-          type: 'unsupported',
-          feature: `reasoningHistory 'preserved' is not supported by model "${this.modelId}"`,
-        });
-      }
-    }
-
-    // Map the generic reasoning call option to Moonshot's reasoning_effort
-    // (explicit provider options win). 'none' cannot disable Moonshot
-    // thinking from here; use thinking: { type: 'disabled' } instead.
-    if (reasoning === 'none') {
+    if (requestedThinking?.budgetTokens != null) {
       allWarnings.push({
-        type: 'unsupported',
-        feature:
-          'reasoning "none" (use providerOptions.moonshotai.thinking to control thinking)',
+        type: 'deprecated',
+        setting: 'providerOptions.moonshotai.thinking.budgetTokens',
+        message:
+          'Moonshot Chat Completions does not support budget_tokens. Remove budgetTokens; the option has been omitted.',
       });
     }
-    const reasoningEffort =
-      moonshotOptions.reasoningEffort ??
-      (isCustomReasoning(reasoning) && reasoning !== 'none'
-        ? mapReasoningToProviderEffort({
-            reasoning,
-            effortMap: {
-              minimal: 'low',
-              low: 'low',
-              medium: 'high',
-              high: 'high',
-              xhigh: 'max',
-            },
-            warnings: allWarnings,
-          })
-        : undefined);
+
+    let thinking: { type: 'enabled' | 'disabled'; keep?: 'all' } | undefined;
+    let reasoningEffort: 'low' | 'high' | 'max' | undefined;
+
+    const warnUnsupportedReasoningEffort = () => {
+      if (requestedReasoningEffort != null) {
+        allWarnings.push({
+          type: 'unsupported',
+          feature: 'reasoningEffort',
+          details: `reasoningEffort is only supported by Kimi K3 and has been omitted for model "${this.modelId}".`,
+        });
+      }
+    };
+
+    switch (modelFamily) {
+      case 'kimi-k3': {
+        if (requestedThinking != null) {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: 'thinking',
+            details:
+              'Kimi K3 always reasons and does not accept the thinking field. The option has been omitted.',
+          });
+        }
+        if (reasoning === 'none') {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: 'reasoning "none"',
+            details: 'Kimi K3 reasoning cannot be disabled.',
+          });
+        }
+        reasoningEffort =
+          requestedReasoningEffort ??
+          (isCustomReasoning(reasoning) && reasoning !== 'none'
+            ? mapReasoningToProviderEffort({
+                reasoning,
+                effortMap: {
+                  minimal: 'low',
+                  low: 'low',
+                  medium: 'high',
+                  high: 'high',
+                  xhigh: 'max',
+                },
+                warnings: allWarnings,
+              })
+            : undefined);
+        break;
+      }
+      case 'kimi-k2.7': {
+        warnUnsupportedReasoningEffort();
+        if (requestedThinking?.type === 'disabled' || reasoning === 'none') {
+          allWarnings.push({
+            type: 'unsupported',
+            feature:
+              requestedThinking?.type === 'disabled'
+                ? 'thinking.type "disabled"'
+                : 'reasoning "none"',
+            details: 'Kimi K2.7 thinking cannot be disabled.',
+          });
+        } else if (requestedThinking?.type === 'enabled') {
+          thinking = { type: 'enabled' };
+        }
+        break;
+      }
+      case 'kimi-k2.6': {
+        warnUnsupportedReasoningEffort();
+        const thinkingType =
+          requestedThinking?.type ??
+          (isCustomReasoning(reasoning)
+            ? reasoning === 'none'
+              ? 'disabled'
+              : 'enabled'
+            : undefined);
+        if (thinkingType != null || preserveReasoning) {
+          thinking = {
+            type: thinkingType ?? 'enabled',
+            ...(preserveReasoning ? { keep: 'all' as const } : {}),
+          };
+        }
+        break;
+      }
+      case 'kimi-k2.5': {
+        warnUnsupportedReasoningEffort();
+        const thinkingType =
+          requestedThinking?.type ??
+          (isCustomReasoning(reasoning)
+            ? reasoning === 'none'
+              ? 'disabled'
+              : 'enabled'
+            : undefined);
+        if (thinkingType != null) {
+          thinking = { type: thinkingType };
+        }
+        if (preserveReasoning) {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: `reasoningHistory 'preserved' is not supported by model "${this.modelId}"`,
+          });
+        }
+        break;
+      }
+      case 'moonshot-v1': {
+        warnUnsupportedReasoningEffort();
+        if (requestedThinking != null) {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: 'thinking',
+            details: `thinking is not supported by model "${this.modelId}" and has been omitted.`,
+          });
+        }
+        if (isCustomReasoning(reasoning) && reasoning !== 'none') {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: 'reasoning',
+            details: `reasoning is not supported by model "${this.modelId}".`,
+          });
+        }
+        if (preserveReasoning) {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: `reasoningHistory 'preserved' is not supported by model "${this.modelId}"`,
+          });
+        }
+        break;
+      }
+      case 'unknown': {
+        if (reasoning === 'none') {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: 'reasoning "none"',
+            details:
+              'Use providerOptions.moonshotai.thinking to control thinking on custom models.',
+          });
+        }
+        reasoningEffort =
+          requestedReasoningEffort ??
+          (isCustomReasoning(reasoning) && reasoning !== 'none'
+            ? mapReasoningToProviderEffort({
+                reasoning,
+                effortMap: {
+                  minimal: 'low',
+                  low: 'low',
+                  medium: 'high',
+                  high: 'high',
+                  xhigh: 'max',
+                },
+                warnings: allWarnings,
+              })
+            : undefined);
+        if (requestedThinking?.type != null) {
+          thinking = { type: requestedThinking.type };
+        }
+        if (preserveReasoning) {
+          allWarnings.push({
+            type: 'unsupported',
+            feature: `reasoningHistory 'preserved' is not supported by model "${this.modelId}"`,
+          });
+        }
+        break;
+      }
+    }
 
     let response_format: Record<string, unknown> | undefined;
     if (responseFormat?.type === 'json') {
@@ -262,17 +391,7 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
         messages,
         tools: moonshotTools,
         tool_choice: moonshotToolChoice,
-        ...(thinking != null || keep != null
-          ? {
-              thinking: {
-                ...(thinking?.type != null && { type: thinking.type }),
-                ...(thinking?.budgetTokens !== undefined && {
-                  budget_tokens: thinking.budgetTokens,
-                }),
-                ...(keep != null && { keep }),
-              },
-            }
-          : {}),
+        ...(thinking != null ? { thinking } : {}),
         ...(reasoningEffort != null && {
           reasoning_effort: reasoningEffort,
         }),

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -167,13 +167,14 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
       });
     }
 
+    const modelFamily = getMoonshotAIModelFamily(this.modelId);
+
     const {
       tools: moonshotTools,
       toolChoice: moonshotToolChoice,
       toolWarnings,
-    } = prepareTools({ tools, toolChoice });
+    } = prepareTools({ modelFamily, tools, toolChoice });
 
-    const modelFamily = getMoonshotAIModelFamily(this.modelId);
     const requestedThinking = moonshotOptions.thinking;
     const requestedReasoningEffort = moonshotOptions.reasoningEffort;
     const preserveReasoning = moonshotOptions.reasoningHistory === 'preserved';

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -45,6 +45,7 @@ import {
   type MoonshotAIChatModelId,
 } from './moonshotai-chat-options';
 import { prepareTools } from './moonshotai-prepare-tools';
+import { normalizeJsonSchemaForMFJS } from './normalize-json-schema-for-mfjs';
 
 export type MoonshotAIChatConfig = {
   provider: string;
@@ -366,10 +367,8 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
           type: 'json_schema',
           json_schema: {
             name: responseFormat.name ?? 'response',
-            schema: schemaWithoutDollarSchema,
-            ...(responseFormat.description != null && {
-              description: responseFormat.description,
-            }),
+            strict: moonshotOptions.strictJsonSchema ?? true,
+            schema: normalizeJsonSchemaForMFJS(schemaWithoutDollarSchema),
           },
         };
       } else {

--- a/packages/moonshotai/src/moonshotai-chat-options.test-d.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.test-d.ts
@@ -10,6 +10,7 @@ describe('MoonshotAILanguageModelOptions', () => {
         budgetTokens?: number;
       };
       reasoningHistory?: 'disabled' | 'interleaved' | 'preserved';
+      strictJsonSchema?: boolean;
       promptCacheKey?: string;
       safetyIdentifier?: string;
     }>();

--- a/packages/moonshotai/src/moonshotai-chat-options.test-d.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.test-d.ts
@@ -1,0 +1,17 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { MoonshotAILanguageModelOptions } from './index';
+
+describe('MoonshotAILanguageModelOptions', () => {
+  it('only exposes official thinking and reasoning effort fields', () => {
+    expectTypeOf<MoonshotAILanguageModelOptions>().toEqualTypeOf<{
+      reasoningEffort?: 'low' | 'high' | 'max';
+      thinking?: {
+        type?: 'enabled' | 'disabled';
+        budgetTokens?: number;
+      };
+      reasoningHistory?: 'disabled' | 'interleaved' | 'preserved';
+      promptCacheKey?: string;
+      safetyIdentifier?: string;
+    }>();
+  });
+});

--- a/packages/moonshotai/src/moonshotai-chat-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.ts
@@ -54,6 +54,12 @@ export const moonshotaiLanguageModelOptions = z.object({
   reasoningHistory: z.enum(['disabled', 'interleaved', 'preserved']).optional(),
 
   /**
+   * Whether to use strict JSON schema validation for structured outputs.
+   * Defaults to true.
+   */
+  strictJsonSchema: z.boolean().optional(),
+
+  /**
    * Used to cache responses for similar requests to optimize cache hit rates.
    * Typically a session or task id.
    */
@@ -82,6 +88,11 @@ export type MoonshotAILanguageModelOptions = {
   };
 
   reasoningHistory?: 'disabled' | 'interleaved' | 'preserved';
+  /**
+   * Whether to use strict JSON schema validation for structured outputs.
+   * Defaults to true.
+   */
+  strictJsonSchema?: boolean;
   promptCacheKey?: string;
   safetyIdentifier?: string;
 };

--- a/packages/moonshotai/src/moonshotai-chat-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.ts
@@ -12,13 +12,28 @@ export type MoonshotAIChatModelId =
   | (string & {});
 
 export function isMoonshotAIKimiModel(modelId: MoonshotAIChatModelId): boolean {
-  return (
-    modelId === 'kimi-k2.5' ||
-    modelId === 'kimi-k2.6' ||
-    modelId === 'kimi-k2.7-code' ||
-    modelId === 'kimi-k2.7-code-highspeed' ||
-    modelId === 'kimi-k3'
-  );
+  return getMoonshotAIModelFamily(modelId).startsWith('kimi-');
+}
+
+export type MoonshotAIModelFamily =
+  | 'kimi-k2.5'
+  | 'kimi-k2.6'
+  | 'kimi-k2.7'
+  | 'kimi-k3'
+  | 'moonshot-v1'
+  | 'unknown';
+
+export function getMoonshotAIModelFamily(
+  modelId: MoonshotAIChatModelId,
+): MoonshotAIModelFamily {
+  if (modelId === 'kimi-k2.5') return 'kimi-k2.5';
+  if (modelId === 'kimi-k2.6') return 'kimi-k2.6';
+  if (modelId === 'kimi-k2.7-code' || modelId === 'kimi-k2.7-code-highspeed') {
+    return 'kimi-k2.7';
+  }
+  if (modelId === 'kimi-k3') return 'kimi-k3';
+  if (modelId.startsWith('moonshot-v1-')) return 'moonshot-v1';
+  return 'unknown';
 }
 
 export const moonshotaiLanguageModelOptions = z.object({
@@ -30,6 +45,8 @@ export const moonshotaiLanguageModelOptions = z.object({
   thinking: z
     .object({
       type: z.enum(['enabled', 'disabled']).optional(),
+      // Accepted at runtime so existing callers receive a migration warning.
+      // This field is intentionally excluded from the public type below.
       budgetTokens: z.number().int().min(1024).optional(),
     })
     .optional(),
@@ -49,21 +66,22 @@ export const moonshotaiLanguageModelOptions = z.object({
   safetyIdentifier: z.string().optional(),
 });
 
-export type MoonshotAILanguageModelOptions = z.infer<
-  typeof moonshotaiLanguageModelOptions
->;
+export type MoonshotAILanguageModelOptions = {
+  /** Reasoning effort for Kimi K3. */
+  reasoningEffort?: 'low' | 'high' | 'max';
 
-/**
- * Whether the model accepts `thinking.keep` (Preserved Thinking). Verified
- * against the live API: kimi-k2.6, kimi-k2.7-code(+highspeed), and kimi-k3
- * accept `keep: 'all'`; other models reject it with a 400.
- */
-export function getModelThinkingKeepSupport(
-  modelId: MoonshotAIChatModelId,
-): boolean {
-  return (
-    modelId === 'kimi-k2.6' ||
-    modelId === 'kimi-k3' ||
-    modelId.startsWith('kimi-k2.7-code')
-  );
-}
+  /** Controls thinking on Kimi K2.5 and K2.6. K2.7 is always enabled. */
+  thinking?: {
+    type?: 'enabled' | 'disabled';
+
+    /**
+     * @deprecated Moonshot Chat Completions does not support thinking budgets.
+     * This value is ignored with a warning.
+     */
+    budgetTokens?: number;
+  };
+
+  reasoningHistory?: 'disabled' | 'interleaved' | 'preserved';
+  promptCacheKey?: string;
+  safetyIdentifier?: string;
+};

--- a/packages/moonshotai/src/moonshotai-prepare-tools.test.ts
+++ b/packages/moonshotai/src/moonshotai-prepare-tools.test.ts
@@ -1,0 +1,67 @@
+import type { LanguageModelV4CallOptions } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { prepareTools } from './moonshotai-prepare-tools';
+
+const tools: NonNullable<LanguageModelV4CallOptions['tools']> = [
+  {
+    type: 'function',
+    name: 'getWeather',
+    description: 'Get the weather in a location',
+    inputSchema: {
+      type: 'object',
+      properties: { location: { type: 'string' } },
+      required: ['location'],
+    },
+  },
+];
+
+describe('prepareTools', () => {
+  it.each(['kimi-k2.6', 'kimi-k2.7'] as const)(
+    'omits required tool choice for %s',
+    modelFamily => {
+      const result = prepareTools({
+        modelFamily,
+        tools,
+        toolChoice: { type: 'required' },
+      });
+
+      expect(result.toolChoice).toBeUndefined();
+      expect(result.tools).toHaveLength(1);
+      expect(result.toolWarnings).toStrictEqual([
+        {
+          type: 'unsupported',
+          feature: 'toolChoice',
+          details: `Required tool choice is not supported by ${modelFamily} models and has been omitted.`,
+        },
+      ]);
+    },
+  );
+
+  it.each(['kimi-k3', 'unknown'] as const)(
+    'preserves required tool choice for %s',
+    modelFamily => {
+      const result = prepareTools({
+        modelFamily,
+        tools,
+        toolChoice: { type: 'required' },
+      });
+
+      expect(result.toolChoice).toBe('required');
+      expect(result.toolWarnings).toStrictEqual([]);
+    },
+  );
+
+  it.each(['auto', 'none'] as const)(
+    'preserves %s tool choice for Kimi K2.6',
+    type => {
+      const result = prepareTools({
+        modelFamily: 'kimi-k2.6',
+        tools,
+        toolChoice: { type },
+      });
+
+      expect(result.toolChoice).toBe(type);
+      expect(result.toolWarnings).toStrictEqual([]);
+    },
+  );
+});

--- a/packages/moonshotai/src/moonshotai-prepare-tools.ts
+++ b/packages/moonshotai/src/moonshotai-prepare-tools.ts
@@ -3,12 +3,15 @@ import {
   type LanguageModelV4CallOptions,
   type SharedV4Warning,
 } from '@ai-sdk/provider';
+import type { MoonshotAIModelFamily } from './moonshotai-chat-options';
 import { normalizeJsonSchemaForMFJS } from './normalize-json-schema-for-mfjs';
 
 export function prepareTools({
+  modelFamily,
   tools,
   toolChoice,
 }: {
+  modelFamily: MoonshotAIModelFamily;
   tools: LanguageModelV4CallOptions['tools'];
   toolChoice?: LanguageModelV4CallOptions['toolChoice'];
 }): {
@@ -78,7 +81,20 @@ export function prepareTools({
   switch (type) {
     case 'auto':
     case 'none':
+      return { tools: moonshotTools, toolChoice: type, toolWarnings };
     case 'required':
+      if (modelFamily === 'kimi-k2.6' || modelFamily === 'kimi-k2.7') {
+        toolWarnings.push({
+          type: 'unsupported',
+          feature: 'toolChoice',
+          details: `Required tool choice is not supported by ${modelFamily} models and has been omitted.`,
+        });
+        return {
+          tools: moonshotTools,
+          toolChoice: undefined,
+          toolWarnings,
+        };
+      }
       return { tools: moonshotTools, toolChoice: type, toolWarnings };
     case 'tool':
       return {


### PR DESCRIPTION
Fixes #19548

## Summary

- validate inline image and video media types against the official Moonshot vision allowlists
- reject unsupported inputs such as SVG and Ogg video before sending a request
- retain wildcard URL handling, base64 data URIs, and ms:// file references
- document supported formats and add a patch changeset

## Tests

- pnpm test:node (packages/moonshotai): 125 passed
- pnpm test:edge (packages/moonshotai): 125 passed
- pnpm type-check (packages/moonshotai)
- pnpm type-check:full
- pnpm check

## Stack dependency

Temporarily based on #19596 so each Moonshot parity change stays isolated while the earlier priority PRs await required review. Retarget this PR after #19596 merges.