### PR TITLE
fix(mcp): tool results - tolerate structured-only responses

### DIFF
--- a/.changeset/shiny-tools-smile.md
+++ b/.changeset/shiny-tools-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+Accept MCP tool results that return `structuredContent` without `content` by adding the serialized structured result as text.

--- a/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
+++ b/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
@@ -347,7 +347,7 @@ This approach provides full TypeScript type safety and IDE autocompletion, letti
 
 ### Typed Tool Outputs
 
-When MCP servers return `structuredContent` (per the [MCP specification](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content)), you can define an `outputSchema` to get typed tool results:
+When MCP servers return `structuredContent` (per the [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/server/tools#structured-content)), you can define an `outputSchema` to get typed tool results:
 
 ```typescript
 import { z } from 'zod';
@@ -383,6 +383,8 @@ When `outputSchema` is provided:
 - You get full TypeScript type safety for the result
 
 If the server doesn't return `structuredContent`, the client falls back to parsing JSON from the text content. If neither is available or validation fails, an error is thrown.
+
+If a server returns `structuredContent` without the backwards-compatible `content` field, the client adds a text content block containing the serialized JSON before returning the result. This compatibility behavior handles servers that omit the text mirror recommended by the MCP specification.
 
 <Note>
   Without `outputSchema`, the tool returns the raw `CallToolResult` object

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -544,6 +544,34 @@ describe('MCPClient', () => {
     `);
   });
 
