### PR TITLE
fix(azure): support Foundry and Cognitive Services v1 URLs

### DIFF
--- a/.changeset/azure-foundry-v1-hosts.md
+++ b/.changeset/azure-foundry-v1-hosts.md
@@ -2,4 +2,4 @@
 "@ai-sdk/azure": patch
 ---
 
-Treat Azure AI Foundry (`*.services.ai.azure.com`) and Cognitive Services (`*.cognitiveservices.azure.com`) hostnames as Azure OpenAI endpoints so `/v1` and `api-version` are applied.
+Construct OpenAI v1 URLs for Azure AI Foundry (`*.services.ai.azure.com`) and Cognitive Services (`*.cognitiveservices.azure.com`) hostnames while preserving complete v1 and Foundry project base URLs.

--- a/.changeset/azure-foundry-v1-hosts.md
+++ b/.changeset/azure-foundry-v1-hosts.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/azure": patch
+---
+
+Treat Azure AI Foundry (`*.services.ai.azure.com`) and Cognitive Services (`*.cognitiveservices.azure.com`) hostnames as Azure OpenAI endpoints so `/v1` and `api-version` are applied.

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -32,6 +32,15 @@ const azure = createAzure({
 });
 ```
 
+You can also use a complete [Microsoft Foundry OpenAI v1 base URL](https://learn.microsoft.com/en-us/azure/foundry/openai/api-version-lifecycle#model-support):
+
+```ts
+const azure = createAzure({
+  baseURL: 'https://your-resource.services.ai.azure.com/openai/v1',
+  apiKey: 'your-api-key',
+});
+```
+
 For Microsoft Entra ID authentication, you can provide a token provider.
 Install `@azure/identity` separately if you want to use its credential helpers:
 
@@ -76,6 +85,8 @@ You can use the following optional settings to customize the OpenAI provider ins
 
   Sets a custom [api version](https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation).
   Defaults to `v1`.
+  This setting is applied when the provider constructs the v1 path or uses
+  deployment-based URLs. Complete v1 base URLs are used as-is.
 
 - **baseURL** _string_
 
@@ -84,7 +95,18 @@ You can use the following optional settings to customize the OpenAI provider ins
   Either this or `resourceName` can be used.
   When a baseURL is provided, the resourceName is ignored.
 
-  With an Azure OpenAI baseURL, the resolved URL is `{baseURL}/v1{path}`.
+  For Azure-hosted URLs ending in `.openai.azure.com`,
+  `.services.ai.azure.com`, or `.cognitiveservices.azure.com`, you can pass
+  either an unversioned OpenAI prefix such as `https://your-resource.services.ai.azure.com/openai`
+  or a complete v1 base URL such as `https://your-resource.services.ai.azure.com/openai/v1`.
+  The provider appends `/v1` and the configured `api-version` to unversioned
+  resource URLs. Complete v1 URLs are used as-is.
+
+  Complete Microsoft Foundry project v1 URLs, such as
+  `https://your-resource.services.ai.azure.com/api/projects/your-project/openai/v1`,
+  are also used as-is. If `/v1` is omitted from a Foundry project URL, the
+  provider appends it without adding an `api-version` query parameter.
+
   With a non-Azure custom gateway baseURL, the resolved URL is `{baseURL}{path}`;
   the SDK does not append `/v1` or an `api-version` query parameter in this mode.
 

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -97,6 +97,9 @@ const server = createTestServer({
   'https://test-resource.openai.azure.com/openai/v1/audio/transcriptions': {},
   'https://test-resource.openai.azure.com/openai/v1/audio/speech': {},
   'https://our-gateway.example.com/azure/chat/completions': {},
+  'https://test-resource.services.ai.azure.com/openai/v1/chat/completions': {},
+  'https://test-resource.cognitiveservices.azure.com/openai/v1/chat/completions':
+    {},
   'https://test-resource.openai.azure.com/openai/deployments/whisper-1/audio/transcriptions':
     {},
 });
