### PR TITLE
[v5.0] fix: preserve Moonshot API error metadata in HTTP and streaming responses

### DIFF
--- a/.changeset/tender-kimis-report.md
+++ b/.changeset/tender-kimis-report.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/moonshotai': patch
+---
+
+Preserve documented Moonshot API error codes in HTTP and streaming errors.

--- a/packages/moonshotai/src/__fixtures__/moonshotai-error.chunks.txt
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-error.chunks.txt
@@ -1,0 +1,1 @@
+{"error":{"message":"Internal server error","type":"server_error","code":"upstream_failure"}}

--- a/packages/moonshotai/src/__fixtures__/moonshotai-error.json
+++ b/packages/moonshotai/src/__fixtures__/moonshotai-error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "message": "Invalid request: invalid part type: file",
+    "type": "invalid_request_error",
+    "code": "invalid_parameter"
+  }
+}

--- a/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
+++ b/packages/moonshotai/src/moonshotai-chat-language-model.test.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import { APICallError, type LanguageModelV2Prompt } from '@ai-sdk/provider';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import fs from 'node:fs';
@@ -16,6 +16,12 @@ const provider = createMoonshotAI({
 const server = createTestServer({
   'https://api.moonshot.ai/v1/chat/completions': {},
 });
+
+function readJsonFixture(filename: string) {
+  return JSON.parse(
+    fs.readFileSync(`src/__fixtures__/${filename}.json`, 'utf8'),
+  );
+}
 
 function prepareJsonResponse() {
   server.urls['https://api.moonshot.ai/v1/chat/completions'].response = {
@@ -634,9 +640,84 @@ describe('MoonshotAIChatLanguageModel', () => {
         }),
       ).rejects.toThrow('invalid moonshotai provider options');
     });
+
+    it('should preserve the moonshot error envelope', async () => {
+      const data = readJsonFixture('moonshotai-error');
+
+      server.urls['https://api.moonshot.ai/v1/chat/completions'].response = {
+        type: 'error',
+        status: 400,
+        body: JSON.stringify(data),
+      };
+
+      const error = await Promise.resolve(
+        provider.chatModel('kimi-k3').doGenerate({ prompt: TEST_PROMPT }),
+      ).catch((error: unknown) => error);
+
+      expect(APICallError.isInstance(error)).toBe(true);
+      if (!APICallError.isInstance(error)) {
+        expect.fail('Expected an APICallError');
+      }
+      expect(error.message).toBe(data.error.message);
+      expect(error.data).toStrictEqual(data);
+    });
+
+    it.each([
+      {
+        name: 'nullable code',
+        data: {
+          error: {
+            message: 'Invalid request with nullable code',
+            type: 'invalid_request_error',
+            code: null,
+          },
+        },
+      },
+      {
+        name: 'message-only error',
+        data: {
+          error: {
+            message: 'Invalid request',
+          },
+        },
+      },
+    ])('should preserve a $name envelope', async ({ data }) => {
+      server.urls['https://api.moonshot.ai/v1/chat/completions'].response = {
+        type: 'error',
+        status: 400,
+        body: JSON.stringify(data),
+      };
+
+      const error = await Promise.resolve(
+        provider.chatModel('kimi-k3').doGenerate({ prompt: TEST_PROMPT }),
+      ).catch((error: unknown) => error);
+
+      expect(APICallError.isInstance(error)).toBe(true);
+      if (!APICallError.isInstance(error)) {
+        expect.fail('Expected an APICallError');
+      }
+      expect(error.message).toBe(data.error.message);
+      expect(error.data).toStrictEqual(data);
+    });
   });
 
   describe('doStream', () => {
+    it('should preserve a provider error envelope in stream errors', async () => {
+      const chunks = await getStreamParts('moonshotai-error');
+      const errorPart = chunks.find(chunk => chunk.type === 'error');
+
+      expect(errorPart?.type).toBe('error');
+      if (errorPart?.type !== 'error') {
+        expect.fail('Expected an error part');
+      }
+
+      expect(errorPart.error).toStrictEqual({
+        message: 'Internal server error',
+        type: 'server_error',
+        code: 'upstream_failure',
+      });
+    });
+
     it('should omit sampling options and add v2 warnings when streaming', async () => {
       prepareChunksFixtureResponse('moonshot-text');
 

--- a/packages/moonshotai/src/moonshotai-provider.ts
+++ b/packages/moonshotai/src/moonshotai-provider.ts
@@ -21,6 +21,7 @@ const moonshotaiErrorSchema = z.object({
   error: z.object({
     message: z.string(),
     type: z.string().nullish(),
+    code: z.string().nullish(),
   }),
 });
 


### PR DESCRIPTION
## Summary

Backports #19763 to release-v5.0.

- preserve documented Moonshot error codes in HTTP APICallError.data
- preserve the complete Moonshot error object in structured SSE errors
- add HTTP and streaming regression fixtures and coverage
- include a patch changeset for @ai-sdk/moonshotai

The v5 implementation adds code to the Moonshot provider-specific error schema. The shared OpenAI-compatible stream adapter on v5 already forwards the parsed error object.

## Testing

- pnpm --filter @ai-sdk/moonshotai test:node
- pnpm --filter @ai-sdk/moonshotai test:edge
- pnpm --filter @ai-sdk/moonshotai type-check
- pnpm type-check:full
- pnpm check