### PR TITLE
fix(provider/moonshotai): preserve API error metadata

### DIFF
--- a/.changeset/clean-kimis-errors.md
+++ b/.changeset/clean-kimis-errors.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+fix(provider/moonshotai): preserve structured API error metadata

--- a/packages/moonshotai/src/__fixtures__/moonshotai-error-message-only.json
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-error-message-only.json
@@ -1,0 +1,5 @@
+{
+  "error": {
+    "message": "Request failed"
+  }
+}

--- a/packages/moonshotai/src/__fixtures__/moonshotai-error-null-code.json
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-error-null-code.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "message": "Request failed with a nullable code",
+    "type": "invalid_request_error",
+    "code": null
+  }
+}

--- a/packages/moonshotai/src/__fixtures__/moonshotai-error.json
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "message": "Invalid request: invalid part type: file",
+    "type": "invalid_request_error",
+    "code": "invalid_part_type"
+  }
+}

--- a/packages/moonshotai/src/__fixtures__/moonshotai-stream-error-message-only.chunks.txt
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-stream-error-message-only.chunks.txt
@@ -1,0 +1,1 @@
+{"error":{"message":"Stream failed without details"}}

--- a/packages/moonshotai/src/__fixtures__/moonshotai-stream-error-null-code.chunks.txt
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-stream-error-null-code.chunks.txt
@@ -1,0 +1,1 @@
+{"error":{"message":"Stream failed with a nullable code","type":"server_error","code":null}}

--- a/packages/moonshotai/src/__fixtures__/moonshotai-stream-error.chunks.txt
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-stream-error.chunks.txt
@@ -1,0 +1,2 @@
+{"id":"chatcmpl-stream-error","object":"chat.completion.chunk","created":1785880003,"model":"kimi-k3","choices":[{"index":0,"delta":{"role":"assistant","content":"Partial"},"finish_reason":null}]}
+{"error":{"message":"Stream failed","type":"server_error","code":"stream_failure"}}

--- a/packages/moonshotai/src/moonshotai-chat-api-types.ts
+++ b/packages/moonshotai/src/moonshotai-chat-api-types.ts
@@ -108,6 +108,7 @@ export const moonshotAIErrorSchema = z.object({
   error: z.object({
     message: z.string(),
     type: z.string().nullish(),
+    code: z.string().nullish(),
   }),
 });
 

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -59,6 +59,14 @@ async function getStreamParts(filename: string) {
   return convertReadableStreamToArray(result.stream);
 }
 
