### PR TITLE
fix(minimax): map 480P and 768P frame sizes onto the named video resolution tiers

### DIFF
--- a/.changeset/lucky-tiers-resolve.md
+++ b/.changeset/lucky-tiers-resolve.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/minimax': patch
+---
+
+Map MiniMax 480P and 768P frame sizes onto their named video resolution tiers, so a typed top-level `resolution` can reach them.

--- a/content/providers/01-ai-sdk-providers/33-minimax.mdx
+++ b/content/providers/01-ai-sdk-providers/33-minimax.mdx
@@ -137,9 +137,10 @@ The following optional provider options are available for MiniMax language model
 
 ## Video Models
 
-You can generate videos with the MiniMax-H3 model using the
-[`experimental_generateVideo`](/docs/reference/ai-sdk-core/generate-video)
-function:
+You can generate videos with the MiniMax-H3 and MiniMax-H3-Max models using
+the [`experimental_generateVideo`](/docs/reference/ai-sdk-core/generate-video)
+function. MiniMax-H3-Max is the faster variant: it renders at lower resolutions
+and serves every mode except reference-to-video.
 
 ```ts
 import { minimax, type MiniMaxVideoModelOptions } from '@ai-sdk/minimax';
@@ -159,7 +160,7 @@ const { video } = await generateVideo({
 });
 ```
 
-MiniMax-H3 generates one video per call. Generation is asynchronous — the model
+Both models generate one video per call. Generation is asynchronous — the model
 creates a task and polls until it completes, then returns the resulting MP4 URL.
 
 `duration` accepts a whole number of seconds and defaults to 5. MiniMax-H3
@@ -167,6 +168,19 @@ supports 4 to 15 seconds; MiniMax-H3-Max supports 5 to 15 seconds. A fractional
 value is rounded and an out-of-range value is clamped, each with a warning.
 MiniMax-H3 supports `768P` and `2K` output, while MiniMax-H3-Max supports `480P`
 and `768P`.
+
+The API takes a named tier rather than a frame size, so a top-level `resolution`
+is matched against a fixed table of one frame size per tier per aspect ratio:
+
+| Tier   | Accepted `resolution` values                                                 |
+| ------ | ---------------------------------------------------------------------------- |
+| `480P` | `480x480`, `1120x480`, `854x480`, `640x480`, `480x854`, `480x640`            |
+| `768P` | `768x768`, `1792x768`, `1366x768`, `1024x768`, `768x1366`, `768x1024`        |
+| `2K`   | `2048x2048`, `2560x1080`, `2560x1440`, `2048x1536`, `1440x2560`, `1536x2048` |
+
+Anything outside the table, or a tier the selected model does not support, warns
+and falls back to the model default. `providerOptions.minimax.resolution` names
+the tier exactly and wins over the top-level value, which is reported as ignored.
 
 For **text-to-video**, `aspectRatio` defaults to `16:9` when omitted. The MiniMax
 API requires a concrete ratio for text-only requests and does not accept

