### PR TITLE
fix(openai): handle null usage in responses

### DIFF
--- a/.changeset/openai-responses-usage-nullish.md
+++ b/.changeset/openai-responses-usage-nullish.md
@@ -2,6 +2,4 @@
 '@ai-sdk/openai': patch
 ---
 
-fix(openai): allow missing usage in response.completed/incomplete streaming chunks
-
-OpenAI-compatible endpoints may send a final `response.completed` or `response.incomplete` chunk without a usage object. The streaming chunk schema previously required `usage.input_tokens` and `usage.output_tokens`, causing a TypeValidationError that rejected the chunk and left `result.usage` unhandled. `usage` is now nullish, matching the `response.failed` chunk schema and the non-streaming response schema.
+fix(openai): handle null usage in responses

--- a/.changeset/openai-responses-usage-nullish.md
+++ b/.changeset/openai-responses-usage-nullish.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): allow missing usage in response.completed/incomplete streaming chunks
+
+OpenAI-compatible endpoints may send a final `response.completed` or `response.incomplete` chunk without a usage object. The streaming chunk schema previously required `usage.input_tokens` and `usage.output_tokens`, causing a TypeValidationError that rejected the chunk and left `result.usage` unhandled. `usage` is now nullish, matching the `response.failed` chunk schema and the non-streaming response schema.

--- a/packages/openai/src/responses/openai-responses-api.test.ts
+++ b/packages/openai/src/responses/openai-responses-api.test.ts
@@ -251,4 +251,24 @@ describe('openaiResponsesChunkSchema', () => {
 
     expect(result.success).toBe(false);
   });
+
+  describe.each(['response.completed', 'response.incomplete'] as const)(
+    '%s',
+    type => {
+      it.each([
+        { name: 'missing usage', response: {} },
+        {
+          name: 'null usage',
+          response: { usage: null },
+        },
+      ])('accepts responses with $name', async ({ response }) => {
+        const result = await safeValidateTypes({
+          value: { type, response },
+          schema: openaiResponsesChunkSchema,
+        });
+
+        expect(result).toMatchObject({ success: true, value: { type } });
+      });
+    },
+  );
 });

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -831,24 +831,26 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
         type: z.enum(['response.completed', 'response.incomplete']),
         response: z.object({
           incomplete_details: z.object({ reason: z.string() }).nullish(),
-          usage: z.object({
-            input_tokens: z.number(),
-            input_tokens_details: z
-              .object({
-                cached_tokens: z.number().nullish(),
-                cache_write_tokens: z.number().nullish(),
-                orchestration_input_tokens: z.number().nullish(),
-                orchestration_input_cached_tokens: z.number().nullish(),
-              })
-              .nullish(),
-            output_tokens: z.number(),
-            output_tokens_details: z
-              .object({
-                reasoning_tokens: z.number().nullish(),
-                orchestration_output_tokens: z.number().nullish(),
-              })
-              .nullish(),
-          }),
+          usage: z
+            .object({
+              input_tokens: z.number(),
+              input_tokens_details: z
+                .object({
+                  cached_tokens: z.number().nullish(),
+                  cache_write_tokens: z.number().nullish(),
+                  orchestration_input_tokens: z.number().nullish(),
+                  orchestration_input_cached_tokens: z.number().nullish(),
+                })
+                .nullish(),
+              output_tokens: z.number(),
+              output_tokens_details: z
+                .object({
+                  reasoning_tokens: z.number().nullish(),
+                  orchestration_output_tokens: z.number().nullish(),
+                })
+                .nullish(),
+            })
+            .nullish(),
           reasoning: z
             .object({
               context: z.string().nullish(),

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -1764,7 +1764,7 @@ export const openaiResponsesResponseSchema = lazySchema(() =>
             })
             .nullish(),
         })
-        .optional(),
+        .nullish(),
     }),
   ),
 );

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -2584,7 +2584,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
                   raw: value.response.incomplete_details?.reason ?? undefined,
                 };
               }
-              usage = value.response.usage;
+              usage = value.response.usage ?? undefined;
               if (typeof value.response.service_tier === 'string') {
                 serviceTier = value.response.service_tier;
               }


### PR DESCRIPTION
I noticed [exa](https://exa.ai/docs/reference/openai-sdk) sends `response.completed` with no usage. 

but `@ai-sdk/openai` requires numbers in `usage.input_tokens`/`usage.output_tokens` for `response.completed`/`response.incomplete`.

**[repro](https://github.com/aldosch/ai-20102-repro)**
```bash
git clone git@github.com:aldosch/ai-20102-repro.git && cd ai-20102-repro
pnpm install
pnpm run repro
pnpm run repro:exa    # if you've set EXA_API_KEY
```

it crashed my opencode tui with a zod error, when using a custom research tool powered by exa.

this PR adds `.nullish()` to the zod schema in `packages/openai/src/responses/openai-responses-api.ts`, so that missing usage doesn't throw. 

**maybe there are scenarios where this is a bad idea?** idk. I see some PRs address it by injecting dummy usage data instead: https://github.com/vercel/ai/pull/12301

my bot's summary:

> An OpenAI-compatible endpoint (Exa, `exa.responses("exa-agent")` via `createOpenAI` with baseURL `https://api.exa.ai`) intermittently sends the final `response.completed` with a missing/empty usage object. The strict schema then rejects the chunk with `TypeValidationError` ("Known response chunk failed schema validation"), and `streamText` surfaces an unhandled rejection on the `result.usage` promise. Verified on `@ai-sdk/openai@4.0.50` and `4.0.52`.
> 
> - Wrap `usage` in `.nullish()` in the `response.completed` / `response.incomplete` chunk variant, matching the `response.failed` chunk schema and the non-streaming response schema
> - Normalize to `?? undefined` when storing the chunk usage in `openai-responses-language-model.ts` (same pattern as the existing `response.failed` path); `convertOpenAIResponsesUsage` already handles null by returning a null usage object
>
> **End-to-End Verification**
> 
> Ran a local mock SSE server serving a Responses API stream whose final `response.completed` chunk has no `usage` object, consumed via `streamText` + `createOpenAI(...).responses(...)`:
> 
> - Before the fix: `AI_TypeValidationError` — `response.usage` fails with `invalid_type` on the `response.completed` chunk, matching the reported failure
> - After the fix: stream completes normally — text resolves, `usage` resolves with null token totals, finish reason `stop`
> 
> Also: `packages/openai` node tests (977 passed, includes 4 new schema regression tests) and full workspace type-check.
> 
> **Future Work**
>
> The non-streaming `openaiResponsesResponseSchema` uses `.optional()` while the streaming variants use `.nullish()`; unifying those is cosmetic and intentionally left out of this change.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)