### PR TITLE
fix(amazon-bedrock): default affected Claude models to JSON tool

### DIFF
--- a/.changeset/bright-bats-juggle.md
+++ b/.changeset/bright-bats-juggle.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Use the JSON tool fallback by default for structured output with Claude Sonnet 4.6 and Claude Haiku 4.5 while preserving strict tool support.

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -238,8 +238,11 @@ choose how Amazon Bedrock generates structured outputs:
 - `"auto"`: Use native structured output when supported and otherwise fall
   back to the JSON tool. This is the default.
 
-Use `"jsonTool"` when native structured output is unreliable for a particular
-model, schema, or workload:
+In `"auto"` mode, Claude Sonnet 4.6 and Claude Haiku 4.5 use the JSON tool
+fallback because native structured output can be unreliable across workloads
+and Bedrock accounts. You can set `"outputFormat"` to opt into native structured
+output when it works for your account and workload, or use `"jsonTool"` to force
+the fallback for any model:
 
 ```ts
 import {

--- a/packages/amazon-bedrock/src/amazon-bedrock-anthropic-model-support.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-anthropic-model-support.ts
@@ -1,14 +1,17 @@
 export function supportsStrictTools(modelId: string): boolean {
-  return !rejectsNewerSchemaFields(modelId);
+  return !matchesModel(modelId, MODELS_WITHOUT_STRICT_TOOL_SUPPORT);
 }
 
 export function supportsNativeStructuredOutput(modelId: string): boolean {
-  return !rejectsNewerSchemaFields(modelId);
+  return !matchesModel(
+    modelId,
+    MODELS_WITHOUT_RELIABLE_NATIVE_STRUCTURED_OUTPUT,
+  );
 }
 
 // Bedrock validates against its own copy of the Messages schema, which rejects
 // `output_config.format` and tool `strict` for the newest Claude models
-const MODELS_REJECTING_NEWER_SCHEMA_FIELDS = [
+const MODELS_WITHOUT_STRICT_TOOL_SUPPORT = [
   'claude-opus-4-7',
   'claude-opus-4-8',
   'claude-opus-5',
@@ -16,8 +19,15 @@ const MODELS_REJECTING_NEWER_SCHEMA_FIELDS = [
   'claude-sonnet-5',
 ];
 
-function rejectsNewerSchemaFields(modelId: string): boolean {
-  return MODELS_REJECTING_NEWER_SCHEMA_FIELDS.some(model =>
-    modelId.includes(model),
-  );
+// Native structured output is unreliable for additional models even though
+// their strict tool support remains available. Sonnet 4.6 can fail to adhere
+// to complex schemas, while Haiku 4.5 support varies between Bedrock accounts.
+const MODELS_WITHOUT_RELIABLE_NATIVE_STRUCTURED_OUTPUT = [
+  ...MODELS_WITHOUT_STRICT_TOOL_SUPPORT,
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5',
+];
+
+function matchesModel(modelId: string, models: string[]): boolean {
+  return models.some(model => modelId.includes(model));
 }

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -117,6 +117,17 @@ const newerAnthropicGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
   newerAnthropicModelId,
 )}/converse`;
 
+const haiku45AnthropicModelId = 'us.anthropic.claude-haiku-4-5-20251001-v1:0';
+const haiku45AnthropicGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
+  haiku45AnthropicModelId,
+)}/converse`;
+
+const nativeStructuredOutputAnthropicModelId =
+  'anthropic.claude-sonnet-4-5-20250929-v1:0';
+const nativeStructuredOutputAnthropicGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
+  nativeStructuredOutputAnthropicModelId,
+)}/converse`;
+
 const opusAnthropicModelId = 'us.anthropic.claude-opus-4-8';
 const opusAnthropicGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
   opusAnthropicModelId,
