### PR TITLE
feat(anthropic): preserve message batch metadata

### DIFF
--- a/.changeset/tidy-batches-count.md
+++ b/.changeset/tidy-batches-count.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/anthropic': patch
+'@ai-sdk/provider': patch
+---
+
+fix(provider/anthropic): preserve native message batch request counts in provider metadata and support the full language-model option surface in batch requests

--- a/.changeset/tidy-batches-count.md
+++ b/.changeset/tidy-batches-count.md
@@ -1,6 +1,7 @@
 ---
 '@ai-sdk/anthropic': patch
 '@ai-sdk/provider': patch
+'ai': patch
 ---
 
 fix(provider/anthropic): preserve native message batch request counts in provider metadata and support the full language-model option surface in batch requests

--- a/packages/ai/src/batch/batch-types.test-d.ts
+++ b/packages/ai/src/batch/batch-types.test-d.ts
@@ -73,6 +73,9 @@ it('only exposes text-generation call options to batch providers', () => {
     | 'frequencyPenalty'
     | 'seed'
     | 'reasoning'
+    | 'responseFormat'
+    | 'toolChoice'
+    | 'tools'
     | 'providerOptions'
   >;
 
@@ -80,12 +83,7 @@ it('only exposes text-generation call options to batch providers', () => {
   expectTypeOf<
     Extract<
       keyof BatchCallOptions,
-      | 'responseFormat'
-      | 'tools'
-      | 'toolChoice'
-      | 'includeRawChunks'
-      | 'abortSignal'
-      | 'headers'
+      'includeRawChunks' | 'abortSignal' | 'headers'
     >
   >().toEqualTypeOf<never>();
 });

--- a/packages/ai/src/batch/batch-types.test-d.ts
+++ b/packages/ai/src/batch/batch-types.test-d.ts
@@ -28,6 +28,8 @@ import {
   type Experimental_TextBatchRequest as TextBatchRequest,
 } from '../index';
 import type { AsyncIterableStream } from '../util/async-iterable-stream';
+import type { ContentPart } from '../generate-text/content-part';
+import type { ToolSet } from '@ai-sdk/provider-utils';
 
 it('exposes typed Gateway async-job metadata', () => {
   expectTypeOf<
@@ -92,6 +94,12 @@ it('uses serializable response timestamps', () => {
   expectTypeOf<
     NonNullable<TextBatchGenerationResult['response']>['timestamp']
   >().toEqualTypeOf<string | undefined>();
+});
+
+it('exposes Core content in successful batch results', () => {
+  expectTypeOf<TextBatchGenerationResult['content']>().toEqualTypeOf<
+    Array<ContentPart<ToolSet>>
+  >();
 });
 
 it('flattens successful Core items while reusing provider status and errors', () => {

--- a/packages/ai/src/batch/batch-types.ts
+++ b/packages/ai/src/batch/batch-types.ts
@@ -3,9 +3,9 @@ import type {
   Experimental_BatchV4StartResult as BatchV4StartResult,
   Experimental_BatchV4Status as BatchV4Status,
   Experimental_BatchLanguageModelV4 as BatchLanguageModelV4,
-  LanguageModelV4GenerateResult,
 } from '@ai-sdk/provider';
-import type { ProviderOptions } from '@ai-sdk/provider-utils';
+import type { ProviderOptions, ToolSet } from '@ai-sdk/provider-utils';
+import type { ContentPart } from '../generate-text/content-part';
 import type { LanguageModelCallOptions } from '../prompt/language-model-call-options';
 import type { Prompt } from '../prompt/prompt';
 import type {
@@ -109,7 +109,7 @@ export type BatchOperationOptions = {
  */
 export type TextBatchGenerationResult = {
   /** Ordered normalized content, including citations, sources, and tool data. */
-  readonly content: LanguageModelV4GenerateResult['content'];
+  readonly content: Array<ContentPart<ToolSet>>;
   readonly text: string;
   readonly finishReason: FinishReason;
   readonly rawFinishReason?: string;

--- a/packages/ai/src/batch/batch-types.ts
+++ b/packages/ai/src/batch/batch-types.ts
@@ -3,6 +3,7 @@ import type {
   Experimental_BatchV4StartResult as BatchV4StartResult,
   Experimental_BatchV4Status as BatchV4Status,
   Experimental_BatchLanguageModelV4 as BatchLanguageModelV4,
+  LanguageModelV4GenerateResult,
 } from '@ai-sdk/provider';
 import type { ProviderOptions } from '@ai-sdk/provider-utils';
 import type { LanguageModelCallOptions } from '../prompt/language-model-call-options';
@@ -107,6 +108,8 @@ export type BatchOperationOptions = {
  * A normalized result for a successful text batch item.
  */
 export type TextBatchGenerationResult = {
+  /** Ordered normalized content, including citations, sources, and tool data. */
+  readonly content: LanguageModelV4GenerateResult['content'];
   readonly text: string;
   readonly finishReason: FinishReason;
   readonly rawFinishReason?: string;

--- a/packages/ai/src/batch/batch.test.ts
+++ b/packages/ai/src/batch/batch.test.ts
@@ -316,4 +316,52 @@ describe('getBatchResults', () => {
       },
     ]);
   });
+
+  it('does not report an unrepresentable client tool call as empty text', async () => {
+    const model = createMockBatchModel({
+      doGetBatchResults: async () =>
+        convertArrayToReadableStream([
+          {
+            id: 'request-1',
+            status: 'succeeded',
+            result: {
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'weather',
+                  input: '{}',
+                },
+              ],
+              finishReason: { unified: 'tool-calls', raw: 'tool_use' },
+              usage: testUsage,
+              warnings: [],
+              providerMetadata: { mock: { result: true } },
+            },
+          },
+        ]),
+    });
+
+    const items = [];
+    for await (const item of getBatchResults({
+      model,
+      batch: batchReference,
+      maxRetries: 0,
+    })) {
+      items.push(item);
+    }
+
+    expect(items).toEqual([
+      {
+        id: 'request-1',
+        status: 'failed',
+        error: {
+          code: 'unsupported_content',
+          message:
+            'Text batch results cannot represent client-executed tool calls.',
+        },
+        providerMetadata: { mock: { result: true } },
+      },
+    ]);
+  });
 });

--- a/packages/ai/src/batch/batch.test.ts
+++ b/packages/ai/src/batch/batch.test.ts
@@ -292,6 +292,7 @@ describe('getBatchResults', () => {
 
     expect(items).toMatchObject([
       {
+        content: [{ text: 'Paris', type: 'text' }],
         id: 'request-1',
         status: 'succeeded',
         text: 'Paris',
@@ -317,7 +318,7 @@ describe('getBatchResults', () => {
     ]);
   });
 
-  it('does not report an unrepresentable client tool call as empty text', async () => {
+  it('preserves client tool calls and usage in normalized batch results', async () => {
     const model = createMockBatchModel({
       doGetBatchResults: async () =>
         convertArrayToReadableStream([
@@ -353,14 +354,35 @@ describe('getBatchResults', () => {
 
     expect(items).toEqual([
       {
+        content: [
+          {
+            input: '{}',
+            toolCallId: 'call-1',
+            toolName: 'weather',
+            type: 'tool-call',
+          },
+        ],
+        finishReason: 'tool-calls',
         id: 'request-1',
-        status: 'failed',
-        error: {
-          code: 'unsupported_content',
-          message:
-            'Text batch results cannot represent client-executed tool calls.',
-        },
         providerMetadata: { mock: { result: true } },
+        rawFinishReason: 'tool_use',
+        status: 'succeeded',
+        text: '',
+        usage: {
+          inputTokenDetails: {
+            cacheReadTokens: 1,
+            cacheWriteTokens: undefined,
+            noCacheTokens: 2,
+          },
+          inputTokens: 3,
+          outputTokenDetails: {
+            reasoningTokens: 1,
+            textTokens: 4,
+          },
+          outputTokens: 5,
+          raw: undefined,
+          totalTokens: 8,
+        },
       },
     ]);
   });

--- a/packages/ai/src/batch/batch.test.ts
+++ b/packages/ai/src/batch/batch.test.ts
@@ -318,7 +318,7 @@ describe('getBatchResults', () => {
     ]);
   });
 
-  it('preserves client tool calls and usage in normalized batch results', async () => {
+  it('normalizes provider-executed tool content and preserves usage', async () => {
     const model = createMockBatchModel({
       doGetBatchResults: async () =>
         convertArrayToReadableStream([
@@ -331,7 +331,17 @@ describe('getBatchResults', () => {
                   type: 'tool-call',
                   toolCallId: 'call-1',
                   toolName: 'weather',
-                  input: '{}',
+                  input: '{"city":"Paris"}',
+                  providerExecuted: true,
+                  dynamic: true,
+                },
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call-1',
+                  toolName: 'weather',
+                  result: { temperature: 20 },
+                  providerExecuted: true,
+                  dynamic: true,
                 },
               ],
               finishReason: { unified: 'tool-calls', raw: 'tool_use' },
@@ -356,10 +366,21 @@ describe('getBatchResults', () => {
       {
         content: [
           {
-            input: '{}',
+            dynamic: true,
+            input: { city: 'Paris' },
+            providerExecuted: true,
             toolCallId: 'call-1',
             toolName: 'weather',
             type: 'tool-call',
+          },
+          {
+            dynamic: true,
+            input: { city: 'Paris' },
+            output: { temperature: 20 },
+            providerExecuted: true,
+            toolCallId: 'call-1',
+            toolName: 'weather',
+            type: 'tool-result',
           },
         ],
         finishReason: 'tool-calls',

--- a/packages/ai/src/batch/batch.ts
+++ b/packages/ai/src/batch/batch.ts
@@ -303,22 +303,6 @@ function convertBatchItemResult(
     return item;
   }
 
-  const clientToolCall = item.result.content.find(
-    part => part.type === 'tool-call' && part.providerExecuted !== true,
-  );
-  if (clientToolCall != null) {
-    return {
-      id: item.id,
-      status: 'failed',
-      error: {
-        code: 'unsupported_content',
-        message:
-          'Text batch results cannot represent client-executed tool calls.',
-      },
-      providerMetadata: item.result.providerMetadata,
-    };
-  }
-
   return {
     id: item.id,
     status: 'succeeded',
@@ -330,6 +314,7 @@ function convertGenerateResult(
   result: LanguageModelV4GenerateResult,
 ): TextBatchGenerationResult {
   return {
+    content: result.content,
     text: result.content
       .filter(
         (part): part is Extract<typeof part, { type: 'text' }> =>

--- a/packages/ai/src/batch/batch.ts
+++ b/packages/ai/src/batch/batch.ts
@@ -303,6 +303,22 @@ function convertBatchItemResult(
     return item;
   }
 
+  const clientToolCall = item.result.content.find(
+    part => part.type === 'tool-call' && part.providerExecuted !== true,
+  );
+  if (clientToolCall != null) {
+    return {
+      id: item.id,
+      status: 'failed',
+      error: {
+        code: 'unsupported_content',
+        message:
+          'Text batch results cannot represent client-executed tool calls.',
+      },
+      providerMetadata: item.result.providerMetadata,
+    };
+  }
+
   return {
     id: item.id,
     status: 'succeeded',

--- a/packages/ai/src/batch/batch.ts
+++ b/packages/ai/src/batch/batch.ts
@@ -4,9 +4,12 @@ import {
   type Experimental_BatchV4ItemResult as BatchV4ItemResult,
   type LanguageModelV4,
   type LanguageModelV4GenerateResult,
+  type LanguageModelV4ToolCall,
 } from '@ai-sdk/provider';
-import { withUserAgentSuffix } from '@ai-sdk/provider-utils';
+import { type ToolSet, withUserAgentSuffix } from '@ai-sdk/provider-utils';
 import { InvalidArgumentError } from '../error/invalid-argument-error';
+import { convertLanguageModelContent } from '../generate-text/convert-language-model-content';
+import { parseToolCall } from '../generate-text/parse-tool-call';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveLanguageModel } from '../model/resolve-model';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
@@ -175,8 +178,8 @@ export function getBatchResults({
     BatchV4ItemResult<LanguageModelV4GenerateResult>,
     TextBatchItemResult
   > & { cancel?: (reason?: unknown) => void } = {
-    transform(item, controller) {
-      controller.enqueue(convertBatchItemResult(item));
+    async transform(item, controller) {
+      controller.enqueue(await convertBatchItemResult(item));
     },
 
     cancel(reason) {
@@ -296,9 +299,9 @@ function validateBatchReference({
   }
 }
 
-function convertBatchItemResult(
+async function convertBatchItemResult(
   item: BatchV4ItemResult<LanguageModelV4GenerateResult>,
-): TextBatchItemResult {
+): Promise<TextBatchItemResult> {
   if (item.status !== 'succeeded') {
     return item;
   }
@@ -306,16 +309,41 @@ function convertBatchItemResult(
   return {
     id: item.id,
     status: 'succeeded',
-    ...convertGenerateResult(item.result),
+    ...(await convertGenerateResult(item.result)),
   };
 }
 
-function convertGenerateResult(
+async function convertGenerateResult(
   result: LanguageModelV4GenerateResult,
-): TextBatchGenerationResult {
-  return {
+): Promise<TextBatchGenerationResult> {
+  const toolCalls = await Promise.all(
+    result.content
+      .filter(
+        (part): part is LanguageModelV4ToolCall => part.type === 'tool-call',
+      )
+      .map(toolCall =>
+        parseToolCall<ToolSet>({
+          toolCall,
+          tools: undefined,
+          repairToolCall: undefined,
+          refineToolInput: undefined,
+          instructions: undefined,
+          messages: [],
+        }),
+      ),
+  );
+  const content = convertLanguageModelContent<ToolSet>({
     content: result.content,
-    text: result.content
+    toolCalls,
+    toolOutputs: [],
+    toolApprovalRequests: [],
+    toolApprovalResponses: [],
+    tools: undefined,
+  });
+
+  return {
+    content,
+    text: content
       .filter(
         (part): part is Extract<typeof part, { type: 'text' }> =>
           part.type === 'text',

--- a/packages/ai/src/generate-text/convert-language-model-content.ts
+++ b/packages/ai/src/generate-text/convert-language-model-content.ts
@@ -1,0 +1,206 @@
+import type { LanguageModelV4Content } from '@ai-sdk/provider';
+import type { ToolSet } from '@ai-sdk/provider-utils';
+import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
+import { getOwn } from '../util/get-own';
+import type { ContentPart } from './content-part';
+import { DefaultGeneratedFile } from './generated-file';
+import type { ToolApprovalRequestOutput } from './tool-approval-request-output';
+import type { ToolApprovalResponseOutput } from './tool-approval-response-output';
+import type { TypedToolCall } from './tool-call';
+import type { TypedToolError } from './tool-error';
+import type { ToolOutput } from './tool-output';
+import type { TypedToolResult } from './tool-result';
+
+export function convertLanguageModelContent<TOOLS extends ToolSet>({
+  content,
+  toolCalls,
+  toolOutputs,
+  toolApprovalRequests,
+  toolApprovalResponses,
+  tools,
+}: {
+  content: Array<LanguageModelV4Content>;
+  toolCalls: Array<TypedToolCall<TOOLS>>;
+  toolOutputs: Array<ToolOutput<TOOLS>>;
+  toolApprovalRequests: Array<ToolApprovalRequestOutput<TOOLS>>;
+  toolApprovalResponses: Array<ToolApprovalResponseOutput<TOOLS>>;
+  tools: TOOLS | undefined;
+}): Array<ContentPart<TOOLS>> {
+  const contentParts: Array<ContentPart<TOOLS>> = [];
+  const toolOutputsWithApprovalResponses: Array<ToolOutput<TOOLS>> = [];
+  const toolOutputsWithoutApprovalResponses: Array<ToolOutput<TOOLS>> = [];
+  const toolCallIdsWithApprovalResponses = new Set(
+    toolApprovalResponses.map(
+      toolApprovalResponse => toolApprovalResponse.toolCall.toolCallId,
+    ),
+  );
+
+  for (const part of content) {
+    switch (part.type) {
+      case 'text':
+      case 'reasoning':
+      case 'custom':
+      case 'source':
+        contentParts.push(part);
+        break;
+
+      case 'file':
+      case 'reasoning-file': {
+        contentParts.push({
+          type: part.type as 'file' | 'reasoning-file',
+          file: new DefaultGeneratedFile({
+            data:
+              part.data.type === 'data'
+                ? part.data.data
+                : part.data.url.toString(),
+            mediaType: part.mediaType,
+          }),
+          ...(part.providerMetadata != null
+            ? { providerMetadata: part.providerMetadata }
+            : {}),
+        });
+        break;
+      }
+
+      case 'tool-call': {
+        const toolCall = toolCalls.find(
+          toolCall => toolCall.toolCallId === part.toolCallId,
+        );
+
+        if (toolCall == null) {
+          throw new Error(`Tool call ${part.toolCallId} not found.`);
+        }
+
+        contentParts.push(toolCall);
+        break;
+      }
+
+      case 'tool-result': {
+        const toolCall = toolCalls.find(
+          toolCall => toolCall.toolCallId === part.toolCallId,
+        );
+
+        // Handle deferred results for provider-executed tools (e.g., programmatic tool calling).
+        // When a server tool (like code_execution) triggers a client tool, the server tool's
+        // result may be deferred to a later turn. In this case, there's no matching tool-call
+        // in the current response.
+        if (toolCall == null) {
+          const tool = getOwn(tools, part.toolName);
+          const supportsDeferredResults =
+            tool?.type === 'provider' && tool.supportsDeferredResults;
+
+          if (!supportsDeferredResults) {
+            throw new Error(`Tool call ${part.toolCallId} not found.`);
+          }
+
+          // Create tool result without tool call input (deferred result)
+          if (part.isError) {
+            contentParts.push({
+              type: 'tool-error' as const,
+              toolCallId: part.toolCallId,
+              toolName: part.toolName as keyof TOOLS & string,
+              input: undefined,
+              error: part.result,
+              providerExecuted: true,
+              dynamic: part.dynamic,
+              ...(part.providerMetadata != null
+                ? { providerMetadata: part.providerMetadata }
+                : {}),
+              ...(tool?.metadata != null
+                ? { toolMetadata: tool.metadata }
+                : {}),
+            } as TypedToolError<TOOLS>);
+          } else {
+            contentParts.push({
+              type: 'tool-result' as const,
+              toolCallId: part.toolCallId,
+              toolName: part.toolName as keyof TOOLS & string,
+              input: undefined,
+              output: part.result,
+              providerExecuted: true,
+              dynamic: part.dynamic,
+              ...(part.providerMetadata != null
+                ? { providerMetadata: part.providerMetadata }
+                : {}),
+              ...(tool?.metadata != null
+                ? { toolMetadata: tool.metadata }
+                : {}),
+            } as TypedToolResult<TOOLS>);
+          }
+          break;
+        }
+
+        if (part.isError) {
+          contentParts.push({
+            type: 'tool-error' as const,
+            toolCallId: part.toolCallId,
+            toolName: part.toolName as keyof TOOLS & string,
+            input: toolCall.input,
+            error: part.result,
+            providerExecuted: true,
+            dynamic: toolCall.dynamic,
+            ...(part.providerMetadata != null
+              ? { providerMetadata: part.providerMetadata }
+              : {}),
+            ...(toolCall.toolMetadata != null
+              ? { toolMetadata: toolCall.toolMetadata }
+              : {}),
+          } as TypedToolError<TOOLS>);
+        } else {
+          contentParts.push({
+            type: 'tool-result' as const,
+            toolCallId: part.toolCallId,
+            toolName: part.toolName as keyof TOOLS & string,
+            input: toolCall.input,
+            output: part.result,
+            providerExecuted: true,
+            dynamic: toolCall.dynamic,
+            ...(part.providerMetadata != null
+              ? { providerMetadata: part.providerMetadata }
+              : {}),
+            ...(toolCall.toolMetadata != null
+              ? { toolMetadata: toolCall.toolMetadata }
+              : {}),
+          } as TypedToolResult<TOOLS>);
+        }
+        break;
+      }
+
+      case 'tool-approval-request': {
+        const toolCall = toolCalls.find(
+          toolCall => toolCall.toolCallId === part.toolCallId,
+        );
+
+        if (toolCall == null) {
+          throw new ToolCallNotFoundForApprovalError({
+            toolCallId: part.toolCallId,
+            approvalId: part.approvalId,
+          });
+        }
+
+        contentParts.push({
+          type: 'tool-approval-request' as const,
+          approvalId: part.approvalId,
+          toolCall,
+        });
+        break;
+      }
+    }
+  }
+
+  for (const toolOutput of toolOutputs) {
+    if (toolCallIdsWithApprovalResponses.has(toolOutput.toolCallId)) {
+      toolOutputsWithApprovalResponses.push(toolOutput);
+    } else {
+      toolOutputsWithoutApprovalResponses.push(toolOutput);
+    }
+  }
+
+  return [
+    ...contentParts,
+    ...toolOutputsWithoutApprovalResponses,
+    ...toolApprovalRequests,
+    ...toolApprovalResponses,
+    ...toolOutputsWithApprovalResponses,
+  ];
+}

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1,5 +1,4 @@
 import type {
-  LanguageModelV4Content,
   LanguageModelV4GenerateResult,
   LanguageModelV4ToolCall,
 } from '@ai-sdk/provider';
@@ -17,7 +16,6 @@ import {
   type ToolSet,
 } from '@ai-sdk/provider-utils';
 import { NoOutputGeneratedError } from '../error';
-import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveLanguageModel } from '../model/resolve-model';
 import type { ModelMessage } from '../prompt';
@@ -64,7 +62,7 @@ import { VERSION } from '../version';
 import type { ActiveTools } from './active-tools';
 import { calculateTokensPerSecond } from './calculate-tokens-per-second';
 import { collectToolApprovals } from './collect-tool-approvals';
-import type { ContentPart } from './content-part';
+import { convertLanguageModelContent } from './convert-language-model-content';
 import { executeToolCall } from './execute-tool-call';
 import {
   filterActiveTools,
@@ -78,7 +76,6 @@ import type {
   GenerateTextOnStepStartCallback,
 } from './generate-text-events';
 import type { GenerateTextResult } from './generate-text-result';
-import { DefaultGeneratedFile } from './generated-file';
 import { isToolExecutionAllowedFinishReason } from './is-tool-execution-allowed-finish-reason';
 import type {
   OnLanguageModelCallEndCallback,
@@ -115,7 +112,6 @@ import {
 } from './tool-caller-configuration';
 import type { TypedToolCall } from './tool-call';
 import type { ToolCallRepairFunction } from './tool-call-repair-function';
-import type { TypedToolError } from './tool-error';
 import type {
   OnToolExecutionEndCallback,
   OnToolExecutionStartCallback,
@@ -123,7 +119,6 @@ import type {
 import type { ToolInputRefinement } from './tool-input-refinement';
 import type { ToolOrder } from './tool-order';
 import type { ToolOutput } from './tool-output';
-import type { TypedToolResult } from './tool-result';
 import type { ToolsContextParameter } from './tools-context-parameter';
 import { maybeSignApproval } from './tool-approval-signature';
 import { validateApprovedToolApprovals } from './validate-tool-approvals';
@@ -1088,7 +1083,7 @@ export async function generateText<
               > = {};
               const blockedToolCallIds = new Set<string>();
 
-              const modelCallContent = asContent({
+              const modelCallContent = convertLanguageModelContent({
                 content: currentModelResponse.content,
                 toolCalls: stepToolCalls,
                 toolOutputs: [],
@@ -1378,7 +1373,7 @@ export async function generateText<
               }
 
               // content:
-              const stepContent = asContent({
+              const stepContent = convertLanguageModelContent({
                 content: currentModelResponse.content,
                 toolCalls: stepToolCalls,
                 toolOutputs: clientToolOutputs,
@@ -1751,192 +1746,4 @@ class DefaultGenerateTextResult<
 
     return this._output;
   }
-}
-
-function asContent<TOOLS extends ToolSet>({
-  content,
-  toolCalls,
-  toolOutputs,
-  toolApprovalRequests,
-  toolApprovalResponses,
-  tools,
-}: {
-  content: Array<LanguageModelV4Content>;
-  toolCalls: Array<TypedToolCall<TOOLS>>;
-  toolOutputs: Array<ToolOutput<TOOLS>>;
-  toolApprovalRequests: Array<ToolApprovalRequestOutput<TOOLS>>;
-  toolApprovalResponses: Array<ToolApprovalResponseOutput<TOOLS>>;
-  tools: TOOLS | undefined;
-}): Array<ContentPart<TOOLS>> {
-  const contentParts: Array<ContentPart<TOOLS>> = [];
-  const toolOutputsWithApprovalResponses: Array<ToolOutput<TOOLS>> = [];
-  const toolOutputsWithoutApprovalResponses: Array<ToolOutput<TOOLS>> = [];
-  const toolCallIdsWithApprovalResponses = new Set(
-    toolApprovalResponses.map(
-      toolApprovalResponse => toolApprovalResponse.toolCall.toolCallId,
-    ),
-  );
-
-  for (const part of content) {
-    switch (part.type) {
-      case 'text':
-      case 'reasoning':
-      case 'custom':
-      case 'source':
-        contentParts.push(part);
-        break;
-
-      case 'file':
-      case 'reasoning-file': {
-        contentParts.push({
-          type: part.type as 'file' | 'reasoning-file',
-          file: new DefaultGeneratedFile({
-            data:
-              part.data.type === 'data'
-                ? part.data.data
-                : part.data.url.toString(),
-            mediaType: part.mediaType,
-          }),
-          ...(part.providerMetadata != null
-            ? { providerMetadata: part.providerMetadata }
-            : {}),
-        });
-        break;
-      }
-
-      case 'tool-call': {
-        contentParts.push(
-          toolCalls.find(toolCall => toolCall.toolCallId === part.toolCallId)!,
-        );
-        break;
-      }
-
-      case 'tool-result': {
-        const toolCall = toolCalls.find(
-          toolCall => toolCall.toolCallId === part.toolCallId,
-        );
-
-        // Handle deferred results for provider-executed tools (e.g., programmatic tool calling).
-        // When a server tool (like code_execution) triggers a client tool, the server tool's
-        // result may be deferred to a later turn. In this case, there's no matching tool-call
-        // in the current response.
-        if (toolCall == null) {
-          const tool = getOwn(tools, part.toolName);
-          const supportsDeferredResults =
-            tool?.type === 'provider' && tool.supportsDeferredResults;
-
-          if (!supportsDeferredResults) {
-            throw new Error(`Tool call ${part.toolCallId} not found.`);
-          }
-
-          // Create tool result without tool call input (deferred result)
-          if (part.isError) {
-            contentParts.push({
-              type: 'tool-error' as const,
-              toolCallId: part.toolCallId,
-              toolName: part.toolName as keyof TOOLS & string,
-              input: undefined,
-              error: part.result,
-              providerExecuted: true,
-              dynamic: part.dynamic,
-              ...(part.providerMetadata != null
-                ? { providerMetadata: part.providerMetadata }
-                : {}),
-              ...(tool?.metadata != null
-                ? { toolMetadata: tool.metadata }
-                : {}),
-            } as TypedToolError<TOOLS>);
-          } else {
-            contentParts.push({
-              type: 'tool-result' as const,
-              toolCallId: part.toolCallId,
-              toolName: part.toolName as keyof TOOLS & string,
-              input: undefined,
-              output: part.result,
-              providerExecuted: true,
-              dynamic: part.dynamic,
-              ...(part.providerMetadata != null
-                ? { providerMetadata: part.providerMetadata }
-                : {}),
-              ...(tool?.metadata != null
-                ? { toolMetadata: tool.metadata }
-                : {}),
-            } as TypedToolResult<TOOLS>);
-          }
-          break;
-        }
-
-        if (part.isError) {
-          contentParts.push({
-            type: 'tool-error' as const,
-            toolCallId: part.toolCallId,
-            toolName: part.toolName as keyof TOOLS & string,
-            input: toolCall.input,
-            error: part.result,
-            providerExecuted: true,
-            dynamic: toolCall.dynamic,
-            ...(part.providerMetadata != null
-              ? { providerMetadata: part.providerMetadata }
-              : {}),
-            ...(toolCall.toolMetadata != null
-              ? { toolMetadata: toolCall.toolMetadata }
-              : {}),
-          } as TypedToolError<TOOLS>);
-        } else {
-          contentParts.push({
-            type: 'tool-result' as const,
-            toolCallId: part.toolCallId,
-            toolName: part.toolName as keyof TOOLS & string,
-            input: toolCall.input,
-            output: part.result,
-            providerExecuted: true,
-            dynamic: toolCall.dynamic,
-            ...(part.providerMetadata != null
-              ? { providerMetadata: part.providerMetadata }
-              : {}),
-            ...(toolCall.toolMetadata != null
-              ? { toolMetadata: toolCall.toolMetadata }
-              : {}),
-          } as TypedToolResult<TOOLS>);
-        }
-        break;
-      }
-
-      case 'tool-approval-request': {
-        const toolCall = toolCalls.find(
-          toolCall => toolCall.toolCallId === part.toolCallId,
-        );
-
-        if (toolCall == null) {
-          throw new ToolCallNotFoundForApprovalError({
-            toolCallId: part.toolCallId,
-            approvalId: part.approvalId,
-          });
-        }
-
-        contentParts.push({
-          type: 'tool-approval-request' as const,
-          approvalId: part.approvalId,
-          toolCall,
-        });
-        break;
-      }
-    }
-  }
-
-  for (const toolOutput of toolOutputs) {
-    if (toolCallIdsWithApprovalResponses.has(toolOutput.toolCallId)) {
-      toolOutputsWithApprovalResponses.push(toolOutput);
-    } else {
-      toolOutputsWithoutApprovalResponses.push(toolOutput);
-    }
-  }
-
-  return [
-    ...contentParts,
-    ...toolOutputsWithoutApprovalResponses,
-    ...toolApprovalRequests,
-    ...toolApprovalResponses,
-    ...toolOutputsWithApprovalResponses,
-  ];
 }

--- a/packages/anthropic/src/anthropic-api.ts
+++ b/packages/anthropic/src/anthropic-api.ts
@@ -681,7 +681,7 @@ export const anthropicResponseSchema = lazySchema(() =>
                     type: z.literal('web_search_result_location'),
                     cited_text: z.string(),
                     url: z.string(),
-                    title: z.string(),
+                    title: z.string().nullable(),
                     encrypted_index: z.string(),
                   }),
                   z.object({
@@ -700,8 +700,27 @@ export const anthropicResponseSchema = lazySchema(() =>
                     start_char_index: z.number(),
                     end_char_index: z.number(),
                   }),
+                  z.object({
+                    type: z.literal('content_block_location'),
+                    cited_text: z.string(),
+                    document_index: z.number(),
+                    document_title: z.string().nullable(),
+                    start_block_index: z.number(),
+                    end_block_index: z.number(),
+                    file_id: z.string().nullable(),
+                  }),
+                  z.object({
+                    type: z.literal('search_result_location'),
+                    cited_text: z.string(),
+                    search_result_index: z.number(),
+                    source: z.string(),
+                    title: z.string().nullable(),
+                    start_block_index: z.number(),
+                    end_block_index: z.number(),
+                  }),
                 ]),
               )
+              .nullable()
               .optional(),
           }),
           z.object({
@@ -926,6 +945,10 @@ export const anthropicResponseSchema = lazySchema(() =>
                 error_code: z.string(),
               }),
             ]),
+          }),
+          z.object({
+            type: z.literal('container_upload'),
+            file_id: z.string(),
           }),
           // advisor results for advisor_20260301:
           z.object({

--- a/packages/anthropic/src/anthropic-api.ts
+++ b/packages/anthropic/src/anthropic-api.ts
@@ -416,7 +416,13 @@ export interface AnthropicMcpToolResultContent {
   type: 'mcp_tool_result';
   tool_use_id: string;
   is_error: boolean;
-  content: string | Array<{ type: 'text'; text: string }>;
+  content:
+    | string
+    | Array<{
+        type: 'text';
+        text: string;
+        citations?: Citation[] | null;
+      }>;
   cache_control: AnthropicCacheControl | undefined;
 }
 
@@ -737,12 +743,19 @@ export const anthropicResponseSchema = lazySchema(() =>
             type: z.literal('mcp_tool_result'),
             tool_use_id: z.string(),
             is_error: z.boolean(),
-            content: z.array(
-              z.union([
-                z.string(),
-                z.object({ type: z.literal('text'), text: z.string() }),
-              ]),
-            ),
+            content: z.union([
+              z.string(),
+              z.array(
+                z.union([
+                  z.string(),
+                  z.object({
+                    type: z.literal('text'),
+                    text: z.string(),
+                    citations: z.array(z.json()).nullable().optional(),
+                  }),
+                ]),
+              ),
+            ]),
           }),
           z.object({
             type: z.literal('web_fetch_tool_result'),
@@ -752,7 +765,7 @@ export const anthropicResponseSchema = lazySchema(() =>
               z.object({
                 type: z.literal('web_fetch_result'),
                 url: z.string(),
-                retrieved_at: z.string(),
+                retrieved_at: z.string().nullable(),
                 content: z.object({
                   type: z.literal('document'),
                   title: z.string().nullable(),
@@ -786,7 +799,7 @@ export const anthropicResponseSchema = lazySchema(() =>
                 z.object({
                   type: z.literal('web_search_result'),
                   url: z.string(),
-                  title: z.string(),
+                  title: z.string().nullable(),
                   encrypted_content: z.string(),
                   page_age: z.string().nullish(),
                 }),
@@ -1103,7 +1116,11 @@ export const anthropicChunkSchema = lazySchema(() =>
             content: z.array(
               z.union([
                 z.string(),
-                z.object({ type: z.literal('text'), text: z.string() }),
+                z.object({
+                  type: z.literal('text'),
+                  text: z.string(),
+                  citations: z.array(z.json()).nullable().optional(),
+                }),
               ]),
             ),
           }),
@@ -1115,7 +1132,7 @@ export const anthropicChunkSchema = lazySchema(() =>
               z.object({
                 type: z.literal('web_fetch_result'),
                 url: z.string(),
-                retrieved_at: z.string(),
+                retrieved_at: z.string().nullable(),
                 content: z.object({
                   type: z.literal('document'),
                   title: z.string().nullable(),
@@ -1149,7 +1166,7 @@ export const anthropicChunkSchema = lazySchema(() =>
                 z.object({
                   type: z.literal('web_search_result'),
                   url: z.string(),
-                  title: z.string(),
+                  title: z.string().nullable(),
                   encrypted_content: z.string(),
                   page_age: z.string().nullish(),
                 }),

--- a/packages/anthropic/src/anthropic-api.ts
+++ b/packages/anthropic/src/anthropic-api.ts
@@ -691,6 +691,7 @@ export const anthropicResponseSchema = lazySchema(() =>
                     document_title: z.string().nullable(),
                     start_page_number: z.number(),
                     end_page_number: z.number(),
+                    file_id: z.string().nullish(),
                   }),
                   z.object({
                     type: z.literal('char_location'),
@@ -699,6 +700,7 @@ export const anthropicResponseSchema = lazySchema(() =>
                     document_title: z.string().nullable(),
                     start_char_index: z.number(),
                     end_char_index: z.number(),
+                    file_id: z.string().nullish(),
                   }),
                   z.object({
                     type: z.literal('content_block_location'),

--- a/packages/anthropic/src/anthropic-api.ts
+++ b/packages/anthropic/src/anthropic-api.ts
@@ -715,7 +715,9 @@ const anthropicMcpToolResultContentSchema = z.union([
       z.object({
         type: z.literal('text'),
         text: z.string(),
-        citations: z.array(anthropicCitationSchema).nullable().optional(),
+        // MCP tool-result citations are opaque third-party pass-through data.
+        // Keep them permissive so new shapes do not reject whole responses.
+        citations: z.array(z.json()).nullable().optional(),
       }),
     ]),
   ),

--- a/packages/anthropic/src/anthropic-api.ts
+++ b/packages/anthropic/src/anthropic-api.ts
@@ -661,6 +661,66 @@ const anthropicToolCallCallerSchema = z.union([
   }),
 ]);
 
+const anthropicCitationSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('web_search_result_location'),
+    cited_text: z.string(),
+    url: z.string(),
+    title: z.string().nullable(),
+    encrypted_index: z.string(),
+  }),
+  z.object({
+    type: z.literal('page_location'),
+    cited_text: z.string(),
+    document_index: z.number(),
+    document_title: z.string().nullable(),
+    start_page_number: z.number(),
+    end_page_number: z.number(),
+    file_id: z.string().nullish(),
+  }),
+  z.object({
+    type: z.literal('char_location'),
+    cited_text: z.string(),
+    document_index: z.number(),
+    document_title: z.string().nullable(),
+    start_char_index: z.number(),
+    end_char_index: z.number(),
+    file_id: z.string().nullish(),
+  }),
+  z.object({
+    type: z.literal('content_block_location'),
+    cited_text: z.string(),
+    document_index: z.number(),
+    document_title: z.string().nullable(),
+    start_block_index: z.number(),
+    end_block_index: z.number(),
+    file_id: z.string().nullable(),
+  }),
+  z.object({
+    type: z.literal('search_result_location'),
+    cited_text: z.string(),
+    search_result_index: z.number(),
+    source: z.string(),
+    title: z.string().nullable(),
+    start_block_index: z.number(),
+    end_block_index: z.number(),
+  }),
+]);
+
+const anthropicMcpToolResultContentSchema = z.union([
+  z.string(),
+  z.array(
+    z.union([
+      z.string(),
+      z.object({
+        type: z.literal('text'),
+        text: z.string(),
+        citations: z.array(anthropicCitationSchema).nullable().optional(),
+      }),
+    ]),
+  ),
+]);
+
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
 export const anthropicResponseSchema = lazySchema(() =>
@@ -674,56 +734,7 @@ export const anthropicResponseSchema = lazySchema(() =>
           z.object({
             type: z.literal('text'),
             text: z.string(),
-            citations: z
-              .array(
-                z.discriminatedUnion('type', [
-                  z.object({
-                    type: z.literal('web_search_result_location'),
-                    cited_text: z.string(),
-                    url: z.string(),
-                    title: z.string().nullable(),
-                    encrypted_index: z.string(),
-                  }),
-                  z.object({
-                    type: z.literal('page_location'),
-                    cited_text: z.string(),
-                    document_index: z.number(),
-                    document_title: z.string().nullable(),
-                    start_page_number: z.number(),
-                    end_page_number: z.number(),
-                    file_id: z.string().nullish(),
-                  }),
-                  z.object({
-                    type: z.literal('char_location'),
-                    cited_text: z.string(),
-                    document_index: z.number(),
-                    document_title: z.string().nullable(),
-                    start_char_index: z.number(),
-                    end_char_index: z.number(),
-                    file_id: z.string().nullish(),
-                  }),
-                  z.object({
-                    type: z.literal('content_block_location'),
-                    cited_text: z.string(),
-                    document_index: z.number(),
-                    document_title: z.string().nullable(),
-                    start_block_index: z.number(),
-                    end_block_index: z.number(),
-                    file_id: z.string().nullable(),
-                  }),
-                  z.object({
-                    type: z.literal('search_result_location'),
-                    cited_text: z.string(),
-                    search_result_index: z.number(),
-                    source: z.string(),
-                    title: z.string().nullable(),
-                    start_block_index: z.number(),
-                    end_block_index: z.number(),
-                  }),
-                ]),
-              )
-              .nullable()
-              .optional(),
+            citations: z.array(anthropicCitationSchema).nullable().optional(),
           }),
           z.object({
             type: z.literal('thinking'),
@@ -764,19 +775,7 @@ export const anthropicResponseSchema = lazySchema(() =>
             type: z.literal('mcp_tool_result'),
             tool_use_id: z.string(),
             is_error: z.boolean(),
-            content: z.union([
-              z.string(),
-              z.array(
-                z.union([
-                  z.string(),
-                  z.object({
-                    type: z.literal('text'),
-                    text: z.string(),
-                    citations: z.array(z.json()).nullable().optional(),
-                  }),
-                ]),
-              ),
-            ]),
+            content: anthropicMcpToolResultContentSchema,
           }),
           z.object({
             type: z.literal('web_fetch_tool_result'),
@@ -1138,16 +1137,7 @@ export const anthropicChunkSchema = lazySchema(() =>
             type: z.literal('mcp_tool_result'),
             tool_use_id: z.string(),
             is_error: z.boolean(),
-            content: z.array(
-              z.union([
-                z.string(),
-                z.object({
-                  type: z.literal('text'),
-                  text: z.string(),
-                  citations: z.array(z.json()).nullable().optional(),
-                }),
-              ]),
-            ),
+            content: anthropicMcpToolResultContentSchema,
           }),
           z.object({
             type: z.literal('web_fetch_tool_result'),
@@ -1373,31 +1363,7 @@ export const anthropicChunkSchema = lazySchema(() =>
           }),
           z.object({
             type: z.literal('citations_delta'),
-            citation: z.discriminatedUnion('type', [
-              z.object({
-                type: z.literal('web_search_result_location'),
-                cited_text: z.string(),
-                url: z.string(),
-                title: z.string(),
-                encrypted_index: z.string(),
-              }),
-              z.object({
-                type: z.literal('page_location'),
-                cited_text: z.string(),
-                document_index: z.number(),
-                document_title: z.string().nullable(),
-                start_page_number: z.number(),
-                end_page_number: z.number(),
-              }),
-              z.object({
-                type: z.literal('char_location'),
-                cited_text: z.string(),
-                document_index: z.number(),
-                document_title: z.string().nullable(),
-                start_char_index: z.number(),
-                end_char_index: z.number(),
-              }),
-            ]),
+            citation: anthropicCitationSchema,
           }),
         ]),
       }),

--- a/packages/anthropic/src/anthropic-language-model-options.ts
+++ b/packages/anthropic/src/anthropic-language-model-options.ts
@@ -268,6 +268,9 @@ export const anthropicLanguageModelOptions = z.object({
    */
   speed: z.enum(['fast', 'standard']).optional(),
 
+  /** Selects Anthropic's service tier for the request. */
+  serviceTier: z.enum(['auto', 'standard_only']).optional(),
+
   /**
    * Controls where model inference runs for this request.
    *

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -168,6 +168,33 @@ describe('AnthropicLanguageModel', () => {
         `);
       });
 
+      it('should preserve container upload response blocks as custom content', async () => {
+        server.urls['https://api.anthropic.com/v1/messages'].response = {
+          type: 'json-value',
+          body: {
+            id: 'msg_container_upload',
+            type: 'message',
+            role: 'assistant',
+            content: [
+              { type: 'text', text: 'Done' },
+              { type: 'container_upload', file_id: 'file_123' },
+            ],
+            model: 'claude-3-haiku-20240307',
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            usage: { input_tokens: 4, output_tokens: 2 },
+          },
+        };
+
+        const { content } = await model.doGenerate({ prompt: TEST_PROMPT });
+
+        expect(content).toContainEqual({
+          type: 'custom',
+          kind: 'anthropic.container_upload',
+          providerMetadata: { anthropic: { fileId: 'file_123' } },
+        });
+      });
+
       it('should use default budget when thinking type is enabled without budgetTokens', async () => {
         prepareJsonFixtureResponse('anthropic-text');
 

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -2953,7 +2953,12 @@ export function hasWebTool20260209WithoutCodeExecution(
       hasWebTool20260209 = true;
       continue;
     }
-    if (tool.name === 'code_execution') {
+    if (
+      'type' in tool &&
+      (tool.type === 'code_execution_20250522' ||
+        tool.type === 'code_execution_20250825' ||
+        tool.type === 'code_execution_20260120')
+    ) {
       hasCodeExecutionTool = true;
       break;
     }

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -118,7 +118,7 @@ function getAnthropicStreamErrorMetadata(type: string): {
   }
 }
 
-function createCitationSource(
+export function createCitationSource(
   citation: Citation,
   citationDocuments: Array<{
     title: string;
@@ -226,7 +226,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
   readonly modelId: AnthropicModelId;
 
   protected readonly config: AnthropicLanguageModelConfig;
-  private readonly generateId: () => string;
+  protected readonly generateId: () => string;
 
   static [WORKFLOW_SERIALIZE](model: AnthropicLanguageModel) {
     return serializeModelOptions({
@@ -599,6 +599,9 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
       }),
       ...(anthropicOptions?.speed && {
         speed: anthropicOptions.speed,
+      }),
+      ...(anthropicOptions?.serviceTier && {
+        service_tier: anthropicOptions.serviceTier,
       }),
       ...(anthropicOptions?.inferenceGeo && {
         inference_geo: anthropicOptions.inferenceGeo,
@@ -1301,7 +1304,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
               toolName: toolNameMapping.toCustomToolName('web_search'),
               result: part.content.map(result => ({
                 url: result.url,
-                title: result.title,
+                ...(result.title != null ? { title: result.title } : {}),
                 pageAge: result.page_age ?? null,
                 encryptedContent: result.encrypted_content,
                 type: result.type,
@@ -1315,7 +1318,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                 sourceType: 'url',
                 id: this.generateId(),
                 url: result.url,
-                title: result.title,
+                ...(result.title != null ? { title: result.title } : {}),
                 providerMetadata: {
                   anthropic: {
                     pageAge: result.page_age ?? null,
@@ -2011,7 +2014,9 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                       toolName: toolNameMapping.toCustomToolName('web_search'),
                       result: part.content.map(result => ({
                         url: result.url,
-                        title: result.title,
+                        ...(result.title != null
+                          ? { title: result.title }
+                          : {}),
                         pageAge: result.page_age ?? null,
                         encryptedContent: result.encrypted_content,
                         type: result.type,
@@ -2025,7 +2030,9 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                         sourceType: 'url',
                         id: generateId(),
                         url: result.url,
-                        title: result.title,
+                        ...(result.title != null
+                          ? { title: result.title }
+                          : {}),
                         providerMetadata: {
                           anthropic: {
                             pageAge: result.page_age ?? null,
@@ -2921,7 +2928,7 @@ export function getModelCapabilities(modelId: string): {
   }
 }
 
-function hasWebTool20260209WithoutCodeExecution(
+export function hasWebTool20260209WithoutCodeExecution(
   tools: AnthropicTool[] | undefined,
 ): boolean {
   if (!tools) {

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -133,7 +133,7 @@ export function createCitationSource(
       sourceType: 'url' as const,
       id: generateId(),
       url: citation.url,
-      title: citation.title,
+      title: citation.title ?? undefined,
       providerMetadata: {
         anthropic: {
           citedText: citation.cited_text,

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -1107,6 +1107,14 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
           });
           break;
         }
+        case 'container_upload': {
+          content.push({
+            type: 'custom',
+            kind: 'anthropic.container_upload',
+            providerMetadata: { anthropic: { fileId: part.file_id } },
+          });
+          break;
+        }
         case 'compaction': {
           content.push({
             type: 'text',

--- a/packages/anthropic/src/anthropic-messages-batch.test.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.test.ts
@@ -979,6 +979,20 @@ describe('Anthropic Messages batch language model', () => {
                     },
                   ],
                 },
+                {
+                  type: 'text',
+                  text: 'Document excerpt',
+                  citations: [
+                    {
+                      type: 'char_location',
+                      cited_text: 'document text',
+                      document_index: 0,
+                      document_title: null,
+                      start_char_index: 0,
+                      end_char_index: 13,
+                    },
+                  ],
+                },
               ],
             },
           },
@@ -1039,6 +1053,24 @@ describe('Anthropic Messages batch language model', () => {
               sourceType: 'url',
               id: 'nullable-source',
               url: 'https://example.com/search-result',
+            },
+            {
+              type: 'text',
+              text: 'Document excerpt',
+            },
+            {
+              type: 'source',
+              sourceType: 'document',
+              id: 'nullable-source',
+              mediaType: 'text/plain',
+              title: 'https://example.com/document',
+              providerMetadata: {
+                anthropic: {
+                  citedText: 'document text',
+                  startCharIndex: 0,
+                  endCharIndex: 13,
+                },
+              },
             },
           ],
         },
@@ -1464,7 +1496,16 @@ describe('Anthropic Messages batch language model', () => {
           id: 'container-upload',
           status: 'succeeded',
           result: {
-            content: [{ type: 'text', text: 'Done' }],
+            content: [
+              { type: 'text', text: 'Done' },
+              {
+                type: 'custom',
+                kind: 'anthropic.container_upload',
+                providerMetadata: {
+                  anthropic: { fileId: 'file_123' },
+                },
+              },
+            ],
             usage: {
               inputTokens: { total: 13 },
               outputTokens: { total: 3 },

--- a/packages/anthropic/src/anthropic-messages-batch.test.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.test.ts
@@ -841,7 +841,7 @@ describe('Anthropic Messages batch language model', () => {
     ]);
   });
 
-  it('preserves web search citations without attaching document citations to text metadata', async () => {
+  it('preserves raw batch citations without misattributing document indices', async () => {
     server.urls[urls.batch].response = {
       type: 'json-value',
       body: batchResponse(),
@@ -904,6 +904,14 @@ describe('Anthropic Messages batch language model', () => {
               providerMetadata: {
                 anthropic: {
                   citations: [
+                    {
+                      type: 'page_location',
+                      cited_text: 'Paris is sunny.',
+                      document_index: 0,
+                      document_title: 'Weather report',
+                      start_page_number: 1,
+                      end_page_number: 1,
+                    },
                     {
                       type: 'web_search_result_location',
                       cited_text: 'Paris is sunny.',
@@ -1057,18 +1065,18 @@ describe('Anthropic Messages batch language model', () => {
             {
               type: 'text',
               text: 'Document excerpt',
-            },
-            {
-              type: 'source',
-              sourceType: 'document',
-              id: 'nullable-source',
-              mediaType: 'text/plain',
-              title: 'https://example.com/document',
               providerMetadata: {
                 anthropic: {
-                  citedText: 'document text',
-                  startCharIndex: 0,
-                  endCharIndex: 13,
+                  citations: [
+                    {
+                      type: 'char_location',
+                      cited_text: 'document text',
+                      document_index: 0,
+                      document_title: null,
+                      start_char_index: 0,
+                      end_char_index: 13,
+                    },
+                  ],
                 },
               },
             },

--- a/packages/anthropic/src/anthropic-messages-batch.test.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.test.ts
@@ -1354,6 +1354,126 @@ describe('Anthropic Messages batch language model', () => {
       ]);
     });
 
+    it('preserves successful messages with nullable and newer citation shapes', async () => {
+      server.urls[urls.batch].response = {
+        type: 'json-value',
+        body: batchResponse(),
+      };
+      server.urls[urls.results].response = {
+        type: 'stream-chunks',
+        chunks: [
+          JSON.stringify({
+            custom_id: 'citation-shapes',
+            result: {
+              type: 'succeeded',
+              message: {
+                ...messageResultBody('Cited answer'),
+                content: [
+                  { type: 'text', text: 'No citations', citations: null },
+                  {
+                    type: 'text',
+                    text: 'New citations',
+                    citations: [
+                      {
+                        type: 'content_block_location',
+                        cited_text: 'block',
+                        document_index: 0,
+                        document_title: null,
+                        start_block_index: 0,
+                        end_block_index: 1,
+                        file_id: null,
+                      },
+                      {
+                        type: 'search_result_location',
+                        cited_text: 'search result',
+                        search_result_index: 0,
+                        source: 'https://example.com',
+                        title: null,
+                        start_block_index: 0,
+                        end_block_index: 1,
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          }),
+        ],
+      };
+      const model = createAnthropic({ apiKey: 'test-api-key' })(
+        'claude-3-haiku-20240307',
+      );
+
+      const stream = await model.experimental_doGetBatchResults({
+        batchId: 'msgbatch_123',
+      });
+      const results = await convertReadableStreamToArray(stream);
+
+      expect(results).toMatchObject([
+        {
+          id: 'citation-shapes',
+          status: 'succeeded',
+          result: {
+            content: [
+              { type: 'text', text: 'No citations' },
+              { type: 'text', text: 'New citations' },
+            ],
+            usage: {
+              inputTokens: { total: 13 },
+              outputTokens: { total: 3 },
+            },
+          },
+        },
+      ]);
+    });
+
+    it('does not fail a successful message for a container upload block', async () => {
+      server.urls[urls.batch].response = {
+        type: 'json-value',
+        body: batchResponse(),
+      };
+      server.urls[urls.results].response = {
+        type: 'stream-chunks',
+        chunks: [
+          JSON.stringify({
+            custom_id: 'container-upload',
+            result: {
+              type: 'succeeded',
+              message: {
+                ...messageResultBody('Done'),
+                content: [
+                  { type: 'text', text: 'Done' },
+                  { type: 'container_upload', file_id: 'file_123' },
+                ],
+              },
+            },
+          }),
+        ],
+      };
+      const model = createAnthropic({ apiKey: 'test-api-key' })(
+        'claude-3-haiku-20240307',
+      );
+
+      const stream = await model.experimental_doGetBatchResults({
+        batchId: 'msgbatch_123',
+      });
+      const results = await convertReadableStreamToArray(stream);
+
+      expect(results).toMatchObject([
+        {
+          id: 'container-upload',
+          status: 'succeeded',
+          result: {
+            content: [{ type: 'text', text: 'Done' }],
+            usage: {
+              inputTokens: { total: 13 },
+              outputTokens: { total: 3 },
+            },
+          },
+        },
+      ]);
+    });
+
     it('rejects a completed batch without output', async () => {
       server.urls[urls.batch].response = {
         type: 'json-value',

--- a/packages/anthropic/src/anthropic-messages-batch.test.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.test.ts
@@ -841,7 +841,7 @@ describe('Anthropic Messages batch language model', () => {
     ]);
   });
 
-  it('preserves text citations as URL sources', async () => {
+  it('preserves web search citations without attaching document citations to text metadata', async () => {
     server.urls[urls.batch].response = {
       type: 'json-value',
       body: batchResponse(),
@@ -860,6 +860,14 @@ describe('Anthropic Messages batch language model', () => {
                   type: 'text',
                   text: 'Paris is sunny.',
                   citations: [
+                    {
+                      type: 'page_location',
+                      cited_text: 'Paris is sunny.',
+                      document_index: 0,
+                      document_title: 'Weather report',
+                      start_page_number: 1,
+                      end_page_number: 1,
+                    },
                     {
                       type: 'web_search_result_location',
                       cited_text: 'Paris is sunny.',

--- a/packages/anthropic/src/anthropic-messages-batch.test.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.test.ts
@@ -331,76 +331,93 @@ describe('Anthropic Messages batch language model', () => {
     expect(server.calls).toHaveLength(0);
   });
 
-  it('rejects implicit code execution that cannot be restored later', async () => {
+  it('allows web tools that implicitly provision code execution', async () => {
+    server.urls[urls.batches].response = {
+      type: 'json-value',
+      body: batchResponse({ processing_status: 'in_progress' }),
+    };
     const model = createAnthropic({ apiKey: 'test-api-key' })(
       'claude-3-haiku-20240307',
     );
 
-    await expect(
-      model.experimental_doStartBatch({
-        requests: [
-          {
-            id: 'request-1',
-            ...request('Search', {
-              tools: [
-                {
-                  type: 'provider',
-                  id: 'anthropic.web_search_20260209',
-                  name: 'web_search',
-                  args: {},
-                },
-              ],
-            }),
-          },
-        ],
-      }),
-    ).rejects.toMatchObject({
-      name: 'AI_UnsupportedFunctionalityError',
-      functionality:
-        'implicit code execution for 20260209 web tools in batches',
+    await model.experimental_doStartBatch({
+      requests: [
+        {
+          id: 'request-1',
+          ...request('Search', {
+            tools: [
+              {
+                type: 'provider',
+                id: 'anthropic.web_search_20260209',
+                name: 'web_search',
+                args: {},
+              },
+            ],
+          }),
+        },
+      ],
     });
-    expect(server.calls).toHaveLength(0);
+
+    await expect(server.calls[0].requestBodyJson).resolves.toMatchObject({
+      requests: [
+        {
+          params: {
+            tools: [{ type: 'web_search_20260209', name: 'web_search' }],
+          },
+        },
+      ],
+    });
   });
 
   it('does not treat a custom code_execution function as the provider tool', async () => {
+    server.urls[urls.batches].response = {
+      type: 'json-value',
+      body: batchResponse({ processing_status: 'in_progress' }),
+    };
     const model = createAnthropic({ apiKey: 'test-api-key' })(
       'claude-3-haiku-20240307',
     );
 
-    await expect(
-      model.experimental_doStartBatch({
-        requests: [
-          {
-            id: 'request-1',
-            ...request('Search', {
-              tools: [
-                {
-                  type: 'provider',
-                  id: 'anthropic.web_search_20260209',
-                  name: 'web_search',
-                  args: {},
+    await model.experimental_doStartBatch({
+      requests: [
+        {
+          id: 'request-1',
+          ...request('Search', {
+            tools: [
+              {
+                type: 'provider',
+                id: 'anthropic.web_search_20260209',
+                name: 'web_search',
+                args: {},
+              },
+              {
+                type: 'function',
+                name: 'code_execution',
+                description: 'A custom client-side function',
+                inputSchema: {
+                  type: 'object',
+                  properties: {},
+                  additionalProperties: false,
                 },
-                {
-                  type: 'function',
-                  name: 'code_execution',
-                  description: 'A custom client-side function',
-                  inputSchema: {
-                    type: 'object',
-                    properties: {},
-                    additionalProperties: false,
-                  },
-                },
-              ],
-            }),
-          },
-        ],
-      }),
-    ).rejects.toMatchObject({
-      name: 'AI_UnsupportedFunctionalityError',
-      functionality:
-        'implicit code execution for 20260209 web tools in batches',
+              },
+            ],
+          }),
+        },
+      ],
     });
-    expect(server.calls).toHaveLength(0);
+
+    await expect(server.calls[0].requestBodyJson).resolves.toMatchObject({
+      requests: [
+        {
+          params: {
+            tools: [
+              { type: 'web_search_20260209', name: 'web_search' },
+              { name: 'code_execution' },
+            ],
+          },
+        },
+      ],
+    });
   });
 
   it.each([
@@ -735,6 +752,12 @@ describe('Anthropic Messages batch language model', () => {
                   input: { query: 'weather Paris' },
                 },
                 {
+                  type: 'server_tool_use',
+                  id: 'code_123',
+                  name: 'code_execution',
+                  input: { code: 'print("Paris")' },
+                },
+                {
                   type: 'web_search_tool_result',
                   tool_use_id: 'srvtoolu_123',
                   content: [
@@ -807,6 +830,15 @@ describe('Anthropic Messages batch language model', () => {
               toolName: 'web_search',
               input: '{"query":"weather Paris"}',
               providerExecuted: true,
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'code_123',
+              toolName: 'code_execution',
+              input:
+                '{"type":"programmatic-tool-call","code":"print(\\"Paris\\")"}',
+              providerExecuted: true,
+              dynamic: true,
             },
             {
               type: 'tool-result',
@@ -908,6 +940,16 @@ describe('Anthropic Messages batch language model', () => {
                       document_title: 'Weather report',
                       start_page_number: 1,
                       end_page_number: 1,
+                      file_id: 'file_page',
+                    },
+                    {
+                      type: 'char_location',
+                      cited_text: 'Paris is sunny.',
+                      document_index: 0,
+                      document_title: 'Weather report',
+                      start_char_index: 0,
+                      end_char_index: 15,
+                      file_id: 'file_char',
                     },
                     {
                       type: 'web_search_result_location',
@@ -952,6 +994,16 @@ describe('Anthropic Messages batch language model', () => {
                       document_title: 'Weather report',
                       start_page_number: 1,
                       end_page_number: 1,
+                      file_id: 'file_page',
+                    },
+                    {
+                      type: 'char_location',
+                      cited_text: 'Paris is sunny.',
+                      document_index: 0,
+                      document_title: 'Weather report',
+                      start_char_index: 0,
+                      end_char_index: 15,
+                      file_id: 'file_char',
                     },
                     {
                       type: 'web_search_result_location',

--- a/packages/anthropic/src/anthropic-messages-batch.test.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.test.ts
@@ -67,6 +67,8 @@ function batchResponse(
     created_at: '2024-09-24T18:37:24.100Z',
     expires_at: '2024-09-25T18:37:24.100Z',
     archived_at: null,
+    cancel_initiated_at: null,
+    ended_at: '2024-09-24T18:38:24.100Z',
     results_url: urls.results,
     ...overrides,
   };
@@ -121,6 +123,9 @@ describe('Anthropic Messages batch language model', () => {
           ...request('What is the capital of France?', {
             maxOutputTokens: 100,
             frequencyPenalty: 0.5,
+            providerOptions: {
+              anthropic: { serviceTier: 'auto' },
+            },
           }),
         },
         {
@@ -183,6 +188,7 @@ describe('Anthropic Messages batch language model', () => {
           params: {
             model: 'claude-3-haiku-20240307',
             max_tokens: 100,
+            service_tier: 'auto',
             messages: [
               {
                 role: 'user',
@@ -262,6 +268,96 @@ describe('Anthropic Messages batch language model', () => {
       functionality: 'per-request providerOptions.anthropic.anthropicBeta',
       message:
         'Anthropic Message Batches do not support per-request betas (request "request-1"). Set providerOptions.anthropic.anthropicBeta on startTextBatch instead.',
+    });
+    expect(server.calls).toHaveLength(0);
+  });
+
+  it('rejects structured-output modes that require start-call context', async () => {
+    const model = createAnthropic({ apiKey: 'test-api-key' }).languageModel(
+      'claude-3-haiku-20240307',
+    );
+
+    await expect(
+      model.experimental_doStartBatch({
+        requests: [
+          {
+            id: 'request-1',
+            ...request('Return JSON', {
+              responseFormat: {
+                type: 'json',
+                schema: {
+                  type: 'object',
+                  properties: { answer: { type: 'string' } },
+                },
+              },
+            }),
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      name: 'AI_UnsupportedFunctionalityError',
+      functionality: 'batch responseFormat JSON-tool fallback',
+    });
+    expect(server.calls).toHaveLength(0);
+  });
+
+  it('rejects aliased provider tool names that cannot be restored later', async () => {
+    const model = createAnthropic({ apiKey: 'test-api-key' })(
+      'claude-3-haiku-20240307',
+    );
+
+    await expect(
+      model.experimental_doStartBatch({
+        requests: [
+          {
+            id: 'request-1',
+            ...request('Search', {
+              tools: [
+                {
+                  type: 'provider',
+                  id: 'anthropic.web_search_20250305',
+                  name: 'custom_search',
+                  args: {},
+                },
+              ],
+            }),
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      name: 'AI_UnsupportedFunctionalityError',
+      functionality: 'aliased provider tool names in batches',
+    });
+    expect(server.calls).toHaveLength(0);
+  });
+
+  it('rejects implicit code execution that cannot be restored later', async () => {
+    const model = createAnthropic({ apiKey: 'test-api-key' })(
+      'claude-3-haiku-20240307',
+    );
+
+    await expect(
+      model.experimental_doStartBatch({
+        requests: [
+          {
+            id: 'request-1',
+            ...request('Search', {
+              tools: [
+                {
+                  type: 'provider',
+                  id: 'anthropic.web_search_20260209',
+                  name: 'web_search',
+                  args: {},
+                },
+              ],
+            }),
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      name: 'AI_UnsupportedFunctionalityError',
+      functionality:
+        'implicit code execution for 20260209 web tools in batches',
     });
     expect(server.calls).toHaveLength(0);
   });
@@ -407,6 +503,21 @@ describe('Anthropic Messages batch language model', () => {
       },
       createdAt: '2024-09-24T18:37:24.100Z',
       expiresAt: '2024-09-25T18:37:24.100Z',
+      providerMetadata: {
+        anthropic: {
+          archivedAt: null,
+          cancelInitiatedAt: null,
+          endedAt: '2024-09-24T18:38:24.100Z',
+          requestCounts: {
+            processing: 0,
+            succeeded: 2,
+            errored: 1,
+            canceled: 1,
+            expired: 1,
+          },
+          resultsUrl: urls.results,
+        },
+      },
     });
   });
 
@@ -552,6 +663,530 @@ describe('Anthropic Messages batch language model', () => {
     expect(server.calls.map(call => call.requestUrl)).toEqual([
       urls.batch,
       urls.results,
+    ]);
+  });
+
+  it('preserves client and provider-executed tool content', async () => {
+    server.urls[urls.batch].response = {
+      type: 'json-value',
+      body: batchResponse(),
+    };
+    server.urls[urls.results].response = {
+      type: 'stream-chunks',
+      chunks: [
+        JSON.stringify({
+          custom_id: 'tool-call',
+          result: {
+            type: 'succeeded',
+            message: {
+              ...messageResultBody(''),
+              content: [
+                {
+                  type: 'tool_use',
+                  id: 'toolu_123',
+                  name: 'get_weather',
+                  input: { city: 'Paris' },
+                },
+                {
+                  type: 'server_tool_use',
+                  id: 'srvtoolu_123',
+                  name: 'web_search',
+                  input: { query: 'weather Paris' },
+                },
+                {
+                  type: 'web_search_tool_result',
+                  tool_use_id: 'srvtoolu_123',
+                  content: [
+                    {
+                      type: 'web_search_result',
+                      url: 'https://example.com/weather',
+                      title: 'Paris weather',
+                      encrypted_content: 'encrypted',
+                    },
+                  ],
+                },
+                {
+                  type: 'mcp_tool_use',
+                  id: 'mcp_123',
+                  name: 'lookup',
+                  server_name: 'weather',
+                  input: { city: 'Paris' },
+                },
+                {
+                  type: 'mcp_tool_result',
+                  tool_use_id: 'mcp_123',
+                  is_error: false,
+                  content: [
+                    {
+                      type: 'text',
+                      text: 'sunny',
+                      citations: [
+                        {
+                          type: 'web_search_result_location',
+                          cited_text: 'sunny',
+                          url: 'https://example.com/weather',
+                          title: 'Paris weather',
+                          encrypted_index: 'encrypted-index',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+              stop_reason: 'tool_use',
+            },
+          },
+        }),
+      ],
+    };
+    const model = createAnthropic({
+      apiKey: 'test-api-key',
+      generateId: () => 'source-1',
+    })('claude-3-haiku-20240307');
+
+    const stream = await model.experimental_doGetBatchResults({
+      batchId: 'msgbatch_123',
+    });
+
+    await expect(convertReadableStreamToArray(stream)).resolves.toMatchObject([
+      {
+        id: 'tool-call',
+        status: 'succeeded',
+        result: {
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'toolu_123',
+              toolName: 'get_weather',
+              input: '{"city":"Paris"}',
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'srvtoolu_123',
+              toolName: 'web_search',
+              input: '{"query":"weather Paris"}',
+              providerExecuted: true,
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'srvtoolu_123',
+              toolName: 'web_search',
+              result: [
+                {
+                  encryptedContent: 'encrypted',
+                  pageAge: null,
+                  title: 'Paris weather',
+                  type: 'web_search_result',
+                  url: 'https://example.com/weather',
+                },
+              ],
+            },
+            {
+              type: 'source',
+              sourceType: 'url',
+              id: 'source-1',
+              url: 'https://example.com/weather',
+              title: 'Paris weather',
+              providerMetadata: {
+                anthropic: {
+                  pageAge: null,
+                },
+              },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'mcp_123',
+              toolName: 'lookup',
+              input: '{"city":"Paris"}',
+              providerExecuted: true,
+              dynamic: true,
+              providerMetadata: {
+                anthropic: {
+                  serverName: 'weather',
+                  type: 'mcp-tool-use',
+                },
+              },
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'mcp_123',
+              toolName: 'lookup',
+              isError: false,
+              result: [
+                {
+                  type: 'text',
+                  text: 'sunny',
+                  citations: [
+                    {
+                      type: 'web_search_result_location',
+                      cited_text: 'sunny',
+                      url: 'https://example.com/weather',
+                      title: 'Paris weather',
+                      encrypted_index: 'encrypted-index',
+                    },
+                  ],
+                },
+              ],
+              dynamic: true,
+              providerMetadata: {
+                anthropic: {
+                  serverName: 'weather',
+                  type: 'mcp-tool-use',
+                },
+              },
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('preserves text citations as URL sources', async () => {
+    server.urls[urls.batch].response = {
+      type: 'json-value',
+      body: batchResponse(),
+    };
+    server.urls[urls.results].response = {
+      type: 'stream-chunks',
+      chunks: [
+        JSON.stringify({
+          custom_id: 'citation',
+          result: {
+            type: 'succeeded',
+            message: {
+              ...messageResultBody('Paris is sunny.'),
+              content: [
+                {
+                  type: 'text',
+                  text: 'Paris is sunny.',
+                  citations: [
+                    {
+                      type: 'web_search_result_location',
+                      cited_text: 'Paris is sunny.',
+                      url: 'https://example.com/weather',
+                      title: 'Paris weather',
+                      encrypted_index: 'encrypted-index',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        }),
+      ],
+    };
+    const model = createAnthropic({
+      apiKey: 'test-api-key',
+      generateId: () => 'citation-source',
+    })('claude-3-haiku-20240307');
+
+    const stream = await model.experimental_doGetBatchResults({
+      batchId: 'msgbatch_123',
+    });
+
+    await expect(convertReadableStreamToArray(stream)).resolves.toMatchObject([
+      {
+        id: 'citation',
+        status: 'succeeded',
+        result: {
+          content: [
+            {
+              type: 'text',
+              text: 'Paris is sunny.',
+              providerMetadata: {
+                anthropic: {
+                  citations: [
+                    {
+                      type: 'web_search_result_location',
+                      cited_text: 'Paris is sunny.',
+                      url: 'https://example.com/weather',
+                      title: 'Paris weather',
+                      encrypted_index: 'encrypted-index',
+                    },
+                  ],
+                },
+              },
+            },
+            {
+              type: 'source',
+              sourceType: 'url',
+              id: 'citation-source',
+              url: 'https://example.com/weather',
+              title: 'Paris weather',
+              providerMetadata: {
+                anthropic: {
+                  citedText: 'Paris is sunny.',
+                  encryptedIndex: 'encrypted-index',
+                },
+              },
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('accepts nullable web result fields', async () => {
+    server.urls[urls.batch].response = {
+      type: 'json-value',
+      body: batchResponse(),
+    };
+    server.urls[urls.results].response = {
+      type: 'stream-chunks',
+      chunks: [
+        JSON.stringify({
+          custom_id: 'nullable-web-fields',
+          result: {
+            type: 'succeeded',
+            message: {
+              ...messageResultBody(''),
+              content: [
+                {
+                  type: 'web_fetch_tool_result',
+                  tool_use_id: 'web-fetch-1',
+                  content: {
+                    type: 'web_fetch_result',
+                    url: 'https://example.com/document',
+                    retrieved_at: null,
+                    content: {
+                      type: 'document',
+                      title: null,
+                      source: {
+                        type: 'text',
+                        media_type: 'text/plain',
+                        data: 'document text',
+                      },
+                    },
+                  },
+                },
+                {
+                  type: 'web_search_tool_result',
+                  tool_use_id: 'web-search-1',
+                  content: [
+                    {
+                      type: 'web_search_result',
+                      url: 'https://example.com/search-result',
+                      title: null,
+                      encrypted_content: 'encrypted',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        }),
+      ],
+    };
+    const model = createAnthropic({
+      apiKey: 'test-api-key',
+      generateId: () => 'nullable-source',
+    })('claude-3-haiku-20240307');
+
+    const stream = await model.experimental_doGetBatchResults({
+      batchId: 'msgbatch_123',
+    });
+
+    const results = await convertReadableStreamToArray(stream);
+
+    expect(results).toMatchObject([
+      {
+        id: 'nullable-web-fields',
+        status: 'succeeded',
+        result: {
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'web-fetch-1',
+              toolName: 'web_fetch',
+              result: {
+                type: 'web_fetch_result',
+                url: 'https://example.com/document',
+                retrievedAt: null,
+                content: {
+                  type: 'document',
+                  title: null,
+                  source: {
+                    type: 'text',
+                    mediaType: 'text/plain',
+                    data: 'document text',
+                  },
+                },
+              },
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'web-search-1',
+              toolName: 'web_search',
+              result: [
+                {
+                  type: 'web_search_result',
+                  url: 'https://example.com/search-result',
+                  pageAge: null,
+                  encryptedContent: 'encrypted',
+                },
+              ],
+            },
+            {
+              type: 'source',
+              sourceType: 'url',
+              id: 'nullable-source',
+              url: 'https://example.com/search-result',
+            },
+          ],
+        },
+      },
+    ]);
+    const result = results[0];
+    if (result?.status !== 'succeeded') {
+      throw new Error('Expected a succeeded batch result.');
+    }
+    expect(result.result.content[1]).not.toHaveProperty('result.0.title');
+    expect(result.result.content[2]).not.toHaveProperty('title');
+  });
+
+  it('normalizes advisor tool results to the provider output shape', async () => {
+    server.urls[urls.batch].response = {
+      type: 'json-value',
+      body: batchResponse(),
+    };
+    server.urls[urls.results].response = {
+      type: 'stream-chunks',
+      chunks: [
+        JSON.stringify({
+          custom_id: 'advisor-results',
+          result: {
+            type: 'succeeded',
+            message: {
+              ...messageResultBody(''),
+              content: [
+                {
+                  type: 'advisor_tool_result',
+                  tool_use_id: 'advisor-plain',
+                  content: {
+                    type: 'advisor_result',
+                    text: 'Use a queue.',
+                    stop_reason: 'end_turn',
+                  },
+                },
+                {
+                  type: 'advisor_tool_result',
+                  tool_use_id: 'advisor-redacted',
+                  content: {
+                    type: 'advisor_redacted_result',
+                    encrypted_content: 'opaque-advice',
+                    stop_reason: 'max_tokens',
+                  },
+                },
+                {
+                  type: 'advisor_tool_result',
+                  tool_use_id: 'advisor-error',
+                  content: {
+                    type: 'advisor_tool_result_error',
+                    error_code: 'max_uses_exceeded',
+                  },
+                },
+              ],
+            },
+          },
+        }),
+      ],
+    };
+    const model = createAnthropic({ apiKey: 'test-api-key' })(
+      'claude-3-haiku-20240307',
+    );
+
+    const stream = await model.experimental_doGetBatchResults({
+      batchId: 'msgbatch_123',
+    });
+
+    await expect(convertReadableStreamToArray(stream)).resolves.toMatchObject([
+      {
+        id: 'advisor-results',
+        status: 'succeeded',
+        result: {
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'advisor-plain',
+              toolName: 'advisor',
+              result: {
+                type: 'advisor_result',
+                text: 'Use a queue.',
+                stopReason: 'end_turn',
+              },
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'advisor-redacted',
+              toolName: 'advisor',
+              result: {
+                type: 'advisor_redacted_result',
+                encryptedContent: 'opaque-advice',
+                stopReason: 'max_tokens',
+              },
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'advisor-error',
+              toolName: 'advisor',
+              isError: true,
+              result: {
+                type: 'advisor_tool_result_error',
+                errorCode: 'max_uses_exceeded',
+              },
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('fails an invalid succeeded item without aborting later results', async () => {
+    server.urls[urls.batch].response = {
+      type: 'json-value',
+      body: batchResponse(),
+    };
+    server.urls[urls.results].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `${JSON.stringify({
+          custom_id: 'invalid',
+          result: {
+            type: 'succeeded',
+            message: { type: 'message' },
+          },
+        })}\n`,
+        JSON.stringify({
+          custom_id: 'valid',
+          result: {
+            type: 'succeeded',
+            message: messageResultBody('Paris'),
+          },
+        }),
+      ],
+    };
+    const model = createAnthropic({ apiKey: 'test-api-key' })(
+      'claude-3-haiku-20240307',
+    );
+
+    const stream = await model.experimental_doGetBatchResults({
+      batchId: 'msgbatch_123',
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchObject([
+      {
+        id: 'invalid',
+        status: 'failed',
+        error: {
+          message: 'Anthropic returned an invalid Message batch result.',
+          code: 'invalid_response',
+        },
+      },
+      {
+        id: 'valid',
+        status: 'succeeded',
+        result: { content: [{ type: 'text', text: 'Paris' }] },
+      },
     ]);
   });
 
@@ -729,7 +1364,7 @@ describe('Anthropic Messages batch language model', () => {
       });
     });
 
-    it('fails unsupported items and continues with later results', async () => {
+    it('preserves tool items and continues with later results', async () => {
       server.urls[urls.batch].response = {
         type: 'json-value',
         body: batchResponse({
@@ -785,11 +1420,16 @@ describe('Anthropic Messages batch language model', () => {
       expect(results).toMatchObject([
         {
           id: 'tool-call',
-          status: 'failed',
-          error: {
-            message:
-              'Anthropic returned a "tool_use" content block, but tool content is not supported in AI SDK text batches.',
-            code: 'unsupported_content',
+          status: 'succeeded',
+          result: {
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'toolu_123',
+                toolName: 'get_weather',
+                input: '{"city":"Paris"}',
+              },
+            ],
           },
         },
         {

--- a/packages/anthropic/src/anthropic-messages-batch.test.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.test.ts
@@ -362,6 +362,47 @@ describe('Anthropic Messages batch language model', () => {
     expect(server.calls).toHaveLength(0);
   });
 
+  it('does not treat a custom code_execution function as the provider tool', async () => {
+    const model = createAnthropic({ apiKey: 'test-api-key' })(
+      'claude-3-haiku-20240307',
+    );
+
+    await expect(
+      model.experimental_doStartBatch({
+        requests: [
+          {
+            id: 'request-1',
+            ...request('Search', {
+              tools: [
+                {
+                  type: 'provider',
+                  id: 'anthropic.web_search_20260209',
+                  name: 'web_search',
+                  args: {},
+                },
+                {
+                  type: 'function',
+                  name: 'code_execution',
+                  description: 'A custom client-side function',
+                  inputSchema: {
+                    type: 'object',
+                    properties: {},
+                    additionalProperties: false,
+                  },
+                },
+              ],
+            }),
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      name: 'AI_UnsupportedFunctionalityError',
+      functionality:
+        'implicit code execution for 20260209 web tools in batches',
+    });
+    expect(server.calls).toHaveLength(0);
+  });
+
   it.each([
     {
       feature: 'providerOptions.anthropic.speed',

--- a/packages/anthropic/src/anthropic-messages-batch.test.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.test.ts
@@ -1331,6 +1331,116 @@ describe('Anthropic Messages batch language model', () => {
     ]);
   });
 
+  it('fails an unknown result type without aborting later results', async () => {
+    server.urls[urls.batch].response = {
+      type: 'json-value',
+      body: batchResponse(),
+    };
+    server.urls[urls.results].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `${JSON.stringify({
+          custom_id: 'unknown',
+          result: { type: 'future_result', data: 'opaque' },
+        })}\n`,
+        JSON.stringify({
+          custom_id: 'valid',
+          result: {
+            type: 'succeeded',
+            message: messageResultBody('Paris'),
+          },
+        }),
+      ],
+    };
+    const model = createAnthropic({ apiKey: 'test-api-key' })(
+      'claude-3-haiku-20240307',
+    );
+
+    const stream = await model.experimental_doGetBatchResults({
+      batchId: 'msgbatch_123',
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchObject([
+      {
+        id: 'unknown',
+        status: 'failed',
+        error: {
+          message: 'Anthropic returned an invalid Message batch result.',
+          code: 'invalid_response',
+        },
+      },
+      {
+        id: 'valid',
+        status: 'succeeded',
+        result: { content: [{ type: 'text', text: 'Paris' }] },
+      },
+    ]);
+  });
+
+  it('skips unknown content blocks in a succeeded result', async () => {
+    server.urls[urls.batch].response = {
+      type: 'json-value',
+      body: batchResponse(),
+    };
+    server.urls[urls.results].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `${JSON.stringify({
+          custom_id: 'future-content',
+          result: {
+            type: 'succeeded',
+            message: {
+              ...messageResultBody('Paris'),
+              content: [
+                { type: 'future_content', data: 'opaque' },
+                { type: 'text', text: 'Paris' },
+              ],
+            },
+          },
+        })}\n`,
+        JSON.stringify({
+          custom_id: 'malformed-known-content',
+          result: {
+            type: 'succeeded',
+            message: {
+              ...messageResultBody('Paris'),
+              content: [{ type: 'text' }, { type: 'text', text: 'Paris' }],
+            },
+          },
+        }),
+      ],
+    };
+    const model = createAnthropic({ apiKey: 'test-api-key' })(
+      'claude-3-haiku-20240307',
+    );
+
+    const stream = await model.experimental_doGetBatchResults({
+      batchId: 'msgbatch_123',
+    });
+
+    expect(await convertReadableStreamToArray(stream)).toMatchObject([
+      {
+        id: 'future-content',
+        status: 'succeeded',
+        result: {
+          content: [{ type: 'text', text: 'Paris' }],
+          usage: {
+            inputTokens: { total: 13 },
+            outputTokens: { total: 3 },
+          },
+        },
+      },
+      {
+        id: 'malformed-known-content',
+        status: 'failed',
+        error: {
+          message: 'Anthropic returned an invalid Message batch result.',
+          code: 'invalid_response',
+        },
+      },
+    ]);
+  });
+
   it('forwards operation headers and the abort signal while retrieving results', async () => {
     server.urls[urls.batch].response = {
       type: 'json-value',

--- a/packages/anthropic/src/anthropic-messages-batch.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.ts
@@ -40,7 +40,6 @@ import { anthropicFailedResponseHandler } from './anthropic-error';
 import {
   AnthropicLanguageModel,
   createCitationSource,
-  hasWebTool20260209WithoutCodeExecution,
   type AnthropicLanguageModelConfig,
 } from './anthropic-language-model';
 import {
@@ -221,16 +220,6 @@ export class AnthropicMessagesBatchLanguageModel
             `Anthropic Message Batches cannot restore the custom provider-tool name ` +
             `"${aliasedProviderTool.name}" when results are retrieved independently of the start call ` +
             `(request "${request.id}"). Use the provider's canonical tool name.`,
-        });
-      }
-      if (hasWebTool20260209WithoutCodeExecution(prepared.args.tools)) {
-        throw new UnsupportedFunctionalityError({
-          functionality:
-            'implicit code execution for 20260209 web tools in batches',
-          message:
-            `Anthropic Message Batches cannot restore the dynamic code-execution context ` +
-            `for 20260209 web tools when results are retrieved independently of the start call ` +
-            `(request "${request.id}"). Include the code execution tool explicitly.`,
         });
       }
       const body = this.transformRequestBody(prepared.args, prepared.betas);
@@ -657,6 +646,8 @@ function convertAnthropicBatchResponse(
         const isCodeExecutionAlias =
           part.name === 'bash_code_execution' ||
           part.name === 'text_editor_code_execution';
+        const isCodeExecution =
+          isCodeExecutionAlias || part.name === 'code_execution';
         const toolName = isCodeExecutionAlias ? 'code_execution' : part.name;
         if (
           part.name === 'tool_search_tool_bm25' ||
@@ -679,6 +670,9 @@ function convertAnthropicBatchResponse(
                 : part.input,
           ),
           providerExecuted: true,
+          // Batch results are retrieved without the original request tools, so
+          // implicitly provisioned code execution must remain self-describing.
+          ...(isCodeExecution ? { dynamic: true } : {}),
           ...anthropicCallerMetadata(part.caller),
         });
         break;

--- a/packages/anthropic/src/anthropic-messages-batch.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.ts
@@ -581,32 +581,28 @@ function convertAnthropicBatchResponse(
       { type: 'tool-call' }
     >
   > = {};
-  const citationDocuments: Array<{ mediaType: string; title: string }> = [];
   const serverToolCalls: Record<string, string> = {};
 
   for (const part of response.content) {
     switch (part.type) {
       case 'text':
-        const webSearchCitations = part.citations?.filter(
-          citation => citation.type === 'web_search_result_location',
-        );
+        const citations = part.citations;
 
         content.push({
           type: 'text',
           text: part.text,
-          ...(webSearchCitations != null &&
-            webSearchCitations.length > 0 && {
+          ...(citations != null &&
+            citations.length > 0 && {
               providerMetadata: {
-                anthropic: { citations: webSearchCitations },
+                anthropic: { citations },
               },
             }),
         });
         for (const citation of part.citations ?? []) {
-          const source = createCitationSource(
-            citation,
-            citationDocuments,
-            generateId,
-          );
+          // Batch result retrieval does not include the original prompt's
+          // document ordering, so indexed document citations cannot be
+          // normalized safely. Preserve them above as provider metadata.
+          const source = createCitationSource(citation, [], generateId);
           if (source != null) {
             content.push(source);
           }
@@ -722,12 +718,6 @@ function convertAnthropicBatchResponse(
         break;
       }
       case 'web_fetch_tool_result':
-        if (part.content.type === 'web_fetch_result') {
-          citationDocuments.push({
-            title: part.content.content.title ?? part.content.url,
-            mediaType: part.content.content.source.media_type,
-          });
-        }
         content.push({
           type: 'tool-result',
           toolCallId: part.tool_use_id,

--- a/packages/anthropic/src/anthropic-messages-batch.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.ts
@@ -629,6 +629,10 @@ function convertAnthropicBatchResponse(
           },
         });
         break;
+      case 'container_upload':
+        // The v4 result contract has no container-upload output block. The
+        // provider message remains successful and its usage is still returned.
+        break;
       case 'compaction':
         content.push({
           type: 'text',

--- a/packages/anthropic/src/anthropic-messages-batch.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.ts
@@ -39,6 +39,8 @@ import {
 import { anthropicFailedResponseHandler } from './anthropic-error';
 import {
   AnthropicLanguageModel,
+  createCitationSource,
+  hasWebTool20260209WithoutCodeExecution,
   type AnthropicLanguageModelConfig,
 } from './anthropic-language-model';
 import {
@@ -78,6 +80,8 @@ const anthropicBatchResponseSchema = lazySchema(() =>
       created_at: z.string(),
       expires_at: z.string(),
       archived_at: z.string().nullish(),
+      cancel_initiated_at: z.string().nullish(),
+      ended_at: z.string().nullish(),
       results_url: z.string().nullish(),
     }),
   ),
@@ -196,6 +200,39 @@ export class AnthropicMessagesBatchLanguageModel
         stream: false,
         userSuppliedBetas: new Set(explicitBatchBetas),
       });
+      if (prepared.usesJsonResponseTool) {
+        throw new UnsupportedFunctionalityError({
+          functionality: 'batch responseFormat JSON-tool fallback',
+          message:
+            `Anthropic Message Batches cannot decode the JSON-tool structured-output fallback ` +
+            `(request "${request.id}") because batch results are retrieved independently of the start call. ` +
+            `Use a model that supports native output_format structured outputs.`,
+        });
+      }
+      const aliasedProviderTool = request.options.tools?.find(
+        tool =>
+          tool.type === 'provider' &&
+          prepared.toolNameMapping.toProviderToolName(tool.name) !== tool.name,
+      );
+      if (aliasedProviderTool != null) {
+        throw new UnsupportedFunctionalityError({
+          functionality: 'aliased provider tool names in batches',
+          message:
+            `Anthropic Message Batches cannot restore the custom provider-tool name ` +
+            `"${aliasedProviderTool.name}" when results are retrieved independently of the start call ` +
+            `(request "${request.id}"). Use the provider's canonical tool name.`,
+        });
+      }
+      if (hasWebTool20260209WithoutCodeExecution(prepared.args.tools)) {
+        throw new UnsupportedFunctionalityError({
+          functionality:
+            'implicit code execution for 20260209 web tools in batches',
+          message:
+            `Anthropic Message Batches cannot restore the dynamic code-execution context ` +
+            `for 20260209 web tools when results are retrieved independently of the start call ` +
+            `(request "${request.id}"). Include the code execution tool explicitly.`,
+        });
+      }
       const body = this.transformRequestBody(prepared.args, prepared.betas);
       validateAnthropicBatchBody({
         body,
@@ -303,7 +340,7 @@ export class AnthropicMessagesBatchLanguageModel
     lines: AsyncIterable<AnthropicBatchResultLine>,
   ): AsyncGenerator<BatchV4ItemResult<LanguageModelV4GenerateResult>> {
     for await (const line of lines) {
-      yield await convertAnthropicBatchResult(line);
+      yield await convertAnthropicBatchResult(line, this.generateId);
     }
   }
 
@@ -438,6 +475,15 @@ function convertAnthropicBatchStatus(
     ...(requestCounts != null ? { requestCounts } : {}),
     createdAt: batch.created_at,
     expiresAt: batch.expires_at,
+    providerMetadata: {
+      anthropic: {
+        archivedAt: batch.archived_at ?? null,
+        cancelInitiatedAt: batch.cancel_initiated_at ?? null,
+        endedAt: batch.ended_at ?? null,
+        requestCounts: batch.request_counts,
+        resultsUrl: batch.results_url ?? null,
+      },
+    },
   };
 }
 
@@ -470,6 +516,7 @@ function convertAnthropicRequestCounts(
 
 async function convertAnthropicBatchResult(
   line: AnthropicBatchResultLine,
+  generateId: () => string,
 ): Promise<BatchV4ItemResult<LanguageModelV4GenerateResult>> {
   switch (line.result.type) {
     case 'canceled':
@@ -513,51 +560,46 @@ async function convertAnthropicBatchResult(
 
       const response = validation.value;
 
-      const unsupportedPart = response.content.find(
-        part => !supportedBatchContentTypes.has(part.type),
-      );
-
-      if (unsupportedPart != null) {
-        return {
-          id: line.custom_id,
-          status: 'failed',
-          error: {
-            message:
-              `Anthropic returned a "${unsupportedPart.type}" content block, ` +
-              'but tool content is not supported in AI SDK text batches.',
-            code: 'unsupported_content',
-          },
-        };
-      }
-
       return {
         id: line.custom_id,
         status: 'succeeded',
-        result: convertAnthropicBatchResponse(response),
+        result: convertAnthropicBatchResponse(response, generateId),
       };
     }
   }
 }
 
-const supportedBatchContentTypes = new Set([
-  'text',
-  'thinking',
-  'redacted_thinking',
-  'compaction',
-  // The normal Anthropic response conversion intentionally drops this marker;
-  // the fallback hop remains available through usage.iterations metadata.
-  'fallback',
-]);
-
 function convertAnthropicBatchResponse(
   response: AnthropicResponse,
+  generateId: () => string,
 ): LanguageModelV4GenerateResult {
   const content: LanguageModelV4GenerateResult['content'] = [];
+  const mcpToolCalls: Record<
+    string,
+    Extract<
+      LanguageModelV4GenerateResult['content'][number],
+      { type: 'tool-call' }
+    >
+  > = {};
+  const serverToolCalls: Record<string, string> = {};
 
   for (const part of response.content) {
     switch (part.type) {
       case 'text':
-        content.push({ type: 'text', text: part.text });
+        content.push({
+          type: 'text',
+          text: part.text,
+          ...(part.citations != null &&
+            part.citations.length > 0 && {
+              providerMetadata: { anthropic: { citations: part.citations } },
+            }),
+        });
+        for (const citation of part.citations ?? []) {
+          const source = createCitationSource(citation, [], generateId);
+          if (source != null) {
+            content.push(source);
+          }
+        }
         break;
       case 'thinking':
         content.push({
@@ -588,6 +630,244 @@ function convertAnthropicBatchResponse(
           providerMetadata: { anthropic: { type: 'compaction' } },
         });
         break;
+      case 'tool_use':
+        content.push({
+          type: 'tool-call',
+          toolCallId: part.id,
+          toolName: part.name,
+          input: JSON.stringify(part.input),
+          ...anthropicCallerMetadata(part.caller),
+        });
+        break;
+      case 'server_tool_use': {
+        const isCodeExecutionAlias =
+          part.name === 'bash_code_execution' ||
+          part.name === 'text_editor_code_execution';
+        const toolName = isCodeExecutionAlias ? 'code_execution' : part.name;
+        if (
+          part.name === 'tool_search_tool_bm25' ||
+          part.name === 'tool_search_tool_regex'
+        ) {
+          serverToolCalls[part.id] = part.name;
+        }
+        content.push({
+          type: 'tool-call',
+          toolCallId: part.id,
+          toolName,
+          input: JSON.stringify(
+            isCodeExecutionAlias
+              ? { type: part.name, ...(part.input ?? {}) }
+              : part.name === 'code_execution' &&
+                  part.input != null &&
+                  'code' in part.input &&
+                  !('type' in part.input)
+                ? { type: 'programmatic-tool-call', ...part.input }
+                : part.input,
+          ),
+          providerExecuted: true,
+          ...anthropicCallerMetadata(part.caller),
+        });
+        break;
+      }
+      case 'mcp_tool_use': {
+        const toolCall = {
+          type: 'tool-call' as const,
+          toolCallId: part.id,
+          toolName: part.name,
+          input: JSON.stringify(part.input),
+          providerExecuted: true,
+          dynamic: true,
+          providerMetadata: {
+            anthropic: {
+              serverName: part.server_name,
+              type: 'mcp-tool-use',
+            },
+          },
+        };
+        mcpToolCalls[part.id] = toolCall;
+        content.push(toolCall);
+        break;
+      }
+      case 'mcp_tool_result': {
+        const toolCall = mcpToolCalls[part.tool_use_id];
+        content.push({
+          type: 'tool-result',
+          toolCallId: part.tool_use_id,
+          toolName: toolCall?.toolName ?? 'mcp',
+          isError: part.is_error,
+          result: part.content,
+          dynamic: true,
+          ...(toolCall?.providerMetadata != null && {
+            providerMetadata: toolCall.providerMetadata,
+          }),
+        });
+        break;
+      }
+      case 'web_fetch_tool_result':
+        content.push({
+          type: 'tool-result',
+          toolCallId: part.tool_use_id,
+          toolName: 'web_fetch',
+          ...(part.content.type === 'web_fetch_tool_result_error'
+            ? {
+                isError: true,
+                result: {
+                  errorCode: part.content.error_code,
+                  type: part.content.type,
+                },
+              }
+            : {
+                result: {
+                  content: {
+                    citations: part.content.content.citations,
+                    source: {
+                      data: part.content.content.source.data,
+                      mediaType: part.content.content.source.media_type,
+                      type: part.content.content.source.type,
+                    },
+                    title: part.content.content.title,
+                    type: part.content.content.type,
+                  },
+                  retrievedAt: part.content.retrieved_at,
+                  type: part.content.type,
+                  url: part.content.url,
+                },
+              }),
+          ...anthropicCallerMetadata(part.caller),
+        });
+        break;
+      case 'web_search_tool_result':
+        content.push({
+          type: 'tool-result',
+          toolCallId: part.tool_use_id,
+          toolName: 'web_search',
+          ...(Array.isArray(part.content)
+            ? {
+                result: part.content.map(result => ({
+                  encryptedContent: result.encrypted_content,
+                  pageAge: result.page_age ?? null,
+                  ...(result.title != null ? { title: result.title } : {}),
+                  type: result.type,
+                  url: result.url,
+                })),
+              }
+            : {
+                isError: true,
+                result: {
+                  errorCode: part.content.error_code,
+                  type: part.content.type,
+                },
+              }),
+          ...anthropicCallerMetadata(part.caller),
+        });
+        if (Array.isArray(part.content)) {
+          for (const result of part.content) {
+            content.push({
+              type: 'source',
+              sourceType: 'url',
+              id: generateId(),
+              url: result.url,
+              ...(result.title != null ? { title: result.title } : {}),
+              providerMetadata: {
+                anthropic: {
+                  pageAge: result.page_age ?? null,
+                },
+              },
+            });
+          }
+        }
+        break;
+      case 'code_execution_tool_result':
+        content.push({
+          type: 'tool-result',
+          toolCallId: part.tool_use_id,
+          toolName: 'code_execution',
+          ...(part.content.type === 'code_execution_tool_result_error'
+            ? {
+                isError: true,
+                result: {
+                  errorCode: part.content.error_code,
+                  type: part.content.type,
+                },
+              }
+            : { result: part.content }),
+        });
+        break;
+      case 'bash_code_execution_tool_result':
+      case 'text_editor_code_execution_tool_result':
+        content.push({
+          type: 'tool-result',
+          toolCallId: part.tool_use_id,
+          toolName: 'code_execution',
+          result: part.content,
+        });
+        break;
+      case 'tool_search_tool_result': {
+        const toolName =
+          serverToolCalls[part.tool_use_id] ?? 'tool_search_tool_regex';
+        content.push({
+          type: 'tool-result',
+          toolCallId: part.tool_use_id,
+          toolName,
+          ...(part.content.type === 'tool_search_tool_result_error'
+            ? {
+                isError: true,
+                result: {
+                  errorCode: part.content.error_code,
+                  type: part.content.type,
+                },
+              }
+            : {
+                result: part.content.tool_references.map(reference => ({
+                  toolName: reference.tool_name,
+                  type: reference.type,
+                })),
+              }),
+        });
+        break;
+      }
+      case 'advisor_tool_result':
+        if (part.content.type === 'advisor_result') {
+          content.push({
+            type: 'tool-result',
+            toolCallId: part.tool_use_id,
+            toolName: 'advisor',
+            result: {
+              type: part.content.type,
+              text: part.content.text,
+              ...(part.content.stop_reason != null
+                ? { stopReason: part.content.stop_reason }
+                : {}),
+            },
+          });
+        } else if (part.content.type === 'advisor_redacted_result') {
+          content.push({
+            type: 'tool-result',
+            toolCallId: part.tool_use_id,
+            toolName: 'advisor',
+            result: {
+              type: part.content.type,
+              encryptedContent: part.content.encrypted_content,
+              ...(part.content.stop_reason != null
+                ? { stopReason: part.content.stop_reason }
+                : {}),
+            },
+          });
+        } else {
+          content.push({
+            type: 'tool-result',
+            toolCallId: part.tool_use_id,
+            toolName: 'advisor',
+            isError: true,
+            result: {
+              errorCode: part.content.error_code,
+              type: part.content.type,
+            },
+          });
+        }
+        break;
+      case 'fallback':
+        break;
     }
   }
 
@@ -609,6 +889,23 @@ function convertAnthropicBatchResponse(
       anthropic: convertAnthropicMessageMetadata(response),
     },
   };
+}
+
+function anthropicCallerMetadata(
+  caller: { type: string; tool_id?: string } | null | undefined,
+) {
+  return caller == null
+    ? {}
+    : {
+        providerMetadata: {
+          anthropic: {
+            caller: {
+              type: caller.type,
+              toolId: caller.tool_id,
+            },
+          },
+        },
+      };
 }
 
 function convertAnthropicMessageMetadata(response: AnthropicResponse) {

--- a/packages/anthropic/src/anthropic-messages-batch.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.ts
@@ -586,12 +586,18 @@ function convertAnthropicBatchResponse(
   for (const part of response.content) {
     switch (part.type) {
       case 'text':
+        const webSearchCitations = part.citations?.filter(
+          citation => citation.type === 'web_search_result_location',
+        );
+
         content.push({
           type: 'text',
           text: part.text,
-          ...(part.citations != null &&
-            part.citations.length > 0 && {
-              providerMetadata: { anthropic: { citations: part.citations } },
+          ...(webSearchCitations != null &&
+            webSearchCitations.length > 0 && {
+              providerMetadata: {
+                anthropic: { citations: webSearchCitations },
+              },
             }),
         });
         for (const citation of part.citations ?? []) {

--- a/packages/anthropic/src/anthropic-messages-batch.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.ts
@@ -17,6 +17,7 @@ import {
   createJsonLinesResponseHandler,
   createJsonResponseHandler,
   getFromApi,
+  isRecord,
   lazySchema,
   normalizeBatchRequestCounts,
   normalizeHeaders,
@@ -88,29 +89,55 @@ const anthropicBatchResponseSchema = lazySchema(() =>
 
 type AnthropicBatchResponse = InferSchema<typeof anthropicBatchResponseSchema>;
 
+const knownAnthropicBatchContentTypes = new Set([
+  'advisor_tool_result',
+  'bash_code_execution_tool_result',
+  'code_execution_tool_result',
+  'compaction',
+  'container_upload',
+  'fallback',
+  'mcp_tool_result',
+  'mcp_tool_use',
+  'redacted_thinking',
+  'server_tool_use',
+  'text',
+  'text_editor_code_execution_tool_result',
+  'thinking',
+  'tool_search_tool_result',
+  'tool_use',
+  'web_fetch_tool_result',
+  'web_search_tool_result',
+]);
+
+const anthropicBatchResultSchema = lazySchema(() =>
+  zodSchema(
+    z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('succeeded'),
+        message: z.unknown(),
+      }),
+      z.object({
+        type: z.literal('errored'),
+        error: z.object({
+          type: z.literal('error'),
+          error: z.object({
+            type: z.string(),
+            message: z.string(),
+          }),
+          request_id: z.string().nullish(),
+        }),
+      }),
+      z.object({ type: z.literal('canceled') }),
+      z.object({ type: z.literal('expired') }),
+    ]),
+  ),
+);
+
 const anthropicBatchResultLineSchema = lazySchema(() =>
   zodSchema(
     z.object({
       custom_id: z.string(),
-      result: z.discriminatedUnion('type', [
-        z.object({
-          type: z.literal('succeeded'),
-          message: z.unknown(),
-        }),
-        z.object({
-          type: z.literal('errored'),
-          error: z.object({
-            type: z.literal('error'),
-            error: z.object({
-              type: z.string(),
-              message: z.string(),
-            }),
-            request_id: z.string().nullish(),
-          }),
-        }),
-        z.object({ type: z.literal('canceled') }),
-        z.object({ type: z.literal('expired') }),
-      ]),
+      result: z.unknown(),
     }),
   ),
 );
@@ -507,19 +534,30 @@ async function convertAnthropicBatchResult(
   line: AnthropicBatchResultLine,
   generateId: () => string,
 ): Promise<BatchV4ItemResult<LanguageModelV4GenerateResult>> {
-  switch (line.result.type) {
+  const resultValidation = await safeValidateTypes({
+    value: line.result,
+    schema: anthropicBatchResultSchema,
+  });
+
+  if (!resultValidation.success) {
+    return invalidAnthropicBatchResult(line.custom_id);
+  }
+
+  const result = resultValidation.value;
+
+  switch (result.type) {
     case 'canceled':
       return { id: line.custom_id, status: 'cancelled' };
     case 'expired':
       return { id: line.custom_id, status: 'expired' };
     case 'errored': {
-      const requestId = line.result.error.request_id;
+      const requestId = result.error.request_id;
       return {
         id: line.custom_id,
         status: 'failed',
         error: {
-          message: line.result.error.error.message,
-          type: line.result.error.error.type,
+          message: result.error.error.message,
+          type: result.error.error.type,
         },
         ...(requestId != null
           ? {
@@ -531,23 +569,11 @@ async function convertAnthropicBatchResult(
       };
     }
     case 'succeeded': {
-      const validation = await safeValidateTypes({
-        value: line.result.message,
-        schema: anthropicResponseSchema,
-      });
+      const response = await parseAnthropicBatchResponse(result.message);
 
-      if (!validation.success) {
-        return {
-          id: line.custom_id,
-          status: 'failed',
-          error: {
-            message: 'Anthropic returned an invalid Message batch result.',
-            code: 'invalid_response',
-          },
-        };
+      if (response == null) {
+        return invalidAnthropicBatchResult(line.custom_id);
       }
-
-      const response = validation.value;
 
       return {
         id: line.custom_id,
@@ -556,6 +582,64 @@ async function convertAnthropicBatchResult(
       };
     }
   }
+}
+
+function invalidAnthropicBatchResult(
+  id: string,
+): BatchV4ItemResult<LanguageModelV4GenerateResult> {
+  return {
+    id,
+    status: 'failed',
+    error: {
+      message: 'Anthropic returned an invalid Message batch result.',
+      code: 'invalid_response',
+    },
+  };
+}
+
+async function parseAnthropicBatchResponse(
+  message: unknown,
+): Promise<AnthropicResponse | undefined> {
+  const validation = await safeValidateTypes({
+    value: message,
+    schema: anthropicResponseSchema,
+  });
+
+  if (validation.success) {
+    return validation.value;
+  }
+
+  if (!isRecord(message) || !Array.isArray(message.content)) {
+    return undefined;
+  }
+
+  const content: AnthropicResponse['content'] = [];
+  for (const part of message.content) {
+    const partValidation = await safeValidateTypes({
+      value: { ...message, content: [part] },
+      schema: anthropicResponseSchema,
+    });
+
+    if (partValidation.success) {
+      const [validatedPart] = partValidation.value.content;
+      if (validatedPart != null) {
+        content.push(validatedPart);
+      }
+    } else if (
+      !isRecord(part) ||
+      typeof part.type !== 'string' ||
+      knownAnthropicBatchContentTypes.has(part.type)
+    ) {
+      return undefined;
+    }
+  }
+
+  const recovered = await safeValidateTypes({
+    value: { ...message, content },
+    schema: anthropicResponseSchema,
+  });
+
+  return recovered.success ? recovered.value : undefined;
 }
 
 function convertAnthropicBatchResponse(

--- a/packages/anthropic/src/anthropic-messages-batch.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.ts
@@ -581,6 +581,7 @@ function convertAnthropicBatchResponse(
       { type: 'tool-call' }
     >
   > = {};
+  const citationDocuments: Array<{ mediaType: string; title: string }> = [];
   const serverToolCalls: Record<string, string> = {};
 
   for (const part of response.content) {
@@ -601,7 +602,11 @@ function convertAnthropicBatchResponse(
             }),
         });
         for (const citation of part.citations ?? []) {
-          const source = createCitationSource(citation, [], generateId);
+          const source = createCitationSource(
+            citation,
+            citationDocuments,
+            generateId,
+          );
           if (source != null) {
             content.push(source);
           }
@@ -630,8 +635,11 @@ function convertAnthropicBatchResponse(
         });
         break;
       case 'container_upload':
-        // The v4 result contract has no container-upload output block. The
-        // provider message remains successful and its usage is still returned.
+        content.push({
+          type: 'custom',
+          kind: 'anthropic.container_upload',
+          providerMetadata: { anthropic: { fileId: part.file_id } },
+        });
         break;
       case 'compaction':
         content.push({
@@ -714,6 +722,12 @@ function convertAnthropicBatchResponse(
         break;
       }
       case 'web_fetch_tool_result':
+        if (part.content.type === 'web_fetch_result') {
+          citationDocuments.push({
+            title: part.content.content.title ?? part.content.url,
+            mediaType: part.content.content.source.media_type,
+          });
+        }
         content.push({
           type: 'tool-result',
           toolCallId: part.tool_use_id,

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -1804,3 +1804,49 @@ describe('anthropicChunkSchema - web_fetch_tool_result', () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe('anthropicChunkSchema - shared batch content variants', () => {
+  it('accepts a string MCP tool result in a streaming content block', async () => {
+    const result = await anthropicChunkSchema().validate!({
+      content_block: {
+        content: 'tool output',
+        is_error: false,
+        tool_use_id: 'mcp_123',
+        type: 'mcp_tool_result',
+      },
+      index: 0,
+      type: 'content_block_start',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each([
+    {
+      cited_text: 'block',
+      document_index: 0,
+      document_title: null,
+      end_block_index: 2,
+      file_id: null,
+      start_block_index: 1,
+      type: 'content_block_location',
+    },
+    {
+      cited_text: 'result',
+      end_block_index: 2,
+      search_result_index: 0,
+      source: 'https://example.com',
+      start_block_index: 1,
+      title: null,
+      type: 'search_result_location',
+    },
+  ])('accepts $type citation deltas', async citation => {
+    const result = await anthropicChunkSchema().validate!({
+      delta: { citation, type: 'citations_delta' },
+      index: 0,
+      type: 'content_block_delta',
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/anthropic/src/anthropic-prepare-tools.test.ts
+++ b/packages/anthropic/src/anthropic-prepare-tools.test.ts
@@ -1821,6 +1821,32 @@ describe('anthropicChunkSchema - shared batch content variants', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts opaque MCP tool result citations', async () => {
+    const result = await anthropicChunkSchema().validate!({
+      content_block: {
+        content: [
+          {
+            citations: [
+              {
+                reference: 'opaque-reference',
+                type: 'future_citation_variant',
+              },
+            ],
+            text: 'tool output',
+            type: 'text',
+          },
+        ],
+        is_error: false,
+        tool_use_id: 'mcp_123',
+        type: 'mcp_tool_result',
+      },
+      index: 0,
+      type: 'content_block_start',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
   it.each([
     {
       cited_text: 'block',

--- a/packages/provider/src/language-model/v4/language-model-v4-batch.ts
+++ b/packages/provider/src/language-model/v4/language-model-v4-batch.ts
@@ -28,6 +28,9 @@ export type LanguageModelV4BatchRequest = {
     | 'frequencyPenalty'
     | 'seed'
     | 'reasoning'
+    | 'responseFormat'
+    | 'toolChoice'
+    | 'tools'
     | 'providerOptions'
   >;
 };


### PR DESCRIPTION
## context

AI SDK already supports creating, polling, and reading Anthropic Message Batches. This PR is a follow-up to make that provider implementation complete enough for downstream integrations that need to preserve Anthropic's response semantics across the asynchronous lifecycle.

Before this change, the generic batch result kept the normalized status and text but discarded provider-specific lifecycle fields, native request counts, and some valid non-text result content. Once polling has completed, a downstream consumer cannot reconstruct those fields from the normalized result alone.

This is not a second batch API or a new orchestration layer. The generic AI SDK batch contract stays provider-neutral, while Anthropic-specific details are retained through `providerMetadata`. A downstream Gateway integration is the immediate consumer and will need a released version of these package changes before it can adopt them.

## summary

- preserve Anthropic Message Batch lifecycle metadata and native request counts in provider metadata
- preserve normalized content and usage for successful results, including citations, reasoning, client tool calls, and provider-executed tool results
- decode Anthropic tool calls and tool results from the batch results stream
- carry the supported language-model option surface into batch requests, with explicit validation for options that depend on request context that is unavailable during later polling
- keep MCP tool-result citation payloads permissive because they are opaque third-party data

The provider adapter remains responsible only for Anthropic request and response translation. Durable job storage, routing, billing, and compatibility endpoints remain outside this PR.

## testing

- `pnpm --filter @ai-sdk/anthropic test`
- `pnpm --filter @ai-sdk/anthropic type-check`
- `pnpm --filter @ai-sdk/provider type-check`
- `pnpm --filter @ai-sdk/anthropic build`
- `pnpm check`
- full GitHub CI
