### PR TITLE
[v5.0] test(zai): align user-agent version assertion

### DIFF
--- a/packages/zai/src/zai-provider.test.ts
+++ b/packages/zai/src/zai-provider.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ZaiChatLanguageModel } from './zai-chat-language-model';
 import { createZai } from './zai-provider';
+import { VERSION } from './version';
 
 const TEST_PROMPT = [
   {
@@ -61,7 +62,7 @@ describe('createZai', () => {
     );
     const headers = new Headers(fetch.mock.calls[0][1].headers);
     expect(headers.get('authorization')).toBe('Bearer test-key');
-    expect(headers.get('user-agent')).toContain('ai-sdk/zai/0.0.0');
+    expect(headers.get('user-agent')).toContain(`ai-sdk/zai/${VERSION}`);
   });
 
   it('reads the API key from ZAI_API_KEY by default', async () => {


### PR DESCRIPTION
The release-v5.0 package version was advanced to `@ai-sdk/zai@1.0.0` by the version-packages commit, but the provider test still asserts the pre-release placeholder `0.0.0`.

This deterministic baseline failure currently blocks unrelated release-v5.0 PRs, including #19744, across Node 20, 22, and 24.

This PR updates only the test expectation to derive the user-agent suffix from the same exported `VERSION` value used by the provider, so future version-package commits cannot stale the assertion again.

Local verification:

- `pnpm --filter @ai-sdk/zai... build`
- `pnpm --filter @ai-sdk/zai test:node` (19/19)
- `pnpm --filter @ai-sdk/zai test:edge` (19/19)
- `pnpm --filter @ai-sdk/zai type-check`
- changed-file lint and formatting

No changeset is needed because this is test-only.