@@ -149,6 +160,8 @@ const server = createTestServer({
   [globalOpenaiGenerateUrl]: {},
   [customOpenaiSubstringGenerateUrl]: {},
   [newerAnthropicGenerateUrl]: {},
+  [haiku45AnthropicGenerateUrl]: {},
+  [nativeStructuredOutputAnthropicGenerateUrl]: {},
   [opusAnthropicGenerateUrl]: {},
   [opus5AnthropicGenerateUrl]: {},
   [sonnet5AnthropicGenerateUrl]: {},
@@ -260,6 +273,26 @@ const legacyAnthropic37Model = new AmazonBedrockChatLanguageModel(
 
 const newerAnthropicModel = new AmazonBedrockChatLanguageModel(
   newerAnthropicModelId,
+  {
+    baseUrl: () => baseUrl,
+    headers: {},
+    fetch: fakeFetchWithAuth,
+    generateId: () => 'test-id',
+  },
+);
+
+const haiku45AnthropicModel = new AmazonBedrockChatLanguageModel(
+  haiku45AnthropicModelId,
+  {
+    baseUrl: () => baseUrl,
+    headers: {},
+    fetch: fakeFetchWithAuth,
+    generateId: () => 'test-id',
+  },
+);
+
+const nativeStructuredOutputAnthropicModel = new AmazonBedrockChatLanguageModel(
+  nativeStructuredOutputAnthropicModelId,
   {
     baseUrl: () => baseUrl,
     headers: {},
@@ -5883,6 +5916,72 @@ describe('doGenerate', () => {
 
   it.each([
     {
+      modelId: newerAnthropicModelId,
+      model: newerAnthropicModel,
+      generateUrl: newerAnthropicGenerateUrl,
+    },
+    {
+      modelId: haiku45AnthropicModelId,
+      model: haiku45AnthropicModel,
+      generateUrl: haiku45AnthropicGenerateUrl,
+    },
+  ])(
+    'should default to the json tool for $modelId',
+    async ({ model, generateUrl }) => {
+      server.urls[generateUrl].response = {
+        type: 'json-value',
+        body: {
+          output: {
+            message: {
+              role: 'assistant',
+              content: [
+                {
+                  toolUse: {
+                    toolUseId: 'json-tool-id',
+                    name: 'json',
+                    input: { name: 'Test' },
+                  },
+                },
+              ],
+            },
+          },
+          usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+          stopReason: 'tool_use',
+        },
+      };
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            required: ['name'],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+
+      expect(requestBody.toolConfig.tools).toHaveLength(1);
+      expect(requestBody.toolConfig.tools[0].toolSpec.name).toBe('json');
+      expect(requestBody.toolConfig.toolChoice).toEqual({ any: {} });
+      expect(
+        requestBody.additionalModelRequestFields?.output_config?.format,
+      ).toBeUndefined();
+      expect(result.content).toEqual([
+        { type: 'text', text: '{"name":"Test"}' },
+      ]);
+      expect(result.finishReason.unified).toBe('stop');
+      expect(result.providerMetadata?.bedrock?.isJsonResponseFromTool).toBe(
+        true,
+      );
+    },
+  );
+
+  it.each([
+    {
       providerOptionsName: 'amazonBedrock',
       providerOptions: {
         amazonBedrock: { structuredOutputMode: 'jsonTool' },
@@ -6109,7 +6208,7 @@ describe('doGenerate', () => {
   });
 
   it('should use native output_config.format for models with structured output support even without thinking enabled', async () => {
-    server.urls[newerAnthropicGenerateUrl].response = {
+    server.urls[nativeStructuredOutputAnthropicGenerateUrl].response = {
       type: 'json-value',
       body: {
         output: {
@@ -6123,7 +6222,7 @@ describe('doGenerate', () => {
       },
     };
 
-    await newerAnthropicModel.doGenerate({
+    await nativeStructuredOutputAnthropicModel.doGenerate({
       prompt: [
         {
           role: 'user',
@@ -6169,7 +6268,7 @@ describe('doGenerate', () => {
   });
 
   it('should sanitize unsupported JSON schema keywords for native structured output', async () => {
-    server.urls[newerAnthropicGenerateUrl].response = {
+    server.urls[nativeStructuredOutputAnthropicGenerateUrl].response = {
       type: 'json-value',
       body: {
         output: {
@@ -6183,7 +6282,7 @@ describe('doGenerate', () => {
       },
     };
 
-    await newerAnthropicModel.doGenerate({
+    await nativeStructuredOutputAnthropicModel.doGenerate({
       prompt: TEST_PROMPT,
       responseFormat: {
         type: 'json',

--- a/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-prepare-tools.test.ts
@@ -366,6 +366,27 @@ describe('prepareTools', () => {
       ]);
     });
 
+    it.each([
+      'anthropic.claude-sonnet-4-6-v1',
+      'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+    ])('should keep strict mode enabled for %s', async modelId => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+        ],
+        modelId,
+      });
+
+      expect((result.toolConfig.tools![0] as any).toolSpec.strict).toBe(true);
+      expect(result.toolWarnings).toEqual([]);
+    });
+
     it('should pass through strict mode when strict is false', async () => {
       const result = await prepareTools({
         tools: [

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
@@ -85,6 +85,14 @@ describe('amazon-bedrock-anthropic-provider', () => {
   });
 
   it.each([
+    'anthropic.claude-haiku-4-5-20251001-v1:0',
+    'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+    'eu.anthropic.claude-haiku-4-5-20251001-v1:0',
+    'global.anthropic.claude-haiku-4-5-20251001-v1:0',
+    'anthropic.claude-sonnet-4-6-v1',
+    'us.anthropic.claude-sonnet-4-6-v1',
+    'eu.anthropic.claude-sonnet-4-6-v1',
+    'global.anthropic.claude-sonnet-4-6-v1',
     'anthropic.claude-opus-4-7',
     'us.anthropic.claude-opus-4-7',
     'eu.anthropic.claude-opus-4-7',
@@ -100,24 +108,21 @@ describe('amazon-bedrock-anthropic-provider', () => {
     'anthropic.claude-sonnet-5',
     'us.anthropic.claude-sonnet-5',
     'eu.anthropic.claude-sonnet-5',
-  ])(
-    'should disable native structured output for %s (Bedrock rejects output_config.format)',
-    modelId => {
-      const provider = createAmazonBedrockAnthropic({
-        region: 'us-east-1',
-        accessKeyId: 'test-key',
-        secretAccessKey: 'test-secret',
-      });
-      provider(modelId as Parameters<typeof provider>[0]);
+  ])('should disable native structured output for %s', modelId => {
+    const provider = createAmazonBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider(modelId as Parameters<typeof provider>[0]);
 
-      expect(AnthropicLanguageModel).toHaveBeenCalledWith(
-        modelId,
-        expect.objectContaining({
-          supportsNativeStructuredOutput: false,
-        }),
-      );
-    },
-  );
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
+      modelId,
+      expect.objectContaining({
+        supportsNativeStructuredOutput: false,
+      }),
+    );
+  });
 
   it.each([
     'anthropic.claude-opus-4-7',
@@ -155,7 +160,7 @@ describe('amazon-bedrock-anthropic-provider', () => {
   );
 
   it.each([
-    'anthropic.claude-sonnet-4-6',
+    'anthropic.claude-sonnet-4-6-v1',
     'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   ])('should keep strict tools enabled for %s', modelId => {
     const provider = createAmazonBedrockAnthropic({


### PR DESCRIPTION
## Summary

- split Bedrock Anthropic native structured-output support from strict-tool support
- make `structuredOutputMode: "auto"` use the JSON tool fallback for Claude Sonnet 4.6 and Claude Haiku 4.5
- preserve strict tools for both models
- document the conservative default and the explicit `"outputFormat"` opt-in

This is a follow-up to #20125. That PR added the explicit structured-output mode; this PR makes its default behavior account for the compatibility problems reported in the two issues.

Fixes #17881
Fixes #19988

## Why

Native structured output is not a reliable default for these models on Amazon Bedrock:

- Claude Sonnet 4.6 can silently fail to adhere to complex schemas and run to the output-token limit.
- Claude Haiku 4.5 can reject `output_config.format` depending on the Bedrock account.

Those failures only establish that native structured output needs a conservative fallback. They do not establish that `tools[].strict` is unsupported, so the capability lists are now independent.

Users whose account and workload support native structured output can still opt in with `structuredOutputMode: "outputFormat"` from #20125.

## Testing

- `CI=true pnpm --filter @ai-sdk/amazon-bedrock test` (523 Node tests and 523 Edge tests)
- `CI=true pnpm check`
- `CI=true pnpm type-check:full`
