### PR TITLE
fix(openai): strip lookaround regex patterns from Responses tool schemas

### DIFF
--- a/.changeset/openai-responses-strip-pattern.md
+++ b/.changeset/openai-responses-strip-pattern.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+Fix OpenAI Responses API failures when zod v4 string-format validators (`z.email()`, `z.uuid()`, `z.iso.date()`) emit JSON Schema `pattern` regexes with lookaround. The `pattern` keyword is stripped from tool parameters, tool `output_schema`, and `text.format.schema`; `format` is kept.

--- a/packages/openai/src/responses/__fixtures__/zod-v4-string-format-schema.json
+++ b/packages/openai/src/responses/__fixtures__/zod-v4-string-format-schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string",
+      "format": "email",
+      "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+    },
+    "kidId": {
+      "type": "string",
+      "format": "uuid",
+      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$"
+    },
+    "birthDate": {
+      "type": "string",
+      "format": "date",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))$"
+    },
+    "contacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+          }
+        },
+        "required": ["email"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["email", "kidId", "birthDate", "contacts"],
+  "additionalProperties": false
+}

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -705,6 +705,55 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should strip zod v4 format patterns from text.format.schema and tool parameters', async () => {
+        const schema = JSON.parse(
+          fs.readFileSync(
+            'src/responses/__fixtures__/zod-v4-string-format-schema.json',
+            'utf8',
+          ),
+        );
+
+        const { warnings } = await createModel('gpt-5.4').doGenerate({
+          prompt: TEST_PROMPT,
+          tools: [
+            {
+              type: 'function',
+              name: 'createContact',
+              description: 'Create a contact',
+              inputSchema: schema,
+            },
+          ],
+          responseFormat: {
+            type: 'json',
+            name: 'contact',
+            description: 'A contact',
+            schema,
+          },
+        });
+
+        const requestBody = await server.calls[0].requestBodyJson;
+        const requestJson = JSON.stringify(requestBody);
+
+        expect(requestJson).not.toContain('"pattern"');
+        expect(requestBody.text.format.schema.properties.email).toEqual({
+          type: 'string',
+          format: 'email',
+        });
+        expect(requestBody.tools[0].parameters.properties.email).toEqual({
+          type: 'string',
+          format: 'email',
+        });
+        expect(requestBody.tools[0].parameters.properties.kidId).toEqual({
+          type: 'string',
+          format: 'uuid',
+        });
+        expect(requestBody.tools[0].parameters.properties.birthDate).toEqual({
+          type: 'string',
+          format: 'date',
+        });
+        expect(warnings).toStrictEqual([]);
+      });
+
       it('should send response format json object', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
           prompt: TEST_PROMPT,

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -85,6 +85,7 @@ import {
   type OpenAIResponsesModelId,
 } from './openai-responses-language-model-options';
 import { prepareResponsesTools } from './openai-responses-prepare-tools';
+import { removePatternKeyword } from './openai-responses-sanitize-schema';
 import type {
   ResponsesCompactionProviderMetadata,
   ResponsesProviderMetadata,
@@ -461,7 +462,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
                     strict: strictJsonSchema,
                     name: responseFormat.name ?? 'response',
                     description: responseFormat.description,
-                    schema: responseFormat.schema,
+                    schema: removePatternKeyword(responseFormat.schema),
                   }
                 : { type: 'json_object' },
           }),

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { NoSuchProviderReferenceError } from '@ai-sdk/provider';
+import {
+  NoSuchProviderReferenceError,
+  type JSONObject,
+  type JSONSchema7,
+} from '@ai-sdk/provider';
 import { describe, expect, it } from 'vitest';
 import { prepareResponsesTools } from './openai-responses-prepare-tools';
 
@@ -13,7 +17,7 @@ const zodV4StringFormatSchema = JSON.parse(
     ),
     'utf8',
   ),
