### PR TITLE
fix(togetherai): enable structured outputs for DeepSeek V4 Flash

### DIFF
--- a/.changeset/togetherai-deepseek-v4-structured-outputs.md
+++ b/.changeset/togetherai-deepseek-v4-structured-outputs.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/togetherai': patch
+---
+
+fix(togetherai): forward JSON schemas for DeepSeek V4 Flash structured outputs

--- a/examples/ai-functions/src/generate-text/togetherai/output-object.ts
+++ b/examples/ai-functions/src/generate-text/togetherai/output-object.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = await generateText({
-    model: togetherai.chatModel('mistralai/Mistral-7B-Instruct-v0.1'),
+    model: togetherai.chatModel('deepseek-ai/DeepSeek-V4-Flash-0731'),
     output: Output.object({
       schema: z.object({
         recipe: z.object({
@@ -20,7 +20,8 @@ run(async () => {
         }),
       }),
     }),
-    prompt: 'Generate a lasagna recipe.',
+    prompt:
+      'Generate a lasagna recipe. Return only JSON with a recipe object containing a name, an ingredients array of name and amount objects, and a steps array.',
   });
 
   console.log(JSON.stringify(result.output?.recipe, null, 2));

--- a/examples/ai-functions/src/stream-text/togetherai/output-object.ts
+++ b/examples/ai-functions/src/stream-text/togetherai/output-object.ts
@@ -5,7 +5,7 @@ import { run } from '../../lib/run';
 
 run(async () => {
   const result = streamText({
-    model: togetherai.chatModel('mistralai/Mistral-7B-Instruct-v0.1'),
+    model: togetherai.chatModel('deepseek-ai/DeepSeek-V4-Flash-0731'),
     output: Output.object({
       schema: z.object({
         characters: z.array(
@@ -20,7 +20,7 @@ run(async () => {
       }),
     }),
     prompt:
-      'Generate 3 character descriptions for a fantasy role playing game.',
+      'Generate 3 fantasy role playing game characters. Return only JSON with a characters array whose items contain a name, class, and description.',
   });
 
   for await (const partialOutput of result.partialOutputStream) {

--- a/packages/togetherai/src/togetherai-chat-options.ts
+++ b/packages/togetherai/src/togetherai-chat-options.ts
@@ -20,6 +20,7 @@ export type TogetherAIChatModelId =
   | 'databricks/dbrx-instruct'
   | 'deepseek-ai/deepseek-llm-67b-chat'
   | 'deepseek-ai/DeepSeek-V3'
+  | 'deepseek-ai/DeepSeek-V4-Flash-0731'
   | 'google/gemma-2b-it'
   | 'Gryphe/MythoMax-L2-13b'
   | 'meta-llama/Llama-2-13b-chat-hf'

--- a/packages/togetherai/src/togetherai-provider.test.ts
+++ b/packages/togetherai/src/togetherai-provider.test.ts
@@ -20,7 +20,10 @@ import {
 } from 'vitest';
 import { TogetherAIRerankingModel } from './reranking/togetherai-reranking-model';
 import { TogetherAIImageModel } from './togetherai-image-model';
-import { createTogetherAI } from './togetherai-provider';
+import {
+  createTogetherAI,
+  getModelStructuredOutputSupport,
+} from './togetherai-provider';
 
 // Add type assertion for the mocked class
 const OpenAICompatibleChatLanguageModelMock =
@@ -204,6 +207,20 @@ describe('TogetherAIProvider', () => {
       const config = OpenAICompatibleChatLanguageModelMock.mock.calls[0][1];
       expect(config.includeUsage).toBe(true);
     });
+
+    it.each([
+      ['deepseek-ai/DeepSeek-V4-Flash-0731', true],
+      ['custom-model-id', false],
+    ] as const)(
+      'should set supportsStructuredOutputs for %s to %s',
+      (modelId, expected) => {
+        const provider = createTogetherAI();
+        provider.chatModel(modelId);
+
+        const config = OpenAICompatibleChatLanguageModelMock.mock.calls[0][1];
+        expect(config.supportsStructuredOutputs).toBe(expected);
+      },
+    );
   });
 
   describe('completionModel', () => {
@@ -288,4 +305,16 @@ describe('TogetherAIProvider', () => {
       expect(model).toBeInstanceOf(TogetherAIRerankingModel);
     });
   });
+});
+
+describe('getModelStructuredOutputSupport', () => {
+  it.each([
+    ['deepseek-ai/DeepSeek-V4-Flash-0731', true],
+    ['custom-model-id', false],
+  ] as const)(
+    'returns structured output support for %s as %s',
+    (modelId, expected) => {
+      expect(getModelStructuredOutputSupport(modelId)).toBe(expected);
+    },
+  );
 });

--- a/packages/togetherai/src/togetherai-provider.ts
+++ b/packages/togetherai/src/togetherai-provider.ts
@@ -114,6 +114,12 @@ function loadDeprecatedApiKey(): string | undefined {
   return key;
 }
 
+export function getModelStructuredOutputSupport(
+  modelId: TogetherAIChatModelId,
+): boolean {
+  return modelId === 'deepseek-ai/DeepSeek-V4-Flash-0731';
+}
+
 export function createTogetherAI(
   options: TogetherAIProviderSettings = {},
 ): TogetherAIProvider {
@@ -151,6 +157,7 @@ export function createTogetherAI(
     return new OpenAICompatibleChatLanguageModel(modelId, {
       ...getCommonModelConfig('chat'),
       includeUsage: true,
+      supportsStructuredOutputs: getModelStructuredOutputSupport(modelId),
     });
   };
 


### PR DESCRIPTION
## Background

Together lists `deepseek-ai/DeepSeek-V4-Flash-0731` as supporting structured outputs in its [serverless model catalog](https://docs.together.ai/docs/serverless/models), and its [structured output guide](https://docs.together.ai/docs/inference/chat/structured-outputs) accepts JSON Schema through `response_format`.

`@ai-sdk/togetherai` currently leaves `supportsStructuredOutputs` disabled. The OpenAI-compatible layer therefore rewrites `json_schema` requests to `json_object`, discarding the schema, name, description, and strict setting with an unsupported-format warning.

## Summary

- Enable structured outputs for the exact documented DeepSeek V4 Flash model.
- Keep unknown and unsupported Together models disabled.
- Add regression coverage for both the capability decision and constructor wiring.
- Update the generate and stream object examples to use DeepSeek V4 Flash with shape-explicit JSON prompts.
- Add the model ID to typed suggestions and include a patch changeset.

## End-to-End Verification

Manually exercised the patched Together provider request path for both generation and streaming with an enum-constrained schema. Both outgoing requests contained `response_format.type: json_schema`, the full schema, name, description, and `strict: true`, with no unsupported-format warning. An unknown model retained the existing `json_object` fallback and warning.

A live native Together request was not run because this environment does not have a `TOGETHER_API_KEY`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)