### PR TITLE
Backport: validate Moonshot multimodal MIME types on v6

### DIFF
--- a/.changeset/small-moons-check.md
+++ b/.changeset/small-moons-check.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+Reject unsupported image and video media types before sending Moonshot chat requests.

--- a/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
+++ b/content/providers/01-ai-sdk-providers/31-moonshotai.mdx
@@ -206,6 +206,14 @@ You can also pass a URL. Since Moonshot AI does not fetch external URLs, the AI 
 ```
 
 <Note>
+  Supported image media types are `image/jpeg`, `image/png`, `image/gif`,
+  `image/webp`, `image/bmp`, `image/heic`, and `image/heif`. Supported video
+  media types are `video/mp4`, `video/mpeg`, `video/mov`, `video/avi`,
+  `video/x-flv`, `video/mpg`, `video/webm`, `video/wmv`, and `video/3gpp`. Other
+  image and video media types are rejected before a request is sent.
+</Note>
+
+<Note>
   Moonshot AI recommends videos up to 1080p. For larger videos, or videos you
   reuse across many requests, upload them with the [Moonshot Files
   API](https://platform.moonshot.ai/docs/api/files) instead. Audio and PDF

--- a/packages/moonshotai/src/convert-to-moonshotai-chat-messages.test.ts
+++ b/packages/moonshotai/src/convert-to-moonshotai-chat-messages.test.ts
@@ -2,6 +2,28 @@ import { describe, expect, it } from 'vitest';
 import { convertToMoonshotAIChatMessages } from './convert-to-moonshotai-chat-messages';
 
 describe('user messages', () => {
+  const supportedImageMediaTypes = [
+    'image/jpeg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+    'image/bmp',
+    'image/heic',
+    'image/heif',
+  ];
+
+  const supportedVideoMediaTypes = [
+    'video/mp4',
+    'video/mpeg',
+    'video/mov',
+    'video/avi',
+    'video/x-flv',
+    'video/mpg',
+    'video/webm',
+    'video/wmv',
+    'video/3gpp',
+  ];
+
   it('should convert a text-only user message to string content', () => {
     const result = convertToMoonshotAIChatMessages([
       { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
@@ -38,6 +60,36 @@ describe('user messages', () => {
       },
     ]);
   });
+
+  it.each(supportedImageMediaTypes)(
+    'should accept supported image media type %s',
+    mediaType => {
+      const result = convertToMoonshotAIChatMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: new Uint8Array([0, 1, 2, 3]),
+              mediaType,
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image_url',
+              image_url: { url: `data:${mediaType};base64,AAECAw==` },
+            },
+          ],
+        },
+      ]);
+    },
+  );
 
   it('should pass through image URLs', () => {
     const result = convertToMoonshotAIChatMessages([
@@ -94,6 +146,36 @@ describe('user messages', () => {
       },
     ]);
   });
+
+  it.each(supportedVideoMediaTypes)(
+    'should accept supported video media type %s',
+    mediaType => {
+      const result = convertToMoonshotAIChatMessages([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              data: new Uint8Array([0, 1, 2, 3]),
+              mediaType,
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'video_url',
+              video_url: { url: `data:${mediaType};base64,AAECAw==` },
+            },
+          ],
+        },
+      ]);
+    },
+  );
 
   it('should pass through video URLs', () => {
     const result = convertToMoonshotAIChatMessages([
@@ -167,6 +249,28 @@ describe('user messages', () => {
       { role: 'user', content: [{ type: 'text', text: 'hello markdown' }] },
     ]);
   });
+
+  it.each(['image/svg+xml', 'image/tiff', 'video/quicktime'])(
+    'should throw for unsupported multimodal media type %s',
+    mediaType => {
+      expect(() =>
+        convertToMoonshotAIChatMessages([
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file',
+                data: new Uint8Array([0, 1, 2, 3]),
+                mediaType,
+              },
+            ],
+          },
+        ]),
+      ).toThrow(
+        `'file part media type ${mediaType}' functionality not supported`,
+      );
+    },
+  );
 
   it('should throw for audio file parts (rejected by the API)', () => {
     expect(() =>

--- a/packages/moonshotai/src/convert-to-moonshotai-chat-messages.ts
+++ b/packages/moonshotai/src/convert-to-moonshotai-chat-messages.ts
@@ -9,6 +9,53 @@ import {
 
 import type { MoonshotAIMessages } from './moonshotai-chat-api-types';
 
+const supportedImageMediaTypes = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/bmp',
+  'image/heic',
+  'image/heif',
+] as const;
+
+const supportedVideoMediaTypes = [
+  'video/mp4',
+  'video/mpeg',
+  'video/mov',
+  'video/avi',
+  'video/x-flv',
+  'video/mpg',
+  'video/webm',
+  'video/wmv',
+  'video/3gpp',
+] as const;
+
+function validateMediaType({
+  mediaType,
+  supportedMediaTypes,
+  topLevelMediaType,
+}: {
+  mediaType: string;
+  supportedMediaTypes: readonly string[];
+  topLevelMediaType: 'image' | 'video';
+}): string {
+  const normalizedMediaType =
+    mediaType === `${topLevelMediaType}/*`
+      ? topLevelMediaType === 'image'
+        ? 'image/jpeg'
+        : 'video/mp4'
+      : mediaType;
+
+  if (!supportedMediaTypes.includes(normalizedMediaType)) {
+    throw new UnsupportedFunctionalityError({
+      functionality: `file part media type ${normalizedMediaType}`,
+    });
+  }
+
+  return normalizedMediaType;
+}
+
 // Moonshot AI chat completions accepts text, image_url, and video_url content
 // parts only. Anything else (audio, PDF, other file types) throws here rather
 // than being rejected by the API with a 400.
@@ -41,10 +88,11 @@ export function convertToMoonshotAIChatMessages(
               }
               case 'file': {
                 if (part.mediaType.startsWith('image/')) {
-                  const mediaType =
-                    part.mediaType === 'image/*'
-                      ? 'image/jpeg'
-                      : part.mediaType;
+                  const mediaType = validateMediaType({
+                    mediaType: part.mediaType,
+                    supportedMediaTypes: supportedImageMediaTypes,
+                    topLevelMediaType: 'image',
+                  });
 
                   return {
                     type: 'image_url' as const,
@@ -58,8 +106,11 @@ export function convertToMoonshotAIChatMessages(
                 }
 
                 if (part.mediaType.startsWith('video/')) {
-                  const mediaType =
-                    part.mediaType === 'video/*' ? 'video/mp4' : part.mediaType;
+                  const mediaType = validateMediaType({
+                    mediaType: part.mediaType,
+                    supportedMediaTypes: supportedVideoMediaTypes,
+                    topLevelMediaType: 'video',
+                  });
 
                   return {
                     type: 'video_url' as const,

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -1,4 +1,7 @@
-import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import {
+  UnsupportedFunctionalityError,
+  type LanguageModelV3Prompt,
+} from '@ai-sdk/provider';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import fs from 'node:fs';
@@ -706,6 +709,27 @@ describe('doGenerate', () => {
   });
 
   describe('errors', () => {
+    it('should reject unsupported media before sending a request', async () => {
+      await expect(
+        provider.chatModel('kimi-k3').doGenerate({
+          prompt: [
+            {
+              role: 'user',
+              content: [
+                {
+                  type: 'file',
+                  data: new TextEncoder().encode('<svg></svg>'),
+                  mediaType: 'image/svg+xml',
+                },
+              ],
+            },
+          ],
+        }),
+      ).rejects.toSatisfy(UnsupportedFunctionalityError.isInstance);
+
+      expect(server.calls).toHaveLength(0);
+    });
+
     it('should map the moonshot error envelope', async () => {
       server.urls['https://api.moonshot.ai/v1/chat/completions'].response = {
         type: 'error',


### PR DESCRIPTION
Backport of #19584 for `release-v6.0`.

Adapts the validation to the v6 `LanguageModelV3` file-part representation (direct `URL`/byte data) while preserving the release line's existing converter interface. This intentionally does not pull in top-level provider-reference behavior from the separate file-input gap.

Validation:
- Moonshot Node: 122 tests passed
- Moonshot Edge: 122 tests passed
- Moonshot package type-check: passed
- full workspace type-check: passed
- formatting/lint: passed

The commit is GitHub-signed and matches the locally tested tree.