### PR TITLE
feat: support Gemini 3.5 Transcribe on Google and Google Vertex providers

### DIFF
--- a/.changeset/gemini-three-five-transcribe.md
+++ b/.changeset/gemini-three-five-transcribe.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/google': patch
+'@ai-sdk/google-vertex': patch
+---
+
+feat (provider/google, provider/google-vertex): Gemini 3.5 Transcribe support — unary transcription (`gemini-3.5-transcribe`) via generateContent with language detection, speaker diarization, word timestamps, and custom vocabulary, plus streaming transcription (`gemini-3.5-transcribe-live`) over the Live API WebSocket with `mode: 'VERBATIM' | 'SMART'` transcription formatting

--- a/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model-options.ts
+++ b/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model-options.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod/v4';
+
+export type GoogleVertexGeminiTranscriptionModelId =
+  | 'gemini-3.5-transcribe'
+  | 'gemini-3.5-transcribe-live'
+  | (string & {});
+
+/**
+ * Speech recognition options for Gemini transcription models on Vertex,
+ * shared by unary (`gemini-3.5-transcribe`) and live
+ * (`gemini-3.5-transcribe-live`) variants. Maps onto Google's
+ * `AudioTranscriptionConfig`.
+ */
+export const googleVertexGeminiTranscriptionModelOptions = z.object({
+  /**
+   * BCP-47 language codes providing hints about the languages present in the
+   * audio. If omitted or empty, defaults to automatic language detection.
+   */
+  languageCodes: z.array(z.string()).optional(),
+
+  /**
+   * Custom vocabulary phrases, which bias the speech recognition model
+   * toward recognizing specific terms.
+   */
+  customVocabulary: z.array(z.string()).optional(),
+
+  /**
+   * Enables word-level timestamp generation.
+   */
+  wordTimestamp: z.boolean().optional(),
+
+  /**
+   * Enables speaker diarization.
+   */
+  diarization: z.boolean().optional(),
+
+  /**
+   * Transcription output formatting mode.
+   *
+   * - `VERBATIM` (default): exact literal transcript preserving filler
+   *   words, repetitions, and false starts.
+   * - `SMART`: cleans up and structures the transcript in real time —
+   *   disfluency removal, inline self-corrections, structured formatting
+   *   (lists, numbers, dates, paragraph breaks), and grammar/casing polish.
+   */
+  mode: z.enum(['SMART', 'VERBATIM']).optional(),
+});
+
+export type GoogleVertexTranscriptionModelGeminiOptions = z.infer<
+  typeof googleVertexGeminiTranscriptionModelOptions
+>;

--- a/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.test.ts
+++ b/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.test.ts
@@ -158,6 +158,66 @@ describe('doGenerate', () => {
     });
   });
 
+  it('extracts text, language, and word segments from the audioTranscription part', async () => {
+    server.urls[
+      `${BASE_URL}/models/gemini-3.5-transcribe:generateContent`
+    ].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  audioTranscription: {
+                    text: 'The quick brown fox.',
+                    languageCode: 'en-US',
+                    speakerLabel: 'spk:0',
+                    words: [
+                      {
+                        word: 'The',
+                        startOffset: '0.100s',
+                        endOffset: '0.100s',
+                      },
+                      {
+                        word: 'quick',
+                        startOffset: '0.100s',
+                        endOffset: '0.400s',
+                      },
+                      {
+                        word: 'brown',
+                        startOffset: '0.400s',
+                        endOffset: '0.700s',
+                      },
+                      { word: 'fox.', startOffset: '0.700s', endOffset: '1s' },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usageMetadata: { promptTokenCount: 64 },
+      },
+    };
+
+    const model = createModel('gemini-3.5-transcribe');
+    const result = await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {},
+    });
+
+    expect(result.text).toBe('The quick brown fox.');
+    expect(result.language).toBe('en-US');
+    expect(result.segments).toEqual([
+      { text: 'The', startSecond: 0.1, endSecond: 0.1 },
+      { text: 'quick', startSecond: 0.1, endSecond: 0.4 },
+      { text: 'brown', startSecond: 0.4, endSecond: 0.7 },
+      { text: 'fox.', startSecond: 0.7, endSecond: 1 },
+    ]);
+  });
+
   it('rejects unary transcription on live model ids', async () => {
     const model = createModel('gemini-3.5-transcribe-live');
 

--- a/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.test.ts
+++ b/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.test.ts
@@ -1,0 +1,343 @@
+import {
+  convertArrayToReadableStream,
+  convertReadableStreamToArray,
+} from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { GoogleVertexGeminiTranscriptionModel } from './google-vertex-gemini-transcription-model';
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  readyState = 0;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = 3;
+  });
+  onopen: ((event: unknown) => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  onclose: ((event: unknown) => void) | null = null;
+
+  constructor(
+    public url: string | URL,
+    public protocols?: string | string[],
+    public options?: { headers?: Record<string, string | undefined> },
+  ) {
+    MockWebSocket.instances.push(this);
+  }
+
+  open() {
+    this.readyState = 1;
+    this.onopen?.({});
+  }
+
+  message(value: unknown) {
+    this.onmessage?.({ data: JSON.stringify(value) });
+  }
+
+  serverClose(code?: number, reason?: string) {
+    this.readyState = 3;
+    this.onclose?.({ code, reason });
+  }
+}
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+const BASE_URL =
+  'https://us-central1-aiplatform.googleapis.com/v1beta1/projects/test-project/locations/us-central1/publishers/google';
+
+function createModel(
+  modelId = 'gemini-3.5-transcribe-live',
+  overrides: Partial<{ finishGraceMs: number }> = {},
+) {
+  MockWebSocket.instances = [];
+  return new GoogleVertexGeminiTranscriptionModel(modelId, {
+    provider: 'test-provider',
+    baseURL: BASE_URL,
+    headers: () => ({ Authorization: 'Bearer test-oauth-token' }),
+    webSocket: MockWebSocket,
+    project: 'test-project',
+    location: 'us-central1',
+    _internal: {
+      finishGraceMs: overrides.finishGraceMs ?? 5000,
+    },
+  });
+}
+
+describe('doGenerate', () => {
+  const server = createTestServer({
+    [`${BASE_URL}/models/gemini-3.5-transcribe:generateContent`]: {
+      response: {
+        type: 'json-value',
+        body: {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: 'Hello ' }, { text: 'world.' }],
+              },
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 10,
+            candidatesTokenCount: 4,
+          },
+        },
+      },
+    },
+  });
+
+  it('transcribes audio via Vertex generateContent with audioTranscriptionConfig', async () => {
+    const model = createModel('gemini-3.5-transcribe');
+
+    const result = await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {
+        googleVertex: {
+          customVocabulary: ['Gemini', 'Kubernetes'],
+          languageCodes: ['es-ES'],
+          mode: 'SMART',
+        },
+      },
+    });
+
+    expect(result.text).toBe('Hello world.');
+    expect(await server.calls[0].requestBodyJson).toEqual({
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              inlineData: {
+                mimeType: 'audio/wav',
+                data: 'AQIDBA==',
+              },
+            },
+          ],
+        },
+      ],
+      generationConfig: {
+        audioTranscriptionConfig: {
+          languageCodes: ['es-ES'],
+          customVocabulary: ['Gemini', 'Kubernetes'],
+          mode: 'SMART',
+        },
+      },
+    });
+    expect(server.calls[0].requestHeaders.authorization).toBe(
+      'Bearer test-oauth-token',
+    );
+    expect(result.providerMetadata).toEqual({
+      google: {
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 4,
+        },
+      },
+    });
+  });
+
+  it('accepts options under the google namespace as a fallback', async () => {
+    const model = createModel('gemini-3.5-transcribe');
+
+    await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {
+        google: { mode: 'SMART' },
+      },
+    });
+
+    const body = (await server.calls[0].requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    expect(body.generationConfig).toEqual({
+      audioTranscriptionConfig: { mode: 'SMART' },
+    });
+  });
+
+  it('rejects unary transcription on live model ids', async () => {
+    const model = createModel('gemini-3.5-transcribe-live');
+
+    await expect(
+      model.doGenerate({
+        audio: new Uint8Array([1]),
+        mediaType: 'audio/wav',
+        providerOptions: {},
+      }),
+    ).rejects.toThrow('only supports streaming transcription');
+  });
+});
+
+describe('doStream', () => {
+  it('streams transcription over the Vertex Live API WebSocket', async () => {
+    const model = createModel();
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {
+        googleVertex: {
+          customVocabulary: ['Gemini'],
+          mode: 'SMART',
+        },
+      },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    expect(ws.url.toString()).toBe(
+      'wss://us-central1-aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent',
+    );
+    expect(ws.options?.headers).toEqual({
+      Authorization: 'Bearer test-oauth-token',
+    });
+
+    ws.open();
+    await flush();
+
+    // audio is gated on setupComplete: only the setup message was sent
+    expect(ws.send).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(ws.send.mock.calls[0][0])).toEqual({
+      setup: {
+        model:
+          'projects/test-project/locations/us-central1/publishers/google/models/gemini-3.5-transcribe-live',
+        inputAudioTranscription: {
+          customVocabulary: ['Gemini'],
+          mode: 'SMART',
+        },
+      },
+    });
+
+    ws.message({ setupComplete: {} });
+    await flush();
+
+    // audio chunk + audioStreamEnd
+    expect(ws.send).toHaveBeenCalledTimes(3);
+    expect(JSON.parse(ws.send.mock.calls[1][0])).toEqual({
+      realtimeInput: {
+        audio: { data: 'AQID', mimeType: 'audio/pcm;rate=16000' },
+      },
+    });
+    expect(JSON.parse(ws.send.mock.calls[2][0])).toEqual({
+      realtimeInput: { audioStreamEnd: true },
+    });
+
+    ws.message({
+      serverContent: { interimInputTranscription: { text: 'hel' } },
+    });
+    ws.message({
+      serverContent: {
+        inputTranscription: { text: 'hello world.', finished: true },
+      },
+    });
+    ws.message({
+      usageMetadata: { promptTokenCount: 7 },
+      serverContent: { turnComplete: true, interactionStatus: 'IDLE' },
+    });
+    await flush();
+
+    const parts = await partsPromise;
+    expect(parts).toEqual([
+      { type: 'stream-start', warnings: [] },
+      { type: 'transcript-partial', id: 'google-segment-0', text: 'hel' },
+      {
+        type: 'transcript-delta',
+        id: 'google-segment-0',
+        delta: 'hello world.',
+      },
+      {
+        type: 'transcript-final',
+        id: 'google-segment-0',
+        text: 'hello world.',
+      },
+      {
+        type: 'finish',
+        text: 'hello world.',
+        segments: [],
+        language: undefined,
+        durationInSeconds: undefined,
+        providerMetadata: {
+          google: { usageMetadata: { promptTokenCount: 7 } },
+        },
+      },
+    ]);
+    expect(ws.close).toHaveBeenCalledWith(1000);
+  });
+
+  it('falls back to the latest interim partial when no final segment arrives', async () => {
+    const model = createModel();
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {},
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ setupComplete: {} });
+    await flush();
+
+    ws.message({
+      serverContent: { interimInputTranscription: { text: 'hello world.' } },
+    });
+    ws.message({ serverContent: { interactionStatus: 'IDLE' } });
+    await flush();
+
+    const parts = await partsPromise;
+    expect(parts.at(-1)).toMatchObject({
+      type: 'finish',
+      text: 'hello world.',
+    });
+  });
+
+  it('errors when the socket closes before the audio ended', async () => {
+    const model = createModel();
+
+    const result = await model.doStream({
+      audio: new ReadableStream<Uint8Array>({ start: () => {} }),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {},
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const rejection = expect(partsPromise).rejects.toThrow(
+      'closed unexpectedly before finishing (code 1011, reason: internal error)',
+    );
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ setupComplete: {} });
+    await flush();
+
+    ws.serverClose(1011, 'internal error');
+    await rejection;
+  });
+
+  it('rejects streaming on unary model ids', async () => {
+    const model = createModel('gemini-3.5-transcribe');
+
+    await expect(
+      model.doStream({
+        audio: convertArrayToReadableStream([new Uint8Array([1])]),
+        inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+        providerOptions: {},
+      }),
+    ).rejects.toThrow('does not support streaming transcription');
+  });
+
+  it('rejects non-16kHz PCM input audio', async () => {
+    const model = createModel();
+
+    await expect(
+      model.doStream({
+        audio: convertArrayToReadableStream([new Uint8Array([1])]),
+        inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+        providerOptions: {},
+      }),
+    ).rejects.toThrow('only supports 16kHz 16-bit PCM input audio');
+  });
+});

