### PR TITLE
fix(amazon-bedrock): backport structured output fallback to v5

### DIFF
--- a/.changeset/warm-cats-mix.md
+++ b/.changeset/warm-cats-mix.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Add a structured output mode option and default Claude Sonnet 4.6 and Claude Haiku 4.5 to the JSON tool fallback.

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -210,6 +210,49 @@ const { text } = await generateText({
 Amazon Bedrock language models can also be used in the `streamText` function
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
+### Structured Outputs
+
+For Anthropic models, you can use the `structuredOutputMode` provider option to
+choose how Amazon Bedrock generates structured outputs:
+
+- `"outputFormat"`: Use Bedrock's native `output_config.format` parameter.
+- `"jsonTool"`: Use a special `json` tool with required tool choice.
+- `"auto"`: Use native structured output when supported by the model and
+  request, and otherwise fall back to the JSON tool. This is the default.
+
+In `"auto"` mode, Claude Sonnet 4.6 and Claude Haiku 4.5 use the JSON tool
+fallback because native structured output can be unreliable across workloads
+and Bedrock accounts. You can set `"outputFormat"` to opt into native structured
+output when it works for your account and workload, or use `"jsonTool"` to force
+the fallback for any model:
+
+```ts
+import {
+  bedrock,
+  type BedrockProviderOptions,
+} from '@ai-sdk/amazon-bedrock';
+import { generateObject } from 'ai';
+import { z } from 'zod';
+
+const { object } = await generateObject({
+  model: bedrock('eu.anthropic.claude-sonnet-4-6'),
+  schema: z.object({
+    summary: z.string(),
+    findings: z.array(z.string()),
+  }),
+  prompt: 'Summarize the inspection report.',
+  providerOptions: {
+    bedrock: {
+      structuredOutputMode: 'jsonTool',
+    } satisfies BedrockProviderOptions,
+  },
+});
+```
+
+For parity with the Anthropic provider,
+`providerOptions.anthropic.structuredOutputMode` is also honored for Anthropic
+models on Bedrock. When both are provided, the `bedrock` value takes precedence.
+
 ### File Inputs
 
 <Note type="warning">

--- a/examples/ai-core/src/generate-object/amazon-bedrock-structured-output-mode.ts
+++ b/examples/ai-core/src/generate-object/amazon-bedrock-structured-output-mode.ts
@@ -1,0 +1,30 @@
+import { bedrock, type BedrockProviderOptions } from '@ai-sdk/amazon-bedrock';
+import { generateObject } from 'ai';
+import 'dotenv/config';
+import { z } from 'zod';
+
+async function main() {
+  const result = await generateObject({
+    model: bedrock('eu.anthropic.claude-sonnet-4-6'),
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(z.string()),
+        steps: z.array(z.string()),
+      }),
+    }),
+    prompt: 'Generate a lasagna recipe.',
+    providerOptions: {
+      bedrock: {
+        structuredOutputMode: 'jsonTool',
+      } satisfies BedrockProviderOptions,
+    },
+  });
+
+  console.log(JSON.stringify(result.object, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.test.ts
@@ -1,4 +1,7 @@
-import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import type {
+  LanguageModelV2Prompt,
+  SharedV2ProviderOptions,
+} from '@ai-sdk/provider';
 import { safeValidateTypes } from '@ai-sdk/provider-utils';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
@@ -76,6 +79,8 @@ const modelId = 'anthropic.claude-3-haiku-20240307-v1:0';
 const anthropicModelId = 'anthropic.claude-3-5-sonnet-20240620-v1:0'; // Define at top level
 const structuredOutputModelId = 'anthropic.claude-opus-4-5-20251101-v1:0';
 const adaptiveStructuredOutputModelId = 'anthropic.claude-opus-4-6-v1';
+const sonnet46ModelId = 'anthropic.claude-sonnet-4-6-v1';
+const haiku45ModelId = 'us.anthropic.claude-haiku-4-5-20251001-v1:0';
 const unsupportedStructuredOutputModelId =
   'anthropic.claude-sonnet-4-20250514-v1:0';
 const baseUrl = 'https://bedrock-runtime.us-east-1.amazonaws.com';
@@ -92,6 +97,12 @@ const structuredOutputGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
 )}/converse`;
 const adaptiveStructuredOutputGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
   adaptiveStructuredOutputModelId,
+)}/converse`;
+const sonnet46GenerateUrl = `${baseUrl}/model/${encodeURIComponent(
+  sonnet46ModelId,
+)}/converse`;
+const haiku45GenerateUrl = `${baseUrl}/model/${encodeURIComponent(
+  haiku45ModelId,
 )}/converse`;
 const unsupportedStructuredOutputGenerateUrl = `${baseUrl}/model/${encodeURIComponent(
   unsupportedStructuredOutputModelId,
@@ -139,6 +150,8 @@ const server = createTestServer({
   [anthropicGenerateUrl]: {},
   [structuredOutputGenerateUrl]: {},
   [adaptiveStructuredOutputGenerateUrl]: {},
+  [sonnet46GenerateUrl]: {},
+  [haiku45GenerateUrl]: {},
   [unsupportedStructuredOutputGenerateUrl]: {},
   [legacyAnthropic37GenerateUrl]: {},
   [novaGenerateUrl]: {},
@@ -261,6 +274,20 @@ const adaptiveStructuredOutputModel = new BedrockChatLanguageModel(
     generateId: () => 'test-id',
   },
 );
+
+const sonnet46Model = new BedrockChatLanguageModel(sonnet46ModelId, {
+  baseUrl: () => baseUrl,
+  headers: {},
+  fetch: fakeFetchWithAuth,
+  generateId: () => 'test-id',
+});
+
+const haiku45Model = new BedrockChatLanguageModel(haiku45ModelId, {
+  baseUrl: () => baseUrl,
+  headers: {},
+  fetch: fakeFetchWithAuth,
+  generateId: () => 'test-id',
+});
 
 const unsupportedStructuredOutputModel = new BedrockChatLanguageModel(
   unsupportedStructuredOutputModelId,
@@ -2583,6 +2610,30 @@ describe('doGenerate', () => {
     };
   }
 
+  function prepareStructuredOutputJsonToolResponse(url: string) {
+    server.urls[url].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                toolUse: {
+                  toolUseId: 'json-tool-id',
+                  name: 'json',
+                  input: { answer: 'ok' },
+                },
+              },
+            ],
+          },
+        },
+        stopReason: 'tool_use',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      },
+    };
+  }
+
   it('should extract text response', async () => {
     prepareJsonResponse({ content: [{ type: 'text', text: 'Hello, World!' }] });
 
@@ -3582,6 +3633,222 @@ describe('doGenerate', () => {
         },
       },
     });
+  });
+
+  it.each([
+    {
+      modelId: sonnet46ModelId,
+      model: sonnet46Model,
+      generateUrl: sonnet46GenerateUrl,
+    },
+    {
+      modelId: haiku45ModelId,
+      model: haiku45Model,
+      generateUrl: haiku45GenerateUrl,
+    },
+  ])(
+    'defaults to the json tool for $modelId when thinking is enabled',
+    async ({ model: affectedModel, generateUrl }) => {
+      prepareStructuredOutputJsonToolResponse(generateUrl);
+
+      const result = await affectedModel.doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: { answer: { type: 'string' } },
+            required: ['answer'],
+          },
+        },
+        providerOptions: {
+          bedrock: {
+            reasoningConfig: { type: 'enabled', budgetTokens: 1024 },
+          },
+        },
+      });
+
+      const requestBody = await server.calls.at(-1)!.requestBodyJson;
+
+      expect(requestBody.toolConfig.tools).toHaveLength(1);
+      expect(requestBody.toolConfig.tools[0].toolSpec.name).toBe('json');
+      expect(requestBody.toolConfig.toolChoice).toEqual({ any: {} });
+      expect(
+        requestBody.additionalModelRequestFields?.output_config?.format,
+      ).toBeUndefined();
+      expect(result.content).toEqual([
+        { type: 'text', text: '{"answer":"ok"}' },
+      ]);
+      expect(result.finishReason).toBe('stop');
+      expect(result.providerMetadata?.bedrock?.isJsonResponseFromTool).toBe(
+        true,
+      );
+    },
+  );
+
+  it.each([
+    {
+      providerOptionsName: 'bedrock',
+      providerOptions: {
+        bedrock: {
+          structuredOutputMode: 'jsonTool',
+          reasoningConfig: { type: 'enabled', budgetTokens: 1024 },
+        },
+      } as SharedV2ProviderOptions,
+    },
+    {
+      providerOptionsName: 'anthropic',
+      providerOptions: {
+        bedrock: {
+          reasoningConfig: { type: 'enabled', budgetTokens: 1024 },
+        },
+        anthropic: { structuredOutputMode: 'jsonTool' },
+      } as SharedV2ProviderOptions,
+    },
+  ])(
+    'forces the json tool wire format with $providerOptionsName provider options',
+    async ({ providerOptions }) => {
+      prepareStructuredOutputJsonToolResponse(structuredOutputGenerateUrl);
+
+      const result = await structuredOutputModel.doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions,
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: { answer: { type: 'string' } },
+            required: ['answer'],
+          },
+        },
+      });
+
+      const requestBody = await server.calls.at(-1)!.requestBodyJson;
+
+      expect(requestBody.toolConfig.tools).toHaveLength(1);
+      expect(requestBody.toolConfig.tools[0].toolSpec.name).toBe('json');
+      expect(requestBody.toolConfig.toolChoice).toEqual({ any: {} });
+      expect(requestBody.structuredOutputMode).toBeUndefined();
+      expect(
+        requestBody.additionalModelRequestFields?.output_config?.format,
+      ).toBeUndefined();
+      expect(result.content).toEqual([
+        { type: 'text', text: '{"answer":"ok"}' },
+      ]);
+      expect(result.finishReason).toBe('stop');
+      expect(result.providerMetadata?.bedrock?.isJsonResponseFromTool).toBe(
+        true,
+      );
+    },
+  );
+
+  it('removes a manually supplied output_config.format in jsonTool mode while preserving sibling fields', async () => {
+    prepareStructuredOutputJsonToolResponse(structuredOutputGenerateUrl);
+
+    await structuredOutputModel.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        bedrock: {
+          structuredOutputMode: 'jsonTool',
+          additionalModelRequestFields: {
+            output_config: {
+              effort: 'medium',
+              format: { type: 'manually-supplied-format' },
+            },
+          },
+        },
+      },
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { answer: { type: 'string' } },
+          required: ['answer'],
+        },
+      },
+    });
+
+    const requestBody = await server.calls.at(-1)!.requestBodyJson;
+
+    expect(requestBody.additionalModelRequestFields?.output_config).toEqual({
+      effort: 'medium',
+    });
+  });
+
+  it('forces output_config.format for a model that auto mode routes to the json tool', async () => {
+    server.urls[sonnet46GenerateUrl].response = {
+      type: 'json-value',
+      body: {
+        output: {
+          message: {
+            content: [{ text: '{"answer":"ok"}' }],
+            role: 'assistant',
+          },
+        },
+        stopReason: 'end_turn',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      },
+    };
+
+    await sonnet46Model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        bedrock: { structuredOutputMode: 'outputFormat' },
+      },
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { answer: { type: 'string' } },
+          required: ['answer'],
+        },
+      },
+    });
+
+    const requestBody = await server.calls.at(-1)!.requestBodyJson;
+
+    expect(requestBody.toolConfig).toBeUndefined();
+    expect(
+      requestBody.additionalModelRequestFields?.output_config?.format,
+    ).toEqual({
+      type: 'json_schema',
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { answer: { type: 'string' } },
+        required: ['answer'],
+      },
+    });
+  });
+
+  it('prefers bedrock structuredOutputMode over anthropic structuredOutputMode', async () => {
+    prepareStructuredOutputJsonToolResponse(structuredOutputGenerateUrl);
+
+    await structuredOutputModel.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        bedrock: {
+          structuredOutputMode: 'jsonTool',
+          reasoningConfig: { type: 'enabled', budgetTokens: 1024 },
+        },
+        anthropic: { structuredOutputMode: 'outputFormat' },
+      },
+      responseFormat: {
+        type: 'json',
+        schema: {
+          type: 'object',
+          properties: { answer: { type: 'string' } },
+          required: ['answer'],
+        },
+      },
+    });
+
+    const requestBody = await server.calls.at(-1)!.requestBodyJson;
+
+    expect(requestBody.toolConfig.toolChoice).toEqual({ any: {} });
+    expect(
+      requestBody.additionalModelRequestFields?.output_config?.format,
+    ).toBeUndefined();
   });
 
   it('does not send native structured output to an unsupported Anthropic model', async () => {

--- a/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-language-model.ts
@@ -48,6 +48,7 @@ type BedrockChatConfig = {
 
 const anthropicProviderOptions = z.object({
   disableParallelToolUse: z.boolean().optional(),
+  structuredOutputMode: z.enum(['outputFormat', 'jsonTool', 'auto']).optional(),
 });
 
 export class BedrockChatLanguageModel implements LanguageModelV2 {
@@ -152,12 +153,46 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
     const isThinkingRequested =
       bedrockOptions.reasoningConfig?.type === 'enabled' ||
       bedrockOptions.reasoningConfig?.type === 'adaptive';
+
+    const structuredOutputMode =
+      bedrockOptions.structuredOutputMode ??
+      anthropicOptions?.structuredOutputMode ??
+      'auto';
+
+    if (structuredOutputMode === 'jsonTool') {
+      const additionalModelRequestFields = {
+        ...bedrockOptions.additionalModelRequestFields,
+      };
+      const outputConfig = additionalModelRequestFields.output_config;
+
+      if (
+        outputConfig != null &&
+        typeof outputConfig === 'object' &&
+        !Array.isArray(outputConfig)
+      ) {
+        const outputConfigWithoutFormat = { ...outputConfig };
+        delete outputConfigWithoutFormat.format;
+
+        if (Object.keys(outputConfigWithoutFormat).length > 0) {
+          additionalModelRequestFields.output_config =
+            outputConfigWithoutFormat;
+        } else {
+          delete additionalModelRequestFields.output_config;
+        }
+
+        bedrockOptions.additionalModelRequestFields =
+          additionalModelRequestFields;
+      }
+    }
+
     const useNativeStructuredOutput =
       isAnthropicModel &&
-      supportsNativeStructuredOutput(this.modelId) &&
-      isThinkingRequested &&
       responseFormat?.type === 'json' &&
-      responseFormat.schema != null;
+      responseFormat.schema != null &&
+      (structuredOutputMode === 'outputFormat' ||
+        (structuredOutputMode === 'auto' &&
+          supportsNativeStructuredOutput(this.modelId) &&
+          isThinkingRequested));
 
     const jsonResponseTool: LanguageModelV2FunctionTool | undefined =
       responseFormat?.type === 'json' &&
@@ -395,6 +430,7 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
       reasoningConfig: _,
       additionalModelRequestFields: __,
       serviceTier: ___,
+      structuredOutputMode: ____,
       ...filteredBedrockOptions
     } = providerOptions?.bedrock || {};
 
@@ -1005,10 +1041,24 @@ export class BedrockChatLanguageModel implements LanguageModelV2 {
   }
 }
 
+// Native structured output can fail to adhere to complex schemas on Sonnet
+// 4.6, while Haiku 4.5 support varies between Bedrock accounts.
+const MODELS_WITHOUT_RELIABLE_NATIVE_STRUCTURED_OUTPUT = [
+  'anthropic.claude-sonnet-4-6',
+  'anthropic.claude-haiku-4-5',
+];
+
 function supportsNativeStructuredOutput(modelId: string): boolean {
+  if (
+    MODELS_WITHOUT_RELIABLE_NATIVE_STRUCTURED_OUTPUT.some(model =>
+      modelId.includes(model),
+    )
+  ) {
+    return false;
+  }
+
   return (
     modelId.includes('anthropic.claude-sonnet-4-5') ||
-    modelId.includes('anthropic.claude-haiku-4-5') ||
     modelId.includes('anthropic.claude-opus-4-5') ||
     modelId.includes('anthropic.claude-opus-4-6')
   );

--- a/packages/amazon-bedrock/src/bedrock-chat-options.test.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-options.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bedrockProviderOptions,
+  type BedrockProviderOptions,
+} from './bedrock-chat-options';
+
+describe('bedrockProviderOptions', () => {
+  describe('structuredOutputMode', () => {
+    it.each(['outputFormat', 'jsonTool', 'auto'] as const)(
+      'accepts %s',
+      structuredOutputMode => {
+        const result = bedrockProviderOptions.safeParse({
+          structuredOutputMode,
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.data?.structuredOutputMode).toBe(structuredOutputMode);
+      },
+    );
+
+    it('rejects invalid values', () => {
+      const result = bedrockProviderOptions.safeParse({
+        structuredOutputMode: 'native',
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  it('infers structuredOutputMode in BedrockProviderOptions', () => {
+    const options: BedrockProviderOptions = {
+      structuredOutputMode: 'jsonTool',
+    };
+
+    expect(options.structuredOutputMode).toBe('jsonTool');
+  });
+});

--- a/packages/amazon-bedrock/src/bedrock-chat-options.ts
+++ b/packages/amazon-bedrock/src/bedrock-chat-options.ts
@@ -108,6 +108,14 @@ export type BedrockFilePartProviderOptions = z.infer<
 
 export const bedrockProviderOptions = z.object({
   /**
+   * Determines how structured outputs are generated for Anthropic models.
+   *
+   * - `outputFormat`: Use the native `output_config.format` parameter.
+   * - `jsonTool`: Use a special 'json' tool to specify the structured output format.
+   * - `auto`: Use `outputFormat` when supported, otherwise use `jsonTool` (default).
+   */
+  structuredOutputMode: z.enum(['outputFormat', 'jsonTool', 'auto']).optional(),
+  /**
    * Additional inference parameters that the model supports,
    * beyond the base set of inference parameters that Converse
    * supports in the inferenceConfig field


### PR DESCRIPTION
## Summary

Combined backport of #20125 and #20128 to `release-v5.0`.

- add `structuredOutputMode` with `auto`, `outputFormat`, and `jsonTool` modes
- default Claude Sonnet 4.6 and Claude Haiku 4.5 to the JSON tool fallback under `auto`
- preserve the native output path as an explicit opt-in
- add regression tests, documentation, an example, and a patch changeset

This uses the v5 `LanguageModelV2` and `generateObject` APIs. The strict-tool capability split from #20128 is not applicable because the v5 Bedrock provider interface does not expose strict tool definitions.

Related to #17881 and #19988.

## Testing

- `CI=true pnpm --filter @ai-sdk/amazon-bedrock test` (272 Node and 272 Edge tests passed)
- `CI=true pnpm check`
- `CI=true pnpm type-check`
- `CI=true pnpm --filter @ai-sdk/amazon-bedrock type-check`
- `CI=true pnpm --filter @example/ai-core type-check`

`CI=true pnpm type-check:full` was also run. It reaches existing React type conflicts in unrelated v5 examples; the repository package build and the affected package/example type checks pass.
