### PR TITLE
fix(harness-cline): use native `skills` tool instead of manual file-based workaround

### DIFF
--- a/.changeset/twenty-wolves-sit.md
+++ b/.changeset/twenty-wolves-sit.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-cline": patch
+---
+
+fix(harness-cline): use native `skills` tool instead of manual file-based workaround

--- a/examples/ai-functions/src/harness-agent/cline/with-skills.ts
+++ b/examples/ai-functions/src/harness-agent/cline/with-skills.ts
@@ -13,8 +13,9 @@ const cline = createCline();
  * auto-fire on every turn. The description has to advertise *when to use
  * this skill* so the agent can recognise the match.
  *
- * Cline materialises skills into `.cline/skills/<name>/SKILL.md` inside the
- * sandbox workspace; Cline's resource loader picks them up from there.
+ * The Cline adapter exposes skills through Cline's native `skills` tool. The
+ * skill instructions and attached files stay in the host process until the
+ * model invokes that tool.
  */
 run(async () => {
   const sandbox = createVercelSandbox({

--- a/packages/harness-cline/src/cline-harness.test.ts
+++ b/packages/harness-cline/src/cline-harness.test.ts
@@ -14,7 +14,7 @@ describe('createCline', () => {
     expect(harness.supportsBuiltinToolFiltering).toBe(true);
   });
 
-  it('declares the seven built-in tools', () => {
+  it('declares the eight built-in tools', () => {
     expect(Object.keys(createCline().builtinTools).sort()).toEqual(
       [...CLINE_NATIVE_BUILTIN_NAMES].sort(),
     );
@@ -49,6 +49,6 @@ describe('resolveActiveClineBuiltinNames', () => {
   it('applies deny filtering', () => {
     expect(
       resolveActiveClineBuiltinNames({ mode: 'deny', toolNames: ['bash'] }),
-    ).toEqual(['read', 'write', 'edit', 'grep', 'glob', 'ls']);
+    ).toEqual(['read', 'write', 'edit', 'grep', 'glob', 'ls', 'skills']);
   });
 });

--- a/packages/harness-cline/src/cline-harness.ts
+++ b/packages/harness-cline/src/cline-harness.ts
@@ -140,6 +140,18 @@ const CLINE_BUILTIN_TOOLS = {
     nativeName: 'ls',
     toolUseKind: 'readonly',
   } as HarnessV1BuiltinTool,
+  skills: {
+    ...tool({
+      description: 'Execute a configured skill by name.',
+      inputSchema: z.object({
+        skill: z.string(),
+        args: z.string().optional(),
+      }),
+      outputSchema: z.string(),
+    }),
+    nativeName: 'skills',
+    toolUseKind: 'readonly',
+  } as HarnessV1BuiltinTool,
 } as const satisfies Record<string, HarnessV1BuiltinTool<any, any>>;
 
 export function createCline(

--- a/packages/harness-cline/src/cline-remote-ops.test.ts
+++ b/packages/harness-cline/src/cline-remote-ops.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from 'vitest';
 import { createClineRemoteOps } from './cline-remote-ops';
 
 const WORK_DIR = '/sandbox/work/cline-s1';
-const SKILL_ROOT = '/sandbox/home/.agents/skills';
 
 type RunInput = {
   command: string;
@@ -199,43 +198,7 @@ describe('file operations', () => {
     expect(run).not.toHaveBeenCalled();
   });
 
-  it('allows read-only operations in configured roots but rejects edits', async () => {
-    const skillPath = `${SKILL_ROOT}/weather/SKILL.md`;
-    const run = vi.fn(async ({ command }: { command: string }) => ({
-      exitCode: 0,
-      stdout: command.includes('ls -1Ap')
-        ? 'SKILL.md\n'
-        : command.includes('find ')
-          ? `${skillPath}\n`
-          : '',
-      stderr: '',
-    }));
-    const { sandbox } = createFakeSandbox({
-      files: new Map([[skillPath, 'skill contents']]),
-      existingPaths: new Set([WORK_DIR, SKILL_ROOT, `${SKILL_ROOT}/weather`]),
-      run,
-    });
-    const ops = createClineRemoteOps({
-      sandbox,
-      workDir: WORK_DIR,
-      readableRoots: [{ sandboxDir: SKILL_ROOT }],
-    });
-
-    expect(await ops.readFile(skillPath)).toBe('skill contents');
-    expect(await ops.grep('skill', { path: skillPath })).toBe(
-      'No matches found',
-    );
-    expect(await ops.glob('*', skillPath)).toEqual(['SKILL.md']);
-    expect(await ops.ls(`${SKILL_ROOT}/weather`)).toEqual(['SKILL.md']);
-    await expect(ops.writeFile(skillPath, 'owned')).rejects.toThrow(
-      /escapes the workspace/,
-    );
-    await expect(ops.editFile(skillPath, 'skill', 'owned')).rejects.toThrow(
-      /escapes the workspace/,
-    );
-  });
-
-  it('rejects symlinks that resolve outside the allowed roots', async () => {
+  it('rejects symlinks that resolve outside the workspace', async () => {
     const linkedPath = `${WORK_DIR}/linked-secret`;
     const outsidePath = '/sandbox/work/cline-s2/.env';
     const { sandbox, readTextFile, writeTextFile } = createFakeSandbox({
@@ -247,16 +210,16 @@ describe('file operations', () => {
     const ops = createClineRemoteOps({ sandbox, workDir: WORK_DIR });
 
     await expect(ops.readFile('linked-secret')).rejects.toThrow(
-      /escapes the readable roots/,
+      /escapes the workspace/,
     );
     await expect(ops.grep('SECRET', { path: 'linked-secret' })).rejects.toThrow(
-      /escapes the readable roots/,
+      /escapes the workspace/,
     );
     await expect(ops.glob('*', 'linked-secret')).rejects.toThrow(
-      /escapes the readable roots/,
+      /escapes the workspace/,
     );
     await expect(ops.ls('linked-secret')).rejects.toThrow(
-      /escapes the readable roots/,
+      /escapes the workspace/,
     );
     await expect(ops.writeFile('linked-secret', 'owned')).rejects.toThrow(
       /escapes the workspace/,

--- a/packages/harness-cline/src/cline-remote-ops.ts
+++ b/packages/harness-cline/src/cline-remote-ops.ts
@@ -14,7 +14,6 @@ export interface ClineRemoteOpsOptions {
   readonly sandbox: Experimental_SandboxSession;
   /** Absolute sandbox path of the session's working directory. */
   readonly workDir: string;
-  readonly readableRoots?: ReadonlyArray<{ readonly sandboxDir: string }>;
 }
 
 export interface ClineRemoteOps {
@@ -50,9 +49,6 @@ export function createClineRemoteOps(
 ): ClineRemoteOps {
   const { sandbox, workDir } = options;
   const normalizedWorkDir = path.posix.normalize(workDir);
-  const readableRoots =
-    options.readableRoots?.map(root => path.posix.normalize(root.sandboxDir)) ??
-    [];
 
   const isInsidePath = ({
     parent,
@@ -78,31 +74,11 @@ export function createClineRemoteOps(
     return normalized;
   };
 
-  const assertReadablePath = (inputPath: string): string => {
-    const normalized = path.posix.normalize(inputPath);
-    if (
-      !isInsidePath({ parent: normalizedWorkDir, candidate: normalized }) &&
-      !readableRoots.some(parent =>
-        isInsidePath({ parent, candidate: normalized }),
-      )
-    ) {
-      throw new Error(`Cline path escapes the readable roots: ${inputPath}`);
-    }
-    return normalized;
-  };
-
   const resolvePath = (inputPath: string): string => {
     const resolved = path.posix.isAbsolute(inputPath)
       ? path.posix.normalize(inputPath)
       : path.posix.normalize(path.posix.join(normalizedWorkDir, inputPath));
     return assertWorkspacePath(resolved);
-  };
-
-  const resolveReadablePath = (inputPath: string): string => {
-    if (!path.posix.isAbsolute(inputPath)) {
-      return resolvePath(inputPath);
-    }
-    return assertReadablePath(inputPath);
   };
 
   const runShell = async ({
@@ -172,7 +148,7 @@ export function createClineRemoteOps(
     inputPath: string;
     missingMessage?: string;
   }): Promise<string> =>
-    assertReadablePath(
+    assertWorkspacePath(
       await resolveExistingSandboxPath({
         remotePath,
         inputPath,
@@ -216,7 +192,7 @@ export function createClineRemoteOps(
   };
 
   const readFile = async (inputPath: string): Promise<string> => {
-    const remotePath = resolveReadablePath(inputPath);
+    const remotePath = resolvePath(inputPath);
     const resolved = await resolveReadableSandboxPath({
       remotePath,
       inputPath,
@@ -305,7 +281,7 @@ export function createClineRemoteOps(
 
     async grep(pattern, input = {}) {
       const inputPath = input.path ?? '.';
-      const remotePath = resolveReadablePath(inputPath);
+      const remotePath = resolvePath(inputPath);
       const target = await resolveReadableSandboxPath({
         remotePath,
         inputPath,
@@ -341,7 +317,7 @@ export function createClineRemoteOps(
     },
 
     async glob(pattern, inputPath = '.', limit = 1_000) {
-      const remotePath = resolveReadablePath(inputPath);
+      const remotePath = resolvePath(inputPath);
       const target = await resolveReadableSandboxPath({
         remotePath,
         inputPath,
@@ -382,7 +358,7 @@ export function createClineRemoteOps(
     },
 
     async ls(inputPath = '.', limit = 500) {
-      const remotePath = resolveReadablePath(inputPath);
+      const remotePath = resolvePath(inputPath);
       const target = await resolveReadableSandboxPath({
         remotePath,
         inputPath,

--- a/packages/harness-cline/src/cline-session.test.ts
+++ b/packages/harness-cline/src/cline-session.test.ts
@@ -1,4 +1,7 @@
-import type { HarnessV1NetworkSandboxSession } from '@ai-sdk/harness';
+import type {
+  HarnessV1BuiltinToolFiltering,
+  HarnessV1NetworkSandboxSession,
+} from '@ai-sdk/harness';
 import type {
   AgentMessage,
   AgentRunInput,
@@ -318,6 +321,145 @@ describe('createClineSession instructions', () => {
       await steering;
       await control.done;
       expect(clineMock.continueInputs).toEqual([]);
+    } finally {
+      await session.doDestroy();
+    }
+  });
+});
+
+describe('createClineSession skills', () => {
+  beforeEach(() => {
+    clineMock.configs = [];
+    clineMock.continueInputs = [];
+    clineMock.modelOptions = [];
+    clineMock.modelSelections = [];
+    clineMock.providerConfigs = [];
+    clineMock.runInputs = [];
+    clineMock.runGate = undefined;
+    clineMock.runStatus = 'completed';
+    clineMock.runError = undefined;
+    clineMock.outputText = '';
+  });
+
+  it('exposes skills through the native tool instead of the system prompt', async () => {
+    const session = await createSession();
+
+    try {
+      const control = await session.doPromptTurn({
+        skills: [
+          {
+            name: 'release-notes',
+            description: 'Use when drafting release notes.',
+            content: 'Follow the release process.',
+          },
+        ],
+        tools: [],
+        prompt: 'Draft release notes.',
+        emit: vi.fn(),
+      });
+      await control.done;
+
+      const config = clineMock.configs[0];
+      expect(config.systemPrompt).not.toContain('## Skills');
+      expect(config.systemPrompt).not.toContain('.agents/skills');
+      expect(findTool({ config, name: 'skills' }).description).toContain(
+        'Available skills: release-notes.',
+      );
+    } finally {
+      await session.doDestroy();
+    }
+  });
+
+  it('rebuilds only when behavior-relevant skill data changes', async () => {
+    const session = await createSession();
+    const firstSkills = [
+      {
+        name: 'release-notes',
+        description: 'Use when drafting release notes.',
+        content: 'Follow the release process.',
+        files: [
+          { path: 'z.md', content: 'Z' },
+          { path: 'a.md', content: 'A' },
+        ],
+      },
+    ];
+
+    try {
+      for (const skills of [
+        firstSkills,
+        [
+          {
+            ...firstSkills[0],
+            files: [...firstSkills[0].files].reverse(),
+          },
+        ],
+      ]) {
+        const control = await session.doPromptTurn({
+          skills,
+          tools: [],
+          prompt: 'Draft release notes.',
+          emit: vi.fn(),
+        });
+        await control.done;
+      }
+      expect(clineMock.configs).toHaveLength(1);
+
+      const changedControl = await session.doPromptTurn({
+        skills: [
+          {
+            ...firstSkills[0],
+            files: [
+              { path: 'a.md', content: 'Changed' },
+              { path: 'z.md', content: 'Z' },
+            ],
+          },
+        ],
+        tools: [],
+        prompt: 'Draft release notes again.',
+        emit: vi.fn(),
+      });
+      await changedControl.done;
+
+      const removedControl = await session.doPromptTurn({
+        skills: [],
+        tools: [],
+        prompt: 'Continue without skills.',
+        emit: vi.fn(),
+      });
+      await removedControl.done;
+
+      expect(clineMock.configs).toHaveLength(3);
+      expect(
+        clineMock.configs[2].tools?.some(tool => tool.name === 'skills'),
+      ).toBe(false);
+    } finally {
+      await session.doDestroy();
+    }
+  });
+
+  it('respects builtin filtering for the skills tool', async () => {
+    const session = await createSession({
+      builtinToolFiltering: { mode: 'deny', toolNames: ['skills'] },
+    });
+
+    try {
+      const control = await session.doPromptTurn({
+        skills: [
+          {
+            name: 'release-notes',
+            description: 'Use when drafting release notes.',
+            content: 'Follow the release process.',
+          },
+        ],
+        tools: [],
+        prompt: 'Draft release notes.',
+        emit: vi.fn(),
+      });
+      await control.done;
+
+      expect(
+        clineMock.configs[0].tools?.some(tool => tool.name === 'skills'),
+      ).toBe(false);
     } finally {
       await session.doDestroy();
     }
@@ -867,6 +1009,7 @@ describe('createClineSession tool execution', () => {
 
 async function createSession(
   input: {
+    builtinToolFiltering?: HarnessV1BuiltinToolFiltering;
     isResume?: boolean;
     settings?: Partial<ClineSessionSettings>;
   } = {},
@@ -882,6 +1025,9 @@ async function createSession(
     },
     clientApp: 'ai-sdk/harness-cline/0.0.0-test',
     isResume: input.isResume ?? false,
+    ...(input.builtinToolFiltering
+      ? { builtinToolFiltering: input.builtinToolFiltering }
+      : {}),
   });
 }
 

--- a/packages/harness-cline/src/cline-session.ts
+++ b/packages/harness-cline/src/cline-session.ts
@@ -26,7 +26,6 @@ import {
   type AgentRunResult,
 } from '@cline/agents';
 import { Llms } from '@cline/core';
-import path from 'node:path';
 import { createClineMcpRuntime } from './cline-mcp';
 import { createClineRemoteOps } from './cline-remote-ops';
 import {
@@ -36,7 +35,10 @@ import {
   resolveClinePrivateSessionDirectory,
   safeClineHistoryFileName,
 } from './cline-resume-state';
-import { renderSkillsPromptSection, writeClineSkills } from './cline-skills';
+import {
+  createClineSkillsRuntime,
+  type ClineSkillsRuntime,
+} from './cline-skills';
 import {
   buildBuiltinAgentTools,
   buildUserAgentTools,
@@ -154,17 +156,12 @@ function clineBuiltinToolRequiresApproval(input: {
 function buildSystemPrompt(input: {
   sessionWorkDir: string;
   sandboxDescription: string;
-  skillsSection?: string;
 }): string {
-  const sections = [
+  return [
     'You are Cline, an autonomous coding agent operating inside a sandboxed workspace.',
     `## Workspace\n\nThe workspace root is \`${input.sessionWorkDir}\`. All relative file paths and shell commands resolve against it. Use the provided tools (read, write, edit, bash, grep, glob, ls) to inspect and modify the workspace.`,
     `## Sandbox\n\n${input.sandboxDescription}`,
-  ];
-  if (input.skillsSection) {
-    sections.push(input.skillsSection);
-  }
-  return sections.join('\n\n');
+  ].join('\n\n');
 }
 
 function toClineBackendProviderBaseUrl(baseUrl: string): string {
@@ -271,12 +268,9 @@ export async function createClineSession(
     input.builtinToolFiltering,
   );
 
-  const skillRootDir = path.posix.join(sandboxHomeDir, '.agents', 'skills');
-
   const ops = createClineRemoteOps({
     sandbox: toolSafeSandboxSession,
     workDir: input.sessionWorkDir,
-    readableRoots: [{ sandboxDir: skillRootDir }],
   });
 
   // On resume: pull the persisted conversation history from the sandbox so
@@ -304,7 +298,7 @@ export async function createClineSession(
   // Per-session mutable state we hold across prompts.
   let agent: Agent | undefined;
   let unsubscribe: (() => void) | undefined;
-  let lastToolsSignature: string | undefined;
+  let lastAgentConfigurationSignature: string | undefined;
   let agentHasRun = false;
   let stopped = false;
   /*
@@ -384,7 +378,7 @@ export async function createClineSession(
 
   function rebuildAgent(rebuildInput: {
     userTools: ReadonlyArray<HarnessV1ToolSpec>;
-    skillsSection?: string;
+    skillsRuntime: ClineSkillsRuntime;
     instructions?: string;
     responseFormat?: HarnessV1PromptTurnOptions['responseFormat'];
   }): void {
@@ -405,9 +399,6 @@ export async function createClineSession(
         const baseSystemPrompt = buildSystemPrompt({
           sessionWorkDir: input.sessionWorkDir,
           sandboxDescription: toolSafeSandboxSession.description,
-          ...(rebuildInput.skillsSection
-            ? { skillsSection: rebuildInput.skillsSection }
-            : {}),
         });
         return rebuildInput.instructions
           ? `${baseSystemPrompt}\n\n${rebuildInput.instructions}`
@@ -420,6 +411,10 @@ export async function createClineSession(
         : {}),
       tools: [
         ...buildBuiltinAgentTools({ ops, activeNames: activeBuiltinNames }),
+        ...(rebuildInput.skillsRuntime.tool &&
+        activeBuiltinNames.includes('skills')
+          ? [rebuildInput.skillsRuntime.tool]
+          : []),
         ...mcpRuntime.tools,
         ...buildUserAgentTools({
           specs: rebuildInput.userTools,
@@ -576,16 +571,9 @@ export async function createClineSession(
     }
 
     const userTools = turnOpts.tools;
-    const skillWrite = await writeClineSkills({
-      sandbox: toolSafeSandboxSession,
-      sandboxHomeDir,
+    const skillsRuntime = createClineSkillsRuntime({
       skills: turnOpts.skills,
-      ...(turnOpts.abortSignal ? { abortSignal: turnOpts.abortSignal } : {}),
     });
-    const skillsSection =
-      turnOpts.skills.length === 0
-        ? undefined
-        : renderSkillsPromptSection(turnOpts.skills, skillWrite.rootDir);
     if (
       turnOpts.responseFormat?.type === 'json' &&
       turnOpts.responseFormat.schema == null
@@ -611,28 +599,28 @@ export async function createClineSession(
       tools: userTools,
       responseFormat: turnOpts.responseFormat,
       instructions: turnOpts.instructions,
+      skills: skillsRuntime.signature,
     });
-    if (
-      agent == null ||
-      signature !== lastToolsSignature ||
-      skillWrite.result.changed
-    ) {
+    if (agent == null || signature !== lastAgentConfigurationSignature) {
       currentMessages = agent?.snapshot().messages ?? currentMessages;
       rebuildAgent({
         userTools,
-        ...(skillsSection ? { skillsSection } : {}),
+        skillsRuntime,
         responseFormat: turnOpts.responseFormat,
         ...(turnOpts.instructions
           ? { instructions: turnOpts.instructions }
           : {}),
       });
-      lastToolsSignature = signature;
+      lastAgentConfigurationSignature = signature;
     }
 
     currentEmit = turnOpts.emit;
+    const userToolNames = new Set(userTools.map(tool => tool.name));
     translatorState = createClineTranslatorState({
-      builtinToolNames: activeBuiltinNames,
-      hostToolNames: userTools.map(tool => tool.name),
+      builtinToolNames: activeBuiltinNames.filter(
+        name => !userToolNames.has(name),
+      ),
+      hostToolNames: userToolNames,
       ignoredToolNames:
         turnOpts.responseFormat?.type === 'json' ? ['structured_output'] : [],
       mcpToolNames: mcpRuntime.toolNames,

--- a/packages/harness-cline/src/cline-skills.test.ts
+++ b/packages/harness-cline/src/cline-skills.test.ts
@@ -1,0 +1,159 @@
+import type { AgentTool } from '@cline/agents';
+import { describe, expect, it } from 'vitest';
+import { createClineSkillsRuntime } from './cline-skills';
+
+describe('createClineSkillsRuntime', () => {
+  it('omits the native tool when no skills are configured', () => {
+    expect(createClineSkillsRuntime({ skills: [] })).toEqual({
+      signature: '[]',
+    });
+  });
+
+  it('advertises and invokes skills with arguments and attached files', async () => {
+    const runtime = createClineSkillsRuntime({
+      skills: [
+        {
+          name: 'release-notes',
+          description: 'Use when drafting release notes.',
+          content: 'Follow the attached templates.',
+          files: [
+            { path: 'templates/short.md', content: '# Short' },
+            { path: 'references/style.md', content: '# Style' },
+          ],
+        },
+      ],
+    });
+
+    expect(runtime.tool?.description).toContain(
+      'Available skills: release-notes.',
+    );
+    await expect(
+      runtime.tool?.execute(
+        { skill: '/RELEASE-NOTES', args: ' v2.0.0 ' },
+        createToolContext(),
+      ),
+    ).resolves.toMatchInlineSnapshot(`
+      "<command-name>release-notes</command-name>
+      <command-args>v2.0.0</command-args>
+      <command-instructions>
+      Description: Use when drafting release notes.
+
+      Follow the attached templates.
+
+      <skill-files>
+      <skill-file path=\"references/style.md\">
+      # Style
+      </skill-file>
+      <skill-file path=\"templates/short.md\">
+      # Short
+      </skill-file>
+      </skill-files>
+      </command-instructions>"
+    `);
+  });
+
+  it('returns a useful response for an unknown skill', async () => {
+    const runtime = createClineSkillsRuntime({
+      skills: [
+        { name: 'alpha', description: 'Alpha.', content: 'Alpha content.' },
+        { name: 'beta', description: 'Beta.', content: 'Beta content.' },
+      ],
+    });
+
+    await expect(
+      runtime.tool?.execute({ skill: 'missing' }, createToolContext()),
+    ).resolves.toBe('Skill "missing" not found. Available skills: alpha, beta');
+  });
+
+  it('uses a deterministic signature for equivalent skill data', () => {
+    const first = createClineSkillsRuntime({
+      skills: [
+        {
+          name: 'beta',
+          description: 'Beta.',
+          content: 'Beta content.',
+        },
+        {
+          name: 'alpha',
+          description: 'Alpha.',
+          content: 'Alpha content.',
+          files: [
+            { path: 'z.md', content: 'Z' },
+            { path: 'a.md', content: 'A' },
+          ],
+        },
+      ],
+    });
+    const reordered = createClineSkillsRuntime({
+      skills: [
+        {
+          name: 'alpha',
+          description: 'Alpha.',
+          content: 'Alpha content.',
+          files: [
+            { path: 'a.md', content: 'A' },
+            { path: 'z.md', content: 'Z' },
+          ],
+        },
+        {
+          name: 'beta',
+          description: 'Beta.',
+          content: 'Beta content.',
+        },
+      ],
+    });
+    const changed = createClineSkillsRuntime({
+      skills: [
+        {
+          name: 'alpha',
+          description: 'Alpha.',
+          content: 'Changed content.',
+          files: [
+            { path: 'a.md', content: 'A' },
+            { path: 'z.md', content: 'Z' },
+          ],
+        },
+        {
+          name: 'beta',
+          description: 'Beta.',
+          content: 'Beta content.',
+        },
+      ],
+    });
+
+    expect(reordered.signature).toBe(first.signature);
+    expect(changed.signature).not.toBe(first.signature);
+  });
+
+  it('rejects ambiguous names and unsafe attached file paths', () => {
+    expect(() =>
+      createClineSkillsRuntime({
+        skills: [
+          { name: 'Demo', description: 'First.', content: 'First.' },
+          { name: 'demo', description: 'Second.', content: 'Second.' },
+        ],
+      }),
+    ).toThrow('Duplicate Cline skill identifier: demo');
+    expect(() =>
+      createClineSkillsRuntime({
+        skills: [
+          {
+            name: 'demo',
+            description: 'Demo.',
+            content: 'Demo.',
+            files: [{ path: '../secret.md', content: 'Secret.' }],
+          },
+        ],
+      }),
+    ).toThrow('Invalid Cline skill file path for demo: ../secret.md');
+  });
+});
+
+function createToolContext(): Parameters<AgentTool['execute']>[1] {
+  return {
+    agentId: 'agent-1',
+    runId: 'run-1',
+    iteration: 1,
+    toolCallId: 'tool-call-1',
+  };
+}

--- a/packages/harness-cline/src/cline-skills.ts
+++ b/packages/harness-cline/src/cline-skills.ts
@@ -1,58 +1,184 @@
 import path from 'node:path';
 import type { HarnessV1Skill } from '@ai-sdk/harness';
-import { writeSkills, type WriteSkillsResult } from '@ai-sdk/harness/utils';
-import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
+import type { AgentTool } from '@cline/agents';
+import { createDefaultTools, type ToolExecutors } from '@cline/core';
+
+const CLINE_SKILL_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+type ProjectedClineSkill = {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly content: string;
+  readonly files: ReadonlyArray<{
+    readonly path: string;
+    readonly content: string;
+  }>;
+};
+
+export type ClineSkillsRuntime = {
+  readonly signature: string;
+  readonly tool?: AgentTool;
+};
 
 /**
- * Materialize harness-provided skills into the sandbox HOME
- * (`~/.agents/skills/<name>/SKILL.md` plus any auxiliary files) and return
- * the root directory they were written to. The Cline runtime has no native
- * skill loader, so the session surfaces them to the model through a system
- * prompt section (see `renderSkillsPromptSection`) that points at these files.
+ * Build Cline's native skills tool around an immutable in-host projection of
+ * the harness skills. The low-level Agent does not discover skills itself, so
+ * the adapter provides the same tool contract that Cline's core orchestration
+ * layer uses without involving the sandbox filesystem.
  */
-export async function writeClineSkills({
-  sandbox,
-  sandboxHomeDir,
+export function createClineSkillsRuntime({
   skills,
-  abortSignal,
 }: {
-  sandbox: Experimental_SandboxSession;
-  sandboxHomeDir: string;
   skills: ReadonlyArray<HarnessV1Skill>;
-  abortSignal?: AbortSignal;
-}): Promise<{ rootDir: string; result: WriteSkillsResult }> {
-  const skillRootDir = path.posix.join(sandboxHomeDir, '.agents', 'skills');
-  const result = await writeSkills({
-    sandbox,
-    rootDir: skillRootDir,
-    skills,
-    ...(abortSignal ? { abortSignal } : {}),
-  });
-  return { rootDir: skillRootDir, result };
+}): ClineSkillsRuntime {
+  const projectedSkills = projectClineSkills({ skills });
+  const signature = JSON.stringify(projectedSkills);
+  if (projectedSkills.length === 0) {
+    return { signature };
+  }
+
+  const executor: NonNullable<ToolExecutors['skills']> = async (
+    ...executorArguments
+  ) => {
+    const [requestedSkill, args] = executorArguments;
+    const skill = projectedSkills.find(
+      candidate => candidate.id === normalizeSkillToken(requestedSkill),
+    );
+    if (skill == null) {
+      const availableSkills = projectedSkills.map(skill => skill.name);
+      return availableSkills.length > 0
+        ? `Skill "${requestedSkill}" not found. Available skills: ${availableSkills.join(', ')}`
+        : 'No skills are currently available.';
+    }
+    return renderSkillInstructions({ skill, args });
+  };
+  executor.configuredSkills = projectedSkills.map(skill => ({
+    id: skill.id,
+    name: skill.name,
+    description: skill.description,
+    disabled: false,
+  }));
+
+  const tool = createDefaultTools({
+    executors: { skills: executor },
+    enableReadFiles: false,
+    enableSearch: false,
+    enableBash: false,
+    enableWebFetch: false,
+    enableApplyPatch: false,
+    enableEditor: false,
+    enableSkills: true,
+    enableAskQuestion: false,
+    enableSubmitAndExit: false,
+  }).find(tool => tool.name === 'skills');
+  if (tool == null) {
+    throw new Error('Cline did not create its native skills tool.');
+  }
+
+  return { signature, tool };
 }
 
-/**
- * Render the system-prompt section that advertises available skills. Only the
- * name + description sit in context; the model loads the full skill via the
- * `read` tool when the task calls for it (progressive disclosure).
- */
-export function renderSkillsPromptSection(
-  skills: ReadonlyArray<HarnessV1Skill>,
-  skillRootDir: string,
-): string {
-  const entries = skills
-    .map(
-      skill =>
-        `- ${skill.name}: ${skill.description}\n  SKILL.md: ${path.posix.join(
-          skillRootDir,
-          skill.name,
-          'SKILL.md',
-        )}`,
-    )
-    .join('\n');
-  return (
-    '## Skills\n\n' +
-    'The following skills are available. When a task matches a skill, read its SKILL.md with the `read` tool and follow its instructions.\n\n' +
-    entries
-  );
+function projectClineSkills({
+  skills,
+}: {
+  skills: ReadonlyArray<HarnessV1Skill>;
+}): ReadonlyArray<ProjectedClineSkill> {
+  const names = new Set<string>();
+  const ids = new Set<string>();
+  return skills
+    .map(skill => {
+      if (
+        !CLINE_SKILL_NAME_PATTERN.test(skill.name) ||
+        skill.name === '.' ||
+        skill.name === '..'
+      ) {
+        throw new Error(`Invalid Cline skill name: ${skill.name}`);
+      }
+      if (names.has(skill.name)) {
+        throw new Error(`Duplicate Cline skill name: ${skill.name}`);
+      }
+      names.add(skill.name);
+
+      const id = normalizeSkillToken(skill.name);
+      if (ids.has(id)) {
+        throw new Error(`Duplicate Cline skill identifier: ${id}`);
+      }
+      ids.add(id);
+
+      return {
+        id,
+        name: skill.name,
+        description: skill.description,
+        content: skill.content,
+        files: (skill.files ?? [])
+          .map(file => ({
+            path: normalizeSkillFilePath({
+              skillName: skill.name,
+              filePath: file.path,
+            }),
+            content: file.content,
+          }))
+          .sort(
+            (left, right) =>
+              left.path.localeCompare(right.path) ||
+              left.content.localeCompare(right.content),
+          ),
+      };
+    })
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function normalizeSkillToken(skill: string): string {
+  return skill.trim().replace(/^\/+/, '').toLowerCase();
+}
+
+function normalizeSkillFilePath({
+  skillName,
+  filePath,
+}: {
+  skillName: string;
+  filePath: string;
+}): string {
+  const normalized = path.posix.normalize(filePath);
+  if (
+    normalized === '' ||
+    normalized === '.' ||
+    normalized.startsWith('../') ||
+    normalized.includes('/../') ||
+    normalized.endsWith('/..') ||
+    path.posix.isAbsolute(normalized)
+  ) {
+    throw new Error(
+      `Invalid Cline skill file path for ${skillName}: ${filePath}`,
+    );
+  }
+  return normalized;
+}
+
+function renderSkillInstructions({
+  skill,
+  args,
+}: {
+  skill: ProjectedClineSkill;
+  args: string | undefined;
+}): string {
+  const trimmedArgs = args?.trim();
+  const argsTag = trimmedArgs
+    ? `\n<command-args>${trimmedArgs}</command-args>`
+    : '';
+  const description = skill.description.trim()
+    ? `Description: ${skill.description.trim()}\n\n`
+    : '';
+  const files =
+    skill.files.length === 0
+      ? ''
+      : `\n\n<skill-files>\n${skill.files
+          .map(
+            file =>
+              `<skill-file path=${JSON.stringify(file.path)}>\n${file.content}\n</skill-file>`,
+          )
+          .join('\n')}\n</skill-files>`;
+
+  return `<command-name>${skill.name}</command-name>${argsTag}\n<command-instructions>\n${description}${skill.content}${files}\n</command-instructions>`;
 }

--- a/packages/harness-cline/src/cline-tools.ts
+++ b/packages/harness-cline/src/cline-tools.ts
@@ -24,6 +24,7 @@ export const CLINE_NATIVE_BUILTIN_NAMES = [
   'grep',
   'glob',
   'ls',
+  'skills',
 ] as const;
 
 export type ClineNativeBuiltinName =
@@ -39,6 +40,7 @@ export const CLINE_NATIVE_TOOL_KINDS: Readonly<
   grep: 'readonly',
   glob: 'readonly',
   ls: 'readonly',
+  skills: 'readonly',
 };
 
 export function isClineBuiltinToolName(
@@ -127,9 +129,9 @@ async function guarded<T>(run: () => Promise<T>): Promise<ClineToolResult> {
 }
 
 /**
- * Build the sandbox-backed built-in `AgentTool`s handed to the Cline runtime.
- * These schemas mirror the zod declarations in `CLINE_BUILTIN_TOOLS`
- * (cline-harness.ts) — keep the two in sync.
+ * Build the sandbox-backed coding tools handed to the Cline runtime. These
+ * schemas mirror their declarations in `CLINE_BUILTIN_TOOLS`
+ * (cline-harness.ts). The in-host skills tool is built separately.
  */
 export function buildBuiltinAgentTools({
   ops,

--- a/packages/harness-cline/src/cline-translate.test.ts
+++ b/packages/harness-cline/src/cline-translate.test.ts
@@ -377,6 +377,36 @@ describe('translateClineEvent', () => {
     ]);
   });
 
+  it('marks the in-host skills tool providerExecuted', () => {
+    const state = createClineTranslatorState({
+      builtinToolNames: ['skills'],
+    });
+    const parts = translateClineEvent(
+      {
+        type: 'tool-started',
+        snapshot,
+        iteration: 1,
+        toolCall: {
+          type: 'tool-call',
+          toolCallId: 'skill-call',
+          toolName: 'skills',
+          input: { skill: 'release-notes' },
+        },
+      },
+      state,
+    );
+
+    expect(parts).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'skill-call',
+        toolName: 'skills',
+        input: JSON.stringify({ skill: 'release-notes' }),
+        providerExecuted: true,
+      },
+    ]);
+  });
+
   it('does not mark user tool calls providerExecuted', () => {
     const state = newState();
     const parts = translateClineEvent(


### PR DESCRIPTION
## Background

The Cline adapter runs in the host process, but harness skills were materialized in the remote sandbox and advertised through the system prompt instead of using Cline's native skill semantics.

## Summary

- Expose harness skills through Cline's native `skills` tool with in-memory metadata and instruction loading.
- Include attached skill files in the native tool result and rebuild the agent only when effective skill data changes.
- Remove sandbox skill writes and the extra readable-root exception while retaining workspace confinement.
- Declare `skills` as a filterable, provider-executed Cline builtin and add regression coverage.

## End-to-End Verification

Ran `./tools/run-harness-agent-examples.sh --harness cline --example with-skills`.

## Checklist

- [x] All commits are signed with a verified signature.
- [x] Tests have been added or updated.
- [x] Documentation has been added or updated.
- [x] A patch changeset has been added.
- [x] The changes have been self-reviewed.