--- a/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.ts
+++ b/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.ts
@@ -208,14 +208,37 @@ export class GoogleVertexGeminiTranscriptionModel implements TranscriptionModelV
       fetch: this.config.fetch,
     });
 
-    const text = (response.candidates?.[0]?.content?.parts ?? [])
-      .map(part => part.text ?? '')
+    const parts = response.candidates?.[0]?.content?.parts ?? [];
+    const plainText = parts.map(part => part.text ?? '').join('');
+    const transcriptionText = parts
+      .map(part => part.audioTranscription?.text ?? '')
       .join('');
+    const text = plainText !== '' ? plainText : transcriptionText;
+
+    let language: string | undefined;
+    const segments: Array<{
+      text: string;
+      startSecond: number;
+      endSecond: number;
+    }> = [];
+    for (const part of parts) {
+      const transcription = part.audioTranscription;
+      if (transcription == null) continue;
+      language ??= transcription.languageCode ?? undefined;
+      for (const word of transcription.words ?? []) {
+        const startSecond = parseOffsetSeconds(word.startOffset);
+        const endSecond = parseOffsetSeconds(word.endOffset);
+        if (word.word == null || startSecond == null || endSecond == null) {
+          continue;
+        }
+        segments.push({ text: word.word, startSecond, endSecond });
+      }
+    }
 
     return {
       text,
-      segments: [],
-      language: undefined,
+      segments,
+      language,
       durationInSeconds: undefined,
       warnings,
       response: {
@@ -639,13 +662,44 @@ function validateLiveInputAudioFormat(
   }
 }
 
+/** Parses a Google duration offset such as `"1s"` or `"9.400s"` to seconds. */
+function parseOffsetSeconds(
+  offset: string | undefined | null,
+): number | undefined {
+  if (offset == null) return undefined;
+  const parsed = Number.parseFloat(offset);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+const googleVertexGeminiTranscriptionWordSchema = z.object({
+  word: z.string().nullish(),
+  startOffset: z.string().nullish(),
+  endOffset: z.string().nullish(),
+});
+
 const googleVertexGeminiTranscriptionResponseSchema = z.object({
   candidates: z
     .array(
       z.object({
         content: z
           .object({
-            parts: z.array(z.object({ text: z.string().nullish() })).nullish(),
+            parts: z
+              .array(
+                z.object({
+                  text: z.string().nullish(),
+                  audioTranscription: z
+                    .object({
+                      text: z.string().nullish(),
+                      languageCode: z.string().nullish(),
+                      speakerLabel: z.string().nullish(),
+                      words: z
+                        .array(googleVertexGeminiTranscriptionWordSchema)
+                        .nullish(),
+                    })
+                    .nullish(),
+                }),
+              )
+              .nullish(),
           })
           .nullish(),
       }),

--- a/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.ts
+++ b/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.ts
@@ -1,0 +1,655 @@
+import {
+  InvalidArgumentError,
+  type Experimental_TranscriptionModelV4StreamOptions as TranscriptionModelV4StreamOptions,
+  type Experimental_TranscriptionModelV4StreamPart as TranscriptionModelV4StreamPart,
+  type JSONObject,
+  type SharedV4Warning,
+  type TranscriptionModelV4,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  connectToWebSocket,
+  convertToBase64,
+  createJsonResponseHandler,
+  parseProviderOptions,
+  postJsonToApi,
+  resolve,
+  safeParseJSON,
+  serializeModelOptions,
+  waitForWebSocketBufferDrain,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+  type FetchFunction,
+  type Resolvable,
+  type WebSocketConnection,
+  type WebSocketConstructor,
+  type WebSocketLike,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { googleVertexFailedResponseHandler } from '../google-vertex-error';
+import {
+  googleVertexGeminiTranscriptionModelOptions,
+  type GoogleVertexGeminiTranscriptionModelId,
+  type GoogleVertexTranscriptionModelGeminiOptions,
+} from './google-vertex-gemini-transcription-model-options';
+
+const liveWebSocketPath =
+  'google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent';
+
+/**
+ * After the input audio has ended, finish when no terminal signal
+ * (`turnComplete` / idle `interactionStatus`) arrives within this window.
+ * Trailing transcripts reset the timer.
+ */
+const defaultFinishGraceMs = 3000;
+
+/** Live transcription is only supported by `*-live` model variants. */
+function isLiveTranscriptionModelId(modelId: string): boolean {
+  return modelId.includes('-live');
+}
+
+/** Regional Vertex hostname (mirrors the provider's base-URL host rules). */
+function vertexHost(location: string): string {
+  if (location === 'global') return 'aiplatform.googleapis.com';
+  if (location === 'eu' || location === 'us') {
+    return `aiplatform.${location}.rep.googleapis.com`;
+  }
+  return `${location}-aiplatform.googleapis.com`;
+}
+
+type GoogleLiveWordInfo = {
+  text?: string;
+  word?: string;
+  startOffset?: string;
+  endOffset?: string;
+};
+
+type GoogleLiveTranscription = {
+  text?: string;
+  finished?: boolean;
+  languageCode?: string;
+  speakerLabel?: string;
+  words?: GoogleLiveWordInfo[];
+};
+
+type GoogleLiveServerMessage = {
+  setupComplete?: unknown;
+  serverContent?: {
+    inputTranscription?: GoogleLiveTranscription;
+    interimInputTranscription?: GoogleLiveTranscription;
+    turnComplete?: boolean;
+    generationComplete?: boolean;
+    interactionStatus?: string;
+  };
+  inputTranscription?: GoogleLiveTranscription;
+  usageMetadata?: JSONObject;
+  error?: { message?: string };
+};
+
+interface GoogleVertexGeminiTranscriptionModelConfig {
+  provider: string;
+  /** Regional base URL ending in `/publishers/google`. */
+  baseURL: string;
+  headers?: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  webSocket?: WebSocketConstructor;
+  project: string;
+  location: string;
+  _internal?: {
+    currentDate?: () => Date;
+    finishGraceMs?: number;
+  };
+}
+
+/**
+ * Gemini transcription on Vertex AI. Unary variants transcribe via
+ * `generateContent`; live variants stream over the Vertex Live API WebSocket
+ * (`LlmBidiService/BidiGenerateContent`) with OAuth Bearer authentication
+ * from the provider's resolved headers.
+ */
+export class GoogleVertexGeminiTranscriptionModel implements TranscriptionModelV4 {
+  readonly specificationVersion = 'v4';
+
+  static [WORKFLOW_SERIALIZE](model: GoogleVertexGeminiTranscriptionModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: GoogleVertexGeminiTranscriptionModelId;
+    config: GoogleVertexGeminiTranscriptionModelConfig;
+  }) {
+    return new GoogleVertexGeminiTranscriptionModel(
+      options.modelId,
+      options.config,
+    );
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: GoogleVertexGeminiTranscriptionModelId,
+    private readonly config: GoogleVertexGeminiTranscriptionModelConfig,
+  ) {}
+
+  private async parseOptions(
+    providerOptions: Record<string, unknown> | undefined,
+  ): Promise<GoogleVertexTranscriptionModelGeminiOptions | undefined> {
+    // The Vertex provider exposes options under `googleVertex`/`vertex`;
+    // accept `google` as a cross-namespace fallback (e.g. via the AI Gateway).
+    for (const provider of ['googleVertex', 'vertex', 'google'] as const) {
+      const parsed = await parseProviderOptions({
+        provider,
+        providerOptions,
+        schema: googleVertexGeminiTranscriptionModelOptions,
+      });
+      if (parsed != null) return parsed;
+    }
+    return undefined;
+  }
+
+  async doGenerate(
+    options: Parameters<TranscriptionModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<TranscriptionModelV4['doGenerate']>>> {
+    if (isLiveTranscriptionModelId(this.modelId)) {
+      throw new InvalidArgumentError({
+        argument: 'modelId',
+        message:
+          `Model '${this.modelId}' only supports streaming transcription. ` +
+          `Use experimental_streamTranscribe, or a unary model such as 'gemini-3.5-transcribe'.`,
+      });
+    }
+
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const warnings: SharedV4Warning[] = [];
+    const googleOptions = await this.parseOptions(options.providerOptions);
+    const audioTranscriptionConfig =
+      buildAudioTranscriptionConfig(googleOptions);
+
+    const requestBody = {
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              inlineData: {
+                mimeType: options.mediaType,
+                data: convertToBase64(options.audio),
+              },
+            },
+          ],
+        },
+      ],
+      ...(audioTranscriptionConfig != null
+        ? { generationConfig: { audioTranscriptionConfig } }
+        : {}),
+    };
+
+    const {
+      value: response,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url: `${this.config.baseURL}/models/${this.modelId}:generateContent`,
+      headers: combineHeaders(
+        this.config.headers ? await resolve(this.config.headers) : undefined,
+        options.headers,
+      ),
+      body: requestBody,
+      failedResponseHandler: googleVertexFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        googleVertexGeminiTranscriptionResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const text = (response.candidates?.[0]?.content?.parts ?? [])
+      .map(part => part.text ?? '')
+      .join('');
+
+    return {
+      text,
+      segments: [],
+      language: undefined,
+      durationInSeconds: undefined,
+      warnings,
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+      ...(response.usageMetadata != null
+        ? {
+            providerMetadata: {
+              google: { usageMetadata: response.usageMetadata as JSONObject },
+            },
+          }
+        : {}),
+    };
+  }
+
+  async doStream(
+    options: TranscriptionModelV4StreamOptions,
+  ): Promise<
+    Awaited<ReturnType<NonNullable<TranscriptionModelV4['doStream']>>>
+  > {
+    if (!isLiveTranscriptionModelId(this.modelId)) {
+      throw new InvalidArgumentError({
+        argument: 'modelId',
+        message:
+          `Model '${this.modelId}' does not support streaming transcription. ` +
+          `Use a live model such as 'gemini-3.5-transcribe-live'.`,
+      });
+    }
+
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const warnings: SharedV4Warning[] = [];
+    const googleOptions = await this.parseOptions(options.providerOptions);
+
+    validateLiveInputAudioFormat(options.inputAudioFormat);
+
+    // Vertex Live authenticates with the same OAuth Bearer header the HTTP
+    // surface uses; a header-capable WebSocket implementation (e.g. `ws`) is
+    // required to send it.
+    const headers = combineHeaders(
+      this.config.headers ? await resolve(this.config.headers) : undefined,
+      options.headers,
+    );
+
+    const { project, location } = this.config;
+    const modelResource = `projects/${project}/locations/${location}/publishers/google/models/${this.modelId}`;
+    const url = new URL(
+      `wss://${vertexHost(location)}/ws/${liveWebSocketPath}`,
+    );
+
+    // NOTE: mirrors the Developer API model — Google's documented setup shape
+    // includes `generationConfig.responseModalities: ['TEXT']`, but sending it
+    // suppresses the final `inputTranscription` segments; omit generationConfig.
+    const setup = {
+      model: modelResource,
+      inputAudioTranscription:
+        buildAudioTranscriptionConfig(googleOptions) ?? {},
+    };
+
+    return {
+      request: { body: setup },
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+      },
+      stream: createVertexLiveTranscriptionStream({
+        webSocket: this.config.webSocket,
+        url,
+        headers,
+        setup,
+        inputAudioRate: options.inputAudioFormat.rate ?? 16000,
+        finishGraceMs:
+          this.config._internal?.finishGraceMs ?? defaultFinishGraceMs,
+        warnings,
+        audio: options.audio,
+        abortSignal: options.abortSignal,
+        includeRawChunks: options.includeRawChunks,
+      }),
+    };
+  }
+}
+
+function createVertexLiveTranscriptionStream({
+  webSocket,
+  url,
+  headers,
+  setup,
+  inputAudioRate,
+  finishGraceMs,
+  warnings,
+  audio,
+  abortSignal,
+  includeRawChunks,
+}: {
+  webSocket: WebSocketConstructor | undefined;
+  url: URL;
+  headers: Record<string, string | undefined>;
+  setup: unknown;
+  inputAudioRate: number;
+  finishGraceMs: number;
+  warnings: SharedV4Warning[];
+  audio: ReadableStream<Uint8Array | string>;
+  abortSignal: AbortSignal | undefined;
+  includeRawChunks: boolean | undefined;
+}) {
+  let finished = false;
+  let cleanup: (closeCode?: number) => void = () => {};
+
+  return new ReadableStream<TranscriptionModelV4StreamPart>({
+    start: controller => {
+      let audioReader:
+        | ReadableStreamDefaultReader<Uint8Array | string>
+        | undefined;
+      let connection: WebSocketConnection | undefined;
+
+      // The Live API contract requires waiting for the `setupComplete`
+      // server message before sending realtime input: the audio send loop
+      // is gated on this promise.
+      let resolveSetupComplete!: () => void;
+      const setupComplete = new Promise<void>(resolvePromise => {
+        resolveSetupComplete = resolvePromise;
+      });
+
+      // Google Live messages carry no response/item IDs; a segment counter
+      // generates consistent synthetic IDs. Transcription fragments arrive
+      // incrementally and are accumulated per segment; a `finished: true`
+      // transcription or `turnComplete` finalizes the current segment.
+      let segmentCounter = 0;
+      let segmentBuffer = '';
+      let fullText = '';
+      // Latest revisable interim text: the fallback final when the server
+      // never delivers a finished `inputTranscription` segment.
+      let latestInterim = '';
+      let language: string | undefined;
+      let audioEnded = false;
+      let usageMetadata: JSONObject | undefined;
+      let finishTimer: ReturnType<typeof setTimeout> | undefined;
+
+      const segmentId = () => `google-segment-${segmentCounter}`;
+
+      const cancelPendingFinish = () => {
+        if (finishTimer != null) {
+          clearTimeout(finishTimer);
+          finishTimer = undefined;
+        }
+      };
+
+      // Trailing transcripts can arrive after audioStreamEnd; without a
+      // terminal signal, finish after a quiet grace window. Transcript
+      // activity reschedules the timer.
+      const schedulePendingFinish = () => {
+        if (finished || !audioEnded) return;
+        cancelPendingFinish();
+        finishTimer = setTimeout(() => {
+          finishTimer = undefined;
+          finish();
+        }, finishGraceMs);
+      };
+
+      cleanup = (closeCode?: number) => {
+        cancelPendingFinish();
+        if (audioReader != null) {
+          void audioReader.cancel().catch(() => {});
+        } else {
+          // pre-open failure or abort: cancel the caller's audio stream so an
+          // upstream producer piping into it does not hang:
+          void audio.cancel().catch(() => {});
+        }
+        connection?.close(closeCode);
+      };
+
+      const finishWithError = (error: unknown) => {
+        if (finished) return;
+        finished = true;
+        cleanup();
+        controller.error(error);
+      };
+
+      const completeSegment = () => {
+        // A finished segment supersedes any interim text it revises.
+        if (segmentBuffer === '') {
+          if (latestInterim === '') return;
+          segmentBuffer = latestInterim;
+        }
+        latestInterim = '';
+        controller.enqueue({
+          type: 'transcript-final',
+          id: segmentId(),
+          text: segmentBuffer,
+        });
+        fullText += fullText === '' ? segmentBuffer : ` ${segmentBuffer}`;
+        segmentBuffer = '';
+        segmentCounter++;
+      };
+
+      const finish = () => {
+        if (finished) return;
+        completeSegment();
+        finished = true;
+        controller.enqueue({
+          type: 'finish',
+          text: fullText,
+          segments: [],
+          language,
+          durationInSeconds: undefined,
+          ...(usageMetadata != null
+            ? { providerMetadata: { google: { usageMetadata } } }
+            : {}),
+        });
+        controller.close();
+        cleanup(1000);
+      };
+
+      const sendAudio = async (socket: WebSocketLike) => {
+        audioReader = audio.getReader();
+        try {
+          while (true) {
+            const { done, value } = await audioReader.read();
+            if (done || finished) break;
+            socket.send(
+              JSON.stringify({
+                realtimeInput: {
+                  audio: {
+                    data: convertToBase64(value),
+                    mimeType: `audio/pcm;rate=${inputAudioRate}`,
+                  },
+                },
+              }),
+            );
+            // backpressure: pause reads while the socket buffer is full
+            await waitForWebSocketBufferDrain(socket);
+          }
+        } finally {
+          audioReader.releaseLock();
+          // unlocked again: cleanup must cancel `audio`, not the reader
+          audioReader = undefined;
+        }
+        if (!finished) {
+          socket.send(
+            JSON.stringify({ realtimeInput: { audioStreamEnd: true } }),
+          );
+          audioEnded = true;
+          schedulePendingFinish();
+        }
+      };
+
+      connection = connectToWebSocket({
+        url,
+        headers,
+        webSocket,
+        abortSignal,
+        onAbort: finishWithError,
+        onProcessingError: finishWithError,
+        onOpen: socket => {
+          controller.enqueue({ type: 'stream-start', warnings });
+          socket.send(JSON.stringify({ setup }));
+          // audio may only be sent after the server acknowledged the setup:
+          void setupComplete
+            .then(() => (finished ? undefined : sendAudio(socket)))
+            .catch(finishWithError);
+        },
+        onMessageText: async text => {
+          if (finished) return;
+          const parsed = await safeParseJSON({ text });
+          if (!parsed.success) return;
+          const message = parsed.value as GoogleLiveServerMessage;
+
+          if (includeRawChunks) {
+            controller.enqueue({ type: 'raw', rawValue: message });
+          }
+
+          if (message.setupComplete != null) {
+            resolveSetupComplete();
+          }
+
+          if (message.usageMetadata != null) {
+            usageMetadata = message.usageMetadata;
+          }
+
+          if (message.error != null) {
+            finishWithError(
+              new Error(message.error.message ?? 'Vertex Live API error'),
+            );
+            return;
+          }
+
+          const serverContent = message.serverContent;
+
+          // Low-latency revisable transcription while the user is speaking.
+          const interim = serverContent?.interimInputTranscription;
+          if (interim?.text) {
+            schedulePendingFinish();
+            latestInterim = interim.text;
+            controller.enqueue({
+              type: 'transcript-partial',
+              id: segmentId(),
+              text: interim.text,
+            });
+          }
+
+          const transcription =
+            serverContent?.inputTranscription ?? message.inputTranscription;
+          if (transcription != null) {
+            if (transcription.languageCode != null) {
+              language = transcription.languageCode;
+            }
+            if (transcription.text) {
+              schedulePendingFinish();
+              // A real transcription delta supersedes interim fallback text.
+              latestInterim = '';
+              segmentBuffer += transcription.text;
+              controller.enqueue({
+                type: 'transcript-delta',
+                id: segmentId(),
+                delta: transcription.text,
+              });
+            }
+            if (transcription.finished === true) {
+              completeSegment();
+            }
+          }
+
+          if (serverContent?.turnComplete) {
+            completeSegment();
+          }
+
+          // `interactionStatus` idle (REQUIRES_ACTION in the EAP builds) is
+          // the definitive all-processing-complete signal: finish as soon as
+          // the input audio has ended.
+          const interactionStatus = serverContent?.interactionStatus;
+          if (
+            audioEnded &&
+            (interactionStatus === 'IDLE' ||
+              interactionStatus === 'REQUIRES_ACTION' ||
+              (serverContent?.turnComplete === true &&
+                interactionStatus == null))
+          ) {
+            finish();
+          }
+        },
+        onSocketError: () => {
+          finishWithError(
+            new Error(
+              'Vertex Live transcription error.' +
+                (webSocket == null
+                  ? ' Note: the native WebSocket implementation cannot send' +
+                    ' the Authorization header required by Vertex. Pass a' +
+                    " header-capable WebSocket implementation (e.g. the 'ws'" +
+                    ' package) via createVertex({ webSocket }).'
+                  : ''),
+            ),
+          );
+        },
+        onClose: ({ code, reason }) => {
+          if (finished) return;
+          // a close after the input audio ended means the server delivered
+          // everything it will deliver: finish with the accumulated text
+          if (audioEnded) {
+            finish();
+            return;
+          }
+          finishWithError(
+            new Error(
+              `Vertex Live transcription WebSocket closed unexpectedly before finishing` +
+                ` (code ${code ?? 'unknown'}${reason ? `, reason: ${reason}` : ''}).`,
+            ),
+          );
+        },
+      });
+    },
+
+    cancel: () => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+    },
+  });
+}
+
+/**
+ * Builds Google's `AudioTranscriptionConfig` from provider options; returns
+ * undefined when no options are set.
+ */
+function buildAudioTranscriptionConfig(
+  options: GoogleVertexTranscriptionModelGeminiOptions | undefined,
+): Record<string, unknown> | undefined {
+  if (options == null) return undefined;
+  const config: Record<string, unknown> = {};
+  if (options.languageCodes != null) {
+    config.languageCodes = options.languageCodes;
+  }
+  if (options.customVocabulary != null) {
+    config.customVocabulary = options.customVocabulary;
+  }
+  if (options.wordTimestamp != null) {
+    config.wordTimestamp = options.wordTimestamp;
+  }
+  if (options.diarization != null) {
+    config.diarization = options.diarization;
+  }
+  if (options.mode != null) {
+    config.mode = options.mode;
+  }
+  return Object.keys(config).length > 0 ? config : undefined;
+}
+
+function validateLiveInputAudioFormat(
+  inputAudioFormat: TranscriptionModelV4StreamOptions['inputAudioFormat'],
+) {
+  if (
+    inputAudioFormat.type !== 'audio/pcm' ||
+    (inputAudioFormat.rate != null && inputAudioFormat.rate !== 16000)
+  ) {
+    throw new InvalidArgumentError({
+      argument: 'inputAudioFormat',
+      message:
+        'The Gemini Live transcription API only supports 16kHz 16-bit PCM input audio.',
+    });
+  }
+}
+
+const googleVertexGeminiTranscriptionResponseSchema = z.object({
+  candidates: z
+    .array(
+      z.object({
+        content: z
+          .object({
+            parts: z.array(z.object({ text: z.string().nullish() })).nullish(),
+          })
+          .nullish(),
+      }),
+    )
+    .nullish(),
+  usageMetadata: z.record(z.string(), z.unknown()).nullish(),
+});

--- a/packages/google-vertex/src/google-vertex-provider-base.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.ts
@@ -24,6 +24,7 @@ import {
   withUserAgentSuffix,
   type FetchFunction,
   type Resolvable,
+  type WebSocketConstructor,
 } from '@ai-sdk/provider-utils';
 import { VERSION } from './version';
 import type { GoogleVertexConfig } from './google-vertex-config';
@@ -36,6 +37,7 @@ import { GoogleVertexCloudTTSSpeechModel } from './google-vertex-cloud-tts-speec
 import { googleVertexTools } from './google-vertex-tools';
 import { GoogleVertexTranscriptionModel } from './google-vertex-transcription-model';
 import type { GoogleVertexTranscriptionModelId } from './google-vertex-transcription-model-options';
+import { GoogleVertexGeminiTranscriptionModel } from './gemini-transcription/google-vertex-gemini-transcription-model';
 import { GoogleVertexVideoModel } from './google-vertex-video-model';
 import type { GoogleVertexVideoModelId } from './google-vertex-video-settings';
 import type { GoogleVertexSpeechModelId } from './google-vertex-speech-model-options';
@@ -184,6 +186,13 @@ export interface GoogleVertexProviderSettings {
    * Base URL for the Google Vertex API calls.
    */
   baseURL?: string;
+
+  /**
+   * Custom WebSocket implementation for streaming transcription. Useful for
+   * runtimes that need a WebSocket constructor with header support (e.g. the
+   * `ws` package in Node.js, which Vertex's OAuth Bearer header requires).
+   */
+  webSocket?: WebSocketConstructor;
 }
 
 /**
@@ -359,6 +368,22 @@ export function createGoogleVertex(
     }
 
     const config = createConfig('transcription');
+
+    // Gemini transcription models (`gemini-3.5-transcribe[-live]`) use the
+    // Vertex generateContent / Live API surfaces; everything else routes to
+    // Cloud Speech-to-Text (Chirp, telephony).
+    if (modelId.startsWith('gemini')) {
+      return new GoogleVertexGeminiTranscriptionModel(modelId, {
+        provider: config.provider,
+        baseURL: loadBaseURL(),
+        headers: config.headers,
+        fetch: config.fetch,
+        webSocket: options.webSocket,
+        project: loadGoogleVertexProject(),
+        location: loadGoogleVertexLocation(),
+      });
+    }
+
     return new GoogleVertexTranscriptionModel(modelId, {
       provider: config.provider,
       headers: config.headers,

--- a/packages/google-vertex/src/index.ts
+++ b/packages/google-vertex/src/index.ts
@@ -30,4 +30,9 @@ export type {
   GoogleVertexProvider,
   GoogleVertexProviderSettings,
 } from './google-vertex-provider';
+export { GoogleVertexGeminiTranscriptionModel } from './gemini-transcription/google-vertex-gemini-transcription-model';
+export type {
+  GoogleVertexGeminiTranscriptionModelId,
+  GoogleVertexTranscriptionModelGeminiOptions,
+} from './gemini-transcription/google-vertex-gemini-transcription-model-options';
 export { VERSION } from './version';

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -10,6 +10,7 @@ import type {
   Experimental_RealtimeFactoryV4GetTokenOptions as RealtimeFactoryV4GetTokenOptions,
   SpeechModelV4,
   Experimental_SpeechTranslationModelV4 as SpeechTranslationModelV4,
+  TranscriptionModelV4,
 } from '@ai-sdk/provider';
 import {
   generateId,
@@ -43,6 +44,8 @@ import {
 import type { GoogleInteractionsModelId } from './interactions/google-interactions-language-model-options';
 import type { GoogleInteractionsAgentName } from './interactions/google-interactions-agent';
 import { GoogleRealtimeModel } from './realtime/google-realtime-model';
+import { GoogleTranscriptionModel } from './transcription/google-transcription-model';
+import type { GoogleTranscriptionModelId } from './transcription/google-transcription-model-options';
 import { GoogleSpeechTranslationModel } from './speech-translation/google-speech-translation-model';
 import type { GoogleSpeechTranslationModelId } from './speech-translation/google-speech-translation-model-options';
 
@@ -119,6 +122,19 @@ export interface GoogleProvider extends ProviderV4 {
    * Creates a model for speech generation (text-to-speech).
    */
   speechModel(modelId: GoogleSpeechModelId): SpeechModelV4;
+
+  /**
+   * Creates a model for transcription (speech-to-text). Unary models
+   * (e.g. `gemini-3.5-transcribe`) transcribe audio files; live models
+   * (e.g. `gemini-3.5-transcribe-live`) stream transcription over the
+   * Gemini Live API WebSocket via `experimental_streamTranscribe`.
+   */
+  transcription(modelId: GoogleTranscriptionModelId): TranscriptionModelV4;
+
+  /**
+   * Creates a model for transcription (speech-to-text).
+   */
+  transcriptionModel(modelId: GoogleTranscriptionModelId): TranscriptionModelV4;
 
   files(): FilesV4;
 
@@ -331,6 +347,15 @@ export function createGoogle(
       fetch: options.fetch,
     });
 
