### PR TITLE
fix(examples): fix harness example runner bug so that examples reading stdin cannot mess up the overall example execution loop

### DIFF
--- a/tools/run-harness-agent-examples.sh
+++ b/tools/run-harness-agent-examples.sh
@@ -266,11 +266,14 @@ for harness in ${HARNESS_TO_RUN[@]+"${HARNESS_TO_RUN[@]}"}; do
   else
     # No explicit examples: run every runnable *.ts file in the harness
     # folder (underscore-prefixed files are helpers, not examples).
-    example_files="$(
+    example_files=()
+    while IFS= read -r example_file; do
+      example_files+=("${example_file}")
+    done < <(
       find "${harness_path}" -mindepth 1 -maxdepth 1 -type f -name '*.ts' ! -name '_*' -print |
         sort
-    )"
-    while IFS= read -r example_file; do
+    )
+    for example_file in ${example_files[@]+"${example_files[@]}"}; do
       example="$(basename "${example_file}" .ts)"
       echo
       echo "▶ ${harness}/${example}"
@@ -286,9 +289,7 @@ for harness in ${HARNESS_TO_RUN[@]+"${HARNESS_TO_RUN[@]}"}; do
         fail=$((fail + 1))
       fi
       total=$((total + 1))
-    done <<EOF
-${example_files}
-EOF
+    done
   fi
 done
 


### PR DESCRIPTION
## Background

The `with-client-side-tool.ts` example which all harnesses have reads from stdin. Since the tool runner was also gathering the example files to iterate over in the same loop as running them, this example file's execution could mess up the runner loop, therefore stopping.

## Summary

Update the runner script to first gather all files in a loop, then run them in a second loop.

**Example/tooling only change.** No changeset needed.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)