### PR TITLE
fix(harness-codex): close inferred step at stream end

### DIFF
--- a/.changeset/bright-codex-streams.md
+++ b/.changeset/bright-codex-streams.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-codex': patch
+---
+
+Close inferred steps before finishing when the Codex event iterator ends without a terminal event.

--- a/packages/harness-codex/src/bridge/index.test.ts
+++ b/packages/harness-codex/src/bridge/index.test.ts
@@ -16,6 +16,8 @@ const state = vi.hoisted(() => ({
   codexOptions: [] as CodexOptions[],
   threadOptions: [] as ThreadOptions[],
   turnOptions: [] as TurnOptions[],
+  events: [{ type: 'turn.completed' }] as Record<string, unknown>[],
+  emitted: [] as Record<string, unknown>[],
   startModel: 'gpt-5.5',
   startResponseFormat: undefined as
     | { type: 'json'; schema: Record<string, unknown> }
@@ -43,7 +45,7 @@ vi.mock('@openai/codex-sdk', () => ({
           state.turnOptions.push(options);
           return {
             events: (async function* () {
-              yield { type: 'turn.completed' };
+              yield* state.events;
             })(),
           };
         },
@@ -81,7 +83,7 @@ vi.mock('@ai-sdk/harness/bridge', () => ({
         ],
       },
       {
-        emit: () => {},
+        emit: (event: Record<string, unknown>) => state.emitted.push(event),
         requestToolResult: async () => ({ output: {} }),
         abortSignal: new AbortController().signal,
         experimental_userMessages: {
@@ -99,6 +101,8 @@ describe('Codex bridge config', () => {
     state.codexOptions = [];
     state.threadOptions = [];
     state.turnOptions = [];
+    state.events = [{ type: 'turn.completed' }];
+    state.emitted = [];
     state.startModel = 'gpt-5.5';
     state.startResponseFormat = undefined;
     state.startInstructions = undefined;
@@ -287,5 +291,29 @@ describe('Codex bridge config', () => {
     expect(state.turnOptions[0]?.outputSchema).toEqual(
       state.startResponseFormat.schema,
     );
+  });
+
+  test('closes an inferred step before finish when the event stream ends without a terminal event', async () => {
+    state.events = [
+      {
+        type: 'item.completed',
+        item: {
+          type: 'agent_message',
+          id: 'message-1',
+          text: 'Done',
+        },
+      },
+    ];
+
+    await import('./index');
+
+    expect(state.emitted.map(event => event.type)).toEqual([
+      'stream-start',
+      'text-start',
+      'text-delta',
+      'text-end',
+      'finish-step',
+      'finish',
+    ]);
   });
 });

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -259,6 +259,11 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
     relay?.close();
   }
 
+  // Codex normally closes the inferred step through `turn.completed`, but an
+  // exhausted or cooperatively aborted iterator can reach this boundary
+  // without that event. Keep the Harness stream valid before emitting its
+  // terminal part. `finishTurn()` is idempotent when the terminal event ran.
+  stepTracker.finishTurn();
   emit({
     type: 'finish',
     finishReason: { unified: 'stop', raw: 'stop' },


### PR DESCRIPTION
## Background

Harness Codex normally closes its inferred step when Codex emits `turn.completed`. The bridge nevertheless emits its own terminal `finish` whenever the SDK event iterator ends normally, including an iterator that exhausts or cooperatively stops without that terminal event. In that path a completed model item can leave an open step immediately before `finish`, producing an invalid Harness stream.

## Summary

- Close any remaining inferred step at the bridge-owned stream boundary before emitting `finish`.
- Keep the existing terminal-event close; the fallback is idempotent after `turn.completed`.
- Add a bridge regression test whose Codex iterator ends after a model item without a terminal event.
- Add a patch changeset for `@ai-sdk/harness-codex`.

## Verification

- `pnpm --filter @ai-sdk/harness-codex test` (109 tests)
- `pnpm --filter @ai-sdk/harness-codex type-check`
- `pnpm --filter @ai-sdk/harness-codex build`
- focused `ultracite check` for both changed TypeScript files
- `git diff --check`

## Checklist

- [x] Commit is signed and verified
- [x] Regression coverage added
- [x] Patch changeset added
- [x] Self-reviewed