### PR TITLE
fix(ui): support resuming streams beginning with text/reasoning deltas

### DIFF
--- a/.changeset/fix-bedrock-multibyte-stream.md
+++ b/.changeset/fix-bedrock-multibyte-stream.md
@@ -1,5 +1,0 @@
----
-'@ai-sdk/amazon-bedrock': patch
----
-
-fix(amazon-bedrock): preserve multibyte characters in streamed event payloads

--- a/.changeset/fix-bedrock-multibyte-stream.md
+++ b/.changeset/fix-bedrock-multibyte-stream.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): preserve multibyte characters in streamed event payloads

--- a/.changeset/fix-ui-resume-stream-text-reasoning.md
+++ b/.changeset/fix-ui-resume-stream-text-reasoning.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ui): support resuming streams beginning with text or reasoning deltas

--- a/packages/ai/src/ui/process-ui-message-stream.ts
+++ b/packages/ai/src/ui/process-ui-message-stream.ts
@@ -438,7 +438,19 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'text-delta': {
-              const textPart = state.activeTextParts[chunk.id];
+              let textPart = state.activeTextParts[chunk.id];
+              if (textPart == null) {
+                // Fallback for resumed streams: if we don't have it in active maps,
+                // check if there's a streaming textPart in the message we can attach to.
+                const streamingParts = state.message.parts.filter(
+                  part => part.type === 'text' && part.state === 'streaming',
+                ) as Extract<UIMessagePart<any, any>, { type: 'text' }>[];
+                if (streamingParts.length === 1) {
+                  textPart = streamingParts[0];
+                  state.activeTextParts[chunk.id] = textPart;
+                }
+              }
+
               if (textPart == null) {
                 throw new UIMessageStreamError({
                   chunkType: 'text-delta',
@@ -456,7 +468,19 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'text-end': {
-              const textPart = state.activeTextParts[chunk.id];
+              let textPart = state.activeTextParts[chunk.id];
+              if (textPart == null) {
+                // Fallback for resumed streams: if we don't have it in active maps,
+                // check if there's a streaming textPart in the message we can attach to.
+                const streamingParts = state.message.parts.filter(
+                  part => part.type === 'text' && part.state === 'streaming',
+                ) as Extract<UIMessagePart<any, any>, { type: 'text' }>[];
+                if (streamingParts.length === 1) {
+                  textPart = streamingParts[0];
+                  state.activeTextParts[chunk.id] = textPart;
+                }
+              }
+
               if (textPart == null) {
                 throw new UIMessageStreamError({
                   chunkType: 'text-end',
@@ -500,7 +524,20 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'reasoning-delta': {
-              const reasoningPart = state.activeReasoningParts[chunk.id];
+              let reasoningPart = state.activeReasoningParts[chunk.id];
+              if (reasoningPart == null) {
+                // Fallback for resumed streams: if we don't have it in active maps,
+                // check if there's a streaming reasoningPart in the message we can attach to.
+                const streamingParts = state.message.parts.filter(
+                  part =>
+                    part.type === 'reasoning' && part.state === 'streaming',
+                ) as Extract<UIMessagePart<any, any>, { type: 'reasoning' }>[];
+                if (streamingParts.length === 1) {
+                  reasoningPart = streamingParts[0];
+                  state.activeReasoningParts[chunk.id] = reasoningPart;
+                }
+              }
+
               if (reasoningPart == null) {
                 throw new UIMessageStreamError({
                   chunkType: 'reasoning-delta',
@@ -518,7 +555,20 @@ export function processUIMessageStream<UI_MESSAGE extends UIMessage>({
             }
 
             case 'reasoning-end': {
-              const reasoningPart = state.activeReasoningParts[chunk.id];
+              let reasoningPart = state.activeReasoningParts[chunk.id];
+              if (reasoningPart == null) {
+                // Fallback for resumed streams: if we don't have it in active maps,
+                // check if there's a streaming reasoningPart in the message we can attach to.
+                const streamingParts = state.message.parts.filter(
+                  part =>
+                    part.type === 'reasoning' && part.state === 'streaming',
+                ) as Extract<UIMessagePart<any, any>, { type: 'reasoning' }>[];
+                if (streamingParts.length === 1) {
+                  reasoningPart = streamingParts[0];
+                  state.activeReasoningParts[chunk.id] = reasoningPart;
+                }
+              }
+
               if (reasoningPart == null) {
                 throw new UIMessageStreamError({
                   chunkType: 'reasoning-end',


### PR DESCRIPTION
### Description
Fixes #13160.
Resolves #16605.

Currently, resuming a `useChat` stream that starts with a `text-delta` or `reasoning-delta` chunk throws a `UIMessageStreamError`. This occurs because `activeTextParts`/`activeReasoningParts` are freshly initialized maps on resume and do not contain mappings to the existing text/reasoning parts from the `lastMessage` state.

This PR adds fallback mapping logic during stream parsing. If a `*-delta` or `*-end` chunk references an unknown chunk ID, the processor checks if there is exactly one `streaming` part of the matching type already in the `lastMessage` state. If so, it maps the chunk ID to that active part instead of throwing an error.

### Testing
- [x] Tested against the reproduction script in #16605 to ensure the stream correctly resumes without errors.
- [x] Verified all existing test suites pass natively via `pnpm test`.