### PR TITLE
test(workflow): failing tests for reasoning loss across steps (#14293)

### DIFF
--- a/packages/workflow/src/do-stream-step.test.ts
+++ b/packages/workflow/src/do-stream-step.test.ts
@@ -295,4 +295,72 @@ describe('doStreamStep', () => {
     });
     expect(streamedParts).toContainEqual({ type: 'error', error: terminal });
   });
+  /**
+   * vercel/ai#14293 — the reasoning attestation is destroyed here, before
+   * anything downstream can use it.
+   *
+   * `reasoningParts` is typed `Array<{ text: string }>` and built as
+   * `{ text: part.text }`, and the switch has no `reasoning-start` /
+   * `reasoning-end` case — which is where providers attach the attestation
+   * (Anthropic `signature`, OpenAI `reasoningEncryptedContent`). Without it a
+   * replayed reasoning part is dropped by the provider, so preserving reasoning
+   * in the conversation prompt is not enough on its own.
+   *
+   * Marked `it.fails` so CI stays green while the bug is open. It flips to a
+   * real failure once the behaviour is fixed, which is the signal to drop the
+   * `.fails`.
+   */
+  it.fails('preserves providerMetadata on reasoning parts', async () => {
+    const signature = 'ErUBCkYIBBgCIkDrKfLtEXAMPLEsignatureBYTES';
+
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start' as const, warnings: [] },
+          { type: 'reasoning-start' as const, id: 'reasoning-1' },
+          {
+            type: 'reasoning-delta' as const,
+            id: 'reasoning-1',
+            delta: 'The discount is a percentage, not a fraction.',
+          },
+          {
+            // Anthropic attaches the signature to reasoning-end.
+            type: 'reasoning-end' as const,
+            id: 'reasoning-1',
+            providerMetadata: { anthropic: { signature } },
+          },
+          {
+            type: 'finish' as const,
+            finishReason: { unified: 'stop' as const, raw: 'stop' },
+            usage: {
+              inputTokens: {
+                total: 1,
+                noCache: 1,
+                cacheRead: undefined,
+                cacheWrite: undefined,
+              },
+              outputTokens: { total: 2, text: 0, reasoning: 2 },
+            },
+          },
+        ]),
+      }),
+    });
+
+    const result = await doStreamStep(
+      prompt,
+      model,
+      new WritableStream({ write() {} }),
+    );
+
+    const reasoning = (result as { raw: { reasoning: unknown[] } }).raw
+      .reasoning as Array<{ text: string; providerMetadata?: unknown }>;
+
+    expect(reasoning).toHaveLength(1);
+    expect(reasoning[0].text).toBe(
+      'The discount is a percentage, not a fraction.',
+    );
+    expect(reasoning[0].providerMetadata).toEqual({
+      anthropic: { signature },
+    });
+  });
 });

--- a/packages/workflow/src/stream-text-iterator.test.ts
+++ b/packages/workflow/src/stream-text-iterator.test.ts
@@ -963,3 +963,113 @@ describe('streamTextIterator', () => {
     });
   });
 });
+
+/**
+ * vercel/ai#14293 — WorkflowAgent does not preserve reasoning across steps.
+ *
+ * The `tool-calls` branch rebuilds the assistant message from text + tool calls
+ * only, so on the next step the model sees the result of a call it made but not
+ * the reasoning that produced it. vercel/workflow#1444 fixed the same defect for
+ * DurableAgent by adding `reasoningParts` to that branch.
+ *
+ * `sanitizeProviderMetadataForToolCall` exists because of this — see its comment,
+ * "requires reasoning items we don't preserve". Fixing this should let that
+ * workaround be removed.
+ *
+ * NOTE: necessary but not sufficient. `doStreamStep` also discards
+ * `providerMetadata` from reasoning chunks, so a part replayed from
+ * `step.reasoning` carries no attestation and providers drop it. See the sibling
+ * test in do-stream-step.test.ts.
+ *
+ * Marked `it.fails` so CI stays green while the bug is open. They flip to real
+ * failures once the behaviour is fixed, which is the signal to drop the `.fails`.
+ */
+describe('reasoning across a tool-call step', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function runToolCallStep(reasoningText: string) {
+    let capturedPrompt: LanguageModelV4Prompt | undefined;
+
+    const toolCall: LanguageModelV4ToolCall = {
+      type: 'tool-call',
+      toolCallId: 'call-1',
+      toolName: 'readFile',
+      input: '{"path":"pricing.ts"}',
+    };
+
+    vi.mocked(doStreamStep)
+      .mockResolvedValueOnce(
+        createMockDoStreamStepResult({
+          toolCalls: [toolCall],
+          finishReason: 'tool-calls',
+          finishRaw: 'tool_calls',
+          rawOverrides: {
+            reasoning: [{ text: reasoningText }],
+          } as Partial<DoStreamStepRawResult>,
+        }),
+      )
+      .mockImplementationOnce(async prompt => {
+        capturedPrompt = prompt;
+        return createMockDoStreamStepResult();
+      });
+
+    const iterator = streamTextIterator({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'why?' }] }],
+      tools: {
+        readFile: {
+          description: 'Read a file',
+          execute: async () => ({ contents: 'export const pct = 20;' }),
+        },
+      } as unknown as ToolSet,
+      writable: createMockWritable(),
+      model: vi.fn() as any,
+    });
+
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+
+    const toolResults: LanguageModelV4ToolResultPart[] = [
+      {
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'readFile',
+        output: {
+          type: 'text',
+          value: '{"contents":"export const pct = 20;"}',
+        },
+      },
+    ];
+    await iterator.next(toolResults);
+
+    return capturedPrompt?.find(m => m.role === 'assistant');
+  }
+
+  it.fails(
+    'includes reasoning in the assistant message sent to the next step',
+    async () => {
+      const assistant = await runToolCallStep(
+        'I should check how the discount is expressed.',
+      );
+
+      expect(assistant).toBeDefined();
+      expect(assistant?.content).toContainEqual(
+        expect.objectContaining({
+          type: 'reasoning',
+          text: 'I should check how the discount is expressed.',
+        }),
+      );
+    },
+  );
+
+  it.fails('puts reasoning before the tool call, as providers expect', async () => {
+    const assistant = await runToolCallStep('thinking first');
+    const types = (assistant?.content as Array<{ type: string }>).map(
+      p => p.type,
+    );
+
+    expect(types).toContain('reasoning');
+    expect(types.indexOf('reasoning')).toBeLessThan(types.indexOf('tool-call'));
+  });
+});


