### PR TITLE
fix(provider/moonshotai): preserve error metadata

### DIFF
--- a/.changeset/clean-kimis-errors.md
+++ b/.changeset/clean-kimis-errors.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+fix(provider/moonshotai): preserve structured API error metadata

--- a/packages/moonshotai/src/__fixtures__/moonshotai-error-message-only.json
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-error-message-only.json
@@ -1,0 +1,5 @@
+{
+  "error": {
+    "message": "Request failed"
+  }
+}

--- a/packages/moonshotai/src/__fixtures__/moonshotai-error.json
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "message": "Invalid request: invalid part type: file",
+    "type": "invalid_request_error",
+    "code": "invalid_part_type"
+  }
+}

--- a/packages/moonshotai/src/__fixtures__/moonshotai-stream-error-message-only.chunks.txt
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-stream-error-message-only.chunks.txt
@@ -1,0 +1,1 @@
+{"error":{"message":"Stream failed without details"}}

--- a/packages/moonshotai/src/__fixtures__/moonshotai-stream-error.chunks.txt
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-stream-error.chunks.txt
@@ -1,0 +1,2 @@
+{"id":"chatcmpl-stream-error","object":"chat.completion.chunk","created":1785880003,"model":"kimi-k3","choices":[{"index":0,"delta":{"role":"assistant","content":"Partial"},"finish_reason":null}]}
+{"error":{"message":"Stream failed","type":"server_error","code":"stream_failure"}}

--- a/packages/moonshotai/src/moonshotai-chat-api-types.ts
+++ b/packages/moonshotai/src/moonshotai-chat-api-types.ts
@@ -108,6 +108,7 @@ export const moonshotAIErrorSchema = z.object({
   error: z.object({
     message: z.string(),
     type: z.string().nullish(),
+    code: z.string().nullish(),
   }),
 });
 

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -40,6 +40,14 @@ function prepareChunksFixtureResponse(filename: string) {
   };
 }
 
+function prepareErrorFixtureResponse(filename: string) {
+  server.urls['https://api.moonshot.ai/v1/chat/completions'].response = {
+    type: 'error',
+    status: 400,
+    body: fs.readFileSync(`src/__fixtures__/${filename}.json`, 'utf8'),
+  };
+}
+
 describe('doGenerate', () => {
   describe('text', () => {
     beforeEach(() => {
@@ -1182,26 +1190,73 @@ describe('doGenerate', () => {
   });
 
   describe('errors', () => {
-    it('should map the moonshot error envelope', async () => {
-      server.urls['https://api.moonshot.ai/v1/chat/completions'].response = {
-        type: 'error',
-        status: 400,
-        body: JSON.stringify({
-          error: {
-            message: 'Invalid request: invalid part type: file',
-            type: 'invalid_request_error',
-          },
-        }),
-      };
+    it('should preserve the full moonshot error envelope', async () => {
+      prepareErrorFixtureResponse('moonshotai-error');
 
       await expect(
         provider.chatModel('kimi-k3').doGenerate({ prompt: TEST_PROMPT }),
-      ).rejects.toThrow('Invalid request: invalid part type: file');
+      ).rejects.toMatchObject({
+        message: 'Invalid request: invalid part type: file',
+        data: {
+          error: {
+            message: 'Invalid request: invalid part type: file',
+            type: 'invalid_request_error',
+            code: 'invalid_part_type',
+          },
+        },
+      });
+    });
+
+    it('should continue to parse message-only errors', async () => {
+      prepareErrorFixtureResponse('moonshotai-error-message-only');
+
+      await expect(
+        provider.chatModel('kimi-k3').doGenerate({ prompt: TEST_PROMPT }),
+      ).rejects.toMatchObject({
+        message: 'Request failed',
+        data: { error: { message: 'Request failed' } },
+      });
     });
   });
 });
 
 describe('doStream', () => {
+  it('should preserve structured streamed errors', async () => {
+    prepareChunksFixtureResponse('moonshotai-stream-error');
+
+    const result = await provider.chatModel('kimi-k3').doStream({
+      prompt: TEST_PROMPT,
+    });
+    const parts = await convertReadableStreamToArray(result.stream);
+
+    expect(parts).toContainEqual({
+      type: 'error',
+      error: {
+        message: 'Stream failed',
+        type: 'server_error',
+        code: 'stream_failure',
+      },
+    });
+    expect(parts.at(-1)).toMatchObject({
+      type: 'finish',
+      finishReason: { unified: 'error' },
+    });
+  });
+
+  it('should continue to parse message-only streamed errors', async () => {
+    prepareChunksFixtureResponse('moonshotai-stream-error-message-only');
+
+    const result = await provider.chatModel('kimi-k3').doStream({
+      prompt: TEST_PROMPT,
+    });
+    const parts = await convertReadableStreamToArray(result.stream);
+
+    expect(parts).toContainEqual({
+      type: 'error',
+      error: { message: 'Stream failed without details' },
+    });
+  });
+
   it('should stream reasoning and text deltas with usage', async () => {
     prepareChunksFixtureResponse('moonshotai-stream');
 

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -581,7 +581,7 @@ export class MoonshotAIChatLanguageModel implements LanguageModelV4 {
             // handle error chunks:
             if ('error' in value) {
               finishReason = { unified: 'error', raw: undefined };
-              controller.enqueue({ type: 'error', error: value.error.message });
+              controller.enqueue({ type: 'error', error: value.error });
               return;
             }
 


### PR DESCRIPTION
## Summary

- parse the official optional Moonshot error `code` field
- retain message, type, and code in non-streaming `APICallError.data`
- emit the structured error object for SSE error parts instead of reducing it to a string
- cover full and message-only HTTP/SSE envelopes with fixtures

## Tests

- `pnpm test:node` (packages/moonshotai; 176 tests)
- `pnpm test:edge` (packages/moonshotai; 176 tests)
- `pnpm type-check` (packages/moonshotai)
- `pnpm type-check:full`
- `pnpm check`

Depends on #19611.
Fixes #19552.