### PR TITLE
[v6.0] feat: support Gemini 3.5 Transcribe on Google and Google Vertex providers

### DIFF
--- a/.changeset/gemini-three-five-transcribe.md
+++ b/.changeset/gemini-three-five-transcribe.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/google': patch
+'@ai-sdk/google-vertex': patch
+---
+
+feat (provider/google, provider/google-vertex): Gemini 3.5 Transcribe support — unary transcription (`gemini-3.5-transcribe`) via generateContent with language detection, speaker diarization, word timestamps, custom vocabulary, and `mode: 'VERBATIM' | 'SMART'` transcription formatting

--- a/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model-options.ts
+++ b/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model-options.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod/v4';
+
+export type GoogleVertexGeminiTranscriptionModelId =
+  | 'gemini-3.5-transcribe'
+  | 'gemini-3.5-transcribe-live'
+  | (string & {});
+
+/**
+ * Speech recognition options for Gemini transcription models
+ * (`gemini-3.5-transcribe`). Maps onto Google's `AudioTranscriptionConfig`.
+ * The live variant (`gemini-3.5-transcribe-live`) requires streaming
+ * transcription, which is only available in AI SDK v7.
+ */
+export const googleVertexGeminiTranscriptionModelOptions = z.object({
+  /**
+   * BCP-47 language codes providing hints about the languages present in the
+   * audio. If omitted or empty, defaults to automatic language detection.
+   */
+  languageCodes: z.array(z.string()).optional(),
+
+  /**
+   * Custom vocabulary phrases, which bias the speech recognition model
+   * toward recognizing specific terms.
+   */
+  customVocabulary: z.array(z.string()).optional(),
+
+  /**
+   * Enables word-level timestamp generation.
+   */
+  wordTimestamp: z.boolean().optional(),
+
+  /**
+   * Enables speaker diarization.
+   */
+  diarization: z.boolean().optional(),
+
+  /**
+   * Transcription output formatting mode.
+   *
+   * - `VERBATIM` (default): exact literal transcript preserving filler
+   *   words, repetitions, and false starts.
+   * - `SMART`: cleans up and structures the transcript in real time —
+   *   disfluency removal, inline self-corrections, structured formatting
+   *   (lists, numbers, dates, paragraph breaks), and grammar/casing polish.
+   */
+  mode: z.enum(['SMART', 'VERBATIM']).optional(),
+});
+
+export type GoogleVertexTranscriptionModelGeminiOptions = z.infer<
+  typeof googleVertexGeminiTranscriptionModelOptions
+>;

--- a/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.test.ts
+++ b/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.test.ts
@@ -132,6 +132,64 @@ describe('doGenerate', () => {
     expect(body.generationConfig).toBeUndefined();
   });
 
