### PR TITLE
fix(ui): encode chatId in URL and consistently route providerExecuted tool errors through onError

### DIFF
--- a/.changeset/fix-ui-chatid-encoding-onerror-consistency.md
+++ b/.changeset/fix-ui-chatid-encoding-onerror-consistency.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ui): encode chatId with encodeURIComponent in reconnectToStream URL, and consistently route providerExecuted tool errors through the onError sanitization callback

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -17882,7 +17882,7 @@ describe('streamText', () => {
                 "type": "tool-input-available",
               },
               {
-                "errorText": "ERROR",
+                "errorText": "An error occurred.",
                 "providerExecuted": true,
                 "providerMetadata": {
                   "provider": {
@@ -17904,8 +17904,8 @@ describe('streamText', () => {
       });
     });
 
-    describe('provider-executed tool error with structured object preserves error in ui message stream', () => {
-      it('should preserve structured error despite custom onError for provider-executed tools', async () => {
+    describe('provider-executed tool error routes through onError for consistent sanitization', () => {
+      it('should route providerExecuted tool errors through onError like all other errors', async () => {
         const result = streamText({
           model: createTestModel({
             stream: convertArrayToReadableStream([
@@ -17957,11 +17957,9 @@ describe('streamText', () => {
           (c: any) => c.type === 'tool-output-error',
         );
 
-        const parsed = JSON.parse((errorChunk as any).errorText);
-        expect(parsed).toEqual({
-          type: 'web_fetch_tool_result_error',
-          errorCode: 'url_not_accessible',
-        });
+        // providerExecuted errors now route through onError() consistently,
+        // so the custom message is returned instead of the raw structured error.
+        expect((errorChunk as any).errorText).toBe('Oops, an error occurred!');
       });
     });
 

--- a/packages/ai/src/ui-message-stream/to-ui-message-chunk.test.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-chunk.test.ts
@@ -532,14 +532,16 @@ describe('toUIMessageChunk', () => {
           dynamic: true,
         },
         {
-          onError: () => 'should not be used for provider-executed errors',
+          // providerExecuted errors are now routed through onError() for
+          // consistent sanitization, same as all other error paths.
+          onError: () => 'sanitized provider error',
           tools,
         },
       ),
     ).toEqual({
       type: 'tool-output-error',
       toolCallId: 'call-2',
-      errorText: '{"code":"provider-error"}',
+      errorText: 'sanitized provider error',
       providerExecuted: true,
       providerMetadata,
       toolMetadata,
@@ -559,7 +561,8 @@ describe('toUIMessageChunk', () => {
     ).toEqual({
       type: 'tool-output-error',
       toolCallId: 'call-string-error',
-      errorText: 'provider string error',
+      // default onError returns 'An error occurred.' for all errors including providerExecuted
+      errorText: 'An error occurred.',
       providerExecuted: true,
       dynamic: true,
     });

--- a/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
+++ b/packages/ai/src/ui-message-stream/to-ui-message-chunk.ts
@@ -301,11 +301,10 @@ export function toUIMessageChunk<
       return {
         type: 'tool-output-error',
         toolCallId: part.toolCallId,
-        errorText: part.providerExecuted
-          ? typeof part.error === 'string'
-            ? part.error
-            : JSON.stringify(part.error)
-          : onError(part.error),
+        // Always route through onError() for consistent sanitization, even for
+        // providerExecuted tools (e.g. hosted web-search). This lets developers
+        // redact provider error metadata, matching the intent of every other error path.
+        errorText: onError(part.error),
         ...(part.providerExecuted != null
           ? { providerExecuted: part.providerExecuted }
           : {}),

--- a/packages/ai/src/ui/http-chat-transport.ts
+++ b/packages/ai/src/ui/http-chat-transport.ts
@@ -233,7 +233,9 @@ export abstract class HttpChatTransport<
       requestMetadata: options.metadata,
     });
 
-    const api = preparedRequest?.api ?? `${this.api}/${options.chatId}/stream`;
+    const api =
+      preparedRequest?.api ??
+      `${this.api}/${encodeURIComponent(options.chatId)}/stream`;
     const headers =
       preparedRequest?.headers !== undefined
         ? normalizeHeaders(preparedRequest.headers)


### PR DESCRIPTION
### Description

Fixes #18187 (findings 3 and 4 from the security hardening report).

---

### Finding 3 — `chatId` URL path encoding

`reconnectToStream` interpolated the developer-supplied `chatId` directly into the URL path with no `encodeURIComponent()`, unlike `sendMessages()` where the same value is safely serialized into the JSON body.

`chatId` is developer-settable via `useChat({ id })` (documented, and commonly used for resumable/URL-driven chat sessions), so a value like `"../other-route"` would silently reshape the request path.

**Fix:** Wrap with `encodeURIComponent` for consistency and defense-in-depth.

---

### Finding 4 — `onError` bypass for `providerExecuted` tool errors

In `to-ui-message-chunk.ts`, the `onError` callback's documented intent is to "prevent leaking server error details to the client by default." It was applied consistently in the `'error'` case and in the non-`providerExecuted` branch of `'tool-error'` — but when `providerExecuted: true`, the raw error object was `JSON.stringify`'d and sent to the client directly, bypassing `onError` entirely.

This is inconsistent with every other error path and violates the contract of `onError`.

**Fix:** Route all tool errors — including `providerExecuted` ones — through `onError()`, matching every other error path.

### Testing
- [x] 2965/2965 tests pass for the `ai` package
- [x] Updated relevant test expectations and inline snapshots to reflect the new behavior