### PR TITLE
fix(provider/moonshotai): gate sampling by model (v5 backport)

### DIFF
--- a/.changeset/tidy-moons-sample.md
+++ b/.changeset/tidy-moons-sample.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+fix(provider/moonshotai): omit unsupported sampling parameters for Kimi models

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -91,6 +91,11 @@ const model = moonshotai.languageModel('kimi-k3');
 Moonshot AI language models can be used in the `streamText` function
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
+Moonshot V1 models support the standard `temperature`, `topP`,
+`presencePenalty`, and `frequencyPenalty` settings. Kimi models use fixed
+sampling parameters; the provider omits those settings for Kimi requests and
+returns an unsupported-setting warning when they are supplied.
+
 ### Reasoning Models
 
 Kimi K3 always reasons. It currently supports only the `max` reasoning effort,

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -17,6 +17,30 @@ const server = createTestServer({
   'https://api.moonshot.ai/v1/chat/completions': {},
 });
 
+function prepareJsonResponse() {
+  server.urls['https://api.moonshot.ai/v1/chat/completions'].response = {
+    type: 'json-value',
+    body: {
+      id: 'chatcmpl-sampling',
+      object: 'chat.completion',
+      created: 1785880000,
+      model: 'kimi-k3',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: 'Hello' },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: {
+        prompt_tokens: 1,
+        completion_tokens: 1,
+        total_tokens: 2,
+      },
+    },
+  };
+}
+
 function prepareChunksFixtureResponse(filename: string) {
   const chunks = fs
     .readFileSync(`src/__fixtures__/${filename}.chunks.txt`, 'utf8')
@@ -32,7 +56,112 @@ function prepareChunksFixtureResponse(filename: string) {
 }
 
 describe('MoonshotAIChatLanguageModel', () => {
+  describe('doGenerate', () => {
+    beforeEach(() => {
+      prepareJsonResponse();
+    });
+
+    it.each([
+      'kimi-k2.5',
+      'kimi-k2.6',
+      'kimi-k2.7-code',
+      'kimi-k2.7-code-highspeed',
+      'kimi-k3',
+    ] as const)(
+      'should omit fixed sampling options and warn for %s',
+      async modelId => {
+        const result = await provider.chatModel(modelId).doGenerate({
+          prompt: TEST_PROMPT,
+          temperature: 0.2,
+          topP: 0.4,
+          frequencyPenalty: 0.5,
+          presencePenalty: 0.6,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: modelId,
+          messages: [{ role: 'user', content: 'Hello' }],
+        });
+        expect(result.warnings).toStrictEqual([
+          {
+            type: 'unsupported-setting',
+            setting: 'temperature',
+            details: `temperature is fixed by model "${modelId}" and has been omitted.`,
+          },
+          {
+            type: 'unsupported-setting',
+            setting: 'topP',
+            details: `topP is fixed by model "${modelId}" and has been omitted.`,
+          },
+          {
+            type: 'unsupported-setting',
+            setting: 'frequencyPenalty',
+            details: `frequencyPenalty is fixed by model "${modelId}" and has been omitted.`,
+          },
+          {
+            type: 'unsupported-setting',
+            setting: 'presencePenalty',
+            details: `presencePenalty is fixed by model "${modelId}" and has been omitted.`,
+          },
+        ]);
+      },
+    );
+
+    it.each(['moonshot-v1-8k', 'custom-model'] as const)(
+      'should preserve sampling options for %s',
+      async modelId => {
+        const result = await provider.chatModel(modelId).doGenerate({
+          prompt: TEST_PROMPT,
+          temperature: 0.2,
+          topP: 0.4,
+          frequencyPenalty: 0.5,
+          presencePenalty: 0.6,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          model: modelId,
+          temperature: 0.2,
+          top_p: 0.4,
+          frequency_penalty: 0.5,
+          presence_penalty: 0.6,
+        });
+        expect(result.warnings).toStrictEqual([]);
+      },
+    );
+  });
+
   describe('doStream', () => {
+    it('should omit sampling options and add v2 warnings when streaming', async () => {
+      prepareChunksFixtureResponse('moonshot-text');
+
+      const result = await provider.chatModel('kimi-k3').doStream({
+        prompt: TEST_PROMPT,
+        temperature: 0.2,
+        topP: 0.4,
+      });
+      const parts = await convertReadableStreamToArray(result.stream);
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).not.toHaveProperty('temperature');
+      expect(requestBody).not.toHaveProperty('top_p');
+      expect(parts[0]).toStrictEqual({
+        type: 'stream-start',
+        warnings: [
+          {
+            type: 'unsupported-setting',
+            setting: 'temperature',
+            details:
+              'temperature is fixed by model "kimi-k3" and has been omitted.',
+          },
+          {
+            type: 'unsupported-setting',
+            setting: 'topP',
+            details: 'topP is fixed by model "kimi-k3" and has been omitted.',
+          },
+        ],
+      });
+    });
+
     describe('cached tokens at top level (MoonshotAI format)', () => {
       beforeEach(() => {
         prepareChunksFixtureResponse('moonshot-cached-tokens');

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -2,10 +2,59 @@ import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
 import type { OpenAICompatibleChatConfig } from '@ai-sdk/openai-compatible/internal';
 import type {
   LanguageModelV2,
+  LanguageModelV2CallOptions,
+  LanguageModelV2CallWarning,
   LanguageModelV2StreamPart,
 } from '@ai-sdk/provider';
 import { convertMoonshotAIChatUsage } from './convert-moonshotai-chat-usage';
-import type { MoonshotAIChatModelId } from './moonshotai-chat-options';
+import {
+  isMoonshotAIKimiModel,
+  type MoonshotAIChatModelId,
+} from './moonshotai-chat-options';
+
+function prepareSamplingOptions({
+  modelId,
+  options,
+}: {
+  modelId: MoonshotAIChatModelId;
+  options: LanguageModelV2CallOptions;
+}): {
+  options: LanguageModelV2CallOptions;
+  warnings: LanguageModelV2CallWarning[];
+} {
+  if (!isMoonshotAIKimiModel(modelId)) {
+    return { options, warnings: [] };
+  }
+
+  const warnings: LanguageModelV2CallWarning[] = [];
+  const samplingSettings = [
+    ['temperature', options.temperature],
+    ['topP', options.topP],
+    ['frequencyPenalty', options.frequencyPenalty],
+    ['presencePenalty', options.presencePenalty],
+  ] as const;
+
+  for (const [setting, value] of samplingSettings) {
+    if (value != null) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting,
+        details: `${setting} is fixed by model "${modelId}" and has been omitted.`,
+      });
+    }
+  }
+
+  return {
+    options: {
+      ...options,
+      temperature: undefined,
+      topP: undefined,
+      frequencyPenalty: undefined,
+      presencePenalty: undefined,
+    },
+    warnings,
+  };
+}
 
 export class MoonshotAIChatLanguageModel extends OpenAICompatibleChatLanguageModel {
   constructor(
@@ -18,7 +67,9 @@ export class MoonshotAIChatLanguageModel extends OpenAICompatibleChatLanguageMod
   async doGenerate(
     options: Parameters<LanguageModelV2['doGenerate']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV2['doGenerate']>>> {
-    const result = await super.doGenerate(options);
+    const { options: sanitizedOptions, warnings: samplingWarnings } =
+      prepareSamplingOptions({ modelId: this.modelId, options });
+    const result = await super.doGenerate(sanitizedOptions);
 
     // @ts-expect-error accessing response body from parent result
     const usage = result.response?.body?.usage;
@@ -26,6 +77,7 @@ export class MoonshotAIChatLanguageModel extends OpenAICompatibleChatLanguageMod
     return {
       ...result,
       usage: convertMoonshotAIChatUsage(usage),
+      warnings: [...result.warnings, ...samplingWarnings],
     };
   }
 
@@ -33,12 +85,14 @@ export class MoonshotAIChatLanguageModel extends OpenAICompatibleChatLanguageMod
     options: Parameters<LanguageModelV2['doStream']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV2['doStream']>>> {
     const originalIncludeRawChunks = options.includeRawChunks;
+    const { options: sanitizedOptions, warnings: samplingWarnings } =
+      prepareSamplingOptions({ modelId: this.modelId, options });
 
     // Enable raw chunks to capture pre-Zod usage data, since MoonshotAI
     // returns cached_tokens at the top level of usage (not nested in
     // prompt_tokens_details) and the parent's z.object() schema strips it.
     const result = await super.doStream({
-      ...options,
+      ...sanitizedOptions,
       includeRawChunks: true,
     });
 
@@ -52,6 +106,14 @@ export class MoonshotAIChatLanguageModel extends OpenAICompatibleChatLanguageMod
           LanguageModelV2StreamPart
         >({
           transform(chunk, controller) {
+            if (chunk.type === 'stream-start') {
+              controller.enqueue({
+                ...chunk,
+                warnings: [...chunk.warnings, ...samplingWarnings],
+              });
+              return;
+            }
+
             if (chunk.type === 'raw') {
               // Capture raw usage data before Zod strips cached_tokens
               const rawValue = chunk.rawValue as Record<string, unknown>;

--- a/packages/moonshotai/src/moonshotai-chat-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.ts
@@ -13,6 +13,16 @@ export type MoonshotAIChatModelId =
   | 'kimi-k3'
   | (string & {});
 
+export function isMoonshotAIKimiModel(modelId: MoonshotAIChatModelId): boolean {
+  return (
+    modelId === 'kimi-k2.5' ||
+    modelId === 'kimi-k2.6' ||
+    modelId === 'kimi-k2.7-code' ||
+    modelId === 'kimi-k2.7-code-highspeed' ||
+    modelId === 'kimi-k3'
+  );
+}
+
 export const moonshotaiProviderOptions = z.object({
   /**
    * Reasoning effort for Kimi K3. Currently, only `max` is supported.


### PR DESCRIPTION
## Summary

Version-adapted backport of #19563 to `release-v5.0`.

- sanitize fixed sampling settings in the Moonshot subclass before calling the shared OpenAI-compatible adapter
- preserve sampling controls for Moonshot V1 and custom model IDs
- merge v2-format warnings into generate results and streaming `stream-start` parts

## Tests

- `pnpm test:node` (packages/moonshotai; 27 tests)
- `pnpm test:edge` (packages/moonshotai; 27 tests)
- `pnpm type-check` (packages/moonshotai)
- `pnpm type-check:full`
- `pnpm check`

Backports #19563.
Tracks #19543.