### PR TITLE
Backport: fix(ci): skip unrelated backport workflow events

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -31,7 +31,20 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: github.repository_owner == 'vercel'
+    if: |
+      github.repository_owner == 'vercel' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'backport'
+        ) ||
+        (
+          github.event.action == 'closed' &&
+          github.event.pull_request.merged == true &&
+          contains(github.event.pull_request.labels.*.name, 'backport')
+        )
+      )
     outputs:
       should-backport: ${{ steps.resolve.outputs.should-backport }}
       pr-number: ${{ steps.resolve.outputs.pr-number }}
@@ -137,10 +150,8 @@ jobs:
           PR_NUMBER=""
 
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            # `labeled`: only react to the "backport" label being added.
-            # `closed`: react to every closed PR here and let the downstream
-            # "is merged" and "has backport label" checks decide. This catches
-            # the case where the label was added before the PR was merged.
+            # The job-level condition filters unrelated labels and closures.
+            # Keep these checks as defense in depth for future trigger changes.
             if [ "$PR_ACTION" = "labeled" ] && [ "$ISSUE_LABEL" != "backport" ]; then
               skip "Ignoring non-backport label: $ISSUE_LABEL"
             fi
@@ -164,9 +175,7 @@ jobs:
           [ "$MERGED" = "true" ] || skip "PR #${PR_NUMBER} is not merged"
 
           # Gate on the backport label before anything else — in particular
-          # before the fork-detection comment below. The `closed` trigger fires
-          # for every merged PR, so without this an unlabeled fork PR would be
-          # spammed with a "use workflow_dispatch" comment it never asked for.
+          # before the fork-detection comment below.
           HAS_BACKPORT_LABEL=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/labels" \
             --jq 'any(.[]; .name == "backport")')
           [ "$HAS_BACKPORT_LABEL" = "true" ] || skip "PR #${PR_NUMBER} does not have the backport label"


### PR DESCRIPTION
Backports #19986 to `release-v6.0`.

The workflow now runs only for manual dispatches, the `backport` label, or merged PR closures that carry the `backport` label.