### PR TITLE
[v6.0] feat(provider/zai,gateway): add GLM-5.3-Flash model support

### DIFF
--- a/.changeset/swift-pandas-flash.md
+++ b/.changeset/swift-pandas-flash.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/gateway': patch
+'@ai-sdk/zai': patch
+---
+
+Backport: Add GLM-5.3-Flash model support to the Z.AI provider and AI Gateway.

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -232,5 +232,6 @@ export type GatewayModelId =
   | 'zai/glm-5.2'
   | 'zai/glm-5.2-fast'
   | 'zai/glm-5.3'
+  | 'zai/glm-5.3-flash'
   | 'zai/glm-5v-turbo'
   | (string & {});

--- a/packages/zai/src/zai-chat-options.ts
+++ b/packages/zai/src/zai-chat-options.ts
@@ -1,6 +1,6 @@
 /**
  * Z.AI chat model ids from the official OpenAPI 1.0.0 specification,
- * retrieved from https://docs.z.ai/openapi.json on 2026-08-25.
+ * retrieved from https://docs.z.ai/openapi.json on 2026-08-26.
  */
 export type ZaiChatModelId =
   | 'glm-5.3'
@@ -18,6 +18,7 @@ export type ZaiChatModelId =
   | 'glm-4.5-airx'
   | 'glm-4.5-flash'
   | 'glm-4-32b-0414-128k'
+  | 'glm-5.3-flash'
   | 'glm-5v-turbo'
   | 'glm-4.6v'
   | 'glm-4.6v-flash'


### PR DESCRIPTION
## Summary

Backport of #19701.

- add GLM-5.3-Flash to the Z.AI provider model IDs
- add zai/glm-5.3-flash to the AI Gateway model IDs
- add patch changesets for @ai-sdk/zai and @ai-sdk/gateway

## Verification

- pnpm --filter @ai-sdk/zai... --filter @ai-sdk/gateway... build
- pnpm --filter @ai-sdk/zai test
- pnpm --filter @ai-sdk/gateway test
- node_modules/.bin/tsc --build tsconfig.with-examples.json
- pnpm exec ultracite check
- git diff --check