### PR TITLE
fix(xai): preserve web_search action (query, sources, open_page) in responses tool results

### DIFF
--- a/.changeset/xai-web-search-action.md
+++ b/.changeset/xai-web-search-action.md
@@ -1,5 +1,5 @@
 ---
-'@ai-sdk/xai': minor
+'@ai-sdk/xai': patch
 ---
 
 fix(xai): preserve web_search action (query, sources, open_page) in responses tool results

--- a/.changeset/xai-web-search-action.md
+++ b/.changeset/xai-web-search-action.md
@@ -1,5 +1,5 @@
 ---
-'@ai-sdk/xai': patch
+'@ai-sdk/xai': minor
 ---
 
 fix(xai): preserve web_search action (query, sources, open_page) in responses tool results

--- a/.changeset/xai-web-search-action.md
+++ b/.changeset/xai-web-search-action.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+fix(xai): preserve web_search action (query, sources, open_page) in responses tool results

--- a/packages/xai/src/responses/__snapshots__/xai-responses-language-model.test.ts.snap
+++ b/packages/xai/src/responses/__snapshots__/xai-responses-language-model.test.ts.snap
@@ -26,6 +26,12 @@ exports[`XaiResponsesLanguageModel > doGenerate > web_search tool > should inclu
     "type": "tool-call",
   },
   {
+    "result": {},
+    "toolCallId": "fc_25de2f84-163c-6e9e-e42e-cd1dbd6f9ed0_0",
+    "toolName": "web_search",
+    "type": "tool-result",
+  },
+  {
     "text": "xAI is an American artificial intelligence company founded by Elon Musk in July 2023. Its mission is to "understand the true nature of the universe" by advancing scientific discovery through AI. The company is based in the San Francisco Bay Area and focuses on building advanced AI systems, including the Grok chatbot (integrated with the X platform, formerly Twitter). Notable team members include former researchers from OpenAI, DeepMind, and other AI labs.
 
 xAI has raised significant funding, including a $6 billion Series B round in 2024, and is competing with major players like OpenAI and Google in the AI space.
@@ -13046,25 +13052,45 @@ exports[`XaiResponsesLanguageModel > doStream > text streaming > should stream x
     "type": "tool-call",
   },
   {
-    "result": {},
+    "result": {
+      "action": {
+        "query": "",
+        "type": "search",
+      },
+    },
     "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_09546004",
     "toolName": "web_search",
     "type": "tool-result",
   },
   {
-    "result": {},
+    "result": {
+      "action": {
+        "query": "",
+        "type": "search",
+      },
+    },
     "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_45339693",
     "toolName": "web_search",
     "type": "tool-result",
   },
   {
-    "result": {},
+    "result": {
+      "action": {
+        "query": "",
+        "type": "search",
+      },
+    },
     "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_55360208",
     "toolName": "web_search",
     "type": "tool-result",
   },
   {
-    "result": {},
+    "result": {
+      "action": {
+        "query": "",
+        "type": "search",
+      },
+    },
     "toolCallId": "ws_b7b464ea-cc85-d44a-0f2f-1f7320e703c3_call_63718660",
     "toolName": "web_search",
     "type": "tool-result",

--- a/packages/xai/src/responses/xai-responses-api.ts
+++ b/packages/xai/src/responses/xai-responses-api.ts
@@ -168,6 +168,31 @@ const toolCallSchema = z.object({
   action: z.any().optional(),
 });
 
+export const webSearchWireSourceSchema = z.object({
+  type: z.literal('url'),
+  url: z.string(),
+});
+
+export const webSearchWireActionSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('search'),
+    query: z.string().nullish(),
+    queries: z.array(z.string()).nullish(),
+    sources: z.array(z.unknown()).nullish(),
+  }),
+  z.object({
+    type: z.literal('open_page'),
+    url: z.string().nullish(),
+    sources: z.array(z.unknown()).nullish(),
+  }),
+  z.object({
+    type: z.literal('find_in_page'),
+    url: z.string().nullish(),
+    pattern: z.string().nullish(),
+    sources: z.array(z.unknown()).nullish(),
+  }),
+]);
+
 const mcpCallSchema = z.object({
   name: z.string().optional(),
   arguments: z.string().optional(),

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -1552,6 +1552,22 @@ describe('XaiResponsesLanguageModel', () => {
                 pattern: 'climate',
               },
             },
+            {
+              type: 'web_search_call',
+              id: 'ws_action_4',
+              name: 'web_search',
+              call_id: '',
+              status: 'completed',
+              action: { type: 'search', query: null, sources: null },
+            },
+            {
+              type: 'web_search_call',
+              id: 'ws_action_5',
+              name: 'web_search',
+              call_id: '',
+              status: 'completed',
+              action: { type: 'open_page', url: null },
+            },
           ],
           usage: { input_tokens: 10, output_tokens: 5 },
         });
