### PR TITLE
feat(ai): support onAbort in ToolLoopAgent

### DIFF
--- a/.changeset/lucky-agents-abort.md
+++ b/.changeset/lucky-agents-abort.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Support `onAbort` in `ToolLoopAgent` settings and `stream()`

--- a/content/docs/03-agents/02-building-agents.mdx
+++ b/content/docs/03-agents/02-building-agents.mdx
@@ -519,8 +519,9 @@ The available lifecycle callbacks are:
 - **`onToolExecutionEnd`**: Called right after a tool's `execute` function completes or errors. Receives the tool call, `toolExecutionMs`, and a `toolOutput` discriminated union (`type: 'tool-result'` with `output`, or `type: 'tool-error'` with `error`).
 - **`onStepEnd`**: Called after each step finishes. Receives step results including usage, performance, finish reason, and tool calls.
 - **`onEnd`**: Called when all steps are finished and the response is complete. Receives all step results, total usage, and `runtimeContext`.
+- **`onAbort`**: Called when the stream is aborted. Receives the steps that finished before the abort. `stream()` only.
 
-For the full event data reference, see [Lifecycle Callbacks](/docs/ai-sdk-core/lifecycle-callbacks). `ToolLoopAgent` uses the same generation lifecycle event types for `onStart`, `onStepStart`, `onToolExecutionStart`, `onToolExecutionEnd`, `onStepEnd`, and `onEnd`.
+For the full event data reference, see [Lifecycle Callbacks](/docs/ai-sdk-core/lifecycle-callbacks). `ToolLoopAgent` uses the same generation lifecycle event types for `onStart`, `onStepStart`, `onToolExecutionStart`, `onToolExecutionEnd`, `onStepEnd`, and `onEnd`, and the same streaming event type for `onAbort`.
 
 #### Constructor vs. Method Callbacks
 

--- a/content/docs/06-advanced/02-stopping-streams.mdx
+++ b/content/docs/06-advanced/02-stopping-streams.mdx
@@ -143,6 +143,18 @@ This is particularly useful for:
 - Cleaning up server-side resources or connections
 - Logging abort events for analytics
 