+  it('extracts text, language, and word segments from the audioTranscription part', async () => {
+    server.urls[generateContentURL].response = {
+      type: 'json-value',
+      body: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  audioTranscription: {
+                    text: 'The quick brown fox.',
+                    languageCode: 'en-US',
+                    speakerLabel: 'spk:0',
+                    words: [
+                      {
+                        word: 'The',
+                        startOffset: '0.100s',
+                        endOffset: '0.100s',
+                      },
+                      {
+                        word: 'quick',
+                        startOffset: '0.100s',
+                        endOffset: '0.400s',
+                      },
+                      {
+                        word: 'brown',
+                        startOffset: '0.400s',
+                        endOffset: '0.700s',
+                      },
+                      { word: 'fox.', startOffset: '0.700s', endOffset: '1s' },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usageMetadata: { promptTokenCount: 64 },
+      },
+    };
+
+    const model = provider.transcription('gemini-3.5-transcribe');
+    const result = await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {},
+    });
+
+    expect(result.text).toBe('The quick brown fox.');
+    expect(result.language).toBe('en-US');
+    expect(result.segments).toEqual([
+      { text: 'The', startSecond: 0.1, endSecond: 0.1 },
+      { text: 'quick', startSecond: 0.1, endSecond: 0.4 },
+      { text: 'brown', startSecond: 0.4, endSecond: 0.7 },
+      { text: 'fox.', startSecond: 0.7, endSecond: 1 },
+    ]);
+  });
+
   it('rejects unary transcription on live model ids', async () => {
     const model = provider.transcription('gemini-3.5-transcribe-live');
 

--- a/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.test.ts
+++ b/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.test.ts
@@ -1,0 +1,146 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { createVertex } from '../google-vertex-provider';
+import { GoogleVertexGeminiTranscriptionModel } from './google-vertex-gemini-transcription-model';
+
+vi.mock('../version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+const provider = createVertex({
+  project: 'test-project',
+  location: 'us-central1',
+  headers: { authorization: 'Bearer test-token' },
+});
+
+const generateContentURL =
+  'https://us-central1-aiplatform.googleapis.com/v1beta1/projects/test-project/locations/us-central1/publishers/google/models/gemini-3.5-transcribe:generateContent';
+
+describe('provider dispatch', () => {
+  it('routes gemini model ids to the Gemini transcription model', () => {
+    const model = provider.transcription('gemini-3.5-transcribe');
+    expect(model).toBeInstanceOf(GoogleVertexGeminiTranscriptionModel);
+    expect(model.provider).toBe('google.vertex.transcription');
+  });
+});
+
+describe('doGenerate', () => {
+  const server = createTestServer({
+    [generateContentURL]: {
+      response: {
+        type: 'json-value',
+        body: {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: 'Hello ' }, { text: 'world.' }],
+              },
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 10,
+            candidatesTokenCount: 4,
+          },
+        },
+      },
+    },
+  });
+
+  it('transcribes audio via generateContent with audioTranscriptionConfig', async () => {
+    const model = provider.transcription('gemini-3.5-transcribe');
+
+    const result = await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {
+        googleVertex: {
+          customVocabulary: ['Gemini', 'Kubernetes'],
+          languageCodes: ['es-ES'],
+          mode: 'SMART',
+        },
+      },
+    });
+
+    expect(result.text).toBe('Hello world.');
+    expect(await server.calls[0].requestBodyJson).toEqual({
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              inlineData: {
+                mimeType: 'audio/wav',
+                data: 'AQIDBA==',
+              },
+            },
+          ],
+        },
+      ],
+      generationConfig: {
+        audioTranscriptionConfig: {
+          languageCodes: ['es-ES'],
+          customVocabulary: ['Gemini', 'Kubernetes'],
+          mode: 'SMART',
+        },
+      },
+    });
+    expect(server.calls[0].requestHeaders.authorization).toBe(
+      'Bearer test-token',
+    );
+    expect(result.providerMetadata).toEqual({
+      google: {
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 4,
+        },
+      },
+    });
+  });
+
+  it('accepts provider options under the google namespace as a fallback', async () => {
+    const model = provider.transcription('gemini-3.5-transcribe');
+
+    await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {
+        google: { mode: 'VERBATIM' },
+      },
+    });
+
+    const body = (await server.calls[0].requestBodyJson) as {
+      generationConfig?: { audioTranscriptionConfig?: { mode?: string } };
+    };
+    expect(body.generationConfig?.audioTranscriptionConfig?.mode).toBe(
+      'VERBATIM',
+    );
+  });
+
+  it('omits generationConfig when no transcription options are set', async () => {
+    const model = provider.transcription('gemini-3.5-transcribe');
+
+    await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {},
+    });
+
+    const body = (await server.calls[0].requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    expect(body.generationConfig).toBeUndefined();
+  });
+
+  it('rejects unary transcription on live model ids', async () => {
+    const model = provider.transcription('gemini-3.5-transcribe-live');
+
+    await expect(
+      model.doGenerate({
+        audio: new Uint8Array([1]),
+        mediaType: 'audio/wav',
+        providerOptions: {},
+      }),
+    ).rejects.toThrow('only supports streaming transcription');
+  });
+});

