### PR TITLE
fix(harness-codex): support Codex `xhigh` and `max` reasoning levels

### DIFF
--- a/.changeset/seven-lions-grab.md
+++ b/.changeset/seven-lions-grab.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-codex": patch
+---
+
+fix(harness-codex): support Codex `xhigh` and `max` reasoning levels

--- a/content/providers/02-ai-sdk-harnesses/02-codex.mdx
+++ b/content/providers/02-ai-sdk-harnesses/02-codex.mdx
@@ -102,7 +102,7 @@ Settings:
   provided, so use the snake_case keys from Codex's `config.toml` reference.
   The adapter's managed values take precedence over conflicting entries.
 - `mcpServers`: MCP server definitions keyed by server name.
-- `reasoningEffort`: `low`, `medium`, or `high`.
+- `reasoningEffort`: `low`, `medium`, `high`, `xhigh`, or `max`.
 - `webSearch`: allow live web search.
 - `port`: bridge port override.
 - `startupTimeoutMs`: maximum time to wait for the bridge to start.

--- a/examples/ai-functions/src/harness-agent/codex/with-reasoning.ts
+++ b/examples/ai-functions/src/harness-agent/codex/with-reasoning.ts
@@ -11,7 +11,7 @@ run(async () => {
     timeout: 10 * 60 * 1000,
   });
   const agent = new HarnessAgent({
-    harness: createCodex({ reasoningEffort: 'high' }),
+    harness: createCodex({ reasoningEffort: 'max' }),
     sandbox,
   });
 

--- a/packages/harness-codex/src/bridge/index.test.ts
+++ b/packages/harness-codex/src/bridge/index.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { ThreadOptions } from '@openai/codex-sdk';
 
 type CodexOptions = {
   config?: Record<string, unknown>;
 };
-type ThreadOptions = { model?: string };
 type TurnOptions = { outputSchema?: Record<string, unknown> };
 const CODEX_ENV_KEYS = [
   'AI_GATEWAY_API_KEY',
@@ -21,6 +21,9 @@ const state = vi.hoisted(() => ({
     | { type: 'json'; schema: Record<string, unknown> }
     | undefined,
   startInstructions: undefined as string | undefined,
+  startReasoningEffort: undefined as
+    | ThreadOptions['modelReasoningEffort']
+    | undefined,
   startResumeThreadId: undefined as string | undefined,
   startRestartThread: false,
   startCodexConfig: undefined as Record<string, unknown> | undefined,
@@ -73,6 +76,9 @@ vi.mock('@ai-sdk/harness/bridge', () => ({
         ...(state.startInstructions
           ? { instructions: state.startInstructions }
           : {}),
+        ...(state.startReasoningEffort
+          ? { reasoningEffort: state.startReasoningEffort }
+          : {}),
         ...(state.startResumeThreadId
           ? { resumeThreadId: state.startResumeThreadId }
           : {}),
@@ -110,6 +116,7 @@ describe('Codex bridge config', () => {
     state.startModel = 'gpt-5.5';
     state.startResponseFormat = undefined;
     state.startInstructions = undefined;
+    state.startReasoningEffort = undefined;
     state.startResumeThreadId = undefined;
     state.startRestartThread = false;
     state.startCodexConfig = undefined;
@@ -213,6 +220,19 @@ describe('Codex bridge config', () => {
       }
     `);
   });
+
+  test.each(['xhigh', 'max'] as const)(
+    'passes %s reasoning effort to Codex',
+    async reasoningEffort => {
+      state.startReasoningEffort = reasoningEffort;
+
+      await import('./index');
+
+      expect(state.threadOptions[0]?.modelReasoningEffort).toBe(
+        reasoningEffort,
+      );
+    },
+  );
 
   test('disables WebSockets for a configured direct OpenAI endpoint', async () => {
     process.env.CODEX_API_KEY = 'CODEX_API_KEY';

--- a/packages/harness-codex/src/codex-bridge-protocol.test.ts
+++ b/packages/harness-codex/src/codex-bridge-protocol.test.ts
@@ -3,6 +3,7 @@ import {
   bridgeReadySchema,
   inboundMessageSchema,
   outboundMessageSchema,
+  startMessageSchema,
 } from './codex-bridge-protocol';
 
 describe('outboundMessageSchema', () => {
@@ -113,6 +114,19 @@ describe('inboundMessageSchema', () => {
       expect(() => inboundMessageSchema.parse(sample)).not.toThrow();
     }
   });
+
+  it.each(['xhigh', 'max'] as const)(
+    'accepts %s reasoning effort in a start message',
+    reasoningEffort => {
+      expect(() =>
+        startMessageSchema.parse({
+          type: 'start',
+          prompt: 'Solve a difficult problem.',
+          reasoningEffort,
+        }),
+      ).not.toThrow();
+    },
+  );
 });
 
 describe('bridgeReadySchema', () => {

--- a/packages/harness-codex/src/codex-bridge-protocol.ts
+++ b/packages/harness-codex/src/codex-bridge-protocol.ts
@@ -18,7 +18,7 @@ export type OutboundMessage = z.infer<typeof outboundMessageSchema>;
 
 export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
   instructions: z.string().optional(),
-  reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+  reasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
   webSearch: z.boolean().optional(),
   codexConfig: z.record(z.string(), z.unknown()).optional(),
   mcpServers: z.record(z.string(), z.unknown()).optional(),

--- a/packages/harness-codex/src/codex-harness.test-d.ts
+++ b/packages/harness-codex/src/codex-harness.test-d.ts
@@ -1,0 +1,12 @@
+import { expectTypeOf, test } from 'vitest';
+import { createCodex, type CodexHarnessSettings } from './codex-harness';
+
+test('accepts supported reasoning effort settings', () => {
+  expectTypeOf<
+    NonNullable<CodexHarnessSettings['reasoningEffort']>
+  >().toEqualTypeOf<'low' | 'medium' | 'high' | 'xhigh' | 'max'>();
+
+  for (const reasoningEffort of ['xhigh', 'max'] as const) {
+    createCodex({ reasoningEffort });
+  }
+});

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -114,7 +114,7 @@ export type CodexHarnessSettings = {
    * Reasoning effort for reasoning-capable models. Leaving this unset
    * defers to the CLI's default.
    */
-  readonly reasoningEffort?: 'low' | 'medium' | 'high';
+  readonly reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
   /**
    * When `true`, allow the underlying runtime to use live web search.
    */
@@ -709,7 +709,7 @@ function createSession({
   /** Undefined on `attach` — the live bridge was spawned by another process. */
   proc: Experimental_SandboxProcess | undefined;
   model: string | undefined;
-  reasoningEffort: 'low' | 'medium' | 'high' | undefined;
+  reasoningEffort: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | undefined;
   webSearch: boolean | undefined;
   codexConfig: Record<string, unknown> | undefined;
   mcpServers: Record<string, unknown> | undefined;


### PR DESCRIPTION
## Background

The Codex harness restricted `reasoningEffort` to `low`, `medium`, and `high` in both its public type and bridge validation, rejecting the supported `xhigh` and `max` values. The currently pinned Codex SDK already accepts both values, so no dependency update is needed.

## Summary

- Accept `xhigh` and `max` across the public settings, internal session type, and bridge schema.
- Add type and runtime coverage confirming both values reach Codex as `modelReasoningEffort`.
- Update the Codex reasoning example, documentation, and patch changeset.

## Contributor Credit

- @StErMi reported the issue and provided the reproduction details.

## End-to-End Verification

Ran `./tools/run-harness-agent-examples.sh --harness codex --example with-reasoning` successfully.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #19908

Closes #19910