+  const createTranscriptionModel = (modelId: GoogleTranscriptionModelId) =>
+    new GoogleTranscriptionModel(modelId, {
+      provider: `${providerName}.transcription`,
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+      webSocket: options.webSocket,
+    });
+
   const experimentalRealtimeFactory = Object.assign(
     (modelId: string) => createRealtimeModel(modelId),
     {
@@ -393,6 +418,8 @@ export function createGoogle(
   provider.files = createFiles;
   provider.speech = createSpeechModel;
   provider.speechModel = createSpeechModel;
+  provider.transcription = createTranscriptionModel;
+  provider.transcriptionModel = createTranscriptionModel;
   provider.translation = createSpeechTranslationModel;
   provider.speechTranslationModel = createSpeechTranslationModel;
   provider.interactions = createInteractionsModel;

--- a/packages/google/src/index.ts
+++ b/packages/google/src/index.ts
@@ -60,6 +60,11 @@ export type {
   GoogleRealtimeModelId as Experimental_GoogleRealtimeModelId,
   GoogleRealtimeModelOptions as Experimental_GoogleRealtimeModelOptions,
 } from './realtime/google-realtime-model-options';
+export { GoogleTranscriptionModel } from './transcription/google-transcription-model';
+export type {
+  GoogleTranscriptionModelId,
+  GoogleTranscriptionModelOptions,
+} from './transcription/google-transcription-model-options';
 export {
   GoogleSpeechTranslationModel as Experimental_GoogleSpeechTranslationModel,
   /** @deprecated Use `Experimental_GoogleSpeechTranslationModel` instead. */

--- a/packages/google/src/transcription/google-transcription-model-options.ts
+++ b/packages/google/src/transcription/google-transcription-model-options.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod/v4';
+
+export type GoogleTranscriptionModelId =
+  | 'gemini-3.5-transcribe'
+  | 'gemini-3.5-transcribe-live'
+  | (string & {});
+
+/**
+ * Speech recognition options shared by unary (`gemini-3.5-transcribe`) and
+ * live (`gemini-3.5-transcribe-live`) transcription. Maps onto Google's
+ * `AudioTranscriptionConfig`.
+ */
+export const googleTranscriptionModelOptions = z.object({
+  /**
+   * BCP-47 language codes providing hints about the languages present in the
+   * audio. If omitted or empty, defaults to automatic language detection.
+   */
+  languageCodes: z.array(z.string()).optional(),
+
+  /**
+   * Custom vocabulary phrases, which bias the speech recognition model
+   * toward recognizing specific terms.
+   */
+  customVocabulary: z.array(z.string()).optional(),
+
+  /**
+   * Enables word-level timestamp generation.
+   */
+  wordTimestamp: z.boolean().optional(),
+
+  /**
+   * Enables speaker diarization.
+   */
+  diarization: z.boolean().optional(),
+
+  /**
+   * Transcription output formatting mode.
+   *
+   * - `VERBATIM` (default): exact literal transcript preserving filler
+   *   words, repetitions, and false starts.
+   * - `SMART`: cleans up and structures the transcript in real time —
+   *   disfluency removal, inline self-corrections, structured formatting
+   *   (lists, numbers, dates, paragraph breaks), and grammar/casing polish.
+   */
+  mode: z.enum(['SMART', 'VERBATIM']).optional(),
+});
+
+export type GoogleTranscriptionModelOptions = z.infer<
+  typeof googleTranscriptionModelOptions
+>;

--- a/packages/google/src/transcription/google-transcription-model.test.ts
+++ b/packages/google/src/transcription/google-transcription-model.test.ts
@@ -1,0 +1,577 @@
+import {
+  convertArrayToReadableStream,
+  convertReadableStreamToArray,
+} from '@ai-sdk/provider-utils/test';
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { GoogleTranscriptionModel } from './google-transcription-model';
+
+vi.mock('../version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  readyState = 0;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = 3;
+  });
+  onopen: ((event: unknown) => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  onclose: ((event: unknown) => void) | null = null;
+
+  constructor(
+    public url: string | URL,
+    public protocols?: string | string[],
+    public options?: { headers?: Record<string, string | undefined> },
+  ) {
+    MockWebSocket.instances.push(this);
+  }
+
+  open() {
+    this.readyState = 1;
+    this.onopen?.({});
+  }
+
+  message(value: unknown) {
+    this.onmessage?.({ data: JSON.stringify(value) });
+  }
+
+  serverClose(code?: number, reason?: string) {
+    this.readyState = 3;
+    this.onclose?.({ code, reason });
+  }
+}
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+function createModel(
+  modelId = 'gemini-3.5-transcribe-live',
+  overrides: Partial<{
+    finishGraceMs: number;
+    currentDate: () => Date;
+  }> = {},
+) {
+  MockWebSocket.instances = [];
+  return new GoogleTranscriptionModel(modelId, {
+    provider: 'test-provider',
+    baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+    headers: () => ({ 'x-goog-api-key': 'test-api-key' }),
+    webSocket: MockWebSocket,
+    _internal: {
+      finishGraceMs: overrides.finishGraceMs ?? 5000,
+      ...(overrides.currentDate != null
+        ? { currentDate: overrides.currentDate }
+        : {}),
+    },
+  });
+}
+
+describe('doGenerate', () => {
+  const server = createTestServer({
+    'https://generativelanguage.googleapis.com/v1beta/interactions': {
+      response: {
+        type: 'json-value',
+        body: {
+          id: 'interactions/test',
+          status: 'completed',
+          steps: [
+            {
+              type: 'model_output',
+              content: [{ type: 'text', text: 'Hello world.' }],
+            },
+          ],
+          usage: {
+            total_tokens: 10,
+            total_input_tokens: 10,
+            total_output_tokens: 0,
+          },
+        },
+      },
+    },
+  });
+
+  it('transcribes audio via the Interactions API with transcription_config', async () => {
+    const model = createModel('gemini-3.5-transcribe');
+
+    const result = await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {
+        google: {
+          customVocabulary: ['Gemini', 'Kubernetes'],
+          languageCodes: ['es-ES'],
+          mode: 'SMART',
+        },
+      },
+    });
+
+    expect(result.text).toBe('Hello world.');
+    expect(await server.calls[0].requestBodyJson).toEqual({
+      model: 'gemini-3.5-transcribe',
+      input: [
+        {
+          type: 'audio',
+          data: 'AQIDBA==',
+          mime_type: 'audio/wav',
+        },
+      ],
+      generation_config: {
+        transcription_config: {
+          language_codes: ['es-ES'],
+          custom_vocabulary: ['Gemini', 'Kubernetes'],
+          mode: { type: 'smart' },
+        },
+      },
+    });
+    expect(server.calls[0].requestHeaders['x-goog-api-key']).toBe(
+      'test-api-key',
+    );
+    expect(result.providerMetadata).toEqual({
+      google: {
+        usage: {
+          total_tokens: 10,
+          total_input_tokens: 10,
+          total_output_tokens: 0,
+        },
+      },
+    });
+  });
+
+  it('maps diarization and word timestamps into the mode object', async () => {
+    const model = createModel('gemini-3.5-transcribe');
+
+    await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {
+        google: { diarization: true, wordTimestamp: true },
+      },
+    });
+
+    const body = (await server.calls[0].requestBodyJson) as {
+      generation_config?: { transcription_config?: unknown };
+    };
+    expect(body.generation_config?.transcription_config).toEqual({
+      mode: {
+        type: 'verbatim',
+        diarization_mode: 'speaker',
+        timestamp_granularities: ['word'],
+      },
+    });
+  });
+
+  it('omits generation_config when no transcription options are set', async () => {
+    const model = createModel('gemini-3.5-transcribe');
+
+    await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {},
+    });
+
+    const body = (await server.calls[0].requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    expect(body.generation_config).toBeUndefined();
+  });
+
+  it('extracts word segments from word_info annotations', async () => {
+    server.urls[
+      'https://generativelanguage.googleapis.com/v1beta/interactions'
+    ].response = {
+      type: 'json-value',
+      body: {
+        id: 'interactions/test',
+        status: 'completed',
+        steps: [
+          {
+            type: 'model_output',
+            content: [
+              {
+                type: 'text',
+                text: 'The quick brown fox.',
+                annotations: [
+                  {
+                    type: 'word_info',
+                    text: 'The',
+                    speaker: 'spk:0',
+                    start_offset: '0.100s',
+                    end_offset: '0.100s',
+                  },
+                  {
+                    type: 'word_info',
+                    text: 'quick',
+                    speaker: 'spk:0',
+                    start_offset: '0.100s',
+                    end_offset: '0.400s',
+                  },
+                  {
+                    type: 'word_info',
+                    text: 'brown',
+                    speaker: 'spk:0',
+                    start_offset: '0.400s',
+                    end_offset: '0.700s',
+                  },
+                  {
+                    type: 'word_info',
+                    text: 'fox.',
+                    speaker: 'spk:0',
+                    start_offset: '0.700s',
+                    end_offset: '1s',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        usage: { total_input_tokens: 64 },
+      },
+    };
+
+    const model = createModel('gemini-3.5-transcribe');
+    const result = await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {},
+    });
+
+    expect(result.text).toBe('The quick brown fox.');
+    expect(result.segments).toEqual([
+      { text: 'The', startSecond: 0.1, endSecond: 0.1 },
+      { text: 'quick', startSecond: 0.1, endSecond: 0.4 },
+      { text: 'brown', startSecond: 0.4, endSecond: 0.7 },
+      { text: 'fox.', startSecond: 0.7, endSecond: 1 },
+    ]);
+  });
+
+  it('rejects unary transcription on live model ids', async () => {
+    const model = createModel('gemini-3.5-transcribe-live');
+
+    await expect(
+      model.doGenerate({
+        audio: new Uint8Array([1]),
+        mediaType: 'audio/wav',
+        providerOptions: {},
+      }),
+    ).rejects.toThrow('only supports streaming transcription');
+  });
+});
+
+describe('doStream', () => {
+  it('streams transcription over the Gemini Live API WebSocket', async () => {
+    const model = createModel();
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2, 3])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {
+        google: {
+          customVocabulary: ['Gemini'],
+          languageCodes: ['en-US'],
+        },
+      },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    expect(ws.url.toString()).toBe(
+      'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=test-api-key',
+    );
+
+    ws.open();
+    await flush();
+
+    // audio is gated on setupComplete: only the setup message was sent
+    expect(ws.send).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(ws.send.mock.calls[0][0])).toEqual({
+      setup: {
+        model: 'models/gemini-3.5-transcribe-live',
+        inputAudioTranscription: {
+          languageCodes: ['en-US'],
+          customVocabulary: ['Gemini'],
+        },
+      },
+    });
+
+    ws.message({ setupComplete: {} });
+    await flush();
+
+    // audio chunk + audioStreamEnd
+    expect(ws.send).toHaveBeenCalledTimes(3);
+    expect(JSON.parse(ws.send.mock.calls[1][0])).toEqual({
+      realtimeInput: {
+        audio: { data: 'AQID', mimeType: 'audio/pcm;rate=16000' },
+      },
+    });
+    expect(JSON.parse(ws.send.mock.calls[2][0])).toEqual({
+      realtimeInput: { audioStreamEnd: true },
+    });
+
+    ws.message({
+      serverContent: {
+        interimInputTranscription: { text: 'hel' },
+      },
+    });
+    ws.message({
+      serverContent: {
+        inputTranscription: { text: 'hello ', languageCode: 'en-US' },
+      },
+    });
+    ws.message({
+      serverContent: {
+        inputTranscription: { text: 'world.', finished: true },
+      },
+    });
+    ws.message({
+      usageMetadata: { promptTokenCount: 7 },
+      serverContent: { turnComplete: true, interactionStatus: 'IDLE' },
+    });
+    await flush();
+
+    const parts = await partsPromise;
+    expect(parts).toEqual([
+      { type: 'stream-start', warnings: [] },
+      { type: 'transcript-partial', id: 'google-segment-0', text: 'hel' },
+      { type: 'transcript-delta', id: 'google-segment-0', delta: 'hello ' },
+      { type: 'transcript-delta', id: 'google-segment-0', delta: 'world.' },
+      {
+        type: 'transcript-final',
+        id: 'google-segment-0',
+        text: 'hello world.',
+      },
+      {
+        type: 'finish',
+        text: 'hello world.',
+        segments: [],
+        language: 'en-US',
+        durationInSeconds: undefined,
+        providerMetadata: {
+          google: { usageMetadata: { promptTokenCount: 7 } },
+        },
+      },
+    ]);
+    expect(ws.close).toHaveBeenCalledWith(1000);
+  });
+
+  it('passes the SMART transcription mode into the live setup', async () => {
+    const model = createModel();
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {
+        google: { mode: 'SMART' },
+      },
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    await flush();
+
+    expect(JSON.parse(ws.send.mock.calls[0][0])).toEqual({
+      setup: {
+        model: 'models/gemini-3.5-transcribe-live',
+        inputAudioTranscription: { mode: 'SMART' },
+      },
+    });
+
+    ws.message({ setupComplete: {} });
+    await flush();
+    ws.message({
+      serverContent: { inputTranscription: { text: 'hi', finished: true } },
+    });
+    ws.message({ serverContent: { interactionStatus: 'IDLE' } });
+    await flush();
+    await expect(partsPromise).resolves.toBeDefined();
+  });
+
+  it('accepts the pre-launch REQUIRES_ACTION interaction status as idle', async () => {
+    const model = createModel();
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {},
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ setupComplete: {} });
+    await flush();
+
+    ws.message({
+      serverContent: { inputTranscription: { text: 'hi', finished: true } },
+    });
+    ws.message({
+      serverContent: { interactionStatus: 'REQUIRES_ACTION' },
+    });
+    await flush();
+
+    const parts = await partsPromise;
+    expect(parts.at(-1)).toMatchObject({ type: 'finish', text: 'hi' });
+  });
+
+  it('falls back to the latest interim partial when no final segment arrives', async () => {
+    const model = createModel();
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {},
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ setupComplete: {} });
+    await flush();
+
+    ws.message({
+      serverContent: { interimInputTranscription: { text: 'hello wor' } },
+    });
+    ws.message({
+      serverContent: { interimInputTranscription: { text: 'hello world.' } },
+    });
+    ws.message({ serverContent: { interactionStatus: 'IDLE' } });
+    await flush();
+
+    const parts = await partsPromise;
+    expect(parts.at(-2)).toEqual({
+      type: 'transcript-final',
+      id: 'google-segment-0',
+      text: 'hello world.',
+    });
+    expect(parts.at(-1)).toMatchObject({
+      type: 'finish',
+      text: 'hello world.',
+    });
+  });
+
+  it('finishes with accumulated text when the server closes after audio ended', async () => {
+    const model = createModel();
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1, 2])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {},
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ setupComplete: {} });
+    await flush();
+
+    ws.message({
+      serverContent: { inputTranscription: { text: 'partial words' } },
+    });
+    ws.serverClose(1000);
+    await flush();
+
+    const parts = await partsPromise;
+    expect(parts.at(-1)).toMatchObject({
+      type: 'finish',
+      text: 'partial words',
+    });
+  });
+
+  it('errors when the socket closes before the audio ended', async () => {
+    const model = createModel();
+
+    const result = await model.doStream({
+      // a never-ending audio stream: the reader stays pending
+      audio: new ReadableStream<Uint8Array>({ start: () => {} }),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {},
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const rejection = expect(partsPromise).rejects.toThrow(
+      'closed unexpectedly before finishing (code 1011, reason: internal error)',
+    );
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ setupComplete: {} });
+    await flush();
+
+    ws.serverClose(1011, 'internal error');
+    await rejection;
+  });
+
+  it('surfaces server error messages', async () => {
+    const model = createModel();
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {},
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const rejection = expect(partsPromise).rejects.toThrow('quota exceeded');
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ setupComplete: {} });
+    await flush();
+    ws.message({ error: { message: 'quota exceeded' } });
+    await flush();
+
+    await rejection;
+  });
+
+  it('rejects streaming on unary model ids', async () => {
+    const model = createModel('gemini-3.5-transcribe');
+
+    await expect(
+      model.doStream({
+        audio: convertArrayToReadableStream([new Uint8Array([1])]),
+        inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+        providerOptions: {},
+      }),
+    ).rejects.toThrow('does not support streaming transcription');
+  });
+
+  it('rejects non-16kHz PCM input audio', async () => {
+    const model = createModel();
+
+    await expect(
+      model.doStream({
+        audio: convertArrayToReadableStream([new Uint8Array([1])]),
+        inputAudioFormat: { type: 'audio/pcm', rate: 24000 },
+        providerOptions: {},
+      }),
+    ).rejects.toThrow('only supports 16kHz 16-bit PCM input audio');
+  });
+
+  it('emits raw chunks when includeRawChunks is set', async () => {
+    const model = createModel();
+
+    const result = await model.doStream({
+      audio: convertArrayToReadableStream([new Uint8Array([1])]),
+      inputAudioFormat: { type: 'audio/pcm', rate: 16000 },
+      providerOptions: {},
+      includeRawChunks: true,
+    });
+
+    const partsPromise = convertReadableStreamToArray(result.stream);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+    ws.message({ setupComplete: {} });
+    await flush();
+    ws.message({
+      serverContent: { inputTranscription: { text: 'ok', finished: true } },
+    });
+    ws.message({ serverContent: { interactionStatus: 'IDLE' } });
+    await flush();
+
+    const parts = await partsPromise;
+    expect(parts.filter(part => part.type === 'raw').length).toBeGreaterThan(0);
+  });
+});