@@ -411,6 +414,76 @@ describe('chat', () => {
 
       expect(server.calls[0].requestUrl).toMatchInlineSnapshot(
         `"https://our-gateway.example.com/azure/chat/completions"`,
+      );
+    });
+
+    it('should use Foundry services.ai.azure.com baseURL with /v1', async () => {
+      server.urls[
+        'https://test-resource.services.ai.azure.com/openai/v1/chat/completions'
+      ].response = {
+        type: 'json-value',
+        body: {
+          id: 'chatcmpl-foundry',
+          object: 'chat.completion',
+          created: 0,
+          model: 'test-deployment',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'ok' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        },
+      };
+
+      const foundryProvider = createAzure({
+        baseURL: 'https://test-resource.services.ai.azure.com/openai',
+        apiKey: 'test-api-key',
+      });
+
+      await foundryProvider.chat('test-deployment').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(server.calls[0].requestUrl).toMatchInlineSnapshot(
+        `"https://test-resource.services.ai.azure.com/openai/v1/chat/completions?api-version=v1"`,
+      );
+    });
+
+    it('should use Cognitive Services baseURL with /v1', async () => {
+      server.urls[
+        'https://test-resource.cognitiveservices.azure.com/openai/v1/chat/completions'
+      ].response = {
+        type: 'json-value',
+        body: {
+          id: 'chatcmpl-cognitive',
+          object: 'chat.completion',
+          created: 0,
+          model: 'test-deployment',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'ok' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        },
+      };
+
+      const cognitiveProvider = createAzure({
+        baseURL: 'https://test-resource.cognitiveservices.azure.com/openai',
+        apiKey: 'test-api-key',
+      });
+
+      await cognitiveProvider.chat('test-deployment').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(server.calls[0].requestUrl).toMatchInlineSnapshot(
+        `"https://test-resource.cognitiveservices.azure.com/openai/v1/chat/completions?api-version=v1"`,
       );
     });
   });

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -100,9 +100,13 @@ const server = createTestServer({
   'https://test-resource.services.ai.azure.com/openai/v1/chat/completions': {},
   'https://test-resource.cognitiveservices.azure.com/openai/v1/chat/completions':
     {},
+  'https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1/chat/completions':
+    {},
   'https://test-resource.openai.azure.com/openai/deployments/whisper-1/audio/transcriptions':
     {},
 });
