### PR TITLE
feat(provider/moonshotai): align models and guidance

### DIFF
--- a/.changeset/wise-kimis-models.md
+++ b/.changeset/wise-kimis-models.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+feat(provider/moonshotai): align model IDs and guidance with the official catalog

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -5,9 +5,9 @@ description: Learn how to use Moonshot AI models with the AI SDK.
 
 # Moonshot AI Provider
 
-The [Moonshot AI](https://www.moonshot.ai) provider offers access to powerful language models through the Moonshot API, including the Kimi series of models with reasoning capabilities.
+The [Moonshot AI](https://platform.kimi.ai/docs/intro) provider offers access to powerful language models through the Moonshot API, including the Kimi series of models with reasoning capabilities.
 
-API keys can be obtained from the [Moonshot Platform](https://platform.moonshot.ai).
+API keys can be obtained from the [Kimi API Platform](https://platform.kimi.ai/).
 
 ## Setup
 
@@ -154,6 +154,19 @@ console.log(reasoningText);
 console.log(text);
 ```
 
+For Kimi K2.7 Code and its high-speed variant, omit both `thinking` and
+`reasoningEffort`; thinking and preserved reasoning are always enabled:
+
+```ts
+const { text, reasoningText } = await generateText({
+  model: moonshotai('kimi-k2.7-code'),
+  prompt: 'Implement quicksort in TypeScript.',
+});
+```
+
+See Moonshot's [model parameter reference](https://platform.kimi.ai/docs/api/models-overview)
+for the current per-model constraints.
+
 See [AI SDK UI: Chatbot](/docs/ai-sdk-ui/chatbot#reasoning) for more details on how to integrate reasoning into your chatbot.
 
 ### Video Input
@@ -216,8 +229,8 @@ File parts containing inline text are sent as ordinary text content parts.
 <Note>
   Moonshot AI recommends videos up to 1080p. For larger videos, or videos you
   reuse across many requests, upload them with the [Moonshot Files
-  API](https://platform.moonshot.ai/docs/api/files) instead. Audio and PDF
-  inputs are not supported by Moonshot AI chat completions.
+  API](https://platform.kimi.ai/docs/api/files) instead. Audio and PDF inputs
+  are not supported by Moonshot AI chat completions.
 </Note>
 
 ### Provider Options
@@ -233,7 +246,8 @@ The following optional provider options are available for Moonshot AI language m
 
 - **reasoningEffort** _'low' | 'high' | 'max'_
 
-  Reasoning effort for Kimi K3.
+  Reasoning effort for Kimi K3. Supports `low`, `high`, and `max`; Moonshot's
+  default is `max`.
 
 - **logprobs** _boolean_
 
@@ -356,22 +370,29 @@ Moonshot's Chat Completions response rather than shared AI SDK result fields.
 
 ## Model Capabilities
 
-| Model                    | Image Input | Video Input | Object Generation | Tool Usage | Tool Streaming |
-| ------------------------ | ----------- | ----------- | ----------------- | ---------- | -------------- |
-| `moonshot-v1-8k`         | <Cross />   | <Cross />   | <Check />         | <Check />  | <Check />      |
-| `moonshot-v1-32k`        | <Cross />   | <Cross />   | <Check />         | <Check />  | <Check />      |
-| `moonshot-v1-128k`       | <Cross />   | <Cross />   | <Check />         | <Check />  | <Check />      |
-| `kimi-k2`                | <Cross />   | <Cross />   | <Check />         | <Check />  | <Check />      |
-| `kimi-k2.5`              | <Check />   | <Check />   | <Check />         | <Check />  | <Check />      |
-| `kimi-k2-thinking`       | <Cross />   | <Cross />   | <Check />         | <Check />  | <Check />      |
-| `kimi-k2-thinking-turbo` | <Cross />   | <Cross />   | <Check />         | <Check />  | <Check />      |
-| `kimi-k2-turbo`          | <Cross />   | <Cross />   | <Check />         | <Check />  | <Check />      |
-| `kimi-k2.6`              | <Check />   | <Check />   | <Check />         | <Check />  | <Check />      |
-| `kimi-k2.7-code`         | <Check />   | <Check />   | <Check />         | <Check />  | <Check />      |
-| `kimi-k3`                | <Check />   | <Check />   | <Check />         | <Check />  | <Check />      |
+| Model                             | Image Input | Video Input | Object Generation | Tool Usage | Tool Streaming | Status  |
+| --------------------------------- | ----------- | ----------- | ----------------- | ---------- | -------------- | ------- |
+| `moonshot-v1-auto`                | <Cross />   | <Cross />   | <Check />         | <Check />  | <Check />      | Legacy¹ |
+| `moonshot-v1-8k`                  | <Cross />   | <Cross />   | <Check />         | <Check />  | <Check />      | Legacy¹ |
+| `moonshot-v1-32k`                 | <Cross />   | <Cross />   | <Check />         | <Check />  | <Check />      | Legacy¹ |
+| `moonshot-v1-128k`                | <Cross />   | <Cross />   | <Check />         | <Check />  | <Check />      | Legacy¹ |
+| `moonshot-v1-8k-vision-preview`   | <Check />   | <Cross />   | <Check />         | <Check />  | <Check />      | Legacy¹ |
+| `moonshot-v1-32k-vision-preview`  | <Check />   | <Cross />   | <Check />         | <Check />  | <Check />      | Legacy¹ |
+| `moonshot-v1-128k-vision-preview` | <Check />   | <Cross />   | <Check />         | <Check />  | <Check />      | Legacy¹ |
+| `kimi-k2.5`                       | <Check />   | <Check />   | <Check />         | <Check />  | <Check />      | Legacy¹ |
+| `kimi-k2.6`                       | <Check />   | <Check />   | <Check />         | <Check />  | <Check />      | Current |
+| `kimi-k2.7-code`                  | <Check />   | <Check />   | <Check />         | <Check />  | <Check />      | Current |
+| `kimi-k2.7-code-highspeed`        | <Check />   | <Check />   | <Check />         | <Check />  | <Check />      | Current |
+| `kimi-k3`                         | <Check />   | <Check />   | <Check />         | <Check />  | <Check />      | Current |
+
+¹ Moonshot reports that Kimi K2.5 and the Moonshot V1 series are unavailable
+to newly registered users and have a full-platform sunset announced for
+August 31, 2026. Use Kimi K3 for new applications. Retired Kimi K2 IDs remain
+accepted through the package's custom string escape hatch but are no longer
+recommended here.
 
 <Note>
-  Please see the [Moonshot AI docs](https://platform.moonshot.ai/docs/intro) for
-  a full list of available models. You can also pass any available provider
-  model ID as a string if needed.
+  See Moonshot's [current model list](https://platform.kimi.ai/docs/models) for
+  availability and migration guidance. You can also pass any available custom or
+  retired provider model ID as a string if needed.
 </Note>

--- a/examples/ai-functions/src/generate-text/moonshot/reasoning-effort.ts
+++ b/examples/ai-functions/src/generate-text/moonshot/reasoning-effort.ts
@@ -1,0 +1,21 @@
+import {
+  moonshotai,
+  type MoonshotAILanguageModelOptions,
+} from '@ai-sdk/moonshotai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: moonshotai('kimi-k3'),
+    prompt: 'Prove that the square root of 2 is irrational.',
+    providerOptions: {
+      moonshotai: {
+        reasoningEffort: 'max',
+      } satisfies MoonshotAILanguageModelOptions,
+    },
+  });
+
+  console.log(result.reasoningText);
+  console.log(result.text);
+});

--- a/examples/ai-functions/src/stream-text/moonshot/thinking.ts
+++ b/examples/ai-functions/src/stream-text/moonshot/thinking.ts
@@ -1,30 +1,19 @@
-import {
-  moonshotai,
-  type MoonshotAILanguageModelOptions,
-} from '@ai-sdk/moonshotai';
+import { moonshotai } from '@ai-sdk/moonshotai';
 import { streamText } from 'ai';
+import { printFullStream } from '../../lib/print-full-stream';
 import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: moonshotai('kimi-k2.6'),
+    model: moonshotai('kimi-k2.7-code'),
     prompt:
-      'Solve this problem step by step: If a train travels 120 miles in 2 hours, how far will it travel in 5 hours at the same speed?',
-    providerOptions: {
-      moonshotai: {
-        thinking: {
-          type: 'enabled',
-        },
-        reasoningHistory: 'preserved',
-      } satisfies MoonshotAILanguageModelOptions,
-    },
+      'Implement a stable merge sort in TypeScript and explain its complexity.',
   });
 
-  for await (const textPart of result.textStream) {
-    process.stdout.write(textPart);
-  }
+  // K2.7 thinking and preserved reasoning are always enabled. Do not send
+  // thinking or reasoningEffort provider options.
+  await printFullStream({ result });
 
-  console.log();
   console.log('Token usage:', await result.usage);
   console.log('Finish reason:', await result.finishReason);
 });

--- a/packages/moonshotai/src/moonshotai-chat-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.ts
@@ -2,9 +2,13 @@ import type { LanguageModelV4FunctionTool } from '@ai-sdk/provider';
 import { z } from 'zod/v4';
 
 export type MoonshotAIChatModelId =
+  | 'moonshot-v1-auto'
   | 'moonshot-v1-8k'
   | 'moonshot-v1-32k'
   | 'moonshot-v1-128k'
+  | 'moonshot-v1-8k-vision-preview'
+  | 'moonshot-v1-32k-vision-preview'
+  | 'moonshot-v1-128k-vision-preview'
   | 'kimi-k2.5'
   | 'kimi-k2.6'
   | 'kimi-k2.7-code'

--- a/packages/moonshotai/src/moonshotai-provider.test-d.ts
+++ b/packages/moonshotai/src/moonshotai-provider.test-d.ts
@@ -1,0 +1,30 @@
+import { expectTypeOf } from 'vitest';
+import { moonshotai } from './index';
+
+type ModelId = Parameters<typeof moonshotai>[0];
+
+type FirstClassModelId<T> = T extends string
+  ? string extends T
+    ? never
+    : T
+  : never;
+
+expectTypeOf<FirstClassModelId<ModelId>>().toEqualTypeOf<
+  | 'moonshot-v1-auto'
+  | 'moonshot-v1-8k'
+  | 'moonshot-v1-32k'
+  | 'moonshot-v1-128k'
+  | 'moonshot-v1-8k-vision-preview'
+  | 'moonshot-v1-32k-vision-preview'
+  | 'moonshot-v1-128k-vision-preview'
+  | 'kimi-k2.5'
+  | 'kimi-k2.6'
+  | 'kimi-k2.7-code'
+  | 'kimi-k2.7-code-highspeed'
+  | 'kimi-k3'
+>();
+
+// Arbitrary, custom, and retired model IDs remain assignable for backwards
+// compatibility.
+moonshotai('custom-model');
+moonshotai('kimi-k2-thinking');


### PR DESCRIPTION
## Summary

- add first-class model IDs for every model in Moonshot's OpenAPI discriminator
- replace deprecated model recommendations with the current K3/K2.7/K2.6 catalog and mark the announced K2.5/V1 sunset
- align K3 and K2.7 reasoning examples with the current parameter guide
- replace legacy documentation URLs with current `platform.kimi.ai` pages

## Tests

- `pnpm test:node` (packages/moonshotai; 176 tests)
- `pnpm test:edge` (packages/moonshotai; 176 tests)
- `pnpm type-check` (packages/moonshotai, including model-ID type test)
- `pnpm type-check:full`
- `pnpm check`

Depends on #19612.
Fixes #19555.