-) as Record<string, unknown>;
+) as JSONSchema7;
 
 describe('prepareResponsesTools', () => {
   describe('function tools strict mode', () => {
@@ -222,7 +226,7 @@ describe('prepareResponsesTools', () => {
             inputSchema: { type: 'object', properties: {} },
             providerOptions: {
               openai: {
-                outputSchema: zodV4StringFormatSchema,
+                outputSchema: zodV4StringFormatSchema as JSONObject,
               },
             },
           },

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -1,6 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { NoSuchProviderReferenceError } from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
 import { prepareResponsesTools } from './openai-responses-prepare-tools';
-import { describe, it, expect } from 'vitest';
+
+const zodV4StringFormatSchema = JSON.parse(
+  readFileSync(
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      '__fixtures__/zod-v4-string-format-schema.json',
+    ),
+    'utf8',
+  ),
+) as Record<string, unknown>;
 
 describe('prepareResponsesTools', () => {
   describe('function tools strict mode', () => {
@@ -168,6 +181,65 @@ describe('prepareResponsesTools', () => {
           ],
         }
       `);
+    });
+  });
+
+  describe('zod v4 string-format patterns', () => {
+    it('strips pattern from function tool parameters and keeps format', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'createContact',
+            description: 'Create a contact',
+            inputSchema: zodV4StringFormatSchema,
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      const parameters = (
+        result.tools?.[0] as { parameters?: Record<string, unknown> }
+      )?.parameters;
+
+      expect(JSON.stringify(parameters)).not.toContain('"pattern"');
+      expect(parameters).toMatchObject({
+        properties: {
+          email: { type: 'string', format: 'email' },
+          kidId: { type: 'string', format: 'uuid' },
+          birthDate: { type: 'string', format: 'date' },
+        },
+      });
+    });
+
+    it('strips pattern from function tool output_schema and keeps format', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'createContact',
+            description: 'Create a contact',
+            inputSchema: { type: 'object', properties: {} },
+            providerOptions: {
+              openai: {
+                outputSchema: zodV4StringFormatSchema,
+              },
+            },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      const outputSchema = (
+        result.tools?.[0] as { output_schema?: Record<string, unknown> }
+      )?.output_schema;
+
+      expect(JSON.stringify(outputSchema)).not.toContain('"pattern"');
+      expect(outputSchema).toMatchObject({
+        properties: {
+          email: { type: 'string', format: 'email' },
+        },
+      });
     });
   });
 

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -26,6 +26,7 @@ import type {
   OpenAIResponsesFunctionTool,
   OpenAIResponsesTool,
 } from './openai-responses-api';
+import { removePatternKeyword } from './openai-responses-sanitize-schema';
 
 type AllowedToolResolution =
   | { supported: true; entry: OpenAIResponsesAllowedTool }
@@ -615,14 +616,18 @@ function prepareFunctionTool({
     type: 'function',
     name: tool.name,
     description: tool.description,
-    parameters: tool.inputSchema,
+    parameters: removePatternKeyword(tool.inputSchema),
     ...(tool.strict != null ? { strict: tool.strict } : {}),
     ...(deferLoading != null ? { defer_loading: deferLoading } : {}),
     ...(options?.allowedCallers != null
       ? { allowed_callers: options.allowedCallers }
       : {}),
     ...(options?.outputSchema != null
-      ? { output_schema: options.outputSchema as JSONSchema7 }
+      ? {
+          output_schema: removePatternKeyword(
+            options.outputSchema,
+          ) as JSONSchema7,
+        }
       : {}),
   };
 }

--- a/packages/openai/src/responses/openai-responses-sanitize-schema.test.ts
+++ b/packages/openai/src/responses/openai-responses-sanitize-schema.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { zodSchema } from '@ai-sdk/provider-utils';
+import { describe, expect, it } from 'vitest';
+import * as z4 from 'zod/v4';
+import { removePatternKeyword } from './openai-responses-sanitize-schema';
+
+const fixturePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '__fixtures__/zod-v4-string-format-schema.json',
+);
+
+const zodV4StringFormatFixture = JSON.parse(
+  readFileSync(fixturePath, 'utf8'),
+) as Record<string, unknown>;
+
+function collectStringPatterns(value: unknown): string[] {
+  const patterns: string[] = [];
+
+  const visit = (node: unknown) => {
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        visit(item);
+      }
+      return;
+    }
+
+    if (node == null || typeof node !== 'object') {
+      return;
+    }
+
+    for (const [key, child] of Object.entries(node)) {
+      if (key === 'pattern' && typeof child === 'string') {
+        patterns.push(child);
+        continue;
+      }
+
+      visit(child);
+    }
+  };
+
+  visit(value);
+  return patterns;
+}
+
+describe('removePatternKeyword', () => {
+  it('strips lookaround and other format patterns from the zod v4 fixture while keeping format', () => {
+    const patterns = collectStringPatterns(zodV4StringFormatFixture);
+
+    expect(patterns.length).toBeGreaterThan(0);
+    expect(patterns.some(pattern => /\(\?[!<=]/.test(pattern))).toBe(true);
+
+    const sanitized = removePatternKeyword(zodV4StringFormatFixture);
+
+    expect(collectStringPatterns(sanitized)).toEqual([]);
+    expect(sanitized).toMatchObject({
+      properties: {
+        email: { type: 'string', format: 'email' },
+        kidId: { type: 'string', format: 'uuid' },
+        birthDate: { type: 'string', format: 'date' },
+        contacts: {
+          items: {
+            properties: {
+              email: { type: 'string', format: 'email' },
+            },
+          },
+        },
+      },
+    });
+    expect(
+      (sanitized.properties as Record<string, { pattern?: string }>).email
+        .pattern,
+    ).toBeUndefined();
+  });
+
+  it('strips pattern from live zod v4 email/uuid/date JSON Schema', () => {
+    const schema = zodSchema(
+      z4.object({
+        email: z4.email(),
+        kidId: z4.uuid(),
+        birthDate: z4.iso.date(),
+        contacts: z4.array(z4.object({ email: z4.email() })),
+      }),
+    ).jsonSchema;
+
+    expect(schema).not.toBeInstanceOf(Promise);
+
+    const jsonSchema = schema as Record<string, unknown>;
+    const patterns = collectStringPatterns(jsonSchema);
+
+    expect(patterns.length).toBeGreaterThan(0);
+    expect(patterns.some(pattern => /\(\?[!<=]/.test(pattern))).toBe(true);
+
+    const sanitized = removePatternKeyword(jsonSchema);
+
+    expect(collectStringPatterns(sanitized)).toEqual([]);
+    expect(sanitized).toMatchObject({
+      properties: {
+        email: { type: 'string', format: 'email' },
+        kidId: { type: 'string', format: 'uuid' },
+        birthDate: { type: 'string', format: 'date' },
+        contacts: {
+          items: {
+            properties: {
+              email: { type: 'string', format: 'email' },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('does not treat a property named pattern as the JSON Schema keyword', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        pattern: {
+          type: 'string',
+          format: 'email',
+          pattern:
+            "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+        },
+      },
+      required: ['pattern'],
+    };
+
+    expect(removePatternKeyword(schema)).toEqual({
+      type: 'object',
+      properties: {
+        pattern: {
+          type: 'string',
+          format: 'email',
+        },
+      },
+      required: ['pattern'],
+    });
+  });
+
+  it('returns non-object values unchanged', () => {
+    expect(removePatternKeyword(undefined)).toBeUndefined();
+    expect(removePatternKeyword(null)).toBeNull();
+    expect(removePatternKeyword('^(?!x).+$')).toBe('^(?!x).+$');
+  });
+});

--- a/packages/openai/src/responses/openai-responses-sanitize-schema.ts
+++ b/packages/openai/src/responses/openai-responses-sanitize-schema.ts
@@ -1,0 +1,34 @@
+/**
+ * Recursively removes JSON Schema `pattern` keywords before sending schemas
+ * to the OpenAI Responses API.
+ *
+ * zod v4's `toJSONSchema()` emits `pattern` for string-format validators such
+ * as `z.email()`, `z.uuid()`, and `z.iso.date()`. Those regexes include
+ * features OpenAI rejects (lookaround: "Invalid JSON schema: regex lookaround
+ * is not supported") and have also triggered in-stream `server_error`s.
+ * `format` is kept so the constraint is still described to the model.
+ *
+ * A property named `"pattern"` is preserved because its value is a subschema
+ * object, not a regex string.
+ */
+export function removePatternKeyword<T>(schema: T): T {
+  if (Array.isArray(schema)) {
+    return schema.map(item => removePatternKeyword(item)) as T;
+  }
+
+  if (schema == null || typeof schema !== 'object') {
+    return schema;
+  }
+
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === 'pattern' && typeof value === 'string') {
+      continue;
+    }
+
+    result[key] = removePatternKeyword(value);
+  }
+
+  return result as T;
+}


### PR DESCRIPTION
Fixes #16021

Zod v4 `toJSONSchema()` emits JSON Schema `pattern` for `z.email()` / `z.uuid()` / `z.iso.date()`. Those regexes include lookaround. The SDK forwarded them into OpenAI function-tool `parameters` and `text.format.schema`; OpenAI then fails (`Invalid JSON schema: regex lookaround is not supported` on 5.6 Luna; earlier an in-stream `server_error` on gpt-5.4).

This recursively strips string `pattern` keywords from schemas sent on the Responses path (tool `parameters`, tool `output_schema`, `text.format.schema`) and keeps `format`. A property named `"pattern"` is not treated as the keyword.

[#16521](https://github.com/vercel/ai/pull/16521) was a prior attempt on an older encoder; it was closed to tidy a stale queue, not rejected. This is a fresh fix on current main.

## Tests

Sanitizer unit tests (including live zod v4 `toJSONSchema()`), `prepareResponsesTools` tests, and a language-model request-body test covering tool parameters and `text.format.schema`.

## AI disclosure

Cursor Cloud Agent wrote most of the diff; I reviewed the approach and the tests.