### PR TITLE
fix(provider/moonshotai): accept stream chunk variants

### DIFF
--- a/.changeset/fuzzy-kimis-stream.md
+++ b/.changeset/fuzzy-kimis-stream.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+fix(provider/moonshotai): accept documented streaming tool-call and usage variants

--- a/packages/moonshotai/src/__fixtures__/moonshotai-stream-malformed-tool-call.chunks.txt
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-stream-malformed-tool-call.chunks.txt
@@ -1,0 +1,1 @@
+{"id":"chatcmpl-malformed","created":1785880003,"model":"kimi-k3","choices":[{"index":0,"delta":{"tool_calls":[{"index":"zero","id":"call-weather","function":{"name":"get_weather","arguments":"{}"}}]},"finish_reason":null}]}

--- a/packages/moonshotai/src/__fixtures__/moonshotai-stream-tool-calls.chunks.txt
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-stream-tool-calls.chunks.txt
@@ -1,0 +1,3 @@
+{"id":"chatcmpl-tools","created":1785880003,"model":"kimi-k3","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"id":"call-weather","function":{"name":"get_weather","arguments":"{\"city\":\""}},{"id":"call-time","function":{"name":"get_time","arguments":"{\"zone\":\""}}]},"finish_reason":null}]}
+{"id":"chatcmpl-tools","created":1785880003,"model":"kimi-k3","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"UTC\"}"}},{"index":0,"function":{"arguments":"Paris\"}"}}]},"finish_reason":null}]}
+{"id":"chatcmpl-tools","created":1785880003,"model":"kimi-k3","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls","usage":{"prompt_tokens":11,"completion_tokens":6,"total_tokens":17}}]}

--- a/packages/moonshotai/src/__fixtures__/moonshotai-stream.chunks.txt
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-stream.chunks.txt
@@ -1,4 +1,4 @@
 {"id":"chatcmpl-stream","created":1785880003,"model":"kimi-k3","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"Thinking "},"finish_reason":null}]}
 {"id":"chatcmpl-stream","created":1785880003,"model":"kimi-k3","choices":[{"index":0,"delta":{"reasoning_content":"aloud. "},"finish_reason":null}]}
 {"id":"chatcmpl-stream","created":1785880003,"model":"kimi-k3","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}
-{"id":"chatcmpl-stream","created":1785880003,"model":"kimi-k3","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":9,"completion_tokens":12,"total_tokens":21,"completion_tokens_details":{"reasoning_tokens":7}}}
+{"id":"chatcmpl-stream","created":1785880003,"model":"kimi-k3","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":"stop","usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}],"usage":{"prompt_tokens":9,"completion_tokens":12,"total_tokens":21,"completion_tokens_details":{"reasoning_tokens":7}}}

--- a/packages/moonshotai/src/moonshotai-chat-api-types.ts
+++ b/packages/moonshotai/src/moonshotai-chat-api-types.ts
@@ -139,7 +139,7 @@ export const moonshotAIChatChunkSchema = lazySchema(() =>
                 tool_calls: z
                   .array(
                     z.object({
-                      index: z.number(),
+                      index: z.number().nullish(),
                       id: z.string().nullish(),
                       function: z.object({
                         name: z.string().nullish(),
@@ -151,6 +151,7 @@ export const moonshotAIChatChunkSchema = lazySchema(() =>
               })
               .nullish(),
             finish_reason: z.string().nullish(),
+            usage: tokenUsageSchema,
           }),
         ),
         usage: tokenUsageSchema,

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -865,4 +865,51 @@ describe('doStream', () => {
       include_usage: true,
     });
   });
+
+  it('should assemble index-less tool calls and use choice-level usage', async () => {
+    prepareChunksFixtureResponse('moonshotai-stream-tool-calls');
+
+    const result = await provider.chatModel('kimi-k3').doStream({
+      prompt: TEST_PROMPT,
+    });
+
+    const parts = await convertReadableStreamToArray(result.stream);
+
+    expect(parts).toContainEqual({
+      type: 'tool-call',
+      toolCallId: 'call-weather',
+      toolName: 'get_weather',
+      input: '{"city":"Paris"}',
+    });
+    expect(parts).toContainEqual({
+      type: 'tool-call',
+      toolCallId: 'call-time',
+      toolName: 'get_time',
+      input: '{"zone":"UTC"}',
+    });
+    expect(parts.at(-1)).toMatchObject({
+      type: 'finish',
+      finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+      usage: {
+        inputTokens: { total: 11 },
+        outputTokens: { total: 6 },
+      },
+    });
+  });
+
+  it('should surface malformed tool-call chunks as validation errors', async () => {
+    prepareChunksFixtureResponse('moonshotai-stream-malformed-tool-call');
+
+    const result = await provider.chatModel('kimi-k3').doStream({
+      prompt: TEST_PROMPT,
+    });
+
+    const parts = await convertReadableStreamToArray(result.stream);
+
+    expect(parts.filter(part => part.type === 'error')).toHaveLength(1);
+    expect(parts.at(-1)).toMatchObject({
+      type: 'finish',
+      finishReason: { unified: 'error' },
+    });
+  });
 });

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -509,6 +509,7 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
       raw: undefined,
     };
     let usage: MoonshotAIChatTokenUsage | undefined = undefined;
+    let hasTopLevelUsage = false;
     let isFirstChunk = true;
     let isActiveReasoning = false;
     let isActiveText = false;
@@ -556,11 +557,14 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
               });
             }
 
+            const choice = value.choices[0];
+
             if (value.usage != null) {
               usage = value.usage;
+              hasTopLevelUsage = true;
+            } else if (!hasTopLevelUsage && choice?.usage != null) {
+              usage = choice.usage;
             }
-
-            const choice = value.choices[0];
 
             if (choice?.finish_reason != null) {
               finishReason = {
@@ -625,8 +629,11 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
                 isActiveReasoning = false;
               }
 
-              for (const toolCallDelta of delta.tool_calls) {
-                toolCallTracker.processDelta(toolCallDelta);
+              for (const [index, toolCallDelta] of delta.tool_calls.entries()) {
+                toolCallTracker.processDelta({
+                  ...toolCallDelta,
+                  index: toolCallDelta.index ?? index,
+                });
               }
             }
           },


### PR DESCRIPTION
Fixes #19546

## Summary

- accept streaming tool-call deltas whose documented index is absent or null
- derive stable positional fallback indices while preserving explicit wire indices
- collect usage from either the chunk or its first choice, with top-level usage taking precedence
- add captured-style SSE fixtures for index-less parallel tools, usage variants, and malformed chunks
- add a patch changeset

## Tests

- pnpm test:node (packages/moonshotai): 127 passed
- pnpm test:edge (packages/moonshotai): 127 passed
- pnpm type-check (packages/moonshotai)
- pnpm type-check:full
- pnpm check

## Stack dependency

Temporarily based on #19597 so each Moonshot parity change stays isolated while the earlier priority PRs await required review. Retarget this PR after #19597 merges.