--- a/packages/minimax/src/minimax-video-model-options.ts
+++ b/packages/minimax/src/minimax-video-model-options.ts
@@ -2,7 +2,7 @@ import { lazySchema, zodSchema } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
 
 /**
- * Aspect ratios supported by the MiniMax-H3 video model.
+ * Aspect ratios supported by the MiniMax video models.
  */
 export const minimaxVideoRatios = [
   'adaptive',

--- a/packages/minimax/src/minimax-video-model.test.ts
+++ b/packages/minimax/src/minimax-video-model.test.ts
@@ -328,6 +328,146 @@ describe('MiniMaxVideoModel', () => {
       },
     );
 
+    // The lower tiers get the same one-frame-size-per-ratio treatment as 2K, so
+    // a typed caller — whose `resolution` is `{width}x{height}` — can reach them
+    // without dropping to provider options.
+    it.each([
+      ['768x768', '1:1'],
+      ['1792x768', '21:9'],
+      ['1366x768', '16:9'],
+      ['1024x768', '4:3'],
+      ['768x1366', '9:16'],
+      ['768x1024', '3:4'],
+    ] as const)(
+      'should map the top-level resolution %s (%s) onto the 768P tier',
+      async (resolution, aspectRatio) => {
+        const model = createModel();
+
+        const { warnings } = await model.doGenerate({
+          ...defaultOptions,
+          resolution,
+          aspectRatio,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'MiniMax-H3',
+          content: [{ type: 'text', text: prompt }],
+          resolution: '768P',
+          duration: 5,
+          ratio: aspectRatio,
+        });
+        expect(
+          warnings.some(
+            w => w.type === 'unsupported' && w.feature === 'resolution',
+          ),
+        ).toBe(false);
+      },
+    );
+
+    it.each([
+      ['480x480', '1:1'],
+      ['1120x480', '21:9'],
+      ['854x480', '16:9'],
+      ['640x480', '4:3'],
+      ['480x854', '9:16'],
+      ['480x640', '3:4'],
+    ] as const)(
+      'should map the top-level resolution %s (%s) onto the 480P tier',
+      async (resolution, aspectRatio) => {
+        const model = createModel({ modelId: 'MiniMax-H3-Max' });
+
+        const { warnings } = await model.doGenerate({
+          ...defaultOptions,
+          resolution,
+          aspectRatio,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'MiniMax-H3-Max',
+          content: [{ type: 'text', text: prompt }],
+          resolution: '480P',
+          duration: 5,
+          ratio: aspectRatio,
+        });
+        expect(
+          warnings.some(
+            w => w.type === 'unsupported' && w.feature === 'resolution',
+          ),
+        ).toBe(false);
+      },
+    );
+
+    it('should map a 768P frame size on MiniMax-H3-Max, not just fall back to its default', async () => {
+      const model = createModel({ modelId: 'MiniMax-H3-Max' });
+
+      const { warnings } = await model.doGenerate({
+        ...defaultOptions,
+        resolution: '1366x768',
+        aspectRatio: '16:9',
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        model: 'MiniMax-H3-Max',
+        resolution: '768P',
+      });
+      expect(
+        warnings.some(
+          w => w.type === 'unsupported' && w.feature === 'resolution',
+        ),
+      ).toBe(false);
+    });
+
+    // Now that every tier has frame sizes, a top-level value can name a real
+    // but different tier than the provider option. The option still wins, but
+    // dropping the top-level value has to be reported.
+    it('should warn when a mapped top-level resolution names a different tier than the provider option', async () => {
+      const model = createModel();
+
+      const { warnings } = await model.doGenerate({
+        ...defaultOptions,
+        resolution: '1366x768',
+        providerOptions: minimaxOptions({ resolution: '2K' }),
+      });
+
+      expect(await server.calls[0].requestBodyJson).toMatchObject({
+        resolution: '2K',
+      });
+      expect(warnings).toContainEqual({
+        type: 'unsupported',
+        feature: 'resolution',
+        details:
+          'The resolution "1366x768" selects 768P, but ' +
+          'providerOptions.minimax.resolution ("2K") was used instead.',
+      });
+    });
+
+    // A frame size can now name a real tier the selected model does not serve.
+    it.each([
+      ['MiniMax-H3', '854x480', '480P', '2K'],
+      ['MiniMax-H3-Max', '2560x1440', '2K', '768P'],
+    ] as const)(
+      'should warn that %s does not support the %s tier and use %s',
+      async (modelId, resolution, tier, expectedResolution) => {
+        const model = createModel({ modelId });
+
+        const { warnings } = await model.doGenerate({
+          ...defaultOptions,
+          resolution,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toMatchObject({
+          resolution: expectedResolution,
+        });
+        expect(warnings).toContainEqual({
+          type: 'unsupported',
+          feature: 'resolution',
+          details: expect.stringContaining(
+            `${modelId} does not support the resolution "${tier}".`,
+          ),
+        });
+      },
+    );
+
     it.each([
       ['MiniMax-H3', '480P', '2K'],
       ['MiniMax-H3-Max', '2K', '768P'],

--- a/packages/minimax/src/minimax-video-model.ts
+++ b/packages/minimax/src/minimax-video-model.ts
@@ -63,20 +63,32 @@ const modelResolutionSettings: Record<
 };
 
 // The top-level `resolution` is `{width}x{height}`, but the API takes a named
-// tier, so map canonical 2K frame sizes onto the API's 2K tier. MiniMax does
-// not document exact dimensions for the 480P and 768P tiers; callers can select
-// those explicitly through provider options.
-// One canonical frame size per ratio H3 supports, so a caller who pairs a
-// resolution with any supported ratio resolves to the tier instead of being
-// told the resolution is unsupported.
+// tier, so map canonical frame sizes onto the tiers. One frame size per ratio
+// per tier, so a caller who pairs a resolution with any supported ratio
+// resolves to the tier instead of being told the resolution is unsupported.
+// MiniMax does not publish tier dimensions, so this is a closed table rather
+// than a rule: 480P and 768P rows are named for the shorter side, the 2K rows
+// for the longer one. A frame size not listed here warns.
 const RESOLUTION_MAP: Record<string, string> = {
-  // Square
+  // 480P — square, landscape, portrait
+  '480x480': '480P',
+  '1120x480': '480P',
+  '854x480': '480P',
+  '640x480': '480P',
+  '480x854': '480P',
+  '480x640': '480P',
+  // 768P — square, landscape, portrait
+  '768x768': '768P',
+  '1792x768': '768P',
+  '1366x768': '768P',
+  '1024x768': '768P',
+  '768x1366': '768P',
+  '768x1024': '768P',
+  // 2K — square, landscape, portrait
   '2048x2048': '2K',
-  // Landscape
   '2560x1080': '2K',
   '2560x1440': '2K',
   '2048x1536': '2K',
-  // Portrait
   '1440x2560': '2K',
   '1536x2048': '2K',
 };
@@ -182,8 +194,9 @@ export class MiniMaxVideoModel implements VideoModelV4 {
     if (options.resolution != null) {
       const mapped = resolveTopLevelResolution(options.resolution);
       if (resolution != null) {
-        // The provider option is already a tier, so the only way the two can
-        // disagree is a top-level value that maps to no tier at all.
+        // The provider option is already a tier and wins, so say so whenever
+        // the top-level value is dropped — it either names no tier, or names a
+        // different one now that every tier has frame sizes.
         if (mapped == null) {
           warnings.push({
             type: 'unsupported',
@@ -191,6 +204,14 @@ export class MiniMaxVideoModel implements VideoModelV4 {
             details:
               `Unrecognized resolution "${options.resolution}". ${this.modelId} supports ${supportedResolutionNames}, ` +
               `so providerOptions.minimax.resolution ("${resolution}") was used instead.`,
+          });
+        } else if (mapped !== resolution) {
+          warnings.push({
+            type: 'unsupported',
+            feature: 'resolution',
+            details:
+              `The resolution "${options.resolution}" selects ${mapped}, but ` +
+              `providerOptions.minimax.resolution ("${resolution}") was used instead.`,
           });
         }
       } else if (mapped != null && supportedResolutionSet.has(mapped)) {


### PR DESCRIPTION
### Background

#20004 adds `480P` and `768P` as MiniMax video resolution tiers, but only wires up frame sizes for `2K`. The top-level `resolution` call option is typed `` `${number}x${number}` ``, so a type-safe caller can only reach a named tier through the frame-size map — which left `480P` and `768P` reachable exclusively via `providerOptions.minimax.resolution`.

Every other provider in the repo that takes named tiers maps a frame size for each tier it serves (xai `480p`/`720p`/`1080p`, alibaba `480P`/`720P`/`1080P`, bytedance, google), so this follows that precedent.

### Summary

- Add frame-size rows for the `480P` and `768P` tiers — one canonical frame size per aspect ratio the models accept, matching the shape of the existing `2K` rows.
- Tests for both new tiers across all six ratios, and for the "tier the model does not support" branch, which a top-level frame size can now reach (`854x480` on MiniMax-H3, `2560x1440` on MiniMax-H3-Max) — it previously had no coverage from that direction.
- Document how a top-level `resolution` resolves to a tier, what happens when it matches no tier or an unsupported one, and that provider options win.

#### Related Issues

Stacked on #20004.
