### PR TITLE
fix(ai): remove tsup build warning

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -77,7 +77,7 @@
     "@types/node": "22.19.19",
     "@vercel/ai-tsconfig": "workspace:*",
     "esbuild": "^0.28.1",
-    "tsup": "^7.2.0",
+    "tsup": "^8.5.1",
     "tsx": "4.23.12",
     "typescript": "5.8.3",
     "zod": "3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1842,8 +1842,8 @@ importers:
         specifier: ^0.28.1
         version: 0.28.1
       tsup:
-        specifier: ^7.2.0
-        version: 7.2.0(@swc/core@1.15.3(@swc/helpers@0.5.21))(postcss@8.5.26)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3))(typescript@5.8.3)
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.26)(supports-color@10.2.2)(tsx@4.23.12)(typescript@5.8.3)(yaml@2.9.0)
       tsx:
         specifier: 4.23.12
         version: 4.23.12


### PR DESCRIPTION
## Background

This warning appeared when building `ai`:

```text
This "import()" was not recognized because this property was not called "assert" (unsupported-dynamic-import)
```

The warning came from the `tsup` config using the modern JSON import-attributes syntax:

```js
import('./package.json', { with: { type: 'json' } })
```

`ai` was using tsup 7.2.0, whose bundled esbuild version only recognized the older `assert` syntax when bundling the config.

## Summary

Update `ai` from tsup 7.2.0 to 8.5.1. This updates tsup’s bundled esbuild and allows the existing `with` syntax to be recognized without a warning.

The newer build tool produces slightly different JavaScript, declaration, and source-map artifacts, but the differences are very small, and there are no behavior changes.