### PR TITLE
fix(minimax): support 480P and 768P video resolutions

### DIFF
--- a/.changeset/bright-videos-resolve.md
+++ b/.changeset/bright-videos-resolve.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/minimax': patch
+---
+
+Add model-aware MiniMax 480P and 768P video resolutions, duration limits, and reference-input validation.

--- a/.changeset/lucky-tiers-resolve.md
+++ b/.changeset/lucky-tiers-resolve.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/minimax': patch
+---
+
+Map MiniMax 480P and 768P frame sizes onto their named video resolution tiers, so a typed top-level `resolution` can reach them.

--- a/content/providers/01-ai-sdk-providers/33-minimax.mdx
+++ b/content/providers/01-ai-sdk-providers/33-minimax.mdx
@@ -152,6 +152,7 @@ const { video } = await generateVideo({
   duration: 5,
   providerOptions: {
     minimax: {
+      resolution: '768P',
       pollTimeoutMs: 600000, // 10 minutes
     } satisfies MiniMaxVideoModelOptions,
   },
@@ -161,9 +162,11 @@ const { video } = await generateVideo({
 MiniMax-H3 generates one video per call. Generation is asynchronous — the model
 creates a task and polls until it completes, then returns the resulting MP4 URL.
 
-`duration` accepts a whole number of seconds from 5 to 15, and defaults to 5. A
-fractional value is rounded and an out-of-range value is clamped, each with a
-warning. The only supported output resolution is `2K`.
+`duration` accepts a whole number of seconds and defaults to 5. MiniMax-H3
+supports 4 to 15 seconds; MiniMax-H3-Max supports 5 to 15 seconds. A fractional
+value is rounded and an out-of-range value is clamped, each with a warning.
+MiniMax-H3 supports `768P` and `2K` output, while MiniMax-H3-Max supports `480P`
+and `768P`.
 
 For **text-to-video**, `aspectRatio` defaults to `16:9` when omitted. The MiniMax
 API requires a concrete ratio for text-only requests and does not accept
@@ -185,9 +188,10 @@ The generation mode is inferred from the inputs you pass:
   `frameType: 'first_frame'`) to animate a starting image.
 - **First-to-last keyframes** — pass `frameImages` with both a `first_frame` and
   a `last_frame` to control the transition.
-- **Reference-to-video** — pass `inputReferences` (images and/or videos, routed
-  by media type) to keep a subject/style or follow motion. Frame images and
-  references are mutually exclusive.
+- **Reference-to-video (MiniMax-H3 only)** — pass `inputReferences` (images
+  and/or videos, routed by media type) to keep a subject/style or follow motion.
+  Frame images and references are mutually exclusive. MiniMax-H3-Max does not
+  support reference-to-video inputs.
 
 When a frame image is supplied, the aspect ratio follows the image and any
 explicit `aspectRatio` is ignored.
@@ -196,9 +200,10 @@ explicit `aspectRatio` is ignored.
 
 The following optional provider options are available for MiniMax video models:
 
-- **resolution** _string_
+- **resolution** _'480P' | '768P' | '2K'_
 
-  Output resolution. MiniMax-H3 currently only supports `'2K'` (the default).
+  Output resolution. MiniMax-H3 supports `'768P'` and `'2K'` (the default).
+  MiniMax-H3-Max supports `'480P'` and `'768P'` (the default).
 
 - **ratio** _'adaptive' | '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16'_
 
@@ -206,8 +211,9 @@ The following optional provider options are available for MiniMax video models:
 
 - **referenceAudioUrls** _string[]_
 
-  Reference audio URLs (or `mm_file://` handles) for reference-to-video
-  generation. Must be paired with at least one reference image or video. Up to 3.
+  Reference audio URLs (or `mm_file://` handles) for MiniMax-H3
+  reference-to-video generation. Must be paired with at least one reference
+  image or video. Up to 3. MiniMax-H3-Max does not support reference audio.
 
 - **aigcWatermark** _boolean_
 

--- a/content/providers/01-ai-sdk-providers/33-minimax.mdx
+++ b/content/providers/01-ai-sdk-providers/33-minimax.mdx
@@ -137,9 +137,10 @@ The following optional provider options are available for MiniMax language model
 
 ## Video Models
 
-You can generate videos with the MiniMax-H3 model using the
-[`experimental_generateVideo`](/docs/reference/ai-sdk-core/generate-video)
-function:
+You can generate videos with the MiniMax-H3 and MiniMax-H3-Max models using
+the [`experimental_generateVideo`](/docs/reference/ai-sdk-core/generate-video)
+function. MiniMax-H3-Max is the faster variant: it renders at lower resolutions
+and serves every mode except reference-to-video.
 
 ```ts
 import { minimax, type MiniMaxVideoModelOptions } from '@ai-sdk/minimax';
@@ -159,7 +160,7 @@ const { video } = await generateVideo({
 });
 ```
 
-MiniMax-H3 generates one video per call. Generation is asynchronous — the model
+Both models generate one video per call. Generation is asynchronous — the model
 creates a task and polls until it completes, then returns the resulting MP4 URL.
 
 `duration` accepts a whole number of seconds and defaults to 5. MiniMax-H3
@@ -167,6 +168,19 @@ supports 4 to 15 seconds; MiniMax-H3-Max supports 5 to 15 seconds. A fractional
 value is rounded and an out-of-range value is clamped, each with a warning.
 MiniMax-H3 supports `768P` and `2K` output, while MiniMax-H3-Max supports `480P`
 and `768P`.
+
+The API takes a named tier rather than a frame size, so a top-level `resolution`
+is matched against a fixed table of one frame size per tier per aspect ratio:
+
+| Tier   | Accepted `resolution` values                                                 |
+| ------ | ---------------------------------------------------------------------------- |
+| `480P` | `480x480`, `1120x480`, `854x480`, `640x480`, `480x854`, `480x640`            |
+| `768P` | `768x768`, `1792x768`, `1366x768`, `1024x768`, `768x1366`, `768x1024`        |
+| `2K`   | `2048x2048`, `2560x1080`, `2560x1440`, `2048x1536`, `1440x2560`, `1536x2048` |
+
+Anything outside the table, or a tier the selected model does not support, warns
+and falls back to the model default. `providerOptions.minimax.resolution` names
+the tier exactly and wins over the top-level value, which is reported as ignored.
 
 For **text-to-video**, `aspectRatio` defaults to `16:9` when omitted. The MiniMax
 API requires a concrete ratio for text-only requests and does not accept

--- a/examples/ai-functions/src/generate-video/minimax/basic.ts
+++ b/examples/ai-functions/src/generate-video/minimax/basic.ts
@@ -16,6 +16,7 @@ run(async () => {
         duration: 5,
         providerOptions: {
           minimax: {
+            resolution: '768P',
             pollTimeoutMs: 600000, // 10 minutes
           } satisfies MiniMaxVideoModelOptions,
         },

--- a/packages/minimax/src/minimax-video-model-options.ts
+++ b/packages/minimax/src/minimax-video-model-options.ts
@@ -2,7 +2,7 @@ import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
 /**
- * Aspect ratios supported by the MiniMax-H3 video model.
+ * Aspect ratios supported by the MiniMax video models.
  */
 export const minimaxVideoRatios = [
   'adaptive',

--- a/packages/minimax/src/minimax-video-model-options.ts
+++ b/packages/minimax/src/minimax-video-model-options.ts
@@ -15,9 +15,10 @@ export const minimaxVideoRatios = [
 ] as const;
 
 /**
- * Output resolutions supported by the MiniMax-H3 video model.
+ * Output resolutions supported by MiniMax video models. Availability depends
+ * on the selected model.
  */
-export const minimaxVideoResolutions = ['2K'] as const;
+export const minimaxVideoResolutions = ['480P', '768P', '2K'] as const;
 
 /**
  * Provider options for MiniMax video generation.

--- a/packages/minimax/src/minimax-video-model.test.ts
+++ b/packages/minimax/src/minimax-video-model.test.ts
@@ -328,6 +328,146 @@ describe('MiniMaxVideoModel', () => {
       },
     );
 
+    // The lower tiers get the same one-frame-size-per-ratio treatment as 2K, so
+    // a typed caller — whose `resolution` is `{width}x{height}` — can reach them
+    // without dropping to provider options.
+    it.each([
+      ['768x768', '1:1'],
+      ['1792x768', '21:9'],
+      ['1366x768', '16:9'],
+      ['1024x768', '4:3'],
+      ['768x1366', '9:16'],
+      ['768x1024', '3:4'],
+    ] as const)(
+      'should map the top-level resolution %s (%s) onto the 768P tier',
+      async (resolution, aspectRatio) => {
+        const model = createModel();
+
+        const { warnings } = await model.doGenerate({
+          ...defaultOptions,
+          resolution,
+          aspectRatio,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'MiniMax-H3',
+          content: [{ type: 'text', text: prompt }],
+          resolution: '768P',
+          duration: 5,
+          ratio: aspectRatio,
+        });
+        expect(
+          warnings.some(
+            w => w.type === 'unsupported' && w.feature === 'resolution',
+          ),
+        ).toBe(false);
+      },
+    );
+
+    it.each([
+      ['480x480', '1:1'],
+      ['1120x480', '21:9'],
+      ['854x480', '16:9'],
+      ['640x480', '4:3'],
+      ['480x854', '9:16'],
+      ['480x640', '3:4'],
+    ] as const)(
+      'should map the top-level resolution %s (%s) onto the 480P tier',
+      async (resolution, aspectRatio) => {
+        const model = createModel({ modelId: 'MiniMax-H3-Max' });
+
+        const { warnings } = await model.doGenerate({
+          ...defaultOptions,
+          resolution,
+          aspectRatio,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'MiniMax-H3-Max',
+          content: [{ type: 'text', text: prompt }],
+          resolution: '480P',
+          duration: 5,
+          ratio: aspectRatio,
+        });
+        expect(
+          warnings.some(
+            w => w.type === 'unsupported' && w.feature === 'resolution',
+          ),
+        ).toBe(false);
+      },
+    );
+
+    it('should map a 768P frame size on MiniMax-H3-Max, not just fall back to its default', async () => {
+      const model = createModel({ modelId: 'MiniMax-H3-Max' });
+
+      const { warnings } = await model.doGenerate({
+        ...defaultOptions,
+        resolution: '1366x768',
+        aspectRatio: '16:9',
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        model: 'MiniMax-H3-Max',
+        resolution: '768P',
+      });
+      expect(
+        warnings.some(
+          w => w.type === 'unsupported' && w.feature === 'resolution',
+        ),
+      ).toBe(false);
+    });
+
+    // Now that every tier has frame sizes, a top-level value can name a real
+    // but different tier than the provider option. The option still wins, but
+    // dropping the top-level value has to be reported.
+    it('should warn when a mapped top-level resolution names a different tier than the provider option', async () => {
+      const model = createModel();
+
+      const { warnings } = await model.doGenerate({
+        ...defaultOptions,
+        resolution: '1366x768',
+        providerOptions: minimaxOptions({ resolution: '2K' }),
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        resolution: '2K',
+      });
+      expect(warnings).toContainEqual({
+        type: 'unsupported',
+        feature: 'resolution',
+        details:
+          'The resolution "1366x768" selects 768P, but ' +
+          'providerOptions.minimax.resolution ("2K") was used instead.',
+      });
+    });
+
+    // A frame size can now name a real tier the selected model does not serve.
+    it.each([
+      ['MiniMax-H3', '854x480', '480P', '2K'],
+      ['MiniMax-H3-Max', '2560x1440', '2K', '768P'],
+    ] as const)(
+      'should warn that %s does not support the %s tier and use %s',
+      async (modelId, resolution, tier, expectedResolution) => {
+        const model = createModel({ modelId });
+
+        const { warnings } = await model.doGenerate({
+          ...defaultOptions,
+          resolution,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          resolution: expectedResolution,
+        });
+        expect(warnings).toContainEqual({
+          type: 'unsupported',
+          feature: 'resolution',
+          details: expect.stringContaining(
+            `${modelId} does not support the resolution "${tier}".`,
+          ),
+        });
+      },
+    );
+
     it.each([
       ['MiniMax-H3', '480P', '2K'],
       ['MiniMax-H3-Max', '2K', '768P'],

--- a/packages/minimax/src/minimax-video-model.test.ts
+++ b/packages/minimax/src/minimax-video-model.test.ts
@@ -7,6 +7,7 @@ import type { FetchFunction } from '@ai-sdk/provider-utils';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { describe, expect, it } from 'vitest';
 import { MiniMaxVideoModel } from './minimax-video-model';
+import type { MiniMaxVideoModelId } from './minimax-video-settings';
 
 const prompt = 'A white kitten chases a butterfly across a sunlit garden.';
 
@@ -85,11 +86,13 @@ const defaultOptions = {
 function createModel({
   currentDate,
   fetch,
+  modelId = 'MiniMax-H3',
 }: {
   currentDate?: () => Date;
   fetch?: FetchFunction;
+  modelId?: MiniMaxVideoModelId;
 } = {}) {
-  return new MiniMaxVideoModel('MiniMax-H3', {
+  return new MiniMaxVideoModel(modelId, {
     provider: 'minimax.video',
     baseURL: TEST_BASE_URL,
     headers: () => ({ Authorization: 'Bearer test-key' }),
@@ -145,6 +148,20 @@ describe('MiniMaxVideoModel', () => {
         model: 'MiniMax-H3',
         content: [{ type: 'text', text: prompt }],
         resolution: '2K',
+        duration: 5,
+        ratio: '16:9',
+      });
+    });
+
+    it('should send the documented default payload for MiniMax-H3-Max', async () => {
+      const model = createModel({ modelId: 'MiniMax-H3-Max' });
+
+      await model.doGenerate({ ...defaultOptions });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'MiniMax-H3-Max',
+        content: [{ type: 'text', text: prompt }],
+        resolution: '768P',
         duration: 5,
         ratio: '16:9',
       });
@@ -218,14 +235,14 @@ describe('MiniMaxVideoModel', () => {
         model: 'MiniMax-H3',
         content: [{ type: 'text', text: prompt }],
         resolution: '2K',
-        duration: 5,
+        duration: 4,
         ratio: '16:9',
       });
       expect(warnings).toContainEqual({
         type: 'unsupported',
         feature: 'duration',
         details:
-          'MiniMax-H3 requires at least 5 seconds. The requested duration of 3 was clamped to 5.',
+          'MiniMax-H3 requires at least 4 seconds. The requested duration of 3 was clamped to 4.',
       });
     });
 
@@ -266,7 +283,7 @@ describe('MiniMaxVideoModel', () => {
         model: 'MiniMax-H3',
         content: [{ type: 'text', text: prompt }],
         resolution: '2K',
-        duration: 5,
+        duration: 4,
         ratio: '16:9',
       });
       expect(
@@ -308,6 +325,32 @@ describe('MiniMaxVideoModel', () => {
             w => w.type === 'unsupported' && w.feature === 'resolution',
           ),
         ).toBe(false);
+      },
+    );
+
+    it.each([
+      ['MiniMax-H3', '480P', '2K'],
+      ['MiniMax-H3-Max', '2K', '768P'],
+    ] as const)(
+      'should reject %s resolution %s and use %s',
+      async (modelId, resolution, expectedResolution) => {
+        const model = createModel({ modelId });
+
+        const { warnings } = await model.doGenerate({
+          ...defaultOptions,
+          providerOptions: minimaxOptions({ resolution }),
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          resolution: expectedResolution,
+        });
+        expect(warnings).toContainEqual({
+          type: 'unsupported',
+          feature: 'resolution',
+          details: expect.stringContaining(
+            `The provider resolution "${resolution}" was ignored.`,
+          ),
+        });
       },
     );
 
@@ -702,6 +745,62 @@ describe('MiniMaxVideoModel', () => {
   });
 
   describe('request body', () => {
+    it.each([
+      ['MiniMax-H3-Max', '480P'],
+      ['MiniMax-H3', '768P'],
+    ] as const)(
+      'should send the %s resolution %s using MiniMax casing',
+      async (modelId, resolution) => {
+        const model = createModel({ modelId });
+
+        await model.doGenerate({
+          ...defaultOptions,
+          providerOptions: minimaxOptions({ resolution }),
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: modelId,
+          content: [{ type: 'text', text: prompt }],
+          resolution,
+          duration: 5,
+          ratio: '16:9',
+        });
+      },
+    );
+
+    it('should omit reference inputs that MiniMax-H3-Max does not support', async () => {
+      const model = createModel({ modelId: 'MiniMax-H3-Max' });
+
+      const { warnings } = await model.doGenerate({
+        ...defaultOptions,
+        inputReferences: [imageUrlFile, videoUrlFile],
+        providerOptions: minimaxOptions({
+          resolution: '480P',
+          referenceAudioUrls: ['https://cdn.example.com/ref.wav'],
+        }),
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'MiniMax-H3-Max',
+        content: [{ type: 'text', text: prompt }],
+        resolution: '480P',
+        duration: 5,
+        ratio: '16:9',
+      });
+      expect(warnings).toContainEqual({
+        type: 'unsupported',
+        feature: 'inputReferences',
+        details:
+          'MiniMax-H3-Max does not support reference-to-video inputs. The references were ignored.',
+      });
+      expect(warnings).toContainEqual({
+        type: 'unsupported',
+        feature: 'referenceAudioUrls',
+        details:
+          'MiniMax-H3-Max does not support reference audio. The audio was ignored.',
+      });
+    });
+
     it('should map aigcWatermark to aigc_watermark', async () => {
       const model = createModel();
 
@@ -960,6 +1059,57 @@ describe('MiniMaxVideoModel', () => {
       expect(warnings).toStrictEqual([]);
     });
 
+    it('should identify MiniMax-H3-Max in warnings shared by both models', async () => {
+      const model = createModel({ modelId: 'MiniMax-H3-Max' });
+
+      const { warnings } = await model.doGenerate({
+        ...defaultOptions,
+        image: videoUrlFile,
+        aspectRatio: '5:3',
+        fps: 30,
+        seed: 42,
+        n: 2,
+        generateAudio: false,
+      });
+
+      expect(warnings).toStrictEqual([
+        {
+          type: 'unsupported',
+          feature: 'fps',
+          details: 'MiniMax-H3-Max does not support a custom frame rate.',
+        },
+        {
+          type: 'unsupported',
+          feature: 'seed',
+          details: 'MiniMax-H3-Max does not support a seed.',
+        },
+        {
+          type: 'unsupported',
+          feature: 'n',
+          details:
+            'MiniMax-H3-Max generates a single video per call. Only 1 video will be generated.',
+        },
+        {
+          type: 'unsupported',
+          feature: 'generateAudio',
+          details:
+            'The MiniMax-H3-Max API does not expose an audio parameter. The generateAudio option was ignored.',
+        },
+        {
+          type: 'unsupported',
+          feature: 'image',
+          details:
+            'MiniMax-H3-Max does not accept a video as a frame image. The video was ignored.',
+        },
+        {
+          type: 'unsupported',
+          feature: 'aspectRatio',
+          details:
+            'MiniMax-H3-Max does not support the aspect ratio "5:3". Using the default (16:9).',
+        },
+      ]);
+    });
+
     it.each([true, false])(
       'should warn when generateAudio is %s',
       async generateAudio => {
@@ -992,13 +1142,13 @@ describe('MiniMaxVideoModel', () => {
         type: 'unsupported',
         feature: 'resolution',
         details:
-          'Unrecognized resolution "1280x720". MiniMax-H3 only supports "2K", ' +
+          'Unrecognized resolution "1280x720". MiniMax-H3 supports "768P" or "2K", ' +
           'so providerOptions.minimax.resolution ("2K") was used instead.',
       });
     });
 
-    // The provider option can only be '2K' and a recognized top-level value can
-    // only map to '2K', so a recognized pair is not a conflict and must not warn.
+    // A recognized top-level value that agrees with the provider option is not
+    // a conflict and must not warn.
     it('should not warn when a recognized resolution agrees with the provider option', async () => {
       const model = createModel();
 
@@ -1016,14 +1166,19 @@ describe('MiniMaxVideoModel', () => {
       ).toStrictEqual([]);
     });
 
-    // `2K` is what the MiniMax API itself takes, so it is the natural thing to
-    // send. The call option is typed `{width}x{height}`, but untyped callers
-    // reach the model too — the AI Gateway forwards `resolution` verbatim — and
-    // the tier must not be reported as unrecognized when it arrives.
-    it.each(['2K', '2k'])(
-      'should accept the named resolution tier %s without warning',
-      async resolution => {
-        const model = createModel();
+    // Named tiers can reach the model through untyped callers such as the AI
+    // Gateway. Normalize them to the exact casing required by MiniMax.
+    it.each([
+      ['MiniMax-H3-Max', '480P', '480P'],
+      ['MiniMax-H3-Max', '480p', '480P'],
+      ['MiniMax-H3', '768P', '768P'],
+      ['MiniMax-H3', '768p', '768P'],
+      ['MiniMax-H3', '2K', '2K'],
+      ['MiniMax-H3', '2k', '2K'],
+    ] as const)(
+      'should accept the %s resolution tier %s without warning',
+      async (modelId, resolution, expectedResolution) => {
+        const model = createModel({ modelId });
 
         const { warnings } = await model.doGenerate({
           ...defaultOptions,
@@ -1038,7 +1193,7 @@ describe('MiniMaxVideoModel', () => {
           ),
         ).toStrictEqual([]);
         expect(await server.calls[0].requestBodyJson).toMatchObject({
-          resolution: '2K',
+          resolution: expectedResolution,
         });
       },
     );
@@ -1226,7 +1381,7 @@ describe('MiniMaxVideoModel', () => {
       });
     });
 
-    it.each([5, 15])(
+    it.each([4, 5, 15])(
       'should not warn for a duration of %i seconds, which is in range',
       async duration => {
         const model = createModel();
@@ -1242,6 +1397,25 @@ describe('MiniMaxVideoModel', () => {
         expect(warnings).toStrictEqual([]);
       },
     );
+
+    it('should clamp MiniMax-H3-Max duration to its 5-second minimum', async () => {
+      const model = createModel({ modelId: 'MiniMax-H3-Max' });
+
+      const { warnings } = await model.doGenerate({
+        ...defaultOptions,
+        duration: 4,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        duration: 5,
+      });
+      expect(warnings).toContainEqual({
+        type: 'unsupported',
+        feature: 'duration',
+        details:
+          'MiniMax-H3-Max requires at least 5 seconds. The requested duration of 4 was clamped to 5.',
+      });
+    });
 
     it('should attribute a video first_frame from frameImages to the frameImages feature', async () => {
       const model = createModel();

--- a/packages/minimax/src/minimax-video-model.ts
+++ b/packages/minimax/src/minimax-video-model.ts
@@ -63,20 +63,32 @@ const modelResolutionSettings: Record<
 };
 
 // The top-level `resolution` is `{width}x{height}`, but the API takes a named
-// tier, so map canonical 2K frame sizes onto the API's 2K tier. MiniMax does
-// not document exact dimensions for the 480P and 768P tiers; callers can select
-// those explicitly through provider options.
-// One canonical frame size per ratio H3 supports, so a caller who pairs a
-// resolution with any supported ratio resolves to the tier instead of being
-// told the resolution is unsupported.
+// tier, so map canonical frame sizes onto the tiers. One frame size per ratio
+// per tier, so a caller who pairs a resolution with any supported ratio
+// resolves to the tier instead of being told the resolution is unsupported.
+// MiniMax does not publish tier dimensions, so this is a closed table rather
+// than a rule: 480P and 768P rows are named for the shorter side, the 2K rows
+// for the longer one. A frame size not listed here warns.
 const RESOLUTION_MAP: Record<string, string> = {
-  // Square
+  // 480P — square, landscape, portrait
+  '480x480': '480P',
+  '1120x480': '480P',
+  '854x480': '480P',
+  '640x480': '480P',
+  '480x854': '480P',
+  '480x640': '480P',
+  // 768P — square, landscape, portrait
+  '768x768': '768P',
+  '1792x768': '768P',
+  '1366x768': '768P',
+  '1024x768': '768P',
+  '768x1366': '768P',
+  '768x1024': '768P',
+  // 2K — square, landscape, portrait
   '2048x2048': '2K',
-  // Landscape
   '2560x1080': '2K',
   '2560x1440': '2K',
   '2048x1536': '2K',
-  // Portrait
   '1440x2560': '2K',
   '1536x2048': '2K',
 };
@@ -182,8 +194,9 @@ export class MiniMaxVideoModel implements VideoModelV4 {
     if (options.resolution != null) {
       const mapped = resolveTopLevelResolution(options.resolution);
       if (resolution != null) {
-        // The provider option is already a tier, so the only way the two can
-        // disagree is a top-level value that maps to no tier at all.
+        // The provider option is already a tier and wins, so say so whenever
+        // the top-level value is dropped — it either names no tier, or names a
+        // different one now that every tier has frame sizes.
         if (mapped == null) {
           warnings.push({
             type: 'unsupported',
@@ -191,6 +204,14 @@ export class MiniMaxVideoModel implements VideoModelV4 {
             details:
               `Unrecognized resolution "${options.resolution}". ${this.modelId} supports ${supportedResolutionNames}, ` +
               `so providerOptions.minimax.resolution ("${resolution}") was used instead.`,
+          });
+        } else if (mapped !== resolution) {
+          warnings.push({
+            type: 'unsupported',
+            feature: 'resolution',
+            details:
+              `The resolution "${options.resolution}" selects ${mapped}, but ` +
+              `providerOptions.minimax.resolution ("${resolution}") was used instead.`,
           });
         }
       } else if (mapped != null && supportedResolutionSet.has(mapped)) {

--- a/packages/minimax/src/minimax-video-model.ts
+++ b/packages/minimax/src/minimax-video-model.ts
@@ -46,7 +46,7 @@ const DEFAULT_RESOLUTION = '2K';
 const DEFAULT_ASPECT_RATIO = '16:9';
 const DEFAULT_POLL_INTERVAL_MS = 10_000;
 const DEFAULT_POLL_TIMEOUT_MS = 600_000;
-const MIN_DURATION_SECONDS = 5;
+const DEFAULT_DURATION_SECONDS = 5;
 const MAX_DURATION_SECONDS = 15;
 const MAX_REFERENCE_IMAGES = 9;
 const MAX_REFERENCE_VIDEOS = 3;
@@ -54,13 +54,21 @@ const MAX_REFERENCE_AUDIOS = 3;
 
 const allowedRatios = new Set<string>(minimaxVideoRatios);
 const allowedResolutions = new Set<string>(minimaxVideoResolutions);
+const modelResolutionSettings: Record<
+  string,
+  { supported: readonly string[]; default: string }
+> = {
+  'MiniMax-H3': { supported: ['768P', '2K'], default: DEFAULT_RESOLUTION },
+  'MiniMax-H3-Max': { supported: ['480P', '768P'], default: '768P' },
+};
 
 // The top-level `resolution` is `{width}x{height}`, but the API takes a named
-// tier, so map the canonical 2K frame sizes onto the single tier H3 supports.
-// Anything else can't be honored and warns.
+// tier, so map canonical 2K frame sizes onto the API's 2K tier. MiniMax does
+// not document exact dimensions for the 480P and 768P tiers; callers can select
+// those explicitly through provider options.
 // One canonical frame size per ratio H3 supports, so a caller who pairs a
 // resolution with any supported ratio resolves to the tier instead of being
-// told 2K is unsupported.
+// told the resolution is unsupported.
 const RESOLUTION_MAP: Record<string, string> = {
   // Square
   '2048x2048': '2K',
@@ -73,9 +81,8 @@ const RESOLUTION_MAP: Record<string, string> = {
   '1536x2048': '2K',
 };
 
-// A caller may pass the named tier itself rather than a frame size — `2K` is
-// what the MiniMax API takes, so it is the natural thing to send. Accept it
-// case-insensitively instead of reporting it as unrecognized.
+// A caller may pass a named tier itself rather than a frame size. Normalize it
+// case-insensitively to the exact casing expected by the MiniMax API.
 function resolveTopLevelResolution(resolution: string): string | undefined {
   const named = resolution.toUpperCase();
   return allowedResolutions.has(named) ? named : RESOLUTION_MAP[resolution];
@@ -124,7 +131,7 @@ export class MiniMaxVideoModel implements VideoModelV4 {
       warnings.push({
         type: 'unsupported',
         feature: 'fps',
-        details: 'MiniMax-H3 does not support a custom frame rate.',
+        details: `${this.modelId} does not support a custom frame rate.`,
       });
     }
 
@@ -132,7 +139,7 @@ export class MiniMaxVideoModel implements VideoModelV4 {
       warnings.push({
         type: 'unsupported',
         feature: 'seed',
-        details: 'MiniMax-H3 does not support a seed.',
+        details: `${this.modelId} does not support a seed.`,
       });
     }
 
@@ -140,8 +147,7 @@ export class MiniMaxVideoModel implements VideoModelV4 {
       warnings.push({
         type: 'unsupported',
         feature: 'n',
-        details:
-          'MiniMax-H3 generates a single video per call. Only 1 video will be generated.',
+        details: `${this.modelId} generates a single video per call. Only 1 video will be generated.`,
       });
     }
 
@@ -149,14 +155,30 @@ export class MiniMaxVideoModel implements VideoModelV4 {
       warnings.push({
         type: 'unsupported',
         feature: 'generateAudio',
-        details:
-          'The MiniMax-H3 API does not expose an audio parameter. The generateAudio option was ignored.',
+        details: `The ${this.modelId} API does not expose an audio parameter. The generateAudio option was ignored.`,
       });
     }
+
+    const resolutionSettings = modelResolutionSettings[this.modelId];
+    const supportedResolutions =
+      resolutionSettings?.supported ?? minimaxVideoResolutions;
+    const supportedResolutionSet = new Set<string>(supportedResolutions);
+    const supportedResolutionNames = supportedResolutions
+      .map(resolution => `"${resolution}"`)
+      .join(' or ');
 
     // Resolution: the API takes a named tier, so an explicit provider option
     // wins and a top-level value is resolved to a tier.
     let resolution: string | undefined = minimaxOptions?.resolution;
+    if (resolution != null && !supportedResolutionSet.has(resolution)) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'resolution',
+        details: `${this.modelId} supports ${supportedResolutionNames}. The provider resolution "${resolution}" was ignored.`,
+      });
+      resolution = undefined;
+    }
+
     if (options.resolution != null) {
       const mapped = resolveTopLevelResolution(options.resolution);
       if (resolution != null) {
@@ -167,23 +189,24 @@ export class MiniMaxVideoModel implements VideoModelV4 {
             type: 'unsupported',
             feature: 'resolution',
             details:
-              `Unrecognized resolution "${options.resolution}". MiniMax-H3 only supports "2K", ` +
+              `Unrecognized resolution "${options.resolution}". ${this.modelId} supports ${supportedResolutionNames}, ` +
               `so providerOptions.minimax.resolution ("${resolution}") was used instead.`,
           });
         }
-      } else if (mapped != null) {
+      } else if (mapped != null && supportedResolutionSet.has(mapped)) {
         resolution = mapped;
       } else {
         warnings.push({
           type: 'unsupported',
           feature: 'resolution',
           details:
-            `Unrecognized resolution "${options.resolution}". MiniMax-H3 only ` +
-            'supports "2K".',
+            mapped == null
+              ? `Unrecognized resolution "${options.resolution}". ${this.modelId} supports ${supportedResolutionNames}.`
+              : `${this.modelId} does not support the resolution "${mapped}". It supports ${supportedResolutionNames}.`,
         });
       }
     }
-    resolution ??= DEFAULT_RESOLUTION;
+    resolution ??= resolutionSettings?.default ?? DEFAULT_RESOLUTION;
 
     // `convertImageModelFileToDataUri` passes `url` files through unchanged and
     // encodes inline data as a data URI. MiniMax `mm_file://…` handles survive
@@ -225,8 +248,8 @@ export class MiniMaxVideoModel implements VideoModelV4 {
         feature: firstFrameImage != null ? 'frameImages' : 'image',
         details:
           firstFrameMediaType === 'video'
-            ? 'MiniMax-H3 does not accept a video as a frame image. The video was ignored.'
-            : `MiniMax-H3 only accepts an image as a frame image; the "${firstFrame.mediaType}" file was ignored.`,
+            ? `${this.modelId} does not accept a video as a frame image. The video was ignored.`
+            : `${this.modelId} only accepts an image as a frame image; the "${firstFrame.mediaType}" file was ignored.`,
       });
       firstFrame = undefined;
     }
@@ -236,8 +259,7 @@ export class MiniMaxVideoModel implements VideoModelV4 {
         warnings.push({
           type: 'unsupported',
           feature: 'frameImages',
-          details:
-            'MiniMax-H3 requires a first_frame when a last_frame is provided. The last_frame was ignored.',
+          details: `${this.modelId} requires a first_frame when a last_frame is provided. The last_frame was ignored.`,
         });
         lastFrame = undefined;
       } else {
@@ -248,8 +270,8 @@ export class MiniMaxVideoModel implements VideoModelV4 {
             feature: 'frameImages',
             details:
               lastFrameMediaType === 'video'
-                ? 'MiniMax-H3 does not accept a video as a frame image. The last_frame video was ignored.'
-                : `MiniMax-H3 only accepts an image as a frame image; the "${lastFrame.mediaType}" last_frame was ignored.`,
+                ? `${this.modelId} does not accept a video as a frame image. The last_frame video was ignored.`
+                : `${this.modelId} only accepts an image as a frame image; the "${lastFrame.mediaType}" last_frame was ignored.`,
           });
           lastFrame = undefined;
         }
@@ -260,8 +282,29 @@ export class MiniMaxVideoModel implements VideoModelV4 {
 
     const referenceFiles = options.inputReferences ?? [];
     const referenceAudioUrls = minimaxOptions?.referenceAudioUrls ?? [];
+    const supportsReferences = this.modelId !== 'MiniMax-H3-Max';
+
+    if (!supportsReferences && referenceFiles.length > 0) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'inputReferences',
+        details:
+          'MiniMax-H3-Max does not support reference-to-video inputs. The references were ignored.',
+      });
+    }
+
+    if (!supportsReferences && referenceAudioUrls.length > 0) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'referenceAudioUrls',
+        details:
+          'MiniMax-H3-Max does not support reference audio. The audio was ignored.',
+      });
+    }
+
     const usesReferences =
-      referenceFiles.length > 0 || referenceAudioUrls.length > 0;
+      supportsReferences &&
+      (referenceFiles.length > 0 || referenceAudioUrls.length > 0);
 
     if (usesFrameImages) {
       if (firstFrame != null) {
@@ -405,8 +448,8 @@ export class MiniMaxVideoModel implements VideoModelV4 {
           type: 'unsupported',
           feature: 'aspectRatio',
           details: isTextToVideo
-            ? `MiniMax-H3 does not support the aspect ratio "${options.aspectRatio}". Using the default (${DEFAULT_ASPECT_RATIO}).`
-            : `MiniMax-H3 does not support the aspect ratio "${options.aspectRatio}". Using the provider default (adaptive).`,
+            ? `${this.modelId} does not support the aspect ratio "${options.aspectRatio}". Using the default (${DEFAULT_ASPECT_RATIO}).`
+            : `${this.modelId} does not support the aspect ratio "${options.aspectRatio}". Using the provider default (adaptive).`,
         });
         if (isTextToVideo) {
           ratio = DEFAULT_ASPECT_RATIO;
@@ -418,7 +461,7 @@ export class MiniMaxVideoModel implements VideoModelV4 {
         type: 'unsupported',
         feature: 'aspectRatio',
         details:
-          'MiniMax-H3 text-to-video does not support the adaptive aspect ratio. ' +
+          `${this.modelId} text-to-video does not support the adaptive aspect ratio. ` +
           `Using the default (${DEFAULT_ASPECT_RATIO}).`,
       });
       ratio = DEFAULT_ASPECT_RATIO;
@@ -427,8 +470,7 @@ export class MiniMaxVideoModel implements VideoModelV4 {
       warnings.push({
         type: 'unsupported',
         feature: 'aspectRatio',
-        details:
-          'MiniMax-H3 derives the aspect ratio from the frame image; the requested ratio was ignored.',
+        details: `${this.modelId} derives the aspect ratio from the frame image; the requested ratio was ignored.`,
       });
       ratio = undefined;
     }
@@ -436,16 +478,18 @@ export class MiniMaxVideoModel implements VideoModelV4 {
       ratio = DEFAULT_ASPECT_RATIO;
     }
 
-    // H3 takes an integer between 5 and 15, so round before clamping: a
-    // fractional duration is rejected by the API just as an out-of-range one is.
-    let duration = options.duration ?? MIN_DURATION_SECONDS;
+    // Both H3 models take an integer duration, but H3 starts at 4 seconds while
+    // H3-Max starts at 5. Round before clamping because the API rejects both
+    // fractional and out-of-range values.
+    const minDurationSeconds = this.modelId === 'MiniMax-H3' ? 4 : 5;
+    let duration = options.duration ?? DEFAULT_DURATION_SECONDS;
     if (options.duration != null) {
       if (!Number.isInteger(duration)) {
         duration = Math.round(duration);
         warnings.push({
           type: 'unsupported',
           feature: 'duration',
-          details: `MiniMax-H3 requires a whole number of seconds. The requested duration of ${options.duration} was rounded to ${duration}.`,
+          details: `${this.modelId} requires a whole number of seconds. The requested duration of ${options.duration} was rounded to ${duration}.`,
         });
       }
 
@@ -453,16 +497,16 @@ export class MiniMaxVideoModel implements VideoModelV4 {
         warnings.push({
           type: 'unsupported',
           feature: 'duration',
-          details: `MiniMax-H3 supports at most ${MAX_DURATION_SECONDS} seconds. The requested duration of ${options.duration} was clamped to ${MAX_DURATION_SECONDS}.`,
+          details: `${this.modelId} supports at most ${MAX_DURATION_SECONDS} seconds. The requested duration of ${options.duration} was clamped to ${MAX_DURATION_SECONDS}.`,
         });
         duration = MAX_DURATION_SECONDS;
-      } else if (duration < MIN_DURATION_SECONDS) {
+      } else if (duration < minDurationSeconds) {
         warnings.push({
           type: 'unsupported',
           feature: 'duration',
-          details: `MiniMax-H3 requires at least ${MIN_DURATION_SECONDS} seconds. The requested duration of ${options.duration} was clamped to ${MIN_DURATION_SECONDS}.`,
+          details: `${this.modelId} requires at least ${minDurationSeconds} seconds. The requested duration of ${options.duration} was clamped to ${minDurationSeconds}.`,
         });
-        duration = MIN_DURATION_SECONDS;
+        duration = minDurationSeconds;
       }
     }
 

--- a/packages/minimax/src/minimax-video-settings.ts
+++ b/packages/minimax/src/minimax-video-settings.ts
@@ -1,2 +1,5 @@
 // https://platform.minimax.io/docs
-export type MiniMaxVideoModelId = 'MiniMax-H3' | (string & {});
+export type MiniMaxVideoModelId =
+  | 'MiniMax-H3'
+  | 'MiniMax-H3-Max'
+  | (string & {});


### PR DESCRIPTION
## Background

MiniMax supports model-specific video resolution tiers with exact casing:

- MiniMax-H3: `768P`, `2K`
- MiniMax-H3-Max: `480P`, `768P`

The provider only accepted `2K`, preventing supported lower-resolution requests.
The V2 API also gives the models different duration bounds and does not support
reference-to-video inputs on MiniMax-H3-Max.

## Summary

- Add `480P` and `768P` MiniMax video resolution options.
- Add MiniMax-H3-Max as a known video model.
- Apply model-specific resolution validation and defaults.
- Normalize named tiers to MiniMax's required uppercase casing.
- Apply the documented 4–15 second H3 and 5–15 second H3-Max duration bounds.
- Prevent unsupported reference inputs from being sent to MiniMax-H3-Max.
- Update tests, documentation, example, and patch changeset.

## End-to-End Verification

Not run against the live MiniMax API because API credentials were unavailable.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
