### PR TITLE
feat(provider/moonshotai): support native file parts

### DIFF
--- a/.changeset/smart-kimis-files.md
+++ b/.changeset/smart-kimis-files.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+feat(provider/moonshotai): support native provider references and text file parts

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -199,6 +199,20 @@ You can also pass a URL. Since Moonshot AI does not fetch external URLs, the AI 
 }
 ```
 
+For files already uploaded through the Moonshot Files API, pass the file ID as
+a provider reference. The provider converts it to Moonshot's native `ms://`
+URL:
+
+```ts
+{
+  type: 'file',
+  data: { moonshotai: 'file-abc123' },
+  mediaType: 'video/mp4',
+}
+```
+
+File parts containing inline text are sent as ordinary text content parts.
+
 <Note>
   Moonshot AI recommends videos up to 1080p. For larger videos, or videos you
   reuse across many requests, upload them with the [Moonshot Files

--- a/examples/ai-functions/src/generate-text/moonshot/video-input.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/video-input.ts
@@ -7,6 +7,8 @@ import { run } from '../../lib/run';
 // file parts. Inline bytes are sent as a base64 data URI; URL parts are
 // downloaded and inlined by the AI SDK (Moonshot AI does not fetch URLs).
 run(async () => {
+  const uploadedFileId = process.env.MOONSHOT_FILE_ID;
+
   const result = await generateText({
     model: moonshotai('kimi-k3'),
     messages: [
@@ -16,7 +18,10 @@ run(async () => {
           { type: 'text', text: 'Summarize what happens in this video.' },
           {
             type: 'file',
-            data: fs.readFileSync('data/prudence.mp4'),
+            data:
+              uploadedFileId == null
+                ? fs.readFileSync('data/prudence.mp4')
+                : { moonshotai: uploadedFileId },
             mediaType: 'video/mp4',
           },
         ],

--- a/packages/moonshotai/src/convert-to-moonshotai-chat-messages.test.ts
+++ b/packages/moonshotai/src/convert-to-moonshotai-chat-messages.test.ts
@@ -358,7 +358,69 @@ describe('user messages', () => {
     );
   });
 
-  it('should throw for file parts with provider references', () => {
+  it.each([
+    {
+      mediaType: 'image/png',
+      reference: 'file-image-123',
+      expected: {
+        type: 'image_url',
+        image_url: { url: 'ms://file-image-123' },
+      },
+    },
+    {
+      mediaType: 'video/*',
+      reference: 'ms://file-video-123',
+      expected: {
+        type: 'video_url',
+        video_url: { url: 'ms://file-video-123' },
+      },
+    },
+  ])(
+    'should convert $mediaType provider references to native URLs',
+    ({ mediaType, reference, expected }) => {
+      expect(
+        convertToMoonshotAIChatMessages([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                data: {
+                  type: 'reference' as const,
+                  reference: { moonshotai: reference },
+                },
+                mediaType,
+              },
+            ],
+          },
+        ]),
+      ).toEqual([{ role: 'user', content: [expected] }]);
+    },
+  );
+
+  it('should throw for foreign provider references', () => {
+    expect(() =>
+      convertToMoonshotAIChatMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: {
+                type: 'reference' as const,
+                reference: { openai: 'file-123' },
+              },
+              mediaType: 'image/png',
+            },
+          ],
+        },
+      ]),
+    ).toThrow(
+      "No provider reference found for provider 'moonshotai'. Available providers: openai",
+    );
+  });
+
+  it('should throw for provider references with unsupported media types', () => {
     expect(() =>
       convertToMoonshotAIChatMessages([
         {
@@ -370,18 +432,18 @@ describe('user messages', () => {
                 type: 'reference' as const,
                 reference: { moonshotai: 'file-123' },
               },
-              mediaType: 'image/png',
+              mediaType: 'application/pdf',
             },
           ],
         },
       ]),
     ).toThrow(
-      "'file parts with provider references' functionality not supported",
+      "'file part media type application/pdf' functionality not supported",
     );
   });
 
-  it('should throw for text file parts', () => {
-    expect(() =>
+  it('should convert text file parts to text content', () => {
+    expect(
       convertToMoonshotAIChatMessages([
         {
           role: 'user',
@@ -394,7 +456,12 @@ describe('user messages', () => {
           ],
         },
       ]),
-    ).toThrow("'text file parts' functionality not supported");
+    ).toEqual([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello' }],
+      },
+    ]);
   });
 });
 

