### PR TITLE
fix(tui): remove terminal escape sequences from untrusted text

### DIFF
--- a/.changeset/lazy-poems-render.md
+++ b/.changeset/lazy-poems-render.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/tui': patch
+---
+
+fix(tui): remove terminal escape sequences from model, tool and pasted text before rendering

--- a/packages/tui/src/tui/layout.ts
+++ b/packages/tui/src/tui/layout.ts
@@ -1,12 +1,18 @@
 import { renderMarkdown } from './markdown';
 import {
-  ansiPrefixPattern,
   codePointWidth,
+  escapeSequencePrefixPattern,
   sliceVisible,
   visibleLength,
 } from './terminal-text';
 
-export { sliceVisible, stripAnsi, visibleLength } from './terminal-text';
+export {
+  sanitizeTerminalLine,
+  sanitizeTerminalText,
+  sliceVisible,
+  stripAnsi,
+  visibleLength,
+} from './terminal-text';
 
 const horizontal = '─';
 
@@ -140,7 +146,7 @@ function findBreakPoint(input: string, width: number): number {
   let lastSpace = -1;
 
   while (index < input.length && visible < width) {
-    const ansiMatch = input.slice(index).match(ansiPrefixPattern);
+    const ansiMatch = input.slice(index).match(escapeSequencePrefixPattern);
 
     if (ansiMatch) {
       index += ansiMatch[0].length;
@@ -216,7 +222,7 @@ function indexAtVisibleWidth(input: string, width: number): number {
   let visible = 0;
 
   while (index < input.length && visible < width) {
-    const ansiMatch = input.slice(index).match(ansiPrefixPattern);
+    const ansiMatch = input.slice(index).match(escapeSequencePrefixPattern);
 
     if (ansiMatch) {
       index += ansiMatch[0].length;
@@ -247,7 +253,7 @@ function indexAfterAnsiSequences(input: string, startIndex: number): number {
   let index = startIndex;
 
   while (index < input.length) {
-    const ansiMatch = input.slice(index).match(ansiPrefixPattern);
+    const ansiMatch = input.slice(index).match(escapeSequencePrefixPattern);
 
     if (!ansiMatch) {
       break;

--- a/packages/tui/src/tui/terminal-renderer.test.ts
+++ b/packages/tui/src/tui/terminal-renderer.test.ts
@@ -7,7 +7,7 @@ import {
   type TerminalOutput,
 } from './terminal-renderer';
 import type { TerminalFrameBuffer } from './terminal-frame-buffer';
-import { stripAnsi } from './layout';
+import { stripAnsi, visibleLength } from './layout';
 import type { AgentTUIStreamResult } from '../agent-tui-runner';
 import type { UIMessageChunk } from 'ai';
 
@@ -674,6 +674,219 @@ describe('TerminalRenderer', () => {
   });
 });
 
+describe('TerminalRenderer escape sequence sanitization', () => {
+  it('removes escape sequences from streamed assistant text', async () => {
+    const input = createInput();
+    const output = createOutput();
+    const renderer = new TerminalRenderer({ input, output });
+
+    await renderer.renderStream(
+      createStream(['before\x1b]52;c;ZXZpbA==\x07after']) as never,
+      {
+        title: 'Test',
+        waitForExit: false,
+      },
+    );
+
+    expectNoInjectedSequences(output);
+    expect(stripAnsi(output.text())).toContain('beforeafter');
+  });
+
+  it('removes escape sequences from reasoning text', async () => {
+    const input = createInput();
+    const output = createOutput();
+    output.rows = 20;
+    const renderer = new TerminalRenderer({
+      input,
+      output,
+      reasoning: 'full',
+    });
+
+    await renderer.renderStream(
+      createEscapeSequenceReasoningStream() as never,
+      {
+        title: 'Test',
+        waitForExit: false,
+      },
+    );
+
+    expectNoInjectedSequences(output);
+    expect(stripAnsi(output.text())).toContain('thinkinghard');
+  });
+
+  it('removes escape sequences from tool names and tool output', async () => {
+    const input = createInput();
+    const output = createOutput();
+    output.rows = 20;
+    const renderer = new TerminalRenderer({ input, output, tools: 'full' });
+
+    await renderer.renderStream(createEscapeSequenceToolStream() as never, {
+      title: 'Test',
+      waitForExit: false,
+    });
+
+    expectNoInjectedSequences(output);
+
+    const rendered = stripAnsi(output.text());
+
+    expect(rendered).toContain('Tool · shell');
+    expect(rendered).toContain('outputtail');
+  });
+
+  it('removes escape sequences from stream errors', async () => {
+    const input = createInput();
+    const output = createOutput();
+    const renderer = new TerminalRenderer({ input, output });
+
+    await renderer.renderStream(
+      createErrorStream(
+        new Error('Bad API key\x1b]52;c;ZXZpbA==\x07'),
+      ) as never,
+      {
+        title: 'Test',
+        waitForExit: false,
+      },
+    );
+
+    expectNoInjectedSequences(output);
+    expect(stripAnsi(output.text())).toContain('Bad API key');
+  });
+
+  it('removes escape sequences from the session title', async () => {
+    const input = createInput();
+    const output = createOutput();
+    const renderer = new TerminalRenderer({ input, output });
+
+    await renderer.renderStream(createStream(['hello']) as never, {
+      title: 'Test\x1b]0;pwned\x07',
+      waitForExit: false,
+    });
+
+    expectNoInjectedSequences(output);
+    expect(stripAnsi(output.text())).toContain('┌ Test ');
+  });
+
+  it('removes escape sequences from pasted prompt input', async () => {
+    const input = createInput();
+    const output = createOutput();
+    const renderer = new TerminalRenderer({ input, output });
+    const promptPromise = renderer.readPrompt({ title: 'Test' });
+
+    input.emit('data', Buffer.from('hi\x1b]52;c;ZXZpbA==\x07'));
+    input.emit('data', Buffer.from('\r'));
+
+    await expect(promptPromise).resolves.toBe('hi');
+    expectNoInjectedSequences(output);
+    expect(stripAnsi(output.text())).toContain('│ > hi█');
+  });
+
+  it('removes escape sequences from initial prompt input', async () => {
+    const input = createInput();
+    const output = createOutput();
+    const renderer = new TerminalRenderer({ input, output });
+    const promptPromise = renderer.readPrompt({
+      title: 'Test',
+      initialPrompt: 'hi\x1b]52;c;ZXZpbA==\x07',
+    });
+
+    input.emit('data', Buffer.from('\r'));
+
+    await expect(promptPromise).resolves.toBe('hi');
+    expectNoInjectedSequences(output);
+  });
+
+  it('removes escape sequences from tool approval prompts', async () => {
+    const input = createInput();
+    const output = createOutput();
+    const renderer = new TerminalRenderer({ input, output });
+    const approvalPromise = renderer.readToolApproval(
+      {
+        approvalId: 'approval-1',
+        toolCallId: 'call-1',
+        toolName: 'shell\x1b]52;c;ZXZpbA==\x07',
+        input: { command: 'date' },
+        messageId: 'message-1',
+        partIndex: 0,
+      },
+      { title: 'Test' },
+    );
+
+    expectNoInjectedSequences(output);
+    expect(stripAnsi(output.text())).toContain('Approve tool shell? y/n');
+
+    input.emit('data', Buffer.from('y'));
+
+    await expect(approvalPromise).resolves.toEqual({ approved: true });
+  });
+
+  it('keeps the frame intact when assistant text moves the cursor', async () => {
+    const input = createInput();
+    const output = createOutput();
+    const frameBuffer = createFrameBuffer();
+    const renderer = new TerminalRenderer({ input, output, frameBuffer });
+
+    await renderer.renderStream(
+      createStream(['hello\r\x1b[2J\x1b[1;1Hgone']) as never,
+      {
+        title: 'Test',
+        waitForExit: false,
+      },
+    );
+
+    const frame = frameBuffer.lastPresentedText();
+
+    expect(frame).not.toContain('\r');
+    expect(frame).not.toContain('\x1b[2J');
+    expect(stripAnsi(frame)).toContain('hellogone');
+    expectSingleFrameWidth(frame);
+  });
+
+  it('keeps the frame intact when a tool name is longer than the frame', async () => {
+    const input = createInput();
+    const output = createOutput();
+    const frameBuffer = createFrameBuffer();
+    output.rows = 20;
+    const renderer = new TerminalRenderer({
+      input,
+      output,
+      frameBuffer,
+      tools: 'full',
+    });
+
+    await renderer.renderStream(createLongToolNameStream() as never, {
+      title: 'Test',
+      waitForExit: false,
+    });
+
+    const frame = frameBuffer.lastPresentedText();
+    const header = stripAnsi(frame)
+      .split('\n')
+      .find(line => line.includes('╭'));
+
+    expect(header).toContain('╮');
+    expectSingleFrameWidth(frame);
+  });
+});
+
+function expectNoInjectedSequences(output: TestOutput) {
+  const rendered = output.text();
+
+  // OSC, DCS, APC, PM and SOS introducers, and the terminators they use.
+  expect(rendered).not.toContain('\x1b]');
+  expect(rendered).not.toContain('\x1bP');
+  expect(rendered).not.toContain('\x1b_');
+  expect(rendered).not.toContain('\x1b^');
+  expect(rendered).not.toContain('\x1bX');
+  expect(rendered).not.toContain('\x1b\\');
+  expect(rendered).not.toContain('\x07');
+}
+
+function expectSingleFrameWidth(frame: string) {
+  const widths = new Set(frame.split('\n').map(line => visibleLength(line)));
+
+  expect([...widths]).toHaveLength(1);
+}
+
 function createInput() {
   const input = new EventEmitter() as TestInput;
 
@@ -1024,6 +1237,59 @@ function createPausedToolStream({
       yield { type: 'text-start', id: 'text-1' };
       yield { type: 'text-delta', id: 'text-1', delta: 'hello' };
       yield { type: 'text-end', id: 'text-1' };
+      yield { type: 'finish' };
+    })(),
+  };
+}
+
+function createEscapeSequenceReasoningStream(): AgentTUIStreamResult {
+  return {
+    uiMessageStream: (async function* () {
+      yield { type: 'start', messageId: 'message-1' };
+      yield { type: 'reasoning-start', id: 'reasoning-1' };
+      yield {
+        type: 'reasoning-delta',
+        id: 'reasoning-1',
+        delta: 'thinking\x1b]52;c;ZXZpbA==\x07hard',
+      };
+      yield { type: 'reasoning-end', id: 'reasoning-1' };
+      yield { type: 'finish' };
+    })(),
+  };
+}
+
+function createEscapeSequenceToolStream(): AgentTUIStreamResult {
+  return {
+    uiMessageStream: (async function* () {
+      yield { type: 'start', messageId: 'message-1' };
+      yield {
+        type: 'tool-input-available',
+        toolCallId: 'call-1',
+        toolName: 'shell',
+        title: 'shell\x1b]0;pwned\x07',
+        input: { command: 'ls' },
+      } satisfies UIMessageChunk;
+      yield {
+        type: 'tool-output-available',
+        toolCallId: 'call-1',
+        output: 'output\x1b]52;c;ZXZpbA==\x07tail',
+      } satisfies UIMessageChunk;
+      yield { type: 'finish' };
+    })(),
+  };
+}
+
+function createLongToolNameStream(): AgentTUIStreamResult {
+  return {
+    uiMessageStream: (async function* () {
+      yield { type: 'start', messageId: 'message-1' };
+      yield {
+        type: 'tool-input-available',
+        toolCallId: 'call-1',
+        toolName: 'shell',
+        title: 'shell'.repeat(40),
+        input: { command: 'ls' },
+      } satisfies UIMessageChunk;
       yield { type: 'finish' };
     })(),
   };

--- a/packages/tui/src/tui/terminal-renderer.ts
+++ b/packages/tui/src/tui/terminal-renderer.ts
@@ -7,7 +7,13 @@ import type {
   ResponseStatisticsMode,
   TerminalPartDisplayMode,
 } from '../run-agent-tui';
-import { renderScreenViewport, sliceVisible, visibleLength } from './layout';
+import {
+  renderScreenViewport,
+  sanitizeTerminalLine,
+  sanitizeTerminalText,
+  sliceVisible,
+  visibleLength,
+} from './layout';
 import { renderMarkdown } from './markdown';
 import { TerminalFrameBuffer } from './terminal-frame-buffer';
 import {
@@ -187,7 +193,7 @@ export class TerminalRenderer {
   async readPrompt(options?: TerminalSessionOptions): Promise<string> {
     this.#start(options);
     this.#inputActive = true;
-    this.#inputText = options?.initialPrompt ?? '';
+    this.#inputText = sanitizeTerminalLine(options?.initialPrompt ?? '');
     this.#status = `Type a prompt and press Enter · ${activeControls}`;
     this.#startInputCursorBlink();
     this.#paint();
@@ -198,7 +204,7 @@ export class TerminalRenderer {
 
         switch (key.type) {
           case 'character':
-            this.#inputText += key.value;
+            this.#inputText += sanitizeTerminalLine(key.value);
             this.#showInputCursor();
             this.#paint();
             break;
@@ -382,7 +388,10 @@ export class TerminalRenderer {
   }
 
   #start(options?: TerminalSessionOptions) {
-    this.#title = options?.title ?? this.#title;
+    this.#title =
+      options?.title == null
+        ? this.#title
+        : sanitizeTerminalLine(options.title);
     this.#contextSize = options?.contextSize ?? this.#defaultContextSize;
 
     if (this.#isInteractive) {
@@ -506,7 +515,10 @@ export class TerminalRenderer {
 
     const section = this.#sections.at(-1);
 
-    if (section?.kind === 'user' && section.content === prompt) {
+    if (
+      section?.kind === 'user' &&
+      section.content === sanitizeTerminalText(prompt)
+    ) {
       return;
     }
 
@@ -514,9 +526,7 @@ export class TerminalRenderer {
   }
 
   #addUserSection(prompt: string) {
-    const previousBodyLineCount = this.#bodyLineCount();
-    this.#sections.push({ kind: 'user', title: 'User', content: prompt });
-    this.#paintAfterBodyChange(previousBodyLineCount);
+    this.#pushSection({ kind: 'user', title: 'User', content: prompt });
   }
 
   #renderAssistantMessage(
@@ -617,7 +627,14 @@ export class TerminalRenderer {
     this.#paintAfterBodyChange(previousBodyLineCount);
   }
 
-  #upsertSection(section: ChatSection) {
+  #pushSection(section: ChatSection) {
+    const previousBodyLineCount = this.#bodyLineCount();
+    this.#sections.push(sanitizeSection(section));
+    this.#paintAfterBodyChange(previousBodyLineCount);
+  }
+
+  #upsertSection(unsafeSection: ChatSection) {
+    const section = sanitizeSection(unsafeSection);
     const existingSection = section.id
       ? this.#sections.find(candidate => candidate.id === section.id)
       : undefined;
@@ -691,9 +708,7 @@ export class TerminalRenderer {
   }
 
   #addErrorSection(title: string, content: string) {
-    const previousBodyLineCount = this.#bodyLineCount();
-    this.#sections.push({ kind: 'error', title, content });
-    this.#paintAfterBodyChange(previousBodyLineCount);
+    this.#pushSection({ kind: 'error', title, content });
   }
 
   #paintAfterBodyChange(previousBodyLineCount: number) {
@@ -852,6 +867,22 @@ export class TerminalRenderer {
 
 function interruptedError() {
   return new Error('Interrupted');
+}
+
+/**
+ * Removes terminal escape sequences and control characters from the parts of a
+ * section that are controlled by the model, by tools or by pasted input.
+ */
+function sanitizeSection(section: ChatSection): ChatSection {
+  return {
+    ...section,
+    title: sanitizeTerminalLine(section.title),
+    rightTitle:
+      section.rightTitle == null
+        ? section.rightTitle
+        : sanitizeTerminalLine(section.rightTitle),
+    content: sanitizeTerminalText(section.content),
+  };
 }
 
 async function* takeUntil<T>(
@@ -1078,7 +1109,7 @@ function formatValue(value: unknown) {
 }
 
 function formatToolApprovalTitle(request: AgentTUIToolApprovalRequest) {
-  return `tool ${request.title ?? request.toolName}`;
+  return `tool ${sanitizeTerminalLine(request.title ?? request.toolName)}`;
 }
 
 function sectionId(messageId: string, partIndex: number) {
@@ -1169,23 +1200,25 @@ function sectionMatchesCache(
 function createSectionLines(section: ChatSection, width: number) {
   const style = sectionStyles[section.kind];
   const contentWidth = Math.max(1, width - 4);
-  const title = ` ${section.title} `;
-  const rightTitle = section.rightTitle ? ` ${section.rightTitle} ` : '';
+  const headerWidth = Math.max(0, width - 2);
+  const title = sliceVisible(` ${section.title} `, headerWidth);
+  const rightTitle = section.rightTitle
+    ? sliceVisible(
+        ` ${section.rightTitle} `,
+        Math.max(0, headerWidth - visibleLength(title)),
+      )
+    : '';
+  const borderWidth = Math.max(
+    0,
+    headerWidth - visibleLength(title) - visibleLength(rightTitle),
+  );
+  const top = `${style.color}╭${title}${style.border.repeat(borderWidth)}${rightTitle}╮${colors.reset}`;
+  const bottom = `${style.color}╰${style.border.repeat(Math.max(0, width - 2))}╯${colors.reset}`;
 
   if (section.collapsed) {
-    const borderWidth = Math.max(
-      0,
-      width - 2 - title.length - rightTitle.length,
-    );
-    const top = `${style.color}╭${title}${style.border.repeat(borderWidth)}${rightTitle}╮${colors.reset}`;
-    const bottom = `${style.color}╰${style.border.repeat(Math.max(0, width - 2))}╯${colors.reset}`;
-
     return [top, bottom];
   }
 
-  const borderWidth = Math.max(0, width - 2 - title.length - rightTitle.length);
-  const top = `${style.color}╭${title}${style.border.repeat(borderWidth)}${rightTitle}╮${colors.reset}`;
-  const bottom = `${style.color}╰${style.border.repeat(Math.max(0, width - 2))}╯${colors.reset}`;
   const content =
     section.content.length > 0
       ? renderMarkdown(section.content)

--- a/packages/tui/src/tui/terminal-text.test.ts
+++ b/packages/tui/src/tui/terminal-text.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import {
+  sanitizeTerminalLine,
+  sanitizeTerminalText,
+  sliceVisible,
+  stripAnsi,
+  visibleLength,
+} from './terminal-text';
+
+describe('sanitizeTerminalText', () => {
+  it('removes OSC sequences terminated by BEL', () => {
+    expect(sanitizeTerminalText('before\x1b]52;c;ZXZpbA==\x07after')).toBe(
+      'beforeafter',
+    );
+  });
+
+  it('removes OSC sequences terminated by ST', () => {
+    expect(sanitizeTerminalText('before\x1b]0;window title\x1b\\after')).toBe(
+      'beforeafter',
+    );
+  });
+
+  it('removes OSC hyperlinks and keeps their label', () => {
+    expect(
+      sanitizeTerminalText(
+        '\x1b]8;;https://evil.example\x1b\\docs\x1b]8;;\x1b\\',
+      ),
+    ).toBe('docs');
+  });
+
+  it('removes DCS sequences, including multiplexer passthrough', () => {
+    expect(
+      sanitizeTerminalText('\x1bPtmux;\x1b\x1b]52;c;ZXZpbA==\x07\x1b\\after'),
+    ).toBe('after');
+  });
+
+  it('removes APC, PM and SOS sequences', () => {
+    expect(sanitizeTerminalText('a\x1b_Ga=T,f=100;payload\x1b\\b')).toBe('ab');
+    expect(sanitizeTerminalText('a\x1b^message\x1b\\b')).toBe('ab');
+    expect(sanitizeTerminalText('a\x1bXmessage\x1b\\b')).toBe('ab');
+  });
+
+  it('removes sequences that are still incomplete', () => {
+    expect(sanitizeTerminalText('before\x1b]52;c;ZXZp')).toBe('before');
+    expect(sanitizeTerminalText('before\x1bPtmux;')).toBe('before');
+    expect(sanitizeTerminalText('before\x1b[38;5')).toBe('before');
+    expect(sanitizeTerminalText('before\x1b')).toBe('before');
+  });
+
+  it('removes CSI sequences, including cursor movement and mode changes', () => {
+    expect(sanitizeTerminalText('a\x1b[2J\x1b[H\x1b[?1049h\x1b[31mb')).toBe(
+      'ab',
+    );
+  });
+
+  it('removes two-character and charset escape sequences', () => {
+    expect(sanitizeTerminalText('a\x1bcb')).toBe('ab');
+    expect(sanitizeTerminalText('a\x1b(0b')).toBe('ab');
+    expect(sanitizeTerminalText('a\x1b7b')).toBe('ab');
+  });
+
+  it('removes control characters but keeps newlines', () => {
+    expect(sanitizeTerminalText('a\rb\x08c\x07d\x00e')).toBe('abcde');
+    expect(sanitizeTerminalText('first\nsecond')).toBe('first\nsecond');
+    expect(sanitizeTerminalText('first\r\nsecond')).toBe('first\nsecond');
+  });
+
+  it('removes 8-bit control characters, including sequence introducers', () => {
+    expect(sanitizeTerminalText('a\u009b31mb\u009d0;title\u0007')).toBe(
+      'a31mb0;title',
+    );
+  });
+
+  it('expands tabs to the width they are measured with', () => {
+    expect(sanitizeTerminalText('a\tb')).toBe('a    b');
+    expect(visibleLength('a\tb')).toBe(visibleLength('a    b'));
+  });
+
+  it('keeps printable text unchanged', () => {
+    const text = 'héllo 世界 ✓ **bold** `code` 🙂';
+
+    expect(sanitizeTerminalText(text)).toBe(text);
+  });
+
+  it('is idempotent', () => {
+    const text = 'a\x1b]52;c;ZXZpbA==\x07b\x1b[31mc\rd\te';
+    const sanitized = sanitizeTerminalText(text);
+
+    expect(sanitizeTerminalText(sanitized)).toBe(sanitized);
+  });
+});
+
+describe('sanitizeTerminalLine', () => {
+  it('replaces newlines with spaces', () => {
+    expect(sanitizeTerminalLine('first\nsecond')).toBe('first second');
+  });
+
+  it('removes escape sequences', () => {
+    expect(sanitizeTerminalLine('shell\x1b]52;c;ZXZpbA==\x07')).toBe('shell');
+  });
+});
+
+describe('visibleLength', () => {
+  it('does not count escape sequences as terminal cells', () => {
+    expect(visibleLength('\x1b]52;c;ZXZpbA==\x07hi')).toBe(2);
+    expect(visibleLength('\x1bPtmux;payload\x1b\\hi')).toBe(2);
+    expect(visibleLength('\x1b[1mhi\x1b[22m')).toBe(2);
+  });
+});
+
+describe('sliceVisible', () => {
+  it('keeps styling sequences', () => {
+    expect(sliceVisible('\x1b[1mbold\x1b[22m', 4)).toBe('\x1b[1mbold\x1b[22m');
+  });
+
+  it('drops sequences that are not text styling', () => {
+    expect(sliceVisible('\x1b]52;c;ZXZpbA==\x07hello', 5)).toBe('hello');
+    expect(sliceVisible('a\x1b[10;10Hb', 2)).toBe('ab');
+  });
+});
+
+describe('stripAnsi', () => {
+  it('strips all escape sequences', () => {
+    expect(stripAnsi('\x1b]0;title\x07a\x1b[31mb\x1bPtmux;c\x1b\\')).toBe('ab');
+  });
+});

--- a/packages/tui/src/tui/terminal-text.ts
+++ b/packages/tui/src/tui/terminal-text.ts
@@ -1,12 +1,81 @@
 const ansiEscape = String.fromCharCode(27);
+const bell = String.fromCharCode(7);
+const stringTerminator = `${ansiEscape}\\\\`;
 
-export const ansiPattern = new RegExp(`${ansiEscape}\\[[0-?]*[ -/]*[@-~]`, 'g');
-export const ansiPrefixPattern = new RegExp(
-  `^${ansiEscape}\\[[0-?]*[ -/]*[@-~]`,
-);
+// CSI sequences: ESC [ parameter bytes intermediate bytes final byte.
+const csiSequence = `${ansiEscape}\\[[0-?]*[ -/]*[@-~]`;
+
+// OSC sequences: ESC ] command, terminated by BEL or ST. Includes unterminated
+// sequences so that partial sequences in streamed text are never forwarded.
+const oscSequence = `${ansiEscape}\\][^${bell}${ansiEscape}]*(?:${bell}|${stringTerminator})?`;
+
+// DCS, SOS, PM and APC sequences: ESC P|X|^|_ command, terminated by ST.
+const stringSequence = `${ansiEscape}[PX^_][^${ansiEscape}]*(?:${stringTerminator})?`;
+
+// A CSI sequence that is still incomplete at the end of the input.
+const partialCsiSequence = `${ansiEscape}\\[[0-?]*[ -/]*$`;
+
+// Remaining escape sequences (e.g. `ESC c`, `ESC ( B`) and a lone escape byte.
+const otherEscapeSequence = `${ansiEscape}[ -/]*[0-~]?`;
+
+// SGR sequences only change text attributes, so they are safe to keep when text
+// that the terminal UI styled itself is measured and sliced.
+const sgrSequence = `${ansiEscape}\\[[0-9;:]*m`;
+
+const escapeSequence = [
+  csiSequence,
+  oscSequence,
+  stringSequence,
+  partialCsiSequence,
+  otherEscapeSequence,
+].join('|');
+
+export const escapeSequencePattern = new RegExp(escapeSequence, 'g');
+export const escapeSequencePrefixPattern = new RegExp(`^(?:${escapeSequence})`);
+
+const safeEscapeSequencePattern = new RegExp(`^(?:${sgrSequence})$`);
+
+// Every C0 and C1 control character except the newline that separates the lines
+// of a rendered frame. Removing the C1 range also removes the 8-bit introducers
+// for CSI, OSC and DCS sequences.
+const controlCharacterPattern = /(?!\n)\p{Cc}/gu;
+
+const tabWidth = 4;
+const tabPattern = /\t/g;
+const tabIndent = ' '.repeat(tabWidth);
 
 export function stripAnsi(input: string): string {
-  return input.replace(ansiPattern, '');
+  return input.replace(escapeSequencePattern, '');
+}
+
+/**
+ * Removes terminal escape sequences and control characters from text that the
+ * terminal UI did not generate itself, such as model output, tool results and
+ * pasted input.
+ *
+ * Terminals act on escape sequences that are embedded in the text they print:
+ * OSC sequences can write the system clipboard or change the window title, DCS
+ * sequences can redefine keys or tunnel sequences through a multiplexer, and CSI
+ * sequences can move the cursor outside of the box the text is rendered in.
+ * Untrusted text is therefore reduced to printable characters and newlines
+ * before it is laid out, and the terminal UI adds its own styling afterwards.
+ *
+ * Incomplete sequences are removed as well, so that a sequence that is split
+ * across streamed chunks is never forwarded to the terminal.
+ */
+export function sanitizeTerminalText(input: string): string {
+  return input
+    .replace(escapeSequencePattern, '')
+    .replace(tabPattern, tabIndent)
+    .replace(controlCharacterPattern, '');
+}
+
+/**
+ * Sanitizes untrusted text that is rendered on a single line, such as a title,
+ * a status message or the prompt input.
+ */
+export function sanitizeTerminalLine(input: string): string {
+  return sanitizeTerminalText(input).replace(/\n/g, ' ');
 }
 
 export function visibleLength(input: string): number {
@@ -14,7 +83,7 @@ export function visibleLength(input: string): number {
   let index = 0;
 
   while (index < input.length) {
-    const ansiMatch = input.slice(index).match(ansiPrefixPattern);
+    const ansiMatch = input.slice(index).match(escapeSequencePrefixPattern);
 
     if (ansiMatch) {
       index += ansiMatch[0].length;
@@ -45,10 +114,10 @@ export function sliceVisible(input: string, width: number): string {
   let index = 0;
 
   while (index < input.length && visible < width) {
-    const ansiMatch = input.slice(index).match(ansiPrefixPattern);
+    const ansiMatch = input.slice(index).match(escapeSequencePrefixPattern);
 
     if (ansiMatch) {
-      output += ansiMatch[0];
+      output += keepSafeEscapeSequence(ansiMatch[0]);
       index += ansiMatch[0].length;
       continue;
     }
@@ -72,22 +141,26 @@ export function sliceVisible(input: string, width: number): string {
   }
 
   while (index < input.length) {
-    const ansiMatch = input.slice(index).match(ansiPrefixPattern);
+    const ansiMatch = input.slice(index).match(escapeSequencePrefixPattern);
 
     if (!ansiMatch) {
       break;
     }
 
-    output += ansiMatch[0];
+    output += keepSafeEscapeSequence(ansiMatch[0]);
     index += ansiMatch[0].length;
   }
 
   return output;
 }
 
+function keepSafeEscapeSequence(sequence: string): string {
+  return safeEscapeSequencePattern.test(sequence) ? sequence : '';
+}
+
 export function codePointWidth(codePoint: number): number {
   if (codePoint === 0x09) {
-    return 4;
+    return tabWidth;
   }
 
   if (codePoint < 0x20 || (codePoint >= 0x7f && codePoint < 0xa0)) {

--- a/packages/tui/src/util/print-stream.ts
+++ b/packages/tui/src/util/print-stream.ts
@@ -1,4 +1,5 @@
 import { type StreamTextResult } from 'ai';
+import { sanitizeTerminalText } from '../tui/terminal-text';
 
 export async function printStream(result: StreamTextResult<any, any, any>) {
   for await (const part of result.fullStream) {
@@ -7,13 +8,13 @@ export async function printStream(result: StreamTextResult<any, any, any>) {
         process.stdout.write('\x1b[94m\n');
         break;
       case 'reasoning-delta':
-        process.stdout.write(part.text);
+        process.stdout.write(sanitizeTerminalText(part.text));
         break;
       case 'reasoning-end':
         process.stdout.write('\x1b[0m\n\n');
         break;
       case 'text-delta':
-        process.stdout.write(part.text);
+        process.stdout.write(sanitizeTerminalText(part.text));
         break;
       case 'tool-call':
         process.stdout.write(


### PR DESCRIPTION
## Background

`@ai-sdk/tui` wrote text it did not generate into the terminal frame unchanged: assistant text, reasoning, tool input, tool output, tool error text, tool names and titles, stream errors, the session title, and typed or pasted prompt input.

Terminals act on escape sequences embedded in the text they print, so any of those sources could make the terminal do things that are invisible on screen. OSC sequences write the system clipboard (OSC 52), set the window title, or emit hyperlinks; DCS sequences redefine keys or tunnel further sequences through a multiplexer; APC/PM/SOS sequences drive terminal-specific protocols; CSI sequences move the cursor, clear the screen, or toggle private modes, which also lets untrusted text draw outside the box it is rendered in and spoof the UI — including the tool approval prompt.

The existing helpers only understood CSI sequences: `stripAnsi()` and the width helpers matched `ESC [ … final byte` and nothing else, and no code path sanitized text on its way into a frame. As a result OSC and DCS bodies were also counted as visible characters, so those sequences both reached the terminal and corrupted the layout.

Internal report: VULN-14070.

## Summary

- Add `sanitizeTerminalText()` and `sanitizeTerminalLine()` in `packages/tui/src/tui/terminal-text.ts`. They remove every escape sequence form — CSI, OSC (BEL- or ST-terminated), DCS/SOS/PM/APC, two-character and charset escapes, and a lone escape byte — plus C0 and C1 control characters, keeping the newlines that separate lines of a frame and expanding tabs to the width they are measured with. Incomplete sequences are removed as well, so a sequence split across streamed chunks is never forwarded.
- Sanitize at every point where text the TUI did not generate enters a frame in `TerminalRenderer`: section titles, right titles and content (which covers assistant text, reasoning, tool input, tool output, tool error text and tool names), stream errors, the session title, the tool approval prompt, `initialPrompt`, and typed or pasted input.
- Defense in depth in the layout helpers: width measurement now treats every escape sequence form as zero width, and `sliceVisible()` only carries SGR (text styling) sequences into a frame, so a non-styling sequence cannot survive slicing even on a path that skipped sanitization.
- Clamp section header labels with `sliceVisible()`/`visibleLength()` so a tool title longer than the terminal can no longer overflow its box and desynchronize the frame diff.
- `printStream()` sanitizes streamed text and reasoning before writing to stdout.

Deliberate behavior change worth a look during review: escape sequences from a model or a tool are now dropped rather than passed through, so colored CLI output captured in a tool result renders as plain text. The TUI's own styling (markdown emphasis, section colors) is applied after sanitization and is unaffected.

## End-to-End Verification

Drove the public `runAgentTUI()` API in a real child process (mock model, real `ToolLoopAgent`, real `process.stdout`) with a scratch script where the model text, the tool result and the session title each carry an OSC 52 clipboard write, an OSC 0 window title change, a `DCS tmux;` passthrough and a CSI screen clear, then scanned the captured stdout bytes:

- Before this change: the OSC, DCS, ST and BEL bytes all reached stdout, and the tool output rendered corrupted (`sunny, 22C` never appeared on screen).
- After this change: none of the OSC, DCS, APC, PM, SOS, ST or BEL bytes appear in stdout, and the intended text (`Berlin is sunny.`, `Bye.`, `sunny, 22C`, the session title) still renders.

The script is not added to `examples/`: a runnable terminal-injection payload is not something to ship as an example. The equivalent coverage lives in the tests below.

## Tests

- `packages/tui/src/tui/terminal-text.test.ts` (new): unit coverage for each sequence form, incomplete sequences, control characters, tabs, idempotency, and the measuring/slicing behavior.
- `packages/tui/src/tui/terminal-renderer.test.ts`: ten renderer-level regression tests covering assistant text, reasoning, tool names and output, stream errors, the session title, pasted and initial prompt input, the tool approval prompt, cursor movement inside assistant text, and an over-long tool title. Nine of them fail on `main`; the tenth (over-long tool title) fails without the header clamp.

`pnpm test`, `pnpm type-check`, `oxlint` and `oxfmt` are clean in `packages/tui`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

No documentation change: the public API and every documented option behave the same, and the terminal UI docs only cover installation and usage.

## Future Work

- Stripped sequences are removed silently. If it turns out to be useful to show that something was removed, the sanitizer is the single place to add a visible marker.
