### PR TITLE
fix(harness-pi): stream Pi tool input while it is generated

### DIFF
--- a/.changeset/olive-pumas-shave.md
+++ b/.changeset/olive-pumas-shave.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-pi': patch
+---
+
+fix(harness-pi): stream Pi tool input while it is generated

--- a/packages/harness-pi/src/pi-events.ts
+++ b/packages/harness-pi/src/pi-events.ts
@@ -12,6 +12,14 @@ export const piSessionEventSchema = z.looseObject({
     .looseObject({
       type: z.string().optional(),
       delta: z.string().optional(),
+      // `toolcall_start` / `toolcall_delta` / `toolcall_end` address a content
+      // block by index rather than by tool call id. The id and name live in the
+      // partial assistant message at that index, which Pi fills in before the
+      // first delta arrives.
+      contentIndex: z.number().optional(),
+      partial: z
+        .looseObject({ content: z.array(z.unknown()).optional() })
+        .optional(),
     })
     .optional(),
   toolCallId: z.string().optional(),

--- a/packages/harness-pi/src/pi-translate.test.ts
+++ b/packages/harness-pi/src/pi-translate.test.ts
@@ -46,6 +46,269 @@ describe('translatePiEvent', () => {
     expect(out[2]).toMatchObject({ type: 'text-delta', id, delta: 'world' });
   });
 
+  it('streams tool input as the model writes it', () => {
+    const state = createPiTranslatorState({ hostToolNames: ['visualize'] });
+    const partial = (args: string) => ({
+      content: [{ type: 'toolCall', id: 'call-1', name: 'visualize', args }],
+    });
+    const out = emit(
+      [
+        { type: 'turn_start' } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_start',
+            contentIndex: 0,
+            partial: partial(''),
+          },
+        } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_delta',
+            contentIndex: 0,
+            delta: '{"html":"<h1>',
+            partial: partial('{"html":"<h1>'),
+          },
+        } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_delta',
+            contentIndex: 0,
+            delta: 'hi</h1>"}',
+            partial: partial('{"html":"<h1>hi</h1>"}'),
+          },
+        } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_end',
+            contentIndex: 0,
+            partial: partial('{"html":"<h1>hi</h1>"}'),
+          },
+        } as PiSessionEvent,
+      ],
+      state,
+    );
+
+    expect(out).toEqual([
+      { type: 'tool-input-start', id: 'call-1', toolName: 'visualize' },
+      { type: 'tool-input-delta', id: 'call-1', delta: '{"html":"<h1>' },
+      { type: 'tool-input-delta', id: 'call-1', delta: 'hi</h1>"}' },
+      { type: 'tool-input-end', id: 'call-1' },
+    ]);
+  });
+
+  it('reports the same dispatch on tool-input-start as on the tool-call', () => {
+    const state = createPiTranslatorState({ builtinToolNames: ['read'] });
+    const out = emit(
+      [
+        { type: 'turn_start' } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_start',
+            contentIndex: 0,
+            partial: {
+              content: [{ type: 'toolCall', id: 'call-1', name: 'read' }],
+            },
+          },
+        } as PiSessionEvent,
+        {
+          type: 'tool_execution_start',
+          toolCallId: 'call-1',
+          toolName: 'read',
+          args: { path: 'a.txt' },
+        } as PiSessionEvent,
+      ],
+      state,
+    );
+
+    expect(out[0]).toMatchObject({
+      type: 'tool-input-start',
+      id: 'call-1',
+      providerExecuted: true,
+    });
+    expect(out[1]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'call-1',
+      providerExecuted: true,
+    });
+  });
+
+  it('marks a streamed MCP tool input as dynamic', () => {
+    const state = createPiTranslatorState();
+    const out = emit(
+      [
+        { type: 'turn_start' } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_start',
+            contentIndex: 0,
+            partial: {
+              content: [
+                { type: 'toolCall', id: 'call-1', name: 'mcp__linear__issue' },
+              ],
+            },
+          },
+        } as PiSessionEvent,
+      ],
+      state,
+    );
+
+    expect(out[0]).toMatchObject({
+      type: 'tool-input-start',
+      id: 'call-1',
+      dynamic: true,
+      providerExecuted: true,
+    });
+  });
+
+  it('keeps tool inputs of concurrent calls on their own ids', () => {
+    const state = createPiTranslatorState();
+    const content = [
+      { type: 'toolCall', id: 'call-1', name: 'read' },
+      { type: 'toolCall', id: 'call-2', name: 'read' },
+    ];
+    const out = emit(
+      [
+        { type: 'turn_start' } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_start',
+            contentIndex: 0,
+            partial: { content },
+          },
+        } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_start',
+            contentIndex: 1,
+            partial: { content },
+          },
+        } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_delta',
+            contentIndex: 1,
+            delta: 'b',
+            partial: { content },
+          },
+        } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_delta',
+            contentIndex: 0,
+            delta: 'a',
+            partial: { content },
+          },
+        } as PiSessionEvent,
+      ],
+      state,
+    );
+
+    expect(out.slice(2)).toEqual([
+      { type: 'tool-input-delta', id: 'call-2', delta: 'b' },
+      { type: 'tool-input-delta', id: 'call-1', delta: 'a' },
+    ]);
+  });
+
+  it('drops tool input deltas that arrive without a start', () => {
+    // Nothing to attach the delta to. The complete input still arrives with
+    // the `tool-call`, so dropping it loses nothing.
+    const state = createPiTranslatorState();
+    const out = emit(
+      [
+        { type: 'turn_start' } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_delta',
+            contentIndex: 0,
+            delta: '{"a":1}',
+          },
+        } as PiSessionEvent,
+      ],
+      state,
+    );
+
+    expect(out).toEqual([]);
+  });
+
+  it('does not stream a tool input whose id is not known yet', () => {
+    const state = createPiTranslatorState();
+    const out = emit(
+      [
+        { type: 'turn_start' } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_start',
+            contentIndex: 0,
+            partial: { content: [{ type: 'toolCall', id: '', name: '' }] },
+          },
+        } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_delta',
+            contentIndex: 0,
+            delta: '{',
+          },
+        } as PiSessionEvent,
+      ],
+      state,
+    );
+
+    expect(out).toEqual([]);
+  });
+
+  it('does not carry tool input ids across assistant messages', () => {
+    // Content-block indices restart with every message.
+    const state = createPiTranslatorState();
+    emit(
+      [
+        { type: 'turn_start' } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_start',
+            contentIndex: 0,
+            partial: {
+              content: [{ type: 'toolCall', id: 'call-1', name: 'read' }],
+            },
+          },
+        } as PiSessionEvent,
+      ],
+      state,
+    );
+    const out = emit(
+      [
+        {
+          type: 'message_start',
+          message: { role: 'assistant' },
+        } as PiSessionEvent,
+        {
+          type: 'message_update',
+          assistantMessageEvent: {
+            type: 'toolcall_delta',
+            contentIndex: 0,
+            delta: '{',
+          },
+        } as PiSessionEvent,
+      ],
+      state,
+    );
+
+    expect(out).toEqual([]);
+  });
+
   it('gap-fills missing text at turn_end and emits text-end', () => {
     const state = createPiTranslatorState();
     emit(

--- a/packages/harness-pi/src/pi-translate.ts
+++ b/packages/harness-pi/src/pi-translate.ts
@@ -28,6 +28,13 @@ export interface PiTranslatorState {
   reasoningStarted: boolean;
   /** Tool-call id → tool name (used to fill in `toolName` on results). */
   observedToolNames: Map<string, string>;
+  /**
+   * Content-block index → tool-call id for tool inputs that are still
+   * streaming. Pi addresses `toolcall_*` events by `contentIndex`, while the
+   * harness stream parts are keyed by the tool call id, so the id is resolved
+   * once at `toolcall_start` and reused for the deltas that follow.
+   */
+  streamingToolInputIds: Map<number, string>;
   /** Tool ids requested by the current assistant message but not yet completed. */
   pendingStepToolCallIds: Set<string>;
   /** Total tool calls requested by the current assistant message. */
@@ -85,6 +92,7 @@ export function createPiTranslatorState(
     currentReasoningId: undefined,
     reasoningStarted: false,
     observedToolNames: new Map(),
+    streamingToolInputIds: new Map(),
     pendingStepToolCallIds: new Set(),
     stepToolCallCount: undefined,
     stepOpen: false,
@@ -152,6 +160,48 @@ function resolveToolName(
 ): { wire: string; native: string } {
   const common = state.nativeToCommonNameMap.get(nativeName);
   return { wire: common ?? nativeName, native: nativeName };
+}
+
+/**
+ * How a tool call is dispatched, from the native tool name. Pi runs its
+ * builtin tools and MCP tools itself; everything else is handed back to the
+ * harness host. `tool-input-start` reports the same flags as the `tool-call`
+ * that follows it so a consumer does not have to wait for the call to know
+ * who will execute it.
+ */
+function resolveToolDispatch(
+  state: PiTranslatorState,
+  nativeName: string,
+): { isMcpTool: boolean; providerExecuted: boolean } {
+  const isMcpTool =
+    !state.hostToolNames.has(nativeName) &&
+    (nativeName === 'mcp' || nativeName.startsWith('mcp__'));
+  return {
+    isMcpTool,
+    providerExecuted: state.builtinToolNames.has(nativeName) || isMcpTool,
+  };
+}
+
+/**
+ * The `{ id, name }` of the tool call a `toolcall_*` event refers to, read out
+ * of the partial assistant message it carries. Returns undefined when the
+ * block is missing or not a tool call yet, in which case the input is left
+ * unstreamed — the complete `tool-call` still arrives at `tool_execution_start`.
+ */
+function readStreamingToolCall(
+  event: PiSessionEvent,
+): { contentIndex: number; id: string; name: string } | undefined {
+  const update = event.assistantMessageEvent;
+  const contentIndex = update?.contentIndex;
+  if (typeof contentIndex !== 'number') return undefined;
+  const block = update?.partial?.content?.[contentIndex];
+  if (!block || typeof block !== 'object') return undefined;
+  const record = block as Record<string, unknown>;
+  if (record.type !== 'toolCall') return undefined;
+  const { id, name } = record;
+  if (typeof id !== 'string' || id.length === 0) return undefined;
+  if (typeof name !== 'string' || name.length === 0) return undefined;
+  return { contentIndex, id, name };
 }
 
 function finishStep(state: PiTranslatorState): HarnessV1StreamPart[] {
@@ -225,6 +275,8 @@ export function translatePiEvent(
       state.currentTextId = undefined;
       state.currentReasoningId = undefined;
       state.reasoningStarted = false;
+      // Content-block indices restart with every assistant message.
+      state.streamingToolInputIds.clear();
       return [];
     }
 
@@ -282,6 +334,43 @@ export function translatePiEvent(
         });
         return parts;
       }
+      // Tool inputs stream as raw JSON text, the same way text and reasoning
+      // stream. Surfacing them lets a consumer show what the model is writing
+      // before the call is complete, instead of waiting for the whole input to
+      // land at `tool_execution_start`.
+      if (update.type === 'toolcall_start') {
+        const call = readStreamingToolCall(event);
+        if (!call) return [];
+        const { wire, native } = resolveToolName(state, call.name);
+        const { isMcpTool, providerExecuted } = resolveToolDispatch(
+          state,
+          native,
+        );
+        state.streamingToolInputIds.set(call.contentIndex, call.id);
+        return [
+          {
+            type: 'tool-input-start',
+            id: call.id,
+            toolName: wire,
+            ...(providerExecuted ? { providerExecuted: true } : {}),
+            ...(isMcpTool ? { dynamic: true } : {}),
+          },
+        ];
+      }
+      if (update.type === 'toolcall_delta' || update.type === 'toolcall_end') {
+        const contentIndex = update.contentIndex;
+        if (typeof contentIndex !== 'number') return [];
+        const id = state.streamingToolInputIds.get(contentIndex);
+        // Without a start there is no id to attach the input to. Dropping it
+        // is safe: the complete input still arrives with the `tool-call`.
+        if (id === undefined) return [];
+        if (update.type === 'toolcall_end') {
+          state.streamingToolInputIds.delete(contentIndex);
+          return [{ type: 'tool-input-end', id }];
+        }
+        if (typeof update.delta !== 'string') return [];
+        return [{ type: 'tool-input-delta', id, delta: update.delta }];
+      }
       return [];
     }
 
@@ -331,10 +420,10 @@ export function translatePiEvent(
       if (!event.toolCallId || !event.toolName) return [];
       const { wire, native } = resolveToolName(state, event.toolName);
       state.observedToolNames.set(event.toolCallId, wire);
-      const isMcpTool =
-        !state.hostToolNames.has(native) &&
-        (native === 'mcp' || native.startsWith('mcp__'));
-      const providerExecuted = state.builtinToolNames.has(native) || isMcpTool;
+      const { isMcpTool, providerExecuted } = resolveToolDispatch(
+        state,
+        native,
+      );
       if (isMcpTool) state.dynamicToolCallIds.add(event.toolCallId);
       const input = serializeToolOutput(event.args ?? event.input ?? {});
       return [


### PR DESCRIPTION
## Background

`@ai-sdk/harness` gained `tool-input-start` / `tool-input-delta` / `tool-input-end` in #19837, and `@ai-sdk/harness-claude-code` emits them today. `@ai-sdk/harness-pi` does not, so a consumer running Pi sees nothing while the model writes a tool input — the whole input appears at once with `tool_execution_start`.

For tools whose input *is* the artifact (a tool that takes a rendered HTML document, for example), that is the difference between watching the output appear and staring at a spinner for the entire generation.

## The gap

Pi already emits the partial input. `@earendil-works/pi-ai` has these in its assistant message event union:

```ts
| { type: "toolcall_start"; contentIndex: number; partial: AssistantMessage }
| { type: "toolcall_delta"; contentIndex: number; delta: string; partial: AssistantMessage }
| { type: "toolcall_end";   contentIndex: number; toolCall: ToolCall; partial: AssistantMessage }
```

`translatePiEvent`'s `message_update` case only handled `text_delta` and `thinking_delta`, so all three fell through to `return []`.

## What this changes

`packages/harness-pi/src/pi-translate.ts` translates the three events into the corresponding harness stream parts.

**Resolving the id.** Pi addresses these events by `contentIndex`, while the harness parts are keyed by tool call id. The id is already present in the partial assistant message at that index — Pi's providers push the `toolCall` block (with `id` and `name`) before emitting `toolcall_start` — so it is read once at start and reused for the deltas that follow. The index → id map is cleared per assistant message, since content block indices restart with each one.

**Degrading safely.** A delta whose start was not seen, or a start whose block has no id yet, is dropped rather than guessed at. The complete input still arrives with the `tool-call` at `tool_execution_start`, so nothing is lost — the input is simply not streamed.

**Consistent dispatch flags.** `tool-input-start` reports the same `providerExecuted` / `dynamic` flags as the `tool-call` that follows it, so a consumer does not have to wait for the call to know who will execute the tool. That decision is factored into `resolveToolDispatch` and shared with `tool_execution_start` so the two cannot drift.

`packages/harness-pi/src/pi-events.ts` gains `contentIndex` and `partial` on the `assistantMessageEvent` schema (it is a `looseObject`, so these were passing through untyped).

## Tests

Seven cases added to `pi-translate.test.ts`:

- streams `start` → `delta` × 2 → `end` for a single tool call
- `tool-input-start` reports the same dispatch as the following `tool-call`
- an MCP tool input is marked `dynamic`
- concurrent tool calls keep their deltas on their own ids
- a delta without a start is dropped
- a start whose block has no id yet does not stream
- ids are not carried across assistant messages

```
pnpm --filter @ai-sdk/harness-pi test        # 13 files, 182 passed
pnpm --filter @ai-sdk/harness-pi type-check
pnpm oxlint packages/harness-pi/src          # 0 warnings, 0 errors
```

## Notes

I have no Pi-backed integration environment to run this end to end, so the behaviour is covered by unit tests against the event shapes in `@earendil-works/pi-ai@0.74.2`. Happy to adjust if the maintainers would rather see this as an issue than a PR — CONTRIBUTING.md notes that a high-quality issue is often more useful, but this seemed small and focused enough to send as a patch.

Related: #19837 (the same change for Claude Code), #18904 (the original broader PR, now conflicting).


Supersedes #20019 — identical changes, recreated with a signed commit as requested.
