### PR TITLE
feat(workflow): add durable video generation

### DIFF
--- a/.changeset/durable-video-webhooks.md
+++ b/.changeset/durable-video-webhooks.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/workflow': patch
+---
+
+Add durable video generation that waits for a Workflow webhook and returns provider video data without downloading hosted URLs.

--- a/content/docs/07-reference/04-ai-sdk-workflow/03-generate-video.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/03-generate-video.mdx
@@ -17,7 +17,7 @@ them in another step without serializing the video bytes through workflow step
 boundaries.
 
 ```ts
-import { experimental_generateVideo as generateVideo } from '@ai-sdk/workflow';
+import { experimental_generateVideo as generateVideo } from '@ai-sdk/workflow/video';
 
 export async function videoWorkflow(prompt: string) {
   'use workflow';
@@ -38,7 +38,7 @@ provider webhooks. The helper must be called from a Workflow SDK workflow.
 ## Import
 
 <Snippet
-  text={`import { experimental_generateVideo as generateVideo } from "@ai-sdk/workflow"`}
+  text={`import { experimental_generateVideo as generateVideo } from "@ai-sdk/workflow/video"`}
   prompt={false}
 />
 

--- a/content/docs/07-reference/04-ai-sdk-workflow/03-generate-video.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/03-generate-video.mdx
@@ -1,0 +1,156 @@
+---
+title: generateVideo
+description: API Reference for durable video generation in workflows.
+---
+
+# `generateVideo()`
+
+Generates videos durably inside a workflow. The helper starts an asynchronous
+video generation job with a Workflow webhook URL, suspends the workflow until
+the provider sends a terminal notification, and then retrieves the completed
+result with one status request.
+
+Unlike [`experimental_generateVideo`](/docs/reference/ai-sdk-core/generate-video)
+from `ai`, this helper does not download provider-hosted videos. URL results
+remain URLs so your workflow can decide whether to persist, copy, or process
+them in another step without serializing the video bytes through workflow step
+boundaries.
+
+```ts
+import { experimental_generateVideo as generateVideo } from '@ai-sdk/workflow';
+
+export async function videoWorkflow(prompt: string) {
+  'use workflow';
+
+  const result = await generateVideo({
+    model: 'klingai/kling-v3.0-t2v',
+    prompt,
+  });
+
+  return result.videos;
+}
+```
+
+The selected model must support asynchronous start and status operations and
+provider webhooks. The helper must be called from a Workflow SDK workflow.
+
+## Import
+
+<Snippet
+  text={`import { experimental_generateVideo as generateVideo } from "@ai-sdk/workflow"`}
+  prompt={false}
+/>
+
+## Parameters
+
+The helper accepts the same parameters as `experimental_startVideo` from `ai`,
+except `webhookUrl` and `abortSignal`. It creates and manages the webhook URL.
+
+<PropertiesTable
+  content={[
+    {
+      name: 'model',
+      type: 'VideoModel',
+      isRequired: true,
+      description:
+        'The asynchronous video model to use. A string compatible with Vercel AI Gateway or a serializable provider model.',
+    },
+    {
+      name: 'prompt',
+      type: 'string | GenerateVideoPrompt',
+      isRequired: true,
+      description: 'The prompt or image prompt used to generate the video.',
+    },
+    {
+      name: 'n',
+      type: 'number',
+      isOptional: true,
+      description: 'Number of videos to generate. Default: 1.',
+    },
+    {
+      name: 'aspectRatio',
+      type: '`${number}:${number}` | "adaptive"',
+      isOptional: true,
+      description: 'Aspect ratio of the generated videos.',
+    },
+    {
+      name: 'resolution',
+      type: '`${number}x${number}`',
+      isOptional: true,
+      description: 'Resolution of the generated videos.',
+    },
+    {
+      name: 'duration',
+      type: 'number',
+      isOptional: true,
+      description: 'Duration of each generated video in seconds.',
+    },
+    {
+      name: 'maxVideosPerCall',
+      type: 'number',
+      isOptional: true,
+      description: 'Maximum number of videos that may be started in one call.',
+    },
+    {
+      name: 'fps',
+      type: 'number',
+      isOptional: true,
+      description: 'Frames per second for the generated videos.',
+    },
+    {
+      name: 'seed',
+      type: 'number',
+      isOptional: true,
+      description: 'Seed used for deterministic generation when supported.',
+    },
+    {
+      name: 'frameImages',
+      type: 'Array<{ image: DataContent; frameType: VideoModelV4FrameType }>',
+      isOptional: true,
+      description: 'Role-tagged first and last frame images.',
+    },
+    {
+      name: 'inputReferences',
+      type: 'Array<DataContent | { data: DataContent; mediaType?: string }>',
+      isOptional: true,
+      description: 'Reference images or videos for the generation.',
+    },
+    {
+      name: 'generateAudio',
+      type: 'boolean',
+      isOptional: true,
+      description: 'Whether to generate audio with the video.',
+    },
+    {
+      name: 'providerOptions',
+      type: 'ProviderOptions',
+      isOptional: true,
+      description: 'Additional provider-specific options.',
+    },
+    {
+      name: 'headers',
+      type: 'Record<string, string>',
+      isOptional: true,
+      description: 'Additional HTTP headers for start and status requests.',
+    },
+    {
+      name: 'maxRetries',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Maximum number of AI SDK retries for each start and status request. Default: 2.',
+    },
+  ]}
+/>
+
+## Returns
+
+Returns the completed status result from the provider. `videos` contains raw
+provider video data discriminated by `type`:
+
+- `url`: A provider-hosted URL and media type
+- `base64`: Base64-encoded video data and media type
+- `binary`: A `Uint8Array` and media type
+
+Hosted URLs can expire. Handle any video you need to retain in a separate
+workflow step.

--- a/content/docs/07-reference/04-ai-sdk-workflow/03-generate-video.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/03-generate-video.mdx
@@ -22,6 +22,7 @@ import { experimental_generateVideo as generateVideo } from '@ai-sdk/workflow';
 export async function videoWorkflow(prompt: string) {
   'use workflow';
 
+  // The workflow suspends while the video renders, consuming no compute.
   const result = await generateVideo({
     model: 'klingai/kling-v3.0-t2v',
     prompt,

--- a/content/docs/07-reference/04-ai-sdk-workflow/index.mdx
+++ b/content/docs/07-reference/04-ai-sdk-workflow/index.mdx
@@ -22,5 +22,11 @@ collapsed: true
         'Chat transport with automatic stream reconnection for workflow-based apps.',
       href: '/docs/reference/ai-sdk-workflow/workflow-chat-transport',
     },
+    {
+      title: 'generateVideo',
+      description:
+        'Generate videos durably with provider webhooks and no implicit downloads.',
+      href: '/docs/reference/ai-sdk-workflow/generate-video',
+    },
   ]}
 />

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -49,7 +49,7 @@ workflow until a provider webhook arrives, and returns the provider's video
 data without downloading hosted URLs.
 
 ```typescript
