### PR TITLE
feat(anthropic): add fable 5.1 support

### DIFF
--- a/.changeset/fuzzy-pandas-think.md
+++ b/.changeset/fuzzy-pandas-think.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/anthropic': patch
+'@ai-sdk/gateway': patch
+---
+
+feat(anthropic): add fable 5.1 support

--- a/content/docs/02-foundations/02-providers-and-models.mdx
+++ b/content/docs/02-foundations/02-providers-and-models.mdx
@@ -145,6 +145,7 @@ Here are the capabilities of popular models:
 | [OpenAI](/providers/ai-sdk-providers/openai)       | `gpt-5-codex`                               | <Check />   | <Check />         | <Check />  | <Check />      |
 | [OpenAI](/providers/ai-sdk-providers/openai)       | `gpt-5-chat-latest`                         | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Anthropic](/providers/ai-sdk-providers/anthropic) | `claude-sonnet-5`                           | <Check />   | <Check />         | <Check />  | <Check />      |
+| [Anthropic](/providers/ai-sdk-providers/anthropic) | `claude-fable-5-1`                          | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Anthropic](/providers/ai-sdk-providers/anthropic) | `claude-fable-5`                            | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Anthropic](/providers/ai-sdk-providers/anthropic) | `claude-opus-4-8`                           | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Anthropic](/providers/ai-sdk-providers/anthropic) | `claude-opus-4-7`                           | <Check />   | <Check />         | <Check />  | <Check />      |

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -492,7 +492,8 @@ console.log(text);
 ##### Thinking Updates
 
 Use `display: 'updates'` with `claude-fable-5-1` to stream thinking summaries
-between tool calls:
+between tool calls. The provider adds the required
+`thinking-display-updates-2026-08-18` beta header automatically:
 
 ```ts highlight="12-16"
 import { anthropic, AnthropicLanguageModelOptions } from '@ai-sdk/anthropic';

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -233,9 +233,14 @@ const result = streamText({
 });
 ```
 
+For `claude-fable-5-1`, the default `"auto"` mode uses native structured
+outputs through `output_config.format`. Fable 5.1 rejects forced tool use, so
+do not use `"jsonTool"` or a required or named tool choice to implement
+structured output with this model.
+
 ### Effort
 
-Anthropic introduced an `effort` option with `claude-opus-4-5` that affects thinking, text responses, and function calls. Effort defaults to `high` and you can set it to `medium` or `low` to save tokens and to lower time-to-last-token latency (TTLT). `claude-opus-4-7`, `claude-opus-4-8`, `claude-opus-5`, `claude-fable-5`, and `claude-sonnet-5` additionally support `xhigh` for maximum reasoning effort.
+Anthropic introduced an `effort` option with `claude-opus-4-5` that affects thinking, text responses, and function calls. Effort defaults to `high` and you can set it to `medium` or `low` to save tokens and to lower time-to-last-token latency (TTLT). `claude-opus-4-7`, `claude-opus-4-8`, `claude-opus-5`, `claude-fable-5`, `claude-fable-5-1`, and `claude-sonnet-5` additionally support `xhigh` for maximum reasoning effort.
 
 On `claude-opus-5`, thinking can only be disabled at effort levels up to and including `high`. When you combine `thinking: { type: 'disabled' }` with `effort: 'xhigh'` or `effort: 'max'`, the AI SDK lowers the effort to `high` and emits a warning instead of sending a request that the API would reject.
 
@@ -483,6 +488,55 @@ console.log(text);
   `"omitted"` display will cause a long pause before output begins. Set
   `display: "summarized"` to restore visible progress during thinking.
 </Note>
