### PR TITLE
feat(provider/gateway): surface marketCost, surchargeCost, gatewayCost in getGenerationInfo

### DIFF
--- a/.changeset/tidy-pandas-shout.md
+++ b/.changeset/tidy-pandas-shout.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+Add marketCost, surchargeCost, and gatewayCost fields to getGenerationInfo() results, surfacing the corresponding fields from the AI Gateway generation lookup API.

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -669,6 +669,9 @@ It returns a `GatewayGenerationInfo` object with the following fields:
 
 - **id** _string_ - The generation ID
 - **totalCost** _number_ - Total cost in USD
+- **marketCost** _number | undefined_ - Cost at undiscounted market rates in USD, excluding surcharges (omitted when not recorded for the generation)
+- **surchargeCost** _number_ - Total surcharges applied in USD
+- **gatewayCost** _number_ - Total amount debited in USD (same as totalCost)
 - **upstreamInferenceCost** _number_ - Upstream inference cost in USD (relevant for BYOK)
 - **usage** _number_ - Usage cost in USD (same as totalCost)
 - **createdAt** _string_ - ISO 8601 timestamp when the generation was created

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -669,7 +669,7 @@ It returns a `GatewayGenerationInfo` object with the following fields:
 
 - **id** _string_ - The generation ID
 - **totalCost** _number_ - Total cost in USD
-- **marketCost** _number | undefined_ - Cost at undiscounted market rates in USD, excluding surcharges (omitted when not recorded for the generation)
+- **marketCost** _number_ - Cost at undiscounted market rates in USD, excluding surcharges (0 when not recorded for the generation)
 - **surchargeCost** _number_ - Total surcharges applied in USD
 - **gatewayCost** _number_ - Total amount debited in USD (same as totalCost)
 - **upstreamInferenceCost** _number_ - Upstream inference cost in USD (relevant for BYOK)

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -669,7 +669,7 @@ It returns a `GatewayGenerationInfo` object with the following fields:
 
 - **id** _string_ - The generation ID
 - **totalCost** _number_ - Total cost in USD
-- **marketCost** _number_ - Cost at undiscounted market rates in USD, excluding surcharges (0 when not recorded for the generation)
+- **marketCost** _number_ - Cost at undiscounted market rates in USD, excluding surcharges
 - **surchargeCost** _number_ - Total surcharges applied in USD
 - **gatewayCost** _number_ - Total amount debited in USD (same as totalCost)
 - **upstreamInferenceCost** _number_ - Upstream inference cost in USD (relevant for BYOK)