+  it('should normalize structured tool results that omit content', async () => {
+    const structuredContent = {
+      products: [{ id: 'gid://shopify/Product/1', title: 'Trail Shoes' }],
+    };
+    client = await createMCPClient({
+      transport: new MockMCPTransport({
+        toolCallResults: {
+          'mock-tool': {
+            structuredContent,
+          } as unknown as CallToolResult,
+        },
+      }),
+    });
+
+    await expect(
+      client.callTool({ name: 'mock-tool', arguments: { foo: 'bar' } }),
+    ).resolves.toEqual({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(structuredContent),
+        },
+      ],
+      structuredContent,
+      isError: false,
+    });
+  });
+
   it('should return tools from all paginated tool list responses', async () => {
     const transport = new PaginatedToolsTransport();
     client = await createMCPClient({ transport });
@@ -668,8 +696,15 @@ describe('MCPClient', () => {
   });
 
   it('should create tools from cached definitions via toolsFromDefinitions()', async () => {
+    const structuredContent = { value: 42 };
     client = await createMCPClient({
-      transport: { type: 'sse', url: 'https://example.com/sse' },
+      transport: new MockMCPTransport({
+        toolCallResults: {
+          'mock-tool': {
+            structuredContent,
+          } as unknown as CallToolResult,
+        },
+      }),
     });
 
     // Get definitions (this would normally be cached)
@@ -688,8 +723,10 @@ describe('MCPClient', () => {
       { foo: 'bar' },
       { messages: [], toolCallId: '1', context: {} },
     );
-    expect(result).toMatchObject({
-      content: [{ type: 'text', text: 'Mock tool call result' }],
+    expect(result).toEqual({
+      content: [{ type: 'text', text: JSON.stringify(structuredContent) }],
+      structuredContent,
+      isError: false,
     });
   });
 
@@ -875,7 +912,7 @@ describe('MCPClient', () => {
             'get-mixed': {
               content: [
                 { type: 'text', text: 'Here is an image:' },
-                { type: 'image', data: 'base64data', mimeType: 'image/png' },
+                { type: 'image', data: 'aGVsbG8=', mimeType: 'image/png' },
               ],
               isError: false,
             },
@@ -900,13 +937,12 @@ describe('MCPClient', () => {
               "type": "text",
             },
             {
-              "data": "base64data",
+              "data": "aGVsbG8=",
               "mimeType": "image/png",
               "type": "image",
             },
           ],
           "isError": false,
-          "toolResult": undefined,
         }
       `);
 
@@ -918,7 +954,7 @@ describe('MCPClient', () => {
         output: {
           content: [
             { type: 'text', text: 'Here is an image:' },
-            { type: 'image', data: 'base64data', mimeType: 'image/png' },
+            { type: 'image', data: 'aGVsbG8=', mimeType: 'image/png' },
           ],
           isError: false,
         },
@@ -933,7 +969,7 @@ describe('MCPClient', () => {
           },
           {
             "data": {
-              "data": "base64data",
+              "data": "aGVsbG8=",
               "type": "data",
             },
             "mediaType": "image/png",
@@ -984,7 +1020,6 @@ describe('MCPClient', () => {
             },
           ],
           "isError": false,
-          "toolResult": undefined,
         }
       `);
 
@@ -1024,9 +1059,9 @@ describe('MCPClient', () => {
           ],
           toolCallResults: {
             'get-raw': {
-              value: 42,
+              toolResult: { value: 42 },
               isError: false,
-            } as unknown as CallToolResult,
+            },
           },
         }),
     );
@@ -1043,8 +1078,9 @@ describe('MCPClient', () => {
     ).toMatchInlineSnapshot(`
         {
           "isError": false,
-          "toolResult": undefined,
-          "value": 42,
+          "toolResult": {
+            "value": 42,
+          },
         }
       `);
 
@@ -1053,14 +1089,16 @@ describe('MCPClient', () => {
       (tool.toModelOutput as Function)({
         toolCallId: '1',
         input: {},
-        output: { value: 42, isError: false },
+        output: { toolResult: { value: 42 }, isError: false },
       }),
     ).toMatchInlineSnapshot(`
       {
         "type": "json",
         "value": {
           "isError": false,
-          "value": 42,
+          "toolResult": {
+            "value": 42,
+          },
         },
       }
     `);
@@ -2367,17 +2405,11 @@ describe('MCPClient', () => {
         ],
         toolCallResults: {
           'weather-tool': {
-            content: [
-              {
-                type: 'text',
-                text: '{"temperature": 22.5, "conditions": "Sunny"}',
-              },
-            ],
             structuredContent: {
               temperature: 22.5,
               conditions: 'Sunny',
             },
-          },
+          } as unknown as CallToolResult,
         },
       });
 

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -1305,7 +1305,10 @@ class DefaultMCPClient implements MCPClient {
 
     // Fallback
     if ('content' in result && Array.isArray(result.content)) {
-      const textContent = result.content.find(c => c.type === 'text');
+      const textContent = result.content.find(
+        (content: { type: string; [key: string]: unknown }) =>
+          content.type === 'text',
+      );
       if (textContent && 'text' in textContent) {
         const parseResult = await safeParseJSON({
           text: textContent.text,

--- a/packages/mcp/src/tool/types.test.ts
+++ b/packages/mcp/src/tool/types.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { CallToolResultSchema } from './types';
+
+describe('CallToolResultSchema', () => {
+  it.each([
+    ['object', { value: 42 }],
+    ['array', [1, 'two', false]],
+    ['string', 'result'],
+    ['number', 42],
+    ['boolean', true],
+    ['null', null],
+  ])('normalizes structured-only results with %s content', (_, value) => {
+    expect(CallToolResultSchema.parse({ structuredContent: value })).toEqual({
+      content: [{ type: 'text', text: JSON.stringify(value) }],
+      structuredContent: value,
+      isError: false,
+    });
+  });
+
+  it('preserves structured-only error results', () => {
+    expect(
+      CallToolResultSchema.parse({
+        structuredContent: { code: 'NOT_FOUND' },
+        isError: true,
+      }),
+    ).toEqual({
+      content: [{ type: 'text', text: '{"code":"NOT_FOUND"}' }],
+      structuredContent: { code: 'NOT_FOUND' },
+      isError: true,
+    });
+  });
+
+  it('preserves results that already contain content', () => {
+    const result = {
+      content: [{ type: 'text' as const, text: 'Existing content' }],
+      structuredContent: { value: 42 },
+    };
+
+    expect(CallToolResultSchema.parse(result)).toEqual({
+      ...result,
+      isError: false,
+    });
+  });
+
+  it.each([{}, { _meta: {} }, { value: 42 }, { toolResult: undefined }])(
+    'rejects results without content, structuredContent, or toolResult',
+    result => {
+      expect(CallToolResultSchema.safeParse(result).success).toBe(false);
+    },
+  );
+
+  it('accepts legacy toolResult responses', () => {
+    expect(CallToolResultSchema.parse({ toolResult: { value: 42 } })).toEqual({
+      toolResult: { value: 42 },
+    });
+  });
+
+  it.each([
+    { content: [{ type: 'text' }] },
+    {
+      content: [{ type: 'image', data: 'not-base64', mimeType: 'image/png' }],
+    },
+  ])('rejects malformed known content types', result => {
+    expect(CallToolResultSchema.safeParse(result).success).toBe(false);
+  });
+
+  it.each([undefined, BigInt(1), Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects non-JSON structured content',
+    structuredContent => {
+      expect(
+        CallToolResultSchema.safeParse({ structuredContent }).success,
+      ).toBe(false);
+    },
+  );
+
+  it('rejects cyclic structured content', () => {
+    const structuredContent: Record<string, unknown> = {};
+    structuredContent.self = structuredContent;
+
+    expect(() => CallToolResultSchema.parse({ structuredContent })).toThrow();
+  });
+});

--- a/packages/mcp/src/tool/types.ts
+++ b/packages/mcp/src/tool/types.ts
@@ -262,24 +262,55 @@ const ResourceLinkContentSchema = z
     mimeType: z.optional(z.string()),
   })
   .loose();
+const UnknownContentSchema = z
+  .object({ type: z.string() })
+  .loose()
+  .refine(
+    content =>
+      !['text', 'image', 'resource', 'resource_link'].includes(content.type),
+    { message: 'Known content types must match their schema' },
+  );
 
-export const CallToolResultSchema = ResultSchema.extend({
+const CallToolResultWithContentSchema = ResultSchema.extend({
   content: z.array(
     z.union([
       TextContentSchema,
       ImageContentSchema,
       EmbeddedResourceSchema,
       ResourceLinkContentSchema,
+      UnknownContentSchema,
     ]),
   ),
   /**
-   * @see https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
+   * @see https://modelcontextprotocol.io/specification/2026-07-28/server/tools#structured-content
    */
   structuredContent: z.optional(z.unknown()),
   isError: z.boolean().default(false).optional(),
-}).or(
+});
+
+const CallToolResultWithStructuredContentSchema = ResultSchema.extend({
+  content: z.never().optional(),
+  structuredContent: z.json(),
+  isError: z.boolean().default(false).optional(),
+})
+  .transform(
+    (result): z.infer<typeof CallToolResultWithContentSchema> => ({
+      ...result,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(result.structuredContent),
+        },
+      ],
+    }),
+  )
+  .pipe(CallToolResultWithContentSchema);
+
+export const CallToolResultSchema = CallToolResultWithContentSchema.or(
+  CallToolResultWithStructuredContentSchema,
+).or(
   ResultSchema.extend({
-    toolResult: z.unknown(),
+    toolResult: z.unknown().nonoptional(),
   }),
 );
 export type CallToolResult = z.infer<typeof CallToolResultSchema>;


### PR DESCRIPTION
## Background

Some MCP servers, including Shopify Global Catalog, return `structuredContent` from `tools/call` without the backwards-compatible `content` field. The MCP client currently rejects those responses during schema validation, before callers can handle the structured result.

## Summary

- Parse structured-only results through a dedicated JSON-value schema, serialize them into a text content block, and pipe the transformed value through the canonical result schema.
- Require the legacy `toolResult` alternative to be genuinely present across supported Zod versions while preserving forward-compatible unknown content types explicitly.
- Cover direct calls, cached tool definitions, typed output schemas, every JSON value kind, error results, invalid serialization, empty-result rejection, and existing result variants.
- Document the compatibility behavior and add a patch changeset for `@ai-sdk/mcp`.

## End-to-End Verification

Called Shopify Global Catalog's live `search_catalog` tool through the patched local package. The call returned `content`, `structuredContent`, and `isError`; the synthesized content contained one text block whose text exactly matched `JSON.stringify(result.structuredContent)`.

Also verified the schema behavior against the repository's Zod 3.25 compatibility layer, native Zod 4.1.8 (the minimum supported peer), and Zod 4.5.4 from the original reproduction.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #20171
