### PR TITLE
fix(provider/bedrock): omit required tool choice for Meta structured output

### DIFF
--- a/.changeset/fuzzy-llamas-answer.md
+++ b/.changeset/fuzzy-llamas-answer.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Omit unsupported required tool choice from structured output requests for Meta models.

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -228,6 +228,14 @@ const { text } = await generateText({
 Amazon Bedrock language models can also be used in the `streamText` function
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
+### Structured Outputs
+
+When native structured output is unavailable, the provider uses a JSON tool fallback.
+
+<Note type="warning">
+  Meta models reject required tool choice, so tool use is not forced and structured output may be less reliable.
+</Note>
+
 ### File Inputs
 
 <Note type="warning">

--- a/packages/amazon-bedrock/src/amazon-bedrock-anthropic-model-support.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-anthropic-model-support.ts
@@ -21,3 +21,13 @@ function rejectsNewerSchemaFields(modelId: string): boolean {
     modelId.includes(model),
   );
 }
+
+export function supportsRequiredToolChoice(modelId: string): boolean {
+  return MODELS_REJECTING_REQUIRED_TOOL_CHOICE.every(
+    model => !model.test(modelId),
+  );
+}
+
+// Meta models support tool calling but reject Bedrock's `toolChoice.any`, so
+// the synthetic JSON response tool cannot be forced.
+const MODELS_REJECTING_REQUIRED_TOOL_CHOICE = [/meta\./];

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -128,6 +128,11 @@ const sonnet5AnthropicGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
   sonnet5AnthropicModelId,
 )}/converse`;
 
+const metaModelId = 'us.meta.llama4-maverick-17b-instruct-v1:0';
+const metaGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
+  metaModelId,
+)}/converse`;
+
 const server = createTestServer({
   [generateUrl]: {},
   [streamUrl]: {
@@ -148,6 +153,7 @@ const server = createTestServer({
   [opusAnthropicGenerateUrl]: {},
   [opus5AnthropicGenerateUrl]: {},
   [sonnet5AnthropicGenerateUrl]: {},
+  [metaGenerateUrl]: {},
 });
 
 describe('supportedUrls', () => {
@@ -228,6 +234,13 @@ const novaModel = new AmazonBedrockChatLanguageModel(novaModelId, {
 });
 
 const openaiModel = new AmazonBedrockChatLanguageModel(openaiModelId, {
+  baseUrl: () => baseUrl,
+  headers: {},
+  fetch: fakeFetchWithAuth,
+  generateId: () => 'test-id',
+});
+
+const metaModel = new AmazonBedrockChatLanguageModel(metaModelId, {
   baseUrl: () => baseUrl,
   headers: {},
   fetch: fakeFetchWithAuth,
@@ -5639,6 +5652,70 @@ describe('doGenerate', () => {
       ]
     `);
     expect(result.providerMetadata?.bedrock?.isJsonResponseFromTool).toBe(true);
+  });
+
+  it('should not force the json tool for Meta models', async () => {
+    server.urls[metaGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                toolUse: {
+                  toolUseId: 'json-tool-id',
+                  name: 'json',
+                  input: { name: 'Test' },
+                },
+              },
+            ],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+        stopReason: 'tool_use',
+      },
+    };
+
+    const result = await metaModel.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Generate a name' }],
+        },
+      ],
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+          required: ['name'],
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.toolConfig).toEqual({
+      tools: [
+        {
+          toolSpec: {
+            description: 'Respond with a JSON object.',
+            inputSchema: {
+              json: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+                required: ['name'],
+              },
+            },
+            name: 'json',
+          },
+        },
+      ],
+    });
+    expect(result.content).toEqual([{ type: 'text', text: '{"name":"Test"}' }]);
   });
 
   it('should use the json tool fallback for claude-opus-5 (Bedrock rejects output_config.format)', async () => {

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -49,6 +49,7 @@ import {
 import {
   supportsNativeStructuredOutput,
   supportsStrictTools,
+  supportsRequiredToolChoice,
 } from './amazon-bedrock-anthropic-model-support';
 import { AmazonBedrockErrorSchema } from './amazon-bedrock-error';
 import { createAmazonBedrockEventStreamResponseHandler } from './amazon-bedrock-event-stream-response-handler';
@@ -259,7 +260,11 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
       await prepareTools({
         tools: jsonResponseTool ? [...(tools ?? []), jsonResponseTool] : tools,
         toolChoice:
-          jsonResponseTool != null ? { type: 'required' } : toolChoice,
+          jsonResponseTool != null
+            ? supportsRequiredToolChoice(this.modelId)
+              ? { type: 'required' }
+              : undefined
+            : toolChoice,
         modelId: this.modelId,
       });
 


### PR DESCRIPTION
## Background

When migrating from LangChain.js, I encountered an error:

```
AI_APICallError: This model doesn't support the toolConfig.toolChoice.any field. Remove toolConfig.toolChoice.any and try again.
 ❯ ../../node_modules/.bun/@ai-sdk+provider-utils@5.0.29+68a1e3a0c4588df3/node_modules/@ai-sdk/provider-utils/src/response-handler.ts:74:15
 ❯ postToApi ../../node_modules/.bun/@ai-sdk+provider-utils@5.0.29+68a1e3a0c4588df3/node_modules/@ai-sdk/provider-utils/src/post-to-api.ts:118:27
 ❯ postJsonToApi ../../node_modules/.bun/@ai-sdk+provider-utils@5.0.29+68a1e3a0c4588df3/node_modules/@ai-sdk/provider-utils/src/post-to-api.ts:31:2
 ❯ _AmazonBedrockChatLanguageModel.doGenerate ../../node_modules/.bun/@ai-sdk+amazon-bedrock@5.0.61+68a1e3a0c4588df3/node_modules/@ai-sdk/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts:514:49
 ❯ doGenerate ../../node_modules/.bun/ai@7.0.78+68a1e3a0c4588df3/node_modules/ai/src/middleware/wrap-language-model.ts:85:37
 ❯ wrapGenerate src/server/cache/CacheMiddleware.ts:57:22
     55|       const cached = await cache.lookup(request);
     56|       if (cached) return cached;
     57|       const result = await doGenerate();
       |                      ^
     58|       await cache.update(request, result);
     59|       return result;
 ❯ Object.doGenerate ../../node_modules/.bun/ai@7.0.78+68a1e3a0c4588df3/node_modules/ai/src/middleware/wrap-language-model.ts:88:10
 ❯ execute ../../node_modules/.bun/ai@7.0.78+68a1e3a0c4588df3/node_modules/ai/src/generate-text/generate-text.ts:1035:22
 ❯ runWithTracingChannelSpan ../../node_modules/.bun/ai@7.0.78+68a1e3a0c4588df3/node_modules/ai/src/telemetry/tracing-channel-publisher.ts:76:11
```

The PR fixes it.

## Summary

I added a condition that omits `{ type: 'required' }` for `/meta\./` models, fixing the issue.

## End-to-End Verification

I applied the fix as [a patch in Alumnium](https://github.com/alumnium-hq/alumnium/pull/437/changes#diff-b47b36b5fd6c3dc0e195383d9755ad709df9ff607163088ff9c4ed190e1e21b1) and it resolved the problem.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)