### PR TITLE
fix(actions): skip unrelated backport label events

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -31,7 +31,13 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: github.repository_owner == 'vercel'
+    # A `labeled` trigger fires for every label. Filter before requesting a
+    # runner so unrelated labels on fork PRs do not leave approval-gated runs.
+    if: >
+      github.repository_owner == 'vercel' &&
+      (github.event_name != 'pull_request' ||
+        github.event.action != 'labeled' ||
+        github.event.label.name == 'backport')
     outputs:
       should-backport: ${{ steps.resolve.outputs.should-backport }}
       pr-number: ${{ steps.resolve.outputs.pr-number }}


### PR DESCRIPTION
## Summary
- skip Backport jobs for ordinary pull-request labels before a runner is requested
- retain Backport handling for the `backport` label, closed PRs, and manual dispatches

## Validation
- pnpm check
- pnpm type-check:full