-import { experimental_generateVideo as generateVideo } from '@ai-sdk/workflow';
+import { experimental_generateVideo as generateVideo } from '@ai-sdk/workflow/video';
 
 export async function videoWorkflow(prompt: string) {
   'use workflow';

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -42,6 +42,30 @@ console.log('Final messages:', result.messages);
 console.log('Steps:', result.steps);
 ```
 
+### Durable video generation
+
+`experimental_generateVideo` starts asynchronous video generation, suspends the
+workflow until a provider webhook arrives, and returns the provider's video
+data without downloading hosted URLs.
+
+```typescript
+import { experimental_generateVideo as generateVideo } from '@ai-sdk/workflow';
+
+export async function videoWorkflow(prompt: string) {
+  'use workflow';
+
+  const result = await generateVideo({
+    model: 'klingai/kling-v3.0-t2v',
+    prompt,
+  });
+
+  return result.videos;
+}
+```
+
+The workflow can persist, copy, or process each returned video URL in a
+separate step without serializing the video bytes through the workflow.
+
 ## Features
 
 - **Streaming Support**: Stream responses in real-time
@@ -52,6 +76,7 @@ console.log('Steps:', result.steps);
 - **Step Callbacks**: Hook into each step of the agent loop
 - **Provider-Executed Tools**: Support for provider-executed tools
 - **Abort Support**: Cancel operations with AbortSignal
+- **Durable Video Generation**: Suspend on video webhooks without polling or automatically downloading hosted videos
 
 ## API
 

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -35,6 +35,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./video": {
+      "types": "./dist/video.d.ts",
+      "import": "./dist/video.js",
+      "default": "./dist/video.js"
     }
   },
   "dependencies": {

--- a/packages/workflow/src/generate-video.integration.test.ts
+++ b/packages/workflow/src/generate-video.integration.test.ts
@@ -1,0 +1,20 @@
+import { expect, it } from 'vitest';
+import { start } from 'workflow/api';
+import { videoGenerationWorkflow } from './test/video-generation-workflow.js';
+
+it('suspends on a webhook and returns provider video URLs', async () => {
+  const run = await start(videoGenerationWorkflow);
+
+  await expect(run.returnValue).resolves.toMatchObject({
+    status: 'completed',
+    videos: [
+      {
+        type: 'url',
+        url: 'https://example.com/video.mp4',
+        mediaType: 'video/mp4',
+      },
+    ],
+    warnings: [{ type: 'other', message: 'start warning' }],
+  });
+  await expect(run.status).resolves.toBe('completed');
+});

--- a/packages/workflow/src/generate-video.test.ts
+++ b/packages/workflow/src/generate-video.test.ts
@@ -1,0 +1,256 @@
+import type {
+  Experimental_VideoModelV4,
+  Experimental_VideoModelV4VideoData,
+} from '@ai-sdk/provider';
+import { createWebhook, getStepMetadata } from 'workflow';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { experimental_generateVideo } from './generate-video.js';
+
+vi.mock('workflow', () => ({
+  createWebhook: vi.fn(),
+  getStepMetadata: vi.fn(() => ({ stepId: 'step-1' })),
+}));
+
+const response = {
+  timestamp: new Date(0),
+  modelId: 'test-model',
+  headers: {},
+};
+
+function mockWebhook() {
+  let resolve!: () => void;
+  const dispose = vi.fn();
+  const promise = new Promise<Request>(resolvePromise => {
+    resolve = () =>
+      resolvePromise(new Request('https://example.com/workflow-webhook'));
+  });
+  const webhook = Object.assign(promise, {
+    url: 'https://example.com/workflow-webhook',
+    [Symbol.dispose]: dispose,
+  });
+
+  vi.mocked(createWebhook).mockReturnValue(
+    webhook as unknown as ReturnType<typeof createWebhook>,
+  );
+
+  return { dispose, resolve };
+}
+
+function createVideoModel({
+  doStart,
+  doStatus,
+}: Pick<Experimental_VideoModelV4, 'doStart' | 'doStatus'>) {
+  return {
+    specificationVersion: 'v4' as const,
+    provider: 'test-provider',
+    modelId: 'test-model',
+    maxVideosPerCall: 1,
+    handleWebhookOption: async ({ webhook }) => {
+      const result = await webhook();
+      return { webhookUrl: result.url, received: result.received };
+    },
+    doStart,
+    doStatus,
+  } satisfies Experimental_VideoModelV4;
+}
+
+describe('experimental_generateVideo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getStepMetadata).mockReturnValue({
+      stepId: 'step-1',
+    } as ReturnType<typeof getStepMetadata>);
+  });
+
+  it('waits for the webhook and returns provider video data unchanged', async () => {
+    const { dispose, resolve } = mockWebhook();
+    const videos: Experimental_VideoModelV4VideoData[] = [
+      {
+        type: 'url',
+        url: 'https://example.com/video.mp4',
+        mediaType: 'video/mp4',
+      },
+      {
+        type: 'base64',
+        data: 'YmFzZTY0',
+        mediaType: 'video/mp4',
+      },
+      {
+        type: 'binary',
+        data: new Uint8Array([1, 2, 3]),
+        mediaType: 'video/mp4',
+      },
+    ];
+    const doStart = vi.fn(
+      async (
+        _options: Parameters<
+          NonNullable<Experimental_VideoModelV4['doStart']>
+        >[0],
+      ) => ({
+        operation: { id: 'operation-1' },
+        warnings: [{ type: 'other' as const, message: 'start warning' }],
+        response,
+      }),
+    );
+    const doStatus = vi.fn(
+      async (
+        _options: Parameters<
+          NonNullable<Experimental_VideoModelV4['doStatus']>
+        >[0],
+      ) => {
+        expect(dispose).toHaveBeenCalledOnce();
+        return {
+          status: 'completed' as const,
+          videos,
+          warnings: [],
+          response,
+        };
+      },
+    );
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const model = createVideoModel({ doStart, doStatus });
+
+    const resultPromise = experimental_generateVideo({
+      model,
+      prompt: 'A lighthouse in fog',
+      headers: { 'x-test': 'test' },
+      maxRetries: 1,
+    });
+
+    await vi.waitFor(() => expect(doStart).toHaveBeenCalledOnce());
+    expect(doStart.mock.calls[0][0].webhookUrl).toBe(
+      'https://example.com/workflow-webhook',
+    );
+    expect(doStart.mock.calls[0][0].headers).toMatchObject({
+      'idempotency-key': 'aisdk_workflow_video_step-1',
+      'x-test': 'test',
+    });
+    expect(doStatus).not.toHaveBeenCalled();
+
+    resolve();
+
+    const result = await resultPromise;
+    expect(doStatus).toHaveBeenCalledOnce();
+    expect(doStatus.mock.calls[0][0].operation).toEqual({ id: 'operation-1' });
+    expect(result.videos).toEqual(videos);
+    expect(result.warnings).toEqual([
+      { type: 'other', message: 'start warning' },
+    ]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it('throws when the provider reports an error', async () => {
+    const { resolve } = mockWebhook();
+    const model = createVideoModel({
+      doStart: async () => ({
+        operation: { id: 'operation-1' },
+        warnings: [],
+        response,
+      }),
+      doStatus: async () => ({
+        status: 'error',
+        error: 'Video generation failed',
+        response,
+      }),
+    });
+
+    const resultPromise = experimental_generateVideo({
+      model,
+      prompt: 'A lighthouse in fog',
+    });
+    resolve();
+
+    await expect(resultPromise).rejects.toThrow('Video generation failed');
+  });
+
+  it('preserves a caller-provided idempotency key', async () => {
+    const { resolve } = mockWebhook();
+    const doStart = vi.fn(
+      async (
+        _options: Parameters<
+          NonNullable<Experimental_VideoModelV4['doStart']>
+        >[0],
+      ) => ({
+        operation: { id: 'operation-1' },
+        warnings: [],
+        response,
+      }),
+    );
+    const model = createVideoModel({
+      doStart,
+      doStatus: async () => ({
+        status: 'completed',
+        videos: [],
+        warnings: [],
+        response,
+      }),
+    });
+
+    const resultPromise = experimental_generateVideo({
+      model,
+      prompt: 'A lighthouse in fog',
+      headers: { 'Idempotency-Key': 'custom-key' },
+    });
+    resolve();
+    await resultPromise;
+
+    expect(doStart.mock.calls[0][0].headers).toMatchObject({
+      'idempotency-key': 'custom-key',
+    });
+    expect(getStepMetadata).not.toHaveBeenCalled();
+  });
+
+  it('throws when the video is pending after the webhook notification', async () => {
+    const { resolve } = mockWebhook();
+    const model = createVideoModel({
+      doStart: async () => ({
+        operation: { id: 'operation-1' },
+        warnings: [],
+        response,
+      }),
+      doStatus: async () => ({
+        status: 'pending',
+        response,
+      }),
+    });
+
+    const resultPromise = experimental_generateVideo({
+      model,
+      prompt: 'A lighthouse in fog',
+    });
+    resolve();
+
+    await expect(resultPromise).rejects.toThrow(
+      'Video generation did not complete after webhook notification.',
+    );
+  });
+
+  it('rejects provider models without native webhook support', async () => {
+    const model: Experimental_VideoModelV4 = {
+      specificationVersion: 'v4',
+      provider: 'test-provider',
+      modelId: 'test-model',
+      maxVideosPerCall: 1,
+      doStart: async () => ({
+        operation: { id: 'operation-1' },
+        warnings: [],
+        response,
+      }),
+      doStatus: async () => ({
+        status: 'pending',
+        response,
+      }),
+    };
+
+    await expect(
+      experimental_generateVideo({
+        model,
+        prompt: 'A lighthouse in fog',
+      }),
+    ).rejects.toThrow(
+      'Workflow video generation requires a model with native webhook support.',
+    );
+    expect(createWebhook).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workflow/src/generate-video.ts
+++ b/packages/workflow/src/generate-video.ts
@@ -1,0 +1,120 @@
+import {
+  experimental_getVideoStatus,
+  experimental_startVideo,
+  type GetVideoStatusResult,
+  type StartVideoResult,
+} from 'ai';
+import { createWebhook, getStepMetadata } from 'workflow';
+
+type StartVideoOptions = Parameters<typeof experimental_startVideo>[0];
+type GetVideoStatusOptions = Parameters<typeof experimental_getVideoStatus>[1];
+
+/**
+ * Options for durable video generation in a workflow.
+ */
+export type WorkflowGenerateVideoOptions = Omit<
+  StartVideoOptions,
+  'abortSignal' | 'webhookUrl'
+>;
+
+/**
+ * A completed video generation result containing provider video data.
+ * Hosted videos remain URLs and are not downloaded automatically.
+ */
+export type WorkflowGenerateVideoResult = Extract<
+  GetVideoStatusResult,
+  { status: 'completed' }
+>;
+
+async function startVideoStep(
+  options: StartVideoOptions,
+): Promise<StartVideoResult> {
+  'use step';
+
+  const hasIdempotencyKey = Object.keys(options.headers ?? {}).some(
+    key => key.toLowerCase() === 'idempotency-key',
+  );
+
+  return experimental_startVideo({
+    ...options,
+    headers: {
+      ...options.headers,
+      ...(hasIdempotencyKey
+        ? {}
+        : {
+            'idempotency-key': `aisdk_workflow_video_${getStepMetadata().stepId}`,
+          }),
+    },
+  });
+}
+
+startVideoStep.maxRetries = 0;
+
+async function getVideoStatusStep(
+  model: StartVideoOptions['model'],
+  options: GetVideoStatusOptions,
+): Promise<GetVideoStatusResult> {
+  'use step';
+
+  return experimental_getVideoStatus(model, options);
+}
+
+getVideoStatusStep.maxRetries = 0;
+
+/**
+ * Generates a video durably inside a workflow using a provider webhook.
+ *
+ * The workflow suspends without consuming compute until the provider calls the
+ * generated webhook URL. The returned video data is not downloaded, allowing
+ * the workflow to decide how to handle provider-hosted URLs.
+ */
+export async function experimental_generateVideo(
+  options: WorkflowGenerateVideoOptions,
+): Promise<WorkflowGenerateVideoResult> {
+  if (
+    typeof options.model !== 'string' &&
+    (options.model.specificationVersion !== 'v4' ||
+      options.model.handleWebhookOption == null)
+  ) {
+    throw new Error(
+      'Workflow video generation requires a model with native webhook support.',
+    );
+  }
+
+  let operation: StartVideoResult['operation'];
+  let startWarnings: StartVideoResult['warnings'];
+
+  {
+    using webhook = createWebhook();
+
+    const startResult = await startVideoStep({
+      ...options,
+      webhookUrl: webhook.url,
+    });
+
+    operation = startResult.operation;
+    startWarnings = startResult.warnings;
+    await webhook;
+  }
+
+  const statusResult = await getVideoStatusStep(options.model, {
+    operation,
+    headers: options.headers,
+    maxRetries: options.maxRetries,
+  });
+
+  if (statusResult.status === 'error') {
+    throw new Error(statusResult.error);
+  }
+
+  if (statusResult.status !== 'completed') {
+    throw new Error(
+      'Video generation did not complete after webhook notification.',
+    );
+  }
+
+  return {
+    ...statusResult,
+    warnings: [...startWarnings, ...statusResult.warnings],
+  };
+}

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -47,3 +47,9 @@ export {
 } from './workflow-chat-transport.js';
 
 export { normalizeUIMessageStreamParts } from './normalize-ui-message-stream.js';
+
+export {
+  experimental_generateVideo,
+  type WorkflowGenerateVideoOptions,
+  type WorkflowGenerateVideoResult,
+} from './generate-video.js';

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -47,9 +47,3 @@ export {
 } from './workflow-chat-transport.js';
 
 export { normalizeUIMessageStreamParts } from './normalize-ui-message-stream.js';
-
-export {
-  experimental_generateVideo,
-  type WorkflowGenerateVideoOptions,
-  type WorkflowGenerateVideoResult,
-} from './generate-video.js';

--- a/packages/workflow/src/test/serializable-video-model.ts
+++ b/packages/workflow/src/test/serializable-video-model.ts
@@ -1,0 +1,87 @@
+import type { Experimental_VideoModelV4 } from '@ai-sdk/provider';
+import {
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+} from '@ai-sdk/provider-utils';
+import { resumeWebhook } from 'workflow/api';
+
+class SerializableVideoModel implements Experimental_VideoModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly provider = 'workflow-test';
+  readonly modelId = 'workflow-test-video';
+  readonly maxVideosPerCall = 1;
+
+  static [WORKFLOW_SERIALIZE]() {
+    return {};
+  }
+
+  static [WORKFLOW_DESERIALIZE]() {
+    return new SerializableVideoModel();
+  }
+
+  async handleWebhookOption({
+    webhook,
+  }: Parameters<
+    NonNullable<Experimental_VideoModelV4['handleWebhookOption']>
+  >[0]) {
+    const result = await webhook();
+    return { webhookUrl: result.url, received: result.received };
+  }
+
+  async doStart(
+    options: Parameters<NonNullable<Experimental_VideoModelV4['doStart']>>[0],
+  ) {
+    if (options.webhookUrl == null) {
+      throw new Error('Expected a webhook URL.');
+    }
+
+    const webhookUrl = new URL(options.webhookUrl);
+    const token = webhookUrl.pathname.split('/').at(-1);
+    if (token == null || token.length === 0) {
+      throw new Error('Expected a webhook token.');
+    }
+
+    const response = await resumeWebhook(
+      token,
+      new Request(options.webhookUrl, { method: 'POST' }),
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Webhook delivery failed with status ${response.status}.`,
+      );
+    }
+
+    return {
+      operation: { id: 'operation-1' },
+      warnings: [{ type: 'other' as const, message: 'start warning' }],
+      response: {
+        timestamp: new Date(0),
+        modelId: this.modelId,
+        headers: {},
+      },
+    };
+  }
+
+  async doStatus() {
+    return {
+      status: 'completed' as const,
+      videos: [
+        {
+          type: 'url' as const,
+          url: 'https://example.com/video.mp4',
+          mediaType: 'video/mp4',
+        },
+      ],
+      warnings: [],
+      response: {
+        timestamp: new Date(0),
+        modelId: this.modelId,
+        headers: {},
+      },
+    };
+  }
+}
+
+export function createSerializableVideoModel(): Experimental_VideoModelV4 {
+  return new SerializableVideoModel();
+}