+
+##### Thinking Updates
+
+Use `display: 'updates'` with `claude-fable-5-1` to stream thinking summaries
+between tool calls:
+
+```ts highlight="12-16"
+import { anthropic, AnthropicLanguageModelOptions } from '@ai-sdk/anthropic';
+import { streamText, tool } from 'ai';
+import { z } from 'zod';
+
+const result = streamText({
+  model: anthropic('claude-fable-5-1'),
+  tools: {
+    weather: tool({
+      inputSchema: z.object({ city: z.string() }),
+    }),
+  },
+  providerOptions: {
+    anthropic: {
+      thinking: { type: 'adaptive', display: 'updates' },
+    } satisfies AnthropicLanguageModelOptions,
+  },
+  prompt: 'Compare the weather in San Francisco and New York.',
+});
+```
+
+##### Thinking Binding Controls
+
+Fable 5.1 can recover from a thinking-block prefix mismatch by dropping the
+mismatched block. Set `blockBinding.prefixMismatchBehavior` to `drop_block`.
+You can provide block binding by itself to preserve the model's default
+thinking mode, or combine it with adaptive thinking.
+
+```ts highlight="7-11"
+const { text } = await generateText({
+  model: anthropic('claude-fable-5-1'),
+  prompt: 'Continue from this conversation.',
+  providerOptions: {
+    anthropic: {
+      thinking: {
+        blockBinding: {
+          prefixMismatchBehavior: 'drop_block',
+        },
+      },
+    } satisfies AnthropicLanguageModelOptions,
+  },
+});
+```
 
 #### Budget-Based Thinking
 
@@ -1279,6 +1333,59 @@ const result = await generateText({
 
 This sends `tool_reference` blocks to Anthropic, which loads the corresponding deferred tool schemas into Claude's context.
 
+### Mid-Conversation System Controls
+
+With `claude-fable-5-1`, a mid-conversation system message can be cleared
+before the next user message with `clearAt: 'next_user_message'`, or set the
+effort for the next turn. The provider adds the required
+`mid-conversation-system-clear-at-2026-08-21` and
+`mid-conversation-effort-2026-08-01` beta headers automatically.
+
+```ts highlight="17-25"
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: anthropic('claude-fable-5-1'),
+  allowSystemInMessages: true,
+  messages: [
+    {
+      role: 'user',
+      content: 'Draft a migration plan.',
+    },
+    {
+      role: 'assistant',
+      content: 'First, inventory the public API.',
+    },
+    {
+      role: 'system',
+      content: 'For the next turn, verify every compatibility claim.',
+      providerOptions: {
+        anthropic: {
+          clearAt: 'next_user_message',
+          effort: 'high',
+        },
+      },
+    },
+    {
+      role: 'user',
+      content: 'Complete the plan.',
+    },
+  ],
+});
+```
+
+An effort-only system message can use an empty content array at the API level;
+in an AI SDK prompt, set `content: ''`. The provider serializes it as
+`content: []`.
+
+<Note>
+  `clearAt` and per-message `effort` apply only to mid-conversation system
+  messages. When used on the initial system message, the provider ignores them
+  and emits a warning. Use the top-level `effort` provider option to configure
+  effort for the full request.
+</Note>
+
 ### Mid-Conversation Tool Changes
 
 With `claude-opus-4-8`, you can add or remove tools between turns of a conversation without invalidating the prompt cache. Attach `toolChanges` to a system message that appears mid-conversation (right before an assistant message or at the end of the messages). The required `mid-conversation-tool-changes-2026-07-01` beta header is added automatically.
@@ -1760,6 +1867,7 @@ and the `mediaType` should be set to `'application/pdf'`.
 | ------------------- | ----------- | ----------------- | ---------- | ------------ | ---------- | ----------- | ---------- |
 | `claude-opus-5`     | <Check />   | <Check />         | <Check />  | <Check />    | <Check />  | <Check />   | <Check />  |
 | `claude-sonnet-5`   | <Check />   | <Check />         | <Check />  | <Check />    | <Check />  | <Check />   | <Check />  |
+| `claude-fable-5-1`  | <Check />   | <Check />         | <Check />  | <Check />    | <Check />  | <Check />   | <Check />  |
 | `claude-fable-5`    | <Check />   | <Check />         | <Check />  | <Check />    | <Check />  | <Check />   | <Check />  |
 | `claude-opus-4-8`   | <Check />   | <Check />         | <Check />  | <Check />    | <Check />  | <Check />   | <Check />  |
 | `claude-opus-4-7`   | <Check />   | <Check />         | <Check />  | <Check />    | <Check />  | <Check />   | <Check />  |

--- a/content/providers/01-ai-sdk-providers/index.mdx
+++ b/content/providers/01-ai-sdk-providers/index.mdx
@@ -43,6 +43,7 @@ Not all providers support all AI SDK features. Here's a quick comparison of the 
 | [OpenAI](/providers/ai-sdk-providers/openai)               | `gpt-4o`                                            | <Check />   | <Check />         | <Check />  | <Check />      |
 | [OpenAI](/providers/ai-sdk-providers/openai)               | `gpt-4o-mini`                                       | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Anthropic](/providers/ai-sdk-providers/anthropic)         | `claude-sonnet-5`                                   | <Check />   | <Check />         | <Check />  | <Check />      |
+| [Anthropic](/providers/ai-sdk-providers/anthropic)         | `claude-fable-5-1`                                  | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Anthropic](/providers/ai-sdk-providers/anthropic)         | `claude-fable-5`                                    | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Anthropic](/providers/ai-sdk-providers/anthropic)         | `claude-opus-4-8`                                   | <Check />   | <Check />         | <Check />  | <Check />      |
 | [Anthropic](/providers/ai-sdk-providers/anthropic)         | `claude-opus-4-7`                                   | <Check />   | <Check />         | <Check />  | <Check />      |

