### PR TITLE
docs(ui): add Expo streaming troubleshooting note

### DIFF
--- a/content/docs/02-getting-started/07-expo.mdx
+++ b/content/docs/02-getting-started/07-expo.mdx
@@ -111,6 +111,13 @@ Let's take a look at what is happening in this code:
 
 This API route creates a POST request endpoint at `/api/chat`.
 
+<Note>
+  If a deployed Expo API Route buffers the response despite the streaming
+  headers above, test the same handler without the deployment adapter to isolate
+  the cause. As a workaround, host the chat endpoint in a separate Vercel
+  Function and set `EXPO_PUBLIC_API_BASE_URL` to that function's base URL.
+</Note>
+
 ## Choosing a Provider
 
 The AI SDK supports dozens of model providers through [first-party](/providers/ai-sdk-providers), [OpenAI-compatible](/providers/openai-compatible-providers), and [ community ](/providers/community-providers) packages.


### PR DESCRIPTION
## Summary

- backport the Expo streaming troubleshooting note from #19810
- recommend testing the handler without the deployment adapter to isolate buffering
- document a separate Vercel Function as a workaround

Backport of #19810.
Refs #11772.

## Verification

- git diff --check
- documentation content matches #19810