### PR TITLE
feat(provider/moonshotai): support K3 dynamic tool loading

### DIFF
--- a/.changeset/witty-kimis-tools.md
+++ b/.changeset/witty-kimis-tools.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+feat(provider/moonshotai): support Kimi K3 dynamic tool-loading messages

--- a/.changeset/witty-kimis-tools.md
+++ b/.changeset/witty-kimis-tools.md
@@ -2,4 +2,4 @@
 '@ai-sdk/moonshotai': patch
 ---
 
-feat(provider/moonshotai): support Kimi K3 dynamic tool-loading messages
+Support Kimi K3 dynamic tool-loading system messages.

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -183,6 +183,67 @@ when you need the complete response.
   validates only the returned continuation.
 </Note>
 
+### Kimi K3 Dynamic Tool Loading
+
+Kimi K3 can load complete function tool definitions at arbitrary positions in
+a conversation. Add `tools` to the Moonshot provider options of an empty system
+message. The provider sends `{ role: 'system', tools: [...] }` without a
+`content` field and applies the same Moonshot Flavored JSON Schema normalization
+used for top-level tools.
+
+```ts
+import {
+  moonshotai,
+  type MoonshotAISystemMessageProviderOptions,
+} from '@ai-sdk/moonshotai';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: moonshotai('kimi-k3'),
+  allowSystemInMessages: true,
+  messages: [
+    { role: 'user', content: 'Help me prepare for a trip.' },
+    { role: 'assistant', content: 'I can help with that.' },
+    {
+      role: 'system',
+      content: '',
+      providerOptions: {
+        moonshotai: {
+          tools: [
+            {
+              type: 'function',
+              name: 'get_weather',
+              description: 'Get the current weather for a city',
+              inputSchema: {
+                type: 'object',
+                properties: { city: { type: 'string' } },
+                required: ['city'],
+                additionalProperties: false,
+              },
+              strict: true,
+            },
+          ],
+        } satisfies MoonshotAISystemMessageProviderOptions,
+      },
+    },
+    { role: 'user', content: 'What is the weather in San Francisco?' },
+  ],
+});
+```
+
+Each entry must include its complete function definition. Top-level tools and
+dynamically loaded tools can be used in the same request. Known unsupported
+official models omit the dynamic message and return an unsupported warning;
+custom model IDs retain it for forward compatibility.
+
+<Note>
+  Keep dynamic system messages in trusted server-side state. Tool names,
+  descriptions, and schemas are sent to Moonshot and consume context. Dynamic
+  declarations are request-local, so retain earlier declarations in later
+  requests while those tools should remain available. Appending messages also
+  preserves prompt-cache prefixes better than rewriting earlier declarations.
+</Note>
+
 ### Reasoning Models
 
 Kimi K3 always reasons. It supports `low`, `high`, and `max` reasoning effort,

--- a/examples/ai-functions/src/generate-text/moonshot/dynamic-tools.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/dynamic-tools.ts
@@ -1,0 +1,38 @@
+import {
+  moonshotai,
+  type MoonshotAISystemMessageProviderOptions,
+} from '@ai-sdk/moonshotai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: moonshotai('kimi-k3'),
+    allowSystemInMessages: true,
+    messages: [
+      { role: 'user', content: 'Calculate 23 * 47.' },
+      {
+        role: 'system',
+        content: '',
+        providerOptions: {
+          moonshotai: {
+            tools: [
+              {
+                type: 'function',
+                name: 'calculator',
+                description: 'Evaluate an arithmetic expression',
+                inputSchema: {
+                  type: 'object',
+                  properties: { expression: { type: 'string' } },
+                  required: ['expression'],
+                },
+              },
+            ],
+          } satisfies MoonshotAISystemMessageProviderOptions,
+        },
+      },
+    ],
+  });
+
+  console.log(result.toolCalls);
+});

--- a/packages/moonshotai/src/convert-to-moonshotai-chat-messages.test.ts
+++ b/packages/moonshotai/src/convert-to-moonshotai-chat-messages.test.ts
@@ -757,6 +757,231 @@ describe('system messages', () => {
 
     expect(result).toEqual([{ role: 'system', content: 'You are Kimi.' }]);
   });
