### PR TITLE
fix(tui): strip terminal escape sequences from untrusted text

### DIFF
--- a/.changeset/witty-donkeys-render.md
+++ b/.changeset/witty-donkeys-render.md
@@ -1,0 +1,22 @@
+---
+'@ai-sdk/tui': patch
+---
+
+fix(tui): strip terminal escape sequences from untrusted text
+
+The terminal UI only stripped CSI sequences (`ESC [ … final`) when measuring and
+slicing lines, so every other escape sequence in model output, reasoning, tool
+inputs and results, error messages, tool names and pasted input was written to
+the terminal verbatim. That let a model or a poisoned tool result silently drive
+the user's terminal: OSC 52 wrote the system clipboard (arming the next paste
+into their shell), OSC 0/2 rewrote the window title, OSC 8 disguised a hyperlink
+target, DCS/APC reached a terminal multiplexer, and unterminated sequences
+swallowed the rest of the frame. CSI sequences were preserved rather than
+dropped, so cursor movement could also rewrite output the user had already read
+and `CSI 6n` could make the terminal report state back on stdin.
+
+Untrusted text is now sanitized before it is rendered: CSI, OSC, DCS, SOS, PM
+and APC sequences (including their 8-bit C1 forms and unterminated variants) and
+control characters are removed, newlines in single-line chrome are collapsed to
+spaces, and the line slicer keeps only the SGR styling the terminal UI itself
+emits.

--- a/examples/ai-functions/src/agent/mock/tui-escape-sequences.ts
+++ b/examples/ai-functions/src/agent/mock/tui-escape-sequences.ts
@@ -1,0 +1,115 @@
+import { runAgentTUI } from '@ai-sdk/tui';
+import { ToolLoopAgent, tool } from 'ai';
+import { convertArrayToReadableStream, MockLanguageModelV4 } from 'ai/test';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+// Terminal escape sequences an attacker can hide in text the model produces or
+// in text a tool returns (a fetched page, a file, an MCP server response):
+//
+// - OSC 52 writes the user's system clipboard, so the next paste into their
+//   shell runs the attacker's command.
+// - OSC 0 rewrites the terminal window title.
+// - OSC 8 shows link text that points somewhere else.
+// - CSI cursor movement rewrites output the user already read.
+// - CSI 6n asks the terminal to report state back on stdin.
+//
+// Run this example and check that none of them take effect: the clipboard and
+// the window title are untouched, the frame is intact, and the payloads show
+// up as plain text inside the boxes.
+const clipboardWrite = `\x1b]52;c;${Buffer.from('echo pwned\n').toString('base64')}\x07`;
+const windowTitle = '\x1b]0;pwned\x07';
+const hyperlink = '\x1b]8;;https://evil.example\x07';
+const cursorAttack = '\x1b[2J\x1b[10A\x1b[6n';
+
+const usage = {
+  inputTokens: {
+    total: 3,
+    noCache: 3,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 10,
+    text: 10,
+    reasoning: undefined,
+  },
+};
+
+const readFile = tool({
+  description: 'Read a file from disk.',
+  inputSchema: z.object({ path: z.string() }),
+  // A poisoned file: the tool result carries the escape sequences.
+  execute: async ({ path }) =>
+    `${path}: all good${clipboardWrite}${windowTitle}`,
+});
+
+let modelCallCount = 0;
+
+const agent = new ToolLoopAgent({
+  model: new MockLanguageModelV4({
+    doStream: async () => {
+      modelCallCount += 1;
+
+      if (modelCallCount === 1) {
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'reasoning-start', id: 'reasoning-1' },
+            {
+              type: 'reasoning-delta',
+              id: 'reasoning-1',
+              delta: `Reading the file${clipboardWrite}`,
+            },
+            { type: 'reasoning-end', id: 'reasoning-1' },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'readFile',
+              input: '{ "path": "notes.txt" }',
+            },
+            {
+              type: 'finish',
+              finishReason: { unified: 'tool-calls' as const, raw: undefined },
+              usage,
+            },
+          ]),
+        };
+      }
+
+      return {
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'text-start', id: 'text-1' },
+          {
+            type: 'text-delta',
+            id: 'text-1',
+            delta: `The file looks fine.${clipboardWrite}${windowTitle}`,
+          },
+          {
+            type: 'text-delta',
+            id: 'text-1',
+            delta: `\n\n${hyperlink}Read the docs\x1b]8;;\x07${cursorAttack}`,
+          },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: { unified: 'stop' as const, raw: undefined },
+            usage,
+          },
+        ]),
+      };
+    },
+  }),
+  instructions: 'You are a helpful terminal assistant.',
+  tools: { readFile },
+});
+
+run(async () => {
+  await runAgentTUI({
+    title: 'Escape Sequence Injection',
+    agent,
+    tools: 'full',
+    reasoning: 'full',
+  });
+});

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -93,3 +93,16 @@ Settings:
 - `reasoning`: reasoning rendering mode. Use `"full"` to show reasoning, `"collapsed"` to show only reasoning cards, `"auto-collapsed"` to show the latest reasoning expanded until another visible section appears, or `"hidden"` to omit reasoning. Defaults to `"auto-collapsed"`.
 - `responseStatistics`: response header statistic. Use `"outputTokensPerSecond"` to show output token throughput or `"outputTokenCount"` to show output token count. Defaults to `"outputTokensPerSecond"`.
 - `sandbox`: optional sandbox session forwarded to every agent call as `experimental_sandbox` for tool descriptions and tool execution. Only available with `agent`.
