### PR TITLE
docs: add SteadIO to observability providers

### DIFF
--- a/content/providers/03-observability/index.mdx
+++ b/content/providers/03-observability/index.mdx
@@ -25,6 +25,7 @@ Several LLM observability providers offer integrations with the AI SDK telemetry
 - [Scorecard](/providers/observability/scorecard)
 - [Sentry](/providers/observability/sentry)
 - [SigNoz](/providers/observability/signoz)
+- [SteadIO](/providers/observability/steadio)
 - [Traceloop](/providers/observability/traceloop)
 - [Weave](/providers/observability/weave)
 

--- a/content/providers/03-observability/steadio.mdx
+++ b/content/providers/03-observability/steadio.mdx
@@ -1,0 +1,66 @@
+---
+title: SteadIO
+description: Attribute LLM spend to an end customer and cap it on the request path with the AI SDK
+---
+
+# SteadIO Observability
+
+[SteadIO](https://www.steadio.ai) records LLM spend against the end customer a request was made for, and enforces a per-customer spend cap on the request path, before the provider is called.
+
+## Setup
+
+SteadIO is an OpenAI-compatible endpoint, so no SteadIO-specific package is required. Point `createOpenAICompatible` at the gateway and pass an end-customer identifier.
+
+1. Create an account at [platform.steadio.ai](https://platform.steadio.ai) and copy your SteadIO key
+2. Set your SteadIO key and your provider key as environment variables:
+
+   ```bash filename=".env"
+   STEADIO_API_KEY=st_your_steadio_key
+   OPENAI_API_KEY=your-openai-api-key
+   ```
+
+3. Use SteadIO in your application:
+
+   ```javascript
+   import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+   import { generateText } from 'ai';
+
+   const steadio = createOpenAICompatible({
+     name: 'steadio',
+     baseURL: 'https://api.steadio.ai/v1',
+     headers: {
+       'X-SteadIO-Key': process.env.STEADIO_API_KEY,
+       Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+       'X-Customer-Id': 'customer_123',
+     },
+   });
+
+   const { text } = await generateText({
+     model: steadio('gpt-4o-mini'),
+     prompt: 'Hello world',
+   });
+
+   console.log(text);
+   ```
+
+The `X-SteadIO-Key` header authenticates you to the gateway. Your provider key travels through on the `Authorization` header and is used for the upstream call. Spend for the request is attributed to `customer_123`, and if that customer is over their configured cap the gateway returns HTTP 402 and the provider is never called.
+
+[→ Full setup, including the OpenAI Agents SDK and the `user` body field as an alternative to `X-Customer-Id`](https://www.steadio.ai/docs/sdk-integrations)
+
+## Key Features
+
+**Per-end-customer attribution**
+
+- Spend is recorded against the end customer each request was made for, not just against your account
+- Attribution works through the `X-Customer-Id` header or the OpenAI `user` body field
+- Streaming responses are metered into per-customer cost
+
+**Caps on the request path**
+
+- A per-customer cap returns HTTP 402 before the provider call, rather than reporting an overage afterwards
+- Requests are forwarded to OpenAI or Anthropic with your own provider key
+
+## Notes
+
+- `createOpenAICompatible` sends requests to `baseURL + /chat/completions`, which SteadIO routes. The default `openai()` provider targets `/responses`, which SteadIO does not forward, so use `createOpenAICompatible` as shown above.
+- Cap enforcement requires a paid plan. Free teams are monitor-only: spend is attributed and visible, but requests are not blocked.


### PR DESCRIPTION
Adds SteadIO to the observability providers list, per the invitation at the bottom of `content/providers/03-observability/index.mdx`.

SteadIO is an OpenAI-compatible gateway that records LLM spend against the end customer a request was made for, and enforces a per-customer spend cap on the request path before the provider is called. It works with the AI SDK through `createOpenAICompatible`, so there is no SteadIO-specific package to install.

Setup docs, including the header shape and the OpenAI Agents SDK variant: https://www.steadio.ai/docs/sdk-integrations

Two things worth flagging up front:

- The integration is a `baseURL` swap rather than a telemetry exporter, so it is closer in shape to the existing Helicone entry than to the tracing integrations. If Observability is the wrong home for it, happy to move this to Community Providers instead.
- The example pins to `createOpenAICompatible` deliberately, because the default `openai()` provider targets `/responses`, which SteadIO does not forward today. That limitation is stated in the page rather than left for a reader to hit.

Docs-only change: one new `.mdx` page plus one line in the index.