+
+  it('should serialize and normalize K3 dynamic tools without content', async () => {
+    const result = await convertToMoonshotAIChatMessages({
+      modelId: 'kimi-k3',
+      prompt: [
+        {
+          role: 'system',
+          content: '',
+          providerOptions: {
+            moonshotai: {
+              tools: [
+                {
+                  type: 'function',
+                  name: 'locate',
+                  description: 'Locate coordinates',
+                  inputSchema: {
+                    type: 'object',
+                    properties: {
+                      coordinates: {
+                        type: 'array',
+                        items: [{ type: 'number' }, { type: 'number' }],
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'system',
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'locate',
+                description: 'Locate coordinates',
+                parameters: {
+                  type: 'object',
+                  properties: {
+                    coordinates: {
+                      type: 'array',
+                      prefixItems: [{ type: 'number' }, { type: 'number' }],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+      warnings: [],
+    });
+  });
+
+  it('should omit dynamic tools and warn for known non-K3 models', async () => {
+    const result = await convertToMoonshotAIChatMessages({
+      modelId: 'kimi-k2.6',
+      prompt: [
+        { role: 'user', content: [{ type: 'text', text: 'Start' }] },
+        {
+          role: 'system',
+          content: '',
+          providerOptions: {
+            moonshotai: {
+              tools: [
+                {
+                  type: 'function',
+                  name: 'calculator',
+                  inputSchema: { type: 'object', properties: {} },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      messages: [{ role: 'user', content: 'Start' }],
+      warnings: [
+        {
+          type: 'unsupported',
+          feature: 'dynamic tool loading for model "kimi-k2.6"',
+          details:
+            'Moonshot documents dynamic tool loading only for Kimi K3. The dynamic system message has been omitted.',
+        },
+      ],
+    });
+  });
+
+  it('should preserve dynamic tools for unknown custom models', async () => {
+    const result = await convertToMoonshotAIChatMessages({
+      modelId: 'custom-model',
+      prompt: [
+        {
+          role: 'system',
+          content: '',
+          providerOptions: {
+            moonshotai: {
+              tools: [
+                {
+                  type: 'function',
+                  name: 'calculator',
+                  inputSchema: { type: 'object', properties: {} },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.messages[0]).toMatchObject({
+      role: 'system',
+      tools: [{ function: { name: 'calculator' } }],
+    });
+  });
+
+  it('should preserve an ordinary system message when tools is empty', async () => {
+    const result = await convertToMoonshotAIChatMessages({
+      modelId: 'kimi-k3',
+      prompt: [
+        {
+          role: 'system',
+          content: 'You are Kimi.',
+          providerOptions: { moonshotai: { tools: [] } },
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      messages: [{ role: 'system', content: 'You are Kimi.' }],
+      warnings: [],
+    });
+  });
+
+  it('should reject incomplete dynamic tool definitions', async () => {
+    await expect(
+      convertToMoonshotAIChatMessages({
+        modelId: 'kimi-k3',
+        prompt: [
+          {
+            role: 'system',
+            content: '',
+            providerOptions: {
+              moonshotai: {
+                tools: [
+                  {
+                    type: 'function',
+                    name: 'calculator',
+                    inputSchema: undefined,
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      name: 'AI_InvalidArgumentError',
+      argument: 'providerOptions',
+      message: 'invalid moonshotai provider options',
+    });
+  });
+
+  it('should reject content alongside dynamic tools', async () => {
+    await expect(
+      convertToMoonshotAIChatMessages({
+        modelId: 'kimi-k3',
+        prompt: [
+          {
+            role: 'system',
+            content: 'Do not send this.',
+            providerOptions: {
+              moonshotai: {
+                tools: [
+                  {
+                    type: 'function',
+                    name: 'calculator',
+                    inputSchema: { type: 'object', properties: {} },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow(
+      'A Moonshot dynamic-tool system message must use empty content because the API forbids content alongside tools.',
+    );
+  });
+
+  it('should reject dynamic tools on non-system messages', async () => {
+    await expect(
+      convertToMoonshotAIChatMessages({
+        modelId: 'kimi-k3',
+        prompt: [
+          {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hello' }],
+            providerOptions: {
+              moonshotai: {
+                tools: [
+                  {
+                    type: 'function',
+                    name: 'calculator',
+                    inputSchema: { type: 'object', properties: {} },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow(
+      'Moonshot dynamic tools must be configured on a system message.',
+    );
+  });
 });
 
 describe('assistant messages', () => {

--- a/packages/moonshotai/src/convert-to-moonshotai-chat-messages.ts
+++ b/packages/moonshotai/src/convert-to-moonshotai-chat-messages.ts
@@ -15,7 +15,12 @@ import {
 } from '@ai-sdk/provider-utils';
 
 import type { MoonshotAIMessages } from './moonshotai-chat-api-types';
-import { moonshotaiAssistantMessageProviderOptions } from './moonshotai-chat-options';
+import {
+  getMoonshotAIModelFamily,
+  moonshotaiAllMessageProviderOptions,
+  type MoonshotAIChatModelId,
+} from './moonshotai-chat-options';
+import { prepareTools } from './moonshotai-prepare-tools';
 
 const supportedImageMediaTypes = [
   'image/jpeg',
@@ -79,10 +84,12 @@ function formatMediaUrl({
 // parts only. Anything else (audio, PDF, other file types) throws here rather
 // than being rejected by the API with a 400.
 export async function convertToMoonshotAIChatMessages({
+  modelId,
   prompt,
   providerOptionsName = 'moonshotai',
   responseFormat,
 }: {
+  modelId?: MoonshotAIChatModelId;
   prompt: LanguageModelV4Prompt;
   providerOptionsName?: string;
   responseFormat?: Record<string, unknown>;
@@ -92,12 +99,14 @@ export async function convertToMoonshotAIChatMessages({
 }> {
   const messages: MoonshotAIMessages = [];
   const warnings: Array<SharedV4Warning> = [];
+  const modelFamily =
+    modelId == null ? 'unknown' : getMoonshotAIModelFamily(modelId);
 
   for (const [index, { role, content, providerOptions }] of prompt.entries()) {
     const moonshotMessageOptions = await parseProviderOptions({
       provider: providerOptionsName,
       providerOptions,
-      schema: moonshotaiAssistantMessageProviderOptions,
+      schema: moonshotaiAllMessageProviderOptions,
     });
 
     if (moonshotMessageOptions?.partial === true && role !== 'assistant') {
@@ -108,8 +117,44 @@ export async function convertToMoonshotAIChatMessages({
       });
     }
 
+    if (moonshotMessageOptions?.tools != null && role !== 'system') {
+      throw new InvalidPromptError({
+        prompt,
+        message:
+          'Moonshot dynamic tools must be configured on a system message.',
+      });
+    }
+
     switch (role) {
       case 'system': {
+        if (moonshotMessageOptions?.tools?.length) {
+          if (content.length > 0) {
+            throw new InvalidPromptError({
+              prompt,
+              message:
+                'A Moonshot dynamic-tool system message must use empty content because the API forbids content alongside tools.',
+            });
+          }
+
+          if (modelFamily !== 'kimi-k3' && modelFamily !== 'unknown') {
+            warnings.push({
+              type: 'unsupported',
+              feature: `dynamic tool loading for model "${modelId}"`,
+              details:
+                'Moonshot documents dynamic tool loading only for Kimi K3. The dynamic system message has been omitted.',
+            });
+            break;
+          }
+
+          const { tools, toolWarnings } = prepareTools({
+            modelId: modelId ?? 'custom-model',
+            tools: moonshotMessageOptions.tools,
+          });
+          warnings.push(...toolWarnings);
+          messages.push({ role: 'system', tools: tools ?? [] });
+          break;
+        }
+
         messages.push({
           role: 'system',
           content,

--- a/packages/moonshotai/src/index.ts
+++ b/packages/moonshotai/src/index.ts
@@ -8,6 +8,7 @@ export type {
   MoonshotAIChatModelId,
   MoonshotAILanguageModelOptions,
   MoonshotAIMessageProviderOptions,
+  MoonshotAISystemMessageProviderOptions,
   /** @deprecated Use `MoonshotAILanguageModelOptions` instead. */
   MoonshotAILanguageModelOptions as MoonshotAIProviderOptions,
 } from './moonshotai-chat-options';

--- a/packages/moonshotai/src/moonshotai-chat-api-types.ts
+++ b/packages/moonshotai/src/moonshotai-chat-api-types.ts
@@ -9,10 +9,25 @@ export type MoonshotAIMessage =
   | MoonshotAIAssistantMessage
   | MoonshotAIToolMessage;
 
-export interface MoonshotAISystemMessage {
-  role: 'system';
-  content: string;
-  name?: string;
+export type MoonshotAISystemMessage =
+  | {
+      role: 'system';
+      content: string;
+      name?: string;
+    }
+  | {
+      role: 'system';
+      tools: Array<MoonshotAIFunctionTool>;
+    };
+
+export interface MoonshotAIFunctionTool {
+  type: 'function';
+  function: {
+    name: string;
+    description: string | undefined;
+    parameters: unknown;
+    strict?: boolean;
+  };
 }
 
 export interface MoonshotAIUserMessage {

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -1094,6 +1094,127 @@ describe('doGenerate', () => {
     });
   });
 
+  describe('dynamic tool loading', () => {
+    beforeEach(() => {
+      prepareJsonFixtureResponse('moonshotai-tool-call');
+    });
+
+    it('should send normalized dynamic tools in a K3 system message', async () => {
+      await provider.chatModel('kimi-k3').doGenerate({
+        prompt: [
+          { role: 'user', content: [{ type: 'text', text: 'Calculate.' }] },
+          {
+            role: 'system',
+            content: '',
+            providerOptions: {
+              moonshotai: {
+                tools: [
+                  {
+                    type: 'function',
+                    name: 'calculator',
+                    description: 'Evaluate an expression',
+                    inputSchema: {
+                      type: 'object',
+                      properties: {
+                        values: {
+                          type: 'array',
+                          items: [{ type: 'number' }, { type: 'number' }],
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      });
+
+      expect((await server.calls[0].requestBodyJson).messages.at(-1)).toEqual({
+        role: 'system',
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'calculator',
+              description: 'Evaluate an expression',
+              parameters: {
+                type: 'object',
+                properties: {
+                  values: {
+                    type: 'array',
+                    prefixItems: [{ type: 'number' }, { type: 'number' }],
+                  },
+                },
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    it('should omit dynamic messages and warn for non-K3 official models', async () => {
+      const result = await provider.chatModel('kimi-k2.6').doGenerate({
+        prompt: [
+          {
+            role: 'system',
+            content: '',
+            providerOptions: {
+              moonshotai: {
+                tools: [
+                  {
+                    type: 'function',
+                    name: 'calculator',
+                    inputSchema: { type: 'object', properties: {} },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        messages: [],
+      });
+      expect(result.warnings).toContainEqual({
+        type: 'unsupported',
+        feature: 'dynamic tool loading for model "kimi-k2.6"',
+        details:
+          'Moonshot documents dynamic tool loading only for Kimi K3. The dynamic system message has been omitted.',
+      });
+    });
+
+    it('should preserve dynamic messages for unknown custom models', async () => {
+      await provider.chatModel('custom-model').doGenerate({
+        prompt: [
+          {
+            role: 'system',
+            content: '',
+            providerOptions: {
+              moonshotai: {
+                tools: [
+                  {
+                    type: 'function',
+                    name: 'calculator',
+                    inputSchema: { type: 'object', properties: {} },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      });
+
+      expect((await server.calls[0].requestBodyJson).messages[0]).toMatchObject(
+        {
+          role: 'system',
+          tools: [{ function: { name: 'calculator' } }],
+        },
+      );
+    });
+  });
+
   describe('logprobs', () => {
     beforeEach(() => {
       prepareJsonFixtureResponse('moonshotai-logprobs');
@@ -1355,6 +1476,35 @@ describe('doStream', () => {
     expect(requestBody.stream).toBe(true);
     expect(requestBody.stream_options).toStrictEqual({
       include_usage: true,
+    });
+  });
+
+  it('should send dynamic tool messages when streaming', async () => {
+    prepareChunksFixtureResponse('moonshotai-stream');
+
+    await provider.chatModel('kimi-k3').doStream({
+      prompt: [
+        {
+          role: 'system',
+          content: '',
+          providerOptions: {
+            moonshotai: {
+              tools: [
+                {
+                  type: 'function',
+                  name: 'calculator',
+                  inputSchema: { type: 'object', properties: {} },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+
+    expect((await server.calls[0].requestBodyJson).messages[0]).toMatchObject({
+      role: 'system',
+      tools: [{ function: { name: 'calculator' } }],
     });
   });
 

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -424,6 +424,7 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
 
     const { messages, warnings: messageWarnings } =
       await convertToMoonshotAIChatMessages({
+        modelId: this.modelId,
         prompt,
         providerOptionsName: this.providerOptionsName,
         responseFormat: response_format,

--- a/packages/moonshotai/src/moonshotai-chat-options.test-d.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.test-d.ts
@@ -2,6 +2,7 @@ import { describe, expectTypeOf, it } from 'vitest';
 import type {
   MoonshotAIAssistantMessageProviderOptions,
   MoonshotAILanguageModelOptions,
+  MoonshotAISystemMessageProviderOptions,
 } from './index';
 
 describe('MoonshotAILanguageModelOptions', () => {
@@ -47,5 +48,20 @@ describe('MoonshotAIAssistantMessageProviderOptions', () => {
     } satisfies MoonshotAIAssistantMessageProviderOptions;
 
     expectTypeOf(options.partial).toEqualTypeOf<false>();
+  });
+});
+
+describe('MoonshotAISystemMessageProviderOptions', () => {
+  it('exposes names and complete dynamic function tools', () => {
+    expectTypeOf<MoonshotAISystemMessageProviderOptions>().toMatchTypeOf<{
+      name?: string;
+      tools?: Array<{
+        type: 'function';
+        name: string;
+        description?: string;
+        inputSchema: object;
+        strict?: boolean;
+      }>;
+    }>();
   });
 });

--- a/packages/moonshotai/src/moonshotai-chat-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.ts
@@ -1,3 +1,4 @@
+import type { LanguageModelV4FunctionTool } from '@ai-sdk/provider';
 import { z } from 'zod/v4';
 
 export type MoonshotAIChatModelId =
@@ -151,3 +152,28 @@ export const moonshotaiAssistantMessageProviderOptions =
 export type MoonshotAIAssistantMessageProviderOptions = z.infer<
   typeof moonshotaiAssistantMessageProviderOptions
 >;
+
+const moonshotaiDynamicToolSchema = z.object({
+  type: z.literal('function'),
+  name: z.string(),
+  description: z.string().optional(),
+  inputSchema: z.record(z.string(), z.unknown()),
+  strict: z.boolean().optional(),
+});
+
+export const moonshotaiAllMessageProviderOptions =
+  moonshotaiAssistantMessageProviderOptions.extend({
+    /** Function tools to load at this point in a Kimi K3 conversation. */
+    tools: z.array(moonshotaiDynamicToolSchema).optional(),
+  });
+
+export type MoonshotAISystemMessageProviderOptions =
+  MoonshotAIMessageProviderOptions & {
+    /** Function tools to load at this point in a Kimi K3 conversation. */
+    tools?: Array<
+      Pick<
+        LanguageModelV4FunctionTool,
+        'type' | 'name' | 'description' | 'inputSchema' | 'strict'
+      >
+    >;
+  };

--- a/packages/moonshotai/src/moonshotai-prepare-tools.ts
+++ b/packages/moonshotai/src/moonshotai-prepare-tools.ts
@@ -3,6 +3,7 @@ import {
   type LanguageModelV4CallOptions,
   type SharedV4Warning,
 } from '@ai-sdk/provider';
+import type { MoonshotAIFunctionTool } from './moonshotai-chat-api-types';
 import type { MoonshotAIChatModelId } from './moonshotai-chat-options';
 import { normalizeJsonSchemaForMFJS } from './normalize-json-schema-for-mfjs';
 
@@ -15,17 +16,7 @@ export function prepareTools({
   toolChoice?: LanguageModelV4CallOptions['toolChoice'];
   modelId: MoonshotAIChatModelId;
 }): {
-  tools:
-    | undefined
-    | Array<{
-        type: 'function';
-        function: {
-          name: string;
-          description: string | undefined;
-          parameters: unknown;
-          strict?: boolean;
-        };
-      }>;
+  tools: undefined | Array<MoonshotAIFunctionTool>;
   toolChoice:
     | { type: 'function'; function: { name: string } }
     | 'auto'
@@ -43,15 +34,7 @@ export function prepareTools({
     return { tools: undefined, toolChoice: undefined, toolWarnings };
   }
 
-  const moonshotTools: Array<{
-    type: 'function';
-    function: {
-      name: string;
-      description: string | undefined;
-      parameters: unknown;
-      strict?: boolean;
-    };
-  }> = [];
+  const moonshotTools: Array<MoonshotAIFunctionTool> = [];
 
   for (const tool of tools) {
     if (tool.type === 'provider') {


### PR DESCRIPTION
## Summary

- add typed Moonshot system-message options for Kimi K3 dynamic tool loading
- emit the official `{ role: "system", tools: [...] }` message shape without `content` and reuse MFJS tool-schema normalization
- reject dynamic-tool messages on non-K3 models or when combined with system content
- document and demonstrate the public behavior

## Tests

- `pnpm test:node` (packages/moonshotai; 163 tests)
- `pnpm test:edge` (packages/moonshotai; 163 tests)
- `pnpm type-check` (packages/moonshotai)
- `pnpm type-check:full`
- `pnpm check`

Depends on #19606.
Fixes #19557.