### PR TITLE
docs: add OpenZoo community provider

### DIFF
--- a/content/providers/05-community-providers/55-openzoo.mdx
+++ b/content/providers/05-community-providers/55-openzoo.mdx
@@ -53,10 +53,11 @@ x402 or presents an OpenZoo subscription key (`ozk_live_…` in
 ## Language Models
 
 You can create language models using a provider instance. The first argument is
-the model id, e.g. `z-ai/glm-5.3-flash`:
+the model id. `auto` lets the proxy pick a model per request; bare ids such as
+`claude-sonnet-5` or `gpt-4o-mini` select one model:
 
 ```ts
-const model = openzoo('z-ai/glm-5.3-flash');
+const model = openzoo('auto');
 ```
 
 ### Example
@@ -71,7 +72,7 @@ import { generateText } from 'ai';
 const openzoo = createOpenZoo({ baseURL: 'http://localhost:8402/v1' });
 
 const { text } = await generateText({
-  model: openzoo('z-ai/glm-5.3-flash'),
+  model: openzoo('auto'),
   prompt: 'Say this is a test',
 });
 

--- a/content/providers/05-community-providers/55-openzoo.mdx
+++ b/content/providers/05-community-providers/55-openzoo.mdx
@@ -6,9 +6,9 @@ description: Learn how to use the OpenZoo provider for the AI SDK.
 # OpenZoo Provider
 
 The [OpenZoo](https://openzoo.fun) provider gives access to pay-per-call,
-OpenAI-compatible inference with no signup and no API key required — each
-request settles via x402 or card — via the hosted endpoint
-`https://api.openzoo.fun/v1` or a local gateway (`npx openzoo`).
+OpenAI-compatible inference with no account. A small local proxy
+(`npx openzoo`) pays for each request over x402 from a local burner wallet,
+and the provider talks to that proxy at `http://localhost:8402/v1`.
 
 ## Setup
 
@@ -18,24 +18,24 @@ module. You can install it with:
 
 <InstallPackages packages="openzoo-ai-provider" />
 
+Then start the local proxy:
+
+```bash
+npx openzoo
+```
+
+`npx openzoo address` prints the proxy's wallet — fund it with USDC on Solana
+or Base; `npx openzoo balance` shows what is left.
+
 ### Credentials
 
-No signup exists. OpenZoo accepts any API key: the provider uses the
-`OPENZOO_API_KEY` environment variable if set, and otherwise sends the literal
-`sk-openzoo`. The model list is free to query at
-`https://api.openzoo.fun/v1/models`.
+No signup exists. The local proxy ignores the API key, so the provider sends
+the literal `sk-openzoo` unless `OPENZOO_API_KEY` is set. The model list is
+free to query at `http://localhost:8402/v1/models`.
 
 ## Provider Instance
 
-You can import the default provider instance `openzoo` from
-`openzoo-ai-provider`:
-
-```ts
-import { openzoo } from 'openzoo-ai-provider';
-```
-
-To use the local gateway started with `npx openzoo` (which pays per call
-automatically from a local burner wallet), create a custom instance:
+Create a provider instance pointed at the local proxy with `createOpenZoo`:
 
 ```ts
 import { createOpenZoo } from 'openzoo-ai-provider';
@@ -44,6 +44,11 @@ const openzoo = createOpenZoo({
   baseURL: 'http://localhost:8402/v1',
 });
 ```
+
+The default instance exported as `openzoo` targets the hosted endpoint
+`https://api.openzoo.fun/v1`, which answers HTTP 402 unless the caller pays
+x402 or presents an OpenZoo subscription key (`ozk_live_…` in
+`OPENZOO_API_KEY`). Without a subscription key, use the local proxy as above.
 
 ## Language Models
 
@@ -60,8 +65,10 @@ You can use OpenZoo language models to generate text with the `generateText`
 function:
 
 ```ts
-import { openzoo } from 'openzoo-ai-provider';
+import { createOpenZoo } from 'openzoo-ai-provider';
 import { generateText } from 'ai';
+
+const openzoo = createOpenZoo({ baseURL: 'http://localhost:8402/v1' });
 
 const { text } = await generateText({
   model: openzoo('z-ai/glm-5.3-flash'),

--- a/content/providers/05-community-providers/55-openzoo.mdx
+++ b/content/providers/05-community-providers/55-openzoo.mdx
@@ -1,0 +1,75 @@
+---
+title: OpenZoo
+description: Learn how to use the OpenZoo provider for the AI SDK.
+---
+
+# OpenZoo Provider
+
+The [OpenZoo](https://openzoo.fun) provider gives access to pay-per-call,
+OpenAI-compatible inference with no signup and no API key required — each
+request settles via x402 or card — via the hosted endpoint
+`https://api.openzoo.fun/v1` or a local gateway (`npx openzoo`).
+
+## Setup
+
+The OpenZoo provider is available via the
+[`openzoo-ai-provider`](https://www.npmjs.com/package/openzoo-ai-provider)
+module. You can install it with:
+
+<InstallPackages packages="openzoo-ai-provider" />
+
+### Credentials
+
+No signup exists. OpenZoo accepts any API key: the provider uses the
+`OPENZOO_API_KEY` environment variable if set, and otherwise sends the literal
+`sk-openzoo`. The model list is free to query at
+`https://api.openzoo.fun/v1/models`.
+
+## Provider Instance
+
+You can import the default provider instance `openzoo` from
+`openzoo-ai-provider`:
+
+```ts
+import { openzoo } from 'openzoo-ai-provider';
+```
+
+To use the local gateway started with `npx openzoo` (which pays per call
+automatically from a local burner wallet), create a custom instance:
+
+```ts
+import { createOpenZoo } from 'openzoo-ai-provider';
+
+const openzoo = createOpenZoo({
+  baseURL: 'http://localhost:8402/v1',
+});
+```
+
+## Language Models
+
+You can create language models using a provider instance. The first argument is
+the model id, e.g. `z-ai/glm-5.3-flash`:
+
+```ts
+const model = openzoo('z-ai/glm-5.3-flash');
+```
+
+### Example
+
+You can use OpenZoo language models to generate text with the `generateText`
+function:
+
+```ts
+import { openzoo } from 'openzoo-ai-provider';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: openzoo('z-ai/glm-5.3-flash'),
+  prompt: 'Say this is a test',
+});
+
+console.log(text);
+```
+
+OpenZoo language models can also be used with `streamText` (SSE streaming is
+supported).


### PR DESCRIPTION
Updated 2026-09-02: corrected — the hosted `https://api.openzoo.fun/v1` endpoint answers HTTP 402 to a plain OpenAI client (it only serves calls that pay x402 or carry an OpenZoo subscription key, `ozk_live_…`). The page now sets up the local `npx openzoo` proxy (`http://localhost:8402/v1`), which pays x402 per call from a local burner wallet and ignores the API key.

## Summary

Adds a community-provider page for [`openzoo-ai-provider`](https://www.npmjs.com/package/openzoo-ai-provider) (published, v0.1.0, MIT — source at https://github.com/staccDOTsol/openzoo-ai-provider), a thin provider over `@ai-sdk/openai-compatible` preconfigured for [OpenZoo](https://openzoo.fun).

Complements #20113 (the openai-compatible-providers page for the same endpoint): that page documents raw `createOpenAICompatible` usage; this one documents the published package, per the community-providers requirement. Happy to keep just one if maintainers prefer — flagging the overlap up front.

The package has unit tests plus a live smoke test against the free `/v1/models` endpoint. The docs example uses `createOpenZoo({ baseURL: 'http://localhost:8402/v1' })` against the local `npx openzoo` proxy (which ignores the API key and pays per call over x402); the page notes that the package's default `openzoo` instance targets the hosted endpoint, which answers 402 without a subscription key (`ozk_live_…`).

Disclosure: I operate OpenZoo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
