### PR TITLE
fix(provider/amazon-bedrock): omit assistant messages whose only remaining content is a cache point

### DIFF
--- a/.changeset/cachepoint-only-assistant-messages.md
+++ b/.changeset/cachepoint-only-assistant-messages.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Omit assistant messages whose only remaining content is a cache point after filtering.

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
@@ -1429,6 +1429,123 @@ describe('assistant messages', () => {
     });
   });
 
+  it('should omit an assistant message whose only remaining content is a message-level cache point', async () => {
+    // A cachePoint provider option on a message whose every content part was
+    // filtered out (unsigned reasoning) must not produce
+    // content: [{ cachePoint }] — Bedrock rejects it with "There is nothing
+    // available to cache. Please remove the invalid cache point and try again."
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Think hard then answer' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'Let me consider the options',
+          },
+        ],
+        providerOptions: { bedrock: { cachePoint: { type: 'default' } } },
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello?' }],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'Think hard then answer' }],
+        },
+        {
+          role: 'user',
+          content: [{ text: 'Hello?' }],
+        },
+      ],
+      system: [],
+    });
+  });
+
+  it('should omit an assistant message whose only remaining content is a part-level cache point', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Think hard then answer' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'Let me consider the options',
+            providerOptions: {
+              bedrock: { cachePoint: { type: 'default' } },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello?' }],
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'Think hard then answer' }],
+        },
+        {
+          role: 'user',
+          content: [{ text: 'Hello?' }],
+        },
+      ],
+      system: [],
+    });
+  });
+
+  it('should keep the cache point when an assistant message retains other content', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Think hard then answer' }],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: 'Let me consider the options',
+          },
+          { type: 'text', text: 'The answer is 42.' },
+        ],
+        providerOptions: { bedrock: { cachePoint: { type: 'default' } } },
+      },
+    ]);
+
+    expect(result).toEqual({
+      messages: [
+        {
+          role: 'user',
+          content: [{ text: 'Think hard then answer' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            { text: 'The answer is 42.' },
+            { cachePoint: { type: 'default' } },
+          ],
+        },
+      ],
+      system: [],
+    });
+  });
+
   it('should omit multiple reasoning parts without signatures', async () => {
     const result = await convertToAmazonBedrockChatMessages([
       {

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -624,7 +624,13 @@ export async function convertToAmazonBedrockChatMessages(
           pushCachePoint(amazonBedrockContent, message.providerOptions);
         }
 
-        if (amazonBedrockContent.length > 0) {
+        // A message that contains only cachePoint blocks is invalid: Bedrock
+        // rejects it with "There is nothing available to cache. Please remove
+        // the invalid cache point and try again." — a cache point must follow
+        // content within its message. This happens when every content part was
+        // filtered out (e.g. unsigned reasoning) while the message carried a
+        // cachePoint provider option.
+        if (amazonBedrockContent.some(block => !('cachePoint' in block))) {
           messages.push({ role: 'assistant', content: amazonBedrockContent });
         }
 


### PR DESCRIPTION
## Background

#18456 fixed assistant messages going out empty after unsigned reasoning is filtered on replay. There's a sibling case it misses: the guard runs after `pushCachePoint`, so a fully-filtered message that carries a `cachePoint` provider option still goes out as `content: [{ cachePoint }]`. Bedrock rejects it, non-retryable:

> There is nothing available to cache. Please remove the invalid cache point and try again.

Same bricked-conversation story as #18452. It bites real users today via opencode, which puts cache points on the last two messages of every request — an assistant turn aborted mid-thinking then poisons the whole session (anomalyco/opencode#11210 has both error strings).

## Summary

Strengthened the omission guard from "non-empty" to "has at least one non-cachePoint block":

```ts
if (amazonBedrockContent.some(block => !('cachePoint' in block))) {
  messages.push({ role: 'assistant', content: amazonBedrockContent });
}
```

Nothing changes for messages that keep real content — the cache point is still emitted after it. Added regression tests (message-level and part-level cache point omission, both fail without the fix, plus one confirming the cache point is kept when other content remains) and a patch changeset. 499/499 package tests pass on node and edge.

## Contributor Credit

@yonatan-shorani — this builds directly on the #18452 reproduction and the #18456 fix.

## End-to-End Verification

Sent the exact payloads to the live Converse API (eu-west-1, Claude): an assistant message whose content is only `[{"cachePoint":{"type":"default"}}]` returns the 400 above, and consecutive user messages — the conversation shape left behind after omission — are accepted, so dropping the message can't produce an invalid request. Applying the same omission downstream in opencode un-bricks a real poisoned session: the exact 400 before, normal completion after.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #19851