--- a/packages/gateway/src/gateway-generation-info.test.ts
+++ b/packages/gateway/src/gateway-generation-info.test.ts
@@ -26,6 +26,9 @@ const mockGenerationResponse = {
   data: {
     id: 'gen_01ARZ3NDEKTSV4RRFFQ69G5FAV',
     total_cost: 0.00123,
+    market_cost: 0.0011,
+    surcharge_cost: 0.00013,
+    gateway_cost: 0.00123,
     upstream_inference_cost: 0.0011,
     usage: 0.00123,
     created_at: '2024-01-01T00:00:00.000Z',
@@ -79,6 +82,9 @@ describe('GatewayGenerationInfoFetcher', () => {
       expect(result).toEqual({
         id: 'gen_01ARZ3NDEKTSV4RRFFQ69G5FAV',
         totalCost: 0.00123,
+        marketCost: 0.0011,
+        surchargeCost: 0.00013,
+        gatewayCost: 0.00123,
         upstreamInferenceCost: 0.0011,
         usage: 0.00123,
         createdAt: '2024-01-01T00:00:00.000Z',
@@ -263,6 +269,27 @@ describe('GatewayGenerationInfoFetcher', () => {
       expect(result.isByok).toBe(true);
       expect(result.upstreamInferenceCost).toBe(0.0009);
       expect(result.providerName).toBe('anthropic');
+    });
+
+    it('should omit marketCost when market_cost is absent from the response', async () => {
+      server.urls['https://api.example.com/*'].response = {
+        type: 'json-value',
+        body: {
+          data: {
+            ...mockGenerationResponse.data,
+            market_cost: undefined,
+          },
+        },
+      };
+
+      const fetcher = createFetcher();
+      const result = await fetcher.getGenerationInfo({
+        id: 'gen_01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      });
+
+      expect(result.marketCost).toBeUndefined();
+      expect(result.surchargeCost).toBe(0.00013);
+      expect(result.gatewayCost).toBe(0.00123);
     });
   });
 });

--- a/packages/gateway/src/gateway-generation-info.test.ts
+++ b/packages/gateway/src/gateway-generation-info.test.ts
@@ -271,7 +271,7 @@ describe('GatewayGenerationInfoFetcher', () => {
       expect(result.providerName).toBe('anthropic');
     });
 
-    it('should omit marketCost when market_cost is absent from the response', async () => {
+    it('should default marketCost to 0 when market_cost is absent from the response', async () => {
       server.urls['https://api.example.com/*'].response = {
         type: 'json-value',
         body: {
@@ -287,7 +287,7 @@ describe('GatewayGenerationInfoFetcher', () => {
         id: 'gen_01ARZ3NDEKTSV4RRFFQ69G5FAV',
       });
 
-      expect(result.marketCost).toBeUndefined();
+      expect(result.marketCost).toBe(0);
       expect(result.surchargeCost).toBe(0.00013);
       expect(result.gatewayCost).toBe(0.00123);
     });

--- a/packages/gateway/src/gateway-generation-info.ts
+++ b/packages/gateway/src/gateway-generation-info.ts
@@ -21,7 +21,7 @@ export interface GatewayGenerationInfo {
   id: string;
   /** Total cost in USD */
   totalCost: number;
-  /** Cost at undiscounted market rates in USD, excluding surcharges (0 when not recorded for the generation) */
+  /** Cost at undiscounted market rates in USD, excluding surcharges */
   marketCost: number;
   /** Total surcharges applied in USD */
   surchargeCost: number;
@@ -143,10 +143,6 @@ const gatewayGenerationInfoResponseSchema = lazySchema(() =>
             }) => ({
               ...rest,
               totalCost: total_cost,
-              // market_cost is omitted on rows predating the column; the REST
-              // endpoint's other always-present numeric fields (e.g.
-              // billable_web_search_calls) already normalize absence to 0, so
-              // we do the same rather than expose an optional field.
               marketCost: market_cost ?? 0,
               surchargeCost: surcharge_cost,
               gatewayCost: gateway_cost,

--- a/packages/gateway/src/gateway-generation-info.ts
+++ b/packages/gateway/src/gateway-generation-info.ts
@@ -21,8 +21,8 @@ export interface GatewayGenerationInfo {
   id: string;
   /** Total cost in USD */
   totalCost: number;
-  /** Cost at undiscounted market rates in USD, excluding surcharges (omitted when not recorded for the generation) */
-  marketCost?: number;
+  /** Cost at undiscounted market rates in USD, excluding surcharges (0 when not recorded for the generation) */
+  marketCost: number;
   /** Total surcharges applied in USD */
   surchargeCost: number;
   /** Total amount debited in USD (same as totalCost) */
@@ -143,7 +143,11 @@ const gatewayGenerationInfoResponseSchema = lazySchema(() =>
             }) => ({
               ...rest,
               totalCost: total_cost,
-              marketCost: market_cost,
+              // market_cost is omitted on rows predating the column; the REST
+              // endpoint's other always-present numeric fields (e.g.
+              // billable_web_search_calls) already normalize absence to 0, so
+              // we do the same rather than expose an optional field.
+              marketCost: market_cost ?? 0,
               surchargeCost: surcharge_cost,
               gatewayCost: gateway_cost,
               upstreamInferenceCost: upstream_inference_cost,

--- a/packages/gateway/src/gateway-generation-info.ts
+++ b/packages/gateway/src/gateway-generation-info.ts
@@ -21,6 +21,12 @@ export interface GatewayGenerationInfo {
   id: string;
   /** Total cost in USD */
   totalCost: number;
+  /** Cost at undiscounted market rates in USD, excluding surcharges (omitted when not recorded for the generation) */
+  marketCost?: number;
+  /** Total surcharges applied in USD */
+  surchargeCost: number;
+  /** Total amount debited in USD (same as totalCost) */
+  gatewayCost: number;
   /** Upstream inference cost in USD (BYOK only) */
   upstreamInferenceCost: number;
   /** Usage cost in USD (same as totalCost) */
@@ -95,6 +101,9 @@ const gatewayGenerationInfoResponseSchema = lazySchema(() =>
           .object({
             id: z.string(),
             total_cost: z.number(),
+            market_cost: z.number().optional(),
+            surcharge_cost: z.number(),
+            gateway_cost: z.number(),
             upstream_inference_cost: z.number(),
             usage: z.number(),
             created_at: z.string(),
@@ -115,6 +124,9 @@ const gatewayGenerationInfoResponseSchema = lazySchema(() =>
           .transform(
             ({
               total_cost,
+              market_cost,
+              surcharge_cost,
+              gateway_cost,
               upstream_inference_cost,
               created_at,
               is_byok,
@@ -131,6 +143,9 @@ const gatewayGenerationInfoResponseSchema = lazySchema(() =>
             }) => ({
               ...rest,
               totalCost: total_cost,
+              marketCost: market_cost,
+              surchargeCost: surcharge_cost,
+              gatewayCost: gateway_cost,
               upstreamInferenceCost: upstream_inference_cost,
               createdAt: created_at,
               isByok: is_byok,


### PR DESCRIPTION
## Background

The AI Gateway generation lookup endpoint (`GET /v1/generation`) now returns three additional cost fields: `market_cost`, `surcharge_cost`, and `gateway_cost`. The gateway provider's `getGenerationInfo()` did not surface them.

## Summary

- Adds `marketCost`, `surchargeCost`, and `gatewayCost` to the `GatewayGenerationInfo` interface
- Parses and transforms the new fields in the response schema; `market_cost` is omitted by the endpoint on rows predating the column, so the SDK normalizes absence to `0`, matching how `billableWebSearchCalls` and `upstreamInferenceCost` already behave
- Updates the Generation Lookup field list in the AI Gateway provider docs

## End-to-End Verification

The schema and transform match the live `/v1/generation` response shape; a new test covers the `market_cost`-absent case for older generations.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)