### PR TITLE
fix(amazon-bedrock): add structured output mode

### DIFF
--- a/.changeset/tidy-cats-compare.md
+++ b/.changeset/tidy-cats-compare.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Add a `structuredOutputMode` provider option for choosing between native structured output and the JSON tool fallback for Anthropic models.

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -228,6 +228,49 @@ const { text } = await generateText({
 Amazon Bedrock language models can also be used in the `streamText` function
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
+### Structured Outputs
+
+For Anthropic models, you can use the `structuredOutputMode` provider option to
+choose how Amazon Bedrock generates structured outputs:
+
+- `"outputFormat"`: Use Bedrock's native `output_config.format` parameter.
+- `"jsonTool"`: Use a special `json` tool with required tool choice.
+- `"auto"`: Use native structured output when supported and otherwise fall
+  back to the JSON tool. This is the default.
+
+Use `"jsonTool"` when native structured output is unreliable for a particular
+model, schema, or workload:
+
+```ts
+import {
+  amazonBedrock,
+  type AmazonBedrockLanguageModelChatOptions,
+} from '@ai-sdk/amazon-bedrock';
+import { generateText, Output } from 'ai';
+import { z } from 'zod';
+
+const { output } = await generateText({
+  model: amazonBedrock('eu.anthropic.claude-sonnet-4-6'),
+  output: Output.object({
+    schema: z.object({
+      summary: z.string(),
+      findings: z.array(z.string()),
+    }),
+  }),
+  prompt: 'Summarize the inspection report.',
+  providerOptions: {
+    amazonBedrock: {
+      structuredOutputMode: 'jsonTool',
+    } satisfies AmazonBedrockLanguageModelChatOptions,
+  },
+});
+```
+
+The legacy `providerOptions.bedrock` key remains supported. For parity with the
+Anthropic provider, `providerOptions.anthropic.structuredOutputMode` is also
+honored for Anthropic models on Bedrock. When both are provided, the
+`amazonBedrock` or legacy `bedrock` value takes precedence.
+
 ### File Inputs
 
 <Note type="warning">

--- a/examples/ai-functions/src/generate-text/amazon-bedrock/structured-output-mode.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock/structured-output-mode.ts
@@ -1,0 +1,33 @@
+import {
+  amazonBedrock,
+  type AmazonBedrockLanguageModelChatOptions,
+} from '@ai-sdk/amazon-bedrock';
+import { generateText, Output } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: amazonBedrock('eu.anthropic.claude-sonnet-4-6'),
+    output: Output.object({
+      schema: z.object({
+        recipe: z.object({
+          name: z.string(),
+          ingredients: z.array(z.string()),
+          steps: z.array(z.string()),
+        }),
+      }),
+    }),
+    prompt: 'Generate a lasagna recipe.',
+    providerOptions: {
+      amazonBedrock: {
+        structuredOutputMode: 'jsonTool',
+      } satisfies AmazonBedrockLanguageModelChatOptions,
+    },
+  });
+
+  console.log(JSON.stringify(result.output, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+});

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.test.ts
@@ -4,6 +4,28 @@ import {
   type AmazonBedrockLanguageModelChatOptions,
 } from './amazon-bedrock-chat-language-model-options';
 describe('amazonBedrockLanguageModelChatOptions', () => {
+  describe('structuredOutputMode', () => {
+    it.each(['outputFormat', 'jsonTool', 'auto'] as const)(
+      'accepts %s',
+      structuredOutputMode => {
+        const result = amazonBedrockLanguageModelChatOptions.safeParse({
+          structuredOutputMode,
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.data?.structuredOutputMode).toBe(structuredOutputMode);
+      },
+    );
+
+    it('rejects invalid values', () => {
+      const result = amazonBedrockLanguageModelChatOptions.safeParse({
+        structuredOutputMode: 'native',
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
   describe('serviceTier', () => {
     it('accepts valid service tier values', () => {
       const validValues = ['reserved', 'priority', 'default', 'flex'] as const;
@@ -35,9 +57,11 @@ describe('amazonBedrockLanguageModelChatOptions', () => {
     it('infers AmazonBedrockLanguageModelChatOptions type correctly', () => {
       const options: AmazonBedrockLanguageModelChatOptions = {
         serviceTier: 'priority',
+        structuredOutputMode: 'jsonTool',
       };
 
       expect(options.serviceTier).toBe('priority');
+      expect(options.structuredOutputMode).toBe('jsonTool');
     });
   });
 });

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.ts
@@ -135,6 +135,14 @@ export type AmazonBedrockImagePartProviderOptions = z.infer<
 
 export const amazonBedrockLanguageModelChatOptions = z.object({
   /**
+   * Determines how structured outputs are generated for Anthropic models.
+   *
+   * - `outputFormat`: Use the native `output_config.format` parameter.
+   * - `jsonTool`: Use a special 'json' tool to specify the structured output format.
+   * - `auto`: Use `outputFormat` when supported, otherwise use `jsonTool` (default).
+   */
+  structuredOutputMode: z.enum(['outputFormat', 'jsonTool', 'auto']).optional(),
+  /**
    * Additional inference parameters that the model supports,
    * beyond the base set of inference parameters that Converse
    * supports in the inferenceConfig field

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -1,5 +1,8 @@
 import type * as AnthropicInternal from '@ai-sdk/anthropic/internal';
-import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import type {
+  LanguageModelV4Prompt,
+  SharedV4ProviderOptions,
+} from '@ai-sdk/provider';
 import { safeValidateTypes } from '@ai-sdk/provider-utils';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
@@ -5875,6 +5878,233 @@ describe('doGenerate', () => {
     expect(requestBody.toolConfig.tools[0].toolSpec.name).toBe('json');
     expect(
       requestBody.additionalModelRequestFields?.output_config,
+    ).toBeUndefined();
+  });
+
+  it.each([
+    {
+      providerOptionsName: 'amazonBedrock',
+      providerOptions: {
+        amazonBedrock: { structuredOutputMode: 'jsonTool' },
+      } as SharedV4ProviderOptions,
+    },
+    {
+      providerOptionsName: 'legacy bedrock',
+      providerOptions: {
+        bedrock: { structuredOutputMode: 'jsonTool' },
+      } as SharedV4ProviderOptions,
+    },
+    {
+      providerOptionsName: 'anthropic',
+      providerOptions: {
+        anthropic: { structuredOutputMode: 'jsonTool' },
+      } as SharedV4ProviderOptions,
+    },
+  ] satisfies Array<{
+    providerOptionsName: string;
+    providerOptions: SharedV4ProviderOptions;
+  }>)(
+    'should force the json tool wire format with $providerOptionsName provider options',
+    async ({ providerOptions }) => {
+      server.urls[newerAnthropicGenerateUrl].response = {
+        type: 'json-value',
+        body: {
+          output: {
+            message: {
+              role: 'assistant',
+              content: [
+                {
+                  toolUse: {
+                    toolUseId: 'json-tool-id',
+                    name: 'json',
+                    input: { name: 'Test' },
+                  },
+                },
+              ],
+            },
+          },
+          usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+          stopReason: 'tool_use',
+        },
+      };
+
+      const result = await newerAnthropicModel.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions,
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+            required: ['name'],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+
+      expect(requestBody.toolConfig.tools).toHaveLength(1);
+      expect(requestBody.toolConfig.tools[0].toolSpec.name).toBe('json');
+      expect(requestBody.toolConfig.toolChoice).toEqual({ any: {} });
+      expect(requestBody.structuredOutputMode).toBeUndefined();
+      expect(
+        requestBody.additionalModelRequestFields?.output_config?.format,
+      ).toBeUndefined();
+      expect(result.content).toEqual([
+        { type: 'text', text: '{"name":"Test"}' },
+      ]);
+      expect(result.finishReason.unified).toBe('stop');
+      expect(result.providerMetadata?.bedrock?.isJsonResponseFromTool).toBe(
+        true,
+      );
+    },
+  );
+
+  it('should remove a manually supplied output_config.format in jsonTool mode while preserving sibling fields', async () => {
+    server.urls[newerAnthropicGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                toolUse: {
+                  toolUseId: 'json-tool-id',
+                  name: 'json',
+                  input: { name: 'Test' },
+                },
+              },
+            ],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+        stopReason: 'tool_use',
+      },
+    };
+
+    await newerAnthropicModel.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        amazonBedrock: {
+          structuredOutputMode: 'jsonTool',
+          additionalModelRequestFields: {
+            output_config: {
+              effort: 'medium',
+              format: { type: 'manually-supplied-format' },
+            },
+          },
+        },
+      },
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.additionalModelRequestFields?.output_config).toEqual({
+      effort: 'medium',
+    });
+  });
+
+  it('should force output_config.format for models that auto mode routes to the json tool', async () => {
+    server.urls[opus5AnthropicGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ text: '{"name":"Test"}' }],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+        stopReason: 'end_turn',
+      },
+    };
+
+    await opus5AnthropicModel.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        amazonBedrock: { structuredOutputMode: 'outputFormat' },
+      },
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.toolConfig).toBeUndefined();
+    expect(
+      requestBody.additionalModelRequestFields?.output_config?.format,
+    ).toEqual({
+      type: 'json_schema',
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { name: { type: 'string' } },
+        required: ['name'],
+      },
+    });
+  });
+
+  it('should prefer amazonBedrock structuredOutputMode over anthropic structuredOutputMode', async () => {
+    server.urls[newerAnthropicGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                toolUse: {
+                  toolUseId: 'json-tool-id',
+                  name: 'json',
+                  input: { name: 'Test' },
+                },
+              },
+            ],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+        stopReason: 'tool_use',
+      },
+    };
+
+    await newerAnthropicModel.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        amazonBedrock: { structuredOutputMode: 'jsonTool' },
+        anthropic: { structuredOutputMode: 'outputFormat' },
+      },
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.toolConfig.toolChoice).toEqual({ any: {} });
+    expect(
+      requestBody.additionalModelRequestFields?.output_config?.format,
     ).toBeUndefined();
   });
 

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -75,6 +75,7 @@ type AmazonBedrockChatConfig = {
 
 const anthropicProviderOptions = z.object({
   disableParallelToolUse: z.boolean().optional(),
+  structuredOutputMode: z.enum(['outputFormat', 'jsonTool', 'auto']).optional(),
 });
 
 function createAmazonBedrockStreamError({
@@ -242,14 +243,54 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
     const { supportsStructuredOutput: modelSupportsStructuredOutput } =
       getModelCapabilities(this.modelId);
 
+    const structuredOutputMode =
+      amazonBedrockOptions.structuredOutputMode ??
+      anthropicOptions?.structuredOutputMode ??
+      'auto';
+
+    if (structuredOutputMode === 'jsonTool') {
+      const additionalModelRequestFields = {
+        ...amazonBedrockOptions.additionalModelRequestFields,
+      };
+      const outputConfig = additionalModelRequestFields.output_config;
+
+      if (
+        outputConfig != null &&
+        typeof outputConfig === 'object' &&
+        !Array.isArray(outputConfig)
+      ) {
+        const outputConfigWithoutFormat = { ...outputConfig };
+        delete outputConfigWithoutFormat.format;
+
+        if (Object.keys(outputConfigWithoutFormat).length > 0) {
+          additionalModelRequestFields.output_config =
+            outputConfigWithoutFormat;
+        } else {
+          delete additionalModelRequestFields.output_config;
+        }
+
+        amazonBedrockOptions = {
+          ...amazonBedrockOptions,
+          additionalModelRequestFields,
+        };
+      }
+    }
+
+    const modelSupportsNativeStructuredOutput =
+      supportsNativeStructuredOutput(this.modelId) &&
+      (modelSupportsStructuredOutput || isThinkingEnabled);
+
     const useNativeStructuredOutput =
       isAnthropicModel &&
-      supportsNativeStructuredOutput(this.modelId) &&
-      (modelSupportsStructuredOutput || isThinkingEnabled) &&
       responseFormat?.type === 'json' &&
-      responseFormat.schema != null;
+      responseFormat.schema != null &&
+      (structuredOutputMode === 'outputFormat' ||
+        (structuredOutputMode === 'auto' &&
+          modelSupportsNativeStructuredOutput));
 
     const useJsonInstructionForStructuredOutput =
+      !useNativeStructuredOutput &&
+      structuredOutputMode !== 'jsonTool' &&
       isAnthropicModel &&
       !supportsStrictTools(this.modelId) &&
       responseFormat?.type === 'json' &&
@@ -503,6 +544,7 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
       reasoningConfig: _,
       additionalModelRequestFields: __,
       serviceTier: ___,
+      structuredOutputMode: ____,
       ...filteredAmazonBedrockOptions
     } = providerOptions?.amazonBedrock ?? providerOptions?.bedrock ?? {};
 


### PR DESCRIPTION
## Background

Fixes #17881.

Amazon Bedrock native structured output can silently run to the output-token cap for workload-dependent Claude Sonnet 4.6 prompts and schemas. The JSON response tool completes the same workload reliably, but the Bedrock Converse provider did not expose the mode override available in the Anthropic provider.

## Summary

- add `structuredOutputMode: 'auto' | 'outputFormat' | 'jsonTool'` to Amazon Bedrock chat provider options
- keep `auto` as the default with the existing capability-based behavior
- make `jsonTool` force the JSON response tool with Bedrock's required `{ any: {} }` tool choice and remove a manually supplied `output_config.format`
- make `outputFormat` explicitly force native structured output, including for models that auto mode routes to the JSON tool
- honor the option through preferred `amazonBedrock`, legacy `bedrock`, and Anthropic-compatible `anthropic` provider-option namespaces, with Bedrock options taking precedence
- document the option, add a runnable example, and include a patch changeset

## Testing

- `pnpm --filter @ai-sdk/amazon-bedrock test` (511 tests in Node and 511 tests in Edge)
- `pnpm check`
- `pnpm type-check:full`