--- a/examples/ai-functions/src/generate-text/anthropic/claude-fable-5-1-mid-conversation-system.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/claude-fable-5-1-mid-conversation-system.ts
@@ -18,19 +18,18 @@ run(async () => {
           'Today we are launching a faster way to build developer tools.',
       },
       {
+        role: 'user',
+        content: 'Rewrite and finalize the announcement.',
+      },
+      {
         role: 'system',
         content:
           'For the next turn only, verify every claim and use high effort.',
         providerOptions: {
           anthropic: {
             clearAt: 'next_user_message',
-            effort: 'high',
           },
         },
-      },
-      {
-        role: 'user',
-        content: 'Rewrite and finalize the announcement.',
       },
     ],
   });

--- a/examples/ai-functions/src/generate-text/anthropic/claude-fable-5-1-mid-conversation-system.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/claude-fable-5-1-mid-conversation-system.ts
@@ -1,0 +1,40 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: anthropic('claude-fable-5-1'),
+    allowSystemInMessages: true,
+    messages: [
+      {
+        role: 'user',
+        content: 'Draft a short launch announcement for a developer tool.',
+      },
+      {
+        role: 'assistant',
+        content:
+          'Today we are launching a faster way to build developer tools.',
+      },
+      {
+        role: 'system',
+        content:
+          'For the next turn only, verify every claim and use high effort.',
+        providerOptions: {
+          anthropic: {
+            clearAt: 'next_user_message',
+            effort: 'high',
+          },
+        },
+      },
+      {
+        role: 'user',
+        content: 'Rewrite and finalize the announcement.',
+      },
+    ],
+  });
+
+  print('Text:', result.text);
+  print('Request:', result.request.body);
+});

--- a/examples/ai-functions/src/generate-text/anthropic/claude-fable-5-1-thinking-binding.ts
+++ b/examples/ai-functions/src/generate-text/anthropic/claude-fable-5-1-thinking-binding.ts
@@ -1,0 +1,25 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: anthropic('claude-fable-5-1'),
+    providerOptions: {
+      anthropic: {
+        thinking: {
+          blockBinding: {
+            prefixMismatchBehavior: 'drop_block',
+          },
+        },
+      },
+    },
+    prompt:
+      'Analyze whether this API change is backwards compatible: an optional response field is added.',
+  });
+
+  print('Reasoning:', result.reasoning);
+  print('Text:', result.text);
+  print('Request:', result.request.body);
+});

--- a/examples/ai-functions/src/stream-text/anthropic/claude-fable-5-1-mid-conversation-system.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/claude-fable-5-1-mid-conversation-system.ts
@@ -18,19 +18,18 @@ run(async () => {
         content: 'First, inventory the public API and current test coverage.',
       },
       {
+        role: 'user',
+        content: 'Continue with the complete plan.',
+      },
+      {
         role: 'system',
         content:
           'For the next turn only, inspect edge cases with xhigh effort.',
         providerOptions: {
           anthropic: {
             clearAt: 'next_user_message',
-            effort: 'xhigh',
           },
         },
-      },
-      {
-        role: 'user',
-        content: 'Continue with the complete plan.',
       },
     ],
   });

