### PR TITLE
fix(provider/moonshotai): preserve complete raw usage objects

### DIFF
--- a/.changeset/loose-kimis-usage.md
+++ b/.changeset/loose-kimis-usage.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+fix(provider/moonshotai): preserve complete raw usage objects

--- a/packages/moonshotai/src/moonshotai-chat-api-types.ts
+++ b/packages/moonshotai/src/moonshotai-chat-api-types.ts
@@ -83,19 +83,20 @@ export interface MoonshotAIToolMessage {
 // Schemas below are limited versions focused on what the implementation
 // needs. This limits breakages when the API changes and increases efficiency.
 
+// Loose, nested objects included: the parsed value is returned as `usage.raw`.
 const tokenUsageSchema = z
-  .object({
+  .looseObject({
     prompt_tokens: z.number().nullish(),
     completion_tokens: z.number().nullish(),
     cached_tokens: z.number().nullish(),
     total_tokens: z.number().nullish(),
     prompt_tokens_details: z
-      .object({
+      .looseObject({
         cached_tokens: z.number().nullish(),
       })
       .nullish(),
     completion_tokens_details: z
-      .object({
+      .looseObject({
         reasoning_tokens: z.number().nullish(),
       })
       .nullish(),

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -270,6 +270,90 @@ describe('doGenerate', () => {
         expect(result.providerMetadata).toEqual({ moonshotai: {} });
       },
     );
+
+    it('should preserve extra top-level and nested fields in raw usage', async () => {
+      server.urls['https://api.moonshot.ai/v1/chat/completions'].response = {
+        type: 'json-value',
+        body: {
+          id: 'chatcmpl-raw-usage',
+          object: 'chat.completion',
+          created: 1785880000,
+          model: 'kimi-k3',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'Hello' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: {
+            prompt_tokens: 100,
+            completion_tokens: 50,
+            total_tokens: 150,
+            cached_tokens: 20,
+            provider_usage_id: 'usage-123',
+            prompt_tokens_details: {
+              cached_tokens: 20,
+              cache_type: 'ephemeral',
+            },
+            completion_tokens_details: {
+              reasoning_tokens: 10,
+              billable_tokens: 42,
+            },
+          },
+        },
+      };
+
+      const result = await provider.chatModel('kimi-k3').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.usage).toMatchObject({
+        inputTokens: { total: 100, noCache: 80, cacheRead: 20 },
+        outputTokens: { total: 50, text: 40, reasoning: 10 },
+        raw: {
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+          cached_tokens: 20,
+          provider_usage_id: 'usage-123',
+          prompt_tokens_details: {
+            cached_tokens: 20,
+            cache_type: 'ephemeral',
+          },
+          completion_tokens_details: {
+            reasoning_tokens: 10,
+            billable_tokens: 42,
+          },
+        },
+      });
+    });
+
+    it('should continue validating known usage field types', async () => {
+      server.urls['https://api.moonshot.ai/v1/chat/completions'].response = {
+        type: 'json-value',
+        body: {
+          id: 'chatcmpl-invalid-usage',
+          created: 1785880000,
+          model: 'kimi-k3',
+          choices: [
+            {
+              message: { role: 'assistant', content: 'Hello' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: {
+            prompt_tokens: '100',
+            completion_tokens: 50,
+            total_tokens: 150,
+          },
+        },
+      };
+
+      await expect(
+        provider.chatModel('kimi-k3').doGenerate({ prompt: TEST_PROMPT }),
+      ).rejects.toThrow();
+    });
   });
 
   describe('video input', () => {
@@ -1592,6 +1676,71 @@ describe('doStream', () => {
       },
     });
   });
+
+  it.each(['choice-level finish chunk', 'separate top-level usage chunk'])(
+    'should preserve extra fields in streamed raw usage from a %s',
+    async usageLocation => {
+      const usage = {
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        total_tokens: 150,
+        cached_tokens: 20,
+        provider_usage_id: 'usage-123',
+        prompt_tokens_details: {
+          cached_tokens: 20,
+          cache_type: 'ephemeral',
+        },
+        completion_tokens_details: {
+          reasoning_tokens: 10,
+          billable_tokens: 42,
+        },
+      };
+      const finishChunk = {
+        id: 'chatcmpl-raw-usage',
+        object: 'chat.completion.chunk',
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: 'stop',
+            ...(usageLocation === 'choice-level finish chunk' && { usage }),
+          },
+        ],
+      };
+      const chunks: Array<Record<string, unknown>> = [finishChunk];
+
+      if (usageLocation === 'separate top-level usage chunk') {
+        chunks.push({
+          id: 'chatcmpl-raw-usage',
+          object: 'chat.completion.chunk',
+          choices: [],
+          usage,
+        });
+      }
+
+      server.urls['https://api.moonshot.ai/v1/chat/completions'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          ...chunks.map(chunk => `data: ${JSON.stringify(chunk)}\n\n`),
+          'data: [DONE]\n\n',
+        ],
+      };
+
+      const result = await provider.chatModel('kimi-k3').doStream({
+        prompt: TEST_PROMPT,
+      });
+      const parts = await convertReadableStreamToArray(result.stream);
+
+      expect(parts.at(-1)).toMatchObject({
+        type: 'finish',
+        usage: {
+          inputTokens: { total: 100, noCache: 80, cacheRead: 20 },
+          outputTokens: { total: 50, text: 40, reasoning: 10 },
+          raw: usage,
+        },
+      });
+    },
+  );
 
   it('should include stream options with usage', async () => {
     prepareChunksFixtureResponse('moonshotai-stream');


### PR DESCRIPTION
Closes #19619

Stacked on #19613; the base will advance with the Moonshot parity stack.

## Summary

- parse Moonshot usage and known token-detail objects with loose schemas
- preserve future provider-specific top-level and nested fields in `usage.raw`
- keep normalized input, cache, output, and reasoning counts unchanged
- cover normal and streaming responses with regression tests

## Verification

- `pnpm --filter @ai-sdk/moonshotai test:node` (178 passed)
- `pnpm --filter @ai-sdk/moonshotai test:edge` (178 passed)
- `pnpm --filter @ai-sdk/moonshotai type-check`
- `pnpm type-check:full`
- `pnpm check`

## Backports

- v6: applicable after this PR merges
- v5: not applicable because `LanguageModelV2Usage` has no `raw` field