### PR TITLE
fix(provider/moonshotai): align reasoning by model (v5 backport)

### DIFF
--- a/.changeset/calm-kimis-think.md
+++ b/.changeset/calm-kimis-think.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+fix(provider/moonshotai): align thinking and reasoning options by model

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -98,7 +98,7 @@ returns an unsupported-setting warning when they are supplied.
 
 ### Reasoning Models
 
-Kimi K3 always reasons. It currently supports only the `max` reasoning effort,
+Kimi K3 always reasons. It supports `low`, `high`, and `max` reasoning effort,
 which you can configure through provider options:
 
 ```ts
@@ -119,18 +119,20 @@ console.log(reasoningText);
 console.log(text);
 ```
 
-Moonshot AI offers thinking models like `kimi-k2-thinking` that generate intermediate reasoning tokens before their final response. The reasoning output is streamed through the standard AI SDK reasoning parts.
+Kimi K2.5 and K2.6 can enable or disable thinking. Kimi K2.7 always has
+thinking and preserved reasoning enabled. The reasoning output is streamed
+through the standard AI SDK reasoning parts.
 
 ```ts
 import { moonshotai, type MoonshotAIProviderOptions } from '@ai-sdk/moonshotai';
 import { generateText } from 'ai';
 
 const { text, reasoningText } = await generateText({
-  model: moonshotai('kimi-k2-thinking'),
+  model: moonshotai('kimi-k2.6'),
   providerOptions: {
     moonshotai: {
-      thinking: { type: 'enabled', budgetTokens: 2048 },
-      reasoningHistory: 'interleaved',
+      thinking: { type: 'enabled' },
+      reasoningHistory: 'preserved',
     } satisfies MoonshotAIProviderOptions,
   },
   prompt: 'How many "r"s are in the word "strawberry"?',
@@ -146,27 +148,29 @@ See [AI SDK UI: Chatbot](/docs/ai-sdk-ui/chatbot#reasoning) for more details on 
 
 The following optional provider options are available for Moonshot AI language models:
 
-- **reasoningEffort** _'max'_
+- **reasoningEffort** _'low' | 'high' | 'max'_
 
-  Reasoning effort for Kimi K3. Currently, only `'max'` is supported.
+  Reasoning effort for Kimi K3.
 
 - **thinking** _object_
 
-  Configuration for thinking/reasoning models like Kimi K2 Thinking.
+  Configuration for Kimi K2.5 and K2.6. Kimi K2.7 accepts only `enabled`
+  because its thinking cannot be disabled. Kimi K3 does not accept this field.
   - **type** _'enabled' | 'disabled'_
 
     Whether to enable thinking mode
 
-  - **budgetTokens** _number_
-
-    Maximum number of tokens for thinking (minimum 1024)
+  The previously exposed `budgetTokens` option is deprecated because Moonshot
+  Chat Completions does not support thinking budgets. The provider omits it and
+  returns a warning.
 
 - **reasoningHistory** _'disabled' | 'interleaved' | 'preserved'_
 
   Controls how reasoning history is handled in multi-turn conversations:
   - `'disabled'`: Remove reasoning from history
   - `'interleaved'`: Include reasoning between tool calls within a single turn
-  - `'preserved'`: Keep all reasoning in history
+  - `'preserved'`: Keep all reasoning in history. For Kimi K2.6, this maps to
+    `thinking.keep: 'all'`. Kimi K2.7 and K3 always preserve reasoning.
 
 ## Model Capabilities
 

--- a/examples/ai-core/src/generate-text/moonshot-thinking.ts
+++ b/examples/ai-core/src/generate-text/moonshot-thinking.ts
@@ -4,15 +4,14 @@ import { run } from '../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: moonshotai('kimi-k2-thinking'),
+    model: moonshotai('kimi-k2.6'),
     prompt: 'How many "r"s are in the word "strawberry"?',
     providerOptions: {
       moonshotai: {
         thinking: {
           type: 'enabled',
-          budgetTokens: 2048,
         },
-        reasoningHistory: 'interleaved',
+        reasoningHistory: 'preserved',
       } satisfies MoonshotAIProviderOptions,
     },
   });

--- a/examples/ai-core/src/stream-text/moonshot-thinking.ts
+++ b/examples/ai-core/src/stream-text/moonshot-thinking.ts
@@ -1,20 +1,19 @@
-import { moonshotai } from '@ai-sdk/moonshotai';
+import { type MoonshotAIProviderOptions, moonshotai } from '@ai-sdk/moonshotai';
 import { streamText } from 'ai';
 import { run } from '../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: moonshotai('kimi-k2-thinking'),
+    model: moonshotai('kimi-k2.6'),
     prompt:
       'Solve this problem step by step: If a train travels 120 miles in 2 hours, how far will it travel in 5 hours at the same speed?',
     providerOptions: {
       moonshotai: {
         thinking: {
           type: 'enabled',
-          budgetTokens: 2048,
         },
-        reasoningHistory: 'interleaved',
-      },
+        reasoningHistory: 'preserved',
+      } satisfies MoonshotAIProviderOptions,
     },
   });
 

--- a/packages/moonshotai/README.md
+++ b/packages/moonshotai/README.md
@@ -43,20 +43,19 @@ const { text } = await generateText({
 ## Thinking Mode Example (Kimi K2 Thinking)
 
 ```ts