--- a/packages/google/src/transcription/google-transcription-model.ts
+++ b/packages/google/src/transcription/google-transcription-model.ts
@@ -1,0 +1,714 @@
+import {
+  InvalidArgumentError,
+  type Experimental_TranscriptionModelV4StreamOptions as TranscriptionModelV4StreamOptions,
+  type Experimental_TranscriptionModelV4StreamPart as TranscriptionModelV4StreamPart,
+  type JSONObject,
+  type SharedV4Warning,
+  type TranscriptionModelV4,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  connectToWebSocket,
+  convertToBase64,
+  createJsonResponseHandler,
+  parseProviderOptions,
+  postJsonToApi,
+  resolve,
+  safeParseJSON,
+  serializeModelOptions,
+  waitForWebSocketBufferDrain,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+  type FetchFunction,
+  type Resolvable,
+  type WebSocketConnection,
+  type WebSocketConstructor,
+  type WebSocketLike,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { getModelPath } from '../get-model-path';
+import { getRealtimeWebSocketURL } from '../get-realtime-base-url';
+import { googleFailedResponseHandler } from '../google-error';
+import {
+  googleTranscriptionModelOptions,
+  type GoogleTranscriptionModelId,
+  type GoogleTranscriptionModelOptions,
+} from './google-transcription-model-options';
+
+const liveWebSocketPath =
+  'google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent';
+
+/**
+ * After the input audio has ended, finish when no terminal signal
+ * (`turnComplete` / idle `interactionStatus`) arrives within this window.
+ * Trailing transcripts reset the timer.
+ */
+const defaultFinishGraceMs = 3000;
+
+function getLiveWebSocketURL(baseURL: string, apiKey: string): URL {
+  const url = getRealtimeWebSocketURL(baseURL, liveWebSocketPath);
+  url.searchParams.set('key', apiKey);
+  return url;
+}
+
+/** Live transcription is only supported by `*-live` model variants. */
+function isLiveTranscriptionModelId(modelId: string): boolean {
+  return modelId.includes('-live');
+}
+
+type GoogleLiveWordInfo = {
+  text?: string;
+  word?: string;
+  startOffset?: string;
+  endOffset?: string;
+};
+
+type GoogleLiveTranscription = {
+  text?: string;
+  finished?: boolean;
+  languageCode?: string;
+  speakerLabel?: string;
+  words?: GoogleLiveWordInfo[];
+};
+
+type GoogleLiveServerMessage = {
+  setupComplete?: unknown;
+  serverContent?: {
+    inputTranscription?: GoogleLiveTranscription;
+    interimInputTranscription?: GoogleLiveTranscription;
+    turnComplete?: boolean;
+    generationComplete?: boolean;
+    interactionStatus?: string;
+  };
+  inputTranscription?: GoogleLiveTranscription;
+  usageMetadata?: JSONObject;
+  error?: { message?: string };
+};
+
+interface GoogleTranscriptionModelConfig {
+  provider: string;
+  baseURL: string;
+  headers?: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  webSocket?: WebSocketConstructor;
+  _internal?: {
+    currentDate?: () => Date;
+    finishGraceMs?: number;
+  };
+}
+
+export class GoogleTranscriptionModel implements TranscriptionModelV4 {
+  readonly specificationVersion = 'v4';
+
+  static [WORKFLOW_SERIALIZE](model: GoogleTranscriptionModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: GoogleTranscriptionModelId;
+    config: GoogleTranscriptionModelConfig;
+  }) {
+    return new GoogleTranscriptionModel(options.modelId, options.config);
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: GoogleTranscriptionModelId,
+    private readonly config: GoogleTranscriptionModelConfig,
+  ) {}
+
+  private async parseOptions(
+    providerOptions: Record<string, unknown> | undefined,
+  ): Promise<GoogleTranscriptionModelOptions | undefined> {
+    return parseProviderOptions({
+      provider: 'google',
+      providerOptions,
+      schema: googleTranscriptionModelOptions,
+    });
+  }
+
+  async doGenerate(
+    options: Parameters<TranscriptionModelV4['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<TranscriptionModelV4['doGenerate']>>> {
+    if (isLiveTranscriptionModelId(this.modelId)) {
+      throw new InvalidArgumentError({
+        argument: 'modelId',
+        message:
+          `Model '${this.modelId}' only supports streaming transcription. ` +
+          `Use experimental_streamTranscribe, or a unary model such as 'gemini-3.5-transcribe'.`,
+      });
+    }
+
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const warnings: SharedV4Warning[] = [];
+    const googleOptions = await this.parseOptions(options.providerOptions);
+    const transcriptionConfig = buildTranscriptionConfig(googleOptions);
+
+    // Unary transcription is served by the Interactions API
+    // (https://ai.google.dev/gemini-api/docs/transcribe).
+    const requestBody = {
+      model: this.modelId,
+      input: [
+        {
+          type: 'audio',
+          data: convertToBase64(options.audio),
+          mime_type: options.mediaType,
+        },
+      ],
+      ...(transcriptionConfig != null
+        ? { generation_config: { transcription_config: transcriptionConfig } }
+        : {}),
+    };
+
+    const {
+      value: response,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url: `${this.config.baseURL}/interactions`,
+      headers: combineHeaders(
+        this.config.headers ? await resolve(this.config.headers) : undefined,
+        options.headers,
+      ),
+      body: requestBody,
+      failedResponseHandler: googleFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        googleInteractionsTranscriptionResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    let text = '';
+    const segments: Array<{
+      text: string;
+      startSecond: number;
+      endSecond: number;
+    }> = [];
+    for (const step of response.steps ?? []) {
+      for (const content of step.content ?? []) {
+        if (content.type !== 'text' || content.text == null) continue;
+        text += content.text;
+        for (const annotation of content.annotations ?? []) {
+          if (annotation.type !== 'word_info') continue;
+          const startSecond = parseOffsetSeconds(annotation.start_offset);
+          const endSecond = parseOffsetSeconds(annotation.end_offset);
+          if (
+            annotation.text == null ||
+            startSecond == null ||
+            endSecond == null
+          ) {
+            continue;
+          }
+          segments.push({ text: annotation.text, startSecond, endSecond });
+        }
+      }
+    }
+
+    return {
+      text,
+      segments,
+      language: undefined,
+      durationInSeconds: undefined,
+      warnings,
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+      ...(response.usage != null
+        ? {
+            providerMetadata: {
+              google: { usage: response.usage as JSONObject },
+            },
+          }
+        : {}),
+    };
+  }
+
+  async doStream(
+    options: TranscriptionModelV4StreamOptions,
+  ): Promise<
+    Awaited<ReturnType<NonNullable<TranscriptionModelV4['doStream']>>>
+  > {
+    if (!isLiveTranscriptionModelId(this.modelId)) {
+      throw new InvalidArgumentError({
+        argument: 'modelId',
+        message:
+          `Model '${this.modelId}' does not support streaming transcription. ` +
+          `Use a live model such as 'gemini-3.5-transcribe-live'.`,
+      });
+    }
+
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const warnings: SharedV4Warning[] = [];
+    const googleOptions = await this.parseOptions(options.providerOptions);
+
+    validateLiveInputAudioFormat(options.inputAudioFormat);
+
+    const headers = combineHeaders(
+      this.config.headers ? await resolve(this.config.headers) : undefined,
+      options.headers,
+    );
+    // last case-variant wins: combineHeaders keeps case-distinct keys and
+    // spreads per-call headers after configuration headers
+    let apiKey: string | undefined;
+    for (const [key, value] of Object.entries(headers)) {
+      if (key.toLowerCase() === 'x-goog-api-key' && value != null) {
+        apiKey = value;
+      }
+    }
+    if (apiKey == null) {
+      throw new Error(
+        'Google Generative AI API key is required for streaming transcription.',
+      );
+    }
+    const webSocketHeaders = Object.fromEntries(
+      Object.entries(headers).filter(
+        ([key]) => key.toLowerCase() !== 'x-goog-api-key',
+      ),
+    );
+
+    // NOTE: Google's GA announcement shows the setup with
+    // `generationConfig: { responseModalities: ['TEXT'] }`, but sending it
+    // suppresses the final `inputTranscription` segments on the current
+    // endpoint (only interim partials arrive). Omit generationConfig — the
+    // empirically working shape — until the endpoint honors the documented
+    // form.
+    const setup = {
+      model: getModelPath(this.modelId),
+      inputAudioTranscription:
+        buildAudioTranscriptionConfig(googleOptions) ?? {},
+    };
+
+    return {
+      request: { body: setup },
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+      },
+      stream: createGoogleLiveTranscriptionStream({
+        webSocket: this.config.webSocket,
+        url: getLiveWebSocketURL(this.config.baseURL, apiKey),
+        headers: webSocketHeaders,
+        setup,
+        inputAudioRate: options.inputAudioFormat.rate ?? 16000,
+        finishGraceMs:
+          this.config._internal?.finishGraceMs ?? defaultFinishGraceMs,
+        warnings,
+        audio: options.audio,
+        abortSignal: options.abortSignal,
+        includeRawChunks: options.includeRawChunks,
+      }),
+    };
+  }
+}
+
+function createGoogleLiveTranscriptionStream({
+  webSocket,
+  url,
+  headers,
+  setup,
+  inputAudioRate,
+  finishGraceMs,
+  warnings,
+  audio,
+  abortSignal,
+  includeRawChunks,
+}: {
+  webSocket: WebSocketConstructor | undefined;
+  url: URL;
+  headers: Record<string, string | undefined>;
+  setup: unknown;
+  inputAudioRate: number;
+  finishGraceMs: number;
+  warnings: SharedV4Warning[];
+  audio: ReadableStream<Uint8Array | string>;
+  abortSignal: AbortSignal | undefined;
+  includeRawChunks: boolean | undefined;
+}) {
+  let finished = false;
+  let cleanup: (closeCode?: number) => void = () => {};
+
+  return new ReadableStream<TranscriptionModelV4StreamPart>({
+    start: controller => {
+      let audioReader:
+        | ReadableStreamDefaultReader<Uint8Array | string>
+        | undefined;
+      let connection: WebSocketConnection | undefined;
+
+      // The Live API contract requires waiting for the `setupComplete`
+      // server message before sending realtime input: the audio send loop
+      // is gated on this promise.
+      let resolveSetupComplete!: () => void;
+      const setupComplete = new Promise<void>(resolve => {
+        resolveSetupComplete = resolve;
+      });
+
+      // Google Live messages carry no response/item IDs; a segment counter
+      // generates consistent synthetic IDs. Transcription fragments arrive
+      // incrementally and are accumulated per segment; a `finished: true`
+      // transcription or `turnComplete` finalizes the current segment.
+      let segmentCounter = 0;
+      let segmentBuffer = '';
+      let fullText = '';
+      // Latest revisable interim text: the fallback final when the server
+      // never delivers a finished `inputTranscription` segment.
+      let latestInterim = '';
+      let language: string | undefined;
+      let audioEnded = false;
+      let usageMetadata: JSONObject | undefined;
+      let finishTimer: ReturnType<typeof setTimeout> | undefined;
+
+      const segmentId = () => `google-segment-${segmentCounter}`;
+
+      const cancelPendingFinish = () => {
+        if (finishTimer != null) {
+          clearTimeout(finishTimer);
+          finishTimer = undefined;
+        }
+      };
+
+      // Trailing transcripts can arrive after audioStreamEnd; without a
+      // terminal signal, finish after a quiet grace window. Transcript
+      // activity reschedules the timer.
+      const schedulePendingFinish = () => {
+        if (finished || !audioEnded) return;
+        cancelPendingFinish();
+        finishTimer = setTimeout(() => {
+          finishTimer = undefined;
+          finish();
+        }, finishGraceMs);
+      };
+
+      cleanup = (closeCode?: number) => {
+        cancelPendingFinish();
+        if (audioReader != null) {
+          void audioReader.cancel().catch(() => {});
+        } else {
+          // pre-open failure or abort: cancel the caller's audio stream so an
+          // upstream producer piping into it does not hang:
+          void audio.cancel().catch(() => {});
+        }
+        connection?.close(closeCode);
+      };
+
+      const finishWithError = (error: unknown) => {
+        if (finished) return;
+        finished = true;
+        cleanup();
+        controller.error(error);
+      };
+
+      const completeSegment = () => {
+        // A finished segment supersedes any interim text it revises.
+        if (segmentBuffer === '') {
+          if (latestInterim === '') return;
+          segmentBuffer = latestInterim;
+        }
+        latestInterim = '';
+        controller.enqueue({
+          type: 'transcript-final',
+          id: segmentId(),
+          text: segmentBuffer,
+        });
+        fullText += fullText === '' ? segmentBuffer : ` ${segmentBuffer}`;
+        segmentBuffer = '';
+        segmentCounter++;
+      };
+
+      const finish = () => {
+        if (finished) return;
+        completeSegment();
+        finished = true;
+        controller.enqueue({
+          type: 'finish',
+          text: fullText,
+          segments: [],
+          language,
+          durationInSeconds: undefined,
+          ...(usageMetadata != null
+            ? { providerMetadata: { google: { usageMetadata } } }
+            : {}),
+        });
+        controller.close();
+        cleanup(1000);
+      };
+
+      const sendAudio = async (socket: WebSocketLike) => {
+        audioReader = audio.getReader();
+        try {
+          while (true) {
+            const { done, value } = await audioReader.read();
+            if (done || finished) break;
+            socket.send(
+              JSON.stringify({
+                realtimeInput: {
+                  audio: {
+                    data: convertToBase64(value),
+                    mimeType: `audio/pcm;rate=${inputAudioRate}`,
+                  },
+                },
+              }),
+            );
+            // backpressure: pause reads while the socket buffer is full
+            await waitForWebSocketBufferDrain(socket);
+          }
+        } finally {
+          audioReader.releaseLock();
+          // unlocked again: cleanup must cancel `audio`, not the reader
+          audioReader = undefined;
+        }
+        if (!finished) {
+          socket.send(
+            JSON.stringify({ realtimeInput: { audioStreamEnd: true } }),
+          );
+          audioEnded = true;
+          schedulePendingFinish();
+        }
+      };
+
+      connection = connectToWebSocket({
+        url,
+        headers,
+        webSocket,
+        abortSignal,
+        onAbort: finishWithError,
+        onProcessingError: finishWithError,
+        onOpen: socket => {
+          controller.enqueue({ type: 'stream-start', warnings });
+          socket.send(JSON.stringify({ setup }));
+          // audio may only be sent after the server acknowledged the setup:
+          void setupComplete
+            .then(() => (finished ? undefined : sendAudio(socket)))
+            .catch(finishWithError);
+        },
+        onMessageText: async text => {
+          if (finished) return;
+          const parsed = await safeParseJSON({ text });
+          if (!parsed.success) return;
+          const message = parsed.value as GoogleLiveServerMessage;
+
+          if (includeRawChunks) {
+            controller.enqueue({ type: 'raw', rawValue: message });
+          }
+
+          if (message.setupComplete != null) {
+            resolveSetupComplete();
+          }
+
+          if (message.usageMetadata != null) {
+            usageMetadata = message.usageMetadata;
+          }
+
+          if (message.error != null) {
+            finishWithError(
+              new Error(message.error.message ?? 'Google Live API error'),
+            );
+            return;
+          }
+
+          const serverContent = message.serverContent;
+
+          // Low-latency revisable transcription while the user is speaking.
+          const interim = serverContent?.interimInputTranscription;
+          if (interim?.text) {
+            schedulePendingFinish();
+            latestInterim = interim.text;
+            controller.enqueue({
+              type: 'transcript-partial',
+              id: segmentId(),
+              text: interim.text,
+            });
+          }
+
+          const transcription =
+            serverContent?.inputTranscription ?? message.inputTranscription;
+          if (transcription != null) {
+            if (transcription.languageCode != null) {
+              language = transcription.languageCode;
+            }
+            if (transcription.text) {
+              schedulePendingFinish();
+              // A real transcription delta supersedes interim fallback text.
+              latestInterim = '';
+              segmentBuffer += transcription.text;
+              controller.enqueue({
+                type: 'transcript-delta',
+                id: segmentId(),
+                delta: transcription.text,
+              });
+            }
+            if (transcription.finished === true) {
+              completeSegment();
+            }
+          }
+
+          if (serverContent?.turnComplete) {
+            completeSegment();
+          }
+
+          // `interactionStatus` idle (REQUIRES_ACTION in the EAP builds) is
+          // the definitive all-processing-complete signal: finish as soon as
+          // the input audio has ended.
+          const interactionStatus = serverContent?.interactionStatus;
+          if (
+            audioEnded &&
+            (interactionStatus === 'IDLE' ||
+              interactionStatus === 'REQUIRES_ACTION' ||
+              (serverContent?.turnComplete === true &&
+                interactionStatus == null))
+          ) {
+            finish();
+          }
+        },
+        onSocketError: () => {
+          finishWithError(new Error('Google Live transcription error'));
+        },
+        onClose: ({ code, reason }) => {
+          if (finished) return;
+          // a close after the input audio ended means the server delivered
+          // everything it will deliver: finish with the accumulated text
+          if (audioEnded) {
+            finish();
+            return;
+          }
+          finishWithError(
+            new Error(
+              `Google Live transcription WebSocket closed unexpectedly before finishing` +
+                ` (code ${code ?? 'unknown'}${reason ? `, reason: ${reason}` : ''}).`,
+            ),
+          );
+        },
+      });
+    },
+
+    cancel: () => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+    },
+  });
+}
+
+/**
+ * Builds Google's `AudioTranscriptionConfig` from provider options; returns
+ * undefined when no options are set.
+ */
+function buildAudioTranscriptionConfig(
+  options: GoogleTranscriptionModelOptions | undefined,
+): Record<string, unknown> | undefined {
+  if (options == null) return undefined;
+  const config: Record<string, unknown> = {};
+  if (options.languageCodes != null) {
+    config.languageCodes = options.languageCodes;
+  }
+  if (options.customVocabulary != null) {
+    config.customVocabulary = options.customVocabulary;
+  }
+  if (options.wordTimestamp != null) {
+    config.wordTimestamp = options.wordTimestamp;
+  }
+  if (options.diarization != null) {
+    config.diarization = options.diarization;
+  }
+  if (options.mode != null) {
+    config.mode = options.mode;
+  }
+  return Object.keys(config).length > 0 ? config : undefined;
+}
+
+/**
+ * Builds the Interactions API `transcription_config` (snake_case wire) from
+ * provider options; returns undefined when no options are set. Diarization
+ * and word timestamps are expressed inside the `mode` object per
+ * https://ai.google.dev/gemini-api/docs/transcribe.
+ */
+function buildTranscriptionConfig(
+  options: GoogleTranscriptionModelOptions | undefined,
+): Record<string, unknown> | undefined {
+  if (options == null) return undefined;
+  const config: Record<string, unknown> = {};
+  if (options.languageCodes != null) {
+    config.language_codes = options.languageCodes;
+  }
+  if (options.customVocabulary != null) {
+    config.custom_vocabulary = options.customVocabulary;
+  }
+  if (
+    options.mode != null ||
+    options.diarization === true ||
+    options.wordTimestamp === true
+  ) {
+    config.mode = {
+      type: (options.mode ?? 'VERBATIM').toLowerCase(),
+      ...(options.diarization === true ? { diarization_mode: 'speaker' } : {}),
+      ...(options.wordTimestamp === true
+        ? { timestamp_granularities: ['word'] }
+        : {}),
+    };
+  }
+  return Object.keys(config).length > 0 ? config : undefined;
+}
+
+/** Parses a Google duration offset such as `"1s"` or `"9.400s"` to seconds. */
+function parseOffsetSeconds(
+  offset: string | undefined | null,
+): number | undefined {
+  if (offset == null) return undefined;
+  const parsed = Number.parseFloat(offset);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function validateLiveInputAudioFormat(
+  inputAudioFormat: TranscriptionModelV4StreamOptions['inputAudioFormat'],
+) {
+  if (
+    inputAudioFormat.type !== 'audio/pcm' ||
+    (inputAudioFormat.rate != null && inputAudioFormat.rate !== 16000)
+  ) {
+    throw new InvalidArgumentError({
+      argument: 'inputAudioFormat',
+      message:
+        'The Gemini Live transcription API only supports 16kHz 16-bit PCM input audio.',
+    });
+  }
+}
+
+const googleInteractionsWordAnnotationSchema = z.object({
+  type: z.string().nullish(),
+  text: z.string().nullish(),
+  speaker: z.string().nullish(),
+  start_offset: z.string().nullish(),
+  end_offset: z.string().nullish(),
+});
+
+const googleInteractionsTranscriptionResponseSchema = z.object({
+  status: z.string().nullish(),
+  steps: z
+    .array(
+      z.object({
+        type: z.string().nullish(),
+        content: z
+          .array(
+            z.object({
+              type: z.string().nullish(),
+              text: z.string().nullish(),
+              annotations: z
+                .array(googleInteractionsWordAnnotationSchema)
+                .nullish(),
+            }),
+          )
+          .nullish(),
+      }),
+    )
+    .nullish(),
+  usage: z.record(z.string(), z.unknown()).nullish(),
+});


### PR DESCRIPTION
## Background

Google launched Gemini 3.5 Transcribe in GA today (Wed Aug 26, 10:00 AM PT) on both the Developer API and Vertex AI:

- `gemini-3.5-transcribe` — unary speech-to-text: POST a complete audio file → transcript
- `gemini-3.5-transcribe-live` — streaming speech-to-text over the Live API WebSocket (`BidiGenerateContent`): interim partials → final segments

Both support automatic language detection, speaker diarization, word timestamps, custom vocabulary, and the new `mode` option: `VERBATIM` (default, literal transcript) or `SMART` (disfluency removal, inline self-corrections, structured formatting, grammar/casing polish).

## Summary

**`@ai-sdk/google`** — new `GoogleTranscriptionModel` (`google.transcription(...)`):
- `doGenerate`: unary transcription via the documented [Interactions API](https://ai.google.dev/gemini-api/docs/transcribe) (`POST {baseURL}/interactions`) with `{ model, input: [{ type: 'audio', data, mime_type }], generation_config: { transcription_config } }`. Inline base64 audio is accepted (no Files-API leg required — verified empirically; the docs only show `uri`). Provider options map to the snake_case wire: `language_codes`, `custom_vocabulary`, and a `mode` object (`type: 'verbatim' | 'smart'`, `diarization_mode: 'speaker'`, `timestamp_granularities: ['word']`). The response's `steps[].content[].text` becomes the transcript and `word_info` annotations map to timed segments; usage is surfaced as `providerMetadata.google.usage`.
- `doStream`: Developer API Live WebSocket (`?key=` auth). Lifecycle: `setup` → gate audio on `setupComplete` → `realtimeInput.audio` (base64 `audio/pcm;rate=16000`) → `audioStreamEnd` → finish on idle `interactionStatus` / `turnComplete`, with a 3s quiet-grace fallback; a close after audio ended is a graceful finish. Emits `transcript-partial` (revisable interims), `transcript-delta`, `transcript-final`, and `finish` with `usageMetadata` in provider metadata. The Live setup uses the camelCase `inputAudioTranscription` config (`AudioTranscriptionConfig`), unchanged.

**`@ai-sdk/google-vertex`** — new `GoogleVertexGeminiTranscriptionModel`, same surface on Vertex:
- unary via `{baseURL}/models/{id}:generateContent`
- streaming via `wss://{location}-aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent` with OAuth Bearer from the resolved provider headers (new `webSocket` provider setting for runtimes that need header-capable WebSocket constructors, e.g. `ws`)
- `vertex.transcription(...)` dispatches `gemini*` ids to the new model; everything else keeps routing to Cloud Speech-to-Text (Chirp)

Known upstream constraints:
- Live setup: Google's announcement shows `generationConfig: { responseModalities: ['TEXT'] }`, but on the current endpoint that suppresses the final `inputTranscription` segments (only interims arrive). The implementation omits `generationConfig` — the empirically working shape — and keeps an interim-partial fallback so finals can't be empty. Flagged to Google.
- Unary: Google rejects `custom_vocabulary` combined with `timestamp_granularities`, and rejects `timestamp_granularities` under `mode: smart` (word timestamps are verbatim-only). Both are 400s passed through as-is.

## Manual Verification

Verified end-to-end against the GA endpoints (real model slugs): full streaming roundtrips for `gemini-3.5-transcribe-live` in both `VERBATIM` and `SMART` modes (synthesized 16 kHz PCM16 audio and live microphone input), including interim partials, final segments, and usage metadata on finish. Unary `gemini-3.5-transcribe` verified against the Interactions API endpoint with inline base64 audio, including word-timestamp segment extraction and exact token-usage parity (25 audio tokens/s).

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Speaker labels from `word_info` annotations are currently available via raw response body / provider metadata; richer typed diarization output can follow.
