### PR TITLE
fix(openai): preserve cache breakpoints on scalar tool results

### DIFF
--- a/.changeset/fix-openai-tool-cache-breakpoints.md
+++ b/.changeset/fix-openai-tool-cache-breakpoints.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Preserve prompt cache breakpoints on scalar OpenAI Responses tool results.

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -2842,6 +2842,220 @@ describe('convertToOpenAIResponsesInput', () => {
       `);
     });
 
+    it('should add prompt cache breakpoints to scalar tool result outputs', async () => {
+      const providerOptions = {
+        openai: { promptCacheBreakpoint: { mode: 'explicit' as const } },
+      };
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_text',
+                toolName: 'search',
+                output: {
+                  type: 'text',
+                  value: 'result',
+                  providerOptions,
+                },
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call_json',
+                toolName: 'search',
+                output: {
+                  type: 'json',
+                  value: { result: true },
+                  providerOptions,
+                },
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call_error_text',
+                toolName: 'search',
+                output: {
+                  type: 'error-text',
+                  value: 'error',
+                  providerOptions,
+                },
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call_error_json',
+                toolName: 'search',
+                output: {
+                  type: 'error-json',
+                  value: { error: true },
+                  providerOptions,
+                },
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call_denied',
+                toolName: 'search',
+                output: {
+                  type: 'execution-denied',
+                  reason: 'denied',
+                  providerOptions,
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+      });
+
+      const output = (text: string) => [
+        {
+          type: 'input_text',
+          text,
+          prompt_cache_breakpoint: { mode: 'explicit' },
+        },
+      ];
+      expect(result.input).toEqual([
+        {
+          type: 'function_call_output',
+          call_id: 'call_text',
+          output: output('result'),
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_json',
+          output: output('{"result":true}'),
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_error_text',
+          output: output('error'),
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_error_json',
+          output: output('{"error":true}'),
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_denied',
+          output: output('denied'),
+        },
+      ]);
+    });
+
+    it('should use tool result part prompt cache breakpoints as a fallback', async () => {
+      const providerOptions = {
+        openai: { promptCacheBreakpoint: { mode: 'explicit' as const } },
+      };
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_json',
+                toolName: 'search',
+                output: { type: 'json', value: { result: true } },
+                providerOptions,
+              },
+              {
+                type: 'tool-result',
+                toolCallId: 'call_content',
+                toolName: 'search',
+                output: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'first' },
+                    { type: 'text', text: 'last' },
+                  ],
+                },
+                providerOptions,
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call_output',
+          call_id: 'call_json',
+          output: [
+            {
+              type: 'input_text',
+              text: '{"result":true}',
+              prompt_cache_breakpoint: { mode: 'explicit' },
+            },
+          ],
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_content',
+          output: [
+            { type: 'input_text', text: 'first' },
+            {
+              type: 'input_text',
+              text: 'last',
+              prompt_cache_breakpoint: { mode: 'explicit' },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('should preserve output schema encoding with a prompt cache breakpoint', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'tool',
+            content: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_text',
+                toolName: 'search',
+                output: {
+                  type: 'text',
+                  value: 'result',
+                  providerOptions: {
+                    openai: {
+                      promptCacheBreakpoint: { mode: 'explicit' },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: true,
+        outputSchemaToolNames: new Set(['search']),
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call_output',
+          call_id: 'call_text',
+          output: [
+            {
+              type: 'input_text',
+              text: '"result"',
+              prompt_cache_breakpoint: { mode: 'explicit' },
+            },
+          ],
+        },
+      ]);
+    });
+
     it('should JSON-encode text outputs only for tools with an output schema', async () => {
       const result = await convertToOpenAIResponsesInput({
         toolNameMapping: testToolNameMapping,

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -69,12 +69,14 @@ function mapToolCaller(
 
 async function convertFunctionToolResultOutput({
   output,
+  toolResultProviderOptions,
   toolName,
   outputSchemaToolNames,
   providerOptionsName,
   warnings,
 }: {
   output: LanguageModelV4ToolResultOutput;
+  toolResultProviderOptions: SharedV4ProviderOptions | undefined;
   toolName: string;
   outputSchemaToolNames: Set<string> | undefined;
   providerOptionsName: string;
@@ -84,20 +86,47 @@ async function convertFunctionToolResultOutput({
   // parses the contents of that string as JSON. Text-like results therefore
   // need JSON.stringify to become valid JSON string literals.
   const hasOutputSchema = outputSchemaToolNames?.has(toolName);
+  const wrapScalarOutput = (
+    value: string,
+    outputProviderOptions: SharedV4ProviderOptions | undefined,
+  ) => {
+    const promptCacheBreakpoint =
+      getPromptCacheBreakpoint(outputProviderOptions, providerOptionsName) ??
+      getPromptCacheBreakpoint(toolResultProviderOptions, providerOptionsName);
+
+    return promptCacheBreakpoint == null
+      ? value
+      : [
+          {
+            type: 'input_text' as const,
+            text: value,
+            prompt_cache_breakpoint: promptCacheBreakpoint,
+          },
+        ];
+  };
 
   switch (output.type) {
     case 'text':
     case 'error-text':
-      return hasOutputSchema ? JSON.stringify(output.value) : output.value;
+      return wrapScalarOutput(
+        hasOutputSchema ? JSON.stringify(output.value) : output.value,
+        output.providerOptions,
+      );
     case 'execution-denied': {
       const reason = output.reason ?? 'Tool call execution denied.';
-      return hasOutputSchema ? JSON.stringify(reason) : reason;
+      return wrapScalarOutput(
+        hasOutputSchema ? JSON.stringify(reason) : reason,
+        output.providerOptions,
+      );
     }
     case 'json':
     case 'error-json':
-      return JSON.stringify(output.value);
-    case 'content':
-      return output.value
+      return wrapScalarOutput(
+        JSON.stringify(output.value),
+        output.providerOptions,
+      );
+    case 'content': {
+      const content = output.value
         .map(item => {
           const promptCacheBreakpoint = getPromptCacheBreakpoint(
             item.providerOptions,
@@ -178,6 +207,25 @@ async function convertFunctionToolResultOutput({
           }
         })
         .filter(isNonNullable);
+
+      if (
+        content.length > 0 &&
+        content.every(item => item.prompt_cache_breakpoint == null)
+      ) {
+        const promptCacheBreakpoint = getPromptCacheBreakpoint(
+          toolResultProviderOptions,
+          providerOptionsName,
+        );
+        if (promptCacheBreakpoint != null) {
+          content[content.length - 1] = {
+            ...content[content.length - 1]!,
+            prompt_cache_breakpoint: promptCacheBreakpoint,
+          };
+        }
+      }
+
+      return content;
+    }
   }
 }
 
@@ -1221,6 +1269,7 @@ export async function convertToOpenAIResponsesInput({
                 parallelToolResultGroup.results.map(async result =>
                   convertFunctionToolResultOutput({
                     output: result.output,
+                    toolResultProviderOptions: result.providerOptions,
                     toolName: result.toolName,
                     outputSchemaToolNames,
                     providerOptionsName,
@@ -1482,6 +1531,7 @@ export async function convertToOpenAIResponsesInput({
 
           const contentValue = await convertFunctionToolResultOutput({
             output,
+            toolResultProviderOptions: part.providerOptions,
             toolName: part.toolName,
             outputSchemaToolNames,
             providerOptionsName,


### PR DESCRIPTION
## Summary

- preserve `promptCacheBreakpoint` from scalar tool-output provider options
- fall back to provider options on the enclosing tool-result part
- wrap marked scalar outputs as `input_text` while preserving existing scalar serialization and output-schema encoding
- apply part-level breakpoints to content outputs only when no nested content item already defines one

## Testing

The factory reproduction in #19922 covers all five scalar output types at both provider-option placements.

- `pnpm test` in `packages/openai` (1,944 tests across Node and edge)
- `pnpm type-check` in `packages/openai`
- `oxfmt` and `oxlint` on the changed files

Fixes #19921
