### PR TITLE
fix(amazon-bedrock): backport structured output fallback to v6

### DIFF
--- a/.changeset/warm-cats-mix.md
+++ b/.changeset/warm-cats-mix.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Add a structured output mode option and default Claude Sonnet 4.6 and Claude Haiku 4.5 to the JSON tool fallback while preserving strict tool support.

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -256,6 +256,51 @@ const { text } = await generateText({
 Amazon Bedrock language models can also be used in the `streamText` function
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
+### Structured Outputs
+
+For Anthropic models, you can use the `structuredOutputMode` provider option to
+choose how Amazon Bedrock generates structured outputs:
+
+- `"outputFormat"`: Use Bedrock's native `output_config.format` parameter.
+- `"jsonTool"`: Use a special `json` tool with required tool choice.
+- `"auto"`: Use native structured output when supported and otherwise fall
+  back to the JSON tool. This is the default.
+
+In `"auto"` mode, Claude Sonnet 4.6 and Claude Haiku 4.5 use the JSON tool
+fallback because native structured output can be unreliable across workloads
+and Bedrock accounts. You can set `"outputFormat"` to opt into native structured
+output when it works for your account and workload, or use `"jsonTool"` to force
+the fallback for any model:
+
+```ts
+import {
+  bedrock,
+  type AmazonBedrockLanguageModelOptions,
+} from '@ai-sdk/amazon-bedrock';
+import { generateText, Output } from 'ai';
+import { z } from 'zod';
+
+const { output } = await generateText({
+  model: bedrock('eu.anthropic.claude-sonnet-4-6'),
+  output: Output.object({
+    schema: z.object({
+      summary: z.string(),
+      findings: z.array(z.string()),
+    }),
+  }),
+  prompt: 'Summarize the inspection report.',
+  providerOptions: {
+    bedrock: {
+      structuredOutputMode: 'jsonTool',
+    } satisfies AmazonBedrockLanguageModelOptions,
+  },
+});
+```
+
+For parity with the Anthropic provider,
+`providerOptions.anthropic.structuredOutputMode` is also honored for Anthropic
+models on Bedrock. When both are provided, the `bedrock` value takes precedence.
+
 ### File Inputs
 
 <Note type="warning">

--- a/examples/ai-functions/src/generate-text/amazon-bedrock/structured-output-mode.ts
+++ b/examples/ai-functions/src/generate-text/amazon-bedrock/structured-output-mode.ts
@@ -1,0 +1,33 @@
+import {
+  bedrock,
+  type AmazonBedrockLanguageModelOptions,
+} from '@ai-sdk/amazon-bedrock';
+import { generateText, Output } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: bedrock('eu.anthropic.claude-sonnet-4-6'),
+    output: Output.object({
+      schema: z.object({
+        recipe: z.object({
+          name: z.string(),
+          ingredients: z.array(z.string()),
+          steps: z.array(z.string()),
+        }),
+      }),
+    }),
+    prompt: 'Generate a lasagna recipe.',
+    providerOptions: {
+      bedrock: {
+        structuredOutputMode: 'jsonTool',
+      } satisfies AmazonBedrockLanguageModelOptions,
+    },
+  });
+
+  console.log(JSON.stringify(result.output, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+});

