### PR TITLE
feat(harness-opencode): support native OpenCode configuration

### DIFF
--- a/.changeset/calm-agents-configure.md
+++ b/.changeset/calm-agents-configure.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-opencode': patch
+---
+
+feat(harness-opencode): pass native OpenCode configuration through the adapter

--- a/content/providers/02-ai-sdk-harnesses/04-opencode.mdx
+++ b/content/providers/02-ai-sdk-harnesses/04-opencode.mdx
@@ -81,6 +81,13 @@ Use `createOpenCode()` to configure the runtime:
 const harness = createOpenCode({
   model: 'anthropic/claude-sonnet-4-6',
   reasoningVariant: 'high',
+  openCodeConfig: {
+    agent: {
+      general: {
+        model: 'openai/gpt-5.4-mini',
+      },
+    },
+  },
 });
 ```
 
@@ -99,6 +106,10 @@ Settings:
 - `mcpServers`: MCP server definitions keyed by server name.
 - `model`: OpenCode model id. Provider-prefixed values such as
   `anthropic/claude-sonnet-4-6` are passed through to OpenCode.
+- `openCodeConfig`: additional native OpenCode configuration. Adapter-managed
+  settings take precedence. Agent-local `permission` and deprecated `tools`
+  settings are ignored so they cannot bypass harness permissions or built-in
+  tool filtering.
 - `provider`: provider id to use with an unprefixed `model`.
 - `reasoningVariant`: OpenCode reasoning/thinking variant for supported models,
   such as `low`, `medium`, or `high`.

--- a/packages/harness-opencode/README.md
+++ b/packages/harness-opencode/README.md
@@ -3,4 +3,28 @@
 The OpenCode harness connects `HarnessAgent` to OpenCode through a sandboxed
 bridge.
 
+## Native OpenCode configuration
+
+Use `openCodeConfig` to pass native OpenCode settings that do not have a
+dedicated adapter option. For example, OpenCode supports selecting a model for
+an individual agent:
+
+```ts
+import { createOpenCode } from '@ai-sdk/harness-opencode';
+
+const adapter = createOpenCode({
+  openCodeConfig: {
+    agent: {
+      general: {
+        model: 'provider/model-id',
+      },
+    },
+  },
+});
+```
+
+Adapter-managed settings take precedence when the same key is present in
+`openCodeConfig`. Agent-local `permission` and deprecated `tools` settings are
+ignored so they cannot bypass harness permissions or built-in tool filtering.
+
 See the AI SDK documentation for usage.

--- a/packages/harness-opencode/src/bridge/index.test.ts
+++ b/packages/harness-opencode/src/bridge/index.test.ts
@@ -11,7 +11,7 @@ const sdkMock = vi.hoisted(() => ({
 
 const permissionReplyMock = vi.hoisted(() => vi.fn());
 const createOpencodeServerMock = vi.hoisted(() =>
-  vi.fn(async () => ({
+  vi.fn(async (_options: Record<string, unknown>) => ({
     url: 'http://127.0.0.1:4096',
     close: vi.fn(),
   })),
@@ -160,10 +160,29 @@ describe('OpenCode bridge turn settlement', () => {
     const emitted: Array<Record<string, unknown>> = [];
     const emitError = vi.fn();
     const userMessages = createUserMessages();
+    const openCodeConfig = {
+      agent: {
+        general: {
+          model: 'openai/gpt-5.4-mini',
+          permission: { bash: 'allow', external_directory: 'allow' },
+          tools: { bash: true, edit: true },
+        },
+      },
+      mode: {
+        plan: {
+          model: 'openai/gpt-5.4-mini',
+          permission: { edit: 'allow' },
+          tools: { edit: true },
+        },
+      },
+      share: 'manual',
+    };
     bridgeMock.start = {
       type: 'start',
       operation: 'prompt',
       prompt: 'Start.',
+      model: 'openai/gpt-5.6-sol',
+      openCodeConfig,
     };
     bridgeMock.turn = {
       emit: (event: Record<string, unknown>) => emitted.push(event),
@@ -209,6 +228,37 @@ describe('OpenCode bridge turn settlement', () => {
 
     await import('./index');
 
+    const serverConfig = createOpencodeServerMock.mock.calls[0]?.[0]
+      .config as Record<string, unknown>;
+    expect(serverConfig).toMatchObject({
+      agent: { general: { model: 'openai/gpt-5.4-mini' } },
+      mode: { plan: { model: 'openai/gpt-5.4-mini' } },
+      model: 'openai/gpt-5.6-sol',
+      share: 'disabled',
+    });
+    expect(serverConfig.agent).toEqual({
+      general: { model: 'openai/gpt-5.4-mini' },
+    });
+    expect(serverConfig.mode).toEqual({
+      plan: { model: 'openai/gpt-5.4-mini' },
+    });
+    expect(openCodeConfig).toEqual({
+      agent: {
+        general: {
+          model: 'openai/gpt-5.4-mini',
+          permission: { bash: 'allow', external_directory: 'allow' },
+          tools: { bash: true, edit: true },
+        },
+      },
+      mode: {
+        plan: {
+          model: 'openai/gpt-5.4-mini',
+          permission: { edit: 'allow' },
+          tools: { edit: true },
+        },
+      },
+      share: 'manual',
+    });
     expect(userMessages.close).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'model step failed' }),
     );

--- a/packages/harness-opencode/src/bridge/index.ts
+++ b/packages/harness-opencode/src/bridge/index.ts
@@ -219,6 +219,7 @@ function buildOpenCodeConfig({
   relayPort: number | undefined;
 }): Record<string, unknown> {
   const config: Record<string, unknown> = {
+    ...withoutAgentPolicyOverrides(start.openCodeConfig),
     share: 'disabled',
     autoupdate: false,
     permission: {
@@ -270,6 +271,27 @@ function buildOpenCodeConfig({
     };
   }
   if (Object.keys(mcp).length > 0) config.mcp = mcp;
+  return config;
+}
+
+function withoutAgentPolicyOverrides(
+  input: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const config = { ...input };
+  for (const key of ['agent', 'mode'] as const) {
+    const agents = asOpenCodeObject(config[key]);
+    if (!agents) continue;
+    config[key] = Object.fromEntries(
+      Object.entries(agents).map(([name, value]) => {
+        const agent = asOpenCodeObject(value);
+        if (!agent) return [name, value];
+        const safeAgent = { ...agent };
+        delete safeAgent.permission;
+        delete safeAgent.tools;
+        return [name, safeAgent];
+      }),
+    );
+  }
   return config;
 }
 

--- a/packages/harness-opencode/src/opencode-bridge-protocol.ts
+++ b/packages/harness-opencode/src/opencode-bridge-protocol.ts
@@ -16,6 +16,7 @@ export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
   instructions: z.string().optional(),
   skillsChanged: z.boolean().optional(),
   resumeSessionId: z.string().optional(),
+  openCodeConfig: z.record(z.string(), z.unknown()).optional(),
   mcpServers: z.record(z.string(), z.unknown()).optional(),
 });
 

--- a/packages/harness-opencode/src/opencode-harness.test.ts
+++ b/packages/harness-opencode/src/opencode-harness.test.ts
@@ -634,7 +634,7 @@ describe('createOpenCode adapter', () => {
     await session.doDestroy();
   });
 
-  it('passes reasoningVariant, instructions, and MCP servers to every OpenCode prompt', async () => {
+  it('passes native config through prompts, compaction, and resumed sessions', async () => {
     harnessUtilsMocks.channels.length = 0;
     harnessUtilsMocks.waitForBridgeReady.mockResolvedValueOnce({ port: 4000 });
     const emptyStream = () =>
@@ -687,15 +687,37 @@ describe('createOpenCode adapter', () => {
         url: 'https://mcp.context7.com/mcp',
       },
     };
-    const session = await createOpenCode({
+    const openCodeConfig = {
+      agent: { general: { model: 'openai/gpt-5.4-mini' } },
+    };
+    const harness = createOpenCode({
+      openCodeConfig,
       reasoningVariant: 'high',
       mcpServers,
-    }).doStart({
+    });
+    const session = await harness.doStart({
       sessionId: 's1',
       sandboxSession,
       sessionWorkDir: '/workspace/project',
     });
-    await session.doPromptTurn({
+    const channel = harnessUtilsMocks.channels.at(-1)!;
+    channel.emit('bridge-thread', {
+      type: 'bridge-thread',
+      threadId: 'opencode-session',
+    });
+
+    const compaction = session.doCompact();
+    expect(channel.sent.at(-1)).toMatchObject({
+      type: 'start',
+      operation: 'compact',
+      openCodeConfig,
+      mcpServers,
+      resumeSessionId: 'opencode-session',
+    });
+    channel.emit('finish', { type: 'finish' });
+    await compaction;
+
+    const firstTurn = await session.doPromptTurn({
       skills: [],
       tools: [],
       prompt: 'think',
@@ -703,33 +725,49 @@ describe('createOpenCode adapter', () => {
       emit: () => {},
     });
 
-    expect(harnessUtilsMocks.channels.at(-1)?.sent.at(-1)).toMatchObject({
+    expect(channel.sent.at(-1)).toMatchObject({
       type: 'start',
       operation: 'prompt',
       prompt: 'think',
       instructions: 'be concise',
       variant: 'high',
+      openCodeConfig,
       mcpServers,
+      resumeSessionId: 'opencode-session',
     });
+    channel.emit('finish', { type: 'finish' });
+    await firstTurn.done;
 
-    await session.doPromptTurn({
+    const resumeFrom = await session.doDetach();
+    const resumedSession = await harness.doStart({
+      sessionId: 's1',
+      sandboxSession,
+      sessionWorkDir: '/workspace/project',
+      resumeFrom,
+    });
+    const resumedTurn = await resumedSession.doPromptTurn({
       skills: [],
       tools: [],
-      prompt: 'think again',
+      prompt: 'resume thinking',
       instructions: 'be concise',
       emit: () => {},
     });
+    const resumedChannel = harnessUtilsMocks.channels.at(-1)!;
 
-    expect(harnessUtilsMocks.channels.at(-1)?.sent.at(-1)).toMatchObject({
+    expect(resumedChannel.sent.at(-1)).toMatchObject({
       type: 'start',
       operation: 'prompt',
-      prompt: 'think again',
+      prompt: 'resume thinking',
       instructions: 'be concise',
       variant: 'high',
+      openCodeConfig,
       mcpServers,
+      resumeSessionId: 'opencode-session',
     });
+    resumedChannel.emit('finish', { type: 'finish' });
+    await resumedTurn.done;
 
-    await session.doDestroy();
+    await resumedSession.doDestroy();
   });
 
   it('waits for the bridge to accept a steering message', async () => {

--- a/packages/harness-opencode/src/opencode-harness.ts
+++ b/packages/harness-opencode/src/opencode-harness.ts
@@ -84,6 +84,12 @@ export type OpenCodeHarnessSettings = {
    */
   readonly credentialForwarding?: HarnessV1CredentialForwarding;
   /**
+   * Additional configuration passed through to OpenCode as-is. OpenCode
+   * config keys must use their native names. Values managed by this adapter
+   * take precedence over conflicting entries.
+   */
+  readonly openCodeConfig?: Record<string, unknown>;
+  /**
    * MCP server definitions keyed by server name. Each definition uses the
    * underlying runtime's native MCP server configuration format.
    */
@@ -392,6 +398,7 @@ export function createOpenCode(
             model,
             provider: settings.provider,
             reasoningVariant: settings.reasoningVariant,
+            openCodeConfig: settings.openCodeConfig,
             mcpServers: settings.mcpServers,
             openCodeSessionId: resumeSessionId,
             isResume: true,
@@ -540,6 +547,7 @@ export function createOpenCode(
         model,
         provider: settings.provider,
         reasoningVariant: settings.reasoningVariant,
+        openCodeConfig: settings.openCodeConfig,
         mcpServers: settings.mcpServers,
         openCodeSessionId: resumeSessionId,
         isResume: respawnStrategy !== undefined,
@@ -768,6 +776,7 @@ function createSession({
   model,
   provider,
   reasoningVariant,
+  openCodeConfig,
   mcpServers,
   openCodeSessionId,
   isResume,
@@ -790,6 +799,7 @@ function createSession({
   model: string | undefined;
   provider: string | undefined;
   reasoningVariant: string | undefined;
+  openCodeConfig: Record<string, unknown> | undefined;
   mcpServers: Record<string, unknown> | undefined;
   openCodeSessionId: string | undefined;
   isResume: boolean;
@@ -966,6 +976,7 @@ function createSession({
     model,
     provider,
     ...(reasoningVariant ? { variant: reasoningVariant } : {}),
+    ...(openCodeConfig == null ? {} : { openCodeConfig }),
     ...(mcpServers == null ? {} : { mcpServers }),
     ...(permissionMode ? { permissionMode } : {}),
     ...(builtinToolFiltering ? { builtinToolFiltering } : {}),
@@ -1088,6 +1099,7 @@ function createSession({
         provider,
         permissionMode,
         debug,
+        openCodeConfig,
         mcpServers,
         resumeSessionId: latestOpenCodeSessionId,
         onCompaction: part => pendingCompactionParts.push(part),
@@ -1260,6 +1272,7 @@ async function runCompactOperation({
   provider,
   permissionMode,
   debug,
+  openCodeConfig,
   mcpServers,
   resumeSessionId,
   onCompaction,
@@ -1269,6 +1282,7 @@ async function runCompactOperation({
   provider: string | undefined;
   permissionMode: HarnessV1PermissionMode | undefined;
   debug: HarnessV1DebugConfig | undefined;
+  openCodeConfig: Record<string, unknown> | undefined;
   mcpServers: Record<string, unknown> | undefined;
   resumeSessionId: string | undefined;
   onCompaction: (part: HarnessV1StreamPart) => void;
@@ -1297,6 +1311,7 @@ async function runCompactOperation({
     tools: [],
     model,
     provider,
+    ...(openCodeConfig == null ? {} : { openCodeConfig }),
     ...(mcpServers == null ? {} : { mcpServers }),
     ...(permissionMode ? { permissionMode } : {}),
     ...(resumeSessionId ? { resumeSessionId } : {}),


### PR DESCRIPTION
Supersedes #19671, recreated at maintainer request with a clean, GitHub-verified commit history.

## Background

OpenCode supports per-agent model selection and other native settings, but `@ai-sdk/harness-opencode` only exposes adapter-level options. As a result, callers cannot configure OpenCode subagents independently from the parent agent.

## Summary

- add an optional `openCodeConfig` adapter setting
- pass it through prompt, resume, and compaction bridge starts
- merge it beneath adapter-managed safety and connectivity settings
- document per-agent model configuration

## End-to-End Verification

Verified in a harness-backed chat with an OpenAI parent model and an OpenCode `general` subagent configured through Vercel AI Gateway to use Anthropic Claude Haiku. The delegated task completed and its OpenCode checkpoint recorded the configured child model independently from the parent.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Closes #19672
