### PR TITLE
[v6.0] chore(deps): bump jsondiffpatch from 0.7.3 to 0.7.6

### DIFF
--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -47,7 +47,7 @@
     "ai": "workspace:*",
     "@ai-sdk/provider": "workspace:*",
     "@ai-sdk/provider-utils": "workspace:*",
-    "jsondiffpatch": "0.7.3"
+    "jsondiffpatch": "0.7.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2987,8 +2987,8 @@ importers:
         specifier: workspace:*
         version: link:../ai
       jsondiffpatch:
-        specifier: 0.7.3
-        version: 0.7.3
+        specifier: 0.7.6
+        version: 0.7.6
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.6.3
@@ -15134,8 +15134,8 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
-  jsondiffpatch@0.7.3:
-    resolution: {integrity: sha512-zd4dqFiXSYyant2WgSXAZ9+yYqilNVvragVNkNRn2IFZKgjyULNrKRznqN4Zon0MkLueCg+3QaPVCnDAVP20OQ==}
+  jsondiffpatch@0.7.6:
+    resolution: {integrity: sha512-zE9+AXFq+MkTolDor2Cw1nJzLC0aleqPkYf52Kb4Kn4mJcka/gFHpGI2JBVEJCfWOvBl0OoxZS+wuLdislQcqg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
@@ -34861,7 +34861,7 @@ snapshots:
 
   jsonc-parser@3.3.1: {}
 
-  jsondiffpatch@0.7.3:
+  jsondiffpatch@0.7.6:
     dependencies:
       '@dmsnell/diff-match-patch': 1.1.0
 


### PR DESCRIPTION
Backports #20062 to the v6 release branch.

Updates the RSC package and lockfile from jsondiffpatch 0.7.3 to 0.7.6.

Validation:
- `pnpm --filter @ai-sdk/rsc type-check`
- `pnpm --filter @ai-sdk/rsc test:node` (21 tests)