--- a/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.ts
+++ b/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.ts
@@ -1,0 +1,199 @@
+import {
+  InvalidArgumentError,
+  type JSONObject,
+  type SharedV3Warning,
+  type TranscriptionModelV3,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertToBase64,
+  createJsonResponseHandler,
+  parseProviderOptions,
+  postJsonToApi,
+  resolve,
+  type FetchFunction,
+  type Resolvable,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { googleVertexFailedResponseHandler } from '../google-vertex-error';
+import {
+  googleVertexGeminiTranscriptionModelOptions,
+  type GoogleVertexGeminiTranscriptionModelId,
+  type GoogleVertexTranscriptionModelGeminiOptions,
+} from './google-vertex-gemini-transcription-model-options';
+
+/**
+ * Live transcription (`*-live` model variants) requires streaming support,
+ * which is only available in AI SDK v7 (transcription specification v4).
+ */
+function isLiveTranscriptionModelId(modelId: string): boolean {
+  return modelId.includes('-live');
+}
+
+interface GoogleVertexGeminiTranscriptionModelConfig {
+  provider: string;
+  /** Regional base URL ending in `/publishers/google`. */
+  baseURL: string;
+  headers?: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+/**
+ * Gemini transcription on Vertex AI (e.g. `gemini-3.5-transcribe`) via
+ * `generateContent` with `generationConfig.audioTranscriptionConfig`.
+ */
+export class GoogleVertexGeminiTranscriptionModel implements TranscriptionModelV3 {
+  readonly specificationVersion = 'v3';
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: GoogleVertexGeminiTranscriptionModelId,
+    private readonly config: GoogleVertexGeminiTranscriptionModelConfig,
+  ) {}
+
+  private async parseOptions(
+    providerOptions: Record<string, unknown> | undefined,
+  ): Promise<GoogleVertexTranscriptionModelGeminiOptions | undefined> {
+    // The Vertex provider exposes options under `googleVertex`/`vertex`;
+    // accept `google` as a cross-namespace fallback (e.g. via the AI Gateway).
+    for (const provider of ['googleVertex', 'vertex', 'google'] as const) {
+      const parsed = await parseProviderOptions({
+        provider,
+        providerOptions,
+        schema: googleVertexGeminiTranscriptionModelOptions,
+      });
+      if (parsed != null) return parsed;
+    }
+    return undefined;
+  }
+
+  async doGenerate(
+    options: Parameters<TranscriptionModelV3['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<TranscriptionModelV3['doGenerate']>>> {
+    if (isLiveTranscriptionModelId(this.modelId)) {
+      throw new InvalidArgumentError({
+        argument: 'modelId',
+        message:
+          `Model '${this.modelId}' only supports streaming transcription, ` +
+          `which requires AI SDK v7. Use a unary model such as 'gemini-3.5-transcribe'.`,
+      });
+    }
+
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const warnings: SharedV3Warning[] = [];
+    const googleOptions = await this.parseOptions(options.providerOptions);
+    const audioTranscriptionConfig =
+      buildAudioTranscriptionConfig(googleOptions);
+
+    const requestBody = {
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              inlineData: {
+                mimeType: options.mediaType,
+                data: convertToBase64(options.audio),
+              },
+            },
+          ],
+        },
+      ],
+      ...(audioTranscriptionConfig != null
+        ? { generationConfig: { audioTranscriptionConfig } }
+        : {}),
+    };
+
+    const {
+      value: response,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url: `${this.config.baseURL}/models/${this.modelId}:generateContent`,
+      headers: combineHeaders(
+        this.config.headers ? await resolve(this.config.headers) : undefined,
+        options.headers,
+      ),
+      body: requestBody,
+      failedResponseHandler: googleVertexFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        googleVertexGeminiTranscriptionResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const text = (response.candidates?.[0]?.content?.parts ?? [])
+      .map(part => part.text ?? '')
+      .join('');
+
+    return {
+      text,
+      segments: [],
+      language: undefined,
+      durationInSeconds: undefined,
+      warnings,
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+      ...(response.usageMetadata != null
+        ? {
+            providerMetadata: {
+              google: { usageMetadata: response.usageMetadata as JSONObject },
+            },
+          }
+        : {}),
+    };
+  }
+}
+
+/**
+ * Builds Google's `AudioTranscriptionConfig` from provider options; returns
+ * undefined when no options are set.
+ */
+function buildAudioTranscriptionConfig(
+  options: GoogleVertexTranscriptionModelGeminiOptions | undefined,
+): Record<string, unknown> | undefined {
+  if (options == null) return undefined;
+  const config: Record<string, unknown> = {};
+  if (options.languageCodes != null) {
+    config.languageCodes = options.languageCodes;
+  }
+  if (options.customVocabulary != null) {
+    config.customVocabulary = options.customVocabulary;
+  }
+  if (options.wordTimestamp != null) {
+    config.wordTimestamp = options.wordTimestamp;
+  }
+  if (options.diarization != null) {
+    config.diarization = options.diarization;
+  }
+  if (options.mode != null) {
+    config.mode = options.mode;
+  }
+  return Object.keys(config).length > 0 ? config : undefined;
+}
+
+const googleVertexGeminiTranscriptionResponseSchema = z.object({
+  candidates: z
+    .array(
+      z.object({
+        content: z
+          .object({
+            parts: z.array(z.object({ text: z.string().nullish() })).nullish(),
+          })
+          .nullish(),
+      }),
+    )
+    .nullish(),
+  usageMetadata: z.record(z.string(), z.unknown()).nullish(),
+});

--- a/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.ts
+++ b/packages/google-vertex/src/gemini-transcription/google-vertex-gemini-transcription-model.ts
@@ -129,14 +129,37 @@ export class GoogleVertexGeminiTranscriptionModel implements TranscriptionModelV
       fetch: this.config.fetch,
     });
 
-    const text = (response.candidates?.[0]?.content?.parts ?? [])
-      .map(part => part.text ?? '')
+    const parts = response.candidates?.[0]?.content?.parts ?? [];
+    const plainText = parts.map(part => part.text ?? '').join('');
+    const transcriptionText = parts
+      .map(part => part.audioTranscription?.text ?? '')
       .join('');