@@ -1599,6 +1615,18 @@ describe('XaiResponsesLanguageModel', () => {
               pattern: 'climate',
             },
           },
+        });
+        expect(result.content).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ws_action_4',
+          toolName: 'web_search',
+          result: { action: { type: 'search' } },
+        });
+        expect(result.content).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ws_action_5',
+          toolName: 'web_search',
+          result: { action: { type: 'openPage', url: null } },
         });
       });
     });
@@ -3386,6 +3414,94 @@ describe('XaiResponsesLanguageModel', () => {
           result: {
             action: { type: 'search', query: 'latest AI news' },
             sources: [{ type: 'url', url: 'https://example.com/a' }],
+          },
+        });
+      });
+
+      it('should map open_page and find_in_page actions in stream tool-results', async () => {
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast-non-reasoning',
+              status: 'in_progress',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'web_search_call',
+              id: 'ws_open',
+              name: 'web_search',
+              call_id: '',
+              status: 'completed',
+              action: { type: 'open_page', url: 'https://example.com/a' },
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'web_search_call',
+              id: 'ws_find',
+              name: 'web_search',
+              call_id: '',
+              status: 'completed',
+              action: {
+                type: 'find_in_page',
+                url: 'https://example.com/a',
+                pattern: 'climate',
+              },
+            },
+            output_index: 1,
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 5 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'xai.web_search',
+              name: 'web_search',
+              args: {},
+            },
+          ],
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+
+        expect(parts).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ws_open',
+          toolName: 'web_search',
+          result: {
+            action: { type: 'openPage', url: 'https://example.com/a' },
+          },
+        });
+        expect(parts).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ws_find',
+          toolName: 'web_search',
+          result: {
+            action: {
+              type: 'findInPage',
+              url: 'https://example.com/a',
+              pattern: 'climate',
+            },
           },
         });
       });

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -1509,6 +1509,98 @@ describe('XaiResponsesLanguageModel', () => {
           }
         `);
       });
+
+      it('should forward web_search_call action and sources to tool-result', async () => {
+        prepareJsonResponse({
+          id: 'resp_123',
+          object: 'response',
+          status: 'completed',
+          model: 'grok-4-fast-non-reasoning',
+          output: [
+            {
+              type: 'web_search_call',
+              id: 'ws_action_1',
+              name: 'web_search',
+              call_id: '',
+              status: 'completed',
+              action: {
+                type: 'search',
+                query: 'latest AI news',
+                sources: [
+                  { type: 'url', url: 'https://example.com/a' },
+                  { type: 'url', url: 'https://example.com/b' },
+                ],
+              },
+            },
+            {
+              type: 'web_search_call',
+              id: 'ws_action_2',
+              name: 'web_search',
+              call_id: '',
+              status: 'completed',
+              action: { type: 'open_page', url: 'https://example.com/a' },
+            },
+            {
+              type: 'web_search_call',
+              id: 'ws_action_3',
+              name: 'web_search',
+              call_id: '',
+              status: 'completed',
+              action: {
+                type: 'find_in_page',
+                url: 'https://example.com/a',
+                pattern: 'climate',
+              },
+            },
+          ],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        });
+
+        const result = await createModel().doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'xai.web_search',
+              name: 'web_search',
+              args: {},
+            },
+          ],
+        });
+
+        expect(result.content).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ws_action_1',
+          toolName: 'web_search',
+          result: {
+            action: { type: 'search', query: 'latest AI news' },
+            sources: [
+              { type: 'url', url: 'https://example.com/a' },
+              { type: 'url', url: 'https://example.com/b' },
+            ],
+          },
+        });
+        expect(result.content).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ws_action_2',
+          toolName: 'web_search',
+          result: {
+            action: { type: 'openPage', url: 'https://example.com/a' },
+          },
+        });
+        expect(result.content).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ws_action_3',
+          toolName: 'web_search',
+          result: {
+            action: {
+              type: 'findInPage',
+              url: 'https://example.com/a',
+              pattern: 'climate',
+            },
+          },
+        });
+      });
     });
 
     describe('x_search tool', () => {
@@ -2192,9 +2284,10 @@ describe('XaiResponsesLanguageModel', () => {
           ],
         });
 
-        expect(result.content).toHaveLength(2);
+        expect(result.content).toHaveLength(3);
         expect(result.content[0].type).toBe('tool-call');
-        expect(result.content[1].type).toBe('tool-call');
+        expect(result.content[1].type).toBe('tool-result');
+        expect(result.content[2].type).toBe('tool-call');
       });
     });
 
@@ -2237,6 +2330,12 @@ describe('XaiResponsesLanguageModel', () => {
             toolName: 'web_search',
             input: '{"query":"test"}',
             providerExecuted: true,
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'ws_123',
+            toolName: 'web_search',
+            result: {},
           },
         ]);
       });
@@ -2405,6 +2504,12 @@ describe('XaiResponsesLanguageModel', () => {
             toolName: 'my_custom_search',
             input: '{}',
             providerExecuted: true,
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'ws_123',
+            toolName: 'my_custom_search',
+            result: {},
           },
         ]);
       });
@@ -3206,6 +3311,82 @@ describe('XaiResponsesLanguageModel', () => {
           toolCallId: 'ws_123',
           toolName: 'web_search',
           result: {},
+        });
+      });
+
+      it('should forward web_search_call action and sources to tool-result', async () => {
+        prepareStreamChunks([
+          JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              model: 'grok-4-fast-non-reasoning',
+              status: 'in_progress',
+              output: [],
+            },
+          }),
+          JSON.stringify({
+            type: 'response.output_item.added',
+            item: {
+              type: 'web_search_call',
+              id: 'ws_action',
+              name: 'web_search',
+              call_id: '',
+              status: 'in_progress',
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.output_item.done',
+            item: {
+              type: 'web_search_call',
+              id: 'ws_action',
+              name: 'web_search',
+              call_id: '',
+              status: 'completed',
+              action: {
+                type: 'search',
+                query: 'latest AI news',
+                sources: [{ type: 'url', url: 'https://example.com/a' }],
+              },
+            },
+            output_index: 0,
+          }),
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              id: 'resp_123',
+              object: 'response',
+              status: 'completed',
+              output: [],
+              usage: { input_tokens: 10, output_tokens: 5 },
+            },
+          }),
+        ]);
+
+        const { stream } = await createModel().doStream({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'provider',
+              id: 'xai.web_search',
+              name: 'web_search',
+              args: {},
+            },
+          ],
+        });
+
+        const parts = await convertReadableStreamToArray(stream);
+
+        expect(parts).toContainEqual({
+          type: 'tool-result',
+          toolCallId: 'ws_action',
+          toolName: 'web_search',
+          result: {
+            action: { type: 'search', query: 'latest AI news' },
+            sources: [{ type: 'url', url: 'https://example.com/a' }],
+          },
         });
       });
 

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -25,7 +25,7 @@ import {
   type InferSchema,
   type ParseResult,
 } from '@ai-sdk/provider-utils';
-import { z } from 'zod/v4';
+import type { z } from 'zod/v4';
 import { getResponseMetadata } from '../get-response-metadata';
 import { supportsReasoningEffort } from '../supports-reasoning-effort';
 import type { webSearchOutputSchema } from '../tool/web-search';
@@ -34,6 +34,8 @@ import { convertToXaiResponsesInput } from './convert-to-xai-responses-input';
 import { convertXaiResponsesUsage } from './convert-xai-responses-usage';
 import { mapXaiResponsesFinishReason } from './map-xai-responses-finish-reason';
 import {
+  webSearchWireActionSchema,
+  webSearchWireSourceSchema,
   xaiResponsesChunkSchema,
   xaiResponsesResponseSchema,
   type XaiResponsesIncludeOptions,
@@ -1371,31 +1373,6 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
     };
   }
 }
-
-const webSearchWireSourceSchema = z.object({
-  type: z.literal('url'),
-  url: z.string(),
-});
-
-const webSearchWireActionSchema = z.discriminatedUnion('type', [
-  z.object({
-    type: z.literal('search'),
-    query: z.string().nullish(),
-    queries: z.array(z.string()).nullish(),
-    sources: z.array(z.unknown()).nullish(),
-  }),
-  z.object({
-    type: z.literal('open_page'),
-    url: z.string().nullish(),
-    sources: z.array(z.unknown()).nullish(),
-  }),
-  z.object({
-    type: z.literal('find_in_page'),
-    url: z.string().nullish(),
-    pattern: z.string().nullish(),
-    sources: z.array(z.unknown()).nullish(),
-  }),
-]);
 
 function mapWebSearchAction(
   action: unknown,

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -22,11 +22,13 @@ import {
   WORKFLOW_SERIALIZE,
   WORKFLOW_DESERIALIZE,
   type FetchFunction,
+  type InferSchema,
   type ParseResult,
 } from '@ai-sdk/provider-utils';
 import type { z } from 'zod/v4';
 import { getResponseMetadata } from '../get-response-metadata';
 import { supportsReasoningEffort } from '../supports-reasoning-effort';
+import type { webSearchOutputSchema } from '../tool/web-search';
 import { xaiFailedResponseHandler } from '../xai-error';
 import { convertToXaiResponsesInput } from './convert-to-xai-responses-input';
 import { convertXaiResponsesUsage } from './convert-xai-responses-usage';
@@ -521,6 +523,15 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
           input: toolInput,
           providerExecuted: true,
         });
+
+        if (part.type === 'web_search_call') {
+          content.push({
+            type: 'tool-result',
+            toolCallId: part.id,
+            toolName,
+            result: mapWebSearchAction(part.action),
+          });
+        }
 
         continue;
       }
@@ -1239,7 +1250,10 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
                     type: 'tool-result',
                     toolCallId: part.id,
                     toolName,
-                    result: {},
+                    result:
+                      part.type === 'web_search_call'
+                        ? mapWebSearchAction(part.action)
+                        : {},
                   });
                 }
 
@@ -1355,5 +1369,66 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
       request: { body },
       response: { headers: responseHeaders },
     };
+  }
+}
+
+function mapWebSearchAction(
+  action: unknown,
+): InferSchema<typeof webSearchOutputSchema> {
+  if (action == null || typeof action !== 'object' || Array.isArray(action)) {
+    return {};
+  }
+
+  const a = action as {
+    type?: unknown;
+    query?: unknown;
+    queries?: unknown;
+    url?: unknown;
+    pattern?: unknown;
+    sources?: unknown;
+  };
+
+  const sources = Array.isArray(a.sources)
+    ? a.sources.filter(
+        (s): s is { type: 'url'; url: string } =>
+          s != null &&
+          typeof s === 'object' &&
+          (s as { type?: unknown }).type === 'url' &&
+          typeof (s as { url?: unknown }).url === 'string',
+      )
+    : undefined;
+
+  switch (a.type) {
+    case 'search':
+      return {
+        action: {
+          type: 'search',
+          ...(typeof a.query === 'string' && { query: a.query }),
+          ...(Array.isArray(a.queries) &&
+            a.queries.every(q => typeof q === 'string') && {
+              queries: a.queries as string[],
+            }),
+        },
+        ...(sources != null && sources.length > 0 && { sources }),
+      };
+    case 'open_page':
+      return {
+        action: {
+          type: 'openPage',
+          url: typeof a.url === 'string' ? a.url : undefined,
+        },
+        ...(sources != null && sources.length > 0 && { sources }),
+      };
+    case 'find_in_page':
+      return {
+        action: {
+          type: 'findInPage',
+          url: typeof a.url === 'string' ? a.url : undefined,
+          pattern: typeof a.pattern === 'string' ? a.pattern : undefined,
+        },
+        ...(sources != null && sources.length > 0 && { sources }),
+      };
+    default:
+      return {};
   }
 }

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -1380,20 +1380,20 @@ const webSearchWireSourceSchema = z.object({
 const webSearchWireActionSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('search'),
-    query: z.string().optional(),
-    queries: z.array(z.string()).optional(),
-    sources: z.array(z.unknown()).optional(),
+    query: z.string().nullish(),
+    queries: z.array(z.string()).nullish(),
+    sources: z.array(z.unknown()).nullish(),
   }),
   z.object({
     type: z.literal('open_page'),
-    url: z.string().optional(),
-    sources: z.array(z.unknown()).optional(),
+    url: z.string().nullish(),
+    sources: z.array(z.unknown()).nullish(),
   }),
   z.object({
     type: z.literal('find_in_page'),
-    url: z.string().optional(),
-    pattern: z.string().optional(),
-    sources: z.array(z.unknown()).optional(),
+    url: z.string().nullish(),
+    pattern: z.string().nullish(),
+    sources: z.array(z.unknown()).nullish(),
   }),
 ]);
 
@@ -1415,8 +1415,8 @@ function mapWebSearchAction(
       return {
         action: {
           type: 'search',
-          ...(a.query !== undefined && { query: a.query }),
-          ...(a.queries !== undefined && { queries: a.queries }),
+          ...(a.query != null && { query: a.query }),
+          ...(a.queries != null && { queries: a.queries }),
         },
         ...sourcesExtra,
       };

--- a/packages/xai/src/responses/xai-responses-language-model.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.ts
@@ -25,7 +25,7 @@ import {
   type InferSchema,
   type ParseResult,
 } from '@ai-sdk/provider-utils';
-import type { z } from 'zod/v4';
+import { z } from 'zod/v4';
 import { getResponseMetadata } from '../get-response-metadata';
 import { supportsReasoningEffort } from '../supports-reasoning-effort';
 import type { webSearchOutputSchema } from '../tool/web-search';
@@ -1372,63 +1372,60 @@ export class XaiResponsesLanguageModel implements LanguageModelV4 {
   }
 }
 
+const webSearchWireSourceSchema = z.object({
+  type: z.literal('url'),
+  url: z.string(),
+});
+
+const webSearchWireActionSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('search'),
+    query: z.string().optional(),
+    queries: z.array(z.string()).optional(),
+    sources: z.array(z.unknown()).optional(),
+  }),
+  z.object({
+    type: z.literal('open_page'),
+    url: z.string().optional(),
+    sources: z.array(z.unknown()).optional(),
+  }),
+  z.object({
+    type: z.literal('find_in_page'),
+    url: z.string().optional(),
+    pattern: z.string().optional(),
+    sources: z.array(z.unknown()).optional(),
+  }),
+]);
+
 function mapWebSearchAction(
   action: unknown,
 ): InferSchema<typeof webSearchOutputSchema> {
-  if (action == null || typeof action !== 'object' || Array.isArray(action)) {
-    return {};
-  }
+  const parsed = webSearchWireActionSchema.safeParse(action);
+  if (!parsed.success) return {};
 
-  const a = action as {
-    type?: unknown;
-    query?: unknown;
-    queries?: unknown;
-    url?: unknown;
-    pattern?: unknown;
-    sources?: unknown;
-  };
-
-  const sources = Array.isArray(a.sources)
-    ? a.sources.filter(
-        (s): s is { type: 'url'; url: string } =>
-          s != null &&
-          typeof s === 'object' &&
-          (s as { type?: unknown }).type === 'url' &&
-          typeof (s as { url?: unknown }).url === 'string',
-      )
-    : undefined;
+  const a = parsed.data;
+  const sources = a.sources?.flatMap(s => {
+    const source = webSearchWireSourceSchema.safeParse(s);
+    return source.success ? [source.data] : [];
+  });
+  const sourcesExtra = sources != null && sources.length > 0 ? { sources } : {};
 
   switch (a.type) {
     case 'search':
       return {
         action: {
           type: 'search',
-          ...(typeof a.query === 'string' && { query: a.query }),
-          ...(Array.isArray(a.queries) &&
-            a.queries.every(q => typeof q === 'string') && {
-              queries: a.queries as string[],
-            }),
+          ...(a.query !== undefined && { query: a.query }),
+          ...(a.queries !== undefined && { queries: a.queries }),
         },
-        ...(sources != null && sources.length > 0 && { sources }),
+        ...sourcesExtra,
       };
     case 'open_page':
-      return {
-        action: {
-          type: 'openPage',
-          url: typeof a.url === 'string' ? a.url : undefined,
-        },
-        ...(sources != null && sources.length > 0 && { sources }),
-      };
+      return { action: { type: 'openPage', url: a.url }, ...sourcesExtra };
     case 'find_in_page':
       return {
-        action: {
-          type: 'findInPage',
-          url: typeof a.url === 'string' ? a.url : undefined,
-          pattern: typeof a.pattern === 'string' ? a.pattern : undefined,
-        },
-        ...(sources != null && sources.length > 0 && { sources }),
+        action: { type: 'findInPage', url: a.url, pattern: a.pattern },
+        ...sourcesExtra,
       };
-    default:
-      return {};
   }
 }

--- a/packages/xai/src/tool/web-search.ts
+++ b/packages/xai/src/tool/web-search.ts
@@ -16,17 +16,30 @@ export const webSearchArgsSchema = lazySchema(() =>
   ),
 );
 
-const webSearchOutputSchema = lazySchema(() =>
+export const webSearchOutputSchema = lazySchema(() =>
   zodSchema(
     z.object({
-      query: z.string(),
-      sources: z.array(
-        z.object({
-          title: z.string(),
-          url: z.string(),
-          snippet: z.string(),
-        }),
-      ),
+      action: z
+        .discriminatedUnion('type', [
+          z.object({
+            type: z.literal('search'),
+            query: z.string().optional(),
+            queries: z.array(z.string()).optional(),
+          }),
+          z.object({
+            type: z.literal('openPage'),
+            url: z.string().nullish(),
+          }),
+          z.object({
+            type: z.literal('findInPage'),
+            url: z.string().nullish(),
+            pattern: z.string().nullish(),
+          }),
+        ])
+        .optional(),
+      sources: z
+        .array(z.object({ type: z.literal('url'), url: z.string() }))
+        .optional(),
     }),
   ),
 );
@@ -34,12 +47,22 @@ const webSearchOutputSchema = lazySchema(() =>
 const webSearchToolFactory = createProviderExecutedToolFactory<
   {},
   {
-    query: string;
-    sources: Array<{
-      title: string;
-      url: string;
-      snippet: string;
-    }>;
+    action?:
+      | {
+          type: 'search';
+          query?: string;
+          queries?: string[];
+        }
+      | {
+          type: 'openPage';
+          url?: string | null;
+        }
+      | {
+          type: 'findInPage';
+          url?: string | null;
+          pattern?: string | null;
+        };
+    sources?: Array<{ type: 'url'; url: string }>;
   },
   {
     allowedDomains?: string[];


### PR DESCRIPTION
## Background

Reported by AthenaHQ ([customer thread](https://vercel.slack.com/archives/C09Q2N54LJC/p1787771675800939)): calling xAI's `web_search` tool through the AI Gateway Responses API returns `web_search_call` items with an empty `action` — `query` is `''`, no `sources`, no `open_page` items. Direct to `api.x.ai/v1/responses` the same request returns everything (8 search calls, 35 source URLs, 5 opened pages in my repro).

Root cause: the xAI responses language model drops `part.action` for `web_search_call` output items. `doGenerate` emitted only a `tool-call` with no `tool-result`, and `doStream` emitted `tool-result` with `result: {}`. Downstream consumers (the gateway's Responses normalization) then fall back to `{type: 'search', query: ''}`.

## Summary

- Emit a `tool-result` for `web_search_call` parts in both `doGenerate` and `doStream`, carrying the mapped action via a new `mapWebSearchAction` helper that mirrors `@ai-sdk/openai`'s `mapWebSearchOutput`: `search` (query/queries + sources), `open_page` → `openPage`, `find_in_page` → `findInPage`
- Update the `webSearch` tool output schema to the Responses-style shape (`action` + `sources`) so the tool output is typed
- Tests for search/open_page/find_in_page action mapping in generate and stream

## Verification

- `vitest run` in packages/xai: 97/97 pass
- End-to-end through a local AI Gateway with this build patched in as `@ai-sdk/xai-v3` plus the companion gateway change: 9 web_search_call items, 40 source URLs, 5 open_page actions (was: 8 items, all empty)

Companion gateway PR forwards `sources` in the Responses output mapper. Linear: [AIG-670](https://linear.app/vercel/issue/AIG-670/xai-web-search-call-items-lose-query-sources-and-open-page-actions)

The customer-facing gateway path runs the v3 (release-v6.0) line today, so this should be backported.