### PR TITLE
fix: mark response body network errors as retryable

### DIFF
--- a/.changeset/tidy-response-body-errors.md
+++ b/.changeset/tidy-response-body-errors.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider-utils': patch
+'@ai-sdk/gateway': patch
+---
+
+Mark transient network errors that occur while reading successful response bodies as retryable.

--- a/packages/gateway/src/errors/as-gateway-error.test.ts
+++ b/packages/gateway/src/errors/as-gateway-error.test.ts
@@ -167,5 +167,22 @@ describe('asGatewayError', () => {
 
       expect(GatewayTimeoutError.isInstance(result)).toBe(false);
     });
+
+    it('should preserve retryability for transport errors after response headers', async () => {
+      const apiCallError = new APICallError({
+        message: 'Failed to process successful response',
+        url: 'https://example.com',
+        requestBodyValues: {},
+        statusCode: 200,
+        isRetryable: true,
+      });
+
+      const result = await asGatewayError(apiCallError);
+
+      expect(GatewayResponseError.isInstance(result)).toBe(true);
+      expect(result.isRetryable).toBe(true);
+      expect(result.statusCode).toBe(200);
+      expect(result.cause).toBe(apiCallError);
+    });
   });
 });

--- a/packages/gateway/src/errors/as-gateway-error.ts
+++ b/packages/gateway/src/errors/as-gateway-error.ts
@@ -59,6 +59,11 @@ export async function asGatewayError(
       defaultMessage: 'Gateway request failed',
       cause: error,
       authMethod,
+      isRetryable:
+        error.isRetryable &&
+        (error.statusCode == null || error.statusCode < 400)
+          ? true
+          : undefined,
     });
   }
 

