### PR TITLE
feat(ai): expose normalized content in successful text batch results

### DIFF
--- a/.changeset/tiny-batches-content.md
+++ b/.changeset/tiny-batches-content.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+feat(ai): expose normalized content in successful text batch results

--- a/packages/ai/src/batch/batch-types.test-d.ts
+++ b/packages/ai/src/batch/batch-types.test-d.ts
@@ -15,6 +15,7 @@ import {
   experimental_startTextBatch as startTextBatch,
   type GatewayProviderMetadata,
   type Experimental_BatchError as BatchError,
+  type Experimental_BatchContentPart as BatchContentPart,
   type Experimental_BatchLanguageModel as BatchLanguageModel,
   type Experimental_BatchOperationOptions as BatchOperationOptions,
   type Experimental_BatchReference as BatchReference,
@@ -94,6 +95,12 @@ it('uses serializable response timestamps', () => {
   expectTypeOf<
     NonNullable<TextBatchGenerationResult['response']>['timestamp']
   >().toEqualTypeOf<string | undefined>();
+});
+
+it('exposes Core-normalized content on successful results', () => {
+  expectTypeOf<TextBatchGenerationResult['content']>().toEqualTypeOf<
+    BatchContentPart[]
+  >();
 });
 
 it('flattens successful Core items while reusing provider status and errors', () => {

--- a/packages/ai/src/batch/batch-types.ts
+++ b/packages/ai/src/batch/batch-types.ts
@@ -4,7 +4,8 @@ import type {
   Experimental_BatchV4Status as BatchV4Status,
   Experimental_BatchLanguageModelV4 as BatchLanguageModelV4,
 } from '@ai-sdk/provider';
-import type { ProviderOptions } from '@ai-sdk/provider-utils';
+import type { ProviderOptions, ToolSet } from '@ai-sdk/provider-utils';
+import type { ContentPart } from '../generate-text/content-part';
 import type { LanguageModelCallOptions } from '../prompt/language-model-call-options';
 import type { Prompt } from '../prompt/prompt';
 import type {
@@ -104,9 +105,17 @@ export type BatchOperationOptions = {
 } & BatchRequestOptions;
 
 /**
+ * A Core-normalized content part returned for a successful text batch item.
+ *
+ * Batch requests do not carry a request-specific typed tool set.
+ */
+export type BatchContentPart = ContentPart<ToolSet>;
+
+/**
  * A normalized result for a successful text batch item.
  */
 export type TextBatchGenerationResult = {
+  readonly content: BatchContentPart[];
   readonly text: string;
   readonly finishReason: FinishReason;
   readonly rawFinishReason?: string;

--- a/packages/ai/src/batch/batch.test.ts
+++ b/packages/ai/src/batch/batch.test.ts
@@ -294,6 +294,7 @@ describe('getBatchResults', () => {
       {
         id: 'request-1',
         status: 'succeeded',
+        content: [{ type: 'text', text: 'Paris' }],
         text: 'Paris',
         finishReason: 'stop',
         rawFinishReason: 'stop',
@@ -315,5 +316,130 @@ describe('getBatchResults', () => {
         error: { message: 'request failed', code: 'bad_request' },
       },
     ]);
+  });
+
+  it('preserves ordered non-text content using Core-normalized shapes', async () => {
+    const model = createMockBatchModel({
+      doGetBatchResults: async () =>
+        convertArrayToReadableStream([
+          {
+            id: 'request-1',
+            status: 'succeeded',
+            result: {
+              content: [
+                {
+                  type: 'reasoning',
+                  text: 'Use the weather tool.',
+                  providerMetadata: { mock: { reasoning: true } },
+                },
+                {
+                  type: 'file',
+                  data: { type: 'data', data: 'aGVsbG8=' },
+                  mediaType: 'text/plain',
+                },
+                {
+                  type: 'source',
+                  sourceType: 'url',
+                  id: 'source-1',
+                  url: 'https://example.com/weather',
+                  title: 'Weather',
+                },
+                {
+                  type: 'custom',
+                  kind: 'mock.trace',
+                  providerMetadata: { mock: { traceId: 'trace-1' } },
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'get_weather',
+                  input: '{"city":"Paris"}',
+                  providerExecuted: true,
+                  dynamic: true,
+                  providerMetadata: { mock: { call: true } },
+                },
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call-1',
+                  toolName: 'get_weather',
+                  result: { temperature: 20 },
+                  dynamic: true,
+                  providerMetadata: { mock: { result: true } },
+                },
+                { type: 'text', text: 'It is 20°C.' },
+              ],
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+              warnings: [],
+            },
+          },
+          {
+            id: 'request-2',
+            status: 'succeeded',
+            result: {
+              content: [{ type: 'reasoning', text: 'No text was generated.' }],
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: testUsage,
+              warnings: [],
+            },
+          },
+        ]),
+    });
+
+    const items = await Array.fromAsync(
+      getBatchResults({ model, batch: batchReference, maxRetries: 0 }),
+    );
+
+    expect(items[0]).toMatchObject({
+      id: 'request-1',
+      status: 'succeeded',
+      text: 'It is 20°C.',
+      content: [
+        {
+          type: 'reasoning',
+          text: 'Use the weather tool.',
+          providerMetadata: { mock: { reasoning: true } },
+        },
+        { type: 'file', file: { mediaType: 'text/plain' } },
+        {
+          type: 'source',
+          sourceType: 'url',
+          id: 'source-1',
+          url: 'https://example.com/weather',
+          title: 'Weather',
+        },
+        {
+          type: 'custom',
+          kind: 'mock.trace',
+          providerMetadata: { mock: { traceId: 'trace-1' } },
+        },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'get_weather',
+          input: { city: 'Paris' },
+          providerExecuted: true,
+          dynamic: true,
+          providerMetadata: { mock: { call: true } },
+        },
+        {
+          type: 'tool-result',
+          toolCallId: 'call-1',
+          toolName: 'get_weather',
+          input: { city: 'Paris' },
+          output: { temperature: 20 },
+          providerExecuted: true,
+          dynamic: true,
+          providerMetadata: { mock: { result: true } },
+        },
+        { type: 'text', text: 'It is 20°C.' },
+      ],
+    });
+    expect(items[1]).toMatchObject({
+      id: 'request-2',
+      status: 'succeeded',
+      content: [{ type: 'reasoning', text: 'No text was generated.' }],
+      text: '',
+    });
   });
 });

--- a/packages/ai/src/batch/batch.ts
+++ b/packages/ai/src/batch/batch.ts
@@ -4,9 +4,13 @@ import {
   type Experimental_BatchV4ItemResult as BatchV4ItemResult,
   type LanguageModelV4,
   type LanguageModelV4GenerateResult,
+  type LanguageModelV4ToolCall,
 } from '@ai-sdk/provider';
-import { withUserAgentSuffix } from '@ai-sdk/provider-utils';
+import { withUserAgentSuffix, type ToolSet } from '@ai-sdk/provider-utils';
 import { InvalidArgumentError } from '../error/invalid-argument-error';
+import { asContent } from '../generate-text/as-content';
+import { parseToolCall } from '../generate-text/parse-tool-call';
+import type { TypedToolCall } from '../generate-text/tool-call';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveLanguageModel } from '../model/resolve-model';
 import { convertToLanguageModelPrompt } from '../prompt/convert-to-language-model-prompt';
