### PR TITLE
feat(provider/moonshotai): support predicted outputs

### DIFF
--- a/.changeset/tasty-kimis-predict.md
+++ b/.changeset/tasty-kimis-predict.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+feat(provider/moonshotai): support predicted outputs

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -224,6 +224,13 @@ File parts containing inline text are sent as ordinary text content parts.
 
 The following optional provider options are available for Moonshot AI language models:
 
+- **prediction** _object_
+
+  Static content that the generated response is expected to match. Use
+  `{ type: 'content', content }`, where `content` is a string or an array of
+  `{ type: 'text', text }` parts. Predicted output can reduce latency when most
+  of a response is already known, such as when regenerating a file.
+
 - **reasoningEffort** _'low' | 'high' | 'max'_
 
   Reasoning effort for Kimi K3.

--- a/examples/ai-functions/src/generate-text/moonshot/predicted-output.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/predicted-output.ts
@@ -1,0 +1,30 @@
+import {
+  moonshotai,
+  type MoonshotAILanguageModelOptions,
+} from '@ai-sdk/moonshotai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+const existingCode = `
+export function greet(name: string) {
+  return 'Hello, ' + name;
+}
+`;
+
+run(async () => {
+  const result = await generateText({
+    model: moonshotai('kimi-k3'),
+    prompt:
+      'Update the function to use a template literal. Respond only with code.',
+    providerOptions: {
+      moonshotai: {
+        prediction: {
+          type: 'content',
+          content: existingCode,
+        },
+      } satisfies MoonshotAILanguageModelOptions,
+    },
+  });
+
+  console.log(result.text);
+});

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -843,6 +843,54 @@ describe('doGenerate', () => {
       expect(requestBody.safety_identifier).toBe('user-hash-7');
     });
 
+    it.each([
+      ['a string', 'The expected response.'],
+      [
+        'text content parts',
+        [
+          { type: 'text', text: 'The expected ' },
+          { type: 'text', text: 'response.' },
+        ],
+      ],
+    ])('should forward predicted output with %s', async (_name, content) => {
+      await provider.chatModel('kimi-k3').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: {
+            prediction: { type: 'content', content },
+          },
+        },
+      });
+
+      expect((await server.calls[0].requestBodyJson).prediction).toEqual({
+        type: 'content',
+        content,
+      });
+    });
+
+    it('should not send prediction by default', async () => {
+      await provider.chatModel('kimi-k3').doGenerate({ prompt: TEST_PROMPT });
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'prediction',
+      );
+    });
+
+    it.each([
+      { type: 'unsupported', content: 'text' },
+      { type: 'content', content: [{ type: 'image', image_url: 'x' }] },
+      { type: 'content', content: 42 },
+    ])('should reject invalid predicted output %#', async prediction => {
+      await expect(
+        provider.chatModel('kimi-k3').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            moonshotai: { prediction },
+          },
+        }),
+      ).rejects.toThrow('invalid moonshotai provider options');
+    });
+
     it('should send participant names on supported message roles', async () => {
       await provider.chatModel('kimi-k3').doGenerate({
         prompt: [

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -389,6 +389,9 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
         ...(moonshotOptions.topLogprobs != null && {
           top_logprobs: moonshotOptions.topLogprobs,
         }),
+        ...(moonshotOptions.prediction != null && {
+          prediction: moonshotOptions.prediction,
+        }),
         max_tokens: maxOutputTokens,
         temperature: supportsSamplingOptions ? temperature : undefined,
         top_p: supportsSamplingOptions ? topP : undefined,

--- a/packages/moonshotai/src/moonshotai-chat-options.test-d.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.test-d.ts
@@ -4,6 +4,10 @@ import type { MoonshotAILanguageModelOptions } from './index';
 describe('MoonshotAILanguageModelOptions', () => {
   it('only exposes official thinking and reasoning effort fields', () => {
     expectTypeOf<MoonshotAILanguageModelOptions>().toEqualTypeOf<{
+      prediction?: {
+        type: 'content';
+        content: string | Array<{ type: 'text'; text: string }>;
+      };
       logprobs?: boolean;
       topLogprobs?: number;
       reasoningEffort?: 'low' | 'high' | 'max';

--- a/packages/moonshotai/src/moonshotai-chat-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.ts
@@ -38,6 +38,22 @@ export function getMoonshotAIModelFamily(
 }
 
 export const moonshotaiLanguageModelOptions = z.object({
+  /** Static content that the model's response is expected to match. */
+  prediction: z
+    .object({
+      type: z.literal('content'),
+      content: z.union([
+        z.string(),
+        z.array(
+          z.object({
+            type: z.literal('text'),
+            text: z.string(),
+          }),
+        ),
+      ]),
+    })
+    .optional(),
+
   /** Whether to return log probabilities for generated tokens. */
   logprobs: z.boolean().optional(),
 
@@ -83,6 +99,12 @@ export const moonshotaiLanguageModelOptions = z.object({
 });
 
 export type MoonshotAILanguageModelOptions = {
+  /** Static content that the model's response is expected to match. */
+  prediction?: {
+    type: 'content';
+    content: string | Array<{ type: 'text'; text: string }>;
+  };
+
   /** Whether to return log probabilities for generated tokens. */
   logprobs?: boolean;
 


### PR DESCRIPTION
## Summary

- add the official Moonshot `prediction` provider option
- validate and serialize string and text-content-part-array predictions exactly
- document the option and add a runnable example

## Tests

- `pnpm test:node` (packages/moonshotai; 169 tests)
- `pnpm test:edge` (packages/moonshotai; 169 tests)
- `pnpm type-check` (packages/moonshotai)
- `pnpm type-check:full`
- `pnpm check`

Depends on #19608.
Fixes #19551.