+`ToolLoopAgent` accepts the same callback, either on the agent for every stream
+or on an individual `stream()` call:
+
+```ts
+const agent = new ToolLoopAgent({
+  model: __MODEL__,
+  onAbort: async ({ steps }) => {
+    await savePartialResults(steps);
+  },
+});
+```
+
 You can also handle abort events directly in the stream using the `abort` stream part:
 
 ```tsx highlight="6-9"

--- a/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/16-tool-loop-agent.mdx
@@ -531,6 +531,13 @@ To see `ToolLoopAgent` in action, check out [these examples](#examples).
       description: 'Deprecated alias for `onEnd`.',
     },
     {
+      name: 'onAbort',
+      type: 'StreamTextOnAbortCallback',
+      isOptional: true,
+      description:
+        'Callback that is called when the stream is aborted. Receives the steps that finished before the abort. Only applies to `stream()`. If also specified in `stream()`, both callbacks are called.',
+    },
+    {
       name: 'runtimeContext',
       type: 'CONTEXT',
       isOptional: true,
@@ -917,6 +924,13 @@ for await (const chunk of stream.textStream) {
       type: 'GenerateTextOnEndCallback',
       isOptional: true,
       description: 'Deprecated alias for `onEnd`.',
+    },
+    {
+      name: 'onAbort',
+      type: 'StreamTextOnAbortCallback',
+      isOptional: true,
+      description:
+        'Callback that is called when the stream is aborted. Receives the steps that finished before the abort. If also specified in the constructor, both callbacks are called.',
     },
   ]}
 />

--- a/examples/ai-functions/src/agent/openai/stream-on-abort.ts
+++ b/examples/ai-functions/src/agent/openai/stream-on-abort.ts
@@ -1,0 +1,37 @@
+import { openai } from '@ai-sdk/openai';
+import { ToolLoopAgent } from 'ai';
+import { run } from '../../lib/run';
+
+const abortController = new AbortController();
+
+const agent = new ToolLoopAgent({
+  model: openai('gpt-4o'),
+  instructions: 'You are a helpful assistant.',
+  onAbort({ steps }) {
+    // persist partial results here: onEnd is not called for aborted streams
+    console.log(`\naborted after ${steps.length} step(s)`);
+  },
+  onEnd({ text }) {
+    console.log(`\nfinished: ${text}`);
+  },
+});
+
+run(async () => {
+  const result = await agent.stream({
+    prompt: 'Invent a new holiday and describe its traditions.',
+    abortSignal: abortController.signal,
+  });
+
+  let characters = 0;
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+
+    characters += textPart.length;
+
+    if (characters > 100) {
+      abortController.abort();
+      break;
+    }
+  }
+});

--- a/packages/ai/src/agent/agent.ts
+++ b/packages/ai/src/agent/agent.ts
@@ -14,7 +14,10 @@ import type {
 } from '../generate-text/generate-text-events';
 import type { GenerateTextResult } from '../generate-text/generate-text-result';
 import type { Output } from '../generate-text/output';
-import type { StreamTextTransform } from '../generate-text/stream-text';
+import type {
+  StreamTextOnAbortCallback,
+  StreamTextTransform,
+} from '../generate-text/stream-text';
 import type { StreamTextResult } from '../generate-text/stream-text-result';
 import type {
   OnToolExecutionEndCallback,
@@ -172,6 +175,12 @@ export type AgentStreamParameters<
    * The stream transformations must maintain the stream structure for streamText to work correctly.
    */
   experimental_transform?: Arrayable<StreamTextTransform<TOOLS>>;
+
+  /**
+   * Callback that is called when the stream is aborted. Receives the steps
+   * that finished before the abort.
+   */
+  onAbort?: StreamTextOnAbortCallback<TOOLS, RUNTIME_CONTEXT>;
 };
 
 /**

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -20,7 +20,10 @@ import type { GenerateTextInclude } from '../generate-text/generate-text';
 import type { Output } from '../generate-text/output';
 import type { PrepareStepFunction } from '../generate-text/prepare-step';
 import type { StopCondition } from '../generate-text/stop-condition';
-import type { StreamTextInclude } from '../generate-text/stream-text';
+import type {
+  StreamTextInclude,
+  StreamTextOnAbortCallback,
+} from '../generate-text/stream-text';
 import type { ToolApprovalConfiguration } from '../generate-text/tool-approval-configuration';
 import type { Experimental_ToolCallers } from '../generate-text/tool-caller-configuration';
 import type { ToolCallRepairFunction } from '../generate-text/tool-call-repair-function';
@@ -244,6 +247,17 @@ export type ToolLoopAgentSettings<
      * @deprecated Use `onEnd` instead.
      */
     onFinish?: GenerateTextOnEndCallback<
+      NoInfer<TOOLS>,
+      NoInfer<RUNTIME_CONTEXT>
+    >;
+
+    /**
+     * Callback that is called when the stream is aborted. Receives the steps
+     * that finished before the abort.
+     *
+     * Only applies to `stream`, since `generate` has no partial result to report.
+     */
+    onAbort?: StreamTextOnAbortCallback<
       NoInfer<TOOLS>,
       NoInfer<RUNTIME_CONTEXT>
     >;

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -67,6 +67,18 @@ describe('ToolLoopAgent', () => {
       });
     });
 
+    it('should not allow onAbort', async () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+      });
+
+      await agent.generate({
+        // @ts-expect-error - onAbort is stream only
+        onAbort: async () => {},
+        prompt: 'Hello, world!',
+      });
+    });
+
     it('should require options when call options are provided', async () => {
       const agent = new ToolLoopAgent<{ callOption: string }>({
         model: new MockLanguageModelV4(),
@@ -235,6 +247,33 @@ describe('ToolLoopAgent', () => {
   });
 
   describe('stream', () => {
+    it('should allow onAbort', () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+      });
+
+      agent.stream({
+        prompt: 'Hello, world!',
+        onAbort: async () => {},
+      });
+    });
+
+    // pins the StreamTextOnAbortCallback<TOOLS, RUNTIME_CONTEXT> argument order:
+    // swapping them would resolve `runtimeContext` to the tool set instead
+    it('should type the onAbort steps for the agent runtime context', () => {
+      const agent = new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+        runtimeContext: { userId: 'user-1' },
+        onAbort: async ({ steps }) => {
+          expectTypeOf(steps[0].runtimeContext).toEqualTypeOf<{
+            userId: string;
+          }>();
+        },
+      });
+
+      agent;
+    });
+
     it('should not allow system prompt', () => {
       const agent = new ToolLoopAgent({
         model: new MockLanguageModelV4(),

--- a/packages/ai/src/agent/tool-loop-agent.test.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test.ts
@@ -3542,6 +3542,330 @@ describe('ToolLoopAgent', () => {
     });
   });
 
+  describe('onAbort', () => {
+    describe('generate', () => {
+      // generateText has no onAbort, so the setting must not reach it.
+      // This guards the `prepareCall` strip; the stream-only call signature
+      // is pinned by the `@ts-expect-error` case in tool-loop-agent.test-d.ts.
+      it('should not forward onAbort to the generateText call', async () => {
+        let capturedCallArgs: Record<string, unknown> | undefined;
+
+        const agent = new ToolLoopAgent({
+          model: new MockLanguageModelV4({
+            doGenerate: async () => ({
+              content: [{ type: 'text', text: 'Hello, world!' }],
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: {
+                inputTokens: {
+                  total: 3,
+                  noCache: 3,
+                  cacheRead: undefined,
+                  cacheWrite: undefined,
+                },
+                outputTokens: { total: 10, text: 10, reasoning: undefined },
+              },
+              warnings: [],
+            }),
+          }),
+          onAbort: async () => {},
+          prepareCall: callArgs => {
+            capturedCallArgs = callArgs as Record<string, unknown>;
+            return callArgs;
+          },
+        });
+
+        await agent.generate({ prompt: 'Hello, world!' });
+
+        expect(capturedCallArgs).toBeDefined();
+        expect('onAbort' in capturedCallArgs!).toBe(false);
+      });
+    });
+
+    describe('stream', () => {
+      function createAbortingModel() {
+        const abortController = new AbortController();
+        let pullCalls = 0;
+
+        const model = new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: new ReadableStream({
+              pull(controller) {
+                switch (pullCalls++) {
+                  case 0:
+                    controller.enqueue({ type: 'stream-start', warnings: [] });
+                    break;
+                  case 1:
+                    controller.enqueue({ type: 'text-start', id: '1' });
+                    break;
+                  case 2:
+                    controller.enqueue({
+                      type: 'text-delta',
+                      id: '1',
+                      delta: 'Hello',
+                    });
+                    break;
+                  case 3:
+                    abortController.abort();
+                    controller.error(
+                      new DOMException(
+                        'The user aborted a request.',
+                        'AbortError',
+                      ),
+                    );
+                    break;
+                }
+              },
+            }),
+          }),
+        });
+
+        return { model, abortSignal: abortController.signal };
+      }
+
+      it('should call onAbort from constructor', async () => {
+        const onAbortCalls: string[] = [];
+        const { model, abortSignal } = createAbortingModel();
+
+        const agent = new ToolLoopAgent({
+          model,
+          onAbort: async () => {
+            onAbortCalls.push('constructor');
+          },
+        });
+
+        const result = await agent.stream({
+          prompt: 'Hello, world!',
+          abortSignal,
+        });
+        await result.consumeStream();
+
+        expect(onAbortCalls).toMatchInlineSnapshot(`
+          [
+            "constructor",
+          ]
+        `);
+      });
+
+      it('should call onAbort from stream method', async () => {
+        const onAbortCalls: string[] = [];
+        const { model, abortSignal } = createAbortingModel();
+
+        const agent = new ToolLoopAgent({ model });
+
+        const result = await agent.stream({
+          prompt: 'Hello, world!',
+          abortSignal,
+          onAbort: async () => {
+            onAbortCalls.push('method');
+          },
+        });
+        await result.consumeStream();
+
+        expect(onAbortCalls).toMatchInlineSnapshot(`
+          [
+            "method",
+          ]
+        `);
+      });
+
+      it('should call onAbort from constructor and stream method', async () => {
+        const onAbortCalls: string[] = [];
+        const { model, abortSignal } = createAbortingModel();
+
+        const agent = new ToolLoopAgent({
+          model,
+          onAbort: async () => {
+            onAbortCalls.push('constructor');
+          },
+        });
+
+        const result = await agent.stream({
+          prompt: 'Hello, world!',
+          abortSignal,
+          onAbort: async () => {
+            onAbortCalls.push('method');
+          },
+        });
+        await result.consumeStream();
+
+        expect(onAbortCalls).toMatchInlineSnapshot(`
+          [
+            "constructor",
+            "method",
+          ]
+        `);
+      });
+
+      it('should receive the steps completed before the abort', async () => {
+        const abortController = new AbortController();
+        let doStreamCalls = 0;
+        let receivedSteps: number | undefined;
+
+        const agent = new ToolLoopAgent({
+          // first step completes with a tool call, the second step is aborted
+          model: new MockLanguageModelV4({
+            doStream: async () => {
+              if (doStreamCalls++ === 0) {
+                return {
+                  stream: convertArrayToReadableStream([
+                    { type: 'stream-start', warnings: [] },
+                    {
+                      type: 'tool-call',
+                      toolCallId: 'call-1',
+                      toolName: 'echo',
+                      input: `{ "value": "hi" }`,
+                    },
+                    {
+                      type: 'finish',
+                      finishReason: {
+                        unified: 'tool-calls',
+                        raw: 'tool_calls',
+                      },
+                      usage: {
+                        inputTokens: {
+                          total: 3,
+                          noCache: 3,
+                          cacheRead: undefined,
+                          cacheWrite: undefined,
+                        },
+                        outputTokens: {
+                          total: 10,
+                          text: 10,
+                          reasoning: undefined,
+                        },
+                      },
+                    },
+                  ]),
+                };
+              }
+
+              return {
+                stream: new ReadableStream({
+                  pull(controller) {
+                    abortController.abort();
+                    controller.error(
+                      new DOMException(
+                        'The user aborted a request.',
+                        'AbortError',
+                      ),
+                    );
+                  },
+                }),
+              };
+            },
+          }),
+          tools: {
+            echo: tool({
+              inputSchema: z.object({ value: z.string() }),
+              execute: async ({ value }) => value,
+            }),
+          },
+          onAbort: async ({ steps }) => {
+            receivedSteps = steps.length;
+          },
+        });
+
+        const result = await agent.stream({
+          prompt: 'Hello, world!',
+          abortSignal: abortController.signal,
+        });
+        await result.consumeStream();
+
+        expect(receivedSteps).toBe(1);
+      });
+
+      it('should not break the stream when onAbort throws', async () => {
+        const { model, abortSignal } = createAbortingModel();
+
+        const agent = new ToolLoopAgent({
+          model,
+          onAbort: async () => {
+            throw new Error('onAbort error');
+          },
+        });
+
+        const result = await agent.stream({
+          prompt: 'Hello, world!',
+          abortSignal,
+        });
+
+        await expect(result.consumeStream()).resolves.toBeUndefined();
+      });
+
+      // whether onEnd also fires depends on how far the stream got, which is
+      // streamText behavior; this pins the no-completed-step case only
+      it('should not call onEnd when aborted before any step completes', async () => {
+        const calls: string[] = [];
+        const { model, abortSignal } = createAbortingModel();
+
+        const agent = new ToolLoopAgent({
+          model,
+          onAbort: async () => {
+            calls.push('onAbort');
+          },
+          onEnd: async () => {
+            calls.push('onEnd');
+          },
+        });
+
+        const result = await agent.stream({
+          prompt: 'Hello, world!',
+          abortSignal,
+        });
+        await result.consumeStream();
+
+        expect(calls).toMatchInlineSnapshot(`
+          [
+            "onAbort",
+          ]
+        `);
+      });
+
+      it('should not call onAbort when the stream finishes normally', async () => {
+        const onAbortCalls: string[] = [];
+
+        const agent = new ToolLoopAgent({
+          model: new MockLanguageModelV4({
+            doStream: async () => ({
+              stream: convertArrayToReadableStream([
+                { type: 'stream-start', warnings: [] },
+                { type: 'text-start', id: '1' },
+                { type: 'text-delta', id: '1', delta: 'Hello, world!' },
+                { type: 'text-end', id: '1' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: {
+                    inputTokens: {
+                      total: 3,
+                      noCache: 3,
+                      cacheRead: undefined,
+                      cacheWrite: undefined,
+                    },
+                    outputTokens: { total: 10, text: 10, reasoning: undefined },
+                  },
+                },
+              ]),
+            }),
+          }),
+          onAbort: async () => {
+            onAbortCalls.push('constructor');
+          },
+        });
+
+        const result = await agent.stream({
+          prompt: 'Hello, world!',
+          onAbort: async () => {
+            onAbortCalls.push('method');
+          },
+        });
+        await result.consumeStream();
+
+        expect(onAbortCalls).toMatchInlineSnapshot(`[]`);
+      });
+    });
+  });
+
   describe('telemetry integrations', () => {
     afterEach(() => {
       globalThis.AI_SDK_TELEMETRY_INTEGRATIONS = undefined;

--- a/packages/ai/src/agent/tool-loop-agent.ts
+++ b/packages/ai/src/agent/tool-loop-agent.ts
@@ -98,6 +98,7 @@ export class ToolLoopAgent<
       | 'onStepFinish'
       | 'onEnd'
       | 'onFinish'
+      | 'onAbort'
     > &
       Prompt
   > {
@@ -124,6 +125,7 @@ export class ToolLoopAgent<
       onStepFinish: _settingsOnStepFinish,
       onFinish: _settingsOnFinish,
       onEnd: _settingsOnEnd,
+      onAbort: _settingsOnAbort,
       ...settingsWithoutCallbacks
     } = this.settings;
 
@@ -273,6 +275,7 @@ export class ToolLoopAgent<
     onStepFinish,
     onFinish,
     onEnd = onFinish,
+    onAbort,
     ...options
   }: AgentStreamParameters<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT>): Promise<
     StreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>
@@ -312,6 +315,7 @@ export class ToolLoopAgent<
         onStepEnd ?? onStepFinish,
       ),
       onEnd: mergeCallbacks(this.settings.onEnd, onEnd),
+      onAbort: mergeCallbacks(this.settings.onAbort, onAbort),
     };
 
     return await stream({

--- a/packages/ai/src/generate-text/index.ts
+++ b/packages/ai/src/generate-text/index.ts
@@ -66,6 +66,7 @@ export {
 export {
   streamText,
   type StreamTextInclude,
+  type StreamTextOnAbortCallback,
   type StreamTextOnChunkCallback,
   type StreamTextOnErrorCallback,
   type StreamTextTransform,


### PR DESCRIPTION
## Background

`streamText` accepts an `onAbort` callback and `WorkflowAgent` has an equivalent, but `ToolLoopAgent` never declared one. Unrecognized settings are spread through to `streamText`, so a constructor `onAbort` does fire today, but untyped, undocumented, and with two bugs behind it: the constructor callback is silently dropped when `stream()` passes one too, and `generate()` forwards `onAbort` to `generateText`, which has no such option.

## Summary

- Add `onAbort` to `ToolLoopAgentSettings` and `AgentStreamParameters`, merged in `ToolLoopAgent.stream` like the sibling callbacks.
- Stream only: `prepareCall` strips it before `generateText`, and `generate()` rejects it at the type level.
- Export the existing `StreamTextOnAbortCallback` type, which was defined but never re-exported, and reuse it instead of adding an agent-specific alias.
- Tests for the settings callback, the per-call callback, both together, steps carried into the event, a throwing callback, and the `generate()` strip; type tests pin the stream-only signature.
- Docs, an example, and a patch changeset.

## End-to-End Verification

| scenario                         | `main`                | this PR           |
| -------------------------------- | --------------------- | ----------------- |
| `onAbort` in settings            | fires, untyped        | fires             |
| `onAbort` in `stream()`          | fires, untyped        | fires             |
| both                             | only `stream()` fires | both fire, merged |
| `onAbort` reaches `generateText` | yes                   | no, stripped      |

Output:

```
===== BEFORE (main) =====
  settings onAbort only        -> [settings]
  per-call onAbort only        -> [call]
  both (expect merged)         -> [call]
  generate() sees onAbort      -> true

