### PR TITLE
fix(harness-opencode): support host tools in subagents

### DIFF
--- a/.changeset/steady-agents-relay.md
+++ b/.changeset/steady-agents-relay.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-opencode': patch
+---
+
+fix(harness-opencode): authorize host tools and resolve permissions for task-linked subagents.

--- a/packages/harness-opencode/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-opencode/src/bridge/create-emit-stream-event.ts
@@ -19,6 +19,11 @@ import {
 
 type Emit = (message: Record<string, unknown>) => void;
 
+type SubagentSession = {
+  parentSessionId: string;
+  sessionId: string;
+};
+
 export function createEmitStreamEvent({
   state,
   emit,
@@ -28,6 +33,7 @@ export function createEmitStreamEvent({
   nativeNameField,
   getHostToolName,
   authorizeHostToolCall,
+  onSubagentSession,
   isMcpToolName,
   stripWorkDir,
   formatError,
@@ -49,6 +55,7 @@ export function createEmitStreamEvent({
     toolName: string;
     input: unknown;
   }) => void;
+  onSubagentSession?: (session: SubagentSession) => void;
   isMcpToolName: (toolName: string) => boolean;
   stripWorkDir: (file: string) => string;
   formatError: (error: unknown) => string;
@@ -83,6 +90,7 @@ export function createEmitStreamEvent({
         nativeNameField,
         getHostToolName,
         authorizeHostToolCall,
+        onSubagentSession,
         isMcpToolName,
       });
       return;
@@ -359,6 +367,7 @@ function emitLegacyToolPart({
   nativeNameField,
   getHostToolName,
   authorizeHostToolCall,
+  onSubagentSession,
   isMcpToolName,
 }: {
   part: unknown;
@@ -377,6 +386,7 @@ function emitLegacyToolPart({
     toolName: string;
     input: unknown;
   }) => void;
+  onSubagentSession?: (session: SubagentSession) => void;
   isMcpToolName: (toolName: string) => boolean;
 }): void {
   const toolPart = legacyToolPartFromValue(part);
@@ -389,6 +399,17 @@ function emitLegacyToolPart({
   const rawToolName = toolPart.tool;
   if (rawToolName === 'StructuredOutput') return;
   const toolName = toWireToolName(rawToolName);
+  if (toolName === 'agent') {
+    const metadata = {
+      ...(toolPart.metadata ?? {}),
+      ...(toolPart.state?.metadata ?? {}),
+    };
+    const parentSessionId = stringValue(metadata.parentSessionId);
+    const sessionId = stringValue(metadata.sessionId);
+    if (parentSessionId && sessionId) {
+      onSubagentSession?.({ parentSessionId, sessionId });
+    }
+  }
   state.toolNames.set(callID, { rawToolName, toolName });
   const hostToolName = getHostToolName(toolName, rawToolName);
   if (hostToolName) {

--- a/packages/harness-opencode/src/bridge/index.test.ts
+++ b/packages/harness-opencode/src/bridge/index.test.ts
@@ -9,6 +9,14 @@ const sdkMock = vi.hoisted(() => ({
   client: undefined as unknown,
 }));
 
+const permissionReplyMock = vi.hoisted(() => vi.fn());
+
+const relayMock = vi.hoisted(() => ({
+  authorizeToolCall: vi.fn(),
+  close: vi.fn(),
+  port: 4097,
+}));
+
 vi.mock('@ai-sdk/harness/bridge', () => ({
   runBridge: vi.fn(async (options: unknown) => {
     const bridge = options as {
@@ -29,9 +37,51 @@ vi.mock('@opencode-ai/sdk/v2', () => ({
 
 vi.mock('node:fs', () => ({ mkdirSync: vi.fn() }));
 
+vi.mock('./tool-relay', () => ({
+  startAuthorizedToolRelay: vi.fn(async () => relayMock),
+}));
+
 vi.mock('./opencode-path', () => ({
   prependOpenCodeBinToPath: vi.fn(),
 }));
+
+function createUserMessages() {
+  let closed = false;
+  const iteratorWaiters: Array<(result: IteratorResult<never>) => void> = [];
+  return {
+    pendingCount: 0,
+    close: vi.fn(() => {
+      closed = true;
+      while (iteratorWaiters.length > 0) {
+        iteratorWaiters.shift()!({ done: true, value: undefined });
+      }
+    }),
+    [Symbol.asyncIterator]() {
+      return {
+        next: () =>
+          closed
+            ? Promise.resolve({ done: true as const, value: undefined })
+            : new Promise<IteratorResult<never>>(resolve => {
+                iteratorWaiters.push(resolve);
+              }),
+      };
+    },
+  };
+}
+
+function setBridgeArgv() {
+  process.argv.length = 0;
+  process.argv.push(
+    process.execPath,
+    'opencode-bridge',
+    '--workdir',
+    '/tmp/opencode-bridge-test',
+    '--bridge-state-dir',
+    '/tmp/opencode-bridge-test-state',
+    '--bootstrap-dir',
+    '/tmp/opencode-bridge-test-bootstrap',
+  );
+}
 
 describe('OpenCode bridge turn settlement', () => {
   const originalArgv = [...process.argv];
@@ -40,32 +90,14 @@ describe('OpenCode bridge turn settlement', () => {
     process.argv.length = 0;
     for (const arg of originalArgv) process.argv.push(arg);
     vi.resetModules();
+    relayMock.authorizeToolCall.mockReset();
+    permissionReplyMock.mockReset();
   });
 
   it('settles when OpenCode emits session.next.step.failed', async () => {
     const emitted: Array<Record<string, unknown>> = [];
     const emitError = vi.fn();
-    let closed = false;
-    const iteratorWaiters: Array<(result: IteratorResult<never>) => void> = [];
-    const userMessages = {
-      pendingCount: 0,
-      close: vi.fn(() => {
-        closed = true;
-        while (iteratorWaiters.length > 0) {
-          iteratorWaiters.shift()!({ done: true, value: undefined });
-        }
-      }),
-      [Symbol.asyncIterator]() {
-        return {
-          next: () =>
-            closed
-              ? Promise.resolve({ done: true as const, value: undefined })
-              : new Promise<IteratorResult<never>>(resolve => {
-                  iteratorWaiters.push(resolve);
-                }),
-        };
-      },
-    };
+    const userMessages = createUserMessages();
     bridgeMock.start = {
       type: 'start',
       operation: 'prompt',
@@ -111,19 +143,7 @@ describe('OpenCode bridge turn settlement', () => {
         },
       },
     };
-    process.argv.length = 0;
-    for (const arg of [
-      process.execPath,
-      'opencode-bridge',
-      '--workdir',
-      '/tmp/opencode-bridge-test',
-      '--bridge-state-dir',
-      '/tmp/opencode-bridge-test-state',
-      '--bootstrap-dir',
-      '/tmp/opencode-bridge-test-bootstrap',
-    ]) {
-      process.argv.push(arg);
-    }
+    setBridgeArgv();
 
     await import('./index');
 
@@ -133,6 +153,153 @@ describe('OpenCode bridge turn settlement', () => {
     expect(emitError).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'OpenCode turn failed' }),
     );
+    expect(emitted.at(-1)).toMatchObject({ type: 'finish' });
+  });
+
+  it('authorizes host tools for task-linked subagents only', async () => {
+    const emitted: Array<Record<string, unknown>> = [];
+    const userMessages = createUserMessages();
+    bridgeMock.start = {
+      type: 'start',
+      operation: 'prompt',
+      prompt: 'Delegate this task.',
+      tools: [{ name: 'lookup' }],
+    };
+    bridgeMock.turn = {
+      emit: (event: Record<string, unknown>) => emitted.push(event),
+      requestToolResult: vi.fn(),
+      requestToolApproval: vi.fn(),
+      experimental_userMessages: userMessages,
+      abortSignal: new AbortController().signal,
+      firstTurn: true,
+      bridgeLog: vi.fn(),
+      emitWarning: vi.fn(),
+      emitError: vi.fn(),
+    };
+    sdkMock.client = {
+      mcp: { status: vi.fn(async () => ({ data: {} })) },
+      session: {
+        create: vi.fn(async () => ({ data: { id: 'parent-session' } })),
+        get: vi.fn(async () => ({ data: {} })),
+        messages: vi.fn(async () => ({ data: [] })),
+        promptAsync: vi.fn(async () => ({ data: {} })),
+      },
+      event: {
+        subscribe: vi.fn(async () => ({
+          stream: {
+            async *[Symbol.asyncIterator]() {
+              yield {
+                type: 'message.part.updated',
+                properties: {
+                  part: {
+                    type: 'tool',
+                    sessionID: 'parent-session',
+                    callID: 'task-call',
+                    tool: 'task',
+                    state: {
+                      status: 'running',
+                      input: { prompt: 'Research this.' },
+                      metadata: {
+                        parentSessionId: 'parent-session',
+                        sessionId: 'child-session',
+                      },
+                    },
+                  },
+                },
+              };
+              yield {
+                type: 'permission.v2.asked',
+                properties: {
+                  sessionID: 'child-session',
+                  id: 'child-permission',
+                  action: 'webfetch',
+                  resources: [],
+                  source: { callID: 'child-webfetch-call' },
+                },
+              };
+              yield {
+                type: 'message.part.updated',
+                properties: {
+                  part: {
+                    type: 'tool',
+                    sessionID: 'unrelated-session',
+                    callID: 'unrelated-call',
+                    tool: 'lookup',
+                    state: {
+                      status: 'running',
+                      input: { query: 'unrelated' },
+                    },
+                  },
+                },
+              };
+              yield {
+                type: 'message.part.updated',
+                properties: {
+                  part: {
+                    type: 'tool',
+                    sessionID: 'child-session',
+                    callID: 'child-call',
+                    tool: 'lookup',
+                    state: {
+                      status: 'running',
+                      input: { query: 'authorized' },
+                    },
+                  },
+                },
+              };
+              yield {
+                type: 'session.next.step.ended',
+                properties: {
+                  sessionID: 'parent-session',
+                  finish: 'stop',
+                  tokens: {
+                    input: 1,
+                    output: 1,
+                    reasoning: 0,
+                    cache: { read: 0, write: 0 },
+                  },
+                  cost: 0,
+                },
+              };
+              yield {
+                type: 'session.status',
+                properties: {
+                  sessionID: 'parent-session',
+                  status: { type: 'busy' },
+                },
+              };
+              yield {
+                type: 'session.status',
+                properties: {
+                  sessionID: 'parent-session',
+                  status: { type: 'idle' },
+                },
+              };
+            },
+          },
+        })),
+      },
+      v2: {
+        session: {
+          context: vi.fn(async () => ({ data: [] })),
+          permission: { reply: permissionReplyMock },
+        },
+      },
+    };
+    setBridgeArgv();
+
+    await import('./index');
+
+    expect(relayMock.authorizeToolCall).toHaveBeenCalledOnce();
+    expect(relayMock.authorizeToolCall).toHaveBeenCalledWith({
+      toolName: 'lookup',
+      input: { query: 'authorized' },
+    });
+    expect(permissionReplyMock).toHaveBeenCalledWith({
+      sessionID: 'child-session',
+      requestID: 'child-permission',
+      reply: 'always',
+    });
     expect(emitted.at(-1)).toMatchObject({ type: 'finish' });
   });
 });

--- a/packages/harness-opencode/src/bridge/index.test.ts
+++ b/packages/harness-opencode/src/bridge/index.test.ts
@@ -164,6 +164,7 @@ describe('OpenCode bridge turn settlement', () => {
       operation: 'prompt',
       prompt: 'Delegate this task.',
       tools: [{ name: 'lookup' }],
+      responseFormat: { type: 'json' },
     };
     bridgeMock.turn = {
       emit: (event: Record<string, unknown>) => emitted.push(event),
@@ -203,6 +204,30 @@ describe('OpenCode bridge turn settlement', () => {
                         parentSessionId: 'parent-session',
                         sessionId: 'child-session',
                       },
+                    },
+                  },
+                },
+              };
+              yield {
+                type: 'message.updated',
+                properties: {
+                  info: {
+                    id: 'child-message',
+                    sessionID: 'child-session',
+                    role: 'assistant',
+                    structured: { leaked: true },
+                  },
+                },
+              };
+              yield {
+                type: 'session.updated',
+                properties: {
+                  info: {
+                    id: 'child-session',
+                    summary: {
+                      additions: 99,
+                      deletions: 99,
+                      files: 99,
                     },
                   },
                 },
@@ -248,31 +273,14 @@ describe('OpenCode bridge turn settlement', () => {
                 },
               };
               yield {
-                type: 'session.next.step.ended',
+                type: 'message.updated',
                 properties: {
-                  sessionID: 'parent-session',
-                  finish: 'stop',
-                  tokens: {
-                    input: 1,
-                    output: 1,
-                    reasoning: 0,
-                    cache: { read: 0, write: 0 },
+                  info: {
+                    id: 'parent-message',
+                    sessionID: 'parent-session',
+                    role: 'assistant',
+                    structured: { result: 'parent' },
                   },
-                  cost: 0,
-                },
-              };
-              yield {
-                type: 'session.status',
-                properties: {
-                  sessionID: 'parent-session',
-                  status: { type: 'busy' },
-                },
-              };
-              yield {
-                type: 'session.status',
-                properties: {
-                  sessionID: 'parent-session',
-                  status: { type: 'idle' },
                 },
               };
             },
@@ -300,6 +308,14 @@ describe('OpenCode bridge turn settlement', () => {
       requestID: 'child-permission',
       reply: 'always',
     });
+    expect(emitted).toContainEqual({
+      type: 'text-delta',
+      id: 'parent-message',
+      delta: JSON.stringify({ result: 'parent' }),
+    });
+    expect(emitted).not.toContainEqual(
+      expect.objectContaining({ delta: JSON.stringify({ leaked: true }) }),
+    );
     expect(emitted.at(-1)).toMatchObject({ type: 'finish' });
   });
 });

--- a/packages/harness-opencode/src/bridge/index.ts
+++ b/packages/harness-opencode/src/bridge/index.ts
@@ -878,6 +878,22 @@ async function consumeEvents({
   const stream = await subscribeLegacyEvents({ client, signal });
   onSubscribed?.();
   if (!stream) return;
+  const taskSessionIds = new Set([sessionId]);
+  const registerSubagentSession = (sourceSessionId: string) =>
+    function register({
+      parentSessionId,
+      sessionId: subagentSessionId,
+    }: {
+      parentSessionId: string;
+      sessionId: string;
+    }) {
+      if (
+        parentSessionId === sourceSessionId &&
+        taskSessionIds.has(sourceSessionId)
+      ) {
+        taskSessionIds.add(subagentSessionId);
+      }
+    };
   const emitStreamEvent = createEmitStreamEvent({
     state,
     emit,
@@ -887,20 +903,59 @@ async function consumeEvents({
     nativeNameField,
     getHostToolName,
     authorizeHostToolCall: input => authorizeHostToolCall({ ...input, state }),
+    onSubagentSession: registerSubagentSession(sessionId),
     isMcpToolName: toolName =>
       [...runtime.mcpToolPrefixes].some(prefix => toolName.startsWith(prefix)),
     stripWorkDir,
     formatError,
   });
+  const descendantEventProcessors = new Map<
+    string,
+    (event: OpenCodeEvent) => void
+  >();
+  const processDescendantEvent = (
+    descendantSessionId: string,
+    event: OpenCodeEvent,
+  ) => {
+    let processEvent = descendantEventProcessors.get(descendantSessionId);
+    if (!processEvent) {
+      const descendantState = createTranslationState();
+      processEvent = createEmitStreamEvent({
+        state: descendantState,
+        emit: () => undefined,
+        emitWarning: () => undefined,
+        emitError: () => undefined,
+        toWireToolName,
+        nativeNameField,
+        getHostToolName,
+        authorizeHostToolCall: input =>
+          authorizeHostToolCall({ ...input, state: descendantState }),
+        onSubagentSession: registerSubagentSession(descendantSessionId),
+        isMcpToolName: () => false,
+        stripWorkDir,
+        formatError,
+      });
+      descendantEventProcessors.set(descendantSessionId, processEvent);
+    }
+    processEvent(event);
+  };
   for await (const rawEvent of stream) {
     if (signal.aborted || turn.abortSignal.aborted) break;
     const event = unwrapOpenCodeEvent(rawEvent);
     const eventSessionId = event ? getOpenCodeEventSessionId(event) : undefined;
-    if (!event || (eventSessionId && eventSessionId !== sessionId)) continue;
+    if (!event) continue;
+    const scopedSessionId =
+      !eventSessionId || eventSessionId === sessionId
+        ? sessionId
+        : taskSessionIds.has(eventSessionId)
+          ? eventSessionId
+          : undefined;
+    if (!scopedSessionId) continue;
+    const isDescendant = scopedSessionId !== sessionId;
     if (event.type === 'permission.v2.asked') {
       await handlePermissionV2({
         client,
-        sessionId,
+        sessionId: scopedSessionId,
         permissionMode,
         builtinToolFiltering,
         turn,
@@ -910,16 +965,19 @@ async function consumeEvents({
     } else if (event.type === 'permission.asked') {
       await handlePermission({
         client,
-        sessionId,
+        sessionId: scopedSessionId,
         permissionMode,
         builtinToolFiltering,
         turn,
         emit,
         event,
       });
+    } else if (isDescendant) {
+      processDescendantEvent(scopedSessionId, event);
     } else {
       emitStreamEvent(event);
     }
+    if (isDescendant) continue;
     if (onEvent?.(event)) break;
   }
 }

--- a/packages/harness-opencode/src/bridge/opencode-events.test.ts
+++ b/packages/harness-opencode/src/bridge/opencode-events.test.ts
@@ -81,6 +81,17 @@ describe('OpenCode event helpers', () => {
     ).toBe('session-1');
   });
 
+  it.each([
+    ['message.updated', { info: { sessionID: 'child-session' } }],
+    ['session.created', { info: { id: 'child-session' } }],
+    ['session.updated', { info: { id: 'child-session' } }],
+    ['session.deleted', { info: { id: 'child-session' } }],
+  ])('finds nested session ids for %s events', (type, properties) => {
+    expect(getOpenCodeEventSessionId({ type, properties })).toBe(
+      'child-session',
+    );
+  });
+
   it('emits the resolved assistant model once', () => {
     const state = createTranslationState();
     const emitted: Record<string, unknown>[] = [];

--- a/packages/harness-opencode/src/bridge/opencode-events.ts
+++ b/packages/harness-opencode/src/bridge/opencode-events.ts
@@ -101,6 +101,16 @@ export function getOpenCodeEventSessionId(
   if (event.type?.startsWith('session.') && typeof props.id === 'string') {
     return props.id;
   }
+  const info = asOpenCodeObject(props.info);
+  if (typeof info?.sessionID === 'string') return info.sessionID;
+  if (
+    (event.type === 'session.created' ||
+      event.type === 'session.updated' ||
+      event.type === 'session.deleted') &&
+    typeof info?.id === 'string'
+  ) {
+    return info.id;
+  }
   const part = props.part;
   const partObject = asOpenCodeObject(part);
   if (typeof partObject?.sessionID === 'string') return partObject.sessionID;

--- a/packages/harness-opencode/src/bridge/opencode-types.ts
+++ b/packages/harness-opencode/src/bridge/opencode-types.ts
@@ -2,6 +2,7 @@ export type OpenCodeObject = Record<string, unknown>;
 
 export type OpenCodeMessageInfo = {
   id?: unknown;
+  sessionID?: unknown;
   role?: unknown;
   type?: unknown;
   providerID?: unknown;


### PR DESCRIPTION
## Background

The OpenCode event subscription includes events from both the parent session and sessions created by its task tool. The bridge currently discards every event whose session ID differs from the parent. As a result, task-linked subagents cannot use host tools: their model-authorized tool event is discarded, so the short-lived relay authorization is never registered and the MCP call returns `401 unauthorized tool relay request`. Permission requests from those children are discarded as well, which can leave built-in tools such as `webfetch` waiting indefinitely.

## Summary

- Track child sessions from OpenCode's task-tool metadata, validating each child against the session that launched it.
- Process descendant events with isolated translation state so host tool calls are authorized without mixing child output or lifecycle events into the parent stream.
- Reply to descendant permission requests using the descendant session ID.
- Continue ignoring unrelated sessions.
- Add a regression test covering linked-child authorization, child permissions, and unrelated-session isolation.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #19646.
