### PR TITLE
feat(amazon-bedrock): add model family setting for embeddings to support ARN

### DIFF
--- a/.changeset/gorgeous-readers-buy.md
+++ b/.changeset/gorgeous-readers-buy.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/amazon-bedrock": patch
+---
+
+feat(amazon-bedrock): add model family setting for embeddings to support ARN

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -991,6 +991,30 @@ The following provider options are available for Cohere embedding models:
 
   Truncation behavior when input exceeds the model's context length. Accepts: `NONE`, `START`, `END`.
 
+### Application Inference Profiles
+
+Application inference profile ARNs do not identify their underlying model. Pass
+the model family when creating an embedding model so the provider can select
+the correct request format and batch size:
+
+```ts
+import {
+  amazonBedrock,
+  type AmazonBedrockEmbeddingModelSettings,
+} from '@ai-sdk/amazon-bedrock';
+import { embedMany } from 'ai';
+
+const profileArn =
+  'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/qibm5eutlkcy';
+
+const { embeddings } = await embedMany({
+  model: amazonBedrock.embedding(profileArn, {
+    modelFamily: 'cohere',
+  } satisfies AmazonBedrockEmbeddingModelSettings),
+  values: ['hello', 'world'],
+});
+```
+
 ### Model Capabilities
 
 | Model                          | Default Dimensions | Custom Dimensions |

--- a/packages/amazon-bedrock/src/amazon-bedrock-embedding-model-options.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-embedding-model-options.ts
@@ -7,6 +7,16 @@ export type AmazonBedrockEmbeddingModelId =
   | 'cohere.embed-multilingual-v3'
   | (string & {});
 