+    const text = plainText !== '' ? plainText : transcriptionText;
+
+    let language: string | undefined;
+    const segments: Array<{
+      text: string;
+      startSecond: number;
+      endSecond: number;
+    }> = [];
+    for (const part of parts) {
+      const transcription = part.audioTranscription;
+      if (transcription == null) continue;
+      language ??= transcription.languageCode ?? undefined;
+      for (const word of transcription.words ?? []) {
+        const startSecond = parseOffsetSeconds(word.startOffset);
+        const endSecond = parseOffsetSeconds(word.endOffset);
+        if (word.word == null || startSecond == null || endSecond == null) {
+          continue;
+        }
+        segments.push({ text: word.word, startSecond, endSecond });
+      }
+    }
 
     return {
       text,
-      segments: [],
-      language: undefined,
+      segments,
+      language,
       durationInSeconds: undefined,
       warnings,
       response: {
@@ -183,13 +206,44 @@ function buildAudioTranscriptionConfig(
   return Object.keys(config).length > 0 ? config : undefined;
 }
 
+/** Parses a Google duration offset such as `"1s"` or `"9.400s"` to seconds. */
+function parseOffsetSeconds(
+  offset: string | undefined | null,
+): number | undefined {
+  if (offset == null) return undefined;
+  const parsed = Number.parseFloat(offset);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+const googleVertexGeminiTranscriptionWordSchema = z.object({
+  word: z.string().nullish(),
+  startOffset: z.string().nullish(),
+  endOffset: z.string().nullish(),
+});
+
 const googleVertexGeminiTranscriptionResponseSchema = z.object({
   candidates: z
     .array(
       z.object({
         content: z
           .object({
-            parts: z.array(z.object({ text: z.string().nullish() })).nullish(),
+            parts: z
+              .array(
+                z.object({
+                  text: z.string().nullish(),
+                  audioTranscription: z
+                    .object({
+                      text: z.string().nullish(),
+                      languageCode: z.string().nullish(),
+                      speakerLabel: z.string().nullish(),
+                      words: z
+                        .array(googleVertexGeminiTranscriptionWordSchema)
+                        .nullish(),
+                    })
+                    .nullish(),
+                }),
+              )
+              .nullish(),
           })
           .nullish(),
       }),

--- a/packages/google-vertex/src/google-vertex-provider.ts
+++ b/packages/google-vertex/src/google-vertex-provider.ts
@@ -33,6 +33,7 @@ import type { GoogleVertexModelId } from './google-vertex-options';
 import { googleVertexTools } from './google-vertex-tools';
 import { GoogleVertexTranscriptionModel } from './google-vertex-transcription-model';
 import type { GoogleVertexTranscriptionModelId } from './google-vertex-transcription-model-options';
+import { GoogleVertexGeminiTranscriptionModel } from './gemini-transcription/google-vertex-gemini-transcription-model';
 import { GoogleVertexVideoModel } from './google-vertex-video-model';
 import type { GoogleVertexVideoModelId } from './google-vertex-video-settings';
 
@@ -305,6 +306,19 @@ export function createVertex(
     }
 
     const config = createConfig('transcription');
+
+    // Gemini transcription models (`gemini-3.5-transcribe`) use the Vertex
+    // generateContent surface; everything else routes to Cloud
+    // Speech-to-Text (Chirp, telephony).
+    if (modelId.startsWith('gemini')) {
+      return new GoogleVertexGeminiTranscriptionModel(modelId, {
+        provider: config.provider,
+        baseURL: loadBaseURL(),
+        headers: config.headers,
+        fetch: config.fetch,
+      });
+    }
+
     return new GoogleVertexTranscriptionModel(modelId, {
       provider: config.provider,
       headers: config.headers,

--- a/packages/google-vertex/src/index.ts
+++ b/packages/google-vertex/src/index.ts
@@ -14,6 +14,11 @@ export type {
   GoogleVertexVideoModelOptions as GoogleVertexVideoProviderOptions,
 } from './google-vertex-video-model';
 export type { GoogleVertexVideoModelId } from './google-vertex-video-settings';
+export { GoogleVertexGeminiTranscriptionModel } from './gemini-transcription/google-vertex-gemini-transcription-model';
+export type {
+  GoogleVertexGeminiTranscriptionModelId,
+  GoogleVertexTranscriptionModelGeminiOptions,
+} from './gemini-transcription/google-vertex-gemini-transcription-model-options';
 export { createVertex, vertex } from './google-vertex-provider-node';
 export type {
   GoogleVertexProvider,

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -4,6 +4,7 @@ import type {
   ImageModelV3,
   LanguageModelV3,
   ProviderV3,
+  TranscriptionModelV3,
 } from '@ai-sdk/provider';
 import {
   generateId,
@@ -32,6 +33,8 @@ import {
 } from './interactions/google-interactions-language-model';
 import type { GoogleInteractionsModelId } from './interactions/google-interactions-language-model-options';
 import type { GoogleInteractionsAgentName } from './interactions/google-interactions-agent';
+import { GoogleTranscriptionModel } from './transcription/google-transcription-model';
+import type { GoogleTranscriptionModelId } from './transcription/google-transcription-model-options';
 
 export interface GoogleGenerativeAIProvider extends ProviderV3 {
   (modelId: GoogleGenerativeAIModelId): LanguageModelV3;
@@ -74,6 +77,17 @@ export interface GoogleGenerativeAIProvider extends ProviderV3 {
   textEmbeddingModel(
     modelId: GoogleGenerativeAIEmbeddingModelId,
   ): EmbeddingModelV3;
+
+  /**
+   * Creates a model for transcription (speech-to-text), e.g.
+   * `gemini-3.5-transcribe`.
+   */
+  transcription(modelId: GoogleTranscriptionModelId): TranscriptionModelV3;
+
+  /**
+   * Creates a model for transcription (speech-to-text).
+   */
+  transcriptionModel(modelId: GoogleTranscriptionModelId): TranscriptionModelV3;
 
   /**
    * Creates a model for video generation.
@@ -245,6 +259,14 @@ export function createGoogleGenerativeAI(
       fetch: options.fetch,
     });
 
+  const createTranscriptionModel = (modelId: GoogleTranscriptionModelId) =>
+    new GoogleTranscriptionModel(modelId, {
+      provider: `${providerName}.transcription`,
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
   const createVideoModel = (modelId: GoogleGenerativeAIVideoModelId) =>
     new GoogleGenerativeAIVideoModel(modelId, {
       provider: providerName,
@@ -291,6 +313,8 @@ export function createGoogleGenerativeAI(
   provider.textEmbeddingModel = createEmbeddingModel;
   provider.image = createImageModel;
   provider.imageModel = createImageModel;
+  provider.transcription = createTranscriptionModel;
+  provider.transcriptionModel = createTranscriptionModel;
   provider.video = createVideoModel;
   provider.videoModel = createVideoModel;
   provider.interactions = createInteractionsModel;

--- a/packages/google/src/index.ts
+++ b/packages/google/src/index.ts
@@ -27,6 +27,11 @@ export type {
 } from './interactions/google-interactions-language-model-options';
 export type { GoogleInteractionsProviderMetadata } from './interactions/google-interactions-provider-metadata';
 export type { GoogleInteractionsAgentName } from './interactions/google-interactions-agent';
+export { GoogleTranscriptionModel } from './transcription/google-transcription-model';
+export type {
+  GoogleTranscriptionModelId,
+  GoogleTranscriptionModelOptions,
+} from './transcription/google-transcription-model-options';
 export { createGoogleGenerativeAI, google } from './google-provider';
 export type {
   GoogleGenerativeAIProvider,

--- a/packages/google/src/transcription/google-transcription-model-options.ts
+++ b/packages/google/src/transcription/google-transcription-model-options.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod/v4';
+
+export type GoogleTranscriptionModelId =
+  | 'gemini-3.5-transcribe'
+  | 'gemini-3.5-transcribe-live'
+  | (string & {});
+
+/**
+ * Speech recognition options for Gemini transcription models
+ * (`gemini-3.5-transcribe`). Maps onto Google's `AudioTranscriptionConfig`.
+ * The live variant (`gemini-3.5-transcribe-live`) requires streaming
+ * transcription, which is only available in AI SDK v7.
+ */
+export const googleTranscriptionModelOptions = z.object({
+  /**
+   * BCP-47 language codes providing hints about the languages present in the
+   * audio. If omitted or empty, defaults to automatic language detection.
+   */
+  languageCodes: z.array(z.string()).optional(),
+
+  /**
+   * Custom vocabulary phrases, which bias the speech recognition model
+   * toward recognizing specific terms.
+   */
+  customVocabulary: z.array(z.string()).optional(),
+
+  /**
+   * Enables word-level timestamp generation.
+   */
+  wordTimestamp: z.boolean().optional(),
+
+  /**
+   * Enables speaker diarization.
+   */
+  diarization: z.boolean().optional(),
+
+  /**
+   * Transcription output formatting mode.
+   *
+   * - `VERBATIM` (default): exact literal transcript preserving filler
+   *   words, repetitions, and false starts.
+   * - `SMART`: cleans up and structures the transcript in real time —
+   *   disfluency removal, inline self-corrections, structured formatting
+   *   (lists, numbers, dates, paragraph breaks), and grammar/casing polish.
+   */
+  mode: z.enum(['SMART', 'VERBATIM']).optional(),
+});
+
+export type GoogleTranscriptionModelOptions = z.infer<
+  typeof googleTranscriptionModelOptions
+>;

--- a/packages/google/src/transcription/google-transcription-model.test.ts
+++ b/packages/google/src/transcription/google-transcription-model.test.ts
@@ -1,0 +1,196 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it } from 'vitest';
+import { GoogleTranscriptionModel } from './google-transcription-model';
+
+function createModel(modelId = 'gemini-3.5-transcribe') {
+  return new GoogleTranscriptionModel(modelId, {
+    provider: 'test-provider',
+    baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+    headers: () => ({ 'x-goog-api-key': 'test-api-key' }),
+  });
+}
+
+describe('doGenerate', () => {
+  const server = createTestServer({
+    'https://generativelanguage.googleapis.com/v1beta/interactions': {
+      response: {
+        type: 'json-value',
+        body: {
+          id: 'interactions/test',
+          status: 'completed',
+          steps: [
+            {
+              type: 'model_output',
+              content: [{ type: 'text', text: 'Hello world.' }],
+            },
+          ],
+          usage: {
+            total_tokens: 10,
+            total_input_tokens: 10,
+            total_output_tokens: 0,
+          },
+        },
+      },
+    },
+  });
+
+  it('transcribes audio via the Interactions API with transcription_config', async () => {
+    const model = createModel('gemini-3.5-transcribe');
+
+    const result = await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {
+        google: {
+          customVocabulary: ['Gemini', 'Kubernetes'],
+          languageCodes: ['es-ES'],
+          mode: 'SMART',
+        },
+      },
+    });
+
+    expect(result.text).toBe('Hello world.');
+    expect(await server.calls[0].requestBodyJson).toEqual({
+      model: 'gemini-3.5-transcribe',
+      input: [
+        {
+          type: 'audio',
+          data: 'AQIDBA==',
+          mime_type: 'audio/wav',
+        },
+      ],
+      generation_config: {
+        transcription_config: {
+          language_codes: ['es-ES'],
+          custom_vocabulary: ['Gemini', 'Kubernetes'],
+          mode: { type: 'smart' },
+        },
+      },
+    });
+    expect(server.calls[0].requestHeaders['x-goog-api-key']).toBe(
+      'test-api-key',
+    );
+    expect(result.providerMetadata).toEqual({
+      google: {
+        usage: {
+          total_tokens: 10,
+          total_input_tokens: 10,
+          total_output_tokens: 0,
+        },
+      },
+    });
+  });
+
+  it('maps diarization and word timestamps into the mode object', async () => {
+    const model = createModel('gemini-3.5-transcribe');
+
+    await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {
+        google: { diarization: true, wordTimestamp: true },
+      },
+    });
+
+    const body = (await server.calls[0].requestBodyJson) as {
+      generation_config?: { transcription_config?: unknown };
+    };
+    expect(body.generation_config?.transcription_config).toEqual({
+      mode: {
+        type: 'verbatim',
+        diarization_mode: 'speaker',
+        timestamp_granularities: ['word'],
+      },
+    });
+  });
+
+  it('omits generation_config when no transcription options are set', async () => {
+    const model = createModel('gemini-3.5-transcribe');
+
+    await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {},
+    });
+
+    const body = (await server.calls[0].requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    expect(body.generation_config).toBeUndefined();
+  });
+
+  it('extracts word segments from word_info annotations', async () => {
+    server.urls[
+      'https://generativelanguage.googleapis.com/v1beta/interactions'
+    ].response = {
+      type: 'json-value',
+      body: {
+        id: 'interactions/test',
+        status: 'completed',
+        steps: [
+          {
+            type: 'model_output',
+            content: [
+              {
+                type: 'text',
+                text: 'The quick fox.',
+                annotations: [
+                  {
+                    type: 'word_info',
+                    text: 'The',
+                    speaker: 'spk:0',
+                    start_offset: '0.100s',
+                    end_offset: '0.300s',
+                  },
+                  {
+                    type: 'word_info',
+                    text: 'quick',
+                    speaker: 'spk:0',
+                    start_offset: '0.300s',
+                    end_offset: '0.600s',
+                  },
+                  {
+                    type: 'word_info',
+                    text: 'fox.',
+                    speaker: 'spk:0',
+                    start_offset: '0.600s',
+                    end_offset: '0.900s',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const model = createModel('gemini-3.5-transcribe');
+    const result = await model.doGenerate({
+      audio: new Uint8Array([1, 2, 3, 4]),
+      mediaType: 'audio/wav',
+      providerOptions: {
+        google: { wordTimestamp: true },
+      },
+    });
+
+    expect(result.text).toBe('The quick fox.');
+    expect(result.segments).toEqual([
+      { text: 'The', startSecond: 0.1, endSecond: 0.3 },
+      { text: 'quick', startSecond: 0.3, endSecond: 0.6 },
+      { text: 'fox.', startSecond: 0.6, endSecond: 0.9 },
+    ]);
+  });
+
+  it('rejects unary transcription on live model ids', async () => {
+    const model = createModel('gemini-3.5-transcribe-live');
+
+    await expect(
+      model.doGenerate({
+        audio: new Uint8Array([1]),
+        mediaType: 'audio/wav',
+        providerOptions: {},
+      }),
+    ).rejects.toThrow('only supports streaming transcription');
+  });
+});

--- a/packages/google/src/transcription/google-transcription-model.ts
+++ b/packages/google/src/transcription/google-transcription-model.ts
@@ -1,0 +1,243 @@
+import {
+  InvalidArgumentError,
+  type JSONObject,
+  type SharedV3Warning,
+  type TranscriptionModelV3,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertToBase64,
+  createJsonResponseHandler,
+  parseProviderOptions,
+  postJsonToApi,
+  resolve,
+  type FetchFunction,
+  type Resolvable,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import { googleFailedResponseHandler } from '../google-error';
+import {
+  googleTranscriptionModelOptions,
+  type GoogleTranscriptionModelId,
+  type GoogleTranscriptionModelOptions,
+} from './google-transcription-model-options';
+
+/**
+ * Live transcription (`*-live` model variants) requires streaming support,
+ * which is only available in AI SDK v7 (transcription specification v4).
+ */
+function isLiveTranscriptionModelId(modelId: string): boolean {
+  return modelId.includes('-live');
+}
+
+interface GoogleTranscriptionModelConfig {
+  provider: string;
+  baseURL: string;
+  headers?: Resolvable<Record<string, string | undefined>>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+}
+
+/**
+ * Gemini transcription (speech-to-text) via the Interactions API
+ * (e.g. `gemini-3.5-transcribe`).
+ *
+ * @see https://ai.google.dev/gemini-api/docs/transcribe
+ */
+export class GoogleTranscriptionModel implements TranscriptionModelV3 {
+  readonly specificationVersion = 'v3';
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: GoogleTranscriptionModelId,
+    private readonly config: GoogleTranscriptionModelConfig,
+  ) {}
+
+  private async parseOptions(
+    providerOptions: Record<string, unknown> | undefined,
+  ): Promise<GoogleTranscriptionModelOptions | undefined> {
+    return parseProviderOptions({
+      provider: 'google',
+      providerOptions,
+      schema: googleTranscriptionModelOptions,
+    });
+  }
+
+  async doGenerate(
+    options: Parameters<TranscriptionModelV3['doGenerate']>[0],
+  ): Promise<Awaited<ReturnType<TranscriptionModelV3['doGenerate']>>> {
+    if (isLiveTranscriptionModelId(this.modelId)) {
+      throw new InvalidArgumentError({
+        argument: 'modelId',
+        message:
+          `Model '${this.modelId}' only supports streaming transcription, ` +
+          `which requires AI SDK v7. Use a unary model such as 'gemini-3.5-transcribe'.`,
+      });
+    }
+
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const warnings: SharedV3Warning[] = [];
+    const googleOptions = await this.parseOptions(options.providerOptions);
+    const transcriptionConfig = buildTranscriptionConfig(googleOptions);
+
+    // Unary transcription is served by the Interactions API
+    // (https://ai.google.dev/gemini-api/docs/transcribe).
+    const requestBody = {
+      model: this.modelId,
+      input: [
+        {
+          type: 'audio',
+          data: convertToBase64(options.audio),
+          mime_type: options.mediaType,
+        },
+      ],
+      ...(transcriptionConfig != null
+        ? { generation_config: { transcription_config: transcriptionConfig } }
+        : {}),
+    };
+
+    const {
+      value: response,
+      responseHeaders,
+      rawValue: rawResponse,
+    } = await postJsonToApi({
+      url: `${this.config.baseURL}/interactions`,
+      headers: combineHeaders(
+        this.config.headers ? await resolve(this.config.headers) : undefined,
+        options.headers,
+      ),
+      body: requestBody,
+      failedResponseHandler: googleFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        googleInteractionsTranscriptionResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    let text = '';
+    const segments: Array<{
+      text: string;
+      startSecond: number;
+      endSecond: number;
+    }> = [];
+    for (const step of response.steps ?? []) {
+      for (const content of step.content ?? []) {
+        if (content.type !== 'text' || content.text == null) continue;
+        text += content.text;
+        for (const annotation of content.annotations ?? []) {
+          if (annotation.type !== 'word_info') continue;
+          const startSecond = parseOffsetSeconds(annotation.start_offset);
+          const endSecond = parseOffsetSeconds(annotation.end_offset);
+          if (
+            annotation.text == null ||
+            startSecond == null ||
+            endSecond == null
+          ) {
+            continue;
+          }
+          segments.push({ text: annotation.text, startSecond, endSecond });
+        }
+      }
+    }
+
+    return {
+      text,
+      segments,
+      language: undefined,
+      durationInSeconds: undefined,
+      warnings,
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+        body: rawResponse,
+      },
+      ...(response.usage != null
+        ? {
+            providerMetadata: {
+              google: { usage: response.usage as JSONObject },
+            },
+          }
+        : {}),
+    };
+  }
+}
+
+/**
+ * Builds the Interactions API `transcription_config` (snake_case wire) from
+ * provider options; returns undefined when no options are set. Diarization
+ * and word timestamps are expressed inside the `mode` object per
+ * https://ai.google.dev/gemini-api/docs/transcribe.
+ */
+function buildTranscriptionConfig(
+  options: GoogleTranscriptionModelOptions | undefined,
+): Record<string, unknown> | undefined {
+  if (options == null) return undefined;
+  const config: Record<string, unknown> = {};
+  if (options.languageCodes != null) {
+    config.language_codes = options.languageCodes;
+  }
+  if (options.customVocabulary != null) {
+    config.custom_vocabulary = options.customVocabulary;
+  }
+  if (
+    options.mode != null ||
+    options.diarization === true ||
+    options.wordTimestamp === true
+  ) {
+    config.mode = {
+      type: (options.mode ?? 'VERBATIM').toLowerCase(),
+      ...(options.diarization === true ? { diarization_mode: 'speaker' } : {}),
+      ...(options.wordTimestamp === true
+        ? { timestamp_granularities: ['word'] }
+        : {}),
+    };
+  }
+  return Object.keys(config).length > 0 ? config : undefined;
+}
+
+/** Parses a Google duration offset such as `"1s"` or `"9.400s"` to seconds. */
+function parseOffsetSeconds(
+  offset: string | undefined | null,
+): number | undefined {
+  if (offset == null) return undefined;
+  const parsed = Number.parseFloat(offset);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+const googleInteractionsWordAnnotationSchema = z.object({
+  type: z.string().nullish(),
+  text: z.string().nullish(),
+  speaker: z.string().nullish(),
+  start_offset: z.string().nullish(),
+  end_offset: z.string().nullish(),
+});
+
+const googleInteractionsTranscriptionResponseSchema = z.object({
+  status: z.string().nullish(),
+  steps: z
+    .array(
+      z.object({
+        type: z.string().nullish(),
+        content: z
+          .array(
+            z.object({
+              type: z.string().nullish(),
+              text: z.string().nullish(),
+              annotations: z
+                .array(googleInteractionsWordAnnotationSchema)
+                .nullish(),
+            }),
+          )
+          .nullish(),
+      }),
+    )
+    .nullish(),
+  usage: z.record(z.string(), z.unknown()).nullish(),
+});


### PR DESCRIPTION
## Background

Google launched Gemini 3.5 Transcribe in GA today (Wed Aug 26, 10:00 AM PT). This is the v6 port of #19723: unary transcription only, since streaming transcription (`doStream`) is part of transcription specification v4 and is not available in spec v3 on this release line.

## Summary

**`@ai-sdk/google`** — new `GoogleTranscriptionModel` (`google.transcription(...)`), implementing `TranscriptionModelV3`:
- `doGenerate` for `gemini-3.5-transcribe` via the documented [Interactions API](https://ai.google.dev/gemini-api/docs/transcribe) (`POST {baseURL}/interactions`) with `{ model, input: [{ type: 'audio', data, mime_type }], generation_config: { transcription_config } }`; inline base64 audio is accepted (no Files-API leg required)
- Provider options map to the snake_case wire: `language_codes`, `custom_vocabulary`, and a `mode` object (`type: 'verbatim' | 'smart'`, `diarization_mode: 'speaker'`, `timestamp_granularities: ['word']`)
- The response's `steps[].content[].text` becomes the transcript; `word_info` annotations map to timed `segments`; usage is surfaced as `providerMetadata.google.usage`
- `*-live` model ids reject with a clear error pointing at AI SDK v7 for streaming

**`@ai-sdk/google-vertex`** — new `GoogleVertexGeminiTranscriptionModel`, same unary surface on Vertex via `{baseURL}/models/{id}:generateContent`: `vertex.transcription(...)` dispatches `gemini*` ids to it; everything else keeps routing to Cloud Speech-to-Text (Chirp). Provider options accepted under `googleVertex`/`vertex` with a `google` cross-namespace fallback.

Known upstream constraints: Google rejects `custom_vocabulary` combined with `timestamp_granularities`, and rejects `timestamp_granularities` under `mode: smart` (word timestamps are verbatim-only). Both are 400s passed through as-is.

## Manual Verification

The identical Interactions request/response shape was verified end-to-end on main (#19723) against the GA endpoint with inline base64 audio, including word-timestamp segment extraction and exact token-usage parity (25 audio tokens/s); this port is covered by unit tests mirroring the verified wire format.

## Checklist

- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Port of #19723 to `release-v6.0`.
