### PR TITLE
[v5.0] chore(deps): upgrade shell-quote to 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
       "esbuild"
     ],
     "overrides": {
+      "shell-quote": "1.10.0",
       "tinyexec": "1.0.2",
       "tar": "7.5.19"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  shell-quote: 1.10.0
   tinyexec: 1.0.2
   tar: 7.5.19
 
@@ -17394,8 +17395,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   shiki@3.13.0:
@@ -29976,7 +29977,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.10.0
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -33616,7 +33617,7 @@ snapshots:
   launch-editor@2.9.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.10.0
 
   layout-base@1.0.2: {}
 
@@ -37481,7 +37482,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.10.0: {}
 
   shiki@3.13.0:
     dependencies:


### PR DESCRIPTION
Backport of #20162 for VULN-13939.

Pins shell-quote to 1.10.0 so the v5 dependency graph no longer resolves the vulnerable 1.8.3 release.

Validation:
- pnpm install --frozen-lockfile --lockfile-only
- pnpm why -r shell-quote