### PR TITLE
feat(provider/moonshotai): support message names

### DIFF
--- a/.changeset/named-kimis-chat.md
+++ b/.changeset/named-kimis-chat.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+feat(provider/moonshotai): support participant names on chat messages

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -263,6 +263,25 @@ The following optional provider options are available for Moonshot AI language m
   Whether to use strict JSON schema validation for structured outputs. Defaults
   to `true`.
 
+### Message Provider Options
+
+System, user, and assistant messages accept a `name` provider option for the
+participant represented by the message:
+
+```ts
+import type { MoonshotAIMessageProviderOptions } from '@ai-sdk/moonshotai';
+
+const message = {
+  role: 'user' as const,
+  content: [{ type: 'text' as const, text: 'Hello' }],
+  providerOptions: {
+    moonshotai: {
+      name: 'alice',
+    } satisfies MoonshotAIMessageProviderOptions,
+  },
+};
+```
+
 ## Model Capabilities
 
 | Model                    | Image Input | Video Input | Object Generation | Tool Usage | Tool Streaming |

--- a/examples/ai-functions/src/generate-text/moonshot/basic.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/basic.ts
@@ -1,11 +1,24 @@
-import { moonshotai } from '@ai-sdk/moonshotai';
+import {
+  moonshotai,
+  type MoonshotAIMessageProviderOptions,
+} from '@ai-sdk/moonshotai';
 import { generateText } from 'ai';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
     model: moonshotai('kimi-k3'),
-    prompt: 'Invent a new holiday and describe its traditions.',
+    messages: [
+      {
+        role: 'user',
+        content: 'Invent a new holiday and describe its traditions.',
+        providerOptions: {
+          moonshotai: {
+            name: 'holiday_planner',
+          } satisfies MoonshotAIMessageProviderOptions,
+        },
+      },
+    ],
   });
 
   console.log(result.text);

