### PR TITLE
feat(provider,anthropic): add batch cancellation

### DIFF
--- a/.changeset/calm-batches-cancel.md
+++ b/.changeset/calm-batches-cancel.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider': patch
+'@ai-sdk/anthropic': patch
+---
+
+feat(provider,anthropic): add optional batch cancellation support

--- a/packages/anthropic/src/anthropic-messages-batch.test.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.test.ts
@@ -15,12 +15,14 @@ vi.mock('./version', () => ({
 const urls = {
   batches: 'https://api.anthropic.com/v1/messages/batches',
   batch: 'https://api.anthropic.com/v1/messages/batches/msgbatch_123',
+  cancel: 'https://api.anthropic.com/v1/messages/batches/msgbatch_123/cancel',
   results: 'https://api.anthropic.com/v1/messages/batches/msgbatch_123/results',
 } as const;
 
 const server = createTestServer({
   [urls.batches]: {},
   [urls.batch]: {},
+  [urls.cancel]: {},
   [urls.results]: {},
 });
 
@@ -529,6 +531,35 @@ describe('Anthropic Messages batch language model', () => {
     await expect(
       model.experimental_doGetBatchStatus({ batchId: 'msgbatch_123' }),
     ).resolves.toMatchObject({ status, rawStatus });
+  });
+
+  it('cancels a batch and returns its normalized status', async () => {
+    server.urls[urls.cancel].response = {
+      type: 'json-value',
+      body: batchResponse({
+        cancel_initiated_at: '2024-09-24T18:38:00.000Z',
+        processing_status: 'canceling',
+        results_url: null,
+      }),
+    };
+    const model = createAnthropic({ apiKey: 'test-api-key' })(
+      'claude-3-haiku-20240307',
+    );
+
+    await expect(
+      model.experimental_doCancelBatch?.({
+        batchId: 'msgbatch_123',
+        headers: { 'Operation-Header': 'operation' },
+      }),
+    ).resolves.toMatchObject({
+      rawStatus: 'canceling',
+      status: 'pending',
+    });
+    expect(await server.calls[0].requestBodyJson).toEqual({});
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      'operation-header': 'operation',
+      'x-api-key': 'test-api-key',
+    });
   });
 
   it('normalizes request counts', async () => {

--- a/packages/anthropic/src/anthropic-messages-batch.ts
+++ b/packages/anthropic/src/anthropic-messages-batch.ts
@@ -289,6 +289,24 @@ export class AnthropicMessagesBatchLanguageModel
     return convertAnthropicBatchStatus(await this.retrieveBatch(options));
   }
 
+  async experimental_doCancelBatch(
+    options: BatchV4OperationOptions,
+  ): Promise<BatchV4Status> {
+    const { value: batch } = await postJsonToApi({
+      url: this.getBatchUrl(`/${encodeURIComponent(options.batchId)}/cancel`),
+      headers: await this.getBatchHeaders(options.headers),
+      body: {},
+      failedResponseHandler: anthropicFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        anthropicBatchResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return convertAnthropicBatchStatus(batch);
+  }
+
   async experimental_doGetBatchResults(
     options: BatchV4OperationOptions,
   ): Promise<ReadableStream<BatchV4ItemResult<LanguageModelV4GenerateResult>>> {

--- a/packages/provider/src/batch/v4/batch-v4.ts
+++ b/packages/provider/src/batch/v4/batch-v4.ts
@@ -108,4 +108,8 @@ export type BatchModelV4<REQUEST, RESULT> = {
   experimental_doGetBatchResults(
     options: BatchV4OperationOptions,
   ): PromiseLike<ReadableStream<BatchV4ItemResult<RESULT>>>;
+
+  experimental_doCancelBatch?(
+    options: BatchV4OperationOptions,
+  ): PromiseLike<BatchV4Status>;
 };


### PR DESCRIPTION
## Summary

- add optional `experimental_doCancelBatch` to the AI SDK v4 batch provider interface
- implement Anthropic Message Batch cancellation through the provider's existing URL, headers, fetch, error handling, and status conversion
- return the normalized `BatchV4Status` from the provider cancellation response

## Scope

High-level batch orchestration is intentionally out of scope for this draft. Providers can implement the optional cancellation operation independently.

## Verification

- Anthropic batch test: 34 passing
- `@ai-sdk/provider` typecheck
- `@ai-sdk/anthropic` typecheck
- full repository `pnpm check`
- isolated correctness and risk reviews: no findings
