### PR TITLE
docs: fix provider model capabilities

### DIFF
--- a/content/providers/01-ai-sdk-providers/index.mdx
+++ b/content/providers/01-ai-sdk-providers/index.mdx
@@ -88,13 +88,13 @@ Not all providers support all AI SDK features. Here's a quick comparison of the 
 | [Together AI](/providers/ai-sdk-providers/togetherai)      | `mistralai/Mixtral-8x22B-Instruct-v0.1`             | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Fireworks](/providers/ai-sdk-providers/fireworks)         | `accounts/fireworks/models/deepseek-r1`             | <Cross />   | <Cross />         | <Cross />  | <Cross />      |
 | [Fireworks](/providers/ai-sdk-providers/fireworks)         | `accounts/fireworks/models/deepseek-v3`             | <Cross />   | <Check />         | <Check />  | <Cross />      |
-| [Fireworks](/providers/ai-sdk-providers/fireworks)         | `accounts/fireworks/models/llama-v3p3-70b-instruct` | <Cross />   | <Check />         | <Check />  | <Check />      |
-| [Fireworks](/providers/ai-sdk-providers/fireworks)         | `accounts/fireworks/models/qwen2-vl-72b-instruct`   | <Check />   | <Cross />         | <Cross />  | <Cross />      |
+| [Fireworks](/providers/ai-sdk-providers/fireworks)         | `accounts/fireworks/models/llama-v3p3-70b-instruct` | <Cross />   | <Check />         | <Check />  | <Cross />      |
+| [Fireworks](/providers/ai-sdk-providers/fireworks)         | `accounts/fireworks/models/qwen2-vl-72b-instruct`   | <Check />   | <Check />         | <Cross />  | <Cross />      |
 | [Alibaba](/providers/ai-sdk-providers/alibaba)             | `qwen3-max`                                         | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [Alibaba](/providers/ai-sdk-providers/alibaba)             | `qwen-plus`                                         | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [DeepInfra](/providers/ai-sdk-providers/deepinfra)         | `meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8` | <Check />   | <Cross />         | <Cross />  | <Cross />      |
 | [DeepInfra](/providers/ai-sdk-providers/deepinfra)         | `meta-llama/Llama-4-Scout-17B-16E-Instruct`         | <Check />   | <Cross />         | <Cross />  | <Cross />      |
-| [DeepInfra](/providers/ai-sdk-providers/deepinfra)         | `meta-llama/Llama-3.3-70B-Instruct`                 | <Cross />   | <Check />         | <Check />  | <Cross />      |
+| [DeepInfra](/providers/ai-sdk-providers/deepinfra)         | `meta-llama/Llama-3.3-70B-Instruct`                 | <Cross />   | <Check />         | <Check />  | <Check />      |
 | [DeepInfra](/providers/ai-sdk-providers/deepinfra)         | `deepseek-ai/DeepSeek-V3`                           | <Cross />   | <Cross />         | <Cross />  | <Cross />      |
 | [DeepInfra](/providers/ai-sdk-providers/deepinfra)         | `deepseek-ai/DeepSeek-R1`                           | <Cross />   | <Cross />         | <Cross />  | <Cross />      |
 | [DeepInfra](/providers/ai-sdk-providers/deepinfra)         | `Qwen/QwQ-32B`                                      | <Cross />   | <Check />         | <Check />  | <Cross />      |


### PR DESCRIPTION
## Summary

- mark tool streaming as supported for DeepInfra Llama 3.3 70B Instruct, based on the [DeepInfra tool calling documentation](https://docs.deepinfra.com/chat/tool-calling)
- mark tool streaming as unsupported for Fireworks Llama 3.3 70B Instruct, based on the [Fireworks model page](https://fireworks.ai/models/fireworks/llama-v3p3-70b-instruct)
- mark object generation as supported for Fireworks Qwen2-VL 72B Instruct, based on the [Fireworks structured outputs documentation](https://docs.fireworks.ai/structured-responses/structured-response-formatting)

The values now match the current provider pages and provider documentation.