### PR TITLE
fix(amazon-bedrock): preserve multibyte characters in streamed event payloads

### DIFF
--- a/.changeset/fix-bedrock-multibyte-stream-chars.md
+++ b/.changeset/fix-bedrock-multibyte-stream-chars.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): preserve multibyte characters in streamed event payloads

--- a/packages/amazon-bedrock/src/amazon-bedrock-event-stream-decoder.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-event-stream-decoder.ts
@@ -50,7 +50,7 @@ export function createAmazonBedrockEventStreamDecoder<T>(
           const exceptionType = decoded.headers[':exception-type']?.value as
             | string
             | undefined;
-          const data = textDecoder.decode(decoded.body);
+          const data = textDecoder.decode(decoded.body, { stream: true });
 
           await processEvent(
             { messageType, eventType, exceptionType, data },

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-fetch.ts
@@ -68,6 +68,7 @@ function transformAmazonBedrockEventStreamToSSE(
   body: ReadableStream<Uint8Array>,
 ): ReadableStream<Uint8Array> {
   const textEncoder = new TextEncoder();
+  const textDecoder = new TextDecoder();
 
   return createAmazonBedrockEventStreamDecoder(
     body,
@@ -81,8 +82,9 @@ function transformAmazonBedrockEventStreamToSSE(
           }
           const bytes = (parsed.value as { bytes?: string }).bytes;
           if (bytes) {
-            const anthropicEvent = new TextDecoder().decode(
+            const anthropicEvent = textDecoder.decode(
               convertBase64ToUint8Array(bytes),
+              { stream: true },
             );
             controller.enqueue(
               textEncoder.encode(`data: ${anthropicEvent}\n\n`),


### PR DESCRIPTION
### Description
Fixes #13299.

When using streaming models on Amazon Bedrock (or through the AI Gateway which proxies Bedrock), multibyte characters (such as Korean, Japanese, Chinese, or emojis) were occasionally getting corrupted (``). 

This happened because the raw byte stream from AWS events could be split across boundaries that truncate a multibyte character. The `TextDecoder` was initialized without the `{ stream: true }` option, so instead of maintaining the partial byte state for the next chunk, it immediately emitted replacement characters. 

This PR fixes the issue by maintaining a persistent `TextDecoder` and passing `{ stream: true }` during decoding in both the general Bedrock event stream decoder and the Anthropic-specific Bedrock fetch implementation.

### Testing
- [x] Verified locally that Amazon Bedrock tests pass successfully.
- [x] Confirmed the `TextDecoder` preserves stream byte state across chunks.