### PR TITLE
feat(provider/moonshotai): support Partial Mode

### DIFF
--- a/.changeset/tiny-kimis-partial.md
+++ b/.changeset/tiny-kimis-partial.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+feat(provider/moonshotai): support Partial Mode on final assistant messages

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -282,6 +282,26 @@ const message = {
 };
 ```
 
+#### Partial Mode
+
+Set `partial: true` on the final assistant message to continue from prefilled
+assistant content. Partial Mode cannot be combined with `Output.object` or
+another JSON response format; the provider rejects that combination locally.
+
+```ts
+import type { MoonshotAIAssistantMessageProviderOptions } from '@ai-sdk/moonshotai';
+
+const partialMessage = {
+  role: 'assistant' as const,
+  content: [{ type: 'text' as const, text: '{' }],
+  providerOptions: {
+    moonshotai: {
+      partial: true,
+    } satisfies MoonshotAIAssistantMessageProviderOptions,
+  },
+};
+```
+
 ## Model Capabilities
 
 | Model                    | Image Input | Video Input | Object Generation | Tool Usage | Tool Streaming |

--- a/examples/ai-functions/src/generate-text/moonshot/partial.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/partial.ts
@@ -1,0 +1,29 @@
+import {
+  moonshotai,
+  type MoonshotAIAssistantMessageProviderOptions,
+} from '@ai-sdk/moonshotai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: moonshotai('kimi-k3'),
+    messages: [
+      {
+        role: 'user',
+        content: 'Return a JSON object with a short holiday name.',
+      },
+      {
+        role: 'assistant',
+        content: '{',
+        providerOptions: {
+          moonshotai: {
+            partial: true,
+          } satisfies MoonshotAIAssistantMessageProviderOptions,
+        },
+      },
+    ],
+  });
+
+  console.log(`{${result.text}`);
+});

--- a/packages/moonshotai/src/convert-to-moonshotai-chat-messages.test.ts
+++ b/packages/moonshotai/src/convert-to-moonshotai-chat-messages.test.ts
@@ -539,6 +539,59 @@ describe('message names', () => {
 });
 
 describe('assistant messages', () => {
+  it('should serialize partial true on the final assistant message', async () => {
+    const result = await convertToMoonshotAIChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Return a JSON object.' }],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: '{' }],
+        providerOptions: { moonshotai: { partial: true } },
+      },
+    ]);
+
+    expect(result.at(-1)).toEqual({
+      role: 'assistant',
+      content: '{',
+      partial: true,
+      tool_calls: undefined,
+    });
+  });
+
+  it('should reject partial on a non-final assistant message', async () => {
+    await expect(
+      convertToMoonshotAIChatMessages([
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'prefix' }],
+          providerOptions: { moonshotai: { partial: true } },
+        },
+        { role: 'user', content: [{ type: 'text', text: 'continue' }] },
+      ]),
+    ).rejects.toThrow(
+      'Moonshot Partial Mode requires the partial assistant message to be the final message.',
+    );
+  });
+
+  it('should reject partial with a JSON response format', async () => {
+    await expect(
+      convertToMoonshotAIChatMessages(
+        [
+          {
+            role: 'assistant',
+            content: [{ type: 'text', text: '{' }],
+            providerOptions: { moonshotai: { partial: true } },
+          },
+        ],
+        { type: 'json' },
+      ),
+    ).rejects.toThrow(
+      'Moonshot Partial Mode cannot be combined with a JSON response format.',
+    );
+  });
+
   it('should emit reasoning_content for reasoning parts', async () => {
     const result = await convertToMoonshotAIChatMessages([
       {

--- a/packages/moonshotai/src/convert-to-moonshotai-chat-messages.ts
+++ b/packages/moonshotai/src/convert-to-moonshotai-chat-messages.ts
@@ -1,5 +1,7 @@
 import {
+  InvalidPromptError,
   UnsupportedFunctionalityError,
+  type LanguageModelV4CallOptions,
   type LanguageModelV4Prompt,
 } from '@ai-sdk/provider';
 import {
@@ -12,7 +14,7 @@ import {
 } from '@ai-sdk/provider-utils';
 
 import type { MoonshotAIMessages } from './moonshotai-chat-api-types';
-import { moonshotaiMessageProviderOptions } from './moonshotai-chat-options';
+import { moonshotaiAssistantMessageProviderOptions } from './moonshotai-chat-options';
 
 const supportedImageMediaTypes = new Set([
   'image/jpeg',
@@ -63,14 +65,25 @@ function validateReferenceMediaType({
 // than being rejected by the API with a 400.
 export async function convertToMoonshotAIChatMessages(
   prompt: LanguageModelV4Prompt,
+  responseFormat?: LanguageModelV4CallOptions['responseFormat'],
 ): Promise<MoonshotAIMessages> {
   const messages: MoonshotAIMessages = [];
+  let index = -1;
   for (const { role, content, providerOptions } of prompt) {
+    index++;
     const messageOptions = await parseProviderOptions({
       provider: 'moonshotai',
       providerOptions,
-      schema: moonshotaiMessageProviderOptions,
+      schema: moonshotaiAssistantMessageProviderOptions,
     });
+
+    if (messageOptions?.partial === true && role !== 'assistant') {
+      throw new InvalidPromptError({
+        prompt,
+        message:
+          'Moonshot Partial Mode requires `partial: true` on an assistant message.',
+      });
+    }
 
     if (role === 'tool' && messageOptions?.name != null) {
       throw new UnsupportedFunctionalityError({
@@ -235,6 +248,24 @@ export async function convertToMoonshotAIChatMessages(
       }
 
       case 'assistant': {
+        if (messageOptions?.partial === true) {
+          if (index !== prompt.length - 1) {
+            throw new InvalidPromptError({
+              prompt,
+              message:
+                'Moonshot Partial Mode requires the partial assistant message to be the final message.',
+            });
+          }
+
+          if (responseFormat?.type === 'json') {
+            throw new InvalidPromptError({
+              prompt,
+              message:
+                'Moonshot Partial Mode cannot be combined with a JSON response format.',
+            });
+          }
+        }
+
         let text = '';
         let reasoning = '';
         const toolCalls: Array<{
@@ -271,6 +302,7 @@ export async function convertToMoonshotAIChatMessages(
           role: 'assistant',
           content: toolCalls.length > 0 ? text || null : text,
           ...(messageOptions?.name != null && { name: messageOptions.name }),
+          ...(messageOptions?.partial === true && { partial: true as const }),
           ...(reasoning.length > 0 ? { reasoning_content: reasoning } : {}),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         });

--- a/packages/moonshotai/src/index.ts
+++ b/packages/moonshotai/src/index.ts
@@ -4,6 +4,7 @@ export type {
   MoonshotAIProviderSettings,
 } from './moonshotai-provider';
 export type {
+  MoonshotAIAssistantMessageProviderOptions,
   MoonshotAIChatModelId,
   MoonshotAILanguageModelOptions,
   MoonshotAIMessageProviderOptions,

--- a/packages/moonshotai/src/moonshotai-chat-api-types.ts
+++ b/packages/moonshotai/src/moonshotai-chat-api-types.ts
@@ -45,6 +45,7 @@ export interface MoonshotAIAssistantMessage {
   role: 'assistant';
   content?: string | null;
   name?: string;
+  partial?: true;
   reasoning_content?: string;
   tool_calls?: Array<MoonshotAIMessageToolCall>;
 }

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -876,6 +876,51 @@ describe('doGenerate', () => {
     });
   });
 
+  describe('Partial Mode', () => {
+    beforeEach(() => {
+      prepareJsonFixtureResponse('moonshotai-text');
+    });
+
+    it('should send partial true on the final assistant message', async () => {
+      await provider.chatModel('kimi-k3').doGenerate({
+        prompt: [
+          { role: 'user', content: [{ type: 'text', text: 'Return JSON.' }] },
+          {
+            role: 'assistant',
+            content: [{ type: 'text', text: '{' }],
+            providerOptions: { moonshotai: { partial: true } },
+          },
+        ],
+      });
+
+      expect((await server.calls[0].requestBodyJson).messages.at(-1)).toEqual({
+        role: 'assistant',
+        content: '{',
+        partial: true,
+      });
+    });
+
+    it('should reject partial with structured outputs before the request', async () => {
+      await expect(
+        provider.chatModel('kimi-k3').doGenerate({
+          prompt: [
+            {
+              role: 'assistant',
+              content: [{ type: 'text', text: '{' }],
+              providerOptions: { moonshotai: { partial: true } },
+            },
+          ],
+          responseFormat: {
+            type: 'json',
+            schema: { type: 'object', properties: {} },
+          },
+        }),
+      ).rejects.toThrow(
+        'Moonshot Partial Mode cannot be combined with a JSON response format.',
+      );
+    });
+  });
+
   describe('logprobs', () => {
     beforeEach(() => {
       prepareJsonFixtureResponse('moonshotai-logprobs');

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -128,7 +128,10 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
         schema: moonshotaiLanguageModelOptions,
       })) ?? {};
 
-    const messages = await convertToMoonshotAIChatMessages(prompt);
+    const messages = await convertToMoonshotAIChatMessages(
+      prompt,
+      responseFormat,
+    );
 
     const allWarnings: SharedV4Warning[] = [];
     if (topK != null) {

--- a/packages/moonshotai/src/moonshotai-chat-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.ts
@@ -123,3 +123,13 @@ export const moonshotaiMessageProviderOptions = z.object({
 export type MoonshotAIMessageProviderOptions = z.infer<
   typeof moonshotaiMessageProviderOptions
 >;
+
+export const moonshotaiAssistantMessageProviderOptions =
+  moonshotaiMessageProviderOptions.extend({
+    /** Continue the final assistant message from its existing content. */
+    partial: z.literal(true).optional(),
+  });
+
+export type MoonshotAIAssistantMessageProviderOptions = z.infer<
+  typeof moonshotaiAssistantMessageProviderOptions
+>;

--- a/packages/moonshotai/src/moonshotai-message-options.test-d.ts
+++ b/packages/moonshotai/src/moonshotai-message-options.test-d.ts
@@ -1,10 +1,20 @@
 import { describe, expectTypeOf, it } from 'vitest';
-import type { MoonshotAIMessageProviderOptions } from './index';
+import type {
+  MoonshotAIAssistantMessageProviderOptions,
+  MoonshotAIMessageProviderOptions,
+} from './index';
 
 describe('MoonshotAIMessageProviderOptions', () => {
   it('exposes participant names', () => {
     expectTypeOf<MoonshotAIMessageProviderOptions>().toEqualTypeOf<{
       name?: string;
+    }>();
+  });
+
+  it('exposes Partial Mode on assistant messages', () => {
+    expectTypeOf<MoonshotAIAssistantMessageProviderOptions>().toEqualTypeOf<{
+      name?: string;
+      partial?: true;
     }>();
   });
 });


### PR DESCRIPTION
Fixes #19545

## Summary

- add and export an assistant-message Partial Mode provider option
- serialize partial: true only on a final assistant prefix
- reject non-final placement and JSON response-format combinations before network I/O
- keep ordinary assistant messages unchanged
- add converter/request/type tests, docs, an example, and a patch changeset

## Tests

- pnpm test:node (packages/moonshotai): 158 passed
- pnpm test:edge (packages/moonshotai): 158 passed
- pnpm type-check (packages/moonshotai)
- pnpm type-check:full
- pnpm check

## Stack dependency

Temporarily based on #19604 so each Moonshot parity change stays isolated while the earlier priority PRs await required review. Retarget this PR after #19604 merges.