+
+## Untrusted output
+
+Model output, tool results and pasted input are treated as untrusted text.
+Terminal escape sequences (CSI, OSC, DCS, SOS, PM, APC — including their 8-bit
+forms) and control characters are removed before anything is rendered, so text
+in the transcript cannot drive the terminal: it cannot write the system
+clipboard (OSC 52), rewrite the window title, disguise a hyperlink target,
+reach a terminal multiplexer, move the cursor to rewrite output the user
+already read, or ask the terminal to report state back on stdin.
+
+Only the styling the terminal UI itself applies is rendered, which means a
+model cannot color, conceal or otherwise style its own output.

--- a/packages/tui/src/tui/layout.test.ts
+++ b/packages/tui/src/tui/layout.test.ts
@@ -204,6 +204,58 @@ describe('renderScreen', () => {
       true,
     );
   });
+
+  it('drops escape sequences in body lines that are not styling', () => {
+    const output = renderScreenLines({
+      width: 30,
+      height: 8,
+      title: 'Chat',
+      bodyLines: ['ok\x1b]52;c;cm0gLXJmIH4K\x07 done'],
+      input: '',
+      inputActive: false,
+      scrollOffset: 0,
+    });
+
+    expect(output).not.toContain('\x1b]');
+    expect(output).not.toContain('\x07');
+    expect(output).toContain('│ ok done                    │');
+  });
+
+  it('sanitizes the frame title, status and prompt', () => {
+    const output = renderScreen({
+      width: 40,
+      height: 8,
+      title: 'Chat\x1b]0;pwned\x07',
+      rightTitle: '9 tokens\x1b]52;c;AAAA\x07',
+      body: 'hello',
+      input: '',
+      inputActive: false,
+      status: 'Done\nInjected status\x1b]52;c;AAAA\x07',
+      scrollOffset: 0,
+    });
+
+    expect(output).not.toContain('\x1b]');
+    expect(output).not.toContain('\x07');
+    expect(output).toContain('┌ Chat ');
+    expect(output).toContain(' 9 tokens ┐');
+    expect(output).toContain('│ Done Injected status');
+    expect(output.split('\n')).toHaveLength(8);
+  });
+
+  it('keeps a newline in the prompt from shifting the frame', () => {
+    const output = renderScreen({
+      width: 40,
+      height: 8,
+      title: 'Chat',
+      body: 'hello',
+      input: 'first\nsecond',
+      inputActive: true,
+      scrollOffset: 0,
+    });
+
+    expect(output.split('\n')).toHaveLength(8);
+    expect(output).toContain('│ > first second█');
+  });
 });
 
 describe('clampScrollOffset', () => {

--- a/packages/tui/src/tui/layout.ts
+++ b/packages/tui/src/tui/layout.ts
@@ -2,11 +2,18 @@ import { renderMarkdown } from './markdown';
 import {
   ansiPrefixPattern,
   codePointWidth,
+  sanitizeTerminalLine,
   sliceVisible,
   visibleLength,
 } from './terminal-text';
 
-export { sliceVisible, stripAnsi, visibleLength } from './terminal-text';
+export {
+  sanitizeTerminalLine,
+  sanitizeTerminalText,
+  sliceVisible,
+  stripAnsi,
+  visibleLength,
+} from './terminal-text';
 
 const horizontal = '─';
 
@@ -77,15 +84,26 @@ export function renderScreenViewport(state: TUIScreenViewportState): string {
     visibleBody.push('');
   }
 
+  // The frame chrome is plain text, so it is sanitized here as well: a newline
+  // or escape sequence in a title, status or prompt would otherwise shift or
+  // drive the rendered frame.
   const lines = [
-    topBorder(width, state.title, state.rightTitle),
+    topBorder(
+      width,
+      sanitizeTerminalLine(state.title),
+      state.rightTitle == null
+        ? undefined
+        : sanitizeTerminalLine(state.rightTitle),
+    ),
     ...visibleBody.map(line => boxLine(line, width)),
     bottomBorder(width),
     topBorder(width, state.inputActive ? 'Input' : 'Status'),
     boxLine(
       state.inputActive
-        ? `> ${state.input}${state.inputCursorVisible === false ? ' ' : '█'}`
-        : (state.status ?? 'Streaming... ↑/↓ scroll · Ctrl+C quit'),
+        ? `> ${sanitizeTerminalLine(state.input)}${state.inputCursorVisible === false ? ' ' : '█'}`
+        : sanitizeTerminalLine(
+            state.status ?? 'Streaming... ↑/↓ scroll · Ctrl+C quit',
+          ),
       width,
     ),
     bottomBorder(width),

--- a/packages/tui/src/tui/terminal-renderer.test.ts
+++ b/packages/tui/src/tui/terminal-renderer.test.ts
@@ -29,6 +29,33 @@ type TestFrameBuffer = TerminalFrameBuffer & {
   lastPresentedText: () => string;
 };
 
+// OSC 52 writes the user's clipboard, so a terminal that receives this from
+// model output silently arms the next paste into the user's shell.
+const clipboardPayload = 'cm0gLXJmIH4K';
+const clipboardWrite = `\x1b]52;c;${clipboardPayload}\x07`;
+const windowTitle = '\x1b]0;pwned\x07';
+const kittyGraphics = '\x1b_Ga=T,f=100;AAAA\x1b\\';
+
+const escapeIntroducers = [
+  ['OSC', '\x1b]'],
+  ['DCS', '\x1bP'],
+  ['SOS', '\x1bX'],
+  ['PM', '\x1b^'],
+  ['APC', '\x1b_'],
+  ['BEL', '\x07'],
+] as const;
+
+function expectNoInjectedSequences(text: string) {
+  for (const [name, introducer] of escapeIntroducers) {
+    expect(
+      text.includes(introducer),
+      `expected no ${name} sequence in terminal output`,
+    ).toBe(false);
+  }
+
+  expect(text).not.toContain(clipboardPayload);
+}
+
 describe('parseKey', () => {
   it('decodes terminal control keys', () => {
     expect(parseKey(Buffer.from('\x1B[A'))).toEqual({ type: 'up' });
@@ -46,6 +73,20 @@ describe('parseKey', () => {
     expect(parseKey(Buffer.from('hello'))).toEqual({
       type: 'character',
       value: 'hello',
+    });
+  });
+
+  it('strips escape sequences from pasted input', () => {
+    expect(parseKey(Buffer.from(`hi${clipboardWrite}there`))).toEqual({
+      type: 'character',
+      value: 'hithere',
+    });
+    expect(parseKey(Buffer.from('one\ntwo'))).toEqual({
+      type: 'character',
+      value: 'one two',
+    });
+    expect(parseKey(Buffer.from('\u009d52;c;AAAA\u009c'))).toEqual({
+      type: 'ignore',
     });
   });
 });
@@ -674,6 +715,150 @@ describe('TerminalRenderer', () => {
   });
 });
 
+describe('TerminalRenderer escape sequence injection', () => {
+  it('does not write escape sequences from assistant text to the terminal', async () => {
+    const input = createInput();
+    const output = createOutput();
+    output.columns = 80;
+    const renderer = new TerminalRenderer({ input, output });
+
+    await renderer.renderStream(
+      createStream([
+        `ok${clipboardWrite}`,
+        `${windowTitle} done\x1b[2J\x1b[10A\x1b[6n`,
+      ]) as never,
+      { title: 'Test', waitForExit: false },
+    );
+
+    expectNoInjectedSequences(output.text());
+    expect(stripAnsi(output.text())).toContain('ok done');
+  });
+
+  it('does not write escape sequences from reasoning to the terminal', async () => {
+    const input = createInput();
+    const output = createOutput();
+    output.columns = 80;
+    const renderer = new TerminalRenderer({
+      input,
+      output,
+      reasoning: 'full',
+    });
+
+    await renderer.renderStream(
+      createReasoningStream(`hmm${kittyGraphics}${clipboardWrite} ok`) as never,
+      { title: 'Test', waitForExit: false },
+    );
+
+    expectNoInjectedSequences(output.text());
+    expect(stripAnsi(output.text())).toContain('hmm ok');
+  });
+
+  it('does not write escape sequences from tool results to the terminal', async () => {
+    const input = createInput();
+    const output = createOutput();
+    output.columns = 80;
+    output.rows = 24;
+    const renderer = new TerminalRenderer({ input, output, tools: 'full' });
+
+    await renderer.renderStream(
+      createToolOutputStream({
+        toolName: `shell${clipboardWrite}`,
+        output: `stdout${clipboardWrite}${windowTitle} clean`,
+      }) as never,
+      { title: 'Test', waitForExit: false },
+    );
+
+    expectNoInjectedSequences(output.text());
+    expect(stripAnsi(output.text())).toContain('stdout clean');
+  });
+
+  it('does not write escape sequences from stream errors to the terminal', async () => {
+    const input = createInput();
+    const output = createOutput();
+    output.columns = 80;
+    const renderer = new TerminalRenderer({ input, output });
+
+    await renderer.renderStream(
+      createErrorStream(new Error(`boom${clipboardWrite}`)) as never,
+      { title: 'Test', waitForExit: false },
+    );
+
+    expectNoInjectedSequences(output.text());
+    expect(stripAnsi(output.text())).toContain('boom');
+  });
+
+  it('does not write escape sequences from the session title to the terminal', async () => {
+    const input = createInput();
+    const output = createOutput();
+    output.columns = 80;
+    const renderer = new TerminalRenderer({ input, output });
+
+    await renderer.renderStream(createStream(['hello']) as never, {
+      title: `Agent${clipboardWrite}`,
+      waitForExit: false,
+    });
+
+    expectNoInjectedSequences(output.text());
+    expect(stripAnsi(output.text())).toContain('┌ Agent ');
+  });
+
+  it('does not write escape sequences from tool approval requests to the status line', async () => {
+    const input = createInput();
+    const output = createOutput();
+    output.columns = 80;
+    const renderer = new TerminalRenderer({ input, output });
+    const approvalPromise = renderer.readToolApproval(
+      {
+        approvalId: 'approval-1',
+        toolCallId: 'call-1',
+        toolName: `shell${clipboardWrite}`,
+        input: { command: 'date' },
+        messageId: 'message-1',
+        partIndex: 0,
+      },
+      { title: 'Test' },
+    );
+
+    expectNoInjectedSequences(output.text());
+    expect(stripAnsi(output.text())).toContain('Approve tool shell? y/n');
+
+    input.emit('data', Buffer.from('y'));
+    await expect(approvalPromise).resolves.toEqual({ approved: true });
+  });
+
+  it('does not send pasted escape sequences to the terminal or the model', async () => {
+    const input = createInput();
+    const output = createOutput();
+    output.columns = 80;
+    const renderer = new TerminalRenderer({ input, output });
+    const promptPromise = renderer.readPrompt({ title: 'Test' });
+
+    input.emit('data', Buffer.from(`hi${clipboardWrite}there`));
+    input.emit('data', Buffer.from('\r'));
+
+    await expect(promptPromise).resolves.toBe('hithere');
+    expectNoInjectedSequences(output.text());
+  });
+
+  it('keeps a newline in a tool name from breaking out of the section header', async () => {
+    const input = createInput();
+    const output = createOutput();
+    output.columns = 80;
+    output.rows = 24;
+    const renderer = new TerminalRenderer({ input, output, tools: 'full' });
+
+    await renderer.renderStream(
+      createToolOutputStream({
+        toolName: 'shell\nInjected',
+        output: 'done',
+      }) as never,
+      { title: 'Test', waitForExit: false },
+    );
+
+    expect(stripAnsi(output.text())).toContain('╭ Tool · shell Injected ');
+  });
+});
+
 function createInput() {
   const input = new EventEmitter() as TestInput;
 
@@ -833,6 +1018,44 @@ function createStream(
                 },
               },
       };
+    })(),
+  };
+}
+
+function createReasoningStream(text: string): AgentTUIStreamResult {
+  return {
+    uiMessageStream: (async function* () {
+      yield { type: 'start', messageId: 'message-1' };
+      yield { type: 'reasoning-start', id: 'reasoning-1' };
+      yield { type: 'reasoning-delta', id: 'reasoning-1', delta: text };
+      yield { type: 'reasoning-end', id: 'reasoning-1' };
+      yield { type: 'finish' };
+    })(),
+  };
+}
+
+function createToolOutputStream({
+  toolName,
+  output,
+}: {
+  toolName: string;
+  output: string;
+}): AgentTUIStreamResult {
+  return {
+    uiMessageStream: (async function* () {
+      yield { type: 'start', messageId: 'message-1' };
+      yield {
+        type: 'tool-input-available',
+        toolCallId: 'call-1',
+        toolName,
+        input: { command: 'date' },
+      } satisfies UIMessageChunk;
+      yield {
+        type: 'tool-output-available',
+        toolCallId: 'call-1',
+        output,
+      } satisfies UIMessageChunk;
+      yield { type: 'finish' };
     })(),
   };
 }

