### PR TITLE
[v6.0] refactor: normalize replayable Bedrock reasoning handling

### DIFF
--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.test.ts
@@ -1036,38 +1036,68 @@ describe('assistant messages', () => {
     `);
   });
 
-  it('should omit assistant messages that become empty after unsigned reasoning is removed', async () => {
-    const result = await convertToBedrockChatMessages([
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'First question' }],
-      },
-      {
-        role: 'assistant',
-        content: [
-          {
-            type: 'reasoning',
-            text: 'Unsigned reasoning',
-          },
-          { type: 'text', text: '' },
-        ],
-      },
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'Follow-up question' }],
-      },
-    ]);
-
-    expect(result).toEqual({
-      messages: [
+  it.each([
+    {
+      description: 'only unsigned reasoning',
+      assistantContent: [
         {
-          role: 'user',
-          content: [{ text: 'First question' }, { text: 'Follow-up question' }],
+          type: 'reasoning' as const,
+          text: 'Unsigned reasoning',
         },
       ],
-      system: [],
-    });
-  });
+    },
+    {
+      description: 'unsigned reasoning and empty text',
+      assistantContent: [
+        {
+          type: 'reasoning' as const,
+          text: 'Unsigned reasoning',
+        },
+        { type: 'text' as const, text: '' },
+      ],
+    },
+    {
+      description: 'unsigned reasoning and whitespace-only text',
+      assistantContent: [
+        {
+          type: 'reasoning' as const,
+          text: 'Unsigned reasoning',
+        },
+        { type: 'text' as const, text: '\n ' },
+      ],
+    },
+  ])(
+    'should omit assistant messages that become empty after filtering $description',
+    async ({ assistantContent }) => {
+      const result = await convertToBedrockChatMessages([
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'First question' }],
+        },
+        {
+          role: 'assistant',
+          content: assistantContent,
+        },
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Follow-up question' }],
+        },
+      ]);
+
+      expect(result).toEqual({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { text: 'First question' },
+              { text: 'Follow-up question' },
+            ],
+          },
+        ],
+        system: [],
+      });
+    },
+  );
 
   it('should omit unsigned reasoning while preserving tool calls in multi-turn tool use', async () => {
     const result = await convertToBedrockChatMessages([
@@ -1455,7 +1485,7 @@ describe('assistant messages', () => {
     });
   });
 
-  it('should preserve empty text blocks when reasoning blocks are present', async () => {
+  it('should preserve empty text blocks when replayable signed reasoning is present', async () => {
     const result = await convertToBedrockChatMessages([
       {
         role: 'user',
@@ -1518,6 +1548,71 @@ describe('assistant messages', () => {
       system: [],
     });
   });
+
+  it.each([
+    {
+      description: 'redactedContent',
+      providerOptions: {
+        bedrock: { redactedContent: 'encrypted-reasoning-payload' },
+      },
+      expectedReasoningContent: {
+        reasoningContent: {
+          redactedContent: 'encrypted-reasoning-payload',
+        },
+      },
+    },
+    {
+      description: 'redactedData',
+      providerOptions: {
+        bedrock: { redactedData: 'redacted-reasoning-data' },
+      },
+      expectedReasoningContent: {
+        reasoningContent: {
+          redactedReasoning: { data: 'redacted-reasoning-data' },
+        },
+      },
+    },
+  ])(
+    'should preserve empty text blocks when replayable $description reasoning is present',
+    async ({ providerOptions, expectedReasoningContent }) => {
+      const result = await convertToBedrockChatMessages([
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'reasoning',
+              text: '',
+              providerOptions,
+            },
+            { type: 'text', text: '' },
+            { type: 'text', text: 'response text' },
+          ],
+        },
+      ]);
+
+      expect(result).toEqual({
+        messages: [
+          {
+            role: 'user',
+            content: [{ text: 'Hello' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              expectedReasoningContent,
+              { text: '' },
+              { text: 'response text' },
+            ],
+          },
+        ],
+        system: [],
+      });
+    },
+  );
 });
 
 describe('tool messages', () => {

--- a/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-bedrock-chat-messages.ts
@@ -352,22 +352,56 @@ export async function convertToBedrockChatMessages(
           const message = block.messages[j];
           const isLastMessage = j === block.messages.length - 1;
           const { content } = message;
-          const reasoningMetadata = await Promise.all(
-            content.map(part =>
-              part.type === 'reasoning'
-                ? parseProviderOptions({
-                    provider: 'bedrock',
-                    providerOptions: part.providerOptions,
-                    schema: bedrockReasoningMetadataSchema,
-                  })
-                : undefined,
-            ),
+          const convertedReasoningContent: Array<
+            BedrockAssistantMessage['content'][number] | undefined
+          > = await Promise.all(
+            content.map(async part => {
+              if (part.type !== 'reasoning') {
+                return undefined;
+              }
+
+              const metadata = await parseProviderOptions({
+                provider: 'bedrock',
+                providerOptions: part.providerOptions,
+                schema: bedrockReasoningMetadataSchema,
+              });
+
+              if (metadata?.signature != null) {
+                return {
+                  reasoningContent: {
+                    reasoningText: {
+                      // do not trim reasoning text when a signature is present:
+                      // the signature validates the exact original bytes
+                      text: part.text,
+                      signature: metadata.signature,
+                    },
+                  },
+                };
+              }
+
+              if (metadata?.redactedContent != null) {
+                return {
+                  reasoningContent: {
+                    redactedContent: metadata.redactedContent,
+                  },
+                };
+              }
+
+              if (metadata?.redactedData != null) {
+                return {
+                  reasoningContent: {
+                    redactedReasoning: {
+                      data: metadata.redactedData,
+                    },
+                  },
+                };
+              }
+
+              return undefined;
+            }),
           );
-          const hasReasoningBlocks = reasoningMetadata.some(
-            metadata =>
-              metadata?.signature != null ||
-              metadata?.redactedContent != null ||
-              metadata?.redactedData != null,
+          const hasReplayableReasoningBlocks = convertedReasoningContent.some(
+            part => part != null,
           );
 
           for (let k = 0; k < content.length; k++) {
@@ -376,8 +410,9 @@ export async function convertToBedrockChatMessages(
 
             switch (part.type) {
               case 'text': {
-                // Skip empty text blocks unless reasoning blocks are present
-                if (!part.text.trim() && !hasReasoningBlocks) {
+                // Skip empty text blocks unless replayable reasoning blocks are
+                // present and the original block order must be preserved.
+                if (!part.text.trim() && !hasReplayableReasoningBlocks) {
                   break;
                 }
 
@@ -397,33 +432,9 @@ export async function convertToBedrockChatMessages(
               }
 
               case 'reasoning': {
-                const metadata = reasoningMetadata[k];
-
-                if (metadata?.signature != null) {
-                  // do not trim reasoning text when a signature is present:
-                  // the signature validates the exact original bytes
-                  bedrockContent.push({
-                    reasoningContent: {
-                      reasoningText: {
-                        text: part.text,
-                        signature: metadata.signature,
-                      },
-                    },
-                  });
-                } else if (metadata?.redactedContent != null) {
-                  bedrockContent.push({
-                    reasoningContent: {
-                      redactedContent: metadata.redactedContent,
-                    },
-                  });
-                } else if (metadata?.redactedData != null) {
-                  bedrockContent.push({
-                    reasoningContent: {
-                      redactedReasoning: {
-                        data: metadata.redactedData,
-                      },
-                    },
-                  });
+                const convertedPart = convertedReasoningContent[k];
+                if (convertedPart != null) {
+                  bedrockContent.push(convertedPart);
                 }
                 // Unsigned reasoning is intentionally not replayed. Some
                 // Bedrock models (for example OpenAI gpt-oss) return reasoning

--- a/packages/zai/src/zai-provider.test.ts
+++ b/packages/zai/src/zai-provider.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ZaiChatLanguageModel } from './zai-chat-language-model';
 import { createZai } from './zai-provider';
+import { VERSION } from './version';
 
 const TEST_PROMPT = [
   {
@@ -61,7 +62,7 @@ describe('createZai', () => {
     );
     const headers = new Headers(fetch.mock.calls[0][1].headers);
     expect(headers.get('authorization')).toBe('Bearer test-key');
-    expect(headers.get('user-agent')).toContain('ai-sdk/zai/1.0.0');
+    expect(headers.get('user-agent')).toContain(`ai-sdk/zai/${VERSION}`);
   });
 
   it('reads the API key from ZAI_API_KEY by default', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #19628, which merged before its review cleanup reached the PR branch.

- Derive replayability from the exact converted Bedrock reasoning block instead of duplicating metadata conditions.
- Rename the predicate to clarify that only signed or redacted reasoning is replayable.
- Cover reasoning-only, empty-text, and whitespace-only filtered assistant turns.
- Verify empty text remains preserved with signed, redacted-content, and redacted-data reasoning.

The changeset merged in #19628 already covers this unreleased fix.

## Testing

- pnpm type-check:full
- pnpm --filter @ai-sdk/amazon-bedrock test:node — 442 passed
- pnpm --filter @ai-sdk/amazon-bedrock test:edge — 442 passed