### PR TITLE
fix(google): recognize Google Files URLs when using a baseUrl

### DIFF
--- a/.changeset/tidy-files-travel.md
+++ b/.changeset/tidy-files-travel.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(google): recognize Google Files URLs when using a baseUrl

--- a/packages/google/src/google-provider.test.ts
+++ b/packages/google/src/google-provider.test.ts
@@ -270,6 +270,38 @@ describe('google-provider', () => {
     `);
   });
 
+  it('should support default and configured Google file URLs with a custom baseURL', () => {
+    const provider = createGoogle({
+      apiKey: 'test-api-key',
+      baseURL: 'https://custom-endpoint.example.com/v1beta',
+    });
+    provider('gemini-2.0-flash');
+
+    const call = vi.mocked(GoogleBatchLanguageModel).mock.calls[0];
+    const supportedUrls = call[1].supportedUrls!() as Record<string, RegExp[]>;
+
+    for (const url of [
+      'https://generativelanguage.googleapis.com/v1beta/files/google-file',
+      'https://custom-endpoint.example.com/v1beta/files/custom-file',
+    ]) {
+      expect(
+        isUrlSupported({
+          url,
+          mediaType: 'text/markdown',
+          supportedUrls,
+        }),
+      ).toBe(true);
+    }
+
+    expect(
+      isUrlSupported({
+        url: 'https://example.com/files/unsupported-file',
+        mediaType: 'text/markdown',
+        supportedUrls,
+      }),
+    ).toBe(false);
+  });
+
   it('should support documented external HTTPS URLs for Gemini models that accept external URLs', () => {
     const provider = createGoogle({
       apiKey: 'test-api-key',

--- a/packages/google/src/google-provider.ts
+++ b/packages/google/src/google-provider.ts
@@ -49,6 +49,10 @@ import type { GoogleTranscriptionModelId } from './transcription/google-transcri
 import { GoogleSpeechTranslationModel } from './speech-translation/google-speech-translation-model';
 import type { GoogleSpeechTranslationModelId } from './speech-translation/google-speech-translation-model-options';
 
+const DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
+const googleFilesUrlPattern =
+  /^https:\/\/generativelanguage\.googleapis\.com\/v1beta\/files\/.*$/;
+
 export interface GoogleProvider extends ProviderV4 {
   (modelId: GoogleModelId): BatchLanguageModelV4;
 
@@ -237,9 +241,7 @@ function supportsExternalFileUrls(modelId: string) {
 export function createGoogle(
   options: GoogleProviderSettings = {},
 ): GoogleProvider {
-  const baseURL =
-    withoutTrailingSlash(options.baseURL) ??
-    'https://generativelanguage.googleapis.com/v1beta';
+  const baseURL = withoutTrailingSlash(options.baseURL) ?? DEFAULT_BASE_URL;
 
   const providerName = options.name ?? 'google.generative-ai';
 
@@ -264,8 +266,10 @@ export function createGoogle(
       generateId: options.generateId ?? generateId,
       supportedUrls: () => ({
         '*': [
-          // Google Generative Language "files" endpoint
+          // Default Google Generative Language "files" endpoint
           // e.g. https://generativelanguage.googleapis.com/v1beta/files/...
+          googleFilesUrlPattern,
+          // Configured Google Generative Language "files" endpoint
           new RegExp(`^${baseURL}/files/.*$`),
           // YouTube URLs (public or unlisted videos)
           new RegExp(


### PR DESCRIPTION
## Background

AI SDK uses a model's `supportedUrls` to decide whether a file URL can be passed directly to the provider or must be downloaded first.

The Google provider constructed its `supportedUrls` Google Files URL from the configured `baseURL`. When `baseURL` points to a Google-compatible proxy, Google Files URLs such as:

`https://generativelanguage.googleapis.com/v1beta/files/...`

do not match the proxy URL.

Core therefore treats the file as unsupported and attempts to download it. Google Files URIs are provider resource references intended to be passed to Gemini as `fileData.fileUri`, not public content URLs that can be downloaded. The generic downloader does not authenticate as the Google provider, so the request fails.

## Summary

Always include the default Google Files URL pattern in `supportedUrls`.

## End-to-End Verification

Verified against the live Gemini API using a local forwarding proxy:

1. Uploaded an MP3 directly through Google's Files API, which returned a canonical `https://generativelanguage.googleapis.com/v1beta/files/...` URI.
2. Created a separate Google provider with its `baseURL` pointing to the local proxy.
3. Passed the canonical Google Files URI as an `audio/mpeg` file part
4. Confirmed that the proxy received only the `generateContent` request and no file download request.
5. The proxy forwarded the request to Google, and Gemini successfully processed the uploaded audio

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [] Documentation has been added / updated
- [x] A *patch* changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes https://github.com/vercel/ai/issues/7796

Closes https://github.com/vercel/ai/pull/8776