### PR TITLE
fix(provider/moonshotai): send max completion tokens

### DIFF
--- a/.changeset/small-kimis-complete.md
+++ b/.changeset/small-kimis-complete.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+fix(provider/moonshotai): send max completion tokens with the preferred API field

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -75,6 +75,27 @@ describe('doGenerate', () => {
       `);
     });
 
+    it('should send maxOutputTokens as max_completion_tokens', async () => {
+      await provider.chatModel('kimi-k3').doGenerate({
+        prompt: TEST_PROMPT,
+        maxOutputTokens: 512,
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.max_completion_tokens).toBe(512);
+      expect(requestBody).not.toHaveProperty('max_tokens');
+    });
+
+    it('should omit token limit fields when maxOutputTokens is undefined', async () => {
+      await provider.chatModel('kimi-k3').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).not.toHaveProperty('max_completion_tokens');
+      expect(requestBody).not.toHaveProperty('max_tokens');
+    });
+
     it.each([
       'kimi-k2.5',
       'kimi-k2.6',
@@ -1191,6 +1212,19 @@ describe('doStream', () => {
     expect(requestBody.stream_options).toStrictEqual({
       include_usage: true,
     });
+  });
+
+  it('should send maxOutputTokens as max_completion_tokens when streaming', async () => {
+    prepareChunksFixtureResponse('moonshotai-stream');
+
+    await provider.chatModel('kimi-k3').doStream({
+      prompt: TEST_PROMPT,
+      maxOutputTokens: 256,
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody.max_completion_tokens).toBe(256);
+    expect(requestBody).not.toHaveProperty('max_tokens');
   });
 
   it('should assemble index-less tool calls and use choice-level usage', async () => {

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -392,7 +392,7 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
         ...(moonshotOptions.prediction != null && {
           prediction: moonshotOptions.prediction,
         }),
-        max_tokens: maxOutputTokens,
+        max_completion_tokens: maxOutputTokens,
         temperature: supportsSamplingOptions ? temperature : undefined,
         top_p: supportsSamplingOptions ? topP : undefined,
         frequency_penalty: supportsSamplingOptions


### PR DESCRIPTION
## Summary

- serialize `maxOutputTokens` with Moonshot's preferred `max_completion_tokens` field
- stop sending the deprecated `max_tokens` spelling
- cover generate, stream, and undefined-option behavior

## Tests

- `pnpm test:node` (packages/moonshotai; 172 tests)
- `pnpm test:edge` (packages/moonshotai; 172 tests)
- `pnpm type-check` (packages/moonshotai)
- `pnpm type-check:full`
- `pnpm check`

Depends on #19609.
Fixes #19556.