### PR TITLE
fix: encode provider-returned identifiers in credentialed follow-up request paths

### DIFF
--- a/.changeset/encode-provider-returned-id-path-segments.md
+++ b/.changeset/encode-provider-returned-id-path-segments.md
@@ -3,6 +3,7 @@
 '@ai-sdk/bytedance': patch
 '@ai-sdk/klingai': patch
 '@ai-sdk/luma': patch
+'@ai-sdk/minimax': patch
 '@ai-sdk/fal': patch
 '@ai-sdk/revai': patch
 ---

--- a/.changeset/encode-provider-returned-id-path-segments.md
+++ b/.changeset/encode-provider-returned-id-path-segments.md
@@ -1,0 +1,10 @@
+---
+'@ai-sdk/alibaba': patch
+'@ai-sdk/bytedance': patch
+'@ai-sdk/klingai': patch
+'@ai-sdk/luma': patch
+'@ai-sdk/fal': patch
+'@ai-sdk/revai': patch
+---
+
+Encode provider-returned identifiers before using them in credentialed follow-up request paths.

--- a/packages/alibaba/src/alibaba-video-model.test.ts
+++ b/packages/alibaba/src/alibaba-video-model.test.ts
@@ -78,6 +78,15 @@ describe('AlibabaVideoModel', () => {
     [TASK_URL]: {
       response: { type: 'json-value', body: succeededTaskResponse },
     },
+    [`${TEST_BASE_URL}/api/v1/tasks/abc%2F..%2F..%2Finternal`]: {
+      response: { type: 'json-value', body: succeededTaskResponse },
+    },
+    [`${TEST_BASE_URL}/api/v1/tasks/%252E`]: {
+      response: { type: 'json-value', body: succeededTaskResponse },
+    },
+    [`${TEST_BASE_URL}/api/v1/tasks/%252E%252E`]: {
+      response: { type: 'json-value', body: succeededTaskResponse },
+    },
   });
 
   describe('constructor', () => {
@@ -1027,6 +1036,33 @@ describe('AlibabaVideoModel', () => {
   });
 
   describe('doStatus', () => {
+    it('should encode the task ID as a single URL path segment', async () => {
+      const model = createModel();
+      const taskId = 'abc/../../internal';
+
+      await model.doStatus({ operation: { taskId } });
+
+      expect(server.calls[0].requestUrl).toBe(
+        `${TEST_BASE_URL}/api/v1/tasks/${encodeURIComponent(taskId)}`,
+      );
+    });
+
+    it.each([
+      { taskId: '.', encodedTaskId: '%252E' },
+      { taskId: '..', encodedTaskId: '%252E%252E' },
+    ])(
+      'should preserve the $taskId task ID as a URL path segment',
+      async ({ taskId, encodedTaskId }) => {
+        const model = createModel();
+
+        await model.doStatus({ operation: { taskId } });
+
+        expect(server.calls[0].requestUrl).toBe(
+          `${TEST_BASE_URL}/api/v1/tasks/${encodedTaskId}`,
+        );
+      },
+    );
+
     it('should return completed with video data when SUCCEEDED', async () => {
       const model = createModel();
 

--- a/packages/alibaba/src/alibaba-video-model.ts
+++ b/packages/alibaba/src/alibaba-video-model.ts
@@ -283,6 +283,17 @@ function resolveReferenceUrls(
   return alibabaOptions?.referenceUrls ?? undefined;
 }
 
+function encodePathSegment(value: string): string {
+  const encodedValue = encodeURIComponent(value);
+
+  // URL parsing normalizes both literal and percent-encoded dot segments.
+  return encodedValue === '.'
+    ? '%252E'
+    : encodedValue === '..'
+      ? '%252E%252E'
+      : encodedValue;
+}
+
 export class AlibabaVideoModel implements VideoModelV4 {
   readonly specificationVersion = 'v4';
   readonly maxVideosPerCall = 1;
@@ -654,7 +665,7 @@ export class AlibabaVideoModel implements VideoModelV4 {
     const { taskId } = options.operation as { taskId: string };
 
     const { value: statusResponse, responseHeaders } = await getFromApi({
-      url: `${this.config.baseURL}/api/v1/tasks/${taskId}`,
+      url: `${this.config.baseURL}/api/v1/tasks/${encodePathSegment(taskId)}`,
       validateUrl: false,
       headers: combineHeaders(
         await resolve(this.config.headers),

--- a/packages/bytedance/src/bytedance-video-model.test.ts
+++ b/packages/bytedance/src/bytedance-video-model.test.ts
@@ -72,6 +72,63 @@ describe('ByteDanceVideoModel', () => {
           },
         },
       },
+    'https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks/abc%2F..%2F..%2Finternal':
+      {
+        response: {
+          type: 'json-value',
+          body: {
+            id: 'test-task-id-123',
+            model: 'seedance-1-0-pro-250528',
+            status: 'succeeded',
+            content: {
+              video_url: 'https://bytedance.cdn/files/video-output.mp4',
+              last_frame_url:
+                'https://bytedance.cdn/files/video-output-last-frame.png',
+            },
+            usage: {
+              completion_tokens: 100,
+            },
+          },
+        },
+      },
+    'https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks/%252E':
+      {
+        response: {
+          type: 'json-value',
+          body: {
+            id: 'test-task-id-123',
+            model: 'seedance-1-0-pro-250528',
+            status: 'succeeded',
+            content: {
+              video_url: 'https://bytedance.cdn/files/video-output.mp4',
+              last_frame_url:
+                'https://bytedance.cdn/files/video-output-last-frame.png',
+            },
+            usage: {
+              completion_tokens: 100,
+            },
+          },
+        },
+      },
+    'https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks/%252E%252E':
+      {
+        response: {
+          type: 'json-value',
+          body: {
+            id: 'test-task-id-123',
+            model: 'seedance-1-0-pro-250528',
+            status: 'succeeded',
+            content: {
+              video_url: 'https://bytedance.cdn/files/video-output.mp4',
+              last_frame_url:
+                'https://bytedance.cdn/files/video-output-last-frame.png',
+            },
+            usage: {
+              completion_tokens: 100,
+            },
+          },
+        },
+      },
   });
 
   describe('constructor', () => {
@@ -1553,6 +1610,35 @@ describe('ByteDanceVideoModel', () => {
   });
 
   describe('doStatus', () => {
+    it('should encode the task ID as a single URL path segment', async () => {
+      const model = createBasicModel();
+      const taskId = 'abc/../../internal';
+
+      await model.doStatus({ operation: { taskId } });
+
+      expect(server.calls[0].requestUrl).toBe(
+        `https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks/${encodeURIComponent(
+          taskId,
+        )}`,
+      );
+    });
+
+    it.each([
+      { taskId: '.', encodedTaskId: '%252E' },
+      { taskId: '..', encodedTaskId: '%252E%252E' },
+    ])(
+      'should preserve the $taskId task ID as a URL path segment',
+      async ({ taskId, encodedTaskId }) => {
+        const model = createBasicModel();
+
+        await model.doStatus({ operation: { taskId } });
+
+        expect(server.calls[0].requestUrl).toBe(
+          `https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks/${encodedTaskId}`,
+        );
+      },
+    );
+
     it('should return completed with video data when succeeded', async () => {
       const model = createBasicModel();
 

--- a/packages/bytedance/src/bytedance-video-model.ts
+++ b/packages/bytedance/src/bytedance-video-model.ts
@@ -173,6 +173,17 @@ function resolveLastFrameImage(
   return byteDanceOptions?.lastFrameImage ?? undefined;
 }
 
+function encodePathSegment(value: string): string {
+  const encodedValue = encodeURIComponent(value);
+
+  // URL parsing normalizes both literal and percent-encoded dot segments.
+  return encodedValue === '.'
+    ? '%252E'
+    : encodedValue === '..'
+      ? '%252E%252E'
+      : encodedValue;
+}
+
 export class ByteDanceVideoModel implements VideoModelV4 {
   readonly specificationVersion = 'v4';
   readonly maxVideosPerCall = 1;
@@ -391,7 +402,7 @@ export class ByteDanceVideoModel implements VideoModelV4 {
     const { taskId } = options.operation as { taskId: string };
 
     const { value: statusResponse, responseHeaders } = await getFromApi({
-      url: `${this.config.baseURL}/contents/generations/tasks/${taskId}`,
+      url: `${this.config.baseURL}/contents/generations/tasks/${encodePathSegment(taskId)}`,
       validateUrl: false,
       headers: combineHeaders(
         await resolve(this.config.headers),

--- a/packages/fal/src/fal-transcription-model.test.ts
+++ b/packages/fal/src/fal-transcription-model.test.ts
@@ -13,6 +13,7 @@ const model = provider.transcription('wizper');
 const server = createTestServer({
   'https://queue.fal.run/fal-ai/wizper': {},
   'https://queue.fal.run/fal-ai/wizper/requests/test-id': {},
+  'https://queue.fal.run/fal-ai/wizper/requests/abc%2F..%2F..%2Finternal': {},
 });
 
 function prepareJsonFixtureResponse(headers?: Record<string, string>) {
@@ -39,6 +40,44 @@ function prepareJsonFixtureResponse(headers?: Record<string, string>) {
 describe('doGenerate', () => {
   describe('transcription', () => {
     beforeEach(() => prepareJsonFixtureResponse());
+
+    it('should encode the request ID as a single URL path segment', async () => {
+      const requestId = 'abc/../../internal';
+
+      server.urls['https://queue.fal.run/fal-ai/wizper'].response = {
+        type: 'json-value',
+        body: {
+          status: 'IN_QUEUE',
+          request_id: requestId,
+          response_url: `https://queue.fal.run/fal-ai/wizper/requests/${requestId}/result`,
+          status_url: `https://queue.fal.run/fal-ai/wizper/requests/${requestId}`,
+          cancel_url: `https://queue.fal.run/fal-ai/wizper/requests/${requestId}/cancel`,
+          logs: null,
+          metrics: {},
+          queue_position: 0,
+        },
+      };
+      server.urls[
+        'https://queue.fal.run/fal-ai/wizper/requests/abc%2F..%2F..%2Finternal'
+      ].response = {
+        type: 'json-value',
+        body: {
+          text: 'Hello from the Versal AISDK.',
+          chunks: [
+            { timestamp: [0, 2.508], text: 'Hello from the Versal AISDK.' },
+          ],
+          languages: ['en'],
+        },
+      };
+
+      await model.doGenerate({ audio: audioData, mediaType: 'audio/wav' });
+
+      expect(server.calls[1].requestUrl).toBe(
+        `https://queue.fal.run/fal-ai/wizper/requests/${encodeURIComponent(
+          requestId,
+        )}`,
+      );
+    });
 
     it('should pass the model', async () => {
       await model.doGenerate({

--- a/packages/fal/src/fal-transcription-model.ts
+++ b/packages/fal/src/fal-transcription-model.ts
@@ -29,6 +29,17 @@ interface FalTranscriptionModelConfig extends FalConfig {
   };
 }
 
+function encodePathSegment(value: string): string {
+  const encodedValue = encodeURIComponent(value);
+
+  // URL parsing normalizes both literal and percent-encoded dot segments.
+  return encodedValue === '.'
+    ? '%252E'
+    : encodedValue === '..'
+      ? '%252E%252E'
+      : encodedValue;
+}
+
 export class FalTranscriptionModel implements TranscriptionModelV4 {
   readonly specificationVersion = 'v4';
 
@@ -143,7 +154,7 @@ export class FalTranscriptionModel implements TranscriptionModelV4 {
           rawValue: statusRawResponse,
         } = await getFromApi({
           url: this.config.url({
-            path: `https://queue.fal.run/fal-ai/${this.modelId}/requests/${queueResponse.request_id}`,
+            path: `https://queue.fal.run/fal-ai/${this.modelId}/requests/${encodePathSegment(queueResponse.request_id ?? '')}`,
             modelId: this.modelId,
           }),
           validateUrl: false,

--- a/packages/klingai/src/klingai-video-model.test.ts
+++ b/packages/klingai/src/klingai-video-model.test.ts
@@ -161,6 +161,24 @@ describe('KlingAIVideoModel', () => {
         body: successfulTaskResponse,
       },
     },
+    [`${TEST_BASE_URL}/v1/videos/text2video/abc%2F..%2F..%2Finternal`]: {
+      response: {
+        type: 'json-value',
+        body: successfulTaskResponse,
+      },
+    },
+    [`${TEST_BASE_URL}/v1/videos/text2video/%252E`]: {
+      response: {
+        type: 'json-value',
+        body: successfulTaskResponse,
+      },
+    },
+    [`${TEST_BASE_URL}/v1/videos/text2video/%252E%252E`]: {
+      response: {
+        type: 'json-value',
+        body: successfulTaskResponse,
+      },
+    },
     // I2V endpoints
     [`${TEST_BASE_URL}/v1/videos/image2video`]: {
       response: {
@@ -1222,6 +1240,37 @@ describe('KlingAIVideoModel', () => {
   });
 
   describe('doStatus', () => {
+    it('should encode the task ID as a single URL path segment', async () => {
+      const model = createBasicModel();
+      const taskId = 'abc/../../internal';
+
+      await model.doStatus({
+        operation: { taskId, endpointPath: '/v1/videos/text2video' },
+      });
+
+      expect(server.calls[0].requestUrl).toBe(
+        `${TEST_BASE_URL}/v1/videos/text2video/${encodeURIComponent(taskId)}`,
+      );
+    });
+
+    it.each([
+      { taskId: '.', encodedTaskId: '%252E' },
+      { taskId: '..', encodedTaskId: '%252E%252E' },
+    ])(
+      'should preserve the $taskId task ID as a URL path segment',
+      async ({ taskId, encodedTaskId }) => {
+        const model = createBasicModel();
+
+        await model.doStatus({
+          operation: { taskId, endpointPath: '/v1/videos/text2video' },
+        });
+
+        expect(server.calls[0].requestUrl).toBe(
+          `${TEST_BASE_URL}/v1/videos/text2video/${encodedTaskId}`,
+        );
+      },
+    );
+
     it('should return completed with video data when succeed', async () => {
       const model = createBasicModel({ modelId: 'kling-v2.6-t2v' });
 

--- a/packages/klingai/src/klingai-video-model.ts
+++ b/packages/klingai/src/klingai-video-model.ts
@@ -203,6 +203,17 @@ interface KlingAIVideoModelConfig {
   };
 }
 
+function encodePathSegment(value: string): string {
+  const encodedValue = encodeURIComponent(value);
+
+  // URL parsing normalizes both literal and percent-encoded dot segments.
+  return encodedValue === '.'
+    ? '%252E'
+    : encodedValue === '..'
+      ? '%252E%252E'
+      : encodedValue;
+}
+
 export class KlingAIVideoModel implements VideoModelV4 {
   readonly specificationVersion = 'v4';
   readonly maxVideosPerCall = 1;
@@ -308,7 +319,7 @@ export class KlingAIVideoModel implements VideoModelV4 {
     };
 
     const { value: statusResponse, responseHeaders } = await getFromApi({
-      url: `${this.config.baseURL}${endpointPath}/${taskId}`,
+      url: `${this.config.baseURL}${endpointPath}/${encodePathSegment(taskId)}`,
       validateUrl: false,
       headers: combineHeaders(
         await resolve(this.config.headers),

--- a/packages/luma/src/luma-image-model.test.ts
+++ b/packages/luma/src/luma-image-model.test.ts
@@ -71,9 +71,70 @@ describe('LumaImageModel', () => {
         body: Buffer.from('test-binary-content'),
       },
     },
+    'https://api.example.com/dream-machine/v1/generations/abc%2F..%2F..%2Finternal':
+      {
+        response: {
+          type: 'json-value',
+          body: {
+            id: 'abc/../../internal',
+            generation_type: 'image',
+            state: 'completed',
+            created_at: '2024-01-01T00:00:00Z',
+            assets: {
+              image: 'https://api.example.com/image.png',
+            },
+            model: 'test-model',
+            request: {
+              generation_type: 'image',
+              model: 'test-model',
+              prompt: 'A cute baby sea otter',
+            },
+          },
+        },
+      },
   });
 
   describe('doGenerate', () => {
+    it('should encode the generation ID as a single URL path segment', async () => {
+      const model = createBasicModel();
+      const generationId = 'abc/../../internal';
+
+      server.urls[
+        'https://api.example.com/dream-machine/v1/generations/image'
+      ].response = {
+        type: 'json-value',
+        body: {
+          id: generationId,
+          generation_type: 'image',
+          state: 'queued',
+          created_at: '2024-01-01T00:00:00Z',
+          model: 'test-model',
+          request: {
+            generation_type: 'image',
+            model: 'test-model',
+            prompt,
+          },
+        },
+      };
+
+      await model.doGenerate({
+        prompt,
+        files: undefined,
+        mask: undefined,
+        n: 1,
+        aspectRatio: '16:9',
+        providerOptions: {},
+        size: undefined,
+        seed: undefined,
+      });
+
+      expect(server.calls[1].requestUrl).toBe(
+        `https://api.example.com/dream-machine/v1/generations/${encodeURIComponent(
+          generationId,
+        )}`,
+      );
+    });
+
     it('should pass the correct parameters including aspect ratio', async () => {
       const model = createBasicModel();
 

--- a/packages/luma/src/luma-image-model.ts
+++ b/packages/luma/src/luma-image-model.ts
@@ -38,6 +38,17 @@ interface LumaImageModelConfig {
   };
 }
 
+function encodePathSegment(value: string): string {
+  const encodedValue = encodeURIComponent(value);
+
+  // URL parsing normalizes both literal and percent-encoded dot segments.
+  return encodedValue === '.'
+    ? '%252E'
+    : encodedValue === '..'
+      ? '%252E%252E'
+      : encodedValue;
+}
+
 export class LumaImageModel implements ImageModelV4 {
   readonly specificationVersion = 'v4';
   readonly maxImagesPerCall = 1;
@@ -335,9 +346,9 @@ export class LumaImageModel implements ImageModelV4 {
   }
 
   private getLumaGenerationsUrl(generationId?: string) {
-    return `${this.config.baseURL}/dream-machine/v1/generations/${
-      generationId ?? 'image'
-    }`;
+    return `${this.config.baseURL}/dream-machine/v1/generations/${encodePathSegment(
+      generationId ?? 'image',
+    )}`;
   }
 
   private async downloadImage(

--- a/packages/minimax/src/minimax-video-model.test.ts
+++ b/packages/minimax/src/minimax-video-model.test.ts
@@ -121,6 +121,9 @@ describe('MiniMaxVideoModel', () => {
     [POLL_URL]: {
       response: { type: 'json-value', body: succeededStatusResponse },
     },
+    [`${TEST_BASE_URL}/v2/query/video_generation/abc%2F..%2F..%2Finternal`]: {
+      response: { type: 'json-value', body: succeededStatusResponse },
+    },
   });
 
   describe('constructor', () => {
@@ -135,6 +138,21 @@ describe('MiniMaxVideoModel', () => {
   });
 
   describe('doGenerate', () => {
+    it('should encode the task ID as a single URL path segment', async () => {
+      const model = createModel();
+
+      server.urls[CREATE_URL].response = {
+        type: 'json-value',
+        body: { task_id: 'abc/../../internal' },
+      };
+
+      await model.doGenerate({ ...defaultOptions });
+
+      expect(server.calls.map(call => call.requestUrl)).toContain(
+        `${TEST_BASE_URL}/v2/query/video_generation/abc%2F..%2F..%2Finternal`,
+      );
+    });
+
     it('should send a text-to-video request with required fields', async () => {
       const model = createModel();
 

--- a/packages/minimax/src/minimax-video-model.ts
+++ b/packages/minimax/src/minimax-video-model.ts
@@ -114,6 +114,17 @@ function nonImageFrameMediaType(file: VideoModelV4File): string | undefined {
   return topLevelMediaType === 'image' ? undefined : topLevelMediaType;
 }
 
+function encodePathSegment(value: string): string {
+  const encodedValue = encodeURIComponent(value);
+
+  // URL parsing normalizes both literal and percent-encoded dot segments.
+  return encodedValue === '.'
+    ? '%252E'
+    : encodedValue === '..'
+      ? '%252E%252E'
+      : encodedValue;
+}
+
 export class MiniMaxVideoModel implements VideoModelV4 {
   readonly specificationVersion = 'v4';
   readonly maxVideosPerCall = 1;
@@ -588,7 +599,7 @@ export class MiniMaxVideoModel implements VideoModelV4 {
 
       const { value: statusResponse, responseHeaders: pollHeaders } =
         await getFromApi({
-          url: `${baseURL}/v2/query/video_generation/${taskId}`,
+          url: `${baseURL}/v2/query/video_generation/${encodePathSegment(taskId)}`,
           validateUrl: false,
           headers: combineHeaders(
             await resolve(this.config.headers),

--- a/packages/revai/src/revai-transcription-model.test.ts
+++ b/packages/revai/src/revai-transcription-model.test.ts
@@ -18,6 +18,9 @@ const server = createTestServer({
   'https://api.rev.ai/speechtotext/v1/jobs': {},
   'https://api.rev.ai/speechtotext/v1/jobs/test-id': {},
   'https://api.rev.ai/speechtotext/v1/jobs/test-id/transcript': {},
+  'https://api.rev.ai/speechtotext/v1/jobs/abc%2F..%2F..%2Finternal': {},
+  'https://api.rev.ai/speechtotext/v1/jobs/abc%2F..%2F..%2Finternal/transcript':
+    {},
 });
 
 function prepareJsonFixtureResponse(headers?: Record<string, string>) {
@@ -49,6 +52,55 @@ function prepareJsonFixtureResponse(headers?: Record<string, string>) {
 describe('doGenerate', () => {
   describe('transcription', () => {
     beforeEach(() => prepareJsonFixtureResponse());
+
+    it('should encode the job ID as a single URL path segment in the poll and transcript URLs', async () => {
+      const jobId = 'abc/../../internal';
+      const encodedJobId = encodeURIComponent(jobId);
+
+      server.urls['https://api.rev.ai/speechtotext/v1/jobs'].response = {
+        type: 'json-value',
+        body: {
+          id: jobId,
+          created_on: '2026-02-12T23:26:22.276Z',
+          name: 'audio.mp3',
+          status: 'in_progress',
+          type: 'async',
+          language: 'en',
+        },
+      };
+      server.urls[
+        'https://api.rev.ai/speechtotext/v1/jobs/abc%2F..%2F..%2Finternal'
+      ].response = {
+        type: 'json-value',
+        body: {
+          id: jobId,
+          created_on: '2026-02-12T23:26:22.276Z',
+          completed_on: '2026-02-12T23:26:26.971Z',
+          name: 'audio.mp3',
+          status: 'transcribed',
+          duration_seconds: 2.51,
+          type: 'async',
+          language: 'en',
+        },
+      };
+      server.urls[
+        'https://api.rev.ai/speechtotext/v1/jobs/abc%2F..%2F..%2Finternal/transcript'
+      ].response = {
+        type: 'json-value',
+        body: JSON.parse(
+          fs.readFileSync('src/__fixtures__/revai-transcript.json', 'utf8'),
+        ),
+      };
+
+      await model.doGenerate({ audio: audioData, mediaType: 'audio/mp3' });
+
+      expect(server.calls[1].requestUrl).toBe(
+        `https://api.rev.ai/speechtotext/v1/jobs/${encodedJobId}`,
+      );
+      expect(server.calls[2].requestUrl).toBe(
+        `https://api.rev.ai/speechtotext/v1/jobs/${encodedJobId}/transcript`,
+      );
+    });
 
     it('should pass the model', async () => {
       await model.doGenerate({

--- a/packages/revai/src/revai-transcription-model.ts
+++ b/packages/revai/src/revai-transcription-model.ts
@@ -29,6 +29,17 @@ interface RevaiTranscriptionModelConfig extends RevaiConfig {
   };
 }
 
+function encodePathSegment(value: string): string {
+  const encodedValue = encodeURIComponent(value);
+
+  // URL parsing normalizes both literal and percent-encoded dot segments.
+  return encodedValue === '.'
+    ? '%252E'
+    : encodedValue === '..'
+      ? '%252E%252E'
+      : encodedValue;
+}
+
 export class RevaiTranscriptionModel implements TranscriptionModelV4 {
   readonly specificationVersion = 'v4';
 
@@ -184,7 +195,7 @@ export class RevaiTranscriptionModel implements TranscriptionModelV4 {
       // Poll for job status
       const pollingResult = await getFromApi({
         url: this.config.url({
-          path: `/speechtotext/v1/jobs/${jobId}`,
+          path: `/speechtotext/v1/jobs/${encodePathSegment(jobId ?? '')}`,
           modelId: this.modelId,
         }),
         validateUrl: false,
@@ -219,7 +230,7 @@ export class RevaiTranscriptionModel implements TranscriptionModelV4 {
       rawValue: rawResponse,
     } = await getFromApi({
       url: this.config.url({
-        path: `/speechtotext/v1/jobs/${jobId}/transcript`,
+        path: `/speechtotext/v1/jobs/${encodePathSegment(jobId ?? '')}/transcript`,
         modelId: this.modelId,
       }),
       validateUrl: false,


### PR DESCRIPTION
## Background

PR #19369 fixed a class of bug where a provider-returned identifier reached a credentialed follow-up request path without encoding. The SDK reads a job id from a create or submit response. It then builds the status or result URL by interpolating that id into a fixed path, and calls `getFromApi` with `validateUrl: false`. The `validateUrl: false` flag tells the SDK to treat the URL as developer-configured and safe. The id is not encoded, so a malformed id that contains `/../` changes the request path. The WHATWG URL parser removes the dot-segments before the request goes out, so the credentialed request lands on a different path on the same host.

That PR fixed the pattern in `@ai-sdk/anthropic`, `@ai-sdk/google` (`google-files.ts`), and `@ai-sdk/xai` (`xai-video-model.ts`). A sweep of the remaining `getFromApi` call sites that pass `validateUrl: false` found seven more call sites in seven packages with the same shape. This PR applies the same fix to them.

## Summary

Each affected file now encodes the provider-returned id with the same `encodePathSegment` helper PR #19369 introduced. The helper wraps `encodeURIComponent` and double-encodes a standalone `.` or `..` so URL normalization cannot remove it.

| Package | File | Encoded id |
| --- | --- | --- |
| `@ai-sdk/alibaba` | `alibaba-video-model.ts` | `output.task_id` |
| `@ai-sdk/bytedance` | `bytedance-video-model.ts` | `id` |
| `@ai-sdk/klingai` | `klingai-video-model.ts` | `data.task_id` |
| `@ai-sdk/luma` | `luma-image-model.ts` | `generationResponse.id` |
| `@ai-sdk/minimax` | `minimax-video-model.ts` | `task_id` |
| `@ai-sdk/fal` | `fal-transcription-model.ts` | `queueResponse.request_id` |
| `@ai-sdk/revai` | `revai-transcription-model.ts` | `submissionResponse.id` (two call sites) |

Each id is a single-segment token, so single-segment encoding is correct and does not change a valid request. The change adds encoding only. It changes no other behavior.

## End-to-End Verification

Each package gets a regression test that mirrors the tests PR #19369 added. The test drives the model with an id of `abc/../../internal` and asserts the request URL keeps the encoded id (`abc%2F..%2F..%2Finternal`) instead of a traversed path. The three video-model packages also cover the standalone `.` and `..` cases. Ran the tests and `type-check` for the six packages. All pass.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- `@ai-sdk/google` `google-video-model.ts` and the status call in `google-batch.ts` also read a provider-returned id (`operation.name`). A Google long-running operation name is a resource path that contains a slash on purpose (`operations/<id>`), so single-segment encoding would break it. Those two sites need per-segment encoding, which is a separate change.
- The `ai-sdk/require-validate-url` lint rule checks that a `getFromApi` call sets `validateUrl`. It does not check that an interpolated id inside a `validateUrl: false` URL is encoded. A lint rule for that would stop this class from returning.

## Related Issues

Extends #19369.