+function prepareErrorFixtureResponse(filename: string) {
+  server.urls['https://api.moonshot.ai/v1/chat/completions'].response = {
+    type: 'error',
+    status: 400,
+    body: fs.readFileSync(`src/__fixtures__/${filename}.json`, 'utf8'),
+  };
+}
+
 describe('doGenerate', () => {
   describe('text', () => {
     beforeEach(() => {
@@ -1503,43 +1511,64 @@ describe('doGenerate', () => {
       expect(server.calls).toHaveLength(0);
     });
 
-    it('should map the moonshot error envelope', async () => {
-      server.urls['https://api.moonshot.ai/v1/chat/completions'].response = {
-        type: 'error',
-        status: 400,
-        body: JSON.stringify({
-          error: {
-            message: 'Invalid request: invalid part type: file',
-            type: 'invalid_request_error',
-          },
-        }),
-      };
+    it('should preserve the full moonshot error envelope', async () => {
+      prepareErrorFixtureResponse('moonshotai-error');
 
       await expect(
         provider.chatModel('kimi-k3').doGenerate({ prompt: TEST_PROMPT }),
-      ).rejects.toThrow('Invalid request: invalid part type: file');
+      ).rejects.toMatchObject({
+        message: 'Invalid request: invalid part type: file',
+        data: {
+          error: {
+            message: 'Invalid request: invalid part type: file',
+            type: 'invalid_request_error',
+            code: 'invalid_part_type',
+          },
+        },
+      });
+    });
+
+    it('should preserve nullable codes in the error envelope', async () => {
+      prepareErrorFixtureResponse('moonshotai-error-null-code');
+
+      await expect(
+        provider.chatModel('kimi-k3').doGenerate({ prompt: TEST_PROMPT }),
+      ).rejects.toMatchObject({
+        message: 'Request failed with a nullable code',
+        data: {
+          error: {
+            message: 'Request failed with a nullable code',
+            type: 'invalid_request_error',
+            code: null,
+          },
+        },
+      });
+    });
+
+    it('should continue to parse message-only errors', async () => {
+      prepareErrorFixtureResponse('moonshotai-error-message-only');
+
+      await expect(
+        provider.chatModel('kimi-k3').doGenerate({ prompt: TEST_PROMPT }),
+      ).rejects.toMatchObject({
+        message: 'Request failed',
+        data: { error: { message: 'Request failed' } },
+      });
     });
   });
 });
 
 describe('doStream', () => {
-  it('should preserve a provider error envelope in stream errors', async () => {
+  it('should preserve the full provider error envelope in stream errors', async () => {
     const data = {
       error: {
-        message: 'Internal server error',
+        message: 'Stream failed',
         type: 'server_error',
+        code: 'stream_failure',
       },
     };
 
-    server.urls['https://api.moonshot.ai/v1/chat/completions'].response = {
-      type: 'stream-chunks',
-      chunks: [`data: ${JSON.stringify(data)}\n\n`, 'data: [DONE]\n\n'],
-    };
-
-    const result = await provider.chatModel('kimi-k3').doStream({
-      prompt: TEST_PROMPT,
-    });
-    const chunks = await convertReadableStreamToArray(result.stream);
+    const chunks = await getStreamParts('moonshotai-stream-error');
     const errorPart = chunks.find(chunk => chunk.type === 'error');
 
     expect(errorPart?.type).toBe('error');
@@ -1549,10 +1578,59 @@ describe('doStream', () => {
 
     expect(isProviderStreamError(errorPart.error)).toBe(true);
     expect(errorPart.error).toMatchObject({
-      message: 'Internal server error',
+      message: 'Stream failed',
       type: 'server_error',
+      code: 'stream_failure',
       statusCode: 500,
       isRetryable: true,
+      data,
+    });
+    expect(chunks.at(-1)).toMatchObject({
+      type: 'finish',
+      finishReason: { unified: 'error' },
+    });
+  });
+
+  it('should preserve nullable codes in the stream error envelope', async () => {
+    const data = {
+      error: {
+        message: 'Stream failed with a nullable code',
+        type: 'server_error',
+        code: null,
+      },
+    };
+    const chunks = await getStreamParts('moonshotai-stream-error-null-code');
+    const errorPart = chunks.find(chunk => chunk.type === 'error');
+
+    expect(errorPart?.type).toBe('error');
+    if (errorPart?.type !== 'error') {
+      expect.fail('Expected an error part');
+    }
+
+    expect(isProviderStreamError(errorPart.error)).toBe(true);
+    expect(errorPart.error).toMatchObject({
+      message: 'Stream failed with a nullable code',
+      type: 'server_error',
+      code: undefined,
+      statusCode: 500,
+      isRetryable: true,
+      data,
+    });
+  });
+
+  it('should continue to parse message-only streamed errors', async () => {
+    const data = { error: { message: 'Stream failed without details' } };
+    const chunks = await getStreamParts('moonshotai-stream-error-message-only');
+    const errorPart = chunks.find(chunk => chunk.type === 'error');
+
+    expect(errorPart?.type).toBe('error');
+    if (errorPart?.type !== 'error') {
+      expect.fail('Expected an error part');
+    }
+
+    expect(isProviderStreamError(errorPart.error)).toBe(true);
+    expect(errorPart.error).toMatchObject({
+      message: 'Stream failed without details',
       data,
     });
   });

--- a/packages/moonshotai/src/moonshotai-chat-language-model.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.ts
@@ -59,12 +59,17 @@ export type MoonshotAIChatConfig = {
 };
 
 function createMoonshotAIStreamError(
-  error: { message: string; type?: string | null },
+  error: {
+    message: string;
+    type?: string | null;
+    code?: string | null;
+  },
   data: unknown,
 ) {
   return createProviderStreamError({
     message: error.message,
     type: error.type ?? undefined,
+    code: error.code ?? undefined,
     ...getMoonshotAIStreamErrorMetadata(error.type),
     data,
   });


### PR DESCRIPTION
Fixes #19552.

Supersedes #19612, which could not be reopened after its stacked base branch was removed.

Preserves the existing createProviderStreamError marker and error contract while retaining Moonshot's complete error envelope in data, exposing the provider error code, and deriving status/retry metadata consistently for HTTP and SSE errors.

Includes string, null, and omitted-code regression fixtures and tests for both normal and streaming responses, plus a patch changeset.