### PR TITLE
fix(google): support video response formats in Gemini Interactions

### DIFF
--- a/.changeset/warm-videos-respond.md
+++ b/.changeset/warm-videos-respond.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+fix(google): support video response formats in Gemini Interactions

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -1262,8 +1262,8 @@ The [Gemini Interactions API](https://ai.google.dev/gemini-api/docs/interactions
 (`POST /v1beta/interactions`) is a separate Google endpoint with server-side
 state, unified content blocks, first-class built-in tools, agent presets,
 managed agents that run in a sandboxed Linux environment, and native
-multimodal image output. It is reached via the `google.interactions(...)`
-factory:
+multimodal image and video output. It is reached via the
+`google.interactions(...)` factory:
 
 ```ts
 import { google } from '@ai-sdk/google';
@@ -1355,17 +1355,42 @@ The following optional provider options are available:
   Whether the model returns synthesized thought summaries on reasoning
   parts. Defaults to the API default.
 
-- **responseFormat** _Array\<\{ type: 'text' | 'image' | 'audio'; mimeType?: string; schema?: unknown; aspectRatio?: string; imageSize?: '1K' \| '2K' \| '4K' \| '512' \}\>_
+- **responseFormat** _Array\<ResponseFormatEntry\>_
 
   Output-format entries that map directly to the API's `response_format`
-  array. Use this for fine-grained control over image, audio, or non-JSON
-  text outputs (e.g. `aspectRatio` and `imageSize` for image generation).
+  array. Entries have the following shape:
+
+  ```ts
+  type ResponseFormatEntry =
+    | { type: 'text'; mimeType?: string; schema?: unknown }
+    | {
+        type: 'image';
+        mimeType?: string;
+        aspectRatio?: string;
+        imageSize?: '1K' | '2K' | '4K' | '512';
+      }
+    | { type: 'audio'; mimeType?: string }
+    | {
+        type: 'video';
+        aspectRatio?: '16:9' | '9:16';
+        resolution?: '360p' | '720p' | '1080p' | '4k';
+        duration?: string;
+        delivery?: 'inline' | 'uri';
+        gcsUri?: string;
+      };
+  ```
+
+  Use this for fine-grained control over image, audio, video, or non-JSON
+  text outputs. Video entries can control aspect ratio, resolution, duration,
+  and inline or URI delivery; set `gcsUri` when delivering to Google Cloud
+  Storage. Inline videos are returned in `result.files` by `generateText` and
+  emitted as `file` parts by `streamText`.
   The AI SDK call-level `responseFormat: { type: 'json', schema }` still
   drives JSON-mode automatically and prepends a matching text entry;
   entries listed here are appended.
 
-  `aspectRatio` accepts `1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`,
-  `9:16`, `16:9`, `21:9`, `1:8`, `8:1`, `1:4`, `4:1`.
+  For image entries, `aspectRatio` accepts `1:1`, `2:3`, `3:2`, `3:4`, `4:3`,
+  `4:5`, `5:4`, `9:16`, `16:9`, `21:9`, `1:8`, `8:1`, `1:4`, `4:1`.
 
 - **imageConfig** _\{ aspectRatio?: string; imageSize?: '1K' | '2K' | '4K' | '512' \}_ (deprecated)
 

--- a/examples/ai-functions/src/generate-text/google/interactions-video-response-format.ts
+++ b/examples/ai-functions/src/generate-text/google/interactions-video-response-format.ts
@@ -1,0 +1,29 @@
+import { google } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: google.interactions('gemini-omni-flash-preview'),
+    prompt:
+      'Generate a four-second landscape video of a red ball rolling across a white floor.',
+    providerOptions: {
+      google: {
+        responseModalities: ['video'],
+        responseFormat: [
+          {
+            type: 'video',
+            aspectRatio: '16:9',
+            resolution: '360p',
+          },
+        ],
+      },
+    },
+  });
+
+  const videos = result.files.filter(file =>
+    file.mediaType.startsWith('video/'),
+  );
+  await presentVideos(videos);
+});

--- a/packages/google/src/interactions/google-interactions-language-model-options.ts
+++ b/packages/google/src/interactions/google-interactions-language-model-options.ts
@@ -75,8 +75,8 @@ export const googleInteractionsLanguageModelOptions = lazySchema(() =>
 
       /**
        * Output-format entries that map directly to the API's `response_format`
-       * array. Use this to request image, audio, or non-JSON text outputs
-       * with full control over `mime_type`, `aspect_ratio`, and `image_size`.
+       * array. Use this to request image, audio, video, or non-JSON text
+       * outputs with modality-specific controls.
        *
        * Entries are sent in order. The AI SDK call-level `responseFormat: {
        * type: 'json', schema }` still drives JSON-mode and adds a matching
@@ -121,6 +121,16 @@ export const googleInteractionsLanguageModelOptions = lazySchema(() =>
               .object({
                 type: z.literal('audio'),
                 mimeType: z.string().nullish(),
+              })
+              .loose(),
+            z
+              .object({
+                type: z.literal('video'),
+                aspectRatio: z.enum(['16:9', '9:16']).nullish(),
+                resolution: z.enum(['360p', '720p', '1080p', '4k']).nullish(),
+                duration: z.string().nullish(),
+                delivery: z.enum(['inline', 'uri']).nullish(),
+                gcsUri: z.string().nullish(),
               })
               .loose(),
           ]),

--- a/packages/google/src/interactions/google-interactions-language-model.test.ts
+++ b/packages/google/src/interactions/google-interactions-language-model.test.ts
@@ -381,6 +381,73 @@ describe('GoogleInteractionsLanguageModel.doGenerate', () => {
       expect(body.response_format).toBeUndefined();
     });
 
+    it('serializes video response format controls and returns inline video data', async () => {
+      server.urls[TEST_URL].response = {
+        type: 'json-value',
+        body: {
+          id: 'v1_video',
+          status: 'completed',
+          model: 'gemini-omni-flash-preview',
+          steps: [
+            {
+              type: 'model_output',
+              content: [
+                {
+                  type: 'video',
+                  mime_type: 'video/mp4',
+                  data: 'AAAAIGZ0eXBpc29t',
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          google: {
+            responseModalities: ['video'],
+            responseFormat: [
+              {
+                type: 'video',
+                aspectRatio: '16:9',
+                resolution: '360p',
+                duration: '4s',
+                delivery: 'uri',
+                gcsUri: 'gs://video-output/clip.mp4',
+              },
+            ],
+          },
+        },
+      });
+
+      const body = (await server.calls[0].requestBodyJson) as Record<
+        string,
+        unknown
+      >;
+      expect(body.response_modalities).toEqual(['video']);
+      expect(body.response_format).toEqual([
+        {
+          type: 'video',
+          aspect_ratio: '16:9',
+          resolution: '360p',
+          duration: '4s',
+          delivery: 'uri',
+          gcs_uri: 'gs://video-output/clip.mp4',
+        },
+      ]);
+      expect(result.content).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'file',
+            mediaType: 'video/mp4',
+            data: { type: 'data', data: 'AAAAIGZ0eXBpc29t' },
+          }),
+        ]),
+      );
+    });
+
     it('returns the JSON-shaped text content from the parsed response', async () => {
       const result = await model.doGenerate({
         prompt: TEST_PROMPT,
@@ -2262,6 +2329,91 @@ describe('GoogleInteractionsLanguageModel.doStream', () => {
       chunks,
     };
   }
+
+  it('serializes video response format controls and streams inline video data', async () => {
+    server.urls[TEST_URL].response = {
+      type: 'stream-chunks',
+      chunks: [
+        {
+          event_type: 'interaction.created',
+          interaction: {
+            id: 'v1_video',
+            status: 'in_progress',
+            model: 'gemini-omni-flash-preview',
+          },
+        },
+        {
+          event_type: 'step.start',
+          index: 0,
+          step: { type: 'model_output' },
+        },
+        {
+          event_type: 'step.delta',
+          index: 0,
+          delta: {
+            type: 'video',
+            mime_type: 'video/mp4',
+            data: 'AAAAIGZ0eXBpc29t',
+          },
+        },
+        {
+          event_type: 'step.stop',
+          index: 0,
+        },
+        {
+          event_type: 'interaction.completed',
+          interaction: {
+            id: 'v1_video',
+            status: 'completed',
+          },
+        },
+      ].map(event => `data: ${JSON.stringify(event)}\n\n`),
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        google: {
+          responseModalities: ['video'],
+          responseFormat: [
+            {
+              type: 'video',
+              aspectRatio: '9:16',
+              resolution: '4k',
+              duration: '8s',
+              delivery: 'inline',
+            },
+          ],
+        },
+      },
+      includeRawChunks: false,
+    });
+
+    const body = (await server.calls[0].requestBodyJson) as Record<
+      string,
+      unknown
+    >;
+    expect(body.response_format).toEqual([
+      {
+        type: 'video',
+        aspect_ratio: '9:16',
+        resolution: '4k',
+        duration: '8s',
+        delivery: 'inline',
+      },
+    ]);
+
+    const parts = await convertReadableStreamToArray(stream);
+    expect(parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'file',
+          mediaType: 'video/mp4',
+          data: { type: 'data', data: 'AAAAIGZ0eXBpc29t' },
+        }),
+      ]),
+    );
+  });
 
   describe('basic text', () => {
     beforeEach(() => {

--- a/packages/google/src/interactions/google-interactions-language-model.ts
+++ b/packages/google/src/interactions/google-interactions-language-model.ts
@@ -245,6 +245,17 @@ export class GoogleInteractionsLanguageModel implements LanguageModelV4 {
               mime_type: entry.mimeType ?? undefined,
             }),
           );
+        } else if (entry.type === 'video') {
+          responseFormatEntries.push(
+            pruneUndefined({
+              type: 'video' as const,
+              aspect_ratio: entry.aspectRatio ?? undefined,
+              resolution: entry.resolution ?? undefined,
+              duration: entry.duration ?? undefined,
+              delivery: entry.delivery ?? undefined,
+              gcs_uri: entry.gcsUri ?? undefined,
+            }),
+          );
         }
       }
     }

--- a/packages/google/src/interactions/google-interactions-prompt.ts
+++ b/packages/google/src/interactions/google-interactions-prompt.ts
@@ -434,6 +434,10 @@ export type GoogleInteractionsImageSize = '1K' | '2K' | '4K' | '512';
  *
  *   { type: 'image', mime_type, aspect_ratio?, image_size? }
  *     -- image generation. `mime_type` defaults to `image/png`.
+ *
+ *   { type: 'video', aspect_ratio?, resolution?, duration?, delivery?,
+ *     gcs_uri? }
+ *     -- video generation and delivery configuration.
  */
 export type GoogleInteractionsResponseFormatTextEntry = {
   type: 'text';
@@ -453,10 +457,20 @@ export type GoogleInteractionsResponseFormatAudioEntry = {
   mime_type?: string;
 };
 
+export type GoogleInteractionsResponseFormatVideoEntry = {
+  type: 'video';
+  aspect_ratio?: '16:9' | '9:16';
+  resolution?: '360p' | '720p' | '1080p' | '4k';
+  duration?: string;
+  delivery?: 'inline' | 'uri';
+  gcs_uri?: string;
+};
+
 export type GoogleInteractionsResponseFormatEntry =
   | GoogleInteractionsResponseFormatTextEntry
   | GoogleInteractionsResponseFormatImageEntry
-  | GoogleInteractionsResponseFormatAudioEntry;
+  | GoogleInteractionsResponseFormatAudioEntry
+  | GoogleInteractionsResponseFormatVideoEntry;
 
 export type GoogleInteractionsGenerationConfig = {
   temperature?: number;


### PR DESCRIPTION
## Background

raised in https://github.com/vercel/ai/issues/19945

the response_format settings passed via providerOptions for interactions API were ignored and resulted in a validation error. the gemini API documents accepting it https://ai.google.dev/gemini-api/docs/omni

## Summary

Extended the shared schema, wire types, and serializer for video aspect ratio, resolution, duration, delivery, and GCS URI; documented the public option and output behavior; retained generate and stream regression coverage; and added a patch changeset.

basically a v7 port of the change in https://github.com/vercel/ai/pull/20025

## End-to-End Verification

verified by running the example `examples/ai-functions/src/generate-text/google/interactions-video-response-format.ts` (change the aspect ratio to observe the API respecting the option) 

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #19945 

Closes #19946 