### PR TITLE
feat(ai): allow removing providerOptions in pruneMessages

### DIFF
--- a/.changeset/fix-ai-prune-messages-provider-options.md
+++ b/.changeset/fix-ai-prune-messages-provider-options.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): add providerOptions: 'remove' option to pruneMessages to strip provider-specific metadata from pruned message parts

--- a/packages/ai/src/generate-text/prune-messages.test.ts
+++ b/packages/ai/src/generate-text/prune-messages.test.ts
@@ -910,5 +910,71 @@ describe('pruneMessages', () => {
         `);
       });
     });
+    describe('providerOptions pruning', () => {
+      it('should keep providerOptions by default', () => {
+        const messages: ModelMessage[] = [
+          {
+            role: 'assistant',
+            providerOptions: { test: { a: 1 } },
+            content: [
+              {
+                type: 'text',
+                text: 'Hello',
+                providerOptions: { test: { b: 2 } },
+              },
+            ],
+          },
+        ];
+
+        const result = pruneMessages({ messages });
+
+        expect(result).toStrictEqual([
+          {
+            role: 'assistant',
+            providerOptions: { test: { a: 1 } },
+            content: [
+              {
+                type: 'text',
+                text: 'Hello',
+                providerOptions: { test: { b: 2 } },
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('should remove providerOptions when configured', () => {
+        const messages: ModelMessage[] = [
+          {
+            role: 'assistant',
+            providerOptions: { test: { a: 1 } },
+            content: [
+              {
+                type: 'text',
+                text: 'Hello',
+                providerOptions: { test: { b: 2 } },
+              },
+            ],
+          },
+        ];
+
+        const result = pruneMessages({
+          messages,
+          providerOptions: 'remove',
+        });
+
+        expect(result).toStrictEqual([
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: 'Hello',
+              },
+            ],
+          },
+        ]);
+      });
+    });
   });
 });

--- a/packages/ai/src/generate-text/prune-messages.ts
+++ b/packages/ai/src/generate-text/prune-messages.ts
@@ -11,6 +11,7 @@ import type {
  * @param reasoning - How to remove reasoning content from assistant messages. Default is `'none'`.
  * @param toolCalls - How to prune tool call/results/approval content. Default is `[]`.
  * @param emptyMessages - Whether to keep or remove messages whose content is empty after pruning. Default is `'remove'`.
+ * @param providerOptions - Whether to keep or remove provider-specific options. Default is `'keep'`.
  *
  * @returns The pruned list of model messages.
  */
@@ -19,6 +20,7 @@ export function pruneMessages({
   reasoning = 'none',
   toolCalls = [],
   emptyMessages = 'remove',
+  providerOptions = 'keep',
 }: {
   messages: ModelMessage[];
   reasoning?: 'all' | 'before-last-message' | 'none';
@@ -32,6 +34,7 @@ export function pruneMessages({
         tools?: string[];
       }>;
   emptyMessages?: 'keep' | 'remove';
+  providerOptions?: 'keep' | 'remove';
 }): ModelMessage[] {
   // filter reasoning parts:
   if (reasoning === 'all' || reasoning === 'before-last-message') {
@@ -190,6 +193,29 @@ export function pruneMessages({
 
   if (emptyMessages === 'remove') {
     messages = messages.filter(message => message.content.length > 0);
+  }
+
+  if (providerOptions === 'remove') {
+    messages = messages.map(message => {
+      // remove providerOptions from message
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { providerOptions: _msgProviderOptions, ...newMessage } = message;
+
+      if (typeof newMessage.content === 'string') {
+        return newMessage as ModelMessage;
+      }
+
+      // remove providerOptions from parts
+      return {
+        ...newMessage,
+        content: newMessage.content.map(part => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { providerOptions: _partProviderOptions, ...newPart } =
+            part as any;
+          return newPart;
+        }),
+      } as ModelMessage;
+    });
   }
 
   return messages;


### PR DESCRIPTION
### Description

Fixes #11036

When `pruneMessages` drops reasoning or tool calls from a message, the remaining parts may still carry `providerOptions` (which OpenAI uses for validation signatures). OpenAI sees the signatures, looks for the pruned reasoning parts, and rejects the request because they are missing.

This PR adds an optional `providerOptions?: 'keep' | 'remove'` flag to `pruneMessages` (defaulting to `'keep'`). When set to `'remove'`, it recursively strips `providerOptions` from messages and their content parts. This tricks the provider into treating them as brand-new messages without strictly checking signatures for pruned parts.

### Testing
- [x] Added unit tests for removing `providerOptions`
- [x] Verified tests pass locally
- [x] Verified types