-import { moonshotai } from '@ai-sdk/moonshotai';
+import { moonshotai, type MoonshotAIProviderOptions } from '@ai-sdk/moonshotai';
 import { generateText } from 'ai';
 
 const { text } = await generateText({
-  model: moonshotai('kimi-k2.5'),
-  prompt: 'Invent a new holiday and describe its traditions.',
+  model: moonshotai('kimi-k2.6'),
+  prompt: 'Solve this problem step by step: What is 15% of 240?',
   providerOptions: {
     moonshotai: {
       thinking: {
         type: 'enabled',
-        budgetTokens: 2048,
       },
-      reasoningHistory: 'interleaved',
-    } as MoonshotAIProviderOptions,
+      reasoningHistory: 'preserved',
+    } satisfies MoonshotAIProviderOptions,
   },
 });
 ```

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -128,6 +128,217 @@ describe('MoonshotAIChatLanguageModel', () => {
         expect(result.warnings).toStrictEqual([]);
       },
     );
+
+    it('should omit unsupported budget tokens and warn', async () => {
+      const result = await provider.chatModel('kimi-k2.6').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: {
+            thinking: { type: 'enabled', budgetTokens: 2048 },
+          },
+        },
+      });
+
+      expect((await server.calls[0].requestBodyJson).thinking).toStrictEqual({
+        type: 'enabled',
+      });
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'other',
+          message:
+            'providerOptions.moonshotai.thinking.budgetTokens is deprecated because Moonshot Chat Completions does not support budget_tokens. The option has been omitted.',
+        },
+      ]);
+    });
+
+    it('should map K2.6 preserved reasoning to thinking.keep', async () => {
+      await provider.chatModel('kimi-k2.6').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: {
+            thinking: { type: 'enabled' },
+            reasoningHistory: 'preserved',
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.thinking).toStrictEqual({
+        type: 'enabled',
+        keep: 'all',
+      });
+      expect(requestBody).not.toHaveProperty('reasoningHistory');
+      expect(requestBody).not.toHaveProperty('reasoning_history');
+    });
+
+    it('should not send other reasoning history modes', async () => {
+      await provider.chatModel('kimi-k2.6').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: { reasoningHistory: 'interleaved' },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).not.toHaveProperty('reasoningHistory');
+      expect(requestBody).not.toHaveProperty('reasoning_history');
+      expect(requestBody).not.toHaveProperty('thinking');
+    });
+
+    it('should pass K3 reasoning effort through', async () => {
+      await provider.chatModel('kimi-k3').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: { reasoningEffort: 'low' },
+        },
+      });
+
+      expect((await server.calls[0].requestBodyJson).reasoning_effort).toBe(
+        'low',
+      );
+    });
+
+    it('should omit thinking for Kimi K3', async () => {
+      const result = await provider.chatModel('kimi-k3').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: {
+            thinking: { type: 'disabled' },
+            reasoningHistory: 'preserved',
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'thinking',
+      );
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'unsupported-setting',
+          setting: 'providerOptions',
+          details:
+            'Kimi K3 always reasons and does not accept providerOptions.moonshotai.thinking. The option has been omitted.',
+        },
+      ]);
+    });
+
+    it.each(['kimi-k2.7-code', 'kimi-k2.7-code-highspeed'] as const)(
+      'should not disable thinking for %s',
+      async modelId => {
+        const result = await provider.chatModel(modelId).doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            moonshotai: { thinking: { type: 'disabled' } },
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+          'thinking',
+        );
+        expect(result.warnings).toStrictEqual([
+          {
+            type: 'unsupported-setting',
+            setting: 'providerOptions',
+            details:
+              'Kimi K2.7 thinking cannot be disabled. providerOptions.moonshotai.thinking has been omitted.',
+          },
+        ]);
+      },
+    );
+
+    it('should rely on K2.7 preserved-thinking defaults', async () => {
+      const result = await provider.chatModel('kimi-k2.7-code').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: { reasoningHistory: 'preserved' },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'thinking',
+      );
+      expect(result.warnings).toStrictEqual([]);
+    });
+
+    it('should omit reasoning effort for K2 models and warn', async () => {
+      const result = await provider.chatModel('kimi-k2.6').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: { reasoningEffort: 'high' },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'reasoning_effort',
+      );
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'unsupported-setting',
+          setting: 'providerOptions',
+          details:
+            'providerOptions.moonshotai.reasoningEffort is only supported by Kimi K3 and has been omitted for model "kimi-k2.6".',
+        },
+      ]);
+    });
+
+    it('should omit thinking and reasoning options for Moonshot V1', async () => {
+      const result = await provider.chatModel('moonshot-v1-8k').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: {
+            reasoningEffort: 'high',
+            thinking: { type: 'enabled' },
+            reasoningHistory: 'preserved',
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody).not.toHaveProperty('reasoning_effort');
+      expect(requestBody).not.toHaveProperty('thinking');
+      expect(requestBody).not.toHaveProperty('reasoningHistory');
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'unsupported-setting',
+          setting: 'providerOptions',
+          details:
+            'providerOptions.moonshotai.reasoningEffort is only supported by Kimi K3 and has been omitted for model "moonshot-v1-8k".',
+        },
+        {
+          type: 'unsupported-setting',
+          setting: 'providerOptions',
+          details:
+            'providerOptions.moonshotai.thinking is not supported by model "moonshot-v1-8k" and has been omitted.',
+        },
+        {
+          type: 'unsupported-setting',
+          setting: 'providerOptions',
+          details:
+            'providerOptions.moonshotai.reasoningHistory \'preserved\' is not supported by model "moonshot-v1-8k" and has been omitted.',
+        },
+      ]);
+    });
+
+    it('should omit preserved reasoning for K2.5 and warn', async () => {
+      const result = await provider.chatModel('kimi-k2.5').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: { reasoningHistory: 'preserved' },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'thinking',
+      );
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'unsupported-setting',
+          setting: 'providerOptions',
+          details:
+            'providerOptions.moonshotai.reasoningHistory \'preserved\' is not supported by model "kimi-k2.5" and has been omitted.',
+        },
+      ]);
+    });
   });
 
   describe('doStream', () => {
@@ -157,6 +368,33 @@ describe('MoonshotAIChatLanguageModel', () => {
             type: 'unsupported-setting',
             setting: 'topP',
             details: 'topP is fixed by model "kimi-k3" and has been omitted.',
+          },
+        ],
+      });
+    });
+
+    it('should sanitize thinking options and add v2 warnings when streaming', async () => {
+      prepareChunksFixtureResponse('moonshot-text');
+
+      const result = await provider.chatModel('kimi-k2.7-code').doStream({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          moonshotai: { thinking: { type: 'disabled' } },
+        },
+      });
+      const parts = await convertReadableStreamToArray(result.stream);
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'thinking',
+      );
+      expect(parts[0]).toStrictEqual({
+        type: 'stream-start',
+        warnings: [
+          {
+            type: 'unsupported-setting',
+            setting: 'providerOptions',
+            details:
+              'Kimi K2.7 thinking cannot be disabled. providerOptions.moonshotai.thinking has been omitted.',
           },
         ],
       });

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -8,8 +8,10 @@ import type {
 } from '@ai-sdk/provider';
 import { convertMoonshotAIChatUsage } from './convert-moonshotai-chat-usage';
 import {
+  getMoonshotAIModelFamily,
   isMoonshotAIKimiModel,
   type MoonshotAIChatModelId,
+  type MoonshotAIProviderOptions,
 } from './moonshotai-chat-options';
 
 function prepareSamplingOptions({
@@ -56,6 +58,158 @@ function prepareSamplingOptions({
   };
 }
 
+function prepareReasoningOptions({
+  modelId,
+  options,
+}: {
+  modelId: MoonshotAIChatModelId;
+  options: LanguageModelV2CallOptions;
+}): {
+  options: LanguageModelV2CallOptions;
+  warnings: LanguageModelV2CallWarning[];
+} {
+  const providerOptions = options.providerOptions?.moonshotai;
+  if (
+    providerOptions == null ||
+    typeof providerOptions !== 'object' ||
+    Array.isArray(providerOptions)
+  ) {
+    return { options, warnings: [] };
+  }
+
+  const moonshotOptions = providerOptions as MoonshotAIProviderOptions;
+  const {
+    reasoningEffort: requestedReasoningEffort,
+    thinking: requestedThinking,
+    reasoningHistory,
+    ...otherMoonshotOptions
+  } = moonshotOptions;
+  const preserveReasoning = reasoningHistory === 'preserved';
+  const warnings: LanguageModelV2CallWarning[] = [];
+
+  if (requestedThinking?.budgetTokens != null) {
+    warnings.push({
+      type: 'other',
+      message:
+        'providerOptions.moonshotai.thinking.budgetTokens is deprecated because Moonshot Chat Completions does not support budget_tokens. The option has been omitted.',
+    });
+  }
+
+  let thinking: { type: 'enabled' | 'disabled'; keep?: 'all' } | undefined;
+  let reasoningEffort: 'low' | 'high' | 'max' | undefined;
+
+  const warnUnsupportedReasoningEffort = () => {
+    if (requestedReasoningEffort != null) {
+      warnings.push({
+        type: 'unsupported-setting',
+        setting: 'providerOptions',
+        details: `providerOptions.moonshotai.reasoningEffort is only supported by Kimi K3 and has been omitted for model "${modelId}".`,
+      });
+    }
+  };
+
+  switch (getMoonshotAIModelFamily(modelId)) {
+    case 'kimi-k3': {
+      if (requestedThinking != null) {
+        warnings.push({
+          type: 'unsupported-setting',
+          setting: 'providerOptions',
+          details:
+            'Kimi K3 always reasons and does not accept providerOptions.moonshotai.thinking. The option has been omitted.',
+        });
+      }
+      reasoningEffort = requestedReasoningEffort;
+      break;
+    }
+    case 'kimi-k2.7': {
+      warnUnsupportedReasoningEffort();
+      if (requestedThinking?.type === 'disabled') {
+        warnings.push({
+          type: 'unsupported-setting',
+          setting: 'providerOptions',
+          details:
+            'Kimi K2.7 thinking cannot be disabled. providerOptions.moonshotai.thinking has been omitted.',
+        });
+      } else if (requestedThinking?.type === 'enabled') {
+        thinking = { type: 'enabled' };
+      }
+      break;
+    }
+    case 'kimi-k2.6': {
+      warnUnsupportedReasoningEffort();
+      const thinkingType = requestedThinking?.type;
+      if (thinkingType != null || preserveReasoning) {
+        thinking = {
+          type: thinkingType ?? 'enabled',
+          ...(preserveReasoning ? { keep: 'all' as const } : {}),
+        };
+      }
+      break;
+    }
+    case 'kimi-k2.5': {
+      warnUnsupportedReasoningEffort();
+      if (requestedThinking?.type != null) {
+        thinking = { type: requestedThinking.type };
+      }
+      if (preserveReasoning) {
+        warnings.push({
+          type: 'unsupported-setting',
+          setting: 'providerOptions',
+          details: `providerOptions.moonshotai.reasoningHistory 'preserved' is not supported by model "${modelId}" and has been omitted.`,
+        });
+      }
+      break;
+    }
+    case 'moonshot-v1': {
+      warnUnsupportedReasoningEffort();
+      if (requestedThinking != null) {
+        warnings.push({
+          type: 'unsupported-setting',
+          setting: 'providerOptions',
+          details: `providerOptions.moonshotai.thinking is not supported by model "${modelId}" and has been omitted.`,
+        });
+      }
+      if (preserveReasoning) {
+        warnings.push({
+          type: 'unsupported-setting',
+          setting: 'providerOptions',
+          details: `providerOptions.moonshotai.reasoningHistory 'preserved' is not supported by model "${modelId}" and has been omitted.`,
+        });
+      }
+      break;
+    }
+    case 'unknown': {
+      reasoningEffort = requestedReasoningEffort;
+      if (requestedThinking?.type != null) {
+        thinking = { type: requestedThinking.type };
+      }
+      if (preserveReasoning) {
+        warnings.push({
+          type: 'unsupported-setting',
+          setting: 'providerOptions',
+          details: `providerOptions.moonshotai.reasoningHistory 'preserved' is not supported by model "${modelId}" and has been omitted.`,
+        });
+      }
+      break;
+    }
+  }
+
+  return {
+    options: {
+      ...options,
+      providerOptions: {
+        ...options.providerOptions,
+        moonshotai: {
+          ...otherMoonshotOptions,
+          ...(reasoningEffort != null ? { reasoningEffort } : {}),
+          ...(thinking != null ? { thinking } : {}),
+        },
+      },
+    },
+    warnings,
+  };
+}
+
 export class MoonshotAIChatLanguageModel extends OpenAICompatibleChatLanguageModel {
   constructor(
     modelId: MoonshotAIChatModelId,
@@ -67,8 +221,13 @@ export class MoonshotAIChatLanguageModel extends OpenAICompatibleChatLanguageMod
   async doGenerate(
     options: Parameters<LanguageModelV2['doGenerate']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV2['doGenerate']>>> {
-    const { options: sanitizedOptions, warnings: samplingWarnings } =
+    const { options: samplingOptions, warnings: samplingWarnings } =
       prepareSamplingOptions({ modelId: this.modelId, options });
+    const { options: sanitizedOptions, warnings: reasoningWarnings } =
+      prepareReasoningOptions({
+        modelId: this.modelId,
+        options: samplingOptions,
+      });
     const result = await super.doGenerate(sanitizedOptions);
 
     // @ts-expect-error accessing response body from parent result
@@ -77,7 +236,7 @@ export class MoonshotAIChatLanguageModel extends OpenAICompatibleChatLanguageMod
     return {
       ...result,
       usage: convertMoonshotAIChatUsage(usage),
-      warnings: [...result.warnings, ...samplingWarnings],
+      warnings: [...result.warnings, ...samplingWarnings, ...reasoningWarnings],
     };
   }
 
@@ -85,8 +244,13 @@ export class MoonshotAIChatLanguageModel extends OpenAICompatibleChatLanguageMod
     options: Parameters<LanguageModelV2['doStream']>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV2['doStream']>>> {
     const originalIncludeRawChunks = options.includeRawChunks;
-    const { options: sanitizedOptions, warnings: samplingWarnings } =
+    const { options: samplingOptions, warnings: samplingWarnings } =
       prepareSamplingOptions({ modelId: this.modelId, options });
+    const { options: sanitizedOptions, warnings: reasoningWarnings } =
+      prepareReasoningOptions({
+        modelId: this.modelId,
+        options: samplingOptions,
+      });
 
     // Enable raw chunks to capture pre-Zod usage data, since MoonshotAI
     // returns cached_tokens at the top level of usage (not nested in
@@ -109,7 +273,11 @@ export class MoonshotAIChatLanguageModel extends OpenAICompatibleChatLanguageMod
             if (chunk.type === 'stream-start') {
               controller.enqueue({
                 ...chunk,
-                warnings: [...chunk.warnings, ...samplingWarnings],
+                warnings: [
+                  ...chunk.warnings,
+                  ...samplingWarnings,
+                  ...reasoningWarnings,
+                ],
               });
               return;
             }

--- a/packages/moonshotai/src/moonshotai-chat-options.test-d.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.test-d.ts
@@ -1,0 +1,15 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { MoonshotAIProviderOptions } from './index';
+
+describe('MoonshotAIProviderOptions', () => {
+  it('only exposes official thinking and reasoning effort fields', () => {
+    expectTypeOf<MoonshotAIProviderOptions>().toEqualTypeOf<{
+      reasoningEffort?: 'low' | 'high' | 'max';
+      thinking?: {
+        type?: 'enabled' | 'disabled';
+        budgetTokens?: number;
+      };
+      reasoningHistory?: 'disabled' | 'interleaved' | 'preserved';
+    }>();
+  });
+});

--- a/packages/moonshotai/src/moonshotai-chat-options.ts
+++ b/packages/moonshotai/src/moonshotai-chat-options.ts
@@ -13,25 +13,42 @@ export type MoonshotAIChatModelId =
   | 'kimi-k3'
   | (string & {});
 
+export type MoonshotAIModelFamily =
+  | 'kimi-k2.5'
+  | 'kimi-k2.6'
+  | 'kimi-k2.7'
+  | 'kimi-k3'
+  | 'moonshot-v1'
+  | 'unknown';
+
+export function getMoonshotAIModelFamily(
+  modelId: MoonshotAIChatModelId,
+): MoonshotAIModelFamily {
+  if (modelId === 'kimi-k2.5') return 'kimi-k2.5';
+  if (modelId === 'kimi-k2.6') return 'kimi-k2.6';
+  if (modelId === 'kimi-k2.7-code' || modelId === 'kimi-k2.7-code-highspeed') {
+    return 'kimi-k2.7';
+  }
+  if (modelId === 'kimi-k3') return 'kimi-k3';
+  if (modelId.startsWith('moonshot-v1-')) return 'moonshot-v1';
+  return 'unknown';
+}
+
 export function isMoonshotAIKimiModel(modelId: MoonshotAIChatModelId): boolean {
-  return (
-    modelId === 'kimi-k2.5' ||
-    modelId === 'kimi-k2.6' ||
-    modelId === 'kimi-k2.7-code' ||
-    modelId === 'kimi-k2.7-code-highspeed' ||
-    modelId === 'kimi-k3'
-  );
+  return getMoonshotAIModelFamily(modelId).startsWith('kimi-');
 }
 
 export const moonshotaiProviderOptions = z.object({
   /**
-   * Reasoning effort for Kimi K3. Currently, only `max` is supported.
+   * Reasoning effort for Kimi K3.
    */
-  reasoningEffort: z.literal('max').optional(),
+  reasoningEffort: z.enum(['low', 'high', 'max']).optional(),
 
   thinking: z
     .object({
       type: z.enum(['enabled', 'disabled']).optional(),
+      // Accepted so existing callers receive a migration warning. It remains
+      // in the public compatibility type below as a deprecated property.
       budgetTokens: z.number().int().min(1024).optional(),
     })
     .optional(),
@@ -39,6 +56,20 @@ export const moonshotaiProviderOptions = z.object({
   reasoningHistory: z.enum(['disabled', 'interleaved', 'preserved']).optional(),
 });
 
-export type MoonshotAIProviderOptions = z.infer<
-  typeof moonshotaiProviderOptions
->;
+export type MoonshotAIProviderOptions = {
+  /** Reasoning effort for Kimi K3. */
+  reasoningEffort?: 'low' | 'high' | 'max';
+
+  /** Controls thinking on Kimi K2.5 and K2.6. K2.7 is always enabled. */
+  thinking?: {
+    type?: 'enabled' | 'disabled';
+
+    /**
+     * @deprecated Moonshot Chat Completions does not support thinking budgets.
+     * This value is ignored with a warning.
+     */
+    budgetTokens?: number;
+  };
+
+  reasoningHistory?: 'disabled' | 'interleaved' | 'preserved';
+};


### PR DESCRIPTION
Backports #19582 to `release-v5.0`.

This adapts Moonshot reasoning options to the v5 `LanguageModelV2` and OpenAI-compatible provider interfaces:

- omits generic `reasoning`, which is not representable by `LanguageModelV2CallOptions`
- sanitizes Moonshot provider options before the OpenAI-compatible request conversion
- preserves K2.6 reasoning history through `thinking.keep: 'all'`
- emits v2-compatible warnings for unsupported model/option combinations and deprecated `budgetTokens`
- adds normal and streaming regression coverage, public option type tests, documentation, examples, and a patch changeset

Closes the v5 backport portion of #19554.

Validation:

- `pnpm --filter @ai-sdk/moonshotai... build`
- `pnpm --filter @ai-sdk/moonshotai test:node`
- `pnpm --filter @ai-sdk/moonshotai test:edge`
- `pnpm --filter @ai-sdk/moonshotai type-check`
- `pnpm check`
- `git diff --check`