--- a/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/bedrock-anthropic-provider.test.ts
@@ -78,6 +78,14 @@ describe('bedrock-anthropic-provider', () => {
   });
 
   it.each([
+    'anthropic.claude-haiku-4-5-20251001-v1:0',
+    'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+    'eu.anthropic.claude-haiku-4-5-20251001-v1:0',
+    'global.anthropic.claude-haiku-4-5-20251001-v1:0',
+    'anthropic.claude-sonnet-4-6-v1',
+    'us.anthropic.claude-sonnet-4-6-v1',
+    'eu.anthropic.claude-sonnet-4-6-v1',
+    'global.anthropic.claude-sonnet-4-6-v1',
     'anthropic.claude-opus-4-7',
     'us.anthropic.claude-opus-4-7',
     'eu.anthropic.claude-opus-4-7',
@@ -93,24 +101,21 @@ describe('bedrock-anthropic-provider', () => {
     'anthropic.claude-sonnet-5',
     'us.anthropic.claude-sonnet-5',
     'eu.anthropic.claude-sonnet-5',
-  ])(
-    'should disable native structured output for %s (Bedrock rejects output_config.format)',
-    modelId => {
-      const provider = createBedrockAnthropic({
-        region: 'us-east-1',
-        accessKeyId: 'test-key',
-        secretAccessKey: 'test-secret',
-      });
-      provider(modelId as Parameters<typeof provider>[0]);
+  ])('should disable native structured output for %s', modelId => {
+    const provider = createBedrockAnthropic({
+      region: 'us-east-1',
+      accessKeyId: 'test-key',
+      secretAccessKey: 'test-secret',
+    });
+    provider(modelId as Parameters<typeof provider>[0]);
 
-      expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
-        modelId,
-        expect.objectContaining({
-          supportsNativeStructuredOutput: false,
-        }),
-      );
-    },
-  );
+    expect(AnthropicMessagesLanguageModel).toHaveBeenCalledWith(
+      modelId,
+      expect.objectContaining({
+        supportsNativeStructuredOutput: false,
+      }),
+    );
+  });
 
   it.each([
     'anthropic.claude-opus-4-7',
@@ -148,7 +153,7 @@ describe('bedrock-anthropic-provider', () => {
   );
 
   it.each([
-    'anthropic.claude-sonnet-4-6',
+    'anthropic.claude-sonnet-4-6-v1',
     'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   ])('should keep strict tools enabled for %s', modelId => {
     const provider = createBedrockAnthropic({

--- a/packages/amazon-bedrock/src/bedrock-anthropic-model-support.ts
+++ b/packages/amazon-bedrock/src/bedrock-anthropic-model-support.ts
@@ -1,14 +1,17 @@
 export function supportsStrictTools(modelId: string): boolean {
-  return !rejectsNewerSchemaFields(modelId);
+  return !matchesModel(modelId, MODELS_WITHOUT_STRICT_TOOL_SUPPORT);
 }
 
 export function supportsNativeStructuredOutput(modelId: string): boolean {
-  return !rejectsNewerSchemaFields(modelId);
+  return !matchesModel(
+    modelId,
+    MODELS_WITHOUT_RELIABLE_NATIVE_STRUCTURED_OUTPUT,
+  );
 }
 
 // Bedrock validates against its own copy of the Messages schema, which rejects
 // `output_config.format` and tool `strict` for the newest Claude models
-const MODELS_REJECTING_NEWER_SCHEMA_FIELDS = [
+const MODELS_WITHOUT_STRICT_TOOL_SUPPORT = [
   'claude-opus-4-7',
   'claude-opus-4-8',
   'claude-opus-5',
@@ -16,8 +19,15 @@ const MODELS_REJECTING_NEWER_SCHEMA_FIELDS = [
   'claude-sonnet-5',
 ];
 
-function rejectsNewerSchemaFields(modelId: string): boolean {
-  return MODELS_REJECTING_NEWER_SCHEMA_FIELDS.some(model =>
-    modelId.includes(model),
-  );
+// Native structured output is unreliable for additional models even though
+// their strict tool support remains available. Sonnet 4.6 can fail to adhere
+// to complex schemas, while Haiku 4.5 support varies between Bedrock accounts.
+const MODELS_WITHOUT_RELIABLE_NATIVE_STRUCTURED_OUTPUT = [
+  ...MODELS_WITHOUT_STRICT_TOOL_SUPPORT,
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5',
+];
+
+function matchesModel(modelId: string, models: string[]): boolean {
+  return models.some(model => modelId.includes(model));
 }

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -2,6 +2,7 @@ import type * as AnthropicInternal from '@ai-sdk/anthropic/internal';
 import type {
   LanguageModelV3CallOptions,
   LanguageModelV3Prompt,
+  SharedV3ProviderOptions,
 } from '@ai-sdk/provider';
 import { safeValidateTypes } from '@ai-sdk/provider-utils';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
@@ -122,6 +123,17 @@ const newerAnthropicGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
   newerAnthropicModelId,
 )}/converse`;
 
+const haiku45AnthropicModelId = 'us.anthropic.claude-haiku-4-5-20251001-v1:0';
+const haiku45AnthropicGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
+  haiku45AnthropicModelId,
+)}/converse`;
+
+const nativeStructuredOutputAnthropicModelId =
+  'anthropic.claude-sonnet-4-5-20250929-v1:0';
+const nativeStructuredOutputAnthropicGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
+  nativeStructuredOutputAnthropicModelId,
+)}/converse`;
+
 const opusAnthropicModelId = 'us.anthropic.claude-opus-4-8';
 const opusAnthropicGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
   opusAnthropicModelId,
@@ -155,6 +167,8 @@ const server = createTestServer({
   [globalOpenaiGenerateUrl]: {},
   [customOpenaiSubstringGenerateUrl]: {},
   [newerAnthropicGenerateUrl]: {},
+  [haiku45AnthropicGenerateUrl]: {},
+  [nativeStructuredOutputAnthropicGenerateUrl]: {},
   [opusAnthropicGenerateUrl]: {},
   [opus5AnthropicGenerateUrl]: {},
   [sonnet5AnthropicGenerateUrl]: {},
@@ -277,6 +291,26 @@ const futureAnthropicModel = new BedrockChatLanguageModel(
 
 const newerAnthropicModel = new BedrockChatLanguageModel(
   newerAnthropicModelId,
+  {
+    baseUrl: () => baseUrl,
+    headers: {},
+    fetch: fakeFetchWithAuth,
+    generateId: () => 'test-id',
+  },
+);
+
+const haiku45AnthropicModel = new BedrockChatLanguageModel(
+  haiku45AnthropicModelId,
+  {
+    baseUrl: () => baseUrl,
+    headers: {},
+    fetch: fakeFetchWithAuth,
+    generateId: () => 'test-id',
+  },
+);
+
+const nativeStructuredOutputAnthropicModel = new BedrockChatLanguageModel(
+  nativeStructuredOutputAnthropicModelId,
   {
     baseUrl: () => baseUrl,
     headers: {},
@@ -5293,8 +5327,290 @@ describe('doGenerate', () => {
     ).toBeUndefined();
   });
 
+  it.each([
+    {
+      modelId: newerAnthropicModelId,
+      model: newerAnthropicModel,
+      generateUrl: newerAnthropicGenerateUrl,
+    },
+    {
+      modelId: haiku45AnthropicModelId,
+      model: haiku45AnthropicModel,
+      generateUrl: haiku45AnthropicGenerateUrl,
+    },
+  ])(
+    'should default to the json tool for $modelId',
+    async ({ model, generateUrl }) => {
+      server.urls[generateUrl].response = {
+        type: 'json-value',
+        body: {
+          output: {
+            message: {
+              role: 'assistant',
+              content: [
+                {
+                  toolUse: {
+                    toolUseId: 'json-tool-id',
+                    name: 'json',
+                    input: { name: 'Test' },
+                  },
+                },
+              ],
+            },
+          },
+          usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+          stopReason: 'tool_use',
+        },
+      };
+
+      const result = await model.doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            required: ['name'],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+
+      expect(requestBody.toolConfig.tools).toHaveLength(1);
+      expect(requestBody.toolConfig.tools[0].toolSpec.name).toBe('json');
+      expect(requestBody.toolConfig.toolChoice).toEqual({ any: {} });
+      expect(
+        requestBody.additionalModelRequestFields?.output_config?.format,
+      ).toBeUndefined();
+      expect(result.content).toEqual([
+        { type: 'text', text: '{"name":"Test"}' },
+      ]);
+      expect(result.finishReason.unified).toBe('stop');
+      expect(result.providerMetadata?.bedrock?.isJsonResponseFromTool).toBe(
+        true,
+      );
+    },
+  );
+
+  it.each([
+    {
+      providerOptionsName: 'bedrock',
+      providerOptions: {
+        bedrock: { structuredOutputMode: 'jsonTool' },
+      } as SharedV3ProviderOptions,
+    },
+    {
+      providerOptionsName: 'anthropic',
+      providerOptions: {
+        anthropic: { structuredOutputMode: 'jsonTool' },
+      } as SharedV3ProviderOptions,
+    },
+  ])(
+    'should force the json tool wire format with $providerOptionsName provider options',
+    async ({ providerOptions }) => {
+      server.urls[nativeStructuredOutputAnthropicGenerateUrl].response = {
+        type: 'json-value',
+        body: {
+          output: {
+            message: {
+              role: 'assistant',
+              content: [
+                {
+                  toolUse: {
+                    toolUseId: 'json-tool-id',
+                    name: 'json',
+                    input: { name: 'Test' },
+                  },
+                },
+              ],
+            },
+          },
+          usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+          stopReason: 'tool_use',
+        },
+      };
+
+      const result = await nativeStructuredOutputAnthropicModel.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions,
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            required: ['name'],
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+
+      expect(requestBody.toolConfig.tools).toHaveLength(1);
+      expect(requestBody.toolConfig.tools[0].toolSpec.name).toBe('json');
+      expect(requestBody.toolConfig.toolChoice).toEqual({ any: {} });
+      expect(requestBody.structuredOutputMode).toBeUndefined();
+      expect(
+        requestBody.additionalModelRequestFields?.output_config?.format,
+      ).toBeUndefined();
+      expect(result.content).toEqual([
+        { type: 'text', text: '{"name":"Test"}' },
+      ]);
+      expect(result.finishReason.unified).toBe('stop');
+      expect(result.providerMetadata?.bedrock?.isJsonResponseFromTool).toBe(
+        true,
+      );
+    },
+  );
+
+  it('should remove a manually supplied output_config.format in jsonTool mode while preserving sibling fields', async () => {
+    server.urls[nativeStructuredOutputAnthropicGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                toolUse: {
+                  toolUseId: 'json-tool-id',
+                  name: 'json',
+                  input: { name: 'Test' },
+                },
+              },
+            ],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+        stopReason: 'tool_use',
+      },
+    };
+
+    await nativeStructuredOutputAnthropicModel.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        bedrock: {
+          structuredOutputMode: 'jsonTool',
+          additionalModelRequestFields: {
+            output_config: {
+              effort: 'medium',
+              format: { type: 'manually-supplied-format' },
+            },
+          },
+        },
+      },
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.additionalModelRequestFields?.output_config).toEqual({
+      effort: 'medium',
+    });
+  });
+
+  it('should force output_config.format for models that auto mode routes to the json tool', async () => {
+    server.urls[opus5AnthropicGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [{ text: '{"name":"Test"}' }],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+        stopReason: 'end_turn',
+      },
+    };
+
+    await opus5AnthropicModel.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        bedrock: { structuredOutputMode: 'outputFormat' },
+      },
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.toolConfig).toBeUndefined();
+    expect(
+      requestBody.additionalModelRequestFields?.output_config?.format,
+    ).toEqual({
+      type: 'json_schema',
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { name: { type: 'string' } },
+        required: ['name'],
+      },
+    });
+  });
+
+  it('should prefer bedrock structuredOutputMode over anthropic structuredOutputMode', async () => {
+    server.urls[nativeStructuredOutputAnthropicGenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                toolUse: {
+                  toolUseId: 'json-tool-id',
+                  name: 'json',
+                  input: { name: 'Test' },
+                },
+              },
+            ],
+          },
+        },
+        usage: { inputTokens: 4, outputTokens: 10, totalTokens: 14 },
+        stopReason: 'tool_use',
+      },
+    };
+
+    await nativeStructuredOutputAnthropicModel.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        bedrock: { structuredOutputMode: 'jsonTool' },
+        anthropic: { structuredOutputMode: 'outputFormat' },
+      },
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.toolConfig.toolChoice).toEqual({ any: {} });
+    expect(
+      requestBody.additionalModelRequestFields?.output_config?.format,
+    ).toBeUndefined();
+  });
+
   it('should use native output_config.format for models with structured output support even without thinking enabled', async () => {
-    server.urls[newerAnthropicGenerateUrl].response = {
+    server.urls[nativeStructuredOutputAnthropicGenerateUrl].response = {
       type: 'json-value',
       body: {
         output: {
@@ -5308,7 +5624,7 @@ describe('doGenerate', () => {
       },
     };
 
-    await newerAnthropicModel.doGenerate({
+    await nativeStructuredOutputAnthropicModel.doGenerate({
       prompt: [
         {
           role: 'user',
@@ -5427,7 +5743,7 @@ describe('doGenerate', () => {
   });
 
   it('should sanitize unsupported JSON schema keywords for native structured output', async () => {
-    server.urls[newerAnthropicGenerateUrl].response = {
+    server.urls[nativeStructuredOutputAnthropicGenerateUrl].response = {
       type: 'json-value',
       body: {
         output: {
@@ -5441,7 +5757,7 @@ describe('doGenerate', () => {
       },
     };
 
-    await newerAnthropicModel.doGenerate({
+    await nativeStructuredOutputAnthropicModel.doGenerate({
       prompt: TEST_PROMPT,
       responseFormat: {
         type: 'json',

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -63,6 +63,7 @@ type BedrockChatConfig = {
 
 const anthropicProviderOptions = z.object({
   disableParallelToolUse: z.boolean().optional(),
+  structuredOutputMode: z.enum(['outputFormat', 'jsonTool', 'auto']).optional(),
 });
 
 export class BedrockChatLanguageModel implements LanguageModelV3 {
@@ -177,14 +178,52 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
     const { supportsStructuredOutput: modelSupportsStructuredOutput } =
       getModelCapabilities(this.modelId);
 
+    const structuredOutputMode =
+      bedrockOptions.structuredOutputMode ??
+      anthropicOptions?.structuredOutputMode ??
+      'auto';
+
+    if (structuredOutputMode === 'jsonTool') {
+      const additionalModelRequestFields = {
+        ...bedrockOptions.additionalModelRequestFields,
+      };
+      const outputConfig = additionalModelRequestFields.output_config;
+
+      if (
+        outputConfig != null &&
+        typeof outputConfig === 'object' &&
+        !Array.isArray(outputConfig)
+      ) {
+        const outputConfigWithoutFormat = { ...outputConfig };
+        delete outputConfigWithoutFormat.format;
+
+        if (Object.keys(outputConfigWithoutFormat).length > 0) {
+          additionalModelRequestFields.output_config =
+            outputConfigWithoutFormat;
+        } else {
+          delete additionalModelRequestFields.output_config;
+        }
+
+        bedrockOptions.additionalModelRequestFields =
+          additionalModelRequestFields;
+      }
+    }
+
+    const modelSupportsNativeStructuredOutput =
+      supportsNativeStructuredOutput(this.modelId) &&
+      (modelSupportsStructuredOutput || isThinkingEnabled);
+
     const useNativeStructuredOutput =
       isAnthropicModel &&
-      supportsNativeStructuredOutput(this.modelId) &&
-      (modelSupportsStructuredOutput || isThinkingEnabled) &&
       responseFormat?.type === 'json' &&
-      responseFormat.schema != null;
+      responseFormat.schema != null &&
+      (structuredOutputMode === 'outputFormat' ||
+        (structuredOutputMode === 'auto' &&
+          modelSupportsNativeStructuredOutput));
 
     const useJsonInstructionForStructuredOutput =
+      !useNativeStructuredOutput &&
+      structuredOutputMode !== 'jsonTool' &&
       isAnthropicModel &&
       !supportsStrictTools(this.modelId) &&
       responseFormat?.type === 'json' &&
@@ -438,6 +477,7 @@ export class BedrockChatLanguageModel implements LanguageModelV3 {
       reasoningConfig: _,
       additionalModelRequestFields: __,
       serviceTier: ___,
+      structuredOutputMode: ____,
       ...filteredBedrockOptions
     } = providerOptions?.bedrock || {};
 

--- a/packages/amazon-bedrock/src/bedrock-chat-options.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-options.test.ts
@@ -5,6 +5,28 @@ import {
 } from './bedrock-chat-options';
 
 describe('amazonBedrockLanguageModelOptions', () => {
+  describe('structuredOutputMode', () => {
+    it.each(['outputFormat', 'jsonTool', 'auto'] as const)(
+      'accepts %s',
+      structuredOutputMode => {
+        const result = amazonBedrockLanguageModelOptions.safeParse({
+          structuredOutputMode,
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.data?.structuredOutputMode).toBe(structuredOutputMode);
+      },
+    );
+
+    it('rejects invalid values', () => {
+      const result = amazonBedrockLanguageModelOptions.safeParse({
+        structuredOutputMode: 'native',
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
   describe('serviceTier', () => {
     it('accepts valid service tier values', () => {
       const validValues = ['reserved', 'priority', 'default', 'flex'] as const;
@@ -36,9 +58,11 @@ describe('amazonBedrockLanguageModelOptions', () => {
     it('infers AmazonBedrockLanguageModelOptions type correctly', () => {
       const options: AmazonBedrockLanguageModelOptions = {
         serviceTier: 'priority',
+        structuredOutputMode: 'jsonTool',
       };
 
       expect(options.serviceTier).toBe('priority');
+      expect(options.structuredOutputMode).toBe('jsonTool');
     });
   });
 });

--- a/packages/amazon-bedrock/src/bedrock-chat-options.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-options.ts
@@ -108,6 +108,14 @@ export type BedrockFilePartProviderOptions = z.infer<
 
 export const amazonBedrockLanguageModelOptions = z.object({
   /**
+   * Determines how structured outputs are generated for Anthropic models.
+   *
+   * - `outputFormat`: Use the native `output_config.format` parameter.
+   * - `jsonTool`: Use a special 'json' tool to specify the structured output format.
+   * - `auto`: Use `outputFormat` when supported, otherwise use `jsonTool` (default).
+   */
+  structuredOutputMode: z.enum(['outputFormat', 'jsonTool', 'auto']).optional(),
+  /**
    * Additional inference parameters that the model supports,
    * beyond the base set of inference parameters that Converse
    * supports in the inferenceConfig field

--- a/packages/amazon-bedrock/src/bedrock-prepare-tools.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-prepare-tools.test.ts
@@ -366,6 +366,27 @@ describe('prepareTools', () => {
       ]);
     });
 
+    it.each([
+      'anthropic.claude-sonnet-4-6-v1',
+      'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+    ])('should keep strict mode enabled for %s', async modelId => {
+      const result = await prepareTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'testFunction',
+            description: 'A test function',
+            inputSchema: { type: 'object', properties: {} },
+            strict: true,
+          },
+        ],
+        modelId,
+      });
+
+      expect((result.toolConfig.tools![0] as any).toolSpec.strict).toBe(true);
+      expect(result.toolWarnings).toEqual([]);
+    });
+
     it('should pass through strict mode when strict is false', async () => {
       const result = await prepareTools({
         tools: [


### PR DESCRIPTION
## Summary

Combined backport of #20125 and #20128 to `release-v6.0`.

- add `structuredOutputMode: "auto" | "outputFormat" | "jsonTool"` to the Bedrock Converse provider
- default Claude Sonnet 4.6 and Claude Haiku 4.5 to the JSON tool fallback under `"auto"`
- keep native structured-output support independent from strict-tool support
- add v6 regression tests, documentation, an example, and a patch changeset

The option uses the v6 `providerOptions.bedrock` namespace and also honors `providerOptions.anthropic.structuredOutputMode` for compatibility.

Related: #17881, #19988

## Testing

- `CI=true pnpm --filter @ai-sdk/amazon-bedrock test` (477 Node tests and 477 Edge tests)
- `CI=true pnpm check`
- `CI=true pnpm type-check:full`