===== AFTER (this branch) =====
  settings onAbort only        -> [settings]
  per-call onAbort only        -> [call]
  both (expect merged)         -> [settings, call]
  generate() sees onAbort      -> false
```

`examples/ai-functions/src/agent/openai/stream-on-abort.ts` streams from a `ToolLoopAgent`, aborts after 100 characters, and logs from both callbacks:

```ts
const agent = new ToolLoopAgent({
  model: openai('gpt-4o'),
  onAbort({ steps }) {
    // persist partial results here: onEnd is not called for aborted streams
    console.log(`aborted after ${steps.length} step(s)`);
  },
  onEnd({ text }) { /* ... */ },
});
```

<details>
<summary>repro script</summary>

```ts
import { ToolLoopAgent } from './src/index';
import { MockLanguageModelV4 } from './src/test/mock-language-model-v4';

function createAbortingModel() {
  const abortController = new AbortController();
  let pullCalls = 0;
  const model = new MockLanguageModelV4({
    doStream: async () => ({
      stream: new ReadableStream({
        pull(controller) {
          switch (pullCalls++) {
            case 0: controller.enqueue({ type: 'stream-start', warnings: [] }); break;
            case 1: controller.enqueue({ type: 'text-start', id: '1' }); break;
            case 2: controller.enqueue({ type: 'text-delta', id: '1', delta: 'Once ' }); break;
            case 3:
              abortController.abort();
              controller.error(new DOMException('The user aborted a request.', 'AbortError'));
              break;
          }
        },
      }),
    }),
  });
  return { model, abortSignal: abortController.signal };
}

