### PR TITLE
fix(harness-pi): support max thinking level

### DIFF
--- a/.changeset/friendly-pis-think.md
+++ b/.changeset/friendly-pis-think.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-pi': patch
+---
+
+fix(harness-pi): accept the Pi SDK's `max` thinking level

--- a/packages/harness-pi/src/pi-session.test.ts
+++ b/packages/harness-pi/src/pi-session.test.ts
@@ -210,6 +210,30 @@ describe('createPiSession', () => {
     }
   });
 
+  it('passes the max thinking level to the Pi agent session', async () => {
+    piMock.session = createFakePiSession().session;
+    const session = await createPi({ thinkingLevel: 'max' }).doStart({
+      sessionId: 'session-max-thinking-level',
+      sandboxSession: createSandboxSession(),
+      sessionWorkDir: '/sandbox/work',
+    });
+
+    try {
+      const control = await session.doPromptTurn({
+        prompt: 'Think deeply.',
+        tools: [],
+        emit: vi.fn(),
+      });
+      await control.done;
+
+      expect(piMock.createAgentSession).toHaveBeenCalledWith(
+        expect.objectContaining({ thinkingLevel: 'max' }),
+      );
+    } finally {
+      await session.doDestroy();
+    }
+  });
+
   it('preserves caller order and passes a fresh mutable factory array', async () => {
     const callOrder: string[] = [];
     const firstFactory: ExtensionFactory = () => {

--- a/packages/harness-pi/src/pi-session.ts
+++ b/packages/harness-pi/src/pi-session.ts
@@ -212,7 +212,8 @@ export type PiThinkingLevel =
   | 'low'
   | 'medium'
   | 'high'
-  | 'xhigh';
+  | 'xhigh'
+  | 'max';
 
 export interface PiSessionSettings {
   readonly auth?: PiAuthOptions;


### PR DESCRIPTION
## Summary

- add max to the public Pi thinking-level type
- verify it is forwarded unchanged to createAgentSession
- add a patch changeset

The underlying @earendil-works/pi-agent-core type already accepts max, but the harness wrapper local union omitted it.

## Testing

- pnpm --filter @ai-sdk/harness-pi... build
- env -u ANTHROPIC_BASE_URL pnpm --filter @ai-sdk/harness-pi test:node
- pnpm --filter @ai-sdk/harness-pi type-check
- pnpm exec oxlint packages/harness-pi/src/pi-session.ts packages/harness-pi/src/pi-session.test.ts
- pnpm exec oxfmt --check packages/harness-pi/src/pi-session.ts packages/harness-pi/src/pi-session.test.ts .changeset/friendly-pis-think.md