### PR TITLE
docs: add OpenZoo to the OpenAI-compatible providers documentation

### DIFF
--- a/content/providers/04-openai-compatible-providers/56-openzoo.mdx
+++ b/content/providers/04-openai-compatible-providers/56-openzoo.mdx
@@ -1,0 +1,109 @@
+---
+title: OpenZoo
+description: Use the OpenZoo OpenAI compatible API with the AI SDK.
+---
+
+# OpenZoo Provider
+
+[OpenZoo](https://openzoo.fun) provides pay-per-call access to a large catalog of
+models through an OpenAI-compatible API. There is no account or signup: a small
+local proxy (`npx openzoo`) pays for each request via the x402 protocol (USDC
+on Solana or Base) from a local burner wallet. You can use it with the AI SDK
+through the `@ai-sdk/openai-compatible` module.
+
+## Setup
+
+The OpenZoo provider is available via the `@ai-sdk/openai-compatible` module as
+it is compatible with the OpenAI API. You can install it with:
+
+<InstallPackages packages="@ai-sdk/openai-compatible" />
+
+Then start the local proxy, which listens on `http://localhost:8402/v1`:
+
+```bash
+npx openzoo
+```
+
+`npx openzoo address` prints the proxy's wallet — fund it with USDC on Solana
+or Base; `npx openzoo balance` shows what is left.
+
+## Provider Instance
+
+To use OpenZoo, create a custom provider instance with the `createOpenAICompatible`
+function from `@ai-sdk/openai-compatible`:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+
+const openzoo = createOpenAICompatible({
+  name: 'openzoo',
+  baseURL: 'http://localhost:8402/v1',
+  apiKey: 'sk-openzoo',
+});
+```
+
+<Note>
+  The local proxy ignores the API key, so any non-empty value works (for example
+  `sk-openzoo`). The hosted endpoint `https://api.openzoo.fun/v1` requires x402
+  payment; a bearer API key alone does not pay for a request. The
+  OpenAI-compatible provider does not settle x402 payments, so use the local
+  proxy.
+</Note>
+
+## Language Models
+
+You can create OpenZoo models using the provider instance. The first argument is
+a model ID from the model catalog at `http://localhost:8402/v1/models`. `auto`
+lets the proxy pick a model per request; bare ids such as `claude-sonnet-5`
+or `gpt-4o-mini` select one model:
+
+```ts
+const model = openzoo('auto');
+```
+
+### Example
+
+You can use OpenZoo language models to generate text with the `generateText`
+function:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { generateText } from 'ai';
+
+const openzoo = createOpenAICompatible({
+  name: 'openzoo',
+  baseURL: 'http://localhost:8402/v1',
+  apiKey: 'sk-openzoo',
+});
+
+const { text } = await generateText({
+  model: openzoo('auto'),
+  prompt: 'Tell me about yourself in one sentence.',
+});
+```
+
+OpenZoo language models can also be used with `streamText` (SSE streaming is
+supported):
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { streamText } from 'ai';
+
+const openzoo = createOpenAICompatible({
+  name: 'openzoo',
+  baseURL: 'http://localhost:8402/v1',
+  apiKey: 'sk-openzoo',
+});
+
+const result = streamText({
+  model: openzoo('auto'),
+  prompt: 'Write a short haiku about micro-payments.',
+});
+
+for await (const textPart of result.textStream) {
+  process.stdout.write(textPart);
+}
+```
+
+The model list at `http://localhost:8402/v1/models` is free to fetch and
+includes per-model pricing and context metadata.

--- a/content/providers/04-openai-compatible-providers/index.mdx
+++ b/content/providers/04-openai-compatible-providers/index.mdx
@@ -16,6 +16,7 @@ We provide detailed documentation for the following OpenAI compatible providers:
 - [Heroku](/providers/openai-compatible-providers/heroku)
 - [Clarifai](/providers/openai-compatible-providers/clarifai)
 - [NEAR AI Cloud](/providers/openai-compatible-providers/nearai)
+- [OpenZoo](/providers/openai-compatible-providers/openzoo)
 
 The general setup and provider instance creation is the same for all of these providers.
 


### PR DESCRIPTION
Updated 2026-09-02: corrected — the hosted `https://api.openzoo.fun/v1` endpoint answers HTTP 402 to a plain OpenAI client (it only serves calls that pay x402 or carry an OpenZoo subscription key, `ozk_live_…`). The page now sets up the local `npx openzoo` proxy (`http://localhost:8402/v1`), which pays x402 per call from a local burner wallet and ignores the API key.

## Summary

Adds a documentation page for [OpenZoo](https://openzoo.fun) under OpenAI-compatible providers, following the format of the existing pages in `04-openai-compatible-providers/` (most recently Synthorai in #19678).

OpenZoo is an OpenAI-compatible provider with a twist worth documenting: there is no signup or API key — a local `npx openzoo` proxy pays each request over x402 from a burner wallet and ignores the key. This makes the docs trivially verifiable: the example on the page runs as-is against `http://localhost:8402/v1` with `apiKey: 'sk-openzoo'`, no credentials needed. The hosted endpoint is mentioned only as needing x402 or a subscription key.

Disclosure: I operate OpenZoo.

## Changes

- New page `content/providers/04-openai-compatible-providers/56-openzoo.mdx` (frontmatter, setup, provider instance, generateText + streamText examples, per house style)
- One link line in `04-openai-compatible-providers/index.mdx`

## Verification

- `npx openzoo` then `curl http://localhost:8402/v1/models` — free, lists model IDs and pricing
- The generateText example on the page is runnable verbatim against the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