--- a/packages/gateway/src/errors/create-gateway-error.ts
+++ b/packages/gateway/src/errors/create-gateway-error.ts
@@ -27,12 +27,14 @@ export async function createGatewayErrorFromResponse({
   defaultMessage = 'Gateway request failed',
   cause,
   authMethod,
+  isRetryable,
 }: {
   response: unknown;
   statusCode: number;
   defaultMessage?: string;
   cause?: unknown;
   authMethod?: 'api-key' | 'oidc';
+  isRetryable?: boolean;
 }): Promise<GatewayError> {
   const parseResult = await safeValidateTypes({
     value: response,
@@ -55,6 +57,7 @@ export async function createGatewayErrorFromResponse({
       validationError: parseResult.error,
       cause,
       generationId: rawGenerationId,
+      isRetryable,
     });
   }
 

--- a/packages/gateway/src/errors/gateway-response-error.ts
+++ b/packages/gateway/src/errors/gateway-response-error.ts
@@ -23,6 +23,7 @@ export class GatewayResponseError extends GatewayError {
     validationError,
     cause,
     generationId,
+    isRetryable,
   }: {
     message?: string;
     statusCode?: number;
@@ -30,8 +31,9 @@ export class GatewayResponseError extends GatewayError {
     validationError?: TypeValidationError;
     cause?: unknown;
     generationId?: string;
+    isRetryable?: boolean;
   } = {}) {
-    super({ message, statusCode, cause, generationId });
+    super({ message, statusCode, cause, generationId, isRetryable });
     this.response = response;
     this.validationError = validationError;
   }

--- a/packages/provider-utils/src/handle-fetch-error.test.ts
+++ b/packages/provider-utils/src/handle-fetch-error.test.ts
@@ -38,6 +38,58 @@ describe('handleFetchError', () => {
         'Cannot connect to API: ECONNREFUSED',
       );
     });
+
+    it('should mark nested Undici socket errors as retryable', () => {
+      const socketError = Object.assign(new Error('other side closed'), {
+        code: 'UND_ERR_SOCKET',
+      });
+      const terminatedError = new TypeError('terminated') as TypeError & {
+        cause?: unknown;
+      };
+      terminatedError.cause = socketError;
+      const apiCallError = new APICallError({
+        message: 'Failed to process successful response',
+        cause: terminatedError,
+        url: testUrl,
+        requestBodyValues: testRequestBodyValues,
+        statusCode: 200,
+        responseHeaders: { 'x-request-id': 'request-id' },
+        responseBody: 'partial response',
+        data: { partial: true },
+      });
+
+      const result = handleFetchError({
+        error: apiCallError,
+        url: testUrl,
+        requestBodyValues: testRequestBodyValues,
+      });
+
+      expect(APICallError.isInstance(result)).toBe(true);
+      expect(result).toMatchObject({
+        message: 'Failed to process successful response',
+        cause: terminatedError,
+        url: testUrl,
+        requestBodyValues: testRequestBodyValues,
+        statusCode: 200,
+        responseHeaders: { 'x-request-id': 'request-id' },
+        responseBody: 'partial response',
+        data: { partial: true },
+        isRetryable: true,
+      });
+    });
+
+    it('should stop traversing cyclic error causes', () => {
+      const error = new Error('cyclic') as Error & { cause?: unknown };
+      error.cause = error;
+
+      const result = handleFetchError({
+        error,
+        url: testUrl,
+        requestBodyValues: testRequestBodyValues,
+      });
+
+      expect(result).toBe(error);
+    });
   });
 
   describe('browser fetch errors', () => {

--- a/packages/provider-utils/src/handle-fetch-error.ts
+++ b/packages/provider-utils/src/handle-fetch-error.ts
@@ -3,7 +3,7 @@ import { isAbortError } from './is-abort-error';
 
 const FETCH_FAILED_ERROR_MESSAGES = ['fetch failed', 'failed to fetch'];
 
-const BUN_ERROR_CODES = [
+const RETRYABLE_NETWORK_ERROR_CODES = new Set([
   'ConnectionRefused',
   'ConnectionClosed',
   'FailedToOpenSocket',
@@ -11,19 +11,33 @@ const BUN_ERROR_CODES = [
   'ECONNREFUSED',
   'ETIMEDOUT',
   'EPIPE',
-];
+  'UND_ERR_SOCKET',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+]);
 
-function isBunNetworkError(error: unknown): error is Error & { code?: string } {
-  if (!(error instanceof Error)) {
-    return false;
+function findNetworkError(
+  error: unknown,
+): (Error & { code?: unknown }) | undefined {
+  const visited = new Set<Error>();
+  let current = error;
+
+  while (current instanceof Error && !visited.has(current)) {
+    visited.add(current);
+
+    const errorWithCode = current as Error & { code?: unknown };
+    if (
+      typeof errorWithCode.code === 'string' &&
+      RETRYABLE_NETWORK_ERROR_CODES.has(errorWithCode.code)
+    ) {
+      return errorWithCode;
+    }
+
+    current = (current as Error & { cause?: unknown }).cause;
   }
 
-  const code = (error as any).code;
-  if (typeof code === 'string' && BUN_ERROR_CODES.includes(code)) {
-    return true;
-  }
-
-  return false;
+  return undefined;
 }
 
 export function handleFetchError({
@@ -58,9 +72,27 @@ export function handleFetchError({
     }
   }
 
-  if (isBunNetworkError(error)) {
+  const networkError = findNetworkError(error);
+
+  if (networkError != null) {
+    if (APICallError.isInstance(error)) {
+      return new APICallError({
+        message: error.message,
+        cause: error.cause,
+        url: error.url,
+        requestBodyValues: error.requestBodyValues,
+        statusCode: error.statusCode,
+        responseHeaders: error.responseHeaders,
+        responseBody: error.responseBody,
+        data: error.data,
+        isRetryable: true,
+      });
+    }
+
     return new APICallError({
-      message: `Cannot connect to API: ${error.message}`,
+      message: `Cannot connect to API: ${
+        error instanceof Error ? error.message : networkError.message
+      }`,
       cause: error,
       url,
       requestBodyValues,

--- a/packages/provider-utils/src/post-to-api.test.ts
+++ b/packages/provider-utils/src/post-to-api.test.ts
@@ -1,0 +1,58 @@
+import { APICallError } from '@ai-sdk/provider';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { postJsonToApi } from './post-to-api';
+import {
+  createJsonResponseHandler,
+  createStatusCodeErrorResponseHandler,
+} from './response-handler';
+
+describe('postJsonToApi', () => {
+  it('should mark socket errors while reading successful response bodies as retryable', async () => {
+    const socketError = Object.assign(new Error('other side closed'), {
+      code: 'UND_ERR_SOCKET',
+    });
+    const terminatedError = new TypeError('terminated') as TypeError & {
+      cause?: unknown;
+    };
+    terminatedError.cause = socketError;
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"value":'));
+            controller.error(terminatedError);
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'x-request-id': 'request-id' },
+        },
+      ),
+    );
+
+    let observedError: unknown;
+    try {
+      await postJsonToApi({
+        url: 'https://api.example.com/v1/generate',
+        body: { prompt: 'test' },
+        successfulResponseHandler: createJsonResponseHandler(
+          z.object({ value: z.string() }),
+        ),
+        failedResponseHandler: createStatusCodeErrorResponseHandler(),
+        fetch,
+      });
+    } catch (error) {
+      observedError = error;
+    }
+
+    expect(APICallError.isInstance(observedError)).toBe(true);
+    expect(observedError).toMatchObject({
+      message: 'Failed to process successful response',
+      cause: terminatedError,
+      statusCode: 200,
+      responseHeaders: { 'x-request-id': 'request-id' },
+      isRetryable: true,
+    });
+  });
+});

--- a/packages/provider-utils/src/response-handler.test.ts
+++ b/packages/provider-utils/src/response-handler.test.ts
@@ -1,9 +1,11 @@
+import { APICallError } from '@ai-sdk/provider';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { DEFAULT_MAX_DOWNLOAD_SIZE } from './read-response-with-size-limit';
 import {
   createJsonErrorResponseHandler,
   createBinaryResponseHandler,
+  createEventSourceResponseHandler,
   createJsonLinesResponseHandler,
   createJsonResponseHandler,
   createStatusCodeErrorResponseHandler,
@@ -84,6 +86,66 @@ describe('createJsonResponseHandler', () => {
     ).rejects.toThrow('exceeded maximum size');
 
     expect(cancelled()).toBe(true);
+  });
+});
+
+describe('createEventSourceResponseHandler', () => {
+  it('should preserve context and mark response body socket errors as retryable', async () => {
+    const socketError = Object.assign(new Error('other side closed'), {
+      code: 'UND_ERR_SOCKET',
+    });
+    const terminatedError = new TypeError('terminated') as TypeError & {
+      cause?: unknown;
+    };
+    terminatedError.cause = socketError;
+    let pullCount = 0;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (pullCount++ === 0) {
+            controller.enqueue(
+              new TextEncoder().encode('data: {"value":"partial"}\n\n'),
+            );
+          } else {
+            controller.error(terminatedError);
+          }
+        },
+      }),
+      {
+        status: 200,
+        headers: { 'x-request-id': 'request-id' },
+      },
+    );
+    const handler = createEventSourceResponseHandler(
+      z.object({ value: z.string() }),
+    );
+    const result = await handler({
+      url: 'test-url',
+      requestBodyValues: { prompt: 'test' },
+      response,
+    });
+    const reader = result.value.getReader();
+
+    await expect(reader.read()).resolves.toMatchObject({
+      value: { success: true, value: { value: 'partial' } },
+    });
+
+    let observedError: unknown;
+    try {
+      await reader.read();
+    } catch (error) {
+      observedError = error;
+    }
+
+    expect(APICallError.isInstance(observedError)).toBe(true);
+    expect(observedError).toMatchObject({
+      name: 'AI_APICallError',
+      message: 'Failed to process successful response',
+      isRetryable: true,
+      statusCode: 200,
+      responseHeaders: { 'x-request-id': 'request-id' },
+      cause: terminatedError,
+    });
   });
 });
 

--- a/packages/provider-utils/src/response-handler.ts
+++ b/packages/provider-utils/src/response-handler.ts
@@ -1,5 +1,7 @@
 import { APICallError, EmptyResponseBodyError } from '@ai-sdk/provider';
 import { extractResponseHeaders } from './extract-response-headers';
+import { handleFetchError } from './handle-fetch-error';
+import { isAbortError } from './is-abort-error';
 import { parseJSON, safeParseJSON, type ParseResult } from './parse-json';
 import { parseJsonEventStream } from './parse-json-event-stream';
 import { readResponseWithSizeLimit } from './read-response-with-size-limit';
@@ -16,6 +18,74 @@ export type ResponseHandler<RETURN_TYPE> = (options: {
 }>;
 
 const textDecoder = new TextDecoder();
+
+function wrapResponseBodyStream({
+  stream,
+  url,
+  requestBodyValues,
+  statusCode,
+  responseHeaders,
+}: {
+  stream: ReadableStream<Uint8Array>;
+  url: string;
+  requestBodyValues: unknown;
+  statusCode: number;
+  responseHeaders: Record<string, string>;
+}): ReadableStream<Uint8Array> {
+  const reader = stream.getReader();
+  let readerReleased = false;
+
+  const releaseReader = () => {
+    if (!readerReleased) {
+      reader.releaseLock();
+      readerReleased = true;
+    }
+  };
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+
+        if (done) {
+          releaseReader();
+          controller.close();
+        } else {
+          controller.enqueue(value);
+        }
+      } catch (error) {
+        releaseReader();
+
+        if (isAbortError(error)) {
+          controller.error(error);
+          return;
+        }
+
+        controller.error(
+          handleFetchError({
+            error: new APICallError({
+              message: 'Failed to process successful response',
+              cause: error,
+              statusCode,
+              url,
+              responseHeaders,
+              requestBodyValues,
+            }),
+            url,
+            requestBodyValues,
+          }),
+        );
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        releaseReader();
+      }
+    },
+  });
+}
 
 async function readResponseBodyAsText({
   response,
@@ -102,7 +172,7 @@ export const createEventSourceResponseHandler =
   <T>(
     chunkSchema: FlexibleSchema<T>,
   ): ResponseHandler<ReadableStream<ParseResult<T>>> =>
-  async ({ response }: { response: Response }) => {
+  async ({ response, url, requestBodyValues }) => {
     const responseHeaders = extractResponseHeaders(response);
 
     if (response.body == null) {
@@ -112,7 +182,13 @@ export const createEventSourceResponseHandler =
     return {
       responseHeaders,
       value: parseJsonEventStream({
-        stream: response.body,
+        stream: wrapResponseBodyStream({
+          stream: response.body,
+          url,
+          requestBodyValues,
+          statusCode: response.status,
+          responseHeaders,
+        }),
         schema: chunkSchema,
       }),
     };


### PR DESCRIPTION
## Background

Transient Undici failures can occur after fetch has returned successful HTTP response headers, while the JSON or SSE body is still being read. These failures are currently wrapped with the HTTP 200 status and treated as non-retryable, so non-streaming language model and Gateway calls do not use their configured retry budget.

## Changes

- recognize retryable Bun and Undici network codes throughout an error cause chain
- preserve APICallError request and response context when marking a nested transport failure retryable
- wrap EventSource response-body failures with the same API call context used for non-streaming responses
- preserve the actual HTTP status while explicitly carrying retryability through Gateway error conversion
- add transport-boundary, EventSource, cause-cycle, and Gateway regression coverage

This intentionally does not retry partial streamText model attempts. Restarting a model after output has already been exposed requires separate semantics for abandoned output and exactly-once tool execution.

## Testing

- provider-utils full Node and Edge suites: 827 tests passed in each runtime
- Gateway full Node suite: 540 tests passed
- Gateway full Edge suite: 532 tests passed, 8 skipped
- pnpm check
- pnpm type-check:full
- pnpm --filter @ai-sdk/gateway... build

## Backports

Recommended for release-v6.0 and release-v5.0 after this PR merges. The issue was reproduced on both release lines, and this is an internal patch-level retry classification fix.

## Related

Refs #9775

Extracts the safe transport-error portion of #18062 without its partial-stream replay behavior.
