### PR TITLE
test(zai): derive user-agent version

### DIFF
--- a/packages/zai/src/zai-provider.test.ts
+++ b/packages/zai/src/zai-provider.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ZaiChatLanguageModel } from './zai-chat-language-model';
 import { createZai } from './zai-provider';
-
-vi.mock('./version', () => ({
-  VERSION: '0.0.0-test',
-}));
+import { VERSION } from './version';
 
 const TEST_PROMPT = [
   {
@@ -64,7 +61,7 @@ describe('createZai', () => {
     );
     const headers = new Headers(fetch.mock.calls[0][1].headers);
     expect(headers.get('authorization')).toBe('Bearer test-key');
-    expect(headers.get('user-agent')).toContain('ai-sdk/zai/0.0.0-test');
+    expect(headers.get('user-agent')).toContain(`ai-sdk/zai/${VERSION}`);
   });
 
   it('reads the API key from ZAI_API_KEY by default', async () => {


### PR DESCRIPTION
## Summary

- derive the expected ZAI user-agent suffix from the exported VERSION value
- remove the hard-coded test version so package releases cannot stale the assertion
- keep coverage that requests identify the ZAI provider and its current package version

## Testing

- pnpm --filter @ai-sdk/zai... build
- pnpm --filter @ai-sdk/zai test:node (17/17)
- pnpm --filter @ai-sdk/zai test:edge (17/17)
- pnpm --filter @ai-sdk/zai type-check
- pnpm check
- pnpm type-check:full

No changeset is needed because this is a test-only change.