--- a/packages/moonshotai/src/convert-to-moonshotai-chat-messages.test.ts
+++ b/packages/moonshotai/src/convert-to-moonshotai-chat-messages.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from 'vitest';
 import { convertToMoonshotAIChatMessages } from './convert-to-moonshotai-chat-messages';
 
 describe('user messages', () => {
-  it('should convert a text-only user message to string content', () => {
-    const result = convertToMoonshotAIChatMessages([
+  it('should convert a text-only user message to string content', async () => {
+    const result = await convertToMoonshotAIChatMessages([
       { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
     ]);
 
     expect(result).toEqual([{ role: 'user', content: 'Hello' }]);
   });
 
-  it('should convert image data parts to image_url data URIs', () => {
-    const result = convertToMoonshotAIChatMessages([
+  it('should convert image data parts to image_url data URIs', async () => {
+    const result = await convertToMoonshotAIChatMessages([
       {
         role: 'user',
         content: [
@@ -47,8 +47,8 @@ describe('user messages', () => {
     'image/bmp',
     'image/heic',
     'image/heif',
-  ])('should accept the supported image media type %s', mediaType => {
-    const result = convertToMoonshotAIChatMessages([
+  ])('should accept the supported image media type %s', async mediaType => {
+    const result = await convertToMoonshotAIChatMessages([
       {
         role: 'user',
         content: [
@@ -74,8 +74,8 @@ describe('user messages', () => {
     ]);
   });
 
-  it('should pass through image URLs', () => {
-    const result = convertToMoonshotAIChatMessages([
+  it('should pass through image URLs', async () => {
+    const result = await convertToMoonshotAIChatMessages([
       {
         role: 'user',
         content: [
@@ -104,8 +104,8 @@ describe('user messages', () => {
     ]);
   });
 
-  it('should convert video data parts to video_url data URIs', () => {
-    const result = convertToMoonshotAIChatMessages([
+  it('should convert video data parts to video_url data URIs', async () => {
+    const result = await convertToMoonshotAIChatMessages([
       {
         role: 'user',
         content: [
@@ -143,8 +143,8 @@ describe('user messages', () => {
     'video/webm',
     'video/wmv',
     'video/3gpp',
-  ])('should accept the supported video media type %s', mediaType => {
-    const result = convertToMoonshotAIChatMessages([
+  ])('should accept the supported video media type %s', async mediaType => {
+    const result = await convertToMoonshotAIChatMessages([
       {
         role: 'user',
         content: [
@@ -170,8 +170,8 @@ describe('user messages', () => {
     ]);
   });
 
-  it('should pass through video URLs', () => {
-    const result = convertToMoonshotAIChatMessages([
+  it('should pass through video URLs', async () => {
+    const result = await convertToMoonshotAIChatMessages([
       {
         role: 'user',
         content: [
@@ -200,8 +200,8 @@ describe('user messages', () => {
     ]);
   });
 
-  it('should pass through ms:// file references from the Files API', () => {
-    const result = convertToMoonshotAIChatMessages([
+  it('should pass through ms:// file references from the Files API', async () => {
+    const result = await convertToMoonshotAIChatMessages([
       {
         role: 'user',
         content: [
@@ -230,8 +230,8 @@ describe('user messages', () => {
     ]);
   });
 
-  it('should decode text/* file parts into text parts', () => {
-    const result = convertToMoonshotAIChatMessages([
+  it('should decode text/* file parts into text parts', async () => {
+    const result = await convertToMoonshotAIChatMessages([
       {
         role: 'user',
         content: [
@@ -252,8 +252,8 @@ describe('user messages', () => {
     ]);
   });
 
-  it('should throw for audio file parts (rejected by the API)', () => {
-    expect(() =>
+  it('should throw for audio file parts (rejected by the API)', async () => {
+    await expect(
       convertToMoonshotAIChatMessages([
         {
           role: 'user',
@@ -269,11 +269,13 @@ describe('user messages', () => {
           ],
         },
       ]),
-    ).toThrow("'file part media type audio/mp3' functionality not supported");
+    ).rejects.toThrow(
+      "'file part media type audio/mp3' functionality not supported",
+    );
   });
 
-  it('should throw for unsupported image media types', () => {
-    expect(() =>
+  it('should throw for unsupported image media types', async () => {
+    await expect(
       convertToMoonshotAIChatMessages([
         {
           role: 'user',
@@ -289,13 +291,13 @@ describe('user messages', () => {
           ],
         },
       ]),
-    ).toThrow(
+    ).rejects.toThrow(
       "'file part media type image/svg+xml' functionality not supported",
     );
   });
 
-  it('should throw for unsupported video media types', () => {
-    expect(() =>
+  it('should throw for unsupported video media types', async () => {
+    await expect(
       convertToMoonshotAIChatMessages([
         {
           role: 'user',
@@ -311,11 +313,13 @@ describe('user messages', () => {
           ],
         },
       ]),
-    ).toThrow("'file part media type video/ogg' functionality not supported");
+    ).rejects.toThrow(
+      "'file part media type video/ogg' functionality not supported",
+    );
   });
 
-  it('should throw for PDF file parts (rejected by the API)', () => {
-    expect(() =>
+  it('should throw for PDF file parts (rejected by the API)', async () => {
+    await expect(
       convertToMoonshotAIChatMessages([
         {
           role: 'user',
@@ -331,13 +335,13 @@ describe('user messages', () => {
           ],
         },
       ]),
-    ).toThrow(
+    ).rejects.toThrow(
       "'file part media type application/pdf' functionality not supported",
     );
   });
 
-  it('should throw for unsupported file types', () => {
-    expect(() =>
+  it('should throw for unsupported file types', async () => {
+    await expect(
       convertToMoonshotAIChatMessages([
         {
           role: 'user',
@@ -353,7 +357,7 @@ describe('user messages', () => {
           ],
         },
       ]),
-    ).toThrow(
+    ).rejects.toThrow(
       "'file part media type application/zip' functionality not supported",
     );
   });
@@ -377,9 +381,9 @@ describe('user messages', () => {
     },
   ])(
     'should convert $mediaType provider references to native URLs',
-    ({ mediaType, reference, expected }) => {
+    async ({ mediaType, reference, expected }) => {
       expect(
-        convertToMoonshotAIChatMessages([
+        await convertToMoonshotAIChatMessages([
           {
             role: 'user',
             content: [
@@ -398,8 +402,8 @@ describe('user messages', () => {
     },
   );
 
-  it('should throw for foreign provider references', () => {
-    expect(() =>
+  it('should throw for foreign provider references', async () => {
+    await expect(
       convertToMoonshotAIChatMessages([
         {
           role: 'user',
@@ -415,13 +419,13 @@ describe('user messages', () => {
           ],
         },
       ]),
-    ).toThrow(
+    ).rejects.toThrow(
       "No provider reference found for provider 'moonshotai'. Available providers: openai",
     );
   });
 
-  it('should throw for provider references with unsupported media types', () => {
-    expect(() =>
+  it('should throw for provider references with unsupported media types', async () => {
+    await expect(
       convertToMoonshotAIChatMessages([
         {
           role: 'user',
@@ -437,14 +441,14 @@ describe('user messages', () => {
           ],
         },
       ]),
-    ).toThrow(
+    ).rejects.toThrow(
       "'file part media type application/pdf' functionality not supported",
     );
   });
 
-  it('should convert text file parts to text content', () => {
+  it('should convert text file parts to text content', async () => {
     expect(
-      convertToMoonshotAIChatMessages([
+      await convertToMoonshotAIChatMessages([
         {
           role: 'user',
           content: [
@@ -466,8 +470,8 @@ describe('user messages', () => {
 });
 
 describe('system messages', () => {
-  it('should pass system messages through', () => {
-    const result = convertToMoonshotAIChatMessages([
+  it('should pass system messages through', async () => {
+    const result = await convertToMoonshotAIChatMessages([
       { role: 'system', content: 'You are Kimi.' },
     ]);
 
@@ -475,9 +479,68 @@ describe('system messages', () => {
   });
 });
 
+describe('message names', () => {
+  it('should serialize names for system, user, and assistant messages', async () => {
+    const result = await convertToMoonshotAIChatMessages([
+      {
+        role: 'system',
+        content: 'You are Kimi.',
+        providerOptions: { moonshotai: { name: 'guide' } },
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+        providerOptions: { moonshotai: { name: 'alice' } },
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hi' }],
+        providerOptions: { moonshotai: { name: 'helper' } },
+      },
+    ]);
+
+    expect(result).toEqual([
+      { role: 'system', content: 'You are Kimi.', name: 'guide' },
+      { role: 'user', content: 'Hello', name: 'alice' },
+      {
+        role: 'assistant',
+        content: 'Hi',
+        name: 'helper',
+        tool_calls: undefined,
+      },
+    ]);
+  });
+
+  it('should reject invalid names through provider option parsing', async () => {
+    await expect(
+      convertToMoonshotAIChatMessages([
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+          providerOptions: { moonshotai: { name: 123 } },
+        },
+      ]),
+    ).rejects.toThrow('invalid moonshotai provider options');
+  });
+
+  it('should reject names on tool messages', async () => {
+    await expect(
+      convertToMoonshotAIChatMessages([
+        {
+          role: 'tool',
+          content: [],
+          providerOptions: { moonshotai: { name: 'tool' } },
+        },
+      ]),
+    ).rejects.toThrow(
+      "'message names on tool messages' functionality not supported",
+    );
+  });
+});
+
 describe('assistant messages', () => {
-  it('should emit reasoning_content for reasoning parts', () => {
-    const result = convertToMoonshotAIChatMessages([
+  it('should emit reasoning_content for reasoning parts', async () => {
+    const result = await convertToMoonshotAIChatMessages([
       {
         role: 'assistant',
         content: [
@@ -497,8 +560,8 @@ describe('assistant messages', () => {
     ]);
   });
 
-  it('should convert tool calls and set content to null when there is no text', () => {
-    const result = convertToMoonshotAIChatMessages([
+  it('should convert tool calls and set content to null when there is no text', async () => {
+    const result = await convertToMoonshotAIChatMessages([
       {
         role: 'assistant',
         content: [
@@ -527,8 +590,8 @@ describe('assistant messages', () => {
     ]);
   });
 
-  it('should keep text content when text and tool calls are present', () => {
-    const result = convertToMoonshotAIChatMessages([
+  it('should keep text content when text and tool calls are present', async () => {
+    const result = await convertToMoonshotAIChatMessages([
       {
         role: 'assistant',
         content: [
@@ -560,8 +623,8 @@ describe('assistant messages', () => {
 });
 
 describe('tool messages', () => {
-  it('should convert text tool results to tool messages', () => {
-    const result = convertToMoonshotAIChatMessages([
+  it('should convert text tool results to tool messages', async () => {
+    const result = await convertToMoonshotAIChatMessages([
       {
         role: 'tool',
         content: [
@@ -580,8 +643,8 @@ describe('tool messages', () => {
     ]);
   });
 
-  it('should stringify json tool results', () => {
-    const result = convertToMoonshotAIChatMessages([
+  it('should stringify json tool results', async () => {
+    const result = await convertToMoonshotAIChatMessages([
       {
         role: 'tool',
         content: [

--- a/packages/moonshotai/src/convert-to-moonshotai-chat-messages.ts
+++ b/packages/moonshotai/src/convert-to-moonshotai-chat-messages.ts
@@ -6,11 +6,13 @@ import {
   convertBase64ToUint8Array,
   convertToBase64,
   getTopLevelMediaType,
+  parseProviderOptions,
   resolveFullMediaType,
   resolveProviderReference,
 } from '@ai-sdk/provider-utils';
 
 import type { MoonshotAIMessages } from './moonshotai-chat-api-types';
+import { moonshotaiMessageProviderOptions } from './moonshotai-chat-options';
 
 const supportedImageMediaTypes = new Set([
   'image/jpeg',
@@ -59,14 +61,30 @@ function validateReferenceMediaType({
 // Moonshot AI chat completions accepts text, image_url, and video_url content
 // parts only. Anything else (audio, PDF, other file types) throws here rather
 // than being rejected by the API with a 400.
-export function convertToMoonshotAIChatMessages(
+export async function convertToMoonshotAIChatMessages(
   prompt: LanguageModelV4Prompt,
-): MoonshotAIMessages {
+): Promise<MoonshotAIMessages> {
   const messages: MoonshotAIMessages = [];
-  for (const { role, content } of prompt) {
+  for (const { role, content, providerOptions } of prompt) {
+    const messageOptions = await parseProviderOptions({
+      provider: 'moonshotai',
+      providerOptions,
+      schema: moonshotaiMessageProviderOptions,
+    });
+
+    if (role === 'tool' && messageOptions?.name != null) {
+      throw new UnsupportedFunctionalityError({
+        functionality: 'message names on tool messages',
+      });
+    }
+
     switch (role) {
       case 'system': {
-        messages.push({ role: 'system', content });
+        messages.push({
+          role: 'system',
+          content,
+          ...(messageOptions?.name != null && { name: messageOptions.name }),
+        });
         break;
       }
 
@@ -75,12 +93,14 @@ export function convertToMoonshotAIChatMessages(
           messages.push({
             role: 'user',
             content: content[0].text,
+            ...(messageOptions?.name != null && { name: messageOptions.name }),
           });
           break;
         }
 
         messages.push({
           role: 'user',
+          ...(messageOptions?.name != null && { name: messageOptions.name }),
           content: content.map(part => {
             switch (part.type) {
               case 'text': {
@@ -250,6 +270,7 @@ export function convertToMoonshotAIChatMessages(
         messages.push({
           role: 'assistant',
           content: toolCalls.length > 0 ? text || null : text,
+          ...(messageOptions?.name != null && { name: messageOptions.name }),
           ...(reasoning.length > 0 ? { reasoning_content: reasoning } : {}),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/moonshotai/src/index.ts
+++ b/packages/moonshotai/src/index.ts
@@ -6,6 +6,7 @@ export type {
 export type {
   MoonshotAIChatModelId,
   MoonshotAILanguageModelOptions,
+  MoonshotAIMessageProviderOptions,
   /** @deprecated Use `MoonshotAILanguageModelOptions` instead. */
   MoonshotAILanguageModelOptions as MoonshotAIProviderOptions,
 } from './moonshotai-chat-options';

--- a/packages/moonshotai/src/moonshotai-chat-api-types.ts
+++ b/packages/moonshotai/src/moonshotai-chat-api-types.ts
@@ -12,11 +12,13 @@ export type MoonshotAIMessage =
 export interface MoonshotAISystemMessage {
   role: 'system';
   content: string;
+  name?: string;
 }
 
 export interface MoonshotAIUserMessage {
   role: 'user';
   content: string | Array<MoonshotAIContentPart>;
+  name?: string;
 }
 
 export type MoonshotAIContentPart =
@@ -42,6 +44,7 @@ export interface MoonshotAIContentPartVideo {
 export interface MoonshotAIAssistantMessage {
   role: 'assistant';
   content?: string | null;
+  name?: string;
   reasoning_content?: string;
   tool_calls?: Array<MoonshotAIMessageToolCall>;
 }

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -842,6 +842,38 @@ describe('doGenerate', () => {
       expect(requestBody.prompt_cache_key).toBe('session-42');
       expect(requestBody.safety_identifier).toBe('user-hash-7');
     });
+
+    it('should send participant names on supported message roles', async () => {
+      await provider.chatModel('kimi-k3').doGenerate({
+        prompt: [
+          {
+            role: 'system',
+            content: 'You are Kimi.',
+            providerOptions: { moonshotai: { name: 'guide' } },
+          },
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Hello' }],
+            providerOptions: { moonshotai: { name: 'alice' } },
+          },
+          {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hi' }],
+            providerOptions: { moonshotai: { name: 'helper' } },
+          },
+        ],
+      });
+
+      expect((await server.calls[0].requestBodyJson).messages).toEqual([
+        { role: 'system', content: 'You are Kimi.', name: 'guide' },
+        { role: 'user', content: 'Hello', name: 'alice' },
+        {
+          role: 'assistant',
+          content: 'Hi',
+          name: 'helper',
+        },
+      ]);
+    });
   });
 
   describe('logprobs', () => {

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -128,7 +128,7 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
         schema: moonshotaiLanguageModelOptions,
       })) ?? {};
 
-    const messages = convertToMoonshotAIChatMessages(prompt);
+    const messages = await convertToMoonshotAIChatMessages(prompt);
 
     const allWarnings: SharedV4Warning[] = [];
     if (topK != null) {

--- a/packages/moonshotai/src/moonshotai-chat-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.ts
@@ -114,3 +114,12 @@ export type MoonshotAILanguageModelOptions = {
   promptCacheKey?: string;
   safetyIdentifier?: string;
 };
+
+export const moonshotaiMessageProviderOptions = z.object({
+  /** The name of the participant represented by the message. */
+  name: z.string().optional(),
+});
+
+export type MoonshotAIMessageProviderOptions = z.infer<
+  typeof moonshotaiMessageProviderOptions
+>;

--- a/packages/moonshotai/src/moonshotai-message-options.test-d.ts
+++ b/packages/moonshotai/src/moonshotai-message-options.test-d.ts
@@ -1,0 +1,10 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { MoonshotAIMessageProviderOptions } from './index';
+
+describe('MoonshotAIMessageProviderOptions', () => {
+  it('exposes participant names', () => {
+    expectTypeOf<MoonshotAIMessageProviderOptions>().toEqualTypeOf<{
+      name?: string;
+    }>();
+  });
+});


### PR DESCRIPTION
Fixes #19550

## Summary

- add and export typed Moonshot message provider options for participant names
- parse message options through the standard provider-option path and serialize names on system, user, and assistant messages
- explicitly reject tool-message names while their semantics remain ambiguous
- convert the prompt converter to async without changing unnamed message serialization
- add converter/request/type tests, docs, an example update, and a patch changeset

## Tests

- pnpm test:node (packages/moonshotai): 153 passed
- pnpm test:edge (packages/moonshotai): 153 passed
- pnpm type-check (packages/moonshotai)
- pnpm type-check:full
- pnpm check

## Stack dependency

Temporarily based on #19603 so each Moonshot parity change stays isolated while the earlier priority PRs await required review. Retarget this PR after #19603 merges.