### PR TITLE
docs(provider): add AI Power Grid community provider

### DIFF
--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -98,6 +98,7 @@ The open-source community has created the following providers:
 - [Crusoe Provider](/providers/community-providers/crusoe) (`crusoe-ai-provider`)
 - [Neon AI Gateway Provider](/providers/community-providers/neon-ai-gateway) (`@neon/ai-sdk-provider`)
 - [Interfaze Provider](/providers/community-providers/interfaze) (`@interfaze-ai/ai-sdk`)
+- [AI Power Grid Provider](/providers/community-providers/aipg) (`@aipowergrid/ai-sdk-provider`)
 
 ## Self-Hosted Models
 

--- a/content/providers/05-community-providers/55-aipg.mdx
+++ b/content/providers/05-community-providers/55-aipg.mdx
@@ -1,0 +1,177 @@
+---
+title: AI Power Grid
+description: Use community-operated text and media models through AI Power Grid.
+---
+
+# AI Power Grid Provider
+
+The [AI Power Grid](https://aipowergrid.io/) community provider supplies AI SDK
+models for text, image, and experimental video generation. It also includes a
+typed music helper because music generation is not speech synthesis.
+
+## Setup
+
+Install the provider with AI SDK 7:
+
+<InstallPackages packages="ai @aipowergrid/ai-sdk-provider" />
+
+Create a scoped key in the [Grid Console](https://console.aipowergrid.io/dashboard/api-key).
+Use `inference.submit` for generation and add `account.read` when the application
+uses model discovery, quotes, or credit summaries. Keep the key server-side:
+
+```bash
+AIPG_API_KEY=grid_...
+```
+
+Do not expose the key through client components, browser JavaScript, or public
+environment-variable prefixes such as `NEXT_PUBLIC_*` and `VITE_*`.
+
+## Provider Instance
+
+Import the default provider when `AIPG_API_KEY` is available in the server
+environment:
+
+```ts
+import { aipg } from '@aipowergrid/ai-sdk-provider';
+```
+
+Use `createAipg` to pass configuration explicitly:
+
+```ts
+import { createAipg } from '@aipowergrid/ai-sdk-provider';
+
+const aipg = createAipg({
+  apiKey: process.env.AIPG_API_KEY,
+});
+```
+
+## Text Generation
+
+`auto` lets Grid route a request to an available text worker:
+
+```ts
+import { generateText } from 'ai';
+import { aipg } from '@aipowergrid/ai-sdk-provider';
+
+const { text } = await generateText({
+  model: aipg('auto'),
+  prompt: 'Explain verifiable inference in two sentences.',
+});
+```
+
+### Streaming
+
+```ts
+import { streamText } from 'ai';
+import { aipg } from '@aipowergrid/ai-sdk-provider';
+
+const result = streamText({
+  model: aipg('auto'),
+  prompt: 'Give me three names for a distributed image application.',
+  maxOutputTokens: 128,
+});
+
+for await (const textPart of result.textStream) {
+  process.stdout.write(textPart);
+}
+```
+
+Pass a named model returned by `aipg.listTextModels()` when the application
+must pin a currently advertised backend. Availability follows connected
+workers and can change between discovery and dispatch.
+
+## Image Generation
+
+```ts
+import { generateImage } from 'ai';
+import { aipg } from '@aipowergrid/ai-sdk-provider';
+
+const result = await generateImage({
+  model: aipg.imageModel('Krea 2 Turbo'),
+  prompt: 'A solar-powered compute cooperative, editorial photography',
+  size: '1024x1024',
+  providerOptions: {
+    aipg: {
+      negativePrompt: 'text, watermark',
+      outputFormat: 'webp',
+    },
+  },
+});
+```
+
+The image model accepts one inline source image for image-to-image generation.
+Remote source URLs and masks are rejected rather than silently ignored.
+
+## Video Generation
+
+AI SDK 7 currently marks video generation experimental:
+
+```ts
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { aipg } from '@aipowergrid/ai-sdk-provider';
+
+const result = await generateVideo({
+  model: aipg.videoModel('LTX Director 2.0'),
+  prompt: 'Slow camera push through a luminous server hall',
+  resolution: '768x512',
+  duration: 4,
+  fps: 24,
+});
+```
+
+Image-to-video models such as `LTX-2.3` require one inline start frame. Remote
+URL inputs, frame arrays, and reference collections are rejected because the
+current Grid request contract does not support them.
+
+## Music Generation
+
+Music uses an explicit helper instead of the AI SDK speech interface:
+
+```ts
+import { aipg } from '@aipowergrid/ai-sdk-provider';
+
+const song = await aipg.generateMusic({
+  prompt: 'Upbeat synth rock, confident, clean harmony',
+  lyrics: 'Power moves across the grid',
+  seconds: 30,
+  bpm: 112,
+  keyScale: 'A minor',
+});
+```
+
+## Discovery, Credits, and Quotes
+
+```ts
+const textModels = await aipg.listTextModels();
+const onlineCapacity = await aipg.listOnlineModels();
+const credits = await aipg.credits();
+const quote = await aipg.quote({
+  model: 'Krea 2 Turbo',
+  modality: 'image',
+  n: 1,
+});
+```
+
+Media calls verify that the selected model is online for the requested modality
+before dispatch. The quote endpoint and settled Grid credit balance are the
+billing authority; callers should not hard-code a price from this page.
+
+## Errors and Trust Boundary
+
+Non-successful Grid responses surface as `AipgApiError` with an HTTP `status`
+and bounded message. Applications must handle authentication, insufficient
+credit, unavailable-model, timeout, and worker-failure responses. A model in a
+discovery result is current capacity evidence, not an uptime guarantee.
+
+Grid routes requests to remote, community-operated workers. The worker executing
+a request may be able to inspect its plaintext input and output. Do not send
+secrets, credentials, personal data, or regulated content unless a separately
+documented confidential tier meets the application's requirements.
+
+This community provider is maintained by AI Power Grid and does not imply a
+partnership with Vercel.
+
+## Additional Resources
+
+- [`@aipowergrid/ai-sdk-provider` on npm](https://www.npmjs.com/package/@aipowergrid/ai-sdk-provider)
+- [Source and documentation](https://github.com/AIPowerGrid/grid-provider-integrations/tree/main/ai-sdk-aipg)


### PR DESCRIPTION
## Background

AI Power Grid publishes `@aipowergrid/ai-sdk-provider@0.1.0`, a community provider for AI SDK 7 that exposes text, image, and experimental video models plus a typed music-generation helper. The package is public on npm with provenance and its packed-package production gate has exercised discovery, quoting, streaming, and charging reconciliation against the live Grid endpoint.

The provider routes work to remote community-operated workers, so the documentation explicitly covers server-side credential handling and the plaintext worker trust boundary.

## Summary

- add an AI Power Grid community-provider page
- document text generation and streaming through standard AI SDK interfaces
- document image and experimental video models plus the explicit music helper
- cover live model discovery, credit summaries, canonical quotes, and failure handling
- add the provider to the community-provider list

This is documentation for a separately maintained community package. It does not add or modify a Vercel-owned package.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Verification

- commit `22b0e4f5438b8bc1b2f6729379ebd7b1bb2e7904` is GitHub-signed and verified
- `oxfmt --check` passes for both changed MDX files
- `node tools/validate-properties-tables.mjs` validates all 156 MDX files
- `git diff --check` passes
- the package name, version, exports, examples, and live model identifiers were checked against the published npm artifact and current Grid model catalog
- every public documentation link was checked; the npm package was separately verified with `npm view`

## Future Work

Model availability follows connected workers and changes over time. The package's discovery methods and Grid quote endpoint remain authoritative rather than a static model or price table in this page.
