### PR TITLE
chore: fix failing CI tests

### DIFF
--- a/packages/openai-compatible/src/chat/openai-compatible-chat-content-array.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-content-array.test.ts
@@ -38,6 +38,15 @@ it('should stream text and thinking content parts', async () => {
           },
         ],
       })}\n\n`,
+      `data: ${JSON.stringify({
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: 'stop',
+          },
+        ],
+      })}\n\n`,
       'data: [DONE]\n\n',
     ],
   };
@@ -79,6 +88,15 @@ it('should ignore unknown streamed content parts', async () => {
               ],
             },
             finish_reason: null,
+          },
+        ],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: 'stop',
           },
         ],
       })}\n\n`,


### PR DESCRIPTION
## Background

Two independent fixes collided:

[PR #17782](https://github.com/vercel/ai/pull/17782) added support for array-based thinking and text content. The tests correctly verify those deltas are converted.

Later, [PR #19169](https://github.com/vercel/ai/pull/19169) made streams without a finish reason produce an error.

The #17782 fixtures only sent `finish_reason: null`, then `[DONE]`. They passed before #19169 but became invalid afterwards

## Summary

added a realistic final chunk with `finish_reason: 'stop'` before `[DONE]`

## End-to-End Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)