### PR DESCRIPTION
Failing tests for #14293, per CONTRIBUTING's "add a failing test or reproduction that precisely captures a bug". No behaviour change — additive tests only.

There are **two independent losses**, and fixing either alone still leaves the model without its reasoning. That's the main thing these tests pin down.

### 1. The attestation is discarded while the stream is consumed

`packages/workflow/src/do-stream-step.ts`

```ts
const reasoningParts: Array<{ text: string }> = [];
...
case 'reasoning-delta':
  reasoningParts.push({ text: part.text });
```

The switch has no `reasoning-start` / `reasoning-end` case, and those are where providers attach the attestation — Anthropic `signature`, OpenAI `reasoningEncryptedContent`. So it never leaves the step, and `buildStepResult` can only surface `{ type, text }`.

Consequence: a reasoning part reconstructed from `step.reasoning` has no signature, and the provider drops it. `@ai-sdk/anthropic` only emits a `thinking` block when `reasoningMetadata.signature != null`; otherwise it warns `unsupported reasoning metadata` and skips the part.

### 2. The rebuilt assistant message omits reasoning on a tool-call step

`packages/workflow/src/stream-text-iterator.ts`

```ts
} else if (finishReason === 'tool-calls') {
  conversationPrompt.push({
    role: 'assistant',
    content: [...textContent, ...toolCalls.map(...)],
  });
```

The model sees the result of a call it made, but not the reasoning that produced it. vercel/workflow#1444 fixed this half for DurableAgent by adding `reasoningParts` to the same branch.

This is also what `sanitizeProviderMetadataForToolCall` exists for — its own comment says *"requires reasoning items we don't preserve"*. Fixing (2) should let that workaround be removed, which is the outcome #14293 points at.

### The tests

| file | test |
|---|---|
| `do-stream-step.test.ts` | `preserves providerMetadata on reasoning parts` |
| `stream-text-iterator.test.ts` | `includes reasoning in the assistant message sent to the next step` |
| `stream-text-iterator.test.ts` | `puts reasoning before the tool call, as providers expect` |

Run against `main` they fail with:

```
AssertionError: expected undefined to deeply equal { Object (anthropic) }
AssertionError: expected [ { type: 'tool-call', …(3) } ] to deep equally contain ObjectContaining{…}
AssertionError: expected [ 'tool-call' ] to include 'reasoning'
```

They're marked `it.fails` so CI stays green while the bug is open — vitest reports `27 passed | 3 expected fail`. They flip to real failures the moment the behaviour is fixed, which is the signal to drop the `.fails`. Happy to switch them to plain `it` if you'd rather have red CI on this.

### Field notes

We hit this running WorkflowAgent in production. Two things that may be useful when fixing:

- **Cross-model replay is safe**, measured against the gateway: a thinking block replayed into a *different* Anthropic model, or a different provider, is dropped silently and unbilled — no error. The only hard failure is an **altered** signature (`400 Invalid \`signature\` in \`thinking\` block`). So `providerMetadata` should be passed through by reference, never rebuilt.
- Ordering matters — reasoning has to precede the tool call in the assistant content, which is what the third test pins.

Also worth noting for anyone reading #14293 on an older version: the **text** half of this was already fixed on `main` (`...textContent` is in that branch now). It's still missing in the published `@ai-sdk/workflow@1.0.28`. Only the reasoning half is outstanding on `main`.

cc @lgrammel @gr2m

🤖 Generated with [Claude Code](https://claude.com/claude-code)