### PR TITLE
docs: document ToolLoopAgent approval secrets

### DIFF
--- a/content/docs/03-agents/06-tool-approvals.mdx
+++ b/content/docs/03-agents/06-tool-approvals.mdx
@@ -284,14 +284,17 @@ If your tools perform sensitive operations (modifying data, spending money, call
 
 ### Signing approvals with `experimental_toolApprovalSecret`
 
-When you provide a secret, the server HMAC-signs each approval request at issuance and verifies the signature when the approval is replayed. A forged or tampered approval is rejected before the tool executes.
+When you provide a secret, the server HMAC-signs each approval request at issuance and verifies the signature when the approval is replayed. A forged or tampered approval is rejected before the tool executes. Configure the secret on `ToolLoopAgent` (or pass it directly to `generateText` or `streamText`).
 
-```ts highlight="5"
-const result = await streamText({
+```ts highlight="6"
+const agent = new ToolLoopAgent({
   model: __MODEL__,
   tools: { deleteFile, runQuery },
   toolApproval: { deleteFile: 'user-approval', runQuery: 'user-approval' },
   experimental_toolApprovalSecret: process.env.TOOL_APPROVAL_SECRET,
+});
+
+const result = await agent.generate({
   messages,
 });
 ```
@@ -308,7 +311,7 @@ The signature binds the approval to the exact tool name, tool call ID, and input
    ```
    TOOL_APPROVAL_SECRET=your-generated-secret-here
    ```
-3. Pass it to `generateText` or `streamText` via `experimental_toolApprovalSecret`.
+3. Pass it to `ToolLoopAgent`, `generateText`, or `streamText` via `experimental_toolApprovalSecret`.
 
 Every serverless instance that might handle a request needs the same secret, since one instance signs the approval and a different instance may verify it on the next turn.
 

--- a/examples/ai-functions/src/agent/openai/generate-tool-approval-secret.ts
+++ b/examples/ai-functions/src/agent/openai/generate-tool-approval-secret.ts
@@ -1,0 +1,67 @@
+import { openai } from '@ai-sdk/openai';
+import {
+  ToolLoopAgent,
+  tool,
+  type ModelMessage,
+  type ToolApprovalResponse,
+} from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const toolApprovalSecret = process.env.TOOL_APPROVAL_SECRET ?? 'secret';
+
+  const agent = new ToolLoopAgent({
+    model: openai('gpt-5.4-mini'),
+    instructions:
+      'Use the weather tool when a user asks for the weather. After a tool result, summarize it briefly.',
+    tools: {
+      weather: tool({
+        description: 'Get the weather in a location.',
+        inputSchema: z.object({ location: z.string() }),
+        execute: async ({ location }) => ({ location, temperature: 72 }),
+      }),
+    },
+    toolApproval: { weather: 'user-approval' },
+    // Keep this secret on the server. It signs each approval request and
+    // prevents clients from forging or modifying approval responses.
+    experimental_toolApprovalSecret: toolApprovalSecret,
+  });
+
+  const messages: ModelMessage[] = [
+    { role: 'user', content: 'What is the weather in San Francisco?' },
+  ];
+  const pendingResult = await agent.generate({ messages });
+
+  let approvalId: string | undefined;
+
+  for (const step of pendingResult.steps) {
+    for (const part of step.content) {
+      if (part.type === 'tool-approval-request') {
+        approvalId = part.approvalId;
+        break;
+      }
+    }
+  }
+
+  if (approvalId == null) {
+    throw new Error('Expected a tool approval request.');
+  }
+
+  // In an application, collect this decision from the user or your approval
+  // system. The signed approval request is included in responseMessages.
+  const approvals: ToolApprovalResponse[] = [
+    {
+      type: 'tool-approval-response',
+      approvalId,
+      approved: true,
+    },
+  ];
+
+  messages.push(...pendingResult.responseMessages);
+  messages.push({ role: 'tool', content: approvals });
+
+  const finalResult = await agent.generate({ messages });
+
+  console.log(finalResult.text);
+});


### PR DESCRIPTION
## Summary
- document experimental_toolApprovalSecret on ToolLoopAgent
- add a runnable OpenAI agent example that replays a signed tool approval

Follow-up to #19883.

## Testing
- pnpm -C examples/ai-functions type-check
- pnpm type-check:full