### PR TITLE
fix(harness-claude-code): mark approval-gated external MCP tool calls as dynamic

### DIFF
--- a/.changeset/tidy-tools-agree.md
+++ b/.changeset/tidy-tools-agree.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-claude-code': patch
+---
+
+fix(harness-claude-code): mark approval-gated external MCP tool calls as dynamic

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
@@ -104,6 +104,13 @@ export function createClaudeStreamEventState(): ClaudeStreamEventState {
 }
 
 const UNRECOVERABLE_API_RETRY_STATUSES = new Set([401, 403, 404]);
+const HOST_TOOL_PREFIX = 'mcp__harness-tools__';
+
+export function isExternalMcpTool(nativeName: string): boolean {
+  return (
+    nativeName.startsWith('mcp__') && !nativeName.startsWith(HOST_TOOL_PREFIX)
+  );
+}
 
 export function createEmitStreamEvent({
   state,
@@ -232,15 +239,14 @@ export function createEmitStreamEvent({
             state.structuredOutputToolUseIds.add(block.id);
             continue;
           }
-          const mcpPrefix = 'mcp__harness-tools__';
-          if (block.name.startsWith(mcpPrefix)) {
+          if (block.name.startsWith(HOST_TOOL_PREFIX)) {
             state.pendingStepToolUseIds.add(block.id);
             state.mcpToolUseIds.add(block.id);
             opensStep = true;
             continue;
           }
           state.nativeToolCallNames.set(block.id, block.name);
-          const dynamic = block.name.startsWith('mcp__');
+          const dynamic = isExternalMcpTool(block.name);
           if (dynamic) state.externalMcpToolUseIds.add(block.id);
           if (state.approvalRequestedToolUseIds.has(block.id)) {
             continue;
@@ -397,8 +403,6 @@ function formatApiRetryWarning(msg: ClaudeMessage): string {
     : 'Claude Code API retry';
 }
 
-const HOST_TOOL_PREFIX = 'mcp__harness-tools__';
-
 function handleStreamEvent({
   event,
   state,
@@ -437,8 +441,7 @@ function handleStreamEvent({
       const hostToolName = nativeName.startsWith(HOST_TOOL_PREFIX)
         ? nativeName.slice(HOST_TOOL_PREFIX.length)
         : undefined;
-      const dynamic =
-        hostToolName === undefined && nativeName.startsWith('mcp__');
+      const dynamic = isExternalMcpTool(nativeName);
       partialBlocks.set(index, { id, kind: 'tool-input' });
       send({
         type: 'tool-input-start',

--- a/packages/harness-claude-code/src/bridge/index.test.ts
+++ b/packages/harness-claude-code/src/bridge/index.test.ts
@@ -356,6 +356,43 @@ describe('Claude Code bridge configuration', () => {
     });
   });
 
+  test('marks approval-gated external MCP tool calls as dynamic', async () => {
+    state.start = {
+      ...state.start,
+      permissionMode: 'allow-reads',
+    };
+
+    await import('./index');
+
+    const canUseTool = state.queryArgs[0]?.options.canUseTool as
+      | ((
+          toolName: string,
+          toolInput: Record<string, unknown>,
+          options: { toolUseID: string },
+        ) => Promise<unknown>)
+      | undefined;
+    await canUseTool?.(
+      'mcp__context7__query-docs',
+      { libraryId: '/vercel/next.js' },
+      { toolUseID: 'external-tool' },
+    );
+
+    expect(
+      state.emitted.find(
+        event =>
+          event.type === 'tool-call' && event.toolCallId === 'external-tool',
+      ),
+    ).toEqual({
+      type: 'tool-call',
+      toolCallId: 'external-tool',
+      toolName: 'mcp__context7__query-docs',
+      nativeName: 'mcp__context7__query-docs',
+      input: '{"libraryId":"/vercel/next.js"}',
+      providerExecuted: true,
+      dynamic: true,
+    });
+  });
+
   test('uses callback metadata to correlate identical parallel host tool calls', async () => {
     state.start = {
       ...state.start,

--- a/packages/harness-claude-code/src/bridge/index.ts
+++ b/packages/harness-claude-code/src/bridge/index.ts
@@ -43,6 +43,7 @@ import {
   defaultUsage,
   emitFinishStep,
   finishApprovalStep,
+  isExternalMcpTool,
   mapUsage,
   type ClaudeMessage,
 } from './create-emit-stream-event';
@@ -201,6 +202,7 @@ function createPermissionOptions(input: {
         nativeName: toolName,
         input: JSON.stringify(toolInput ?? {}),
         providerExecuted: true,
+        ...(isExternalMcpTool(toolName) ? { dynamic: true } : {}),
       });
       input.emit({
         type: 'tool-approval-request',


### PR DESCRIPTION
## Background

Approval-gated external MCP calls emitted a settled `tool-call` without `dynamic: true`, even though their streamed input and result carried that flag. This could leave the dynamic UI part pending and create a duplicate static part.

## Summary

- Reuse one external MCP classification for streamed inputs, settled calls, results, and approval-gated calls.
- Mark approval-gated external MCP tool calls as dynamic.
- Add regression coverage for the Claude Code approval callback.

## Contributor Credit

Credit to @gdaybrice for identifying and originally implementing this fix in #18904.

## End-to-End Verification

Ran `./tools/run-harness-agent-examples.sh --example with-tools --example with-mcp --harness claude-code`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

Co-Authored-by: Brice Lechatellier <brice@brand.ai>