@@ -21,6 +25,7 @@ import { prepareRetries } from '../util/prepare-retries';
 import { VERSION } from '../version';
 import type {
   BatchOperationOptions,
+  BatchContentPart,
   BatchReference,
   BatchStatus,
   StartTextBatchOptions,
@@ -175,8 +180,8 @@ export function getBatchResults({
     BatchV4ItemResult<LanguageModelV4GenerateResult>,
     TextBatchItemResult
   > & { cancel?: (reason?: unknown) => void } = {
-    transform(item, controller) {
-      controller.enqueue(convertBatchItemResult(item));
+    async transform(item, controller) {
+      controller.enqueue(await convertBatchItemResult(item));
     },
 
     cancel(reason) {
@@ -296,9 +301,9 @@ function validateBatchReference({
   }
 }
 
-function convertBatchItemResult(
+async function convertBatchItemResult(
   item: BatchV4ItemResult<LanguageModelV4GenerateResult>,
-): TextBatchItemResult {
+): Promise<TextBatchItemResult> {
   if (item.status !== 'succeeded') {
     return item;
   }
@@ -306,14 +311,15 @@ function convertBatchItemResult(
   return {
     id: item.id,
     status: 'succeeded',
-    ...convertGenerateResult(item.result),
+    ...(await convertGenerateResult(item.result)),
   };
 }
 
-function convertGenerateResult(
+async function convertGenerateResult(
   result: LanguageModelV4GenerateResult,
-): TextBatchGenerationResult {
+): Promise<TextBatchGenerationResult> {
   return {
+    content: await convertContent(result.content),
     text: result.content
       .filter(
         (part): part is Extract<typeof part, { type: 'text' }> =>
@@ -335,4 +341,33 @@ function convertGenerateResult(
       : {}),
     providerMetadata: result.providerMetadata,
   };
+}
+
+async function convertContent(
+  content: LanguageModelV4GenerateResult['content'],
+): Promise<Array<BatchContentPart>> {
+  const toolCalls: Array<TypedToolCall<ToolSet>> = await Promise.all(
+    content
+      .filter(
+        (part): part is LanguageModelV4ToolCall => part.type === 'tool-call',
+      )
+      .map(toolCall =>
+        parseToolCall<ToolSet>({
+          toolCall,
+          tools: undefined,
+          repairToolCall: undefined,
+          messages: [],
+          instructions: undefined,
+        }),
+      ),
+  );
+
+  return asContent<ToolSet>({
+    content,
+    toolCalls,
+    toolOutputs: [],
+    toolApprovalRequests: [],
+    toolApprovalResponses: [],
+    tools: undefined,
+  });
 }

--- a/packages/ai/src/batch/index.ts
+++ b/packages/ai/src/batch/index.ts
@@ -4,6 +4,7 @@ export {
   getBatchStatus as experimental_getBatchStatus,
 } from './batch';
 export type {
+  BatchContentPart as Experimental_BatchContentPart,
   BatchError as Experimental_BatchError,
   BatchLanguageModel as Experimental_BatchLanguageModel,
   BatchOperationOptions as Experimental_BatchOperationOptions,

--- a/packages/ai/src/generate-text/as-content.ts
+++ b/packages/ai/src/generate-text/as-content.ts
@@ -1,0 +1,200 @@
+import type { LanguageModelV4Content } from '@ai-sdk/provider';
+import type { ToolSet } from '@ai-sdk/provider-utils';
+import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
+import { getOwn } from '../util/get-own';
+import type { ContentPart } from './content-part';
+import { DefaultGeneratedFile } from './generated-file';
+import type { ToolApprovalRequestOutput } from './tool-approval-request-output';
+import type { ToolApprovalResponseOutput } from './tool-approval-response-output';
+import type { TypedToolCall } from './tool-call';
+import type { TypedToolError } from './tool-error';
+import type { ToolOutput } from './tool-output';
+import type { TypedToolResult } from './tool-result';
+
+export function asContent<TOOLS extends ToolSet>({
+  content,
+  toolCalls,
+  toolOutputs,
+  toolApprovalRequests,
+  toolApprovalResponses,
+  tools,
+}: {
+  content: Array<LanguageModelV4Content>;
+  toolCalls: Array<TypedToolCall<TOOLS>>;
+  toolOutputs: Array<ToolOutput<TOOLS>>;
+  toolApprovalRequests: Array<ToolApprovalRequestOutput<TOOLS>>;
+  toolApprovalResponses: Array<ToolApprovalResponseOutput<TOOLS>>;
+  tools: TOOLS | undefined;
+}): Array<ContentPart<TOOLS>> {
+  const contentParts: Array<ContentPart<TOOLS>> = [];
+  const toolOutputsWithApprovalResponses: Array<ToolOutput<TOOLS>> = [];
+  const toolOutputsWithoutApprovalResponses: Array<ToolOutput<TOOLS>> = [];
+  const toolCallIdsWithApprovalResponses = new Set(
+    toolApprovalResponses.map(
+      toolApprovalResponse => toolApprovalResponse.toolCall.toolCallId,
+    ),
+  );
+
+  for (const part of content) {
+    switch (part.type) {
+      case 'text':
+      case 'reasoning':
+      case 'custom':
+      case 'source':
+        contentParts.push(part);
+        break;
+
+      case 'file':
+      case 'reasoning-file': {
+        contentParts.push({
+          type: part.type as 'file' | 'reasoning-file',
+          file: new DefaultGeneratedFile({
+            data:
+              part.data.type === 'data'
+                ? part.data.data
+                : part.data.url.toString(),
+            mediaType: part.mediaType,
+          }),
+          ...(part.providerMetadata != null
+            ? { providerMetadata: part.providerMetadata }
+            : {}),
+        });
+        break;
+      }
+
+      case 'tool-call': {
+        contentParts.push(
+          toolCalls.find(toolCall => toolCall.toolCallId === part.toolCallId)!,
+        );
+        break;
+      }
+
+      case 'tool-result': {
+        const toolCall = toolCalls.find(
+          toolCall => toolCall.toolCallId === part.toolCallId,
+        );
+
+        // Handle deferred results for provider-executed tools (e.g., programmatic tool calling).
+        // When a server tool (like code_execution) triggers a client tool, the server tool's
+        // result may be deferred to a later turn. In this case, there's no matching tool-call
+        // in the current response.
+        if (toolCall == null) {
+          const tool = getOwn(tools, part.toolName);
+          const supportsDeferredResults =
+            tool?.type === 'provider' && tool.supportsDeferredResults;
+
+          if (!supportsDeferredResults) {
+            throw new Error(`Tool call ${part.toolCallId} not found.`);
+          }
+
+          // Create tool result without tool call input (deferred result)
+          if (part.isError) {
+            contentParts.push({
+              type: 'tool-error' as const,
+              toolCallId: part.toolCallId,
+              toolName: part.toolName as keyof TOOLS & string,
+              input: undefined,
+              error: part.result,
+              providerExecuted: true,
+              dynamic: part.dynamic,
+              ...(part.providerMetadata != null
+                ? { providerMetadata: part.providerMetadata }
+                : {}),
+              ...(tool?.metadata != null
+                ? { toolMetadata: tool.metadata }
+                : {}),
+            } as TypedToolError<TOOLS>);
+          } else {
+            contentParts.push({
+              type: 'tool-result' as const,
+              toolCallId: part.toolCallId,
+              toolName: part.toolName as keyof TOOLS & string,
+              input: undefined,
+              output: part.result,
+              providerExecuted: true,
+              dynamic: part.dynamic,
+              ...(part.providerMetadata != null
+                ? { providerMetadata: part.providerMetadata }
+                : {}),
+              ...(tool?.metadata != null
+                ? { toolMetadata: tool.metadata }
+                : {}),
+            } as TypedToolResult<TOOLS>);
+          }
+          break;
+        }
+
+        if (part.isError) {
+          contentParts.push({
+            type: 'tool-error' as const,
+            toolCallId: part.toolCallId,
+            toolName: part.toolName as keyof TOOLS & string,
+            input: toolCall.input,
+            error: part.result,
+            providerExecuted: true,
+            dynamic: toolCall.dynamic,
+            ...(part.providerMetadata != null
+              ? { providerMetadata: part.providerMetadata }
+              : {}),
+            ...(toolCall.toolMetadata != null
+              ? { toolMetadata: toolCall.toolMetadata }
+              : {}),
+          } as TypedToolError<TOOLS>);
+        } else {
+          contentParts.push({
+            type: 'tool-result' as const,
+            toolCallId: part.toolCallId,
+            toolName: part.toolName as keyof TOOLS & string,
+            input: toolCall.input,
+            output: part.result,
+            providerExecuted: true,
+            dynamic: toolCall.dynamic,
+            ...(part.providerMetadata != null
+              ? { providerMetadata: part.providerMetadata }
+              : {}),
+            ...(toolCall.toolMetadata != null
+              ? { toolMetadata: toolCall.toolMetadata }
+              : {}),
+          } as TypedToolResult<TOOLS>);
+        }
+        break;
+      }
+
+      case 'tool-approval-request': {
+        const toolCall = toolCalls.find(
+          toolCall => toolCall.toolCallId === part.toolCallId,
+        );
+
+        if (toolCall == null) {
+          throw new ToolCallNotFoundForApprovalError({
+            toolCallId: part.toolCallId,
+            approvalId: part.approvalId,
+          });
+        }
+
+        contentParts.push({
+          type: 'tool-approval-request' as const,
+          approvalId: part.approvalId,
+          toolCall,
+        });
+        break;
+      }
+    }
+  }
+
+  for (const toolOutput of toolOutputs) {
+    if (toolCallIdsWithApprovalResponses.has(toolOutput.toolCallId)) {
+      toolOutputsWithApprovalResponses.push(toolOutput);
+    } else {
+      toolOutputsWithoutApprovalResponses.push(toolOutput);
+    }
+  }
+
+  return [
+    ...contentParts,
+    ...toolOutputsWithoutApprovalResponses,
+    ...toolApprovalRequests,
+    ...toolApprovalResponses,
+    ...toolOutputsWithApprovalResponses,
+  ];
+}

--- a/packages/ai/src/generate-text/generate-text.ts
+++ b/packages/ai/src/generate-text/generate-text.ts
@@ -1,5 +1,4 @@
 import type {
-  LanguageModelV4Content,
   LanguageModelV4GenerateResult,
   LanguageModelV4ToolCall,
 } from '@ai-sdk/provider';
@@ -17,7 +16,6 @@ import {
   type ToolSet,
 } from '@ai-sdk/provider-utils';
 import { NoOutputGeneratedError } from '../error';
-import { ToolCallNotFoundForApprovalError } from '../error/tool-call-not-found-for-approval-error';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveLanguageModel } from '../model/resolve-model';
 import type { ModelMessage } from '../prompt';
@@ -62,9 +60,9 @@ import { prepareRetries } from '../util/prepare-retries';
 import { setAbortTimeout } from '../util/set-abort-timeout';
 import { VERSION } from '../version';
 import type { ActiveTools } from './active-tools';
+import { asContent } from './as-content';
 import { calculateTokensPerSecond } from './calculate-tokens-per-second';
 import { collectToolApprovals } from './collect-tool-approvals';
-import type { ContentPart } from './content-part';
 import { executeToolCall } from './execute-tool-call';
 import {
   filterActiveTools,
@@ -78,7 +76,6 @@ import type {
   GenerateTextOnStepStartCallback,
 } from './generate-text-events';
 import type { GenerateTextResult } from './generate-text-result';
-import { DefaultGeneratedFile } from './generated-file';
 import { isToolExecutionAllowedFinishReason } from './is-tool-execution-allowed-finish-reason';
 import type {
   OnLanguageModelCallEndCallback,
@@ -115,7 +112,6 @@ import {
 } from './tool-caller-configuration';
 import type { TypedToolCall } from './tool-call';
 import type { ToolCallRepairFunction } from './tool-call-repair-function';
-import type { TypedToolError } from './tool-error';
 import type {
   OnToolExecutionEndCallback,
   OnToolExecutionStartCallback,
@@ -123,7 +119,6 @@ import type {
 import type { ToolInputRefinement } from './tool-input-refinement';
 import type { ToolOrder } from './tool-order';
 import type { ToolOutput } from './tool-output';
-import type { TypedToolResult } from './tool-result';
 import type { ToolsContextParameter } from './tools-context-parameter';
 import { maybeSignApproval } from './tool-approval-signature';
 import { validateApprovedToolApprovals } from './validate-tool-approvals';
@@ -1754,192 +1749,4 @@ class DefaultGenerateTextResult<
 
     return this._output;
   }
-}
-
-function asContent<TOOLS extends ToolSet>({
-  content,
-  toolCalls,
-  toolOutputs,
-  toolApprovalRequests,
-  toolApprovalResponses,
-  tools,
-}: {
-  content: Array<LanguageModelV4Content>;
-  toolCalls: Array<TypedToolCall<TOOLS>>;
-  toolOutputs: Array<ToolOutput<TOOLS>>;
-  toolApprovalRequests: Array<ToolApprovalRequestOutput<TOOLS>>;
-  toolApprovalResponses: Array<ToolApprovalResponseOutput<TOOLS>>;
-  tools: TOOLS | undefined;
-}): Array<ContentPart<TOOLS>> {
-  const contentParts: Array<ContentPart<TOOLS>> = [];
-  const toolOutputsWithApprovalResponses: Array<ToolOutput<TOOLS>> = [];
-  const toolOutputsWithoutApprovalResponses: Array<ToolOutput<TOOLS>> = [];
-  const toolCallIdsWithApprovalResponses = new Set(
-    toolApprovalResponses.map(
-      toolApprovalResponse => toolApprovalResponse.toolCall.toolCallId,
-    ),
-  );
-
-  for (const part of content) {
-    switch (part.type) {
-      case 'text':
-      case 'reasoning':
-      case 'custom':
-      case 'source':
-        contentParts.push(part);
-        break;
-
-      case 'file':
-      case 'reasoning-file': {
-        contentParts.push({
-          type: part.type as 'file' | 'reasoning-file',
-          file: new DefaultGeneratedFile({
-            data:
-              part.data.type === 'data'
-                ? part.data.data
-                : part.data.url.toString(),
-            mediaType: part.mediaType,
-          }),
-          ...(part.providerMetadata != null
-            ? { providerMetadata: part.providerMetadata }
-            : {}),
-        });
-        break;
-      }
-
-      case 'tool-call': {
-        contentParts.push(
-          toolCalls.find(toolCall => toolCall.toolCallId === part.toolCallId)!,
-        );
-        break;
-      }
-
-      case 'tool-result': {
-        const toolCall = toolCalls.find(
-          toolCall => toolCall.toolCallId === part.toolCallId,
-        );
-
-        // Handle deferred results for provider-executed tools (e.g., programmatic tool calling).
-        // When a server tool (like code_execution) triggers a client tool, the server tool's
-        // result may be deferred to a later turn. In this case, there's no matching tool-call
-        // in the current response.
-        if (toolCall == null) {
-          const tool = getOwn(tools, part.toolName);
-          const supportsDeferredResults =
-            tool?.type === 'provider' && tool.supportsDeferredResults;
-
-          if (!supportsDeferredResults) {
-            throw new Error(`Tool call ${part.toolCallId} not found.`);
-          }
-
-          // Create tool result without tool call input (deferred result)
-          if (part.isError) {
-            contentParts.push({
-              type: 'tool-error' as const,
-              toolCallId: part.toolCallId,
-              toolName: part.toolName as keyof TOOLS & string,
-              input: undefined,
-              error: part.result,
-              providerExecuted: true,
-              dynamic: part.dynamic,
-              ...(part.providerMetadata != null
-                ? { providerMetadata: part.providerMetadata }
-                : {}),
-              ...(tool?.metadata != null
-                ? { toolMetadata: tool.metadata }
-                : {}),
-            } as TypedToolError<TOOLS>);
-          } else {
-            contentParts.push({
-              type: 'tool-result' as const,
-              toolCallId: part.toolCallId,
-              toolName: part.toolName as keyof TOOLS & string,
-              input: undefined,
-              output: part.result,
-              providerExecuted: true,
-              dynamic: part.dynamic,
-              ...(part.providerMetadata != null
-                ? { providerMetadata: part.providerMetadata }
-                : {}),
-              ...(tool?.metadata != null
-                ? { toolMetadata: tool.metadata }
-                : {}),
-            } as TypedToolResult<TOOLS>);
-          }
-          break;
-        }
-
-        if (part.isError) {
-          contentParts.push({
-            type: 'tool-error' as const,
-            toolCallId: part.toolCallId,
-            toolName: part.toolName as keyof TOOLS & string,
-            input: toolCall.input,
-            error: part.result,
-            providerExecuted: true,
-            dynamic: toolCall.dynamic,
-            ...(part.providerMetadata != null
-              ? { providerMetadata: part.providerMetadata }
-              : {}),
-            ...(toolCall.toolMetadata != null
-              ? { toolMetadata: toolCall.toolMetadata }
-              : {}),
-          } as TypedToolError<TOOLS>);
-        } else {
-          contentParts.push({
-            type: 'tool-result' as const,
-            toolCallId: part.toolCallId,
-            toolName: part.toolName as keyof TOOLS & string,
-            input: toolCall.input,
-            output: part.result,
-            providerExecuted: true,
-            dynamic: toolCall.dynamic,
-            ...(part.providerMetadata != null
-              ? { providerMetadata: part.providerMetadata }
-              : {}),
-            ...(toolCall.toolMetadata != null
-              ? { toolMetadata: toolCall.toolMetadata }
-              : {}),
-          } as TypedToolResult<TOOLS>);
-        }
-        break;
-      }
-
-      case 'tool-approval-request': {
-        const toolCall = toolCalls.find(
-          toolCall => toolCall.toolCallId === part.toolCallId,
-        );
-
-        if (toolCall == null) {
-          throw new ToolCallNotFoundForApprovalError({
-            toolCallId: part.toolCallId,
-            approvalId: part.approvalId,
-          });
-        }
-
-        contentParts.push({
-          type: 'tool-approval-request' as const,
-          approvalId: part.approvalId,
-          toolCall,
-        });
-        break;
-      }
-    }
-  }
-
-  for (const toolOutput of toolOutputs) {
-    if (toolCallIdsWithApprovalResponses.has(toolOutput.toolCallId)) {
-      toolOutputsWithApprovalResponses.push(toolOutput);
-    } else {
-      toolOutputsWithoutApprovalResponses.push(toolOutput);
-    }
-  }
-
-  return [
-    ...contentParts,
-    ...toolOutputsWithoutApprovalResponses,
-    ...toolApprovalRequests,
-    ...toolApprovalResponses,
-    ...toolOutputsWithApprovalResponses,
-  ];
 }


### PR DESCRIPTION
## Background

Successful `getBatchResults` items currently expose only concatenated `text`, even though providers return complete ordered content. This discards reasoning, files, sources, custom content, tool calls and results, and part-level provider metadata, making batch results inconsistent with `generateText`. Fixes #19899.

## Summary

- expose Core-normalized `content` alongside the existing `text` property for successful batch results
- share existing `generateText` content converter is with batch retrieval

## End-to-End Verification

ran openai and anthropic batch examples. batch completed successfully and returned normalized text content arrays.

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Future Work

- add tool calling support https://github.com/vercel/ai/issues/19898

## Related Issues

Fixes https://github.com/vercel/ai/issues/19899
