### PR TITLE
fix: avoid WebKit deadlock in concurrent useChat streams

### DIFF
--- a/.changeset/webkit-stream-concurrency-fix.md
+++ b/.changeset/webkit-stream-concurrency-fix.md
@@ -1,0 +1,8 @@
+---
+'@ai-sdk/provider-utils': patch
+'ai': patch
+---
+
+fix useChat stream stall on Linux WebKit under concurrent contexts
+
+Replace `TextDecoderStream` with a custom `TextDecoder`-based transform in `parseJsonEventStream` to avoid a Linux WebKit `pipeThrough` deadlock that stalled ~30% of concurrent browser contexts. Add `cache: no-store` to `HttpChatTransport` fetches to prevent WebKit HTTP-cache serialization of concurrent POSTs.

--- a/packages/ai/src/ui/http-chat-transport.ts
+++ b/packages/ai/src/ui/http-chat-transport.ts
@@ -197,6 +197,7 @@ export abstract class HttpChatTransport<
       body: JSON.stringify(body),
       credentials,
       signal: abortSignal,
+      cache: 'no-store',
     });
 
     if (!response.ok) {
@@ -248,6 +249,7 @@ export abstract class HttpChatTransport<
       headers,
       credentials,
       signal: options.abortSignal,
+      cache: 'no-store',
     });
 
     // no active stream found, so we do not resume

--- a/packages/provider-utils/src/parse-json-event-stream.ts
+++ b/packages/provider-utils/src/parse-json-event-stream.ts
@@ -4,6 +4,7 @@ import {
 } from 'eventsource-parser/stream';
 import { safeParseJSON, type ParseResult } from './parse-json';
 import type { FlexibleSchema } from './schema';
+import { createTextDecoderStream } from './uint8-utils';
 
 /**
  * Parses a JSON event stream into a stream of parsed JSON objects.
@@ -16,7 +17,7 @@ export function parseJsonEventStream<T>({
   schema: FlexibleSchema<T>;
 }): ReadableStream<ParseResult<T>> {
   return stream
-    .pipeThrough(new TextDecoderStream())
+    .pipeThrough(createTextDecoderStream())
     .pipeThrough(new EventSourceParserStream())
     .pipeThrough(
       new TransformStream<EventSourceMessage, ParseResult<T>>({

--- a/packages/provider-utils/src/uint8-utils.test.ts
+++ b/packages/provider-utils/src/uint8-utils.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createTextDecoderStream,
+  toArrayBufferBackedUint8Array,
+} from './uint8-utils';
+
+describe('createTextDecoderStream', () => {
+  it('decodes multi-byte characters split across chunks', async () => {
+    const bytes = new TextEncoder().encode('A🙂B');
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes.subarray(0, 3));
+        controller.enqueue(bytes.subarray(3));
+        controller.close();
+      },
+    });
+
+    expect(await readText(stream.pipeThrough(createTextDecoderStream()))).toBe(
+      'A🙂B',
+    );
+  });
+
+  it('decodes SharedArrayBuffer-backed chunks', async () => {
+    const bytes = new TextEncoder().encode('shared');
+    const buffer = new SharedArrayBuffer(bytes.byteLength);
+    const chunk = new Uint8Array(buffer);
+    chunk.set(bytes);
+    const stream = new ReadableStream<Uint8Array<SharedArrayBuffer>>({
+      start(controller) {
+        controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+
+    expect(await readText(stream.pipeThrough(createTextDecoderStream()))).toBe(
+      'shared',
+    );
+  });
+
+  it('handles empty stream via flush', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    });
+    expect(await readText(stream.pipeThrough(createTextDecoderStream()))).toBe(
+      '',
+    );
+  });
+});
+
+describe('toArrayBufferBackedUint8Array', () => {
+  it('converts ArrayBuffer view to backed array', () => {
+    const arr = new Uint8Array([1, 2, 3]);
+    const result = toArrayBufferBackedUint8Array(arr);
+    expect(result).toEqual(new Uint8Array([1, 2, 3]));
+  });
+});
+
+async function readText(stream: ReadableStream<string>): Promise<string> {
+  const reader = stream.getReader();
+  let result = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      return result;
+    }
+    result += value;
+  }
+}

--- a/packages/provider-utils/src/uint8-utils.ts
+++ b/packages/provider-utils/src/uint8-utils.ts
@@ -3,6 +3,36 @@
 // "TypeError: Illegal invocation: function called with incorrect this reference"
 const { btoa, atob } = globalThis;
 
+/**
+ * Creates a transform stream that decodes binary chunks into strings.
+ *
+ * Unlike `TextDecoderStream`, this accepts shared buffer sources, matching the
+ * input supported by `TextDecoder.decode`. It also avoids the native
+ * `TextDecoderStream` implementation which deadlocks on Linux WebKit under
+ * concurrent `pipeThrough` load (see https://github.com/vercel/ai/issues/19949).
+ */
+export function createTextDecoderStream(): TransformStream<
+  AllowSharedBufferSource,
+  string
+> {
+  const decoder = new TextDecoder();
+
+  return new TransformStream<AllowSharedBufferSource, string>({
+    transform(chunk, controller) {
+      const text = decoder.decode(chunk, { stream: true });
+      if (text.length > 0) {
+        controller.enqueue(text);
+      }
+    },
+    flush(controller) {
+      const text = decoder.decode();
+      if (text.length > 0) {
+        controller.enqueue(text);
+      }
+    },
+  });
+}
+
 export function convertBase64ToUint8Array(base64String: string) {
   const base64Url = base64String.replace(/-/g, '+').replace(/_/g, '/');
   const latin1string = atob(base64Url);


### PR DESCRIPTION
## Background

On Linux WebKit, two concurrent `useChat` contexts stalled ~30% of the time after receiving only the first SSE frame (39 of 471 bytes). The status stayed `streaming` with an empty assistant message while the server completed the response normally, and a plain `fetch` + manual reader to the same route always succeeded. Chromium and Firefox were unaffected, and single-context runs never stalled.

## Summary

`parseJsonEventStream` now uses the project's own `TextDecoder`-based transform (restoring a previously reviewed implementation) instead of the native `TextDecoderStream`, which deadlocks under concurrent `pipeThrough` on Linux WebKit and cannot decode `SharedArrayBuffer`-backed chunks. `HttpChatTransport` fetches now send `cache: 'no-store'` so WebKit's HTTP-cache lock does not serialize concurrent requests to the same route.

## End-to-End Verification

The stall was reported with two concurrent Playwright WebKit contexts against a plain SSE route (#19949), where a plain `fetch` + manual reader from the same page always succeeded. The restored decoder is covered by unit tests for split multi-byte sequences, `SharedArrayBuffer` input, and empty streams; full verification under Linux WebKit requires the Playwright WebKit environment.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [ ] I have reviewed this pull request (self-review)

## Future Work

The same native `TextDecoderStream` replacement can be applied to the remaining `pipeThrough` call sites (e.g. MCP and gateway transports) in a follow-up PR.

## Related Issues

Fixes #19949