### PR TITLE
fix(anthropic): filter out empty compaction blocks to prevent api rejection

### DIFF
--- a/.changeset/fix-anthropic-empty-compaction-blocks.md
+++ b/.changeset/fix-anthropic-empty-compaction-blocks.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): filter out empty compaction blocks to prevent API rejection

--- a/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
@@ -1489,6 +1489,47 @@ describe('tool messages', () => {
 });
 
 describe('assistant messages', () => {
+  it('should ignore empty compaction content blocks', async () => {
+    const result = await convertToAnthropicPrompt({
+      prompt: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'user content' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: '',
+              providerOptions: { anthropic: { type: 'compaction' } },
+            },
+            { type: 'text', text: 'assistant content' },
+          ],
+        },
+      ],
+      sendReasoning: true,
+      warnings: [],
+      toolNameMapping: defaultToolNameMapping,
+    });
+
+    expect(result).toEqual({
+      prompt: {
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'user content' }],
+          },
+          {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'assistant content' }],
+          },
+        ],
+      },
+      betas: new Set(),
+    });
+  });
+
   it('should preserve citations on assistant text', async () => {
     const result = await convertToAnthropicPrompt({
       prompt: [

--- a/packages/anthropic/src/convert-to-anthropic-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.ts
@@ -700,11 +700,13 @@ export async function convertToAnthropicPrompt({
                   | undefined;
 
                 if (textMetadata?.type === 'compaction') {
-                  anthropicContent.push({
-                    type: 'compaction',
-                    content: part.text,
-                    cache_control: cacheControl,
-                  });
+                  if (part.text) {
+                    anthropicContent.push({
+                      type: 'compaction',
+                      content: part.text,
+                      cache_control: cacheControl,
+                    });
+                  }
                 } else {
                   anthropicContent.push({
                     type: 'text',


### PR DESCRIPTION
### Description
Fixes #13335.

When using Anthropic's native compaction (`compact_20260112`), the API occasionally returns a compaction block with empty/null content. Previously, `@ai-sdk/anthropic` persisted this faithfully, which caused the Anthropic API to throw a 400 error (`content can't be empty`) when the message history was sent back on the next turn.

This PR filters out compaction blocks with falsy/empty content during request building to prevent them from entering the payload sent to the API.

### Testing
- [x] Added unit tests mocking Anthropic's empty compaction API response.
- [x] Verified tests pass locally.