### PR TITLE
fix(examples): update undici for CVE-2026-13697

### DIFF
--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -69,7 +69,7 @@
     "mathjs": "14.0.0",
     "sharp": "^0.33.5",
     "terminal-image": "^2.0.0",
-    "undici": "^7.21.0",
+    "undici": "^7.29.0",
     "valibot": "1.1.0",
     "zod": "3.25.76"
   },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "overrides": {
       "shell-quote": "1.10.0",
       "tinyexec": "1.0.2",
-      "tar": "7.5.19"
+      "tar": "7.5.19",
+      "@vercel/sandbox@0.0.21>undici": "7.29.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   shell-quote: 1.10.0
   tinyexec: 1.0.2
   tar: 7.5.19
+  '@vercel/sandbox@0.0.21>undici': 7.29.0
 
 importers:
 
@@ -408,8 +409,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       undici:
-        specifier: ^7.21.0
-        version: 7.22.0
+        specifier: ^7.29.0
+        version: 7.29.0
       valibot:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.8.3)
@@ -19180,8 +19181,8 @@ packages:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@1.10.0:
@@ -29851,7 +29852,7 @@ snapshots:
       jsonlines: 0.1.1
       ms: 2.1.3
       tar-stream: 3.1.7
-      undici: 7.22.0
+      undici: 7.29.0
       zod: 3.24.4
 
   '@vitejs/plugin-basic-ssl@2.1.0(vite@7.1.11(@types/node@20.17.24)(jiti@2.6.1)(less@4.4.0)(lightningcss@1.31.1)(sass@1.90.0)(terser@5.43.1)(tsx@4.19.2)(yaml@2.7.0))':
@@ -40412,7 +40413,7 @@ snapshots:
 
   undici@6.28.0: {}
 
-  undici@7.22.0: {}
+  undici@7.29.0: {}
 
   unenv@1.10.0:
     dependencies:


### PR DESCRIPTION
## Summary

- update the v6 ai-functions example from Undici 7.22 to the patched 7.29 release
- add a scoped override so `@vercel/sandbox@0.0.21` also resolves its compatible `^7.16.0` dependency to 7.29
- remove the vulnerable Undici 7.22 release from the v6 lockfile

This backports the repository-level fix for [VULN-13682](https://linear.app/vercel/issue/VULN-13682/dependency-vulnerability-cve-2026-13697-affects-undici7280-in) / CVE-2026-13697 (GHSA-4cwx-7wf7-3272). The published v6 `@ai-sdk/provider-utils` dependency remains on unaffected Undici 6.28, so no published package or changeset is involved.

## Compatibility

- stays on Undici 7 and preserves the existing Node >=20.18.1 engine requirement
- the ai-functions examples use `Agent` and `fetch`; their type-check and a loopback runtime smoke test pass on 7.29
- the old sandbox package declares Undici `^7.16.0`, so the scoped 7.29 resolution is semver-compatible; its installed `Agent` import resolves to 7.29

## Verification

- frozen lockfile install
- `pnpm audit --json` (CVE-2026-13697 / GHSA-4cwx-7wf7-3272 absent)
- `pnpm --filter @example/ai-functions type-check`
- Undici 7.29 `Agent` + `fetch` loopback smoke test
- `pnpm type-check:full`
- `pnpm check`