--- a/packages/workflow/src/test/video-generation-workflow.ts
+++ b/packages/workflow/src/test/video-generation-workflow.ts
@@ -1,0 +1,11 @@
+import { experimental_generateVideo } from '../generate-video.js';
+import { createSerializableVideoModel } from './serializable-video-model.js';
+
+export async function videoGenerationWorkflow() {
+  'use workflow';
+
+  return experimental_generateVideo({
+    model: createSerializableVideoModel(),
+    prompt: 'A lighthouse in fog',
+  });
+}

--- a/packages/workflow/src/video.ts
+++ b/packages/workflow/src/video.ts
@@ -1,0 +1,5 @@
+export {
+  experimental_generateVideo,
+  type WorkflowGenerateVideoOptions,
+  type WorkflowGenerateVideoResult,
+} from './generate-video.js';

--- a/packages/workflow/tsup.config.ts
+++ b/packages/workflow/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/video.ts'],
   format: ['esm'],
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
## Summary

- add an experimental `@ai-sdk/workflow/video` video generation helper that starts a job with a durable Workflow webhook
- **suspend the workflow for the entire video render, consuming no compute until the webhook resumes it**
- run start and status operations in steps, using a stable step-derived idempotency key for billable starts
- return raw provider `url | base64 | binary` video data without downloading hosted videos across step boundaries
- add API docs, README usage, unit coverage, a Workflow suspend/resume integration test, and a patch changeset

## Example

```ts
import { experimental_generateVideo as generateVideo } from '@ai-sdk/workflow/video';

export async function videoWorkflow(prompt: string) {
  'use workflow';

  // The workflow suspends while the video renders, consuming no compute.
  const result = await generateVideo({
    model: 'klingai/kling-v3.0-t2v',
    prompt,
  });

  return result.videos;
}
```

## Suspension behavior

While `generateVideo()` waits for the provider to render the video, the workflow is durably suspended. No function remains running and no compute is consumed. The provider webhook resumes the workflow, which then makes one status request to retrieve the result.