async function scenario(name: string, useSettings: boolean, useCall: boolean) {
  const fired: string[] = [];
  const { model, abortSignal } = createAbortingModel();
  const agent = new ToolLoopAgent({
    model,
    ...(useSettings ? { onAbort: () => { fired.push('settings'); } } : {}),
  } as any);
  const result = await agent.stream({
    prompt: 'Tell me a story.',
    abortSignal,
    ...(useCall ? { onAbort: () => { fired.push('call'); } } : {}),
  } as any);
  try { await result.consumeStream(); } catch {}
  console.log(`  ${name.padEnd(28)} -> [${fired.join(', ')}]`);
}

async function generateLeak() {
  let captured: Record<string, unknown> | undefined;
  const agent = new ToolLoopAgent({
    model: new MockLanguageModelV4({
      doGenerate: async () => ({
        content: [{ type: 'text', text: 'hi' }],
        finishReason: { unified: 'stop', raw: 'stop' },
        usage: {
          inputTokens: { total: 3, noCache: 3, cacheRead: undefined, cacheWrite: undefined },
          outputTokens: { total: 2, text: 2, reasoning: undefined },
        },
        warnings: [],
      }),
    }),
    onAbort: () => {},
    prepareCall: (a: any) => { captured = a; return a; },
  } as any);
  await agent.generate({ prompt: 'hi' });
  console.log(`  ${'generate() sees onAbort'.padEnd(28)} -> ${'onAbort' in (captured ?? {})}`);
}

async function main() {
  await scenario('settings onAbort only', true, false);
  await scenario('per-call onAbort only', false, true);
  await scenario('both (expect merged)', true, true);
  await generateLeak();
}
main();
```

</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #12117.