+export type AmazonBedrockEmbeddingModelSettings = {
+  /**
+   * The embedding model family.
+   *
+   * Specify this when the model ID does not identify the underlying model,
+   * such as an application inference profile ARN.
+   */
+  modelFamily?: 'titan' | 'cohere' | 'nova';
+};
+
 export const amazonBedrockEmbeddingModelOptionsSchema = z.object({
   /**
    * The number of dimensions the resulting output embeddings should have (defaults to 1024).

--- a/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.test.ts
@@ -28,6 +28,13 @@ const cohereV4UsProfileEmbedUrl = `https://bedrock-runtime.us-east-1.amazonaws.c
   'us.cohere.embed-v4:0',
 )}/invoke`;
 
+const cohereV4ApplicationProfileArn =
+  'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/qibm5eutlkcy';
+
+const cohereV4ApplicationProfileEmbedUrl = `https://bedrock-runtime.us-east-1.amazonaws.com/model/${encodeURIComponent(
+  cohereV4ApplicationProfileArn,
+)}/invoke`;
+
 describe('doEmbed', () => {
   const mockConfigHeaders = {
     'config-header': 'config-value',
@@ -87,6 +94,20 @@ describe('doEmbed', () => {
         body: Buffer.from(
           JSON.stringify({
             embeddings: { float: [mockEmbeddings[0]] },
+          }),
+        ),
+      },
+    },
+    [cohereV4ApplicationProfileEmbedUrl]: {
+      response: {
+        type: 'binary',
+        headers: {
+          'content-type': 'application/json',
+          'x-amzn-bedrock-input-token-count': '12',
+        },
+        body: Buffer.from(
+          JSON.stringify({
+            embeddings: { float: mockEmbeddings },
           }),
         ),
       },
@@ -337,6 +358,36 @@ describe('doEmbed', () => {
       truncate: undefined,
       output_dimension: undefined,
     });
+  });
+
+  it('should support Cohere models behind application inference profile ARNs', async () => {
+    const cohereV4ApplicationProfileModel = new AmazonBedrockEmbeddingModel(
+      cohereV4ApplicationProfileArn,
+      {
+        baseUrl: () => 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        headers: mockConfigHeaders,
+        fetch: fakeFetchWithAuth,
+        modelFamily: 'cohere',
+      },
+    );
+
+    const { embeddings, usage } = await cohereV4ApplicationProfileModel.doEmbed(
+      {
+        values: [testValues[0]],
+      },
+    );
+
+    expect(embeddings).toStrictEqual(mockEmbeddings);
+    expect(usage?.tokens).toBe(12);
+
+    const body = await server.calls[0].requestBodyJson;
+    expect(body).toEqual({
+      input_type: 'search_query',
+      texts: [testValues[0]],
+      truncate: undefined,
+      output_dimension: undefined,
+    });
+    expect(cohereV4ApplicationProfileModel.maxEmbeddingsPerCall).toBe(96);
   });
 
   it('should pass outputDimension for Cohere v4 embedding models', async () => {

--- a/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-embedding-model.ts
@@ -18,6 +18,7 @@ import {
 import {
   amazonBedrockEmbeddingModelOptionsSchema,
   type AmazonBedrockEmbeddingModelId,
+  type AmazonBedrockEmbeddingModelSettings,
 } from './amazon-bedrock-embedding-model-options';
 import { AmazonBedrockErrorSchema } from './amazon-bedrock-error';
 import { z } from 'zod/v4';
@@ -26,6 +27,7 @@ type AmazonBedrockEmbeddingConfig = {
   baseUrl: () => string;
   headers?: Resolvable<Record<string, string | undefined>>;
   fetch?: FetchFunction;
+  modelFamily?: AmazonBedrockEmbeddingModelSettings['modelFamily'];
 };
 
 type DoEmbedResponse = Awaited<ReturnType<EmbeddingModelV4['doEmbed']>>;
@@ -36,7 +38,11 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
   readonly supportsParallelCalls = true;
 
   get maxEmbeddingsPerCall() {
-    return isCohereEmbeddingModel(this.modelId) ? 96 : 1;
+    return this.modelFamily === 'cohere' ? 96 : 1;
+  }
+
+  private get modelFamily() {
+    return this.config.modelFamily ?? detectEmbeddingModelFamily(this.modelId);
   }
 
   static [WORKFLOW_SERIALIZE](model: AmazonBedrockEmbeddingModel) {
@@ -98,36 +104,37 @@ export class AmazonBedrockEmbeddingModel implements EmbeddingModelV4 {
     // Note: Different embedding model families expect different request/response
     // payloads (e.g. Titan vs Cohere vs Nova). We keep the public interface stable and
     // adapt here based on the modelId.
-    const isNovaModel = isNovaEmbeddingModel(this.modelId);
-    const isCohereModel = isCohereEmbeddingModel(this.modelId);
+    const modelFamily = this.modelFamily;
 
-    const args = isNovaModel
-      ? {
-          taskType: 'SINGLE_EMBEDDING',
-          singleEmbeddingParams: {
-            embeddingPurpose:
-              amazonBedrockOptions.embeddingPurpose ?? 'GENERIC_INDEX',
-            embeddingDimension: amazonBedrockOptions.embeddingDimension ?? 1024,
-            text: {
-              truncationMode: amazonBedrockOptions.truncate ?? 'END',
-              value: values[0],
-            },
-          },
-        }
-      : isCohereModel
+    const args =
+      modelFamily === 'nova'
         ? {
-            // Cohere embedding models on Bedrock require `input_type`.
-            // Without it, the service attempts other schema branches and rejects the request.
-            input_type: amazonBedrockOptions.inputType ?? 'search_query',
-            texts: values,
-            truncate: amazonBedrockOptions.truncate,
-            output_dimension: amazonBedrockOptions.outputDimension,
+            taskType: 'SINGLE_EMBEDDING',
+            singleEmbeddingParams: {
+              embeddingPurpose:
+                amazonBedrockOptions.embeddingPurpose ?? 'GENERIC_INDEX',
+              embeddingDimension:
+                amazonBedrockOptions.embeddingDimension ?? 1024,
+              text: {
+                truncationMode: amazonBedrockOptions.truncate ?? 'END',
+                value: values[0],
+              },
+            },
           }
-        : {
-            inputText: values[0],
-            dimensions: amazonBedrockOptions.dimensions,
-            normalize: amazonBedrockOptions.normalize,
-          };
+        : modelFamily === 'cohere'
+          ? {
+              // Cohere embedding models on Bedrock require `input_type`.
+              // Without it, the service attempts other schema branches and rejects the request.
+              input_type: amazonBedrockOptions.inputType ?? 'search_query',
+              texts: values,
+              truncate: amazonBedrockOptions.truncate,
+              output_dimension: amazonBedrockOptions.outputDimension,
+            }
+          : {
+              inputText: values[0],
+              dimensions: amazonBedrockOptions.dimensions,
+              normalize: amazonBedrockOptions.normalize,
+            };
 
     const url = this.getUrl(this.modelId);
     const { value: response, responseHeaders } = await postJsonToApi({
@@ -199,7 +206,17 @@ function isCohereEmbeddingModel(modelId: string) {
 }
 
 function isNovaEmbeddingModel(modelId: string) {
-  return modelId.startsWith('amazon.nova-') && modelId.includes('embed');
+  return modelId.includes('amazon.nova-') && modelId.includes('embed');
+}
+
+function detectEmbeddingModelFamily(
+  modelId: string,
+): NonNullable<AmazonBedrockEmbeddingModelSettings['modelFamily']> {
+  return isNovaEmbeddingModel(modelId)
+    ? 'nova'
+    : isCohereEmbeddingModel(modelId)
+      ? 'cohere'
+      : 'titan';
 }
 
 const AmazonBedrockEmbeddingResponseSchema = z.union([

--- a/packages/amazon-bedrock/src/amazon-bedrock-provider.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-provider.test.ts
@@ -473,6 +473,17 @@ describe('AmazonBedrockProvider', () => {
       expect(model).toBeInstanceOf(AmazonBedrockEmbeddingModel);
     });
 
+    it('should pass embedding model settings to the model', () => {
+      const provider = createAmazonBedrock();
+      const modelId =
+        'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/qibm5eutlkcy';
+
+      provider.embedding(modelId, { modelFamily: 'cohere' });
+
+      const constructorCall = AmazonBedrockEmbeddingModelMock.mock.calls[0];
+      expect(constructorCall[1].modelFamily).toBe('cohere');
+    });
+
     it('should create an image model', () => {
       const provider = createAmazonBedrock();
       const modelId = 'amazon.titan-image-generator';

--- a/packages/amazon-bedrock/src/amazon-bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-provider.ts
@@ -17,7 +17,10 @@ import {
 import { AmazonBedrockChatLanguageModel } from './amazon-bedrock-chat-language-model';
 import type { AmazonBedrockChatModelId } from './amazon-bedrock-chat-language-model-options';
 import { AmazonBedrockEmbeddingModel } from './amazon-bedrock-embedding-model';
-import type { AmazonBedrockEmbeddingModelId } from './amazon-bedrock-embedding-model-options';
+import type {
+  AmazonBedrockEmbeddingModelId,
+  AmazonBedrockEmbeddingModelSettings,
+} from './amazon-bedrock-embedding-model-options';
 import { AmazonBedrockImageModel } from './amazon-bedrock-image-model';
 import type { AmazonBedrockImageModelId } from './amazon-bedrock-image-settings';
 import {
@@ -119,22 +122,34 @@ export interface AmazonBedrockProvider extends ProviderV4 {
   /**
    * Creates a model for text embeddings.
    */
-  embedding(modelId: AmazonBedrockEmbeddingModelId): EmbeddingModelV4;
+  embedding(
+    modelId: AmazonBedrockEmbeddingModelId,
+    settings?: AmazonBedrockEmbeddingModelSettings,
+  ): EmbeddingModelV4;
 
   /**
    * Creates a model for text embeddings.
    */
-  embeddingModel(modelId: AmazonBedrockEmbeddingModelId): EmbeddingModelV4;
+  embeddingModel(
+    modelId: AmazonBedrockEmbeddingModelId,
+    settings?: AmazonBedrockEmbeddingModelSettings,
+  ): EmbeddingModelV4;
 
   /**
    * @deprecated Use `embedding` instead.
    */
-  textEmbedding(modelId: AmazonBedrockEmbeddingModelId): EmbeddingModelV4;
+  textEmbedding(
+    modelId: AmazonBedrockEmbeddingModelId,
+    settings?: AmazonBedrockEmbeddingModelSettings,
+  ): EmbeddingModelV4;
 
   /**
    * @deprecated Use `embeddingModel` instead.
    */
-  textEmbeddingModel(modelId: AmazonBedrockEmbeddingModelId): EmbeddingModelV4;
+  textEmbeddingModel(
+    modelId: AmazonBedrockEmbeddingModelId,
+    settings?: AmazonBedrockEmbeddingModelSettings,
+  ): EmbeddingModelV4;
 
   /**
    * Creates a model for image generation.
@@ -310,11 +325,15 @@ export function createAmazonBedrock(
     return createChatModel(modelId);
   };
 
-  const createEmbeddingModel = (modelId: AmazonBedrockEmbeddingModelId) =>
+  const createEmbeddingModel = (
+    modelId: AmazonBedrockEmbeddingModelId,
+    settings: AmazonBedrockEmbeddingModelSettings = {},
+  ) =>
     new AmazonBedrockEmbeddingModel(modelId, {
       baseUrl: getAmazonBedrockRuntimeBaseUrl,
       headers: getHeaders,
       fetch: fetchFunction,
+      modelFamily: settings.modelFamily,
     });
 
   const createImageModel = (modelId: AmazonBedrockImageModelId) =>

--- a/packages/amazon-bedrock/src/index.ts
+++ b/packages/amazon-bedrock/src/index.ts
@@ -1,6 +1,9 @@
 export type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 
-export type { AmazonBedrockEmbeddingModelOptions } from './amazon-bedrock-embedding-model-options';
+export type {
+  AmazonBedrockEmbeddingModelOptions,
+  AmazonBedrockEmbeddingModelSettings,
+} from './amazon-bedrock-embedding-model-options';
 export type { AmazonBedrockImageModelOptions } from './amazon-bedrock-image-model-options';
 export type {
   AmazonBedrockLanguageModelChatOptions,


### PR DESCRIPTION
## Background

bedrock tried to identify Cohere/Nova from the model ID. Opaque application profile ARNs contain no model name, so they were mistaken for Titan, causing the wrong request format and batch size

## Summary

we introduced a new embedding model setting to specify family: 

```ts
amazonBedrock.embedding(profileArn, { modelFamily: 'cohere' })
```

this correctly controls both payload formatting and batching

## End-to-End Verification

needs an account configured with an ARN profile but verified with unit tests

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #19829 

closes #19834 

closes #19830 