### PR TITLE
feat(harness): enhance per-turn telemetry with recently added per-turn configuration data

### DIFF
--- a/.changeset/polite-tips-give.md
+++ b/.changeset/polite-tips-give.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness": patch
+---
+
+feat(harness): enhance per-turn telemetry with recently added per-turn configuration data

--- a/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
+++ b/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
@@ -526,6 +526,10 @@ console.log(preparation.identity);
 - `sandboxConfig`: sandbox working-directory and lifecycle hook configuration.
 - `telemetry`, `debug`, and `onLog`: observability and diagnostics.
 
+Telemetry reports each turn's resolved model, instructions, and active
+host-defined tools. Skills are adapter context and do not have a corresponding
+AI SDK telemetry field, so they are not included in standard telemetry events.
+
 Adapter-specific settings belong on the adapter factory, for example
 `createCodex({ reasoningEffort: 'high' })`.
 

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -458,7 +458,10 @@ describe('HarnessAgent', () => {
       options: { tenant: 'beta' },
     });
 
+    expect(doStart.mock.calls[0]?.[0]).not.toHaveProperty('model');
     expect(doStart.mock.calls[0]?.[0]).not.toHaveProperty('skills');
+    expect(doStart.mock.calls[0]?.[0]).not.toHaveProperty('instructions');
+    expect(doStart.mock.calls[0]?.[0]).not.toHaveProperty('tools');
     expect(promptOptions).toHaveLength(2);
     expect(promptOptions[0]).toMatchObject({
       prompt: 'Hello for alpha',

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -138,12 +138,27 @@ export function runPrompt<
   const onPendingToolResult = input.onPendingToolResult ?? (() => {});
   const onToolResultSettled = input.onToolResultSettled ?? (() => {});
   const activeTools = input.activeTools ?? input.tools;
+  const activeToolNames = Object.keys(input.tools).filter(
+    toolName =>
+      Object.prototype.hasOwnProperty.call(activeTools, toolName) ||
+      (Object.prototype.hasOwnProperty.call(
+        input.harness.builtinTools,
+        toolName,
+      ) &&
+        isHarnessV1BuiltinToolIncluded({
+          toolName,
+          toolFiltering: input.builtinToolFiltering,
+        })),
+  );
 
   const telemetry = createTurnTelemetry({
     telemetry: input.telemetry,
     harnessId: input.harness.harnessId,
     modelId: input.model,
     instructions: input.instructions,
+    tools: input.tools,
+    activeToolNames,
+    toolSpecs: input.toolSpecs,
     promptText: input.prompt != null ? promptToText(input.prompt) : '',
     runtimeContext: input.runtimeContext,
   });

--- a/packages/harness/src/agent/internal/turn-telemetry.test.ts
+++ b/packages/harness/src/agent/internal/turn-telemetry.test.ts
@@ -30,6 +30,9 @@ describe('createTurnTelemetry', () => {
       harnessId: 'mock',
       modelId: 'mock-model',
       instructions: undefined,
+      tools: {},
+      activeToolNames: [],
+      toolSpecs: [],
       promptText: 'go',
       runtimeContext: undefined,
     });

--- a/packages/harness/src/agent/internal/turn-telemetry.ts
+++ b/packages/harness/src/agent/internal/turn-telemetry.ts
@@ -1,6 +1,11 @@
-import { generateId, type ModelMessage } from '@ai-sdk/provider-utils';
+import {
+  generateId,
+  type ModelMessage,
+  type ToolSet,
+} from '@ai-sdk/provider-utils';
 import { createTelemetryDispatcher } from 'ai/internal';
 import type { LanguageModelUsage, TelemetryOptions } from 'ai';
+import type { HarnessV1ToolSpec } from '../../v1';
 
 /*
  * Drives AI SDK's pluggable `Telemetry` lifecycle from a harness turn.
@@ -13,8 +18,9 @@ import type { LanguageModelUsage, TelemetryOptions } from 'ai';
  * step boundary, tool-calls = tool executions, `finish` = operation end. The
  * model-call-only event fields the harness has no value for (sampling params,
  * standardized prompt) are left `undefined` / cast; the fields the integrations
- * actually read (`callId`, `operationId`, `provider`, `modelId`, `messages`,
- * `toolCall`, `usage`, `finishReason`) carry real values.
+ * actually read (`callId`, `operationId`, `provider`, `modelId`,
+ * `instructions`, `messages`, `tools`, `toolCall`, `usage`, `finishReason`)
+ * carry real values.
  *
  * Telemetry is opt-in: the framework only drives it when `settings.telemetry`
  * is set (the dispatcher then also honours globally-registered integrations).
@@ -160,6 +166,9 @@ export function createTurnTelemetry(opts: {
   harnessId: string;
   modelId: string | undefined;
   instructions: string | undefined;
+  tools: ToolSet;
+  activeToolNames: string[];
+  toolSpecs: HarnessV1ToolSpec[];
   promptText: string;
   runtimeContext: unknown;
 }): TurnTelemetry {
@@ -177,6 +186,19 @@ export function createTurnTelemetry(opts: {
   const inputMessages: ModelMessage[] = [
     { role: 'user', content: opts.promptText },
   ];
+  const languageModelTools =
+    opts.toolSpecs.length === 0
+      ? undefined
+      : opts.toolSpecs.map(tool => ({
+          type: 'function' as const,
+          name: tool.name,
+          ...(tool.description != null
+            ? { description: tool.description }
+            : {}),
+          ...(tool.inputSchema != null
+            ? { inputSchema: tool.inputSchema }
+            : {}),
+        }));
 
   let started = false;
   let stepOpen = false;
@@ -211,9 +233,9 @@ export function createTurnTelemetry(opts: {
         operationId: 'ai.harness',
         provider,
         modelId,
-        tools: undefined,
+        tools: opts.tools,
         toolChoice: undefined,
-        activeTools: undefined,
+        activeTools: opts.activeToolNames,
         maxRetries: 0,
         timeout: undefined,
         headers: undefined,
@@ -243,13 +265,14 @@ export function createTurnTelemetry(opts: {
         provider,
         modelId,
         stepNumber,
-        tools: undefined,
+        tools: opts.tools,
         toolChoice: undefined,
-        activeTools: undefined,
+        activeTools: opts.activeToolNames,
         steps: new Array(stepNumber),
         providerOptions: undefined,
         output: undefined,
         runtimeContext,
+        instructions: opts.instructions,
         messages: inputMessages,
       }),
     );
@@ -260,8 +283,9 @@ export function createTurnTelemetry(opts: {
         callId,
         provider,
         modelId,
+        instructions: opts.instructions,
         messages: inputMessages,
-        tools: undefined,
+        tools: languageModelTools,
       }),
     );
   };
@@ -279,6 +303,8 @@ export function createTurnTelemetry(opts: {
     await dispatcher.onLanguageModelCallEnd?.(
       cast<'onLanguageModelCallEnd'>({
         callId,
+        provider,
+        modelId,
         finishReason,
         responseId: callId,
         usage,

--- a/packages/harness/src/agent/telemetry-integration.test.ts
+++ b/packages/harness/src/agent/telemetry-integration.test.ts
@@ -4,8 +4,10 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
+import { tool } from '@ai-sdk/provider-utils';
 import type { Telemetry } from 'ai';
 import { describe, expect, test } from 'vitest';
+import { z } from 'zod/v4';
 import type {
   HarnessV1,
   HarnessV1NetworkSandboxSession,
@@ -116,18 +118,22 @@ function recordingIntegration(): {
   integration: Telemetry;
   calls: Array<{ method: string; callId: unknown }>;
   events: Record<string, unknown>;
+  eventLists: Record<string, unknown[]>;
 } {
   const calls: Array<{ method: string; callId: unknown }> = [];
   const events: Record<string, unknown> = {};
+  const eventLists: Record<string, unknown[]> = {};
   const rec =
     (method: string) =>
     (event: unknown): void => {
       calls.push({ method, callId: (event as { callId?: unknown }).callId });
       events[method] = event;
+      (eventLists[method] ??= []).push(event);
     };
   return {
     calls,
     events,
+    eventLists,
     integration: {
       onStart: rec('onStart'),
       onStepStart: rec('onStepStart'),
@@ -183,6 +189,7 @@ describe('HarnessAgent telemetry integration', () => {
       telemetry: { integrations: [integration] },
     });
     const session = await agent.createSession();
+    expect(calls).toEqual([]);
     await agent.generate({ session, prompt: 'go' });
     await session.destroy();
 
@@ -270,6 +277,198 @@ describe('HarnessAgent telemetry integration', () => {
     const callIds = new Set(calls.map(c => c.callId));
     expect(callIds.size).toBe(1);
     expect([...callIds][0]).toBeTruthy();
+  });
+
+  test('reports fresh turn settings without exposing skills', async () => {
+    const harness = scriptedHarness([
+      { type: 'stream-start' },
+      { type: 'text-start', id: 't1' },
+      { type: 'text-delta', id: 't1', delta: 'done' },
+      { type: 'text-end', id: 't1' },
+      {
+        type: 'finish-step',
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage,
+      },
+      {
+        type: 'finish',
+        finishReason: { unified: 'stop', raw: 'stop' },
+        totalUsage: usage,
+      },
+    ]);
+    const echo = tool({
+      description: 'Echo a value.',
+      inputSchema: z.object({ value: z.string() }),
+    });
+    const reverse = tool({
+      description: 'Reverse a value.',
+      inputSchema: z.object({ value: z.string() }),
+    });
+    const { integration, eventLists } = recordingIntegration();
+    const agent = new HarnessAgent({
+      harness,
+      sandbox: makeSandboxProvider(),
+      telemetry: { integrations: [integration] },
+      callOptionsSchema: z.object({ tenant: z.enum(['alpha', 'beta']) }),
+      prepareCall: ({ options, ...call }) => ({
+        ...call,
+        model: `model-${options.tenant}`,
+        skills: [
+          {
+            name: `${options.tenant}-skill`,
+            description: `${options.tenant} skill`,
+            content: `${options.tenant} skill instructions`,
+          },
+        ],
+        instructions: `${options.tenant} instructions`,
+        tools: options.tenant === 'alpha' ? { echo } : { reverse },
+      }),
+    });
+    const session = await agent.createSession();
+
+    await agent.generate({
+      session,
+      prompt: 'first',
+      options: { tenant: 'alpha' },
+    });
+    await agent.generate({
+      session,
+      prompt: 'second',
+      options: { tenant: 'beta' },
+    });
+    await session.destroy();
+
+    const starts = eventLists.onStart as Array<{
+      modelId: string;
+      instructions: string;
+      tools: Record<string, unknown>;
+      activeTools: string[];
+    }>;
+    expect(
+      starts.map(({ modelId, instructions, tools, activeTools }) => ({
+        modelId,
+        instructions,
+        toolNames: Object.keys(tools),
+        activeTools,
+      })),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "activeTools": [
+            "echo",
+          ],
+          "instructions": "alpha instructions",
+          "modelId": "model-alpha",
+          "toolNames": [
+            "echo",
+          ],
+        },
+        {
+          "activeTools": [
+            "reverse",
+          ],
+          "instructions": "beta instructions",
+          "modelId": "model-beta",
+          "toolNames": [
+            "reverse",
+          ],
+        },
+      ]
+    `);
+
+    const stepStarts = eventLists.onStepStart as Array<{
+      modelId: string;
+      instructions: string;
+      tools: Record<string, unknown>;
+      activeTools: string[];
+    }>;
+    expect(
+      stepStarts.map(({ modelId, instructions, tools, activeTools }) => ({
+        modelId,
+        instructions,
+        toolNames: Object.keys(tools),
+        activeTools,
+      })),
+    ).toEqual(
+      starts.map(({ modelId, instructions, tools, activeTools }) => ({
+        modelId,
+        instructions,
+        toolNames: Object.keys(tools),
+        activeTools,
+      })),
+    );
+
+    const modelCallStarts = eventLists.onLanguageModelCallStart as Array<{
+      modelId: string;
+      instructions: string;
+      tools: unknown[];
+    }>;
+    expect(
+      modelCallStarts.map(({ modelId, instructions, tools }) => ({
+        modelId,
+        instructions,
+        tools,
+      })),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "instructions": "alpha instructions",
+          "modelId": "model-alpha",
+          "tools": [
+            {
+              "description": "Echo a value.",
+              "inputSchema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "value": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "value",
+                ],
+                "type": "object",
+              },
+              "name": "echo",
+              "type": "function",
+            },
+          ],
+        },
+        {
+          "instructions": "beta instructions",
+          "modelId": "model-beta",
+          "tools": [
+            {
+              "description": "Reverse a value.",
+              "inputSchema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "additionalProperties": false,
+                "properties": {
+                  "value": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "value",
+                ],
+                "type": "object",
+              },
+              "name": "reverse",
+              "type": "function",
+            },
+          ],
+        },
+      ]
+    `);
+    expect(
+      Object.values(eventLists)
+        .flat()
+        .every(
+          event =>
+            !Object.prototype.hasOwnProperty.call(event as object, 'skills'),
+        ),
+    ).toBe(true);
   });
 
   test('uses final-step text and reasoning on the telemetry end event', async () => {
@@ -361,8 +560,15 @@ describe('HarnessAgent telemetry integration', () => {
       },
     ]);
     const { exporter, tracer } = createSdkTracer();
+    const echo = tool({
+      description: 'Echo a value.',
+      inputSchema: z.object({ value: z.string() }),
+    });
     const agent = new HarnessAgent({
       harness,
+      model: 'requested-model',
+      instructions: 'Answer concisely.',
+      tools: { echo },
       sandbox: makeSandboxProvider(),
       telemetry: {
         isEnabled: true,
@@ -388,6 +594,8 @@ describe('HarnessAgent telemetry integration', () => {
     const rootSpan = getExportedSpan(exporter, 'ai.harness otel-model');
 
     expect(chatSpan!.attributes).toMatchObject({
+      'gen_ai.request.model': 'otel-model',
+      'gen_ai.response.model': 'otel-model',
       'gen_ai.input.messages': JSON.stringify([
         { role: 'user', parts: [{ type: 'text', content: 'go' }] },
       ]),
@@ -395,6 +603,40 @@ describe('HarnessAgent telemetry integration', () => {
       'gen_ai.usage.input_tokens': 5,
       'gen_ai.usage.output_tokens': 2,
     });
+    expect(chatSpan!.attributes['gen_ai.system_instructions']).toBe(
+      JSON.stringify([
+        {
+          type: 'text',
+          content: 'Answer concisely.',
+        },
+      ]),
+    );
+    expect(
+      JSON.parse(
+        chatSpan!.attributes['gen_ai.tool.definitions'] as string,
+      ) as unknown,
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "description": "Echo a value.",
+          "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "value",
+            ],
+            "type": "object",
+          },
+          "name": "echo",
+          "type": "function",
+        },
+      ]
+    `);
     expect(chatSpan!.attributes['gen_ai.output.messages']).toBe(
       JSON.stringify([
         {
@@ -406,6 +648,13 @@ describe('HarnessAgent telemetry integration', () => {
     );
 
     expect(rootSpan.attributes).toMatchObject({
+      'gen_ai.request.model': 'otel-model',
+      'gen_ai.system_instructions': JSON.stringify([
+        {
+          type: 'text',
+          content: 'Answer concisely.',
+        },
+      ]),
       'gen_ai.response.finish_reasons': ['stop'],
       'gen_ai.usage.input_tokens': 5,
       'gen_ai.usage.output_tokens': 2,
@@ -427,6 +676,53 @@ describe('HarnessAgent telemetry integration', () => {
         },
       ]),
     );
+  });
+
+  test('omits turn input attributes when recordInputs is false', async () => {
+    const harness = scriptedHarness([
+      { type: 'stream-start', modelId: 'private-model' },
+      { type: 'text-start', id: 't1' },
+      { type: 'text-delta', id: 't1', delta: 'done' },
+      { type: 'text-end', id: 't1' },
+      {
+        type: 'finish-step',
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage,
+      },
+      {
+        type: 'finish',
+        finishReason: { unified: 'stop', raw: 'stop' },
+        totalUsage: usage,
+      },
+    ]);
+    const { exporter, tracer } = createSdkTracer();
+    const agent = new HarnessAgent({
+      harness,
+      instructions: 'Do not record.',
+      tools: {
+        secret: tool({
+          inputSchema: z.object({ value: z.string() }),
+        }),
+      },
+      sandbox: makeSandboxProvider(),
+      telemetry: {
+        isEnabled: true,
+        recordInputs: false,
+        integrations: [new OpenTelemetry({ tracer })],
+      },
+    });
+
+    const session = await agent.createSession();
+    await agent.generate({ session, prompt: 'private prompt' });
+    await session.destroy();
+
+    const chatSpan = getExportedSpan(exporter, 'chat private-model');
+    expect(chatSpan.attributes['gen_ai.request.model']).toBe('private-model');
+    expect(chatSpan.attributes).not.toHaveProperty('gen_ai.input.messages');
+    expect(chatSpan.attributes).not.toHaveProperty(
+      'gen_ai.system_instructions',
+    );
+    expect(chatSpan.attributes).not.toHaveProperty('gen_ai.tool.definitions');
   });
 
   test('fires no telemetry when settings.telemetry is unset', async () => {


### PR DESCRIPTION
## Background

Harness call options can now change model, instructions, skills, and tools between turns, but standard telemetry did not fully reflect those turn-scoped values.

## Summary

- Report each turn's resolved model, instructions, tools, and active tool names through existing telemetry events.
- Convert active host tools into model-call tool definitions without synthesizing adapter-native built-ins or exposing skills.
- Keep session creation free of turn-scoped telemetry and preserve `recordInputs: false` behavior.
- Add regression coverage and document the telemetry behavior.

## End-to-End Verification

Ran `./tools/run-harness-agent-examples.sh --harness codex --example changing-settings`; all model and profile change turns passed.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
