### PR TITLE
fix(release): handle package-less examples on v5

### DIFF
--- a/.github/scripts/cleanup-examples-changesets.mjs
+++ b/.github/scripts/cleanup-examples-changesets.mjs
@@ -7,6 +7,7 @@
  */
 
 import {
+  existsSync,
   readFileSync,
   writeFileSync,
   unlinkSync,
@@ -23,6 +24,12 @@ function cleanup(app, url) {
 
   if (statSync(appPath).isDirectory()) {
     const packageJsonPath = join(appPath, 'package.json');
+
+    if (!existsSync(packageJsonPath)) {
+      console.log('Skipping directory without package.json', appPath);
+      return;
+    }
+
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
     packageJson.version = '0.0.0';
     writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
       - release-v*
     paths:
       - '.changeset/**'
+      - '.github/scripts/cleanup-examples-changesets.mjs'
       - '.github/workflows/release.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
The v5 release workflow currently fails during ci:version because examples/ai-functions remains as a directory on release-v5.0 but no longer has a package.json.

This change skips example directories without a package manifest. It also adds the cleanup script to the release workflow path filter so merging this fix immediately retries release-PR preparation.

Failed runs:
- https://github.com/vercel/ai/actions/runs/32997268656
- https://github.com/vercel/ai/actions/runs/32997504953
- https://github.com/vercel/ai/actions/runs/32997959179
- https://github.com/vercel/ai/actions/runs/33003082064

Verification:
- node syntax check
- isolated fixture with a package-less examples/ai-functions directory
- git diff --check