--- a/examples/ai-functions/src/stream-text/anthropic/claude-fable-5-1-mid-conversation-system.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/claude-fable-5-1-mid-conversation-system.ts
@@ -1,0 +1,40 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { streamText } from 'ai';
+import { print } from '../../lib/print';
+import { printFullStream } from '../../lib/print-full-stream';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: anthropic('claude-fable-5-1'),
+    allowSystemInMessages: true,
+    messages: [
+      {
+        role: 'user',
+        content: 'Suggest a migration plan for a small TypeScript library.',
+      },
+      {
+        role: 'assistant',
+        content: 'First, inventory the public API and current test coverage.',
+      },
+      {
+        role: 'system',
+        content:
+          'For the next turn only, inspect edge cases with xhigh effort.',
+        providerOptions: {
+          anthropic: {
+            clearAt: 'next_user_message',
+            effort: 'xhigh',
+          },
+        },
+      },
+      {
+        role: 'user',
+        content: 'Continue with the complete plan.',
+      },
+    ],
+  });
+
+  await printFullStream({ result });
+  print('Request:', await result.request);
+});

--- a/examples/ai-functions/src/stream-text/anthropic/claude-fable-5-1-thinking-updates.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/claude-fable-5-1-thinking-updates.ts
@@ -1,0 +1,27 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import { isStepCount, streamText } from 'ai';
+import { printFullStream } from '../../lib/print-full-stream';
+import { run } from '../../lib/run';
+import { weatherTool } from '../../tools/weather-tool';
+
+run(async () => {
+  const result = streamText({
+    model: anthropic('claude-fable-5-1'),
+    stopWhen: isStepCount(5),
+    tools: {
+      weather: weatherTool,
+    },
+    providerOptions: {
+      anthropic: {
+        thinking: {
+          type: 'adaptive',
+          display: 'updates',
+        },
+      },
+    },
+    prompt:
+      'Compare the weather in San Francisco and New York, then recommend where to hold an outdoor event.',
+  });
+
+  await printFullStream({ result });
+});