+
+type TestServerURL = keyof typeof server.urls;
 
 describe('responses (default language model)', () => {
   describe('doGenerate', () => {
@@ -281,10 +285,11 @@ describe('responses (default language model)', () => {
 
 describe('chat', () => {
   describe('doGenerate', () => {
-    function prepareJsonResponse({ content = '' }: { content?: string } = {}) {
-      server.urls[
-        'https://test-resource.openai.azure.com/openai/v1/chat/completions'
-      ].response = {
+    function prepareJsonResponse({
+      content = '',
+      url = 'https://test-resource.openai.azure.com/openai/v1/chat/completions',
+    }: { content?: string; url?: TestServerURL } = {}) {
+      server.urls[url].response = {
         type: 'json-value',
         body: {
           id: 'chatcmpl-95ZTZkhr0mHNKqerQfiwkuox3PHAd',
@@ -382,6 +387,88 @@ describe('chat', () => {
       );
     });
 
+    it.each([
+      {
+        name: 'complete Azure OpenAI v1',
+        baseURL: 'https://test-resource.openai.azure.com/openai/v1',
+        expectedURL:
+          'https://test-resource.openai.azure.com/openai/v1/chat/completions',
+        responseURL:
+          'https://test-resource.openai.azure.com/openai/v1/chat/completions',
+      },
+      {
+        name: 'unversioned Foundry',
+        baseURL: 'https://test-resource.services.ai.azure.com/openai',
+        expectedURL:
+          'https://test-resource.services.ai.azure.com/openai/v1/chat/completions?api-version=v1',
+        responseURL:
+          'https://test-resource.services.ai.azure.com/openai/v1/chat/completions',
+      },
+      {
+        name: 'complete Foundry v1',
+        baseURL: 'https://test-resource.services.ai.azure.com/openai/v1/',
+        expectedURL:
+          'https://test-resource.services.ai.azure.com/openai/v1/chat/completions',
+        responseURL:
+          'https://test-resource.services.ai.azure.com/openai/v1/chat/completions',
+      },
+      {
+        name: 'unversioned Cognitive Services',
+        baseURL: 'https://test-resource.cognitiveservices.azure.com/openai',
+        expectedURL:
+          'https://test-resource.cognitiveservices.azure.com/openai/v1/chat/completions?api-version=v1',
+        responseURL:
+          'https://test-resource.cognitiveservices.azure.com/openai/v1/chat/completions',
+      },
+      {
+        name: 'complete Cognitive Services v1',
+        baseURL: 'https://test-resource.cognitiveservices.azure.com/openai/v1',
+        expectedURL:
+          'https://test-resource.cognitiveservices.azure.com/openai/v1/chat/completions',
+        responseURL:
+          'https://test-resource.cognitiveservices.azure.com/openai/v1/chat/completions',
+      },
+      {
+        name: 'unversioned Foundry project',
+        baseURL:
+          'https://test-resource.services.ai.azure.com/api/projects/test-project/openai',
+        expectedURL:
+          'https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1/chat/completions',
+        responseURL:
+          'https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1/chat/completions',
+      },
+      {
+        name: 'complete Foundry project v1',
+        baseURL:
+          'https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1',
+        expectedURL:
+          'https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1/chat/completions',
+        responseURL:
+          'https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1/chat/completions',
+      },
+    ] satisfies Array<{
+      name: string;
+      baseURL: string;
+      expectedURL: string;
+      responseURL: TestServerURL;
+    }>)(
+      'should use $name baseURL correctly',
+      async ({ baseURL, expectedURL, responseURL }) => {
+        prepareJsonResponse({ url: responseURL });
+
+        const provider = createAzure({
+          baseURL,
+          apiKey: 'test-api-key',
+        });
+
+        await provider.chat('test-deployment').doGenerate({
+          prompt: TEST_PROMPT,
+        });
+
+        expect(server.calls[0].requestUrl).toBe(expectedURL);
+      },
+    );
+
     it('should use custom gateway baseURL as-is', async () => {
       server.urls[
         'https://our-gateway.example.com/azure/chat/completions'
@@ -414,76 +501,6 @@ describe('chat', () => {
 
       expect(server.calls[0].requestUrl).toMatchInlineSnapshot(
         `"https://our-gateway.example.com/azure/chat/completions"`,
-      );
-    });
-
-    it('should use Foundry services.ai.azure.com baseURL with /v1', async () => {
-      server.urls[
-        'https://test-resource.services.ai.azure.com/openai/v1/chat/completions'
-      ].response = {
-        type: 'json-value',
-        body: {
-          id: 'chatcmpl-foundry',
-          object: 'chat.completion',
-          created: 0,
-          model: 'test-deployment',
-          choices: [
-            {
-              index: 0,
-              message: { role: 'assistant', content: 'ok' },
-              finish_reason: 'stop',
-            },
-          ],
-          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
-        },
-      };
-
-      const foundryProvider = createAzure({
-        baseURL: 'https://test-resource.services.ai.azure.com/openai',
-        apiKey: 'test-api-key',
-      });
-
-      await foundryProvider.chat('test-deployment').doGenerate({
-        prompt: TEST_PROMPT,
-      });
-
-      expect(server.calls[0].requestUrl).toMatchInlineSnapshot(
-        `"https://test-resource.services.ai.azure.com/openai/v1/chat/completions?api-version=v1"`,
-      );
-    });
-
-    it('should use Cognitive Services baseURL with /v1', async () => {
-      server.urls[
-        'https://test-resource.cognitiveservices.azure.com/openai/v1/chat/completions'
-      ].response = {
-        type: 'json-value',
-        body: {
-          id: 'chatcmpl-cognitive',
-          object: 'chat.completion',
-          created: 0,
-          model: 'test-deployment',
-          choices: [
-            {
-              index: 0,
-              message: { role: 'assistant', content: 'ok' },
-              finish_reason: 'stop',
-            },
-          ],
-          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
-        },
-      };
-
-      const cognitiveProvider = createAzure({
-        baseURL: 'https://test-resource.cognitiveservices.azure.com/openai',
-        apiKey: 'test-api-key',
-      });
-
-      await cognitiveProvider.chat('test-deployment').doGenerate({
-        prompt: TEST_PROMPT,
-      });
-
-      expect(server.calls[0].requestUrl).toMatchInlineSnapshot(
-        `"https://test-resource.cognitiveservices.azure.com/openai/v1/chat/completions?api-version=v1"`,
       );
     });
   });

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -156,8 +156,15 @@ export interface AzureOpenAIProviderSettings {
 }
 
 function isAzureOpenAIBaseURL(baseURL: string | undefined) {
+  if (baseURL == null) {
+    return true;
+  }
+
+  const hostname = new URL(baseURL).hostname;
   return (
-    baseURL == null || new URL(baseURL).hostname.endsWith('.openai.azure.com')
+    hostname.endsWith('.openai.azure.com') ||
+    hostname.endsWith('.services.ai.azure.com') ||
+    hostname.endsWith('.cognitiveservices.azure.com')
   );
 }
 

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -114,7 +114,8 @@ export interface AzureOpenAIProviderSettings {
    * Use a different URL prefix for API calls, e.g. to use proxy servers. Either this or `resourceName` can be used.
    * When a baseURL is provided, the resourceName is ignored.
    *
-   * With an Azure OpenAI baseURL, the resolved URL is `{baseURL}/v1{path}`.
+   * With an unversioned Azure OpenAI baseURL, the resolved URL is `{baseURL}/v1{path}`.
+   * Azure OpenAI base URLs that already end in `/openai/v1` are used as-is.
    * With a non-Azure custom gateway baseURL, the resolved URL is `{baseURL}{path}`.
    */
   baseURL?: string;
@@ -143,7 +144,8 @@ export interface AzureOpenAIProviderSettings {
   fetch?: FetchFunction;
 
   /**
-   * Custom api version to use. Defaults to `preview`.
+   * Custom api version to use. Defaults to `v1`.
+   * Complete v1 base URLs are used as-is.
    */
   apiVersion?: string;
 
@@ -155,17 +157,30 @@ export interface AzureOpenAIProviderSettings {
   useDeploymentBasedUrls?: boolean;
 }
 
-function isAzureOpenAIBaseURL(baseURL: string | undefined) {
+function getAzureOpenAIBaseURLInfo(baseURL: string | undefined) {
   if (baseURL == null) {
-    return true;
+    return {
+      isAzureOpenAI: true,
+      isFoundryProject: false,
+      isVersioned: false,
+    };
   }
 
-  const hostname = new URL(baseURL).hostname;
-  return (
+  const url = new URL(baseURL);
+  const hostname = url.hostname;
+  const isAzureOpenAI =
     hostname.endsWith('.openai.azure.com') ||
     hostname.endsWith('.services.ai.azure.com') ||
-    hostname.endsWith('.cognitiveservices.azure.com')
-  );
+    hostname.endsWith('.cognitiveservices.azure.com');
+  const pathname = url.pathname.replace(/\/+$/, '');
+
+  return {
+    isAzureOpenAI,
+    isFoundryProject:
+      hostname.endsWith('.services.ai.azure.com') &&
+      pathname.startsWith('/api/projects/'),
+    isVersioned: isAzureOpenAI && pathname.toLowerCase().endsWith('/openai/v1'),
+  };
 }
 
 /**
@@ -228,7 +243,11 @@ export function createAzure(
     });
 
   const apiVersion = options.apiVersion ?? 'v1';
-  const useAzureOpenAIEndpoint = isAzureOpenAIBaseURL(options.baseURL);
+  const {
+    isAzureOpenAI,
+    isFoundryProject,
+    isVersioned: isAzureOpenAIVersioned,
+  } = getAzureOpenAIBaseURLInfo(options.baseURL);
 
   const url = ({ path, modelId }: { path: string; modelId: string }) => {
     const baseUrlPrefix = withoutTrailingSlash(
@@ -239,15 +258,19 @@ export function createAzure(
     if (options.useDeploymentBasedUrls) {
       // Use deployment-based format for compatibility with certain Azure OpenAI models
       fullUrl = new URL(`${baseUrlPrefix}/deployments/${modelId}${path}`);
-    } else if (!useAzureOpenAIEndpoint) {
+    } else if (!isAzureOpenAI || isAzureOpenAIVersioned) {
       // Custom gateways can own Azure routing and versioning themselves.
+      // Complete Azure OpenAI v1 URLs also own their versioning.
       fullUrl = new URL(`${baseUrlPrefix}${path}`);
     } else {
       // Use v1 API format - no deployment ID in URL
       fullUrl = new URL(`${baseUrlPrefix}/v1${path}`);
     }
 
-    if (useAzureOpenAIEndpoint || options.useDeploymentBasedUrls) {
+    if (
+      options.useDeploymentBasedUrls ||
+      (isAzureOpenAI && !isAzureOpenAIVersioned && !isFoundryProject)
+    ) {
       fullUrl.searchParams.set('api-version', apiVersion);
     }
 


### PR DESCRIPTION
## Summary

- recognize Azure AI Foundry (`*.services.ai.azure.com`) and Cognitive Services (`*.cognitiveservices.azure.com`) resource hostnames as Azure endpoints
- append `/v1` only to unversioned Azure base URLs, preserving complete `/openai/v1` URLs without producing `/v1/v1`
- preserve Foundry project endpoint routing without adding the `api-version` query parameter
- document the accepted Azure base URL forms and add regression coverage for resource, complete v1, project, and custom-gateway URLs

This supersedes #19839. Its feature commit is replayed here with Shobhan Karthish preserved as the author and with a verified signature; the old merge-from-`main` commit is subsumed by this branch's current `main` base.

Closes #19817

## Azure documentation review

Microsoft's [Azure OpenAI v1 API documentation](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/api-version-lifecycle) explicitly documents complete v1 base URLs on both `*.openai.azure.com` and `*.services.ai.azure.com`. The implementation now accepts those complete URLs as-is as well as unversioned resource URLs. Cognitive Services remains supported for the Azure resource endpoint reported in #19817, without claiming that Microsoft documents it as an OpenAI v1 base URL example.

## Test plan

- `pnpm --filter @ai-sdk/azure test:node`
- `pnpm --filter @ai-sdk/azure test:edge`
- `pnpm --filter @ai-sdk/azure type-check`
- `pnpm check`
- `pnpm type-check:full`

All commits in this PR have verified signatures.