--- a/packages/moonshotai/src/convert-to-moonshotai-chat-messages.ts
+++ b/packages/moonshotai/src/convert-to-moonshotai-chat-messages.ts
@@ -7,6 +7,7 @@ import {
   convertToBase64,
   getTopLevelMediaType,
   resolveFullMediaType,
+  resolveProviderReference,
 } from '@ai-sdk/provider-utils';
 
 import type { MoonshotAIMessages } from './moonshotai-chat-api-types';
@@ -32,6 +33,28 @@ const supportedVideoMediaTypes = new Set([
   'video/wmv',
   'video/3gpp',
 ]);
+
+function validateReferenceMediaType({
+  mediaType,
+  topLevel,
+  supportedMediaTypes,
+}: {
+  mediaType: string;
+  topLevel: 'image' | 'video';
+  supportedMediaTypes: Set<string>;
+}) {
+  if (
+    mediaType === topLevel ||
+    mediaType === `${topLevel}/*` ||
+    supportedMediaTypes.has(mediaType)
+  ) {
+    return;
+  }
+
+  throw new UnsupportedFunctionalityError({
+    functionality: `file part media type ${mediaType}`,
+  });
+}
 
 // Moonshot AI chat completions accepts text, image_url, and video_url content
 // parts only. Anything else (audio, PDF, other file types) throws here rather
@@ -66,14 +89,45 @@ export function convertToMoonshotAIChatMessages(
               case 'file': {
                 switch (part.data.type) {
                   case 'reference': {
+                    const reference = resolveProviderReference({
+                      reference: part.data.reference,
+                      provider: 'moonshotai',
+                    });
+                    const url = reference.startsWith('ms://')
+                      ? reference
+                      : `ms://${reference}`;
+                    const topLevel = getTopLevelMediaType(part.mediaType);
+
+                    if (topLevel === 'image') {
+                      validateReferenceMediaType({
+                        mediaType: part.mediaType,
+                        topLevel,
+                        supportedMediaTypes: supportedImageMediaTypes,
+                      });
+                      return {
+                        type: 'image_url' as const,
+                        image_url: { url },
+                      };
+                    }
+
+                    if (topLevel === 'video') {
+                      validateReferenceMediaType({
+                        mediaType: part.mediaType,
+                        topLevel,
+                        supportedMediaTypes: supportedVideoMediaTypes,
+                      });
+                      return {
+                        type: 'video_url' as const,
+                        video_url: { url },
+                      };
+                    }
+
                     throw new UnsupportedFunctionalityError({
-                      functionality: 'file parts with provider references',
+                      functionality: `file part media type ${part.mediaType}`,
                     });
                   }
                   case 'text': {
-                    throw new UnsupportedFunctionalityError({
-                      functionality: 'text file parts',
-                    });
+                    return { type: 'text' as const, text: part.data.text };
                   }
                   case 'url':
                   case 'data': {

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -280,6 +280,40 @@ describe('doGenerate', () => {
         },
       ]);
     });
+
+    it('should send provider references and text file parts', async () => {
+      await provider.chatModel('kimi-k3').doGenerate({
+        prompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                data: {
+                  type: 'reference' as const,
+                  reference: { moonshotai: 'file-video-123' },
+                },
+                mediaType: 'video/mp4',
+              },
+              {
+                type: 'file',
+                data: { type: 'text' as const, text: 'Transcript text' },
+                mediaType: 'text/plain',
+              },
+            ],
+          },
+        ],
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.messages[0].content).toEqual([
+        {
+          type: 'video_url',
+          video_url: { url: 'ms://file-video-123' },
+        },
+        { type: 'text', text: 'Transcript text' },
+      ]);
+    });
   });
 
   describe('thinking options', () => {


### PR DESCRIPTION
Fixes #19549

## Summary

- map Moonshot provider references to native ms:// image and video content parts
- preserve already-prefixed ms:// references and reject foreign provider references through the shared resolver
- convert inline text file data to ordinary text content
- validate referenced media types and keep existing data/URL behavior unchanged
- add converter/request tests, docs, an example update, and a patch changeset

## Tests

- pnpm test:node (packages/moonshotai): 143 passed
- pnpm test:edge (packages/moonshotai): 143 passed
- pnpm type-check (packages/moonshotai)
- pnpm type-check:full
- pnpm check

## Stack dependency

Temporarily based on #19600 so each Moonshot parity change stays isolated while the earlier priority PRs await required review. Retarget this PR after #19600 merges.