### PR TITLE
[v6.0] fix(ai): handle late streams after cancellation

### DIFF
--- a/.changeset/tidy-streams-cancel.md
+++ b/.changeset/tidy-streams-cancel.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Handle stitchable stream cancellation before an inner stream is registered.

--- a/packages/ai/src/generate-object/stream-object.test.ts
+++ b/packages/ai/src/generate-object/stream-object.test.ts
@@ -918,6 +918,68 @@ describe('streamObject', () => {
         }
       });
 
+      it('should not emit background errors when cancelled before the provider stream is registered', async () => {
+        const backgroundErrors: unknown[] = [];
+        const onUnhandledRejection = (error: unknown) => {
+          backgroundErrors.push(error);
+        };
+        const onUncaughtException = (error: unknown) => {
+          backgroundErrors.push(error);
+        };
+        let releaseProvider!: () => void;
+        const providerGate = new Promise<void>(resolve => {
+          releaseProvider = resolve;
+        });
+        let providerStreamCreated!: () => void;
+        const providerStreamCreation = new Promise<void>(resolve => {
+          providerStreamCreated = resolve;
+        });
+        let providerStreamCancelled = false;
+
+        process.on('unhandledRejection', onUnhandledRejection);
+        process.on('uncaughtException', onUncaughtException);
+
+        try {
+          const result = streamObject({
+            model: new MockLanguageModelV3({
+              doStream: async () => {
+                await providerGate;
+
+                return {
+                  stream: new ReadableStream({
+                    start() {
+                      providerStreamCreated();
+                    },
+                    cancel() {
+                      providerStreamCancelled = true;
+                    },
+                  }),
+                };
+              },
+            }),
+            schema: z.object({ content: z.string() }),
+            prompt: 'prompt',
+            onError: () => {},
+          });
+
+          const reader = result.partialObjectStream.getReader();
+          const pendingRead = reader.read().catch(() => undefined);
+
+          await reader.cancel();
+          releaseProvider();
+
+          await pendingRead;
+          await providerStreamCreation;
+          await new Promise(resolve => setTimeout(resolve, 0));
+
+          expect(providerStreamCancelled).toBe(true);
+          expect(backgroundErrors).toStrictEqual([]);
+        } finally {
+          process.off('unhandledRejection', onUnhandledRejection);
+          process.off('uncaughtException', onUncaughtException);
+        }
+      });
+
       it('should reject pending result promises and report failure for an error stream part', async () => {
         const error = new Error('test error');
         const onError = vitest.fn();

--- a/packages/ai/src/util/create-stitchable-stream.test.ts
+++ b/packages/ai/src/util/create-stitchable-stream.test.ts
@@ -214,6 +214,28 @@ describe('createStitchableStream', () => {
       expect(stream2CallbackCalled).toBe(true);
     });
 
+    it('should discard streams added after cancellation and allow closing', async () => {
+      const { stream, addStream, close } = createStitchableStream<number>();
+      let lateStreamCancelled = false;
+
+      await stream.cancel();
+
+      expect(() =>
+        addStream(
+          new ReadableStream({
+            cancel() {
+              lateStreamCancelled = true;
+            },
+          }),
+        ),
+      ).not.toThrow();
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(lateStreamCancelled).toBe(true);
+      expect(() => close()).not.toThrow();
+    });
+
     it('should throw an error when adding a stream after closing', async () => {
       const { addStream, close } = createStitchableStream<number>();
 

--- a/packages/ai/src/util/create-stitchable-stream.ts
+++ b/packages/ai/src/util/create-stitchable-stream.ts
@@ -25,9 +25,14 @@ export function createStitchableStream<T>(): {
   }> = [];
   let controller: ReadableStreamDefaultController<T> | null = null;
   let isClosed = false;
+  let isCancelled = false;
   let waitForNewStream = createResolvablePromise<void>();
 
   const terminate = () => {
+    if (isCancelled) {
+      return;
+    }
+
     isClosed = true;
     waitForNewStream.resolve();
 
@@ -40,6 +45,10 @@ export function createStitchableStream<T>(): {
   };
 
   const processPull = async () => {
+    if (isCancelled) {
+      return;
+    }
+
     // Case 1: Outer stream is closed and no more inner streams
     if (isClosed && innerStreams.length === 0) {
       controller?.close();
@@ -54,8 +63,14 @@ export function createStitchableStream<T>(): {
       return processPull();
     }
 
+    const currentStream = innerStreams[0];
+
     try {
-      const { value, done } = await innerStreams[0].reader.read();
+      const { value, done } = await currentStream.reader.read();
+
+      if (isCancelled) {
+        return;
+      }
 
       if (done) {
         // Case 3: Current inner stream is done
@@ -73,8 +88,12 @@ export function createStitchableStream<T>(): {
         controller?.enqueue(value);
       }
     } catch (error) {
+      if (isCancelled) {
+        return;
+      }
+
       // Case 5: Current inner stream throws an error
-      innerStreams[0].onError?.(error);
+      currentStream.onError?.(error);
       controller?.error(error);
       innerStreams.shift(); // Remove the errored stream
       terminate(); // we have errored, terminate all streams
@@ -88,12 +107,15 @@ export function createStitchableStream<T>(): {
       },
       pull: processPull,
       async cancel() {
+        isCancelled = true;
+        isClosed = true;
+        waitForNewStream.resolve();
+
         for (const { reader, onCancel } of innerStreams) {
           onCancel?.();
           await reader.cancel();
         }
         innerStreams = [];
-        isClosed = true;
       },
     }),
     addStream: (
@@ -103,6 +125,12 @@ export function createStitchableStream<T>(): {
         onCancel?: () => void;
       },
     ) => {
+      if (isCancelled) {
+        callbacks?.onCancel?.();
+        void innerStream.cancel().catch(() => {});
+        return;
+      }
+
       if (isClosed) {
         throw new Error('Cannot add inner stream: outer stream is closed');
       }
@@ -119,6 +147,10 @@ export function createStitchableStream<T>(): {
      * finish processing and then close the outer stream.
      */
     close: () => {
+      if (isCancelled) {
+        return;
+      }
+
       isClosed = true;
       waitForNewStream.resolve();
 


### PR DESCRIPTION
## Background

This backports #19741 to AI SDK 6. In `streamObject`, a consumer can cancel the outer stitchable stream while provider setup is still running; when the provider stream arrives later, `addStream()` throws and the late stream remains active.

## Summary

Track cancellation separately from graceful closure in `createStitchableStream`. Late inner streams are canceled and discarded, pending pulls stop after cancellation, and later close operations are safe.

## End-to-End Verification

The cancellation flow was reproduced on `release-v6.0` before the change by canceling the consumer before the provider stream was registered. After the change, the late provider stream is canceled and the flow completes without a background stream error.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (not needed; no public API change)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Backport of #19741. Related to #8102.