### PR TITLE
fix(ai): use || so an empty error body falls back to the default message

### DIFF
--- a/.changeset/empty-error-body-fallback.md
+++ b/.changeset/empty-error-body-fallback.md
@@ -1,0 +1,8 @@
+---
+"ai": patch
+"@ai-sdk/react": patch
+"@ai-sdk/svelte": patch
+"@ai-sdk/angular": patch
+---
+
+fix: fall back to the default message when an error response has an empty body

--- a/packages/ai/src/ui/call-completion-api.ts
+++ b/packages/ai/src/ui/call-completion-api.ts
@@ -76,7 +76,7 @@ export async function callCompletionApi({
 
     if (!response.ok) {
       throw new Error(
-        (await response.text()) ?? 'Failed to fetch the chat response.',
+        (await response.text()) || 'Failed to fetch the chat response.',
       );
     }
 

--- a/packages/ai/src/ui/http-chat-transport.test.ts
+++ b/packages/ai/src/ui/http-chat-transport.test.ts
@@ -202,4 +202,51 @@ describe('HttpChatTransport', () => {
       expect(receivedAbortSignal).toBe(abortController.signal);
     });
   });
+  describe('error responses', () => {
+    it('should fall back to the default message when the error body is empty', async () => {
+      const transport = new MockHttpChatTransport({
+        api: 'http://localhost/api/chat',
+        fetch: async () => new Response(null, { status: 502 }),
+      });
+
+      await expect(
+        transport.sendMessages({
+          chatId: 'c123',
+          messageId: 'm123',
+          trigger: 'submit-message',
+          messages: [
+            {
+              id: 'm123',
+              role: 'user',
+              parts: [{ text: 'Hello, world!', type: 'text' }],
+            },
+          ],
+          abortSignal: new AbortController().signal,
+        }),
+      ).rejects.toThrowError('Failed to fetch the chat response.');
+    });
+
+    it('should surface a non-empty error body verbatim', async () => {
+      const transport = new MockHttpChatTransport({
+        api: 'http://localhost/api/chat',
+        fetch: async () => new Response('rate limited', { status: 429 }),
+      });
+
+      await expect(
+        transport.sendMessages({
+          chatId: 'c123',
+          messageId: 'm123',
+          trigger: 'submit-message',
+          messages: [
+            {
+              id: 'm123',
+              role: 'user',
+              parts: [{ text: 'Hello, world!', type: 'text' }],
+            },
+          ],
+          abortSignal: new AbortController().signal,
+        }),
+      ).rejects.toThrowError('rate limited');
+    });
+  });
 });

--- a/packages/ai/src/ui/http-chat-transport.ts
+++ b/packages/ai/src/ui/http-chat-transport.ts
@@ -201,7 +201,7 @@ export abstract class HttpChatTransport<
 
     if (!response.ok) {
       throw new Error(
-        (await response.text()) ?? 'Failed to fetch the chat response.',
+        (await response.text()) || 'Failed to fetch the chat response.',
       );
     }
 
@@ -257,7 +257,7 @@ export abstract class HttpChatTransport<
 
     if (!response.ok) {
       throw new Error(
-        (await response.text()) ?? 'Failed to fetch the chat response.',
+        (await response.text()) || 'Failed to fetch the chat response.',
       );
     }
 

--- a/packages/angular/src/lib/structured-object.ng.ts
+++ b/packages/angular/src/lib/structured-object.ng.ts
@@ -159,7 +159,7 @@ export class StructuredObject<
 
       if (!response.ok) {
         throw new Error(
-          (await response.text()) ?? 'Failed to fetch the response.',
+          (await response.text()) || 'Failed to fetch the response.',
         );
       }
 

--- a/packages/react/src/use-object.ts
+++ b/packages/react/src/use-object.ts
@@ -185,7 +185,7 @@ export function useObject<
 
       if (!response.ok) {
         throw new Error(
-          (await response.text()) ?? 'Failed to fetch the response.',
+          (await response.text()) || 'Failed to fetch the response.',
         );
       }
 

--- a/packages/svelte/src/structured-object.svelte.ts
+++ b/packages/svelte/src/structured-object.svelte.ts
@@ -170,7 +170,7 @@ export class StructuredObject<
 
       if (!response.ok) {
         throw new Error(
-          (await response.text()) ?? 'Failed to fetch the response.',
+          (await response.text()) || 'Failed to fetch the response.',
         );
       }
 


### PR DESCRIPTION
## Background

`Response.text()` resolves to a string, empty for an empty body, never `null` or `undefined`. so in

```ts
(await response.text()) ?? 'Failed to fetch the chat response.'
```

the `??` can never take the fallback, and an error response with an empty body throws `new Error('')`. a ui rendering `{error.message}` then shows nothing at all, and the server log shows a bare `Error`.

`packages/vue/src/use-object.ts:164` is the same copied block and already uses `||`. one of the seven was right and six were not, which is what makes this look like a slip rather than a deliberate choice.

## Summary

changed `??` to `||` at the six remaining sites:

- `packages/ai/src/ui/http-chat-transport.ts` (two)
- `packages/ai/src/ui/call-completion-api.ts`
- `packages/react/src/use-object.ts`
- `packages/svelte/src/structured-object.svelte.ts`
- `packages/angular/src/lib/structured-object.ng.ts`

vue is already correct and untouched, so all seven now agree.

behaviour changes only for a response that is both not ok and has an empty body: previously `Error('')`, now the intended default message. a non empty body still surfaces verbatim.

## End-to-End Verification

confirmed the premise at runtime rather than assuming it:

```js
const t = await new Response(null, { status: 502 }).text()
JSON.stringify(t)   // '""'
t ?? 'fallback'     // ''
t || 'fallback'     // 'fallback'
```

then end to end through `HttpChatTransport` with a fetch returning `new Response(null, { status: 502 })`. before the change `error.message` is `""` and `String(error)` is `"Error"`, so a ui rendering the message shows nothing. after the change the error reads `Failed to fetch the chat response.`

i also reverted the source change and re-ran the added tests to check they actually catch this. they fail on the old code with `expected [Function] to throw error including 'Failed to fetch the chat response.' but got ''`, which is the bug itself.

`src/ui/` is green, 13 files and 346 tests.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #20107
