### PR TITLE
feat(bytedance): add chat language model support

### DIFF
--- a/.changeset/bytedance-chat-model.md
+++ b/.changeset/bytedance-chat-model.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/bytedance': patch
+---
+
+Add chat (language) model support for ByteDance Ark

--- a/content/providers/01-ai-sdk-providers/85-bytedance.mdx
+++ b/content/providers/01-ai-sdk-providers/85-bytedance.mdx
@@ -1,11 +1,11 @@
 ---
 title: ByteDance
-description: Learn how to use ByteDance Seedance video and Seedream image models with the AI SDK.
+description: Learn how to use ByteDance Doubao language models, Seedance video models, and Seedream image models with the AI SDK.
 ---
 
 # ByteDance Provider
 
-The [ByteDance](https://www.bytedance.com/) provider contains support for the Seedance family of video generation models and the Seedream family of image generation models through the [BytePlus ModelArk](https://docs.byteplus.com/en/docs/ModelArk/) platform. Seedance provides high-quality text-to-video and image-to-video generation capabilities, including audio-video synchronization, first-and-last frame control, and multi-reference image generation (see the [video generation API](https://docs.byteplus.com/en/docs/ModelArk/Video_Generation_API)). Seedream provides text-to-image and image-to-image generation, including multi-image blending and batch image generation (see the [image generation API](https://docs.byteplus.com/en/docs/ModelArk/1824690)).
+The [ByteDance](https://www.bytedance.com/) provider contains support for Doubao chat (language) models, Seedance video models, and Seedream image models through the [BytePlus ModelArk](https://docs.byteplus.com/en/docs/ModelArk/) platform.
 
 ## Setup
 
@@ -39,7 +39,7 @@ You can use the following optional settings to customize the ByteDance provider 
 
 - **baseURL** _string_
 
-  Use a different URL prefix for API calls, e.g. to use proxy servers.
+  Use a different URL prefix for API calls, e.g. to use proxy servers or the China region endpoint (`https://ark.cn-beijing.volces.com/api/v3`).
   The default prefix is `https://ark.ap-southeast.bytepluses.com/api/v3`.
 
 - **apiKey** _string_
@@ -57,6 +57,76 @@ You can use the following optional settings to customize the ByteDance provider 
   Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
   You can use it as a middleware to intercept requests,
   or to provide a custom fetch implementation for e.g. testing.
+
+## Language Models
+
+You can create ByteDance language models using the default provider instance:
+
+```ts
+import { byteDance } from '@ai-sdk/bytedance';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: byteDance('doubao-seed-2-1-pro-260628'),
+  prompt: 'Write a haiku about the ocean.',
+});
+```
+
+ByteDance language models can be used with `generateText`, `streamText`, `generateObject`, and `streamObject` (see [AI SDK Core](/docs/ai-sdk-core)).
+
+You can create ByteDance language models using a provider instance. The first argument is the model ID:
+
+```ts
+const model = byteDance('doubao-seed-2-1-pro-260628');
+```
+
+You can also use the `.languageModel()` and `.chat()` methods:
+
+```ts
+const model = byteDance.languageModel('doubao-seed-2-1-pro-260628');
+const model = byteDance.chat('doubao-seed-2-1-pro-260628');
+```
+
+### Model IDs
+
+The ByteDance provider supports Doubao models and open models hosted on Ark:
+
+- `doubao-seed-2-1-pro-260628`
+- `doubao-seed-2-1-turbo-260628`
+- `doubao-seed-evolving`
+- `doubao-seed-2-0-pro-260215`
+- `doubao-seed-2-0-lite-260428`
+- `doubao-seed-2-0-mini-260428`
+- `doubao-seed-2-0-code-preview-260215`
+- `doubao-seed-character-260628`
+- `deepseek-v4-pro-ga-260813`
+- `deepseek-v4-flash-ga-260731`
+- `glm-5-2-260617`
+
+### Reasoning & Thinking
+
+Ark models support deep thinking and reasoning. Intermediate reasoning content is streamed and returned as reasoning parts.
+
+You can configure thinking and reasoning intensity via provider options:
+
+```ts
+import {
+  byteDance,
+  type ByteDanceLanguageModelChatOptions,
+} from '@ai-sdk/bytedance';
+import { streamText } from 'ai';
+
+const result = streamText({
+  model: byteDance('doubao-seed-2-1-pro-260628'),
+  prompt: 'Explain the P vs NP problem.',
+  providerOptions: {
+    bytedance: {
+      thinking: { type: 'enabled' },
+      reasoningEffort: 'high',
+    } satisfies ByteDanceLanguageModelChatOptions,
+  },
+});
+```
 
 ## Image Models
 
@@ -100,13 +170,11 @@ import { readFileSync } from 'node:fs';
 import { byteDance, type ByteDanceImageModelOptions } from '@ai-sdk/bytedance';
 import { generateImage } from 'ai';
 
-const inputImage = readFileSync('./input-image.png');
-
 const { image } = await generateImage({
   model: byteDance.image('seedream-5-0-260128'),
   prompt: {
-    text: 'Change the salamander to a snow weasel',
-    images: [inputImage],
+    text: 'A cozy cottage in the style of a watercolor painting',
+    images: [readFileSync('cottage.jpg')],
   },
   providerOptions: {
     bytedance: {
@@ -116,19 +184,24 @@ const { image } = await generateImage({
 });
 ```
 
-You can also pass multiple images to blend styles and elements from several
-references into a single output (multi-image blending). Images may be provided
-as binary data, base64 strings, or URLs:
+### Multi-Image Blending
+
+Pass multiple images (up to 10) in `prompt.images` to blend them together:
 
 ```ts
+import { readFileSync } from 'node:fs';
 import { byteDance, type ByteDanceImageModelOptions } from '@ai-sdk/bytedance';
 import { generateImage } from 'ai';
 
 const { image } = await generateImage({
   model: byteDance.image('seedream-5-0-260128'),
   prompt: {
-    text: 'Replace the clothing in image 1 with the outfit from image 2',
-    images: ['https://example.com/model.png', 'https://example.com/outfit.png'],
+    text: 'A room decorated with the furniture and wallpaper from the images',
+    images: [
+      readFileSync('furniture.jpg'),
+      readFileSync('wallpaper.jpg'),
+      readFileSync('lighting.jpg'),
+    ],
   },
   providerOptions: {
     bytedance: {
@@ -138,72 +211,50 @@ const { image } = await generateImage({
 });
 ```
 
-<Note>
-  Seedream does not support mask-based inpainting. Describe the edit in the
-  prompt, optionally with markers drawn on the input image (interactive editing,
-  supported by `dola-seedream-5-0-pro-260628`).
-</Note>
+### Sequential Image Generation
 
-### Image Model Options
+Generate a sequence of images in a single call while preserving context and
+character consistency across images. Set `sequentialImageGeneration: true` and
+specify `maxImages` (up to 15):
 
-The following options are available via `providerOptions.bytedance`. You can
-type them with `ByteDanceImageModelOptions`.
+```ts
+import { byteDance, type ByteDanceImageModelOptions } from '@ai-sdk/bytedance';
+import { generateImage } from 'ai';
 
-- **watermark** _boolean_
+const { image, providerMetadata } = await generateImage({
+  model: byteDance.image('seedream-5-0-260128'),
+  prompt:
+    'A red fox waking up in the snow, then stretching, then walking into a dense pine forest',
+  providerOptions: {
+    bytedance: {
+      sequentialImageGeneration: true,
+      maxImages: 3,
+      watermark: false,
+    } satisfies ByteDanceImageModelOptions,
+  },
+});
 
-  Whether to add an "AI generated" watermark to the bottom-right corner of the
-  output image.
+// Primary image returned as standard result
+console.log(image.base64);
 
-- **outputFormat** _'png' | 'jpeg'_
+// Additional images in the sequence are available in providerMetadata
+const sequence = providerMetadata?.bytedance?.images;
+```
 
-  Format of the generated image file. Supported by `seedream-5-0` and
-  `dola-seedream-5-0-pro`; `seedream-4-5` / `seedream-4-0` always return `jpeg`.
+### Image Provider Options
 
-- **size** _string_
-
-  A resolution level (e.g. `1K`, `2K`, `3K`, `4K`) as an alternative to passing
-  pixel dimensions via the top-level `size` parameter. When set, this overrides
-  the top-level `size`. Available levels vary by model.
-
-- **sequentialImageGeneration** _'auto' | 'disabled'_
-
-  Set to `'auto'` to generate a batch of related images (e.g. storyboards or
-  brand visuals). Defaults to `'disabled'` (single image).
-
-- **maxImages** _number_
-
-  Maximum number of images to generate when `sequentialImageGeneration` is
-  `'auto'`. The number of input reference images plus generated images must not
-  exceed the model's limit.
-
-- **optimizePromptMode** _'standard' | 'fast'_
-
-  Prompt optimization mode. `seedream-4-0` supports both `standard` and `fast`;
-  other models support `standard` only.
-
-<Note>
-  Additional ModelArk fields can also be passed through
-  `providerOptions.bytedance` and are validated by ModelArk.
-</Note>
-
-### Image Model Capabilities
-
-| Model             | Model ID                                                 | Capabilities                                                                                                                          |
-| ----------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Seedream 5.0 Pro  | `dola-seedream-5-0-pro-260628`                           | Text-to-image, single/multi image-to-image, interactive editing (markers). Sizes: 1K, 2K. Formats: png, jpeg. Up to 10 references.    |
-| Seedream 5.0 Lite | `seedream-5-0-260128` (alias `seedream-5-0-lite-260128`) | Text-to-image, single/multi image-to-image, batch generation. Sizes: 2K, 3K, 4K. Formats: png, jpeg. Up to 14 references.             |
-| Seedream 4.5      | `seedream-4-5-251128`                                    | Text-to-image, single/multi image-to-image, batch generation. Sizes: 2K, 4K. Format: jpeg. Up to 14 references.                       |
-| Seedream 4.0      | `seedream-4-0-250828`                                    | Text-to-image, single/multi image-to-image, batch generation, fast prompt mode. Sizes: 1K, 2K, 4K. Format: jpeg. Up to 14 references. |
-
-<Note>
-  You can also pass any model or endpoint id string if needed, e.g. for future
-  models not yet listed here. Streaming image output is not currently supported
-  through the AI SDK integration.
-</Note>
+| Option                      | Type                                          | Description                                                                                                                                                                                                                                        |
+| --------------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `watermark`                 | `boolean`                                     | Whether to add a watermark to the generated image. Defaults to `true`.                                                                                                                                                                             |
+| `outputFormat`              | `'png' \| 'jpeg'`                             | Image format for the response. Defaults to `'png'`.                                                                                                                                                                                                |
+| `size`                      | `'2K' \| '4K' \| 'general'`                   | Resolution level preset. When passed, takes precedence over the standard `size` parameter. Defaults to `'general'`.                                                                                                                                |
+| `sequentialImageGeneration` | `boolean`                                     | Enables multi-image narrative generation (up to 15 images). Additional images are accessible in `providerMetadata.bytedance.images`. Defaults to `false`.                                                                                          |
+| `maxImages`                 | `number`                                      | Maximum number of images to generate when `sequentialImageGeneration` is `true`. Integer between 1 and 15.                                                                                                                                         |
+| `optimizePromptMode`        | `'standard' \| 'fast' \| 'creative' \| 'off'` | Controls prompt enhancement behavior. `'standard'` gives balanced enhancement, `'fast'` uses a lighter model for lower latency, `'creative'` generates more varied additions, and `'off'` disables enhancement entirely. Defaults to `'standard'`. |
 
 ## Video Models
 
-You can create ByteDance video models using the `.video()` factory method.
+You can create ByteDance Seedance video models using the `.video()` factory method.
 For more on video generation with the AI SDK see [generateVideo()](/docs/reference/ai-sdk-core/generate-video).
 
 ### Text-to-Video
@@ -215,9 +266,8 @@ import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
 const { video } = await generateVideo({
-  model: byteDance.video('seedance-1-0-pro-250528'),
-  prompt:
-    'Photorealistic style: Under a clear blue sky, a vast expanse of white daisy fields stretches out. The camera gradually zooms in and fixates on a close-up of a single daisy.',
+  model: byteDance.video('seedance-1-5-pro-251215'),
+  prompt: 'A golden retriever running through a field of wildflowers at sunset',
   aspectRatio: '16:9',
   duration: 5,
   providerOptions: {
@@ -226,13 +276,11 @@ const { video } = await generateVideo({
     } satisfies ByteDanceVideoModelOptions,
   },
 });
-
-console.log(video.url);
 ```
 
 ### Image-to-Video
 
-Generate videos from a first-frame image with an optional text prompt:
+Generate videos from a starting image:
 
 ```ts
 import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
@@ -242,7 +290,7 @@ const { video } = await generateVideo({
   model: byteDance.video('seedance-1-5-pro-251215'),
   prompt: {
     image: 'https://example.com/first-frame.png',
-    text: 'The cat slowly turns its head and blinks',
+    text: 'The camera slowly zooms in as gentle snow falls around the cabin',
   },
   duration: 5,
   providerOptions: {
@@ -253,17 +301,9 @@ const { video } = await generateVideo({
 });
 ```
 
-<Note>
-  When the output ratio is dictated by an input — first-frame or
-  first-and-last-frame image-to-video, video editing, and video extension — pass
-  `aspectRatio: 'adaptive'` or omit `aspectRatio` entirely. Newer Seedance
-  models reject an explicit ratio on those paths, because the output inherits
-  the ratio of the input media.
-</Note>
-
 ### Image-to-Video with Audio
 
-Seedance 1.5 Pro supports generating synchronized audio alongside the video:
+Generate synchronized audio alongside the video:
 
 ```ts
 import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
@@ -273,7 +313,7 @@ const { video } = await generateVideo({
   model: byteDance.video('seedance-1-5-pro-251215'),
   prompt: {
     image: 'https://example.com/pianist.png',
-    text: 'A young man sits at a piano, playing calmly. Gentle piano music plays in sync with his movements.',
+    text: 'A young man sits at a piano, playing calmly. Gentle piano music plays in sync.',
   },
   duration: 5,
   providerOptions: {
@@ -287,7 +327,7 @@ const { video } = await generateVideo({
 
 ### First-and-Last Frame Video
 
-Generate smooth transitions between a starting and ending keyframe image:
+Generate transitions between starting and ending frames:
 
 ```ts
 import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
@@ -297,7 +337,7 @@ const { video } = await generateVideo({
   model: byteDance.video('seedance-1-5-pro-251215'),
   prompt: {
     image: 'https://example.com/first-frame.jpg',
-    text: 'Create a 360-degree orbiting camera shot based on this photo',
+    text: 'Create a smooth transition between the two scenes',
   },
   duration: 5,
   providerOptions: {
@@ -312,7 +352,7 @@ const { video } = await generateVideo({
 
 ### Multi-Reference Image-to-Video
 
-Using the Seedance 1.0 Lite I2V model, you can provide multiple reference images (1-4) that the model uses to faithfully reproduce object shapes, colors, and textures:
+Provide multiple reference images to guide generation:
 
 ```ts
 import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
@@ -321,7 +361,7 @@ import { experimental_generateVideo as generateVideo } from 'ai';
 const { video } = await generateVideo({
   model: byteDance.video('seedance-1-0-lite-i2v-250428'),
   prompt:
-    'A boy wearing glasses and a blue T-shirt from [Image 1] and a corgi dog from [Image 2], sitting on the lawn from [Image 3], in 3D cartoon style',
+    'A boy from [Image 1] and a corgi from [Image 2], sitting on the lawn from [Image 3]',
   aspectRatio: '16:9',
   duration: 5,
   providerOptions: {
@@ -337,147 +377,19 @@ const { video } = await generateVideo({
 });
 ```
 
-### Reference Video
+### Video Provider Options
 
-Seedance 2.0 supports reference videos that guide the style, motion, or composition of the generated video:
-
-```ts
-import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
-import { experimental_generateVideo as generateVideo } from 'ai';
-
-const { video } = await generateVideo({
-  model: byteDance.video('dreamina-seedance-2-0-260128'),
-  prompt:
-    'First-person perspective promotional ad, using the composition and camera movement from the reference video',
-  aspectRatio: '16:9',
-  duration: 4,
-  providerOptions: {
-    bytedance: {
-      referenceVideos: ['https://example.com/reference-video.mp4'],
-      watermark: false,
-    } satisfies ByteDanceVideoModelOptions,
-  },
-});
-```
-
-### Reference Audio
-
-Seedance 2.0 supports reference audio that is used as background music or sound for the generated video:
-
-```ts
-import { byteDance, type ByteDanceVideoModelOptions } from '@ai-sdk/bytedance';
-import { experimental_generateVideo as generateVideo } from 'ai';
-
-const { video } = await generateVideo({
-  model: byteDance.video('dreamina-seedance-2-0-260128'),
-  prompt: 'A serene mountain landscape at sunrise with gentle camera movement',
-  aspectRatio: '16:9',
-  duration: 4,
-  providerOptions: {
-    bytedance: {
-      referenceAudio: ['https://example.com/background-music.mp3'],
-      generateAudio: true,
-      watermark: false,
-    } satisfies ByteDanceVideoModelOptions,
-  },
-});
-```
-
-### Video Model Options
-
-The following options are available via `providerOptions.bytedance`. You can
-type them with `ByteDanceVideoModelOptions`.
-
-#### Generation Options
-
-- **watermark** _boolean_
-
-  Whether to add a watermark to the generated video.
-
-- **generateAudio** _boolean_
-
-  Whether to generate synchronized audio for the video. Supported by Seedance
-  1.5 Pro and Seedance 2.0.
-
-- **cameraFixed** _boolean_
-
-  Whether to fix the camera during generation.
-
-- **returnLastFrame** _boolean_
-
-  Whether to return the last frame of the generated video. Useful for chaining consecutive videos.
-
-- **serviceTier** _'default' | 'flex'_
-
-  Inference tier. `'default'` for online inference. `'flex'` for offline inference at 50% of the price, with higher latency (response times on the order of hours).
-
-- **draft** _boolean_
-
-  Enable draft sample mode for low-cost preview generation. Only supported by Seedance 1.5 Pro. Generates a 480p preview video for rapid iteration before committing to a full-quality generation.
-
-#### Image Input Options
-
-- **lastFrameImage** _string_
-
-  URL of the last frame image for first-and-last frame video generation. The model generates smooth transitions between the first frame (provided via the `image` prompt) and this last frame. Supported by Seedance 1.5 Pro, 1.0 Pro, and 1.0 Lite I2V.
-
-- **referenceImages** _string[]_
-
-  Array of reference image URLs for multi-reference image-to-video generation.
-  The model extracts key features from each image and reproduces them in the
-  video. Use `[Image 1]`, `[Image 2]`, etc. in your prompt to reference
-  specific images.
-
-#### Media Reference Options
-
-- **referenceVideos** _string[]_
-
-  Array of reference video URLs (up to 3 videos, max 15 seconds each) for reference-guided video generation. The model uses the referenced videos to guide style, motion, or composition. Supported by Seedance 2.0.
-
-- **referenceAudio** _string[]_
-
-  Array of reference audio URLs (up to 3, max 15 seconds each) for audio-guided video generation. The model uses the referenced audio as background music or synchronized sound. Supports data URIs (e.g., `data:audio/wav;base64,...`). Supported by Seedance 2.0.
-
-#### Polling Options
-
-ByteDance video generation is task-based: the provider creates a task and the AI
-SDK polls it until it completes. Configure polling with the top-level `poll`
-option of [`generateVideo()`](/docs/reference/ai-sdk-core/generate-video):
-
-```ts
-const { video } = await generateVideo({
-  model: byteDance.video('seedance-1-0-pro-250528'),
-  prompt: 'A futuristic city with flying cars',
-  poll: {
-    intervalMs: 2000, // how often to check the task (default: 5000)
-    timeoutMs: 900000, // give up after 15 minutes (default: 600000)
-  },
-});
-```
-
-<Note>
-  The `pollIntervalMs` and `pollTimeoutMs` provider options are deprecated and
-  ignored. Passing either emits a warning. Video generation can take several
-  minutes, so raise `poll.timeoutMs` above the 10 minute default for long jobs.
-</Note>
-
-### Video Model Capabilities
-
-| Model                   | Model ID                            | Capabilities                                                                                                                                     |
-| ----------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Seedance 2.0            | `dreamina-seedance-2-0-260128`      | T2V, I2V, reference videos (up to 3), reference audio (up to 3), audio-video sync. Duration: 4-15s. Resolution: 480p, 720p.                      |
-| Seedance 2.0 Fast       | `dreamina-seedance-2-0-fast-260128` | T2V, I2V, reference videos (up to 3), reference audio (up to 3), audio-video sync. Optimized for speed. Duration: 4-15s. Resolution: 480p, 720p. |
-| Seedance 1.5 Pro        | `seedance-1-5-pro-251215`           | T2V, I2V (first frame), I2V (first+last frame), audio-video sync, draft mode. Duration: 4-12s. Resolution: 480p, 720p, 1080p.                    |
-| Seedance 1.0 Pro        | `seedance-1-0-pro-250528`           | T2V, I2V (first frame), I2V (first+last frame). Duration: 2-12s. Resolution: 480p, 720p, 1080p.                                                  |
-| Seedance 1.0 Pro Fast   | `seedance-1-0-pro-fast-251015`      | T2V, I2V (first frame). Optimized for speed and cost. Duration: 2-12s.                                                                           |
-| Seedance 1.0 Lite (T2V) | `seedance-1-0-lite-t2v-250428`      | Text-to-video only. Duration: 2-12s. Resolution: 480p, 720p, 1080p.                                                                              |
-| Seedance 1.0 Lite (I2V) | `seedance-1-0-lite-i2v-250428`      | I2V (first frame), I2V (first+last frame), multi-reference images (1-4). Duration: 2-12s. Resolution: 480p, 720p.                                |
-
-Supported aspect ratios: `16:9`, `4:3`, `1:1`, `3:4`, `9:16`, `21:9`, `adaptive` (image-to-video only).
-
-All models output MP4 video at 24 fps.
-
-<Note>
-  You can also pass any model ID string if needed, e.g. for future models not
-  yet listed here.
-</Note>
+| Option            | Type                  | Description                                                                |
+| ----------------- | --------------------- | -------------------------------------------------------------------------- |
+| `watermark`       | `boolean`             | Whether to add a watermark to the generated video.                         |
+| `generateAudio`   | `boolean`             | Generate synchronized audio for supported Seedance models.                 |
+| `cameraFixed`     | `boolean`             | Whether to fix the camera during generation.                               |
+| `returnLastFrame` | `boolean`             | Return the last frame of the generated video (useful for chaining).        |
+| `serviceTier`     | `'default' \| 'flex'` | `'default'` for online inference, `'flex'` for offline at lower cost.      |
+| `draft`           | `boolean`             | Enable draft mode for low-cost preview generation (Seedance 1.5 Pro only). |
+| `lastFrameImage`  | `string`              | URL of last frame image for first-and-last frame generation.               |
+| `referenceImages` | `string[]`            | Array of reference image URLs for multi-reference generation.              |
+| `referenceVideos` | `string[]`            | Array of reference video URLs for reference-guided generation.             |
+| `referenceAudio`  | `string[]`            | Array of reference audio URLs for audio-guided generation.                 |
+| `pollIntervalMs`  | `number`              | Poll interval for async generation (default: 3000ms).                      |
+| `pollTimeoutMs`   | `number`              | Max wait time for generation (default: 300000ms).                          |

--- a/examples/ai-functions/src/generate-text/bytedance/basic.ts
+++ b/examples/ai-functions/src/generate-text/bytedance/basic.ts
@@ -1,0 +1,15 @@
+import { byteDance as provider } from '@ai-sdk/bytedance';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: provider.chat('doubao-seed-2-1-pro-260628'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  console.log(result.text);
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+});

--- a/examples/ai-functions/src/stream-text/bytedance/basic.ts
+++ b/examples/ai-functions/src/stream-text/bytedance/basic.ts
@@ -1,0 +1,19 @@
+import { byteDance } from '@ai-sdk/bytedance';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: byteDance('doubao-seed-2-1-pro-260628'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  console.log(result);
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+});

--- a/packages/bytedance/README.md
+++ b/packages/bytedance/README.md
@@ -1,6 +1,6 @@
 # AI SDK - ByteDance Provider
 
-The **ByteDance provider** for the [AI SDK](https://ai-sdk.dev/docs) contains video model support for ByteDance's Seedance family of video generation models through the [BytePlus ModelArk](https://docs.byteplus.com/en/docs/ModelArk/Video_Generation_API) platform.
+The **ByteDance provider** for the [AI SDK](https://ai-sdk.dev/docs) contains language, image, and video model support for ByteDance's Doubao, Seedream, and Seedance models through the [BytePlus ModelArk](https://docs.byteplus.com/en/docs/ModelArk/) platform.
 
 > **Deploying to Vercel?** With Vercel's AI Gateway you can access ByteDance (and hundreds of models from other providers) — no additional packages, API keys, or extra cost. [Get started with AI Gateway](https://vercel.com/ai-gateway).
 
@@ -26,6 +26,50 @@ You can import the default provider instance `byteDance` from `@ai-sdk/bytedance
 
 ```ts
 import { byteDance } from '@ai-sdk/bytedance';
+```
+
+## Language Models
+
+You can create ByteDance language models using the provider instance:
+
+```ts
+import { byteDance } from '@ai-sdk/bytedance';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: byteDance('doubao-seed-2-1-pro-260628'),
+  prompt: 'Write a haiku about the ocean.',
+});
+```
+
+You can also use `.languageModel()` and `.chat()` methods:
+
+```ts
+const model = byteDance.languageModel('doubao-seed-2-1-pro-260628');
+const model = byteDance.chat('doubao-seed-2-1-pro-260628');
+```
+
+### Thinking & Reasoning Models
+
+Ark models support deep thinking and reasoning. Configure thinking and reasoning intensity via provider options:
+
+```ts
+import {
+  byteDance,
+  type ByteDanceLanguageModelChatOptions,
+} from '@ai-sdk/bytedance';
+import { streamText } from 'ai';
+
+const result = streamText({
+  model: byteDance('doubao-seed-2-1-pro-260628'),
+  prompt: 'Explain quantum computing simply.',
+  providerOptions: {
+    bytedance: {
+      thinking: { type: 'enabled' },
+      reasoningEffort: 'high',
+    } satisfies ByteDanceLanguageModelChatOptions,
+  },
+});
 ```
 
 ## Video Models

--- a/packages/bytedance/package.json
+++ b/packages/bytedance/package.json
@@ -31,6 +31,7 @@
     }
   },
   "dependencies": {
+    "@ai-sdk/openai-compatible": "workspace:*",
     "@ai-sdk/provider": "workspace:*",
     "@ai-sdk/provider-utils": "workspace:*"
   },

--- a/packages/bytedance/src/bytedance-chat-language-model-options.ts
+++ b/packages/bytedance/src/bytedance-chat-language-model-options.ts
@@ -1,0 +1,59 @@
+import * as z4 from 'zod/v4';
+
+export type { ByteDanceChatModelId } from './bytedance-chat-options';
+
+export const bytedanceLanguageModelChatOptions = z4.object({
+  /**
+   * A unique identifier representing your end-user, which can help the provider to
+   * monitor and detect abuse.
+   */
+  user: z4.string().optional(),
+
+  /**
+   * Whether to use strict JSON schema validation.
+   * When true, the model uses constrained decoding to guarantee schema compliance.
+   * Only used when the provider supports structured outputs and a schema is provided.
+   *
+   * @default true
+   */
+  strictJsonSchema: z4.boolean().optional(),
+
+  /**
+   * Whether to enable parallel function calling during tool use.
+   */
+  parallelToolCalls: z4.boolean().optional(),
+
+  /**
+   * Whether to return log probabilities of the output tokens or not.
+   */
+  logprobs: z4.boolean().optional(),
+
+  /**
+   * An integer between 0 and 20 specifying the number of most likely tokens to
+   * return at each token position, each with an associated log probability.
+   */
+  topLogprobs: z4.number().int().min(0).max(20).optional(),
+
+  /**
+   * Modify the likelihood of specified tokens appearing in the completion.
+   */
+  logitBias: z4.record(z4.string(), z4.number().min(-100).max(100)).optional(),
+
+  /**
+   * Reasoning effort for reasoning models.
+   */
+  reasoningEffort: z4.enum(['minimal', 'low', 'medium', 'high']).optional(),
+
+  /**
+   * Thinking configuration for Ark models.
+   */
+  thinking: z4
+    .object({
+      type: z4.enum(['enabled', 'disabled', 'auto']),
+    })
+    .optional(),
+});
+
+export type ByteDanceLanguageModelChatOptions = z4.infer<
+  typeof bytedanceLanguageModelChatOptions
+>;

--- a/packages/bytedance/src/bytedance-chat-language-model.test.ts
+++ b/packages/bytedance/src/bytedance-chat-language-model.test.ts
@@ -1,0 +1,506 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { createByteDance } from './bytedance-provider';
+import type {
+  ByteDanceChatModelId,
+  ByteDanceLanguageModelChatOptions,
+} from './index';
+
+const TEST_PROMPT: LanguageModelV4Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+];
+
+const server = createTestServer({
+  'https://ark.cn-beijing.volces.com/api/v3/chat/completions': {},
+});
+
+const defaultModel = createByteDance({
+  apiKey: 'test-api-key',
+  baseURL: 'https://ark.cn-beijing.volces.com/api/v3',
+})('doubao-seed-2-1-pro-260628');
+
+describe('ByteDanceChatLanguageModel', () => {
+  describe('doGenerate', () => {
+    it('should generate basic text completion', async () => {
+      server.urls[
+        'https://ark.cn-beijing.volces.com/api/v3/chat/completions'
+      ].response = {
+        type: 'json-value',
+        body: {
+          id: 'chatcmpl-123',
+          object: 'chat.completion',
+          created: 1694268190,
+          model: 'doubao-seed-2-1-pro-260628',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: 'Hello, how can I help you today?',
+              },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 8,
+            total_tokens: 18,
+            prompt_tokens_details: {
+              cached_tokens: 4,
+            },
+          },
+        },
+      };
+
+      const result = await defaultModel.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.content).toEqual([
+        { type: 'text', text: 'Hello, how can I help you today?' },
+      ]);
+      expect(result.finishReason).toEqual({
+        unified: 'stop',
+        raw: 'stop',
+      });
+      expect(result.usage).toEqual({
+        inputTokens: {
+          total: 10,
+          noCache: 6,
+          cacheRead: 4,
+          cacheWrite: undefined,
+        },
+        outputTokens: {
+          total: 8,
+          text: 8,
+          reasoning: 0,
+        },
+        raw: {
+          prompt_tokens: 10,
+          completion_tokens: 8,
+          total_tokens: 18,
+          prompt_tokens_details: {
+            cached_tokens: 4,
+          },
+        },
+      });
+    });
+
+    it('should extract reasoning content when returned by model', async () => {
+      server.urls[
+        'https://ark.cn-beijing.volces.com/api/v3/chat/completions'
+      ].response = {
+        type: 'json-value',
+        body: {
+          id: 'chatcmpl-456',
+          object: 'chat.completion',
+          created: 1694268190,
+          model: 'doubao-seed-2-1-pro-260628',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: '42 is the answer.',
+                reasoning_content:
+                  'Let me think step by step about the ultimate question.',
+              },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: {
+            prompt_tokens: 15,
+            completion_tokens: 20,
+            total_tokens: 35,
+            completion_tokens_details: {
+              reasoning_tokens: 12,
+            },
+          },
+        },
+      };
+
+      const result = await defaultModel.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.content).toEqual([
+        { type: 'text', text: '42 is the answer.' },
+        {
+          type: 'reasoning',
+          text: 'Let me think step by step about the ultimate question.',
+        },
+      ]);
+      expect(result.usage.outputTokens).toEqual({
+        total: 20,
+        text: 8,
+        reasoning: 12,
+      });
+    });
+
+    it('should handle tool calls in generation', async () => {
+      server.urls[
+        'https://ark.cn-beijing.volces.com/api/v3/chat/completions'
+      ].response = {
+        type: 'json-value',
+        body: {
+          id: 'chatcmpl-789',
+          object: 'chat.completion',
+          created: 1694268190,
+          model: 'doubao-seed-2-1-pro-260628',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'call_abc123',
+                    type: 'function',
+                    function: {
+                      name: 'getWeather',
+                      arguments: '{"location":"Beijing"}',
+                    },
+                  },
+                ],
+              },
+              finish_reason: 'tool_calls',
+            },
+          ],
+          usage: {
+            prompt_tokens: 25,
+            completion_tokens: 12,
+            total_tokens: 37,
+          },
+        },
+      };
+
+      const result = await defaultModel.doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: 'tool-call',
+          toolCallId: 'call_abc123',
+          toolName: 'getWeather',
+          input: '{"location":"Beijing"}',
+        },
+      ]);
+      expect(result.finishReason).toEqual({
+        unified: 'tool-calls',
+        raw: 'tool_calls',
+      });
+    });
+
+    it('should map ByteDance provider options to request fields', async () => {
+      server.urls[
+        'https://ark.cn-beijing.volces.com/api/v3/chat/completions'
+      ].response = {
+        type: 'json-value',
+        body: {
+          id: 'chatcmpl-opts',
+          object: 'chat.completion',
+          created: 1694268190,
+          model: 'doubao-seed-2-1-pro-260628',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: 'Response with options',
+              },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      };
+
+      const providerOptions: ByteDanceLanguageModelChatOptions = {
+        user: 'user-456',
+        parallelToolCalls: false,
+        logprobs: true,
+        topLogprobs: 3,
+        logitBias: { '1234': 2 },
+        reasoningEffort: 'high',
+        thinking: { type: 'enabled' },
+      };
+
+      await defaultModel.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: { bytedance: providerOptions },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+
+      expect(requestBody).toMatchObject({
+        user: 'user-456',
+        parallel_tool_calls: false,
+        logprobs: true,
+        top_logprobs: 3,
+        logit_bias: { '1234': 2 },
+        reasoning_effort: 'high',
+        thinking: { type: 'enabled' },
+      });
+      expect(requestBody).not.toHaveProperty('parallelToolCalls');
+      expect(requestBody).not.toHaveProperty('topLogprobs');
+      expect(requestBody).not.toHaveProperty('logitBias');
+    });
+
+    it('should map reasoning effort when passed via reasoning call option', async () => {
+      server.urls[
+        'https://ark.cn-beijing.volces.com/api/v3/chat/completions'
+      ].response = {
+        type: 'json-value',
+        body: {
+          id: 'chatcmpl-reasoning',
+          object: 'chat.completion',
+          created: 1694268190,
+          model: 'doubao-seed-2-1-pro-260628',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: 'Reasoned output',
+              },
+              finish_reason: 'stop',
+            },
+          ],
+        },
+      };
+
+      await defaultModel.doGenerate({
+        prompt: TEST_PROMPT,
+        reasoning: 'high',
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+
+      expect(requestBody).toMatchObject({
+        reasoning_effort: 'high',
+      });
+    });
+
+    it('should throw APICallError on error response', async () => {
+      server.urls[
+        'https://ark.cn-beijing.volces.com/api/v3/chat/completions'
+      ].response = {
+        type: 'error',
+        status: 400,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          error: {
+            message: 'Invalid model ID or endpoint not found',
+            type: 'invalid_request_error',
+            code: 'InvalidEndpointOrModel.NotFound',
+          },
+        }),
+      };
+
+      await expect(
+        defaultModel.doGenerate({
+          prompt: TEST_PROMPT,
+        }),
+      ).rejects.toThrow('Invalid model ID or endpoint not found');
+    });
+  });
+
+  describe('doStream', () => {
+    it('should stream text chunks and finish with usage', async () => {
+      server.urls[
+        'https://ark.cn-beijing.volces.com/api/v3/chat/completions'
+      ].response = {
+        type: 'stream-chunks',
+        chunks: [
+          'data: {"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1694268190,"model":"doubao-seed-2-1-pro-260628","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}\n\n',
+          'data: {"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1694268190,"model":"doubao-seed-2-1-pro-260628","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
+          'data: {"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1694268190,"model":"doubao-seed-2-1-pro-260628","choices":[{"index":0,"delta":{"content":" world!"},"finish_reason":null}]}\n\n',
+          'data: {"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1694268190,"model":"doubao-seed-2-1-pro-260628","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+          'data: {"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1694268190,"model":"doubao-seed-2-1-pro-260628","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}\n\n',
+          'data: [DONE]\n\n',
+        ],
+      };
+
+      const { stream } = await defaultModel.doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+
+      expect(chunks).toEqual([
+        { type: 'stream-start', warnings: [] },
+        {
+          type: 'response-metadata',
+          id: 'chatcmpl-stream',
+          modelId: 'doubao-seed-2-1-pro-260628',
+          timestamp: expect.any(Date),
+        },
+        { type: 'text-start', id: 'txt-0' },
+        { type: 'text-delta', delta: 'Hello', id: 'txt-0' },
+        { type: 'text-delta', delta: ' world!', id: 'txt-0' },
+        { type: 'text-end', id: 'txt-0' },
+        {
+          type: 'finish',
+          finishReason: { unified: 'stop', raw: 'stop' },
+          usage: {
+            inputTokens: {
+              total: 5,
+              noCache: 5,
+              cacheRead: 0,
+              cacheWrite: undefined,
+            },
+            outputTokens: { total: 3, text: 3, reasoning: 0 },
+            raw: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+          },
+          providerMetadata: { bytedance: {} },
+        },
+      ]);
+    });
+
+    it('should stream reasoning deltas', async () => {
+      server.urls[
+        'https://ark.cn-beijing.volces.com/api/v3/chat/completions'
+      ].response = {
+        type: 'stream-chunks',
+        chunks: [
+          'data: {"id":"chatcmpl-stream-reasoning","object":"chat.completion.chunk","created":1694268190,"model":"doubao-seed-2-1-pro-260628","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"Thinking..."},"finish_reason":null}]}\n\n',
+          'data: {"id":"chatcmpl-stream-reasoning","object":"chat.completion.chunk","created":1694268190,"model":"doubao-seed-2-1-pro-260628","choices":[{"index":0,"delta":{"content":"Answer"},"finish_reason":null}]}\n\n',
+          'data: {"id":"chatcmpl-stream-reasoning","object":"chat.completion.chunk","created":1694268190,"model":"doubao-seed-2-1-pro-260628","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+          'data: [DONE]\n\n',
+        ],
+      };
+
+      const { stream } = await defaultModel.doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+
+      expect(chunks).toEqual([
+        { type: 'stream-start', warnings: [] },
+        {
+          type: 'response-metadata',
+          id: 'chatcmpl-stream-reasoning',
+          modelId: 'doubao-seed-2-1-pro-260628',
+          timestamp: expect.any(Date),
+        },
+        { type: 'reasoning-start', id: 'reasoning-0' },
+        {
+          type: 'reasoning-delta',
+          delta: 'Thinking...',
+          id: 'reasoning-0',
+        },
+        { type: 'reasoning-end', id: 'reasoning-0' },
+        { type: 'text-start', id: 'txt-0' },
+        { type: 'text-delta', delta: 'Answer', id: 'txt-0' },
+        { type: 'text-end', id: 'txt-0' },
+        {
+          type: 'finish',
+          finishReason: { unified: 'stop', raw: 'stop' },
+          usage: {
+            inputTokens: {
+              total: undefined,
+              noCache: undefined,
+              cacheRead: undefined,
+              cacheWrite: undefined,
+            },
+            outputTokens: {
+              total: undefined,
+              text: undefined,
+              reasoning: undefined,
+            },
+            raw: undefined,
+          },
+          providerMetadata: { bytedance: {} },
+        },
+      ]);
+    });
+
+    it('should stream tool calls', async () => {
+      server.urls[
+        'https://ark.cn-beijing.volces.com/api/v3/chat/completions'
+      ].response = {
+        type: 'stream-chunks',
+        chunks: [
+          'data: {"id":"chatcmpl-stream-tool","object":"chat.completion.chunk","created":1694268190,"model":"doubao-seed-2-1-pro-260628","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search","arguments":""}}]},"finish_reason":null}]}\n\n',
+          'data: {"id":"chatcmpl-stream-tool","object":"chat.completion.chunk","created":1694268190,"model":"doubao-seed-2-1-pro-260628","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"query\\":\\"ai\\"}"}}]},"finish_reason":null}]}\n\n',
+          'data: {"id":"chatcmpl-stream-tool","object":"chat.completion.chunk","created":1694268190,"model":"doubao-seed-2-1-pro-260628","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}\n\n',
+          'data: [DONE]\n\n',
+        ],
+      };
+
+      const { stream } = await defaultModel.doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      const chunks = await convertReadableStreamToArray(stream);
+
+      expect(chunks).toEqual([
+        { type: 'stream-start', warnings: [] },
+        {
+          type: 'response-metadata',
+          id: 'chatcmpl-stream-tool',
+          modelId: 'doubao-seed-2-1-pro-260628',
+          timestamp: expect.any(Date),
+        },
+        { type: 'tool-input-start', id: 'call_1', toolName: 'search' },
+        { type: 'tool-input-delta', id: 'call_1', delta: '{"query":"ai"}' },
+        { type: 'tool-input-end', id: 'call_1' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName: 'search',
+          input: '{"query":"ai"}',
+        },
+        {
+          type: 'finish',
+          finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+          usage: {
+            inputTokens: {
+              total: undefined,
+              noCache: undefined,
+              cacheRead: undefined,
+              cacheWrite: undefined,
+            },
+            outputTokens: {
+              total: undefined,
+              text: undefined,
+              reasoning: undefined,
+            },
+            raw: undefined,
+          },
+          providerMetadata: { bytedance: {} },
+        },
+      ]);
+    });
+  });
+
+  describe('type testing', () => {
+    it('exports the constrained ByteDance provider options type', () => {
+      expectTypeOf<
+        NonNullable<ByteDanceLanguageModelChatOptions['reasoningEffort']>
+      >().toEqualTypeOf<'minimal' | 'low' | 'medium' | 'high'>();
+      expectTypeOf<
+        NonNullable<ByteDanceLanguageModelChatOptions['thinking']>['type']
+      >().toEqualTypeOf<'enabled' | 'disabled' | 'auto'>();
+    });
+
+    it('exports valid ByteDanceChatModelId types', () => {
+      expectTypeOf<'doubao-seed-2-1-pro-260628'>().toMatchTypeOf<ByteDanceChatModelId>();
+      expectTypeOf<'doubao-seed-2-1-turbo-260628'>().toMatchTypeOf<ByteDanceChatModelId>();
+      expectTypeOf<'doubao-seed-evolving'>().toMatchTypeOf<ByteDanceChatModelId>();
+      expectTypeOf<'doubao-seed-2-0-pro-260215'>().toMatchTypeOf<ByteDanceChatModelId>();
+      expectTypeOf<'doubao-seed-2-0-lite-260428'>().toMatchTypeOf<ByteDanceChatModelId>();
+      expectTypeOf<'doubao-seed-2-0-mini-260428'>().toMatchTypeOf<ByteDanceChatModelId>();
+      expectTypeOf<'doubao-seed-2-0-code-preview-260215'>().toMatchTypeOf<ByteDanceChatModelId>();
+      expectTypeOf<'doubao-seed-character-260628'>().toMatchTypeOf<ByteDanceChatModelId>();
+      expectTypeOf<'deepseek-v4-pro-ga-260813'>().toMatchTypeOf<ByteDanceChatModelId>();
+      expectTypeOf<'deepseek-v4-flash-ga-260731'>().toMatchTypeOf<ByteDanceChatModelId>();
+      expectTypeOf<'glm-5-2-260617'>().toMatchTypeOf<ByteDanceChatModelId>();
+      expectTypeOf<string>().toMatchTypeOf<ByteDanceChatModelId>();
+    });
+  });
+});

--- a/packages/bytedance/src/bytedance-chat-language-model.ts
+++ b/packages/bytedance/src/bytedance-chat-language-model.ts
@@ -1,0 +1,31 @@
+import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
+import type { LanguageModelV4 } from '@ai-sdk/provider';
+import {
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+} from '@ai-sdk/provider-utils';
+import type { ByteDanceChatModelId } from './bytedance-chat-language-model-options';
+
+type ByteDanceChatConfig = ConstructorParameters<
+  typeof OpenAICompatibleChatLanguageModel
+>[1];
+
+export class ByteDanceChatLanguageModel
+  extends OpenAICompatibleChatLanguageModel
+  implements LanguageModelV4
+{
+  static [WORKFLOW_SERIALIZE](model: ByteDanceChatLanguageModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: ByteDanceChatModelId;
+    config: ByteDanceChatConfig;
+  }) {
+    return new ByteDanceChatLanguageModel(options.modelId, options.config);
+  }
+}

--- a/packages/bytedance/src/bytedance-chat-options.ts
+++ b/packages/bytedance/src/bytedance-chat-options.ts
@@ -1,0 +1,14 @@
+// https://www.volcengine.com/docs/82379/1330310
+export type ByteDanceChatModelId =
+  | 'doubao-seed-2-1-pro-260628'
+  | 'doubao-seed-2-1-turbo-260628'
+  | 'doubao-seed-evolving'
+  | 'doubao-seed-2-0-pro-260215'
+  | 'doubao-seed-2-0-lite-260428'
+  | 'doubao-seed-2-0-mini-260428'
+  | 'doubao-seed-2-0-code-preview-260215'
+  | 'doubao-seed-character-260628'
+  | 'deepseek-v4-pro-ga-260813'
+  | 'deepseek-v4-flash-ga-260731'
+  | 'glm-5-2-260617'
+  | (string & {});

--- a/packages/bytedance/src/bytedance-provider.test.ts
+++ b/packages/bytedance/src/bytedance-provider.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { createByteDance } from './bytedance-provider';
+import { loadApiKey } from '@ai-sdk/provider-utils';
+import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
+import { ByteDanceImageModel } from './bytedance-image-model';
+import { ByteDanceVideoModel } from './bytedance-video-model';
+
+const OpenAICompatibleChatLanguageModelMock =
+  OpenAICompatibleChatLanguageModel as unknown as Mock;
+
+vi.mock('@ai-sdk/openai-compatible', () => ({
+  OpenAICompatibleChatLanguageModel: vi.fn(),
+}));
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+vi.mock('@ai-sdk/provider-utils', async () => {
+  const actual = await vi.importActual('@ai-sdk/provider-utils');
+  return {
+    ...actual,
+    loadApiKey: vi.fn().mockReturnValue('mock-api-key'),
+    withoutTrailingSlash: vi.fn(url => url),
+  };
+});
+
+describe('ByteDanceProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createByteDance', () => {
+    it('should create a ByteDanceProvider instance with default options', () => {
+      const provider = createByteDance();
+      provider('doubao-seed-2-1-pro-260628');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[1];
+      config.headers!();
+
+      expect(loadApiKey).toHaveBeenCalledWith({
+        apiKey: undefined,
+        environmentVariableName: 'ARK_API_KEY',
+        description: 'ByteDance ModelArk',
+      });
+    });
+
+    it('should create a ByteDanceProvider instance with custom options', () => {
+      const options = {
+        apiKey: 'custom-key',
+        baseURL: 'https://ark.cn-beijing.volces.com/api/v3',
+        headers: { 'Custom-Header': 'value' },
+      };
+      const provider = createByteDance(options);
+      provider('doubao-seed-2-1-pro-260628');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[1];
+      config.headers!();
+
+      expect(loadApiKey).toHaveBeenCalledWith({
+        apiKey: 'custom-key',
+        environmentVariableName: 'ARK_API_KEY',
+        description: 'ByteDance ModelArk',
+      });
+    });
+
+    it('should pass user-agent header', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const provider = createByteDance({ fetch: fetchMock });
+      provider('doubao-seed-2-1-pro-260628');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[1];
+      const headers = config.headers!();
+
+      await fetchMock(
+        'https://ark.ap-southeast.bytepluses.com/api/v3/chat/completions',
+        {
+          method: 'POST',
+          headers,
+        },
+      );
+
+      expect(fetchMock.mock.calls[0][1].headers['user-agent']).toContain(
+        'ai-sdk/bytedance/0.0.0-test',
+      );
+    });
+
+    it('should transform request body options properly', () => {
+      const provider = createByteDance();
+      provider('doubao-seed-2-1-pro-260628');
+
+      const constructorCall =
+        OpenAICompatibleChatLanguageModelMock.mock.calls[0];
+      const config = constructorCall[1];
+
+      const transformed = config.transformRequestBody({
+        model: 'doubao-seed-2-1-pro-260628',
+        parallelToolCalls: false,
+        topLogprobs: 5,
+        logitBias: { '42': 1 },
+        thinking: { type: 'enabled' },
+      });
+
+      expect(transformed).toEqual({
+        model: 'doubao-seed-2-1-pro-260628',
+        parallel_tool_calls: false,
+        top_logprobs: 5,
+        logit_bias: { '42': 1 },
+        thinking: { type: 'enabled' },
+      });
+    });
+
+    it('should return a chat model when called as a function', () => {
+      const provider = createByteDance();
+      const model = provider('doubao-seed-2-1-pro-260628');
+      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
+    });
+  });
+
+  describe('languageModel', () => {
+    it('should construct a language model with correct configuration', () => {
+      const provider = createByteDance();
+      const model = provider.languageModel('doubao-seed-2-1-pro-260628');
+      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
+    });
+  });
+
+  describe('chat', () => {
+    it('should construct a chat model with correct configuration', () => {
+      const provider = createByteDance();
+      const model = provider.chat('doubao-seed-2-1-pro-260628');
+      expect(model).toBeInstanceOf(OpenAICompatibleChatLanguageModel);
+    });
+  });
+
+  describe('image and imageModel', () => {
+    it('should construct image model', () => {
+      const provider = createByteDance();
+      expect(provider.image('seedream-5-0-260128')).toBeInstanceOf(
+        ByteDanceImageModel,
+      );
+      expect(provider.imageModel('seedream-5-0-260128')).toBeInstanceOf(
+        ByteDanceImageModel,
+      );
+    });
+  });
+
+  describe('video and videoModel', () => {
+    it('should construct video model', () => {
+      const provider = createByteDance();
+      expect(provider.video('seedance-2-0-260128')).toBeInstanceOf(
+        ByteDanceVideoModel,
+      );
+      expect(provider.videoModel('seedance-2-0-260128')).toBeInstanceOf(
+        ByteDanceVideoModel,
+      );
+    });
+  });
+
+  describe('embeddingModel', () => {
+    it('should throw NoSuchModelError when attempting to create embedding model', () => {
+      const provider = createByteDance();
+      expect(() => provider.embeddingModel('any-model')).toThrow(
+        'No such embeddingModel: any-model',
+      );
+    });
+  });
+});

--- a/packages/bytedance/src/bytedance-provider.ts
+++ b/packages/bytedance/src/bytedance-provider.ts
@@ -2,17 +2,37 @@ import {
   NoSuchModelError,
   type Experimental_VideoModelV4,
   type ImageModelV4,
+  type LanguageModelV4,
   type ProviderV4,
 } from '@ai-sdk/provider';
 import {
   loadApiKey,
   withoutTrailingSlash,
+  withUserAgentSuffix,
   type FetchFunction,
 } from '@ai-sdk/provider-utils';
+import { ByteDanceChatLanguageModel } from './bytedance-chat-language-model';
+import type { ByteDanceChatModelId } from './bytedance-chat-options';
 import { ByteDanceImageModel } from './bytedance-image-model';
 import type { ByteDanceImageModelId } from './bytedance-image-settings';
 import { ByteDanceVideoModel } from './bytedance-video-model';
 import type { ByteDanceVideoModelId } from './bytedance-video-settings';
+import { VERSION } from './version';
+
+function transformByteDanceRequestBody(
+  args: Record<string, any>,
+): Record<string, any> {
+  const { parallelToolCalls, topLogprobs, logitBias, ...restArgs } = args;
+
+  return {
+    ...restArgs,
+    ...(parallelToolCalls !== undefined && {
+      parallel_tool_calls: parallelToolCalls,
+    }),
+    ...(topLogprobs !== undefined && { top_logprobs: topLogprobs }),
+    ...(logitBias !== undefined && { logit_bias: logitBias }),
+  };
+}
 
 export interface ByteDanceProviderSettings {
   /**
@@ -40,6 +60,21 @@ export interface ByteDanceProviderSettings {
 }
 
 export interface ByteDanceProvider extends ProviderV4 {
+  /**
+   * Creates a ByteDance model for text generation.
+   */
+  (modelId: ByteDanceChatModelId): LanguageModelV4;
+
+  /**
+   * Creates a ByteDance chat model for text generation.
+   */
+  chat(modelId: ByteDanceChatModelId): LanguageModelV4;
+
+  /**
+   * Creates a ByteDance chat model for text generation.
+   */
+  languageModel(modelId: ByteDanceChatModelId): LanguageModelV4;
+
   /**
    * Creates a model for video generation.
    */
@@ -71,15 +106,29 @@ export function createByteDance(
 ): ByteDanceProvider {
   const baseURL = withoutTrailingSlash(options.baseURL ?? defaultBaseURL);
 
-  const getHeaders = () => ({
-    Authorization: `Bearer ${loadApiKey({
-      apiKey: options.apiKey,
-      environmentVariableName: 'ARK_API_KEY',
-      description: 'ByteDance ModelArk',
-    })}`,
-    'Content-Type': 'application/json',
-    ...options.headers,
-  });
+  const getHeaders = () =>
+    withUserAgentSuffix(
+      {
+        Authorization: `Bearer ${loadApiKey({
+          apiKey: options.apiKey,
+          environmentVariableName: 'ARK_API_KEY',
+          description: 'ByteDance ModelArk',
+        })}`,
+        'Content-Type': 'application/json',
+        ...options.headers,
+      },
+      `ai-sdk/bytedance/${VERSION}`,
+    );
+
+  const createChatModel = (modelId: ByteDanceChatModelId) =>
+    new ByteDanceChatLanguageModel(modelId, {
+      provider: 'bytedance.chat',
+      url: ({ path }) => `${baseURL}${path}`,
+      headers: getHeaders,
+      fetch: options.fetch,
+      supportsStructuredOutputs: true,
+      transformRequestBody: transformByteDanceRequestBody,
+    });
 
   const createVideoModel = (modelId: ByteDanceVideoModelId) =>
     new ByteDanceVideoModel(modelId, {
@@ -97,19 +146,20 @@ export function createByteDance(
       fetch: options.fetch,
     });
 
-  return {
-    specificationVersion: 'v4' as const,
-    embeddingModel: (modelId: string) => {
-      throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
-    },
-    languageModel: (modelId: string) => {
-      throw new NoSuchModelError({ modelId, modelType: 'languageModel' });
-    },
-    image: createImageModel,
-    imageModel: createImageModel,
-    video: createVideoModel,
-    videoModel: createVideoModel,
+  const provider = (modelId: ByteDanceChatModelId) => createChatModel(modelId);
+
+  provider.specificationVersion = 'v4' as const;
+  provider.languageModel = createChatModel;
+  provider.chat = createChatModel;
+  provider.embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
   };
+  provider.image = createImageModel;
+  provider.imageModel = createImageModel;
+  provider.video = createVideoModel;
+  provider.videoModel = createVideoModel;
+
+  return provider;
 }
 
 /**

--- a/packages/bytedance/src/index.ts
+++ b/packages/bytedance/src/index.ts
@@ -3,6 +3,9 @@ export type {
   ByteDanceProviderSettings,
 } from './bytedance-provider';
 export { byteDance, createByteDance } from './bytedance-provider';
+export { ByteDanceChatLanguageModel } from './bytedance-chat-language-model';
+export type { ByteDanceChatModelId } from './bytedance-chat-options';
+export type { ByteDanceLanguageModelChatOptions } from './bytedance-chat-language-model-options';
 export { ByteDanceImageModel } from './bytedance-image-model';
 export type { ByteDanceImageModelOptions } from './bytedance-image-model-options';
 export type { ByteDanceImageModelId } from './bytedance-image-settings';

--- a/packages/bytedance/tsconfig.json
+++ b/packages/bytedance/tsconfig.json
@@ -13,6 +13,9 @@
   ],
   "references": [
     {
+      "path": "../openai-compatible"
+    },
+    {
       "path": "../provider"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2147,6 +2147,9 @@ importers:
 
   packages/bytedance:
     dependencies:
+      '@ai-sdk/openai-compatible':
+        specifier: workspace:*
+        version: link:../openai-compatible
       '@ai-sdk/provider':
         specifier: workspace:*
         version: link:../provider


### PR DESCRIPTION
## Background

`packages/bytedance` already ships config, image and video models, but no chat
model — so the provider exists while its main use case doesn't. Ark is ByteDance's
model platform and speaks an OpenAI-compatible API, which is why this can build on
`@ai-sdk/openai-compatible` rather than hand-rolling a transport.

## Summary

Adds the chat language model to `packages/bytedance`, wired through
`@ai-sdk/openai-compatible`, plus tests, docs and examples.

Also fixes the branch's lockfile: it had been generated in a way that dropped the
entire `snapshots:` section (13,923 lines against main's 51,854), which produced a
misleading `+5173/-3438` diff on `pnpm-lock.yaml` and a merge conflict. It's now
main's lockfile plus the single `@ai-sdk/openai-compatible` importer entry, so that
file is `+3/-0` and the PR total went from `+6267/-3693` to `+1097/-255`.

`packages/bytedance/package.json` keeps main's `2.0.35` version rather than the
`2.0.33` my branch had, so the release bump isn't reverted.

## Contributor Credit

@chyroc

## End-to-End Verification

Against the live Ark endpoint with a real key, not mocks:

- Chat completion returns normally for the versioned Doubao model ids.
- Tool calling returns the standard `tool_calls` shape.
- Vision: an image is genuinely ingested — `prompt_tokens` rises from ~40 to
  ~1340 and the model names the colour correctly for two different colours
  (a single colour can be guessed, and this endpoint can return 200 while
  silently dropping an image).
- Reasoning: `reasoning_content` is populated, and streaming emits
  `reasoning_content` deltas.

Note on model ids: Ark only resolves **fully versioned** ids
(`doubao-seed-2-1-pro-260628`). The short forms shown in the console
(`doubao-seed-2.1-pro`) return `InvalidEndpointOrModel.NotFound`.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added
- [x] I have reviewed this pull request (self-review)

**On the signing box — flagging this rather than quietly leaving it unticked:**
the commit on this branch is unsigned (`verified: false`, reason `unsigned`). It
was created through the GitHub API, which doesn't sign, and I don't have a signing
key set up for this account. Every recently-merged PR here shows
`verified: true`, so I take this as a real blocker rather than a formality. I'll
re-push signed commits once that's sorted; if you'd prefer, I can close and
reopen from a signed branch.

## Future Work

The `bytedance` package could also expose the BytePlus endpoint
(`https://ark.ap-southeast.bytepluses.com/api/v3`) as a documented option — it
serves the same models outside mainland China on a separate account, and this
package already defaults to that base URL.

## Related Issues

None open for this specific gap.
