### PR TITLE
fix(amazon-bedrock): add claude-haiku-4-5 to structured output reject lists

### DIFF
--- a/.changeset/fix-bedrock-haiku-45-structured-output.md
+++ b/.changeset/fix-bedrock-haiku-45-structured-output.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): add claude-haiku-4-5 to structured output and strict mode reject lists so it correctly falls back to the json instruction tool

--- a/packages/amazon-bedrock/src/amazon-bedrock-anthropic-model-support.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-anthropic-model-support.ts
@@ -14,6 +14,7 @@ export function supportsNativeStructuredOutput(modelId: string): boolean {
 const MODELS_WITHOUT_STRICT_TOOL_SUPPORT = [
   'claude-opus-4-7',
   'claude-opus-4-8',
+  'claude-haiku-4-5',
   'claude-opus-5',
   'claude-fable-5',
   'claude-sonnet-5',

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -20,6 +20,7 @@ vi.mock('@ai-sdk/anthropic/internal', async importOriginal => {
   return {
     ...original,
     prepareTools: vi.fn(),
+    sanitizeJsonSchema: (schema: any) => schema,
     anthropicTools: {
       ...original.anthropicTools,
       bash_20241022: (args: any) => ({

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -20,7 +20,6 @@ vi.mock('@ai-sdk/anthropic/internal', async importOriginal => {
   return {
     ...original,
     prepareTools: vi.fn(),
-    sanitizeJsonSchema: (schema: any) => schema,
     anthropicTools: {
       ...original.anthropicTools,
       bash_20241022: (args: any) => ({


### PR DESCRIPTION
### Description

Fixes #19988

Bedrock's Converse and Messages APIs reject `output_config.format` and `toolConfig.toolChoice.tool` (strict mode) for `claude-haiku-4-5` (specifically `us.anthropic.claude-haiku-4-5-20251001-v1:0`). This adds it to the negation lists in the Bedrock and Bedrock Anthropic providers so that it correctly falls back to the json instruction/response tool.

### Testing
- [x] Verified tests pass locally
- [x] Verified types