--- a/packages/anthropic/src/anthropic-api.ts
+++ b/packages/anthropic/src/anthropic-api.ts
@@ -24,6 +24,10 @@ export type AnthropicCacheControl = {
 export interface AnthropicSystemMessage {
   role: 'system';
   content: Array<AnthropicTextContent | AnthropicToolChangeContent>;
+  clear_at?: 'next_user_message';
+  output_config?: {
+    effort: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+  };
 }
 
 /**

--- a/packages/anthropic/src/anthropic-language-model-options.ts
+++ b/packages/anthropic/src/anthropic-language-model-options.ts
@@ -21,6 +21,7 @@ export type AnthropicModelId =
   | 'claude-opus-4-8'
   | 'claude-opus-5'
   | 'claude-fable-5'
+  | 'claude-fable-5-1'
   | 'claude-sonnet-5'
   | (string & {});
 
@@ -70,6 +71,22 @@ export type AnthropicFilePartProviderOptions = z.infer<
  * Anthropic provider options for system messages.
  */
 export const anthropicSystemMessageProviderOptions = z.object({
+  /**
+   * Controls when an ephemeral mid-conversation system message is cleared.
+   *
+   * Only supported on system messages that appear mid-conversation.
+   * The required `mid-conversation-system-clear-at-2026-08-21` beta is
+   * added automatically.
+   */
+  clearAt: z.literal('next_user_message').optional(),
+
+  /**
+   * Sets the model effort for the turn that follows this mid-conversation
+   * system message. The required `mid-conversation-effort-2026-08-01` beta
+   * is added automatically.
+   */
+  effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
+
   /**
    * Mid-conversation tool changes. Adds or removes tools from the
    * conversation's tool set between turns without invalidating the prompt
@@ -128,24 +145,42 @@ export const anthropicLanguageModelOptions = z.object({
    * Requires a minimum budget of 1,024 tokens and counts towards the `max_tokens` limit.
    */
   thinking: z
-    .discriminatedUnion('type', [
+    .union([
+      z.discriminatedUnion('type', [
+        z.object({
+          /** for Sonnet 4.6, Opus 4.6, and newer models */
+          type: z.literal('adaptive'),
+          /**
+           * Controls whether thinking content is included in the response.
+           * - `"omitted"`: Thinking blocks are present but text is empty (default for Opus 4.7+).
+           * - `"summarized"`: Thinking content is returned.
+           * - `"updates"`: Thinking updates are returned between tool calls.
+           */
+          display: z.enum(['omitted', 'summarized', 'updates']).optional(),
+          /**
+           * Controls how thinking blocks are bound to an existing thinking
+           * prefix. Requires the `thinking-binding-controls-2026-08-01` beta.
+           */
+          blockBinding: z
+            .object({
+              prefixMismatchBehavior: z.literal('drop_block'),
+            })
+            .optional(),
+        }),
+        z.object({
+          /** for models before Opus 4.6, except Sonnet 4.6 still supports it */
+          type: z.literal('enabled'),
+          budgetTokens: z.number().optional(),
+        }),
+        z.object({
+          type: z.literal('disabled'),
+        }),
+      ]),
       z.object({
-        /** for Sonnet 4.6, Opus 4.6, and newer models */
-        type: z.literal('adaptive'),
-        /**
-         * Controls whether thinking content is included in the response.
-         * - `"omitted"`: Thinking blocks are present but text is empty (default for Opus 4.7+).
-         * - `"summarized"`: Thinking content is returned. Required to see reasoning output.
-         */
-        display: z.enum(['omitted', 'summarized']).optional(),
-      }),
-      z.object({
-        /** for models before Opus 4.6, except Sonnet 4.6 still supports it */
-        type: z.literal('enabled'),
-        budgetTokens: z.number().optional(),
-      }),
-      z.object({
-        type: z.literal('disabled'),
+        type: z.never().optional(),
+        blockBinding: z.object({
+          prefixMismatchBehavior: z.literal('drop_block'),
+        }),
       }),
     ])
     .optional(),

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -11851,6 +11851,9 @@ describe('claude-opus-4-7 specific behavior', () => {
       type: 'adaptive',
       display: 'updates',
     });
+    expect(server.calls[0].requestHeaders['anthropic-beta']).toContain(
+      'thinking-display-updates-2026-08-18',
+    );
   });
 
   it('should serialize thinking binding controls and add the beta header', async () => {

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -1200,6 +1200,36 @@ describe('AnthropicLanguageModel', () => {
       });
     });
 
+    it('should use native structured output by default for claude-fable-5', async () => {
+      prepareJsonFixtureResponse('anthropic-json-output-format.1');
+
+      await provider('claude-fable-5').doGenerate({
+        prompt: TEST_PROMPT,
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            required: ['name'],
+            additionalProperties: false,
+          },
+        },
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.output_config?.format).toEqual({
+        type: 'json_schema',
+        schema: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+          additionalProperties: false,
+        },
+      });
+      expect(requestBody.tools).toBeUndefined();
+      expect(requestBody.tool_choice).toBeUndefined();
+    });
+
     it('should sanitize unsupported JSON schema keywords for output format', async () => {
       prepareJsonFixtureResponse('anthropic-json-output-format.1');
 
@@ -7485,6 +7515,69 @@ describe('AnthropicLanguageModel', () => {
       `);
     });
 
+    it('should stream thinking updates between tool calls', async () => {
+      server.urls['https://api.anthropic.com/v1/messages'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: {"type":"message_start","message":{"id":"msg_updates","type":"message","role":"assistant","content":[],"model":"claude-fable-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}\n\n`,
+          `data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"First update"}}\n\n`,
+          `data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-1"}}\n\n`,
+          `data: {"type":"content_block_stop","index":0}\n\n`,
+          `data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tool-1","name":"lookup","input":{}}}\n\n`,
+          `data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{}"}}\n\n`,
+          `data: {"type":"content_block_stop","index":1}\n\n`,
+          `data: {"type":"content_block_start","index":2,"content_block":{"type":"thinking","thinking":""}}\n\n`,
+          `data: {"type":"content_block_delta","index":2,"delta":{"type":"thinking_delta","thinking":"Second update"}}\n\n`,
+          `data: {"type":"content_block_delta","index":2,"delta":{"type":"signature_delta","signature":"sig-2"}}\n\n`,
+          `data: {"type":"content_block_stop","index":2}\n\n`,
+          `data: {"type":"content_block_start","index":3,"content_block":{"type":"text","text":""}}\n\n`,
+          `data: {"type":"content_block_delta","index":3,"delta":{"type":"text_delta","text":"Done"}}\n\n`,
+          `data: {"type":"content_block_stop","index":3}\n\n`,
+          `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":20}}\n\n`,
+          `data: {"type":"message_stop"}\n\n`,
+        ],
+      };
+
+      const { stream } = await provider('claude-fable-5').doStream({
+        prompt: TEST_PROMPT,
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+        providerOptions: {
+          anthropic: {
+            thinking: { type: 'adaptive', display: 'updates' },
+          } satisfies AnthropicLanguageModelOptions,
+        },
+      });
+
+      const result = await convertReadableStreamToArray(stream);
+      expect(
+        result.flatMap<{
+          type: 'reasoning-start' | 'reasoning-delta';
+          id: string;
+          delta?: string;
+        }>(part => {
+          if (part.type === 'reasoning-start') {
+            return [{ type: part.type, id: part.id }];
+          }
+          if (part.type === 'reasoning-delta' && part.delta !== '') {
+            return [{ type: part.type, id: part.id, delta: part.delta }];
+          }
+          return [];
+        }),
+      ).toEqual([
+        { type: 'reasoning-start', id: '0' },
+        { type: 'reasoning-delta', id: '0', delta: 'First update' },
+        { type: 'reasoning-start', id: '2' },
+        { type: 'reasoning-delta', id: '2', delta: 'Second update' },
+      ]);
+    });
+
     it('should stream redacted reasoning', async () => {
       server.urls['https://api.anthropic.com/v1/messages'].response = {
         type: 'stream-chunks',
@@ -11547,6 +11640,42 @@ describe('mid-conversation tool changes', () => {
       'mid-conversation-tool-changes-2026-07-01',
     );
   });
+
+  it('should send clearAt and per-turn effort with their beta headers', async () => {
+    prepareJsonFixtureResponse('anthropic-text');
+
+    await provider('claude-fable-5').doGenerate({
+      prompt: [
+        { role: 'user', content: [{ type: 'text', text: 'Draft an answer.' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'Draft.' }] },
+        {
+          role: 'system',
+          content: '',
+          providerOptions: {
+            anthropic: {
+              clearAt: 'next_user_message',
+              effort: 'xhigh',
+            },
+          },
+        },
+        { role: 'user', content: [{ type: 'text', text: 'Now finalize it.' }] },
+      ],
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody.messages).toContainEqual({
+      role: 'system',
+      content: [],
+      clear_at: 'next_user_message',
+      output_config: { effort: 'xhigh' },
+    });
+    expect(server.calls[0].requestHeaders['anthropic-beta']).toContain(
+      'mid-conversation-system-clear-at-2026-08-21',
+    );
+    expect(server.calls[0].requestHeaders['anthropic-beta']).toContain(
+      'mid-conversation-effort-2026-08-01',
+    );
+  });
 });
 
 describe('claude-opus-4-7 specific behavior', () => {
@@ -11703,5 +11832,51 @@ describe('claude-opus-4-7 specific behavior', () => {
       type: 'adaptive',
       display: 'summarized',
     });
+  });
+
+  it('should include the updates thinking display mode', async () => {
+    prepareJsonFixtureResponse('anthropic-text');
+
+    await opusModel.doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      providerOptions: {
+        anthropic: {
+          thinking: { type: 'adaptive', display: 'updates' },
+        } satisfies AnthropicLanguageModelOptions,
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody.thinking).toEqual({
+      type: 'adaptive',
+      display: 'updates',
+    });
+  });
+
+  it('should serialize thinking binding controls and add the beta header', async () => {
+    prepareJsonFixtureResponse('anthropic-text');
+
+    await provider('claude-fable-5').doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      providerOptions: {
+        anthropic: {
+          thinking: {
+            blockBinding: {
+              prefixMismatchBehavior: 'drop_block',
+            },
+          },
+        } satisfies AnthropicLanguageModelOptions,
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+    expect(requestBody.thinking).toEqual({
+      block_binding: {
+        prefix_mismatch_behavior: 'drop_block',
+      },
+    });
+    expect(server.calls[0].requestHeaders['anthropic-beta']).toContain(
+      'thinking-binding-controls-2026-08-01',
+    );
   });
 });

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -535,10 +535,17 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
     const thinkingType = anthropicOptions?.thinking?.type;
     const isThinking =
       thinkingType === 'enabled' || thinkingType === 'adaptive';
+    const thinkingBlockBinding =
+      anthropicOptions?.thinking != null &&
+      'blockBinding' in anthropicOptions.thinking
+        ? anthropicOptions.thinking.blockBinding
+        : undefined;
     // `disabled` must still be forwarded to the API: some models (e.g. Sonnet 5)
     // default thinking on, so omitting it would leave thinking enabled and
-    // consume the max_tokens budget.
-    const sendThinking = isThinking || thinkingType === 'disabled';
+    // consume the max_tokens budget. Binding-only recovery requests must also
+    // send a thinking object without a type.
+    const sendThinking =
+      isThinking || thinkingType === 'disabled' || thinkingBlockBinding != null;
     let thinkingBudget =
       thinkingType === 'enabled'
         ? anthropicOptions?.thinking?.budgetTokens
@@ -564,9 +571,15 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
       // provider specific settings:
       ...(sendThinking && {
         thinking: {
-          type: thinkingType,
+          ...(thinkingType != null && { type: thinkingType }),
           ...(thinkingBudget != null && { budget_tokens: thinkingBudget }),
           ...(thinkingDisplay != null && { display: thinkingDisplay }),
+          ...(thinkingBlockBinding != null && {
+            block_binding: {
+              prefix_mismatch_behavior:
+                thinkingBlockBinding.prefixMismatchBehavior,
+            },
+          }),
         },
       }),
       ...((anthropicOptions?.effort ||
@@ -841,6 +854,10 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
 
     if (anthropicOptions?.speed === 'fast') {
       betas.add('fast-mode-2026-02-01');
+    }
+
+    if (thinkingBlockBinding != null) {
+      betas.add('thinking-binding-controls-2026-08-01');
     }
 
     if (anthropicOptions?.fallbacks === 'default') {

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -856,6 +856,10 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
       betas.add('fast-mode-2026-02-01');
     }
 
+    if (thinkingDisplay === 'updates') {
+      betas.add('thinking-display-updates-2026-08-18');
+    }
+
     if (thinkingBlockBinding != null) {
       betas.add('thinking-binding-controls-2026-08-01');
     }

--- a/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.test.ts
@@ -73,6 +73,49 @@ describe('system messages', () => {
     expect(result.betas.has('mid-conversation-system-2026-04-07')).toBe(true);
   });
 
+  it('should serialize clearAt and effort on individual mid-conversation system messages', async () => {
+    const result = await convertToAnthropicPrompt({
+      prompt: [
+        { role: 'system', content: 'initial' },
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+        {
+          role: 'system',
+          content: '',
+          providerOptions: {
+            anthropic: {
+              clearAt: 'next_user_message',
+              effort: 'high',
+            },
+          },
+        },
+        {
+          role: 'system',
+          content: 'this instruction persists',
+        },
+        { role: 'user', content: [{ type: 'text', text: 'go' }] },
+      ],
+      sendReasoning: true,
+      warnings: [],
+      toolNameMapping: defaultToolNameMapping,
+    });
+
+    expect(result.prompt.messages).toContainEqual({
+      role: 'system',
+      content: [],
+      clear_at: 'next_user_message',
+      output_config: { effort: 'high' },
+    });
+    expect(result.prompt.messages).toContainEqual({
+      role: 'system',
+      content: [{ type: 'text', text: 'this instruction persists' }],
+    });
+    expect(
+      result.betas.has('mid-conversation-system-clear-at-2026-08-21'),
+    ).toBe(true);
+    expect(result.betas.has('mid-conversation-effort-2026-08-01')).toBe(true);
+  });
+
   it('should emit tool change blocks on a mid-conversation system message and add the beta', async () => {
     const result = await convertToAnthropicPrompt({
       prompt: [

--- a/packages/anthropic/src/convert-to-anthropic-prompt.ts
+++ b/packages/anthropic/src/convert-to-anthropic-prompt.ts
@@ -144,8 +144,12 @@ export async function convertToAnthropicPrompt({
 
     switch (type) {
       case 'system': {
-        const content: AnthropicSystemMessage['content'] = [];
-        let toolChangeCount = 0;
+        const convertedMessages: Array<{
+          content: AnthropicSystemMessage['content'];
+          clearAt?: 'next_user_message';
+          effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+          toolChangeCount: number;
+        }> = [];
 
         for (const { content: text, providerOptions } of block.messages) {
           const systemMessageOptions = await parseProviderOptions({
@@ -154,10 +158,16 @@ export async function convertToAnthropicPrompt({
             schema: anthropicSystemMessageProviderOptions,
           });
           const toolChanges = systemMessageOptions?.toolChanges ?? [];
+          const content: AnthropicSystemMessage['content'] = [];
 
-          // A system message that only carries tool changes may have empty
-          // text; do not emit an empty text block for it.
-          if (text !== '' || toolChanges.length === 0) {
+          // A system message that only carries message-level controls may have
+          // empty text; do not emit an empty text block for it.
+          if (
+            text !== '' ||
+            (toolChanges.length === 0 &&
+              systemMessageOptions?.clearAt == null &&
+              systemMessageOptions?.effort == null)
+          ) {
             content.push({
               type: 'text' as const,
               text,
@@ -169,7 +179,6 @@ export async function convertToAnthropicPrompt({
           }
 
           for (const toolChange of toolChanges) {
-            toolChangeCount++;
             content.push({
               type: toolChange.type,
               tool: {
@@ -178,6 +187,13 @@ export async function convertToAnthropicPrompt({
               },
             } satisfies AnthropicToolChangeContent);
           }
+
+          convertedMessages.push({
+            content,
+            clearAt: systemMessageOptions?.clearAt,
+            effort: systemMessageOptions?.effort,
+            toolChangeCount: toolChanges.length,
+          });
         }
 
         // The first block becomes the top-level system prompt. Later system
@@ -185,7 +201,17 @@ export async function convertToAnthropicPrompt({
         // tool changes (which are only valid mid-conversation), and otherwise
         // only when a top-level system prompt already exists (preserving the
         // existing hoisting behavior for plain text).
-        if (i === 0 || (system == null && toolChangeCount === 0)) {
+        const toolChangeCount = convertedMessages.reduce(
+          (count, message) => count + message.toolChangeCount,
+          0,
+        );
+        const hasInlineSystemOptions = convertedMessages.some(
+          message => message.clearAt != null || message.effort != null,
+        );
+        if (
+          i === 0 ||
+          (system == null && toolChangeCount === 0 && !hasInlineSystemOptions)
+        ) {
           if (toolChangeCount > 0) {
             warnings.push({
               type: 'other',
@@ -195,14 +221,45 @@ export async function convertToAnthropicPrompt({
                 'The tool changes have been ignored.',
             });
           }
-          system = content.filter(
-            (part): part is AnthropicTextContent => part.type === 'text',
+
+          for (const message of convertedMessages) {
+            if (message.clearAt != null || message.effort != null) {
+              warnings.push({
+                type: 'other',
+                message:
+                  'clearAt and effort on the initial system message are not supported by Anthropic. ' +
+                  'These options have been ignored.',
+              });
+            }
+          }
+
+          system = convertedMessages.flatMap(message =>
+            message.content.filter(
+              (part): part is AnthropicTextContent => part.type === 'text',
+            ),
           );
         } else {
-          messages.push({ role: 'system', content });
           betas.add('mid-conversation-system-2026-04-07');
-          if (toolChangeCount > 0) {
-            betas.add('mid-conversation-tool-changes-2026-07-01');
+
+          for (const message of convertedMessages) {
+            messages.push({
+              role: 'system',
+              content: message.content,
+              ...(message.clearAt != null && { clear_at: message.clearAt }),
+              ...(message.effort != null && {
+                output_config: { effort: message.effort },
+              }),
+            });
+
+            if (message.toolChangeCount > 0) {
+              betas.add('mid-conversation-tool-changes-2026-07-01');
+            }
+            if (message.clearAt != null) {
+              betas.add('mid-conversation-system-clear-at-2026-08-21');
+            }
+            if (message.effort != null) {
+              betas.add('mid-conversation-effort-2026-08-01');
+            }
           }
         }
 

--- a/packages/gateway/src/gateway-language-model-settings.ts
+++ b/packages/gateway/src/gateway-language-model-settings.ts
@@ -34,6 +34,7 @@ export type GatewayModelId =
   | 'amazon/nova-pro'
   | 'anthropic/claude-3-haiku'
   | 'anthropic/claude-fable-5'
+  | 'anthropic/claude-fable-5-1'
   | 'anthropic/claude-haiku-4.5'
   | 'anthropic/claude-opus-4'
   | 'anthropic/claude-opus-4.5'


### PR DESCRIPTION
## Background

Anthropic launched the new Fable 5.1 model

## Summary

- add the provider model id changes
- new API changes

## End-to-End Verification

verified by running the examples in the PR

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)