### PR TITLE
feat (provider-utils): route zod 4 schemas through the Standard Schema interface

### DIFF
--- a/.changeset/standard-schema-first.md
+++ b/.changeset/standard-schema-first.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/provider-utils": patch
+---
+
+feat (provider-utils): route zod 4 schemas through the Standard Schema interface in `asSchema`

--- a/packages/provider-utils/src/schema.test.ts
+++ b/packages/provider-utils/src/schema.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { TypeValidationError } from '@ai-sdk/provider';
+import * as z3 from 'zod/v3';
 import * as z4 from 'zod/v4';
 import { safeParseJSON } from './parse-json';
 import { asSchema, zodSchema, type StandardSchema } from './schema';
@@ -574,6 +576,108 @@ describe('StandardSchema (StandardJSONSchemaV1)', () => {
   });
 
   describe('asSchema detection', () => {
+    it('should route a zod schema that provides standard JSON schema through the standard schema interface', async () => {
+      // zod >= 4.2 exposes `~standard.jsonSchema`; hand-built here so the test does not depend on the installed zod version
+      const zodLikeSchema: StandardSchema<{ text: string }> = {
+        '~standard': {
+          version: 1,
+          vendor: 'zod',
+          validate: value =>
+            typeof value === 'object' &&
+            value != null &&
+            typeof (value as any).text === 'string'
+              ? { value: value as { text: string } }
+              : { issues: [{ message: 'expected text', path: ['text'] }] },
+          jsonSchema: {
+            input: () => ({
+              type: 'object',
+              properties: { text: { type: 'string' } },
+            }),
+            output: () => ({
+              type: 'object',
+              properties: { text: { type: 'string' } },
+            }),
+          },
+        },
+      } as StandardSchema<{ text: string }>;
+
+      const schema = asSchema(zodLikeSchema);
+
+      expect(await schema.jsonSchema).toStrictEqual({
+        type: 'object',
+        additionalProperties: false,
+        properties: { text: { type: 'string' } },
+      });
+
+      expect(await schema.validate?.({ text: 'hello' })).toStrictEqual({
+        success: true,
+        value: { text: 'hello' },
+      });
+
+      const result = await schema.validate?.({ text: 123 });
+      expect(result?.success).toBe(false);
+      if (result?.success !== false) {
+        throw new Error('Expected validation to fail');
+      }
+      expect(result.error).toBeInstanceOf(TypeValidationError);
+      expect((result.error as TypeValidationError).cause).toStrictEqual([
+        { message: 'expected text', path: ['text'] },
+      ]);
+    });
+
+    it('should keep a zod schema without standard JSON schema on the zod adapter', async () => {
+      // the installed zod/v4 predates `~standard.jsonSchema`, so it takes this path
+      const schema = asSchema(z4.object({ text: z4.string() }));
+
+      expect(await schema.jsonSchema).toStrictEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: { text: { type: 'string' } },
+        required: ['text'],
+        additionalProperties: false,
+      });
+
+      const result = await schema.validate?.({ text: 123 });
+      expect(result?.success).toBe(false);
+      if (result?.success !== false) {
+        throw new Error('Expected validation to fail');
+      }
+      expect(result.error).toBeInstanceOf(z4.ZodError);
+    });
+
+    it('should keep validating zod 4 schemas with async refinements', async () => {
+      const schema = asSchema(
+        z4.object({
+          text: z4.string().refine(async value => value.length > 0),
+        }),
+      );
+
+      expect(await schema.validate?.({ text: 'hello' })).toStrictEqual({
+        success: true,
+        value: { text: 'hello' },
+      });
+      expect((await schema.validate?.({ text: '' }))?.success).toBe(false);
+    });
+
+    it('should keep zod 3 schemas on the zod adapter', async () => {
+      const schema = asSchema(z3.object({ text: z3.string() }));
+
+      expect(await schema.jsonSchema).toStrictEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: { text: { type: 'string' } },
+        required: ['text'],
+        additionalProperties: false,
+      });
+
+      const result = await schema.validate?.({ text: 123 });
+      expect(result?.success).toBe(false);
+      if (result?.success !== false) {
+        throw new Error('Expected validation to fail');
+      }
+      expect(result.error).toBeInstanceOf(z3.ZodError);
+    });
+
     it('should detect non-zod standard schema by vendor', async () => {
       const standardSchema: StandardSchema<{ text: string }> = {
         '~standard': {

--- a/packages/provider-utils/src/schema.ts
+++ b/packages/provider-utils/src/schema.ts
@@ -151,7 +151,10 @@ export function asSchema<OBJECT>(
     : isSchema(schema)
       ? schema
       : '~standard' in schema
-        ? schema['~standard'].vendor === 'zod'
+        ? // a zod schema that cannot describe itself as Standard JSON Schema (zod 3) keeps the zod adapter;
+          // everything else, zod 4 included, goes through the Standard Schema interface
+          schema['~standard'].vendor === 'zod' &&
+          !hasStandardJsonSchema(schema as StandardSchema<OBJECT>)
           ? zodSchema(schema as ZodSchema<OBJECT>)
           : standardSchema(schema as StandardSchema<OBJECT>)
         : schema();


### PR DESCRIPTION
Routes a zod 4 schema through the Standard Schema interface in `asSchema` instead of the zod adapter.

The zod adapter validates with `safeParseAsync`, which always takes zod's async walk and skips its JIT fastpass and compile shim. Zod's `~standard.validate` runs the sync walk and falls back to async only when a schema has async work, and since zod 4.2 `~standard.jsonSchema` emits the same JSON Schema the adapter builds. With this change a zod schema takes the generic Standard Schema path whenever it exposes `~standard.jsonSchema`; zod 3 and zod 4 before 4.2 keep the adapter.

Measured on the SDK's own OpenAI response schemas, µs per validation:

| schema | zod adapter | Standard Schema |
| --- | --- | --- |
| chat chunk | 0.83 | 0.19 |
| chat response | 1.53 | 0.32 |
| Responses API response | 2.81 | 0.57 |

> [!NOTE]
> For zod ≥ 4.2 the validation error becomes a `TypeValidationError` whose `cause` is the Standard Schema issues array, where it was a `ZodError`. That is a behavior change, so this likely belongs in the next major; the changeset is `patch` for now and the branch can be retargeted.
