### PR TITLE
fix(harness-claude-code): use structured `tool_result` blocks when present for tool results instead of agent-facing response

### DIFF
--- a/.changeset/sour-papayas-travel.md
+++ b/.changeset/sour-papayas-travel.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-claude-code": patch
+---
+
+fix(harness-claude-code): use structured `tool_result` blocks when present for tool results instead of agent-facing response

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.test.ts
@@ -7,6 +7,225 @@ import {
 } from './create-emit-stream-event';
 
 describe('createEmitStreamEvent', () => {
+  it.each([
+    {
+      name: 'TaskCreate object output',
+      nativeName: 'TaskCreate',
+      content: 'Task #1 created successfully: probe-task',
+      toolUseResult: { task: { id: '1', subject: 'probe-task' } },
+      isError: false,
+      expectedResult: { task: { id: '1', subject: 'probe-task' } },
+    },
+    {
+      name: 'Read object output',
+      nativeName: 'Read',
+      content: '1\talpha\n2\tbeta\n3\tgamma\n4\t',
+      toolUseResult: {
+        type: 'text',
+        file: {
+          filePath: '/tmp/sample.txt',
+          content: 'alpha\nbeta\ngamma\n',
+          numLines: 4,
+          startLine: 1,
+          totalLines: 4,
+        },
+      },
+      isError: false,
+      expectedResult: {
+        type: 'text',
+        file: {
+          filePath: '/tmp/sample.txt',
+          content: 'alpha\nbeta\ngamma\n',
+          numLines: 4,
+          startLine: 1,
+          totalLines: 4,
+        },
+      },
+    },
+    {
+      name: 'successful Bash object output',
+      nativeName: 'Bash',
+      content: 'hello-stdouthello-stderr',
+      toolUseResult: {
+        stdout: 'hello-stdouthello-stderr',
+        stderr: '',
+        interrupted: false,
+        isImage: false,
+        noOutputExpected: false,
+      },
+      isError: false,
+      expectedResult: {
+        stdout: 'hello-stdouthello-stderr',
+        stderr: '',
+        interrupted: false,
+        isImage: false,
+        noOutputExpected: false,
+      },
+    },
+    {
+      name: 'failed Bash string output',
+      nativeName: 'Bash',
+      content: 'Exit code 2\nmissing',
+      toolUseResult: 'Error: Exit code 2\nmissing',
+      isError: true,
+      expectedResult: 'Error: Exit code 2\nmissing',
+    },
+  ])(
+    'uses the Claude Agent SDK output for $name',
+    ({ nativeName, content, toolUseResult, isError, expectedResult }) => {
+      const state = createClaudeStreamEventState();
+      const emitted: Record<string, unknown>[] = [];
+      const emitStreamEvent = createEmitStreamEvent({
+        state,
+        emit: event => emitted.push(event),
+        emitWarning: () => {},
+        emitTerminalError: () => {},
+        onCompactionBoundary: () => {},
+        toCommonName: name => (name === 'Bash' ? 'bash' : name),
+      });
+
+      emitStreamEvent({
+        type: 'assistant',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tool-1',
+              name: nativeName,
+              input: {},
+            },
+          ],
+        },
+      });
+      emitStreamEvent({
+        type: 'user',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tool-1',
+              content,
+              is_error: isError,
+            },
+          ],
+        },
+        tool_use_result: toolUseResult,
+      });
+
+      expect(emitted.find(event => event.type === 'tool-result')).toEqual({
+        type: 'tool-result',
+        toolCallId: 'tool-1',
+        toolName: nativeName === 'Bash' ? 'bash' : nativeName,
+        result: expectedResult,
+        isError,
+      });
+    },
+  );
+
+  it('falls back to model-facing content when the SDK does not provide an output', () => {
+    const state = createClaudeStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: event => emitted.push(event),
+      emitWarning: () => {},
+      emitTerminalError: () => {},
+      onCompactionBoundary: () => {},
+      toCommonName: name => name,
+    });
+
+    emitStreamEvent({
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-1',
+            name: 'Read',
+            input: {},
+          },
+        ],
+      },
+    });
+    emitStreamEvent({
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-1',
+            content: 'file contents',
+          },
+        ],
+      },
+    });
+
+    expect(emitted.find(event => event.type === 'tool-result')).toEqual({
+      type: 'tool-result',
+      toolCallId: 'tool-1',
+      toolName: 'Read',
+      result: 'file contents',
+      isError: false,
+    });
+  });
+
+  it('falls back to model-facing content when a singular output cannot be paired with multiple results', () => {
+    const state = createClaudeStreamEventState();
+    const emitted: Record<string, unknown>[] = [];
+    const emitStreamEvent = createEmitStreamEvent({
+      state,
+      emit: event => emitted.push(event),
+      emitWarning: () => {},
+      emitTerminalError: () => {},
+      onCompactionBoundary: () => {},
+      toCommonName: name => name,
+    });
+
+    emitStreamEvent({
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-1',
+            name: 'Read',
+            input: {},
+          },
+          {
+            type: 'tool_use',
+            id: 'tool-2',
+            name: 'Glob',
+            input: {},
+          },
+        ],
+      },
+    });
+    emitStreamEvent({
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-1',
+            content: 'file contents',
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-2',
+            content: 'sample.txt',
+          },
+        ],
+      },
+      tool_use_result: { filenames: ['sample.txt'] },
+    });
+
+    expect(
+      emitted
+        .filter(event => event.type === 'tool-result')
+        .map(event => event.result),
+    ).toEqual(['file contents', 'sample.txt']);
+  });
+
   it('streams native tool input before the complete tool call', () => {
     const state = createClaudeStreamEventState();
     const emitted: Record<string, unknown>[] = [];

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
@@ -42,6 +42,7 @@ export type ClaudeMessage = {
   usage?: Record<string, unknown>;
   total_cost_usd?: number;
   structured_output?: unknown;
+  tool_use_result?: unknown;
 };
 
 type MessageBlock = {
@@ -265,6 +266,12 @@ export function createEmitStreamEvent({
     }
 
     if (type === 'user' && msg.message?.content) {
+      const toolResultBlocks = msg.message.content.filter(
+        block => block.type === 'tool_result',
+      );
+      const toolUseResult =
+        toolResultBlocks.length === 1 ? msg.tool_use_result : undefined;
+
       for (const block of msg.message.content) {
         if (
           block.type === 'tool_result' &&
@@ -291,17 +298,19 @@ export function createEmitStreamEvent({
            * numeric exit code — the SDK exposes only stdout/stderr text and
            * an is_error flag. Consumers (and the example UI) render bash
            * failures from an `exitCode` field on a structured result, the
-           * shape Codex's shell tool provides natively. To match it, derive
-           * a binary code from is_error: 1 on failure, 0 on success. This is
-           * a stand-in for failed/succeeded, not the process's true exit
-           * status.
+           * shape Codex's shell tool provides natively. When Claude omits
+           * `tool_use_result`, derive a binary code from is_error: 1 on
+           * failure, 0 on success. This fallback is a stand-in for
+           * failed/succeeded, not the process's true exit status.
            */
-          const result =
+          const contentResult =
             toolName === 'bash'
               ? { exitCode: isError ? 1 : 0, stdout: content }
               : dynamic
                 ? parseMcpToolResult(content)
                 : content;
+          const result =
+            toolUseResult !== undefined ? toolUseResult : contentResult;
           emit({
             type: 'tool-result',
             toolCallId: block.tool_use_id,

--- a/packages/harness-claude-code/src/claude-code-bridge-protocol.test.ts
+++ b/packages/harness-claude-code/src/claude-code-bridge-protocol.test.ts
@@ -69,6 +69,17 @@ describe('outboundMessageSchema', () => {
       outboundMessageSchema.parse({ type: 'mystery' as 'error', error: 1 }),
     ).toThrow();
   });
+
+  it('preserves structured Claude Code tool results', () => {
+    const message = {
+      type: 'tool-result' as const,
+      toolCallId: 't1',
+      toolName: 'TaskCreate',
+      result: { task: { id: '1', subject: 'probe-task' } },
+    };
+
+    expect(outboundMessageSchema.parse(message)).toEqual(message);
+  });
 });
 
 describe('inboundMessageSchema', () => {


### PR DESCRIPTION
## Background

The Claude Code bridge discarded `SDKUserMessage.tool_use_result`, causing consumers to receive model-facing text instead of the tool's structured output.

## Summary

- Use `tool_use_result` as the canonical result when it can be paired with a single tool result.
- Preserve Claude's structured outputs for tools such as TaskCreate, Read, and Bash, including string error results.
- Fall back to the existing content-derived result when structured output is absent or cannot be paired unambiguously.

## End-to-End Verification

Ran the Claude Code `file-edit` harness example through create, edit, and read turns. Each public tool result contained Claude's structured Bash output, including separate `stdout`, `stderr`, and interruption metadata.

Replayed the captured reproduction from #19895 and confirmed its TaskCreate, Read, successful Bash, and failed Bash cases pass.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #19894

Closes #19895
