### PR TITLE
docs: update model names in code examples

### DIFF
--- a/content/providers/05-community-providers/32-openrouter.mdx
+++ b/content/providers/05-community-providers/32-openrouter.mdx
@@ -42,11 +42,11 @@ OpenRouter supports both chat and completion models. Use `openrouter.chat()` for
 
 ```typescript
 // Chat models (recommended)
-const chatModel = openrouter.chat('anthropic/claude-3.5-sonnet');
+const chatModel = openrouter.chat('anthropic/claude-sonnet-4');
 
 // Completion models
 const completionModel = openrouter.completion(
-  'meta-llama/llama-3.1-405b-instruct',
+  'meta-llama/llama-3.3-70b-instruct',
 );
 ```
 
@@ -67,7 +67,7 @@ const openrouter = createOpenRouter({
 });
 
 const { text } = await generateText({
-  model: openrouter.chat('anthropic/claude-3.5-sonnet'),
+  model: openrouter.chat('anthropic/claude-sonnet-4'),
   prompt: 'What is OpenRouter?',
 });
 
@@ -85,7 +85,7 @@ const openrouter = createOpenRouter({
 });
 
 const result = streamText({
-  model: openrouter.chat('meta-llama/llama-3.1-405b-instruct'),
+  model: openrouter.chat('meta-llama/llama-3.3-70b-instruct'),
   prompt: 'Write a short story about AI.',
 });
 


### PR DESCRIPTION
<!--Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md

AI SDK maintenance is becoming increasingly automated. High-quality issues, reproductions,
failing tests, docs fixes, and focused clarifications are especially valuable. You do not
need to send a complete bug fix for your contribution to be appreciated or credited.
-->

## Background

Code examples in the documentation for the community provider OpenRouter referenced unavailable models, resulting in errors when run:
`APICallError [AI_APICallError]: No endpoints found for anthropic/claude-3.5-sonnet.`
`APICallError [AI_APICallError]: No endpoints found for meta-llama/llama-3.1-405b-instruct.`

<!--
Why was this change necessary?
If this PR clarifies or reproduces an issue, please explain that context here.
-->

## Summary

I changed the model references in the code examples to more recent versions (Claude Sonnet 4, Llama 3.3 70B Instruct), which are available on OpenRouter as of August 2026.

<!-- What did you change? -->

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