--- a/packages/tui/src/tui/terminal-renderer.ts
+++ b/packages/tui/src/tui/terminal-renderer.ts
@@ -7,7 +7,13 @@ import type {
   ResponseStatisticsMode,
   TerminalPartDisplayMode,
 } from '../run-agent-tui';
-import { renderScreenViewport, sliceVisible, visibleLength } from './layout';
+import {
+  renderScreenViewport,
+  sanitizeTerminalLine,
+  sanitizeTerminalText,
+  sliceVisible,
+  visibleLength,
+} from './layout';
 import { renderMarkdown } from './markdown';
 import { TerminalFrameBuffer } from './terminal-frame-buffer';
 import {
@@ -382,7 +388,10 @@ export class TerminalRenderer {
   }
 
   #start(options?: TerminalSessionOptions) {
-    this.#title = options?.title ?? this.#title;
+    this.#title =
+      options?.title == null
+        ? this.#title
+        : sanitizeTerminalLine(options.title);
     this.#contextSize = options?.contextSize ?? this.#defaultContextSize;
 
     if (this.#isInteractive) {
@@ -515,7 +524,9 @@ export class TerminalRenderer {
 
   #addUserSection(prompt: string) {
     const previousBodyLineCount = this.#bodyLineCount();
-    this.#sections.push({ kind: 'user', title: 'User', content: prompt });
+    this.#sections.push(
+      sanitizeSection({ kind: 'user', title: 'User', content: prompt }),
+    );
     this.#paintAfterBodyChange(previousBodyLineCount);
   }
 
@@ -617,7 +628,8 @@ export class TerminalRenderer {
     this.#paintAfterBodyChange(previousBodyLineCount);
   }
 
-  #upsertSection(section: ChatSection) {
+  #upsertSection(unsafeSection: ChatSection) {
+    const section = sanitizeSection(unsafeSection);
     const existingSection = section.id
       ? this.#sections.find(candidate => candidate.id === section.id)
       : undefined;
@@ -692,7 +704,7 @@ export class TerminalRenderer {
 
   #addErrorSection(title: string, content: string) {
     const previousBodyLineCount = this.#bodyLineCount();
-    this.#sections.push({ kind: 'error', title, content });
+    this.#sections.push(sanitizeSection({ kind: 'error', title, content }));
     this.#paintAfterBodyChange(previousBodyLineCount);
   }
 
@@ -852,6 +864,26 @@ export class TerminalRenderer {
 
 function interruptedError() {
   return new Error('Interrupted');
+}
+
+/**
+ * Strips terminal escape sequences and control characters from section text.
+ *
+ * Section titles and content come from the model, from tool inputs and results
+ * and from user input, so they are untrusted. Sanitizing here — before
+ * markdown rendering adds the styling sequences the terminal UI itself uses —
+ * keeps escape sequence injection out of every section kind.
+ */
+function sanitizeSection(section: ChatSection): ChatSection {
+  return {
+    ...section,
+    title: sanitizeTerminalLine(section.title),
+    rightTitle:
+      section.rightTitle == null
+        ? undefined
+        : sanitizeTerminalLine(section.rightTitle),
+    content: sanitizeTerminalText(section.content),
+  };
 }
 
 async function* takeUntil<T>(
@@ -1078,7 +1110,7 @@ function formatValue(value: unknown) {
 }
 
 function formatToolApprovalTitle(request: AgentTUIToolApprovalRequest) {
-  return `tool ${request.title ?? request.toolName}`;
+  return `tool ${sanitizeTerminalLine(request.title ?? request.toolName)}`;
 }
 
 function sectionId(messageId: string, partIndex: number) {
@@ -1401,11 +1433,19 @@ export function parseKey(chunk: Buffer): TerminalKey {
       return { type: 'page-up' };
     case '\x1B[6~':
       return { type: 'page-down' };
-    default:
-      if (value >= ' ' && value !== '\x7F') {
-        return { type: 'character', value };
+    default: {
+      if (value < ' ' || value === '\x7F') {
+        return { type: 'ignore' };
       }
 
-      return { type: 'ignore' };
+      // A paste arrives as a single chunk and can carry escape sequences after
+      // its first printable character. Sanitize it so the sequences neither
+      // reach the terminal nor end up in the prompt that is sent to the model.
+      const character = sanitizeTerminalLine(value);
+
+      return character.length > 0
+        ? { type: 'character', value: character }
+        : { type: 'ignore' };
+    }
   }
 }

--- a/packages/tui/src/tui/terminal-text.test.ts
+++ b/packages/tui/src/tui/terminal-text.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import {
+  sanitizeTerminalLine,
+  sanitizeTerminalText,
+  sliceVisible,
+  stripAnsi,
+  visibleLength,
+} from './terminal-text';
+
+const clipboardWrite = '\x1b]52;c;cm0gLXJmIH4K\x07';
+const hyperlink = '\x1b]8;;https://evil.example\x07';
+const windowTitle = '\x1b]0;pwned\x07';
+const kittyGraphics = '\x1b_Ga=T,f=100;AAAA\x1b\\';
+const tmuxPassthrough = '\x1bPtmux;\x1b\x1b]52;c;AAAA\x07\x1b\\';
+
+describe('stripAnsi', () => {
+  it('strips CSI sequences', () => {
+    expect(stripAnsi('\x1b[92mgreen\x1b[0m')).toBe('green');
+  });
+
+  it('strips OSC sequences terminated by BEL or ST', () => {
+    expect(stripAnsi(`a${clipboardWrite}b`)).toBe('ab');
+    expect(stripAnsi('a\x1b]0;title\x1b\\b')).toBe('ab');
+  });
+
+  it('strips DCS, SOS, PM and APC sequences', () => {
+    expect(stripAnsi(`a${kittyGraphics}b`)).toBe('ab');
+    expect(stripAnsi(`a${tmuxPassthrough}b`)).toBe('ab');
+    expect(stripAnsi('a\x1b^privacy\x1b\\b')).toBe('ab');
+    expect(stripAnsi('a\x1bXstring\x1b\\b')).toBe('ab');
+  });
+
+  it('strips 8-bit C1 introducers', () => {
+    expect(stripAnsi('a\u009b31mb')).toBe('ab');
+    expect(stripAnsi('a\u009d52;c;AAAA\u009cb')).toBe('ab');
+    expect(stripAnsi('a\u009fpayload\u009cb')).toBe('ab');
+  });
+
+  it('strips single escapes such as a full terminal reset', () => {
+    expect(stripAnsi('a\x1bcb')).toBe('ab');
+    expect(stripAnsi('a\x1b(0b')).toBe('ab');
+    expect(stripAnsi('a\x1b')).toBe('a');
+  });
+});
+
+describe('sanitizeTerminalText', () => {
+  it('keeps plain text, newlines and tabs', () => {
+    expect(sanitizeTerminalText('hello\nworld\tagain 世界 🎉')).toBe(
+      'hello\nworld\tagain 世界 🎉',
+    );
+  });
+
+  it('removes clipboard writes', () => {
+    expect(sanitizeTerminalText(`Done!${clipboardWrite} Bye`)).toBe(
+      'Done! Bye',
+    );
+  });
+
+  it('removes hyperlink and window title sequences', () => {
+    expect(
+      sanitizeTerminalText(`${hyperlink}docs\x1b]8;;\x07${windowTitle}`),
+    ).toBe('docs');
+  });
+
+  it('removes an unterminated OSC sequence together with its payload', () => {
+    expect(sanitizeTerminalText('a\x1b]52;c;cm0gLXJmIH4K')).toBe('a');
+    expect(sanitizeTerminalText('a\x1b]52;c;AAAA\x1b[0mb')).toBe('ab');
+  });
+
+  it('removes DCS and APC passthrough sequences', () => {
+    expect(sanitizeTerminalText(`a${kittyGraphics}b`)).toBe('ab');
+    expect(sanitizeTerminalText(`a${tmuxPassthrough}b`)).toBe('ab');
+  });
+
+  it('removes cursor control and device status report requests', () => {
+    expect(sanitizeTerminalText('safe\x1b[2J\x1b[10A\x1b[6nspoofed')).toBe(
+      'safespoofed',
+    );
+  });
+
+  it('removes styling sequences so only the terminal UI can style output', () => {
+    expect(sanitizeTerminalText('\x1b[92mfake success\x1b[0m')).toBe(
+      'fake success',
+    );
+    expect(sanitizeTerminalText('\x1b[8mhidden\x1b[28m')).toBe('hidden');
+  });
+
+  it('removes control characters that move the cursor or ring the bell', () => {
+    expect(sanitizeTerminalText('a\x07b\rc\bd\x7fe\x00f\x0bg')).toBe('abcdefg');
+  });
+
+  it('is idempotent', () => {
+    const input = `a${clipboardWrite}b${tmuxPassthrough}c`;
+
+    expect(sanitizeTerminalText(sanitizeTerminalText(input))).toBe(
+      sanitizeTerminalText(input),
+    );
+  });
+});
+
+describe('sanitizeTerminalLine', () => {
+  it('replaces newlines with spaces so text cannot break out of its line', () => {
+    expect(sanitizeTerminalLine('title\nsecond line')).toBe(
+      'title second line',
+    );
+  });
+
+  it('removes escape sequences', () => {
+    expect(sanitizeTerminalLine(`title${clipboardWrite}`)).toBe('title');
+  });
+});
+
+describe('visibleLength', () => {
+  it('does not count OSC or DCS payloads as visible cells', () => {
+    expect(visibleLength(`${clipboardWrite}hello`)).toBe(5);
+    expect(visibleLength(`${kittyGraphics}hello`)).toBe(5);
+    expect(visibleLength('\u009d52;c;AAAA\u009chello')).toBe(5);
+  });
+});
+
+describe('sliceVisible', () => {
+  it('keeps the styling sequences the terminal UI emits', () => {
+    expect(sliceVisible('\x1b[92mhello\x1b[0m', 10)).toBe(
+      '\x1b[92mhello\x1b[0m',
+    );
+  });
+
+  it('drops escape sequences that are not styling', () => {
+    expect(sliceVisible(`ok${clipboardWrite} done`, 20)).toBe('ok done');
+    expect(sliceVisible(`ok${kittyGraphics} done`, 20)).toBe('ok done');
+    expect(sliceVisible('ok\x1b[2J\x1b[6n done', 20)).toBe('ok done');
+    expect(sliceVisible('ok\x1bc done', 20)).toBe('ok done');
+  });
+
+  it('drops control characters', () => {
+    expect(sliceVisible('ok\x07\r\b done', 20)).toBe('ok done');
+  });
+});

--- a/packages/tui/src/tui/terminal-text.ts
+++ b/packages/tui/src/tui/terminal-text.ts
@@ -1,12 +1,87 @@
-const ansiEscape = String.fromCharCode(27);
+const ansiEscape = String.fromCharCode(0x1b);
+const bell = String.fromCharCode(0x07);
 
-export const ansiPattern = new RegExp(`${ansiEscape}\\[[0-?]*[ -/]*[@-~]`, 'g');
-export const ansiPrefixPattern = new RegExp(
-  `^${ansiEscape}\\[[0-?]*[ -/]*[@-~]`,
-);
+// 8-bit (C1) equivalents of the 7-bit escape introducers. Terminals honour
+// these just like their `ESC`-prefixed counterparts, so they have to be
+// recognized as well.
+const csiIntroducer8Bit = String.fromCharCode(0x9b);
+const oscIntroducer8Bit = String.fromCharCode(0x9d);
+const stringTerminator8Bit = String.fromCharCode(0x9c);
+const stringIntroducers8Bit =
+  String.fromCharCode(0x90) + // DCS
+  String.fromCharCode(0x98) + // SOS
+  String.fromCharCode(0x9e) + // PM
+  String.fromCharCode(0x9f); // APC
+
+// A string sequence ends at BEL, `ESC \` or the 8-bit string terminator.
+const stringTerminator = `(?:${bell}|${ansiEscape}\\\\|${stringTerminator8Bit})`;
+
+// CSI sequences, e.g. `ESC [ 1 m` or `ESC [ 6 n`. The final byte is optional so
+// that a truncated sequence at the end of the input is still consumed.
+const csiSequence = `(?:${ansiEscape}\\[|${csiIntroducer8Bit})[0-?]*[ -/]*[@-~]?`;
+
+// OSC sequences, e.g. `ESC ] 52 ; c ; <base64> BEL` (clipboard write) or
+// `ESC ] 8 ; ; <url> BEL` (hyperlink). The payload cannot contain `ESC` or BEL,
+// so an unterminated sequence is consumed up to the next escape.
+const oscSequence = `(?:${ansiEscape}\\]|${oscIntroducer8Bit})[^${bell}${ansiEscape}${stringTerminator8Bit}]*${stringTerminator}?`;
+
+// DCS, SOS, PM and APC sequences, e.g. `ESC P tmux ; ... ESC \`.
+const stringSequence = `(?:${ansiEscape}[PX^_]|[${stringIntroducers8Bit}])[^${ansiEscape}${stringTerminator8Bit}]*(?:${ansiEscape}\\\\|${stringTerminator8Bit})?`;
+
+// Remaining escapes such as `ESC c` (full reset), `ESC 7` (save cursor) or
+// `ESC ( 0` (charset selection), plus a trailing lone `ESC`.
+const otherEscapeSequence = `${ansiEscape}[ -/]*[0-~]?`;
+
+// Ordered alternation: the introducer-specific rules have to be tried before
+// the catch-all escape rule.
+const escapeSequence = [
+  csiSequence,
+  oscSequence,
+  stringSequence,
+  otherEscapeSequence,
+].join('|');
+
+// C0 control characters (except tab and newline), DEL and the C1 range. These
+// can reposition the cursor (CR, BS), ring the bell or terminate sequences.
+const controlCharacter = '[\\u0000-\\u0008\\u000b-\\u001f\\u007f-\\u009f]';
+
+export const ansiPattern = new RegExp(escapeSequence, 'g');
+export const ansiPrefixPattern = new RegExp(`^(?:${escapeSequence})`);
+
+// The only escape sequences the terminal UI emits inside content are SGR
+// (colors and text styles). Everything else is dropped before it is written.
+const sgrPrefixPattern = new RegExp(`^${ansiEscape}\\[[0-9;:]*m`);
+const controlCharacterPattern = new RegExp(controlCharacter, 'g');
 
 export function stripAnsi(input: string): string {
   return input.replace(ansiPattern, '');
+}
+
+/**
+ * Removes every terminal escape sequence and control character from untrusted
+ * text (model output, tool results, error messages, pasted input).
+ *
+ * Writing such text to a terminal verbatim lets it drive the terminal instead
+ * of just being displayed: OSC 52 writes the user's clipboard, OSC 8 hides a
+ * different target behind link text, OSC 0/2 rewrites the window title,
+ * DCS/APC passthrough reaches the multiplexer, and CSI can move the cursor to
+ * rewrite already-rendered output or ask the terminal to report state back on
+ * stdin.
+ *
+ * Newlines and tabs are preserved; use {@link sanitizeTerminalLine} for text
+ * that is rendered on a single line.
+ */
+export function sanitizeTerminalText(input: string): string {
+  return input.replace(ansiPattern, '').replace(controlCharacterPattern, '');
+}
+
+/**
+ * Sanitizes untrusted text that is rendered on a single line, e.g. a section
+ * title, the status line or the prompt input. Newlines are replaced with
+ * spaces so the text cannot break out of its line and shift the frame.
+ */
+export function sanitizeTerminalLine(input: string): string {
+  return sanitizeTerminalText(input).replace(/\n/g, ' ');
 }
 
 export function visibleLength(input: string): number {
@@ -48,7 +123,7 @@ export function sliceVisible(input: string, width: number): string {
     const ansiMatch = input.slice(index).match(ansiPrefixPattern);
 
     if (ansiMatch) {
-      output += ansiMatch[0];
+      output += keptEscapeSequence(ansiMatch[0]);
       index += ansiMatch[0].length;
       continue;
     }
@@ -60,6 +135,12 @@ export function sliceVisible(input: string, width: number): string {
     }
 
     const character = String.fromCodePoint(codePoint);
+
+    if (isControlCodePoint(codePoint)) {
+      index += character.length;
+      continue;
+    }
+
     const characterWidth = codePointWidth(codePoint);
 
     if (characterWidth > 0 && visible + characterWidth > width) {
@@ -78,11 +159,27 @@ export function sliceVisible(input: string, width: number): string {
       break;
     }
 
-    output += ansiMatch[0];
+    output += keptEscapeSequence(ansiMatch[0]);
     index += ansiMatch[0].length;
   }
 
   return output;
+}
+
+/**
+ * Drops escape sequences that are not styling. `sliceVisible` runs on every
+ * line right before it is written to the terminal, so this is the last barrier
+ * against a sequence that was not sanitized at its source.
+ */
+function keptEscapeSequence(sequence: string): string {
+  return sgrPrefixPattern.test(sequence) ? sequence : '';
+}
+
+function isControlCodePoint(codePoint: number): boolean {
+  return (
+    codePoint !== 0x09 &&
+    (codePoint < 0x20 || (codePoint >= 0x7f && codePoint <= 0x9f))
+  );
 }
 
 export function codePointWidth(codePoint: number): number {

--- a/packages/tui/src/util/print-stream.ts
+++ b/packages/tui/src/util/print-stream.ts
@@ -1,3 +1,4 @@
+import { sanitizeTerminalText } from '../tui/terminal-text';
 import { type StreamTextResult } from 'ai';
 
 export async function printStream(result: StreamTextResult<any, any, any>) {
@@ -7,13 +8,13 @@ export async function printStream(result: StreamTextResult<any, any, any>) {
         process.stdout.write('\x1b[94m\n');
         break;
       case 'reasoning-delta':
-        process.stdout.write(part.text);
+        process.stdout.write(sanitizeTerminalText(part.text));
         break;
       case 'reasoning-end':
         process.stdout.write('\x1b[0m\n\n');
         break;
       case 'text-delta':
-        process.stdout.write(part.text);
+        process.stdout.write(sanitizeTerminalText(part.text));
         break;
       case 'tool-call':
         process.stdout.write(


### PR DESCRIPTION
Fixes VULN-14070.

## Background

`@ai-sdk/tui` renders model output, reasoning, tool inputs/results, error text, tool names and pasted input into a full-screen terminal frame. Before writing a line it measured and sliced it with `ansiPattern` / `sliceVisible`, which only recognized **CSI** sequences (`ESC [ … final`).

Everything else passed through to the terminal verbatim, and CSI sequences were *preserved* rather than dropped. So a model — or, more realistically, a poisoned tool result (a fetched page, a file, an MCP server response) — could drive the user's terminal:

| Payload | Effect |
| --- | --- |
| `ESC ] 52 ; c ; <base64> BEL` | writes the user's **system clipboard**, arming the next paste into their shell |
| `ESC ] 0 ; … BEL` | rewrites the window title |
| `ESC ] 8 ; ; <url> BEL` | shows link text pointing somewhere else |
| `ESC P … ESC \` / `ESC _ … ESC \` | DCS/APC passthrough reaching a terminal multiplexer |
| `ESC [ 10 A`, `ESC [ 2 J` | moves the cursor to rewrite output the user already read |
| `ESC [ 6 n` | asks the terminal to report state back on **stdin** |
| unterminated `ESC ]` | swallows the rest of the frame |
| `ESC c` | full terminal reset |

The 8-bit C1 forms (`0x9b` CSI, `0x9d` OSC, `0x90`/`0x98`/`0x9e`/`0x9f`) were not recognized either. The clipboard write is the "silent" part: nothing visible changes, and the payload only executes later, in the user's own shell, from their own paste.

Pasted input was affected too. `parseKey` classified a chunk as printable based on its *first* character, so `hi<ESC>]52;c;…BEL` was appended whole to the prompt buffer — reaching both the frame and the prompt sent to the model.

## Fix

New in `terminal-text.ts`:

- **`sanitizeTerminalText`** removes CSI, OSC, DCS, SOS, PM and APC sequences — including their 8-bit C1 introducers and unterminated variants (an unterminated `ESC ]` consumes its payload rather than leaking it as text) — plus control characters (BEL, BS, CR, VT, FF, NUL, DEL, C1). Newlines and tabs are kept.
- **`sanitizeTerminalLine`** additionally collapses newlines to spaces, for single-line chrome where a newline would shift the whole frame.

Applied at every point where untrusted text enters the UI:

- `sanitizeSection` in `terminal-renderer.ts` sanitizes section titles, right titles and content for **all** section kinds (user, assistant, reasoning, tool, error) at ingestion — before `renderMarkdown` adds the styling sequences the TUI itself uses.
- `formatToolApprovalTitle` and the session title are sanitized.
- `parseKey` sanitizes pasted chunks.
- `renderScreenViewport` sanitizes the frame chrome (title, right title, status, prompt).

And as a last barrier, `sliceVisible` — which runs on every line immediately before it is written — now keeps **only** SGR sequences (`ESC [ … m`, what the TUI itself emits) and drops every other sequence and any control character. A consequence worth noting: a model can no longer color, conceal or otherwise style its own output; only the TUI's styling is rendered.

`printStream` (currently unexported) also sanitizes its text and reasoning deltas.

## Tests

97 → 129 tests in `packages/tui`. All 32 new tests were verified to fail against the unpatched source.

- `src/tui/terminal-text.test.ts` (new): the sequence grammar — OSC (BEL- and ST-terminated), DCS/SOS/PM/APC, 8-bit C1, single escapes, unterminated OSC, control characters, idempotence, and `visibleLength` / `sliceVisible` behavior.
- `src/tui/terminal-renderer.test.ts`: end-to-end — no OSC/DCS/SOS/PM/APC introducer, no BEL and no clipboard payload reaches the terminal from assistant text, reasoning, tool names, tool results, stream errors, the session title or a tool approval request; a pasted payload reaches neither the terminal nor the resolved prompt; a newline in a tool name cannot break out of its section header.
- `src/tui/layout.test.ts`: non-styling sequences dropped from body lines; title/status/prompt sanitized; a newline in the prompt does not change the frame's line count.

## Manual verification

`examples/ai-functions/src/agent/mock/tui-escape-sequences.ts` runs the real TUI against a mock model that emits the payloads in reasoning and text, plus a "poisoned file" tool whose result carries them. No API key needed:

```bash
cd examples/ai-functions
pnpm tsx src/agent/mock/tui-escape-sequences.ts
```

Before the fix the window title changes and the clipboard is overwritten; after it, the payloads render as plain text inside the boxes and the frame stays intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)