### PR TITLE
fix(provider-utils): update undici for CVE-2026-13697

### DIFF
--- a/.changeset/green-pumas-fetch.md
+++ b/.changeset/green-pumas-fetch.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+Update Undici to a version patched for CVE-2026-13697.

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -93,7 +93,7 @@
     "mathjs": "^15.2.0",
     "sharp": "^0.33.5",
     "terminal-image": "^2.0.0",
-    "undici": "^8.5.0",
+    "undici": "^8.9.0",
     "valibot": "1.1.0",
     "workflow": "5.0.0-beta.42",
     "ws": "^8.21.0",

--- a/packages/provider-utils/package.json
+++ b/packages/provider-utils/package.json
@@ -47,7 +47,7 @@
     "@standard-schema/spec": "^1.1.0",
     "@workflow/serde": "4.1.0",
     "eventsource-parser": "^3.0.8",
-    "undici": "^7.28.0"
+    "undici": "^7.29.0"
   },
   "devDependencies": {
     "@types/node": "22.19.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   tinyexec: 1.0.2
   oxlint: 1.56.0
   tar: 7.5.19
+  '@workflow/world-local@4>undici': 7.29.0
+  '@workflow/world-vercel@4>undici': 7.29.0
 
 importers:
 
@@ -577,8 +579,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(debug@4.4.3(supports-color@8.1.1))
       undici:
-        specifier: ^8.5.0
-        version: 8.5.0
+        specifier: ^8.9.0
+        version: 8.9.0
       valibot:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.8.3)
@@ -3779,8 +3781,8 @@ importers:
         specifier: ^3.0.8
         version: 3.0.8
       undici:
-        specifier: ^7.28.0
-        version: 7.28.0
+        specifier: ^7.29.0
+        version: 7.29.0
     devDependencies:
       '@types/node':
         specifier: 22.19.19
@@ -23670,17 +23672,9 @@ packages:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
-
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
-    engines: {node: '>=22.19.0'}
 
   undici@8.9.0:
     resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
@@ -38656,7 +38650,7 @@ snapshots:
       '@workflow/world': 4.2.1
       async-sema: 3.1.1
       ulid: 3.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       zod: 4.3.6
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -38682,7 +38676,7 @@ snapshots:
       '@workflow/errors': 4.1.4
       '@workflow/world': 4.2.1
       cbor-x: 1.6.0
-      undici: 7.28.0
+      undici: 7.29.0
       zod: 4.3.6
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -50664,11 +50658,7 @@ snapshots:
 
   undici@6.28.0: {}
 
-  undici@7.28.0: {}
-
   undici@7.29.0: {}
-
-  undici@8.5.0: {}
 
   undici@8.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,8 @@ overrides:
   tinyexec: 1.0.2
   oxlint: 1.56.0
   tar: 7.5.19
+  '@workflow/world-local@4>undici': 7.29.0
+  '@workflow/world-vercel@4>undici': 7.29.0
 
 minimumReleaseAge: 4320 # 3 days
 


### PR DESCRIPTION
## Summary

- update `@ai-sdk/provider-utils` from Undici 7.28 to the patched 7.29 release
- update the ai-functions example workspace from Undici 8.5 to the patched 8.9 release
- override the exact Undici 7.28 pins in Workflow v4's local and Vercel world packages
- add a patch changeset for `@ai-sdk/provider-utils`

This addresses [VULN-13682](https://linear.app/vercel/issue/VULN-13682/dependency-vulnerability-cve-2026-13697-affects-undici7280-in) / CVE-2026-13697 (GHSA-4cwx-7wf7-3272). The vulnerable 7.28 and 8.5 releases are no longer present in the lockfile.

## Compatibility

- stays within each consumer's current Undici major
- preserves Node engine requirements: Undici 7.28 and 7.29 both require Node >=20.18.1; Undici 8.5 and 8.9 both require Node >=22.19.0
- keeps provider-utils on Undici 7 because moving it to 8 would conflict with the repository's supported Node 22.13 floor
- verified the provider-utils `Agent` + custom DNS lookup + `fetch` path against 7.29
- verified the ai-functions `Agent` + `fetch` path against 8.9
- verified Workflow v4's affected dependency paths against 7.29 through the workflow-harness tests

## Verification

- `pnpm audit --json` (CVE-2026-13697 / GHSA-4cwx-7wf7-3272 absent)
- `pnpm --filter @ai-sdk/provider-utils test:node` (842 tests)
- `pnpm --filter @ai-sdk/provider-utils type-check`
- `pnpm --filter @ai-sdk/workflow-harness test:node` (15 tests)
- `pnpm --filter @ai-sdk/workflow-harness type-check`
- `pnpm --filter @example/ai-functions type-check`
- `pnpm type-check:full`
- `pnpm check`
