### PR TITLE
Add LangChain message history hydration helpers

### DIFF
--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -13,6 +13,7 @@ npm install @ai-sdk/langchain @langchain/core
 ## Features
 
 - Convert AI SDK `UIMessage` to LangChain `BaseMessage` format
+- Convert LangChain `BaseMessage` and LangGraph `StateSnapshot` history back to AI SDK `UIMessage` format
 - Transform LangChain/LangGraph streams to AI SDK `UIMessageStream`
 - `ChatTransport` implementation for LangSmith deployments
 - Full support for text, tool calls, and tool results
@@ -32,6 +33,18 @@ const langchainMessages = await toBaseMessages(uiMessages);
 
 // Use with any LangChain model
 const response = await model.invoke(langchainMessages);
+```
+
+Use `baseMessagesToUIMessages` or `stateSnapshotToUIMessages` to restore persisted LangChain/LangGraph history for AI SDK UI components:
+
+```ts
+import { stateSnapshotToUIMessages } from '@ai-sdk/langchain';
+
+const state = await graph.getState({
+  configurable: { thread_id: threadId },
+});
+
+const initialMessages = stateSnapshotToUIMessages(state);
 ```
 
 ### Streaming from LangGraph
@@ -220,6 +233,28 @@ Converts AI SDK `ModelMessage` objects to LangChain `BaseMessage` objects.
 - `modelMessages`: `ModelMessage[]` - Array of model messages
 
 **Returns:** `BaseMessage[]`
+
+### `baseMessagesToUIMessages(messages)`
+
+Converts LangChain `BaseMessage` objects to AI SDK `UIMessage` objects.
+Matching `ToolMessage` results are attached to the corresponding assistant tool call part by `tool_call_id`.
+
+**Parameters:**
+
+- `messages`: `BaseMessage[]` - Array of LangChain messages
+
+**Returns:** `UIMessage[]`
+
+### `stateSnapshotToUIMessages(snapshot)`
+
+Converts the `messages` channel from a LangGraph `StateSnapshot` to AI SDK `UIMessage` objects.
+Pending human-in-the-loop interrupts are reflected as approval-requested tool parts when present in the snapshot.
+
+**Parameters:**
+
+- `snapshot`: `StateSnapshot` - LangGraph state snapshot returned from `getState`
+
+**Returns:** `UIMessage[]`
 
 ### `toUIMessageStream(stream, options?)`
 

--- a/packages/langchain/src/adapter.test.ts
+++ b/packages/langchain/src/adapter.test.ts
@@ -3,9 +3,11 @@ import {
   convertReadableStreamToArray,
 } from '@ai-sdk/provider-utils/test';
 import {
+  baseMessagesToUIMessages,
   toUIMessageStream,
   toBaseMessages,
   convertModelMessages,
+  stateSnapshotToUIMessages,
 } from './adapter';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { readUIMessageStream, type ModelMessage, type UIMessage } from 'ai';
@@ -16,6 +18,7 @@ import {
   SystemMessage,
   ToolMessage,
 } from '@langchain/core/messages';
+import type { StateSnapshot } from '@langchain/langgraph';
 import {
   LANGGRAPH_RESPONSE_1,
   LANGGRAPH_RESPONSE_2,
@@ -2343,6 +2346,198 @@ describe('toBaseMessages', () => {
         mimeType: 'image/png',
       },
     ]);
+  });
+});
+
+describe('baseMessagesToUIMessages', () => {
+  it('should convert LangChain text messages to UIMessages', () => {
+    const result = baseMessagesToUIMessages([
+      new SystemMessage({ id: 'system-1', content: 'Be helpful.' }),
+      new HumanMessage({ id: 'human-1', content: 'Hello!' }),
+      new AIMessage({ id: 'ai-1', content: 'Hi there!' }),
+    ]);
+
+    expect(result).toEqual([
+      {
+        id: 'system-1',
+        role: 'system',
+        parts: [{ type: 'text', text: 'Be helpful.' }],
+      },
+      {
+        id: 'human-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Hello!' }],
+      },
+      {
+        id: 'ai-1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Hi there!' }],
+      },
+    ]);
+  });
+
+  it('should attach ToolMessage outputs to matching assistant tool calls', () => {
+    const result = baseMessagesToUIMessages([
+      new HumanMessage({ id: 'human-1', content: 'What is the weather?' }),
+      new AIMessage({
+        id: 'ai-1',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call-1',
+            name: 'get_weather',
+            args: { location: 'NYC' },
+          },
+        ],
+      }),
+      new ToolMessage({
+        id: 'tool-1',
+        tool_call_id: 'call-1',
+        content: 'Sunny',
+      }),
+    ]);
+
+    expect(result).toEqual([
+      {
+        id: 'human-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'What is the weather?' }],
+      },
+      {
+        id: 'ai-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'dynamic-tool',
+            toolCallId: 'call-1',
+            toolName: 'get_weather',
+            state: 'output-available',
+            input: { location: 'NYC' },
+            output: 'Sunny',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should convert user multimodal content blocks to file parts', () => {
+    const result = baseMessagesToUIMessages([
+      new HumanMessage({
+        id: 'human-1',
+        content: [
+          { type: 'text', text: 'Describe this image.' },
+          { type: 'image', data: 'abc123', mimeType: 'image/png' },
+        ],
+      }),
+    ]);
+
+    expect(result).toEqual([
+      {
+        id: 'human-1',
+        role: 'user',
+        parts: [
+          { type: 'text', text: 'Describe this image.' },
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            url: 'data:image/png;base64,abc123',
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe('stateSnapshotToUIMessages', () => {
+  it('should convert a LangGraph StateSnapshot messages channel to UIMessages', () => {
+    const result = stateSnapshotToUIMessages({
+      values: {
+        messages: [
+          new HumanMessage({ id: 'human-1', content: 'Hello!' }),
+          new AIMessage({ id: 'ai-1', content: 'Hi there!' }),
+        ],
+      },
+    } as unknown as StateSnapshot);
+
+    expect(result).toEqual([
+      {
+        id: 'human-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Hello!' }],
+      },
+      {
+        id: 'ai-1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Hi there!' }],
+      },
+    ]);
+  });
+
+  it('should mark matching snapshot interrupts as pending approvals', () => {
+    const result = stateSnapshotToUIMessages({
+      values: {
+        messages: [
+          new HumanMessage({ id: 'human-1', content: 'Delete report.pdf' }),
+          new AIMessage({
+            id: 'ai-1',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call-1',
+                name: 'delete_file',
+                args: { filename: 'report.pdf' },
+              },
+            ],
+          }),
+        ],
+      },
+      tasks: [
+        {
+          interrupts: [
+            {
+              value: {
+                actionRequests: [
+                  {
+                    name: 'delete_file',
+                    args: { filename: 'report.pdf' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    } as unknown as StateSnapshot);
+
+    expect(result).toEqual([
+      {
+        id: 'human-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Delete report.pdf' }],
+      },
+      {
+        id: 'ai-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'dynamic-tool',
+            toolCallId: 'call-1',
+            toolName: 'delete_file',
+            state: 'approval-requested',
+            input: { filename: 'report.pdf' },
+            approval: {
+              id: 'call-1',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should return an empty array when the snapshot has no messages channel', () => {
+    expect(
+      stateSnapshotToUIMessages({ values: {} } as unknown as StateSnapshot),
+    ).toEqual([]);
   });
 });
 

--- a/packages/langchain/src/adapter.ts
+++ b/packages/langchain/src/adapter.ts
@@ -1,10 +1,15 @@
 import {
+  AIMessage,
+  HumanMessage,
   SystemMessage,
+  ToolMessage,
   type BaseMessage,
   type AIMessageChunk,
 } from '@langchain/core/messages';
+import type { StateSnapshot } from '@langchain/langgraph';
 import {
   convertToModelMessages,
+  type DynamicToolUIPart,
   type UIMessage,
   type UIMessageChunk,
   type ModelMessage,
@@ -24,6 +29,21 @@ import {
 } from './utils';
 import type { LangGraphEventState } from './types';
 import type { StreamCallbacks } from './stream-callbacks';
+
+type DefaultUIMessagePart = UIMessage['parts'][number];
+type StateSnapshotLike = Pick<StateSnapshot, 'values'> & {
+  interrupts?: unknown;
+  tasks?: ReadonlyArray<{ readonly interrupts?: unknown }>;
+};
+
+type ActionRequest = {
+  name: string;
+  id?: string;
+  args?: unknown;
+  arguments?: unknown;
+  requestReason?: string;
+  request_reason?: string;
+};
 
 /**
  * Options for converting a LangChain stream to an AI SDK UIMessageStream.
@@ -113,6 +133,475 @@ export function convertModelMessages(
   }
 
   return result;
+}
+
+/**
+ * Converts LangChain BaseMessage objects to AI SDK UIMessage objects.
+ *
+ * ToolMessage objects are attached to the matching assistant tool call part when
+ * possible, matching how AI SDK UIMessages represent completed tool calls.
+ *
+ * @param messages - Array of LangChain BaseMessage objects to convert.
+ * @returns Array of AI SDK UIMessage objects.
+ */
+export function baseMessagesToUIMessages(messages: BaseMessage[]): UIMessage[] {
+  const result: UIMessage[] = [];
+
+  messages.forEach((message, index) => {
+    if (ToolMessage.isInstance(message)) {
+      applyToolMessageToLastMatchingAssistantMessage(result, message);
+      return;
+    }
+
+    if (SystemMessage.isInstance(message)) {
+      result.push({
+        id: getMessageId(message, index),
+        role: 'system',
+        parts: contentToUIParts(message.content, 'system'),
+      });
+      return;
+    }
+
+    if (HumanMessage.isInstance(message)) {
+      result.push({
+        id: getMessageId(message, index),
+        role: 'user',
+        parts: contentToUIParts(message.content, 'user'),
+      });
+      return;
+    }
+
+    if (AIMessage.isInstance(message)) {
+      result.push({
+        id: getMessageId(message, index),
+        role: 'assistant',
+        parts: [
+          ...contentToUIParts(message.content, 'assistant'),
+          ...toolCallsToUIParts(message, index),
+        ],
+      });
+    }
+  });
+
+  return result;
+}
+
+/**
+ * Converts a LangGraph StateSnapshot with a `messages` channel to AI SDK
+ * UIMessage objects.
+ *
+ * @param snapshot - LangGraph state snapshot returned from getState.
+ * @returns Array of AI SDK UIMessage objects.
+ */
+export function stateSnapshotToUIMessages(
+  snapshot: StateSnapshot,
+): UIMessage[] {
+  const snapshotLike = snapshot as StateSnapshotLike;
+  const values = snapshotLike.values;
+
+  if (values == null || typeof values !== 'object') {
+    return [];
+  }
+
+  const messages = (values as { messages?: unknown }).messages;
+
+  if (!Array.isArray(messages)) {
+    return [];
+  }
+
+  const uiMessages = baseMessagesToUIMessages(messages as BaseMessage[]);
+  applySnapshotInterrupts(uiMessages, snapshotLike);
+  return uiMessages;
+}
+
+function getMessageId(message: BaseMessage, index: number): string {
+  return typeof message.id === 'string' && message.id.length > 0
+    ? message.id
+    : `message-${index}`;
+}
+
+function contentToUIParts(
+  content: BaseMessage['content'],
+  role: UIMessage['role'],
+): DefaultUIMessagePart[] {
+  if (typeof content === 'string') {
+    return content.length > 0 ? [{ type: 'text', text: content }] : [];
+  }
+
+  if (!Array.isArray(content)) {
+    return [];
+  }
+
+  const parts: DefaultUIMessagePart[] = [];
+
+  for (const block of content) {
+    if (typeof block !== 'object' || block == null) {
+      continue;
+    }
+
+    const record = block as Record<string, unknown>;
+
+    if (record.type === 'text' && typeof record.text === 'string') {
+      parts.push({ type: 'text', text: record.text });
+      continue;
+    }
+
+    if (role === 'user' && isFileLikeContentBlock(record)) {
+      const mediaType =
+        typeof record.mimeType === 'string'
+          ? record.mimeType
+          : typeof record.mediaType === 'string'
+            ? record.mediaType
+            : record.type === 'image'
+              ? 'image'
+              : 'application/octet-stream';
+
+      const url =
+        typeof record.url === 'string'
+          ? record.url
+          : typeof record.data === 'string'
+            ? `data:${mediaType};base64,${record.data}`
+            : undefined;
+
+      if (url != null) {
+        parts.push({
+          type: 'file',
+          mediaType,
+          url,
+          ...(typeof record.filename === 'string'
+            ? { filename: record.filename }
+            : {}),
+        });
+      }
+    }
+  }
+
+  return parts;
+}
+
+function isFileLikeContentBlock(record: Record<string, unknown>): boolean {
+  return (
+    record.type === 'image' ||
+    record.type === 'file' ||
+    record.url != null ||
+    record.data != null
+  );
+}
+
+function toolCallsToUIParts(
+  message: AIMessage,
+  messageIndex: number,
+): DynamicToolUIPart[] {
+  return getNormalizedToolCalls(message).map((toolCall, toolIndex) => ({
+    type: 'dynamic-tool',
+    toolCallId:
+      typeof toolCall.id === 'string' && toolCall.id.length > 0
+        ? toolCall.id
+        : `tool-call-${messageIndex}-${toolIndex}`,
+    toolName: toolCall.name,
+    state: 'input-available',
+    input: toolCall.args,
+  }));
+}
+
+function getNormalizedToolCalls(message: AIMessage): Array<{
+  id?: string;
+  name: string;
+  args: unknown;
+}> {
+  if (message.tool_calls != null && message.tool_calls.length > 0) {
+    return message.tool_calls;
+  }
+
+  const additionalKwargs = message.additional_kwargs as
+    | {
+        tool_calls?: Array<{
+          id?: string;
+          function?: { name?: string; arguments?: string };
+        }>;
+      }
+    | undefined;
+  const toolCalls = additionalKwargs?.tool_calls;
+
+  if (!Array.isArray(toolCalls)) {
+    return [];
+  }
+
+  return toolCalls.flatMap(toolCall => {
+    const name = toolCall.function?.name;
+    if (typeof name !== 'string') {
+      return [];
+    }
+
+    return [
+      {
+        id: toolCall.id,
+        name,
+        args: parseToolCallArguments(toolCall.function?.arguments),
+      },
+    ];
+  });
+}
+
+function parseToolCallArguments(args: string | undefined): unknown {
+  if (args == null || args.length === 0) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(args);
+  } catch {
+    return args;
+  }
+}
+
+function applyToolMessageToLastMatchingAssistantMessage(
+  messages: UIMessage[],
+  toolMessage: ToolMessage,
+): void {
+  const toolCallId = toolMessage.tool_call_id;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+
+    if (message.role !== 'assistant') {
+      continue;
+    }
+
+    const toolPartIndex = message.parts.findIndex(
+      part => part.type === 'dynamic-tool' && part.toolCallId === toolCallId,
+    );
+
+    if (toolPartIndex === -1) {
+      continue;
+    }
+
+    const toolPart = message.parts[toolPartIndex] as DynamicToolUIPart;
+    message.parts[toolPartIndex] = createCompletedToolUIPart(
+      toolPart,
+      toolMessage,
+    );
+    return;
+  }
+}
+
+function createCompletedToolUIPart(
+  toolPart: DynamicToolUIPart,
+  toolMessage: ToolMessage,
+): DynamicToolUIPart {
+  const input = 'input' in toolPart ? toolPart.input : undefined;
+
+  if ((toolMessage as { status?: string }).status === 'error') {
+    return {
+      type: 'dynamic-tool',
+      toolName: toolPart.toolName,
+      toolCallId: toolPart.toolCallId,
+      state: 'output-error',
+      input,
+      errorText: contentToText(toolMessage.content),
+    };
+  }
+
+  return {
+    type: 'dynamic-tool',
+    toolName: toolPart.toolName,
+    toolCallId: toolPart.toolCallId,
+    state: 'output-available',
+    input,
+    output: contentToToolOutput(toolMessage.content),
+  };
+}
+
+function contentToToolOutput(content: BaseMessage['content']): unknown {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    const text = contentToText(content);
+    return text.length > 0 ? text : content;
+  }
+
+  return content;
+}
+
+function contentToText(content: BaseMessage['content']): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return '';
+  }
+
+  return content
+    .map(block =>
+      typeof block === 'object' &&
+      block != null &&
+      'text' in block &&
+      typeof block.text === 'string'
+        ? block.text
+        : '',
+    )
+    .join('');
+}
+
+function applySnapshotInterrupts(
+  messages: UIMessage[],
+  snapshot: StateSnapshotLike,
+): void {
+  getSnapshotActionRequests(snapshot).forEach((actionRequest, index) => {
+    applyActionRequest(messages, actionRequest, index);
+  });
+}
+
+function getSnapshotActionRequests(
+  snapshot: StateSnapshotLike,
+): ActionRequest[] {
+  const interrupts: unknown[] = [];
+
+  if (snapshot.interrupts !== undefined) {
+    interrupts.push(snapshot.interrupts);
+  }
+
+  const values = snapshot.values as Record<string, unknown>;
+  if (values.__interrupt__ !== undefined) {
+    interrupts.push(values.__interrupt__);
+  }
+
+  if (Array.isArray(snapshot.tasks)) {
+    for (const task of snapshot.tasks) {
+      if (
+        task != null &&
+        typeof task === 'object' &&
+        'interrupts' in task &&
+        Array.isArray(task.interrupts)
+      ) {
+        interrupts.push(task.interrupts);
+      }
+    }
+  }
+
+  return interrupts
+    .flatMap(interrupt => (Array.isArray(interrupt) ? interrupt : [interrupt]))
+    .flatMap(getActionRequestsFromInterrupt);
+}
+
+function getActionRequestsFromInterrupt(interrupt: unknown): ActionRequest[] {
+  if (interrupt == null || typeof interrupt !== 'object') {
+    return [];
+  }
+
+  const interruptRecord = interrupt as Record<string, unknown>;
+  const value =
+    interruptRecord.value != null && typeof interruptRecord.value === 'object'
+      ? (interruptRecord.value as Record<string, unknown>)
+      : interruptRecord;
+  const actionRequests = value.actionRequests ?? value.action_requests;
+
+  if (!Array.isArray(actionRequests)) {
+    return [];
+  }
+
+  return actionRequests.filter(isActionRequest);
+}
+
+function isActionRequest(value: unknown): value is ActionRequest {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    typeof (value as { name?: unknown }).name === 'string'
+  );
+}
+
+function applyActionRequest(
+  messages: UIMessage[],
+  actionRequest: ActionRequest,
+  actionIndex: number,
+): void {
+  const input = actionRequest.args ?? actionRequest.arguments ?? {};
+  const matchingToolPart = findMatchingToolPart(messages, actionRequest, input);
+  const toolCallId =
+    matchingToolPart?.part.toolCallId ??
+    actionRequest.id ??
+    `hitl-${actionRequest.name}-${actionIndex}`;
+  const approvalPart: DynamicToolUIPart = {
+    type: 'dynamic-tool',
+    toolName: matchingToolPart?.part.toolName ?? actionRequest.name,
+    toolCallId,
+    state: 'approval-requested',
+    input,
+    approval: {
+      id: toolCallId,
+      ...getActionRequestReason(actionRequest),
+    },
+  };
+
+  if (matchingToolPart != null) {
+    matchingToolPart.message.parts[matchingToolPart.partIndex] = approvalPart;
+    return;
+  }
+
+  messages.push({
+    id: `message-hitl-${actionIndex}`,
+    role: 'assistant',
+    parts: [approvalPart],
+  });
+}
+
+function findMatchingToolPart(
+  messages: UIMessage[],
+  actionRequest: ActionRequest,
+  input: unknown,
+):
+  | {
+      message: UIMessage;
+      part: DynamicToolUIPart;
+      partIndex: number;
+    }
+  | undefined {
+  for (
+    let messageIndex = messages.length - 1;
+    messageIndex >= 0;
+    messageIndex--
+  ) {
+    const message = messages[messageIndex];
+
+    if (message.role !== 'assistant') {
+      continue;
+    }
+
+    const partIndex = message.parts.findIndex(
+      part =>
+        part.type === 'dynamic-tool' &&
+        ((actionRequest.id != null && part.toolCallId === actionRequest.id) ||
+          (part.toolName === actionRequest.name &&
+            isJsonEqual('input' in part ? part.input : undefined, input))),
+    );
+
+    if (partIndex !== -1) {
+      return {
+        message,
+        part: message.parts[partIndex] as DynamicToolUIPart,
+        partIndex,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function getActionRequestReason(actionRequest: ActionRequest): {
+  requestReason?: string;
+} {
+  const requestReason =
+    actionRequest.requestReason ?? actionRequest.request_reason;
+
+  return typeof requestReason === 'string' ? { requestReason } : {};
+}
+
+function isJsonEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
 }
 
 /**

--- a/packages/langchain/src/index.ts
+++ b/packages/langchain/src/index.ts
@@ -1,7 +1,9 @@
 export {
+  baseMessagesToUIMessages,
   toBaseMessages,
   toUIMessageStream,
   convertModelMessages,
+  stateSnapshotToUIMessages,
   type ToUIMessageStreamOptions,
 } from './adapter';
 


### PR DESCRIPTION
## Summary

Adds reverse message conversion helpers for `@ai-sdk/langchain` so persisted LangChain and LangGraph histories can be restored into AI SDK `UIMessage[]`:

- `baseMessagesToUIMessages(messages)` converts LangChain `BaseMessage[]` to AI SDK UI messages.
- `stateSnapshotToUIMessages(snapshot)` converts a LangGraph `StateSnapshot` messages channel to UI messages.
- Matching `ToolMessage` results are attached to assistant dynamic tool parts by `tool_call_id`.
- Pending LangGraph human-in-the-loop interrupts are reflected as approval-requested dynamic tool parts.
- README and tests cover the new public API.

Closes #12680.

## Tests

- `pnpm --filter @ai-sdk/langchain test:node`
- `pnpm --filter @ai-sdk/langchain test:edge`
- `pnpm --filter @ai-sdk/langchain type-check`
- `pnpm --filter @ai-sdk/langchain build`