### PR TITLE
fix(harness-acp): place skills in their harnesses' natively supported directory instead of applying a manual workaround

### DIFF
--- a/.changeset/lucky-actors-juggle.md
+++ b/.changeset/lucky-actors-juggle.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-acp": patch
+---
+
+fix(harness-acp): place skills in their harnesses' natively supported directory instead of applying a manual workaround

--- a/content/providers/02-ai-sdk-harnesses/06-acp.mdx
+++ b/content/providers/02-ai-sdk-harnesses/06-acp.mdx
@@ -97,6 +97,9 @@ try {
     unavailable. This requires `providerAuthentication` configuration.
 - `providerAuthentication`: declarative runtime-specific Gateway environment.
 - `modelId`: a known implementation model identifier for Harness metadata.
+- `skillsDirectory`: native skills directory relative to the implementation's
+  effective `$HOME`. It defaults to `.agents/skills`; override it for runtimes
+  that use a different location.
 - `instructionMapping`: optional mapping from `HarnessAgent` instructions to
   an implementation's native system or developer prompt. Use `session-meta`
   for a path below the ACP session request's `_meta` field, or
@@ -271,9 +274,10 @@ By default, the adapter uses the first exposed port. Set `port` on `createACP`
 to select another exposed port. If neither is available, session startup throws
 `HarnessCapabilityUnsupportedError` with instructions to configure one.
 
-Bridge packages, ACP installations, state, replay logs, and projected skills
-live in adapter-owned directories outside the session project. The session
-workspace starts empty.
+Bridge packages, ACP installations, and replay state live in adapter-owned
+directories outside the session project. Skills are written to the configured
+native directory below the implementation's `$HOME`. The session workspace
+starts empty.
 
 ## Tools and Approvals
 
@@ -322,6 +326,7 @@ export const claudeCodeACPHarness = createACP({
     packageVersion: '0.61.0',
   },
   executable: 'claude-agent-acp',
+  skillsDirectory: '.claude/skills',
   credentialEnv: ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'],
   credentialBrokering: ({ env }) => {
     const apiKey = env.ANTHROPIC_API_KEY;

--- a/packages/harness-acp/README.md
+++ b/packages/harness-acp/README.md
@@ -95,3 +95,8 @@ instructions below the ACP session request's `_meta` field. A
 the implementation starts. Without a mapping, the adapter preserves its
 backward-compatible behavior and prepends instructions to the first user
 prompt.
+
+Skills are written to `.agents/skills` below the ACP implementation's effective
+`$HOME` and discovered natively by the implementation. Set `skillsDirectory`
+to another relative path, such as `.claude/skills`, when required by the
+implementation.

--- a/packages/harness-acp/src/acp-harness.test-d.ts
+++ b/packages/harness-acp/src/acp-harness.test-d.ts
@@ -100,6 +100,7 @@ describe('createACP built-in tool inference', () => {
         packageName: '@agentclientprotocol/claude-agent-acp',
       },
       executable: 'claude-agent-acp',
+      skillsDirectory: '.claude/skills',
       instructionMapping: {
         type: 'session-meta',
         path: ['systemPrompt', 'append'],

--- a/packages/harness-acp/src/acp-harness.test.ts
+++ b/packages/harness-acp/src/acp-harness.test.ts
@@ -1710,7 +1710,7 @@ describe('createACP', () => {
     await session.doDestroy();
   });
 
-  it('materializes skills outside the workspace and announces guidance exactly once', async () => {
+  it('materializes skills in the native directory without adding them to prompt guidance', async () => {
     const runs: string[] = [];
     const spawns: Array<{
       command: string;
@@ -1749,8 +1749,8 @@ describe('createACP', () => {
       write.path.endsWith('/release-notes/SKILL.md'),
     );
     expect(skillDefinition).toBeDefined();
-    expect(skillDefinition?.path).toMatch(
-      /^\/home\/agent\/\.ai-sdk\/harness-acp\/codex-acp\/[a-f0-9]{64}\/skills\/release-notes\/SKILL\.md$/,
+    expect(skillDefinition?.path).toBe(
+      '/home/agent/.agents/skills/release-notes/SKILL.md',
     );
     expect(skillDefinition?.path.startsWith('/workspace/user-project')).toBe(
       false,
@@ -1789,7 +1789,8 @@ describe('createACP', () => {
     expect(firstStart.prompt[0]?.text).toContain(
       'Use the supplied project context.',
     );
-    expect(firstStart.prompt[0]?.text).toContain(
+    expect(JSON.stringify(firstStart.prompt)).not.toContain('release-notes');
+    expect(JSON.stringify(firstStart.prompt)).not.toContain(
       skillDefinition?.path ?? 'missing skill path',
     );
     expect(JSON.stringify(firstStart.prompt)).not.toContain(
@@ -1831,13 +1832,57 @@ describe('createACP', () => {
       initialGuidanceApplied: true,
       skillsMaterialized: true,
       skillsFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+      skillsDirectory: '/home/agent/.agents/skills',
     });
   });
 
-  it('keeps mapped instructions separate from prompts while preserving skill guidance', async () => {
+  it('materializes install-command skills relative to the private implementation home', async () => {
+    const writes: Array<{ path: string; content: string }> = [];
+    const harness = createACP({
+      harnessId: 'cursor-skills-acp',
+      source: {
+        type: 'install-command',
+        command: 'curl https://cursor.com/install -fsS | bash',
+      },
+      executable: 'agent',
+      args: ['--disable-auto-update', 'acp'],
+    });
+    const session = await harness.doStart({
+      sessionId: 'session-1',
+      sandboxSession: fakeSandbox({
+        runs: [],
+        spawns: [],
+        writes,
+        stop: async () => {},
+      }),
+      sessionWorkDir: '/workspace/user-project',
+      skills: [
+        {
+          name: 'release-notes',
+          description: 'Prepare release notes.',
+          content: 'Use active voice.',
+        },
+      ],
+    });
+
+    expect(writes).toContainEqual({
+      path: '/workspace/.harness-bootstrap/cursor-skills-acp/implementation/home/.agents/skills/release-notes/SKILL.md',
+      content:
+        '---\n' +
+        'name: release-notes\n' +
+        'description: Prepare release notes.\n' +
+        '---\n\n' +
+        'Use active voice.',
+    });
+    await session.doDestroy();
+  });
+
+  it('keeps mapped instructions and native skills separate from prompts', async () => {
+    const writes: Array<{ path: string; content: string }> = [];
     const harness = createACP({
       harnessId: 'claude-acp',
       ...agentSettings,
+      skillsDirectory: '.claude/skills',
       instructionMapping: {
         type: 'session-meta',
         path: ['systemPrompt', 'append'],
@@ -1848,6 +1893,7 @@ describe('createACP', () => {
       sandboxSession: fakeSandbox({
         runs: [],
         spawns: [],
+        writes,
         stop: async () => {},
       }),
       sessionWorkDir: '/workspace/user-project',
@@ -1873,17 +1919,23 @@ describe('createACP', () => {
         type: 'session-meta',
         path: ['systemPrompt', 'append'],
       },
-      prompt: [
-        {
-          type: 'text',
-          text: expect.stringContaining('<available-skills>'),
-        },
-        { type: 'text', text: 'Draft release notes.' },
-      ],
+      prompt: [{ type: 'text', text: 'Draft release notes.' }],
+    });
+    expect(writes).toContainEqual({
+      path: '/home/agent/.claude/skills/release-notes/SKILL.md',
+      content:
+        '---\n' +
+        'name: release-notes\n' +
+        'description: Prepare concise release notes.\n' +
+        '---\n\n' +
+        'Use active voice.',
     });
     expect(
       JSON.stringify(Reflect.get(channel.sent[0]!, 'prompt')),
     ).not.toContain('Answer every question in German.');
+    expect(
+      JSON.stringify(Reflect.get(channel.sent[0]!, 'prompt')),
+    ).not.toContain('release-notes');
     channel.emit({
       type: 'finish',
       finishReason: { unified: 'stop', raw: 'end_turn' },
@@ -1981,6 +2033,7 @@ describe('createACP', () => {
       initialGuidanceApplied: true,
       skillsMaterialized: true,
       skillsFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+      skillsDirectory: '/home/agent/.agents/skills',
     });
     expect(JSON.stringify(resumeFrom)).not.toContain('test-key');
     const writeCount = writes.length;
@@ -2122,6 +2175,7 @@ describe('createACP', () => {
       initialGuidanceApplied: true,
       skillsMaterialized: true,
       skillsFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+      skillsDirectory: '/home/agent/.agents/skills',
     });
     expect(stopped.data).not.toHaveProperty('bridge');
     expect(stopped.data).not.toHaveProperty('turnStartConfig');

--- a/packages/harness-acp/src/acp-harness.ts
+++ b/packages/harness-acp/src/acp-harness.ts
@@ -50,6 +50,7 @@ export type ACPHarnessSettings<TBuiltinTools extends ToolSet = {}> = {
   readonly authentication?: ACPV1Settings['authentication'];
   readonly providerAuthentication?: ACPV1Settings['providerAuthentication'];
   readonly modelId?: ACPV1Settings['modelId'];
+  readonly skillsDirectory?: ACPV1Settings['skillsDirectory'];
   readonly instructionMapping?: ACPV1Settings['instructionMapping'];
   readonly outputSchemaMapping?: ACPV1Settings['outputSchemaMapping'];
   readonly permissionModeMapping?: ACPV1Settings['permissionModeMapping'];
@@ -103,6 +104,7 @@ const acpResumeStateSchema = z.object({
   initialGuidanceApplied: z.boolean().optional(),
   skillsMaterialized: z.boolean().optional(),
   skillsFingerprint: z.string().optional(),
+  skillsDirectory: z.string().optional(),
 });
 
 export function createACP<TBuiltinTools extends ToolSet = {}>(

--- a/packages/harness-acp/src/v1/acp-v1-harness.ts
+++ b/packages/harness-acp/src/v1/acp-v1-harness.ts
@@ -76,7 +76,6 @@ import {
 import {
   convertHarnessPromptToACPTextBlocks,
   prependACPInitialGuidance,
-  type ACPSkillCatalogEntry,
 } from './acp-v1-prompt';
 import type {
   ACPInstructionMapping,
@@ -91,6 +90,7 @@ import {
   createACPSkillsFingerprint,
   materializeACPSkills,
   resolveACPPrivateSessionDirectory,
+  resolveACPSkillsDirectory,
 } from './acp-v1-skills';
 
 const HARNESS_ID_REGEXP = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -339,6 +339,14 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
         harnessId: settings.harnessId,
         sessionId: startOptions.sessionId,
       });
+      const skillsDirectory = resolveACPSkillsDirectory({
+        implementationHomeDir:
+          implementation.source.type === 'install-command'
+            ? `${resolvedImplementationDir}/home`
+            : sandboxHomeDir,
+        skillsDirectory: settings.skillsDirectory,
+        sessionWorkDir: workDir,
+      });
       const bridgeStateDir = `${privateSessionDir}/bridge`;
       const continueFrom =
         startOptions.continueFrom ?? startOptions.resumeFrom?.continueFrom;
@@ -365,21 +373,17 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
         isResume,
         lifecycleState: lifecycleData,
         skillsFingerprint,
+        skillsDirectory,
       });
-      let skillCatalog: ReadonlyArray<ACPSkillCatalogEntry> = [];
       if (skills.length > 0) {
-        skillCatalog = (
-          await materializeACPSkills({
-            sandbox: toolSafeSandboxSession,
-            sandboxHomeDir,
-            sessionWorkDir: workDir,
-            harnessId: settings.harnessId,
-            sessionId: startOptions.sessionId,
-            skills,
-            shouldMaterialize: shouldMaterializeSkills,
-            abortSignal: startOptions.abortSignal,
-          })
-        ).catalog;
+        await materializeACPSkills({
+          sandbox: toolSafeSandboxSession,
+          rootDir: skillsDirectory,
+          sessionWorkDir: workDir,
+          skills,
+          shouldMaterialize: shouldMaterializeSkills,
+          abortSignal: startOptions.abortSignal,
+        });
       }
       const report = startOptions.observability?.report;
       const onDiagnostic = report
@@ -451,8 +455,8 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
                 isResume: true,
                 lifecycleState: lifecycleData,
               }),
-              skillCatalog,
               skillsFingerprint,
+              skillsDirectory,
               acpSessionId: lifecycleData.acpSessionId,
               bridgePort: coords.port,
               bridgeToken: coords.token,
@@ -714,8 +718,8 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
           isResume,
           lifecycleState: lifecycleData,
         }),
-        skillCatalog,
         skillsFingerprint,
+        skillsDirectory,
         acpSessionId: lifecycleData?.acpSessionId,
         bridgePort: boundPort,
         bridgeToken: token,
@@ -1071,8 +1075,8 @@ function createSession({
   mcpServers,
   isMcpToolCall,
   initialGuidanceApplied: initialGuidanceAppliedAtStart,
-  skillCatalog,
   skillsFingerprint,
+  skillsDirectory,
   acpSessionId: acpSessionIdAtStart,
   bridgePort,
   bridgeToken,
@@ -1103,8 +1107,8 @@ function createSession({
   mcpServers: Record<string, unknown> | undefined;
   isMcpToolCall: ((toolCall: ACPToolCall) => boolean) | undefined;
   initialGuidanceApplied: boolean;
-  skillCatalog: ReadonlyArray<ACPSkillCatalogEntry>;
   skillsFingerprint: string;
+  skillsDirectory: string;
   acpSessionId: string | undefined;
   bridgePort: number;
   bridgeToken: string;
@@ -1388,6 +1392,7 @@ function createSession({
     initialGuidanceApplied,
     skillsMaterialized: true,
     skillsFingerprint,
+    skillsDirectory,
   });
 
   return {
@@ -1458,7 +1463,6 @@ function createSession({
                     instructionMapping == null
                       ? options.instructions
                       : undefined,
-                  skills: skillCatalog,
                 }),
             ...(instructionMapping == null
               ? {}

--- a/packages/harness-acp/src/v1/acp-v1-lifecycle.test.ts
+++ b/packages/harness-acp/src/v1/acp-v1-lifecycle.test.ts
@@ -41,6 +41,7 @@ describe('ACP skill materialization lifecycle', () => {
         isResume: false,
         lifecycleState: undefined,
         skillsFingerprint: 'current',
+        skillsDirectory: '/home/agent/.agents/skills',
       }),
     ).toBe(true);
   });
@@ -52,8 +53,10 @@ describe('ACP skill materialization lifecycle', () => {
         lifecycleState: {
           skillsMaterialized: true,
           skillsFingerprint: 'current',
+          skillsDirectory: '/home/agent/.agents/skills',
         },
         skillsFingerprint: 'current',
+        skillsDirectory: '/home/agent/.agents/skills',
       }),
     ).toBe(false);
   });
@@ -64,6 +67,22 @@ describe('ACP skill materialization lifecycle', () => {
         isResume: true,
         lifecycleState: {},
         skillsFingerprint: 'current',
+        skillsDirectory: '/home/agent/.agents/skills',
+      }),
+    ).toBe(true);
+  });
+
+  it('materializes skills when the resolved directory changes', () => {
+    expect(
+      shouldMaterializeACPSkills({
+        isResume: true,
+        lifecycleState: {
+          skillsMaterialized: true,
+          skillsFingerprint: 'current',
+          skillsDirectory: '/home/agent/.agents/skills',
+        },
+        skillsFingerprint: 'current',
+        skillsDirectory: '/home/agent/.claude/skills',
       }),
     ).toBe(true);
   });
@@ -77,6 +96,7 @@ describe('ACP skill materialization lifecycle', () => {
           skillsFingerprint: 'previous',
         },
         skillsFingerprint: 'current',
+        skillsDirectory: '/home/agent/.agents/skills',
       }),
     ).toThrow('different set of skills');
   });
@@ -90,6 +110,7 @@ describe('ACP skill materialization lifecycle', () => {
           skillsFingerprint: 'previous',
         },
         skillsFingerprint: 'current',
+        skillsDirectory: '/home/agent/.agents/skills',
       }),
     ).toThrow('different set of skills');
   });

--- a/packages/harness-acp/src/v1/acp-v1-lifecycle.ts
+++ b/packages/harness-acp/src/v1/acp-v1-lifecycle.ts
@@ -8,6 +8,7 @@ export type ACPPromptGuidanceLifecycleState = {
   readonly initialGuidanceApplied?: boolean;
   readonly skillsMaterialized?: boolean;
   readonly skillsFingerprint?: string;
+  readonly skillsDirectory?: string;
 };
 
 export type ACPBridgeCoordinates = {
@@ -49,10 +50,12 @@ export function shouldMaterializeACPSkills({
   isResume,
   lifecycleState,
   skillsFingerprint,
+  skillsDirectory,
 }: {
   isResume: boolean;
   lifecycleState: ACPPromptGuidanceLifecycleState | undefined;
   skillsFingerprint: string;
+  skillsDirectory: string;
 }): boolean {
   if (
     isResume &&
@@ -63,7 +66,11 @@ export function shouldMaterializeACPSkills({
       'ACP lifecycle state was created with a different set of skills.',
     );
   }
-  return !isResume || lifecycleState?.skillsMaterialized !== true;
+  return (
+    !isResume ||
+    lifecycleState?.skillsMaterialized !== true ||
+    lifecycleState.skillsDirectory !== skillsDirectory
+  );
 }
 
 export function validateACPLifecycleCompatibility({

--- a/packages/harness-acp/src/v1/acp-v1-prompt.test.ts
+++ b/packages/harness-acp/src/v1/acp-v1-prompt.test.ts
@@ -108,20 +108,13 @@ describe('convertHarnessPromptToACPTextBlocks', () => {
 });
 
 describe('prependACPInitialGuidance', () => {
-  it('prepends delimited instructions and a compact skill catalog', () => {
+  it('prepends delimited instructions without skill guidance', () => {
     const result = prependACPInitialGuidance({
       prompt: [
         { type: 'text', text: 'First' },
         { type: 'text', text: 'Second' },
       ],
       instructions: 'Prefer concise answers.',
-      skills: [
-        {
-          name: 'release-notes',
-          description: 'Prepare release notes.',
-          path: '/home/user/.ai-sdk/harness-acp/demo/session/skills/release-notes/SKILL.md',
-        },
-      ],
     });
 
     expect(result).toEqual([
@@ -133,16 +126,12 @@ describe('prependACPInitialGuidance', () => {
           '<instructions>\n' +
           'Prefer concise answers.\n' +
           '</instructions>\n' +
-          '<available-skills>\n' +
-          'Load a skill only when relevant by reading its SKILL.md file at the listed absolute path.\n' +
-          '- release-notes: Prepare release notes. (/home/user/.ai-sdk/harness-acp/demo/session/skills/release-notes/SKILL.md)\n' +
-          '</available-skills>\n' +
           '</session-guidance>',
       },
       { type: 'text', text: 'First' },
       { type: 'text', text: 'Second' },
     ]);
-    expect(result[0]?.text).not.toContain('Complete private skill content');
+    expect(result[0]?.text).not.toContain('available-skills');
   });
 
   it('does not add an empty guidance block', () => {
@@ -150,7 +139,6 @@ describe('prependACPInitialGuidance', () => {
       prependACPInitialGuidance({
         prompt: [{ type: 'text', text: 'Hello' }],
         instructions: '',
-        skills: [],
       }),
     ).toEqual([{ type: 'text', text: 'Hello' }]);
   });

--- a/packages/harness-acp/src/v1/acp-v1-prompt.ts
+++ b/packages/harness-acp/src/v1/acp-v1-prompt.ts
@@ -11,12 +11,6 @@ export const acpTextContentBlockSchema = z.object({
 
 export type ACPTextContentBlock = z.infer<typeof acpTextContentBlockSchema>;
 
-export type ACPSkillCatalogEntry = {
-  readonly name: string;
-  readonly description: string;
-  readonly path: string;
-};
-
 export function convertHarnessPromptToACPTextBlocks({
   prompt,
   harnessId,
@@ -75,32 +69,18 @@ export function convertHarnessPromptToACPTextBlocks({
 export function prependACPInitialGuidance({
   prompt,
   instructions,
-  skills,
 }: {
   prompt: ReadonlyArray<ACPTextContentBlock>;
   instructions: string | undefined;
-  skills: ReadonlyArray<ACPSkillCatalogEntry>;
 }): ACPTextContentBlock[] {
   const hasInstructions = instructions != null && instructions.length > 0;
-  if (!hasInstructions && skills.length === 0) return [...prompt];
+  if (!hasInstructions) return [...prompt];
 
   const lines = [
     '<session-guidance>',
     'This block is operating guidance from the harness, not user-authored content.',
   ];
-  if (hasInstructions) {
-    lines.push('<instructions>', instructions, '</instructions>');
-  }
-  if (skills.length > 0) {
-    lines.push(
-      '<available-skills>',
-      'Load a skill only when relevant by reading its SKILL.md file at the listed absolute path.',
-    );
-    for (const skill of skills) {
-      lines.push(`- ${skill.name}: ${skill.description} (${skill.path})`);
-    }
-    lines.push('</available-skills>');
-  }
+  lines.push('<instructions>', instructions, '</instructions>');
   lines.push('</session-guidance>');
 
   return [{ type: 'text', text: lines.join('\n') }, ...prompt];

--- a/packages/harness-acp/src/v1/acp-v1-settings.ts
+++ b/packages/harness-acp/src/v1/acp-v1-settings.ts
@@ -143,6 +143,11 @@ export type ACPV1Settings = {
   readonly providerAuthentication?: ACPProviderAuthentication;
   readonly modelId?: string;
   /**
+   * Native skills directory relative to the ACP implementation's home
+   * directory. Defaults to `.agents/skills`.
+   */
+  readonly skillsDirectory?: string;
+  /**
    * Routes HarnessAgent instructions to a runtime-native system or developer
    * prompt. When omitted, instructions are prepended to the first user prompt.
    */

--- a/packages/harness-acp/src/v1/acp-v1-skills.test.ts
+++ b/packages/harness-acp/src/v1/acp-v1-skills.test.ts
@@ -1,8 +1,10 @@
 import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
 import { describe, expect, it } from 'vitest';
 import {
+  DEFAULT_ACP_SKILLS_DIRECTORY,
   createACPSkillsFingerprint,
   materializeACPSkills,
+  resolveACPSkillsDirectory,
 } from './acp-v1-skills';
 
 function makeSandbox({
@@ -36,27 +38,22 @@ const skill = {
 } as const;
 
 describe('materializeACPSkills', () => {
-  it('writes complete skills beneath sandbox home and returns a compact catalog', async () => {
+  it('writes complete skills to the resolved native directory', async () => {
     const runs: string[] = [];
     const writes: Array<{ path: string; content: string }> = [];
-    const result = await materializeACPSkills({
+    const rootDir = '/home/agent/.agents/skills';
+    await materializeACPSkills({
       sandbox: makeSandbox({ runs, writes }),
-      sandboxHomeDir: '/home/agent',
+      rootDir,
       sessionWorkDir: '/workspace/project',
-      harnessId: 'portable-acp',
-      sessionId: '../../untrusted-session',
       skills: [skill],
       shouldMaterialize: true,
     });
 
-    expect(result.rootDir).toMatch(
-      /^\/home\/agent\/\.ai-sdk\/harness-acp\/portable-acp\/[a-f0-9]{64}\/skills$/,
-    );
-    expect(result.rootDir).not.toContain('untrusted-session');
-    expect(runs).toEqual([`mkdir -p '${result.rootDir}'`]);
+    expect(runs).toEqual([`mkdir -p '${rootDir}'`]);
     expect(writes).toEqual([
       {
-        path: `${result.rootDir}/release-notes/SKILL.md`,
+        path: `${rootDir}/release-notes/SKILL.md`,
         content:
           '---\n' +
           'name: release-notes\n' +
@@ -65,21 +62,10 @@ describe('materializeACPSkills', () => {
           'Complete private skill content.',
       },
       {
-        path: `${result.rootDir}/release-notes/references/style.md`,
+        path: `${rootDir}/release-notes/references/style.md`,
         content: 'Use active voice.',
       },
     ]);
-    expect(result.catalog).toEqual([
-      {
-        name: 'release-notes',
-        description: 'Prepare release notes.',
-        path: `${result.rootDir}/release-notes/SKILL.md`,
-      },
-    ]);
-    expect(JSON.stringify(result.catalog)).not.toContain(
-      'Complete private skill content.',
-    );
-    expect(JSON.stringify(result.catalog)).not.toContain('Use active voice.');
   });
 
   it.each([
@@ -122,10 +108,8 @@ describe('materializeACPSkills', () => {
     await expect(
       materializeACPSkills({
         sandbox: makeSandbox({ runs, writes }),
-        sandboxHomeDir: '/home/agent',
+        rootDir: '/home/agent/.agents/skills',
         sessionWorkDir: '/workspace/project',
-        harnessId: 'portable-acp',
-        sessionId: 'session',
         skills: [{ ...skill, files }],
         shouldMaterialize: true,
       }),
@@ -142,10 +126,8 @@ describe('materializeACPSkills', () => {
     await expect(
       materializeACPSkills({
         sandbox,
-        sandboxHomeDir: '/home/agent',
+        rootDir: '/home/agent/.agents/skills',
         sessionWorkDir: '/workspace/project',
-        harnessId: 'portable-acp',
-        sessionId: 'session',
         skills: [{ ...skill, name: '../release-notes' }],
         shouldMaterialize: true,
       }),
@@ -153,10 +135,8 @@ describe('materializeACPSkills', () => {
     await expect(
       materializeACPSkills({
         sandbox,
-        sandboxHomeDir: '/home/agent',
+        rootDir: '/home/agent/.agents/skills',
         sessionWorkDir: '/workspace/project',
-        harnessId: 'portable-acp',
-        sessionId: 'session',
         skills: [skill, skill],
         shouldMaterialize: true,
       }),
@@ -169,33 +149,62 @@ describe('materializeACPSkills', () => {
     await expect(
       materializeACPSkills({
         sandbox: makeSandbox({ runs: [], writes: [] }),
-        sandboxHomeDir: '/workspace/project',
+        rootDir: '/workspace/project/.agents/skills',
         sessionWorkDir: '/workspace/project',
-        harnessId: 'portable-acp',
-        sessionId: 'session',
         skills: [skill],
         shouldMaterialize: true,
       }),
     ).rejects.toThrow('must be outside sessionWorkDir');
   });
 
-  it('can reconstruct the catalog without rewriting matching resumed skills', async () => {
+  it('does not rewrite matching resumed skills', async () => {
     const runs: string[] = [];
     const writes: Array<{ path: string; content: string }> = [];
-    const result = await materializeACPSkills({
+    await materializeACPSkills({
       sandbox: makeSandbox({ runs, writes }),
-      sandboxHomeDir: '/home/agent',
+      rootDir: '/home/agent/.agents/skills',
       sessionWorkDir: '/workspace/project',
-      harnessId: 'portable-acp',
-      sessionId: 'session',
       skills: [skill],
       shouldMaterialize: false,
     });
 
-    expect(result.catalog).toHaveLength(1);
     expect(runs).toEqual([]);
     expect(writes).toEqual([]);
   });
+});
+
+describe('resolveACPSkillsDirectory', () => {
+  it('uses the standard directory by default', () => {
+    expect(
+      resolveACPSkillsDirectory({
+        implementationHomeDir: '/home/agent',
+        sessionWorkDir: '/workspace/project',
+      }),
+    ).toBe(`/home/agent/${DEFAULT_ACP_SKILLS_DIRECTORY}`);
+  });
+
+  it('resolves a runtime-specific directory relative to implementation home', () => {
+    expect(
+      resolveACPSkillsDirectory({
+        implementationHomeDir: '/home/agent',
+        skillsDirectory: '.claude/skills',
+        sessionWorkDir: '/workspace/project',
+      }),
+    ).toBe('/home/agent/.claude/skills');
+  });
+
+  it.each(['', '.', '/skills', 'C:\\skills', '.agents\\skills', '../skills'])(
+    'rejects invalid directory %j',
+    skillsDirectory => {
+      expect(() =>
+        resolveACPSkillsDirectory({
+          implementationHomeDir: '/home/agent',
+          skillsDirectory,
+          sessionWorkDir: '/workspace/project',
+        }),
+      ).toThrow('must be a relative POSIX path without traversal');
+    },
+  );
 });
 
 describe('createACPSkillsFingerprint', () => {

--- a/packages/harness-acp/src/v1/acp-v1-skills.ts
+++ b/packages/harness-acp/src/v1/acp-v1-skills.ts
@@ -3,9 +3,9 @@ import path from 'node:path';
 import type { HarnessV1Skill } from '@ai-sdk/harness';
 import { writeSkills } from '@ai-sdk/harness/utils';
 import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
-import type { ACPSkillCatalogEntry } from './acp-v1-prompt';
 
 const ACP_SKILL_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export const DEFAULT_ACP_SKILLS_DIRECTORY = '.agents/skills';
 
 export function createACPSkillsFingerprint({
   skills,
@@ -59,37 +59,21 @@ export function resolveACPPrivateSessionDirectory({
 
 export async function materializeACPSkills({
   sandbox,
-  sandboxHomeDir,
+  rootDir,
   sessionWorkDir,
-  harnessId,
-  sessionId,
   skills,
   shouldMaterialize,
   abortSignal,
 }: {
   sandbox: Experimental_SandboxSession;
-  sandboxHomeDir: string;
+  rootDir: string;
   sessionWorkDir: string;
-  harnessId: string;
-  sessionId: string;
   skills: ReadonlyArray<HarnessV1Skill>;
   shouldMaterialize: boolean;
   abortSignal?: AbortSignal;
-}): Promise<{
-  readonly catalog: ReadonlyArray<ACPSkillCatalogEntry>;
-  readonly rootDir: string;
-}> {
+}): Promise<void> {
   validateACPSkills({ skills });
-
-  const rootDir = path.posix.join(
-    resolveACPPrivateSessionDirectory({
-      sandboxHomeDir,
-      sessionWorkDir,
-      harnessId,
-      sessionId,
-    }),
-    'skills',
-  );
+  assertOutsideSessionWorkDir({ rootDir, sessionWorkDir });
 
   if (shouldMaterialize) {
     await writeSkills({
@@ -106,15 +90,40 @@ export async function materializeACPSkills({
         )}: expected a relative POSIX path without traversal.`,
     });
   }
+}
 
-  return {
-    rootDir,
-    catalog: skills.map(skill => ({
-      name: skill.name,
-      description: skill.description,
-      path: path.posix.join(rootDir, skill.name, 'SKILL.md'),
-    })),
-  };
+export function resolveACPSkillsDirectory({
+  implementationHomeDir,
+  skillsDirectory = DEFAULT_ACP_SKILLS_DIRECTORY,
+  sessionWorkDir,
+}: {
+  implementationHomeDir: string;
+  skillsDirectory?: string;
+  sessionWorkDir: string;
+}): string {
+  const containsTraversal = skillsDirectory
+    .split(/[\\/]/)
+    .some(segment => segment === '..');
+  const normalizedDirectory = path.posix.normalize(skillsDirectory);
+  if (
+    skillsDirectory.length === 0 ||
+    skillsDirectory.includes('\\') ||
+    path.posix.isAbsolute(skillsDirectory) ||
+    path.win32.isAbsolute(skillsDirectory) ||
+    containsTraversal ||
+    normalizedDirectory === '.' ||
+    normalizedDirectory.startsWith('../') ||
+    normalizedDirectory.includes('/../') ||
+    normalizedDirectory.endsWith('/..')
+  ) {
+    throw new Error(
+      `ACP skillsDirectory ${JSON.stringify(skillsDirectory)} must be a relative POSIX path without traversal.`,
+    );
+  }
+
+  const rootDir = path.posix.join(implementationHomeDir, normalizedDirectory);
+  assertOutsideSessionWorkDir({ rootDir, sessionWorkDir });
+  return rootDir;
 }
 
 function validateACPSkills({


### PR DESCRIPTION
## Background

ACP implementations already support native skill discovery, but the generic adapter wrote skills to a private session directory and manually advertised them through the prompt.

This was likely chosen because ACP itself does not natively support providing skills. But that still shouldn't have led to the workaround. Since skills are supported natively by basically every single harness, the ACP meta harness adapter should simply place the files in the correct directory per concrete ACP backed adapter.

## Summary

- Write skills to the implementation's native directory under its effective `$HOME`, defaulting to `.agents/skills`.
- Add `skillsDirectory` for runtime-specific overrides, e.g. for Claude ACP to use `.claude/skills`.
- Remove the manual prompt catalog while preserving resume-safe skill materialization.

## End-to-End Verification

Ran the `with-skills` harness example successfully for all ACP backed harness adapters.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
