### PR TITLE
fix(openai): flatten mid-stream Responses error events

### DIFF
--- a/.changeset/flat-openai-stream-errors.md
+++ b/.changeset/flat-openai-stream-errors.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): flatten mid-stream Responses error events

--- a/packages/openai/src/openai-stream-error.test.ts
+++ b/packages/openai/src/openai-stream-error.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { createOpenAIProviderStreamError } from './openai-stream-error';
+
+describe('createOpenAIProviderStreamError', () => {
+  it('flattens a nested error event', () => {
+    const data = {
+      type: 'error',
+      sequence_number: 114,
+      error: {
+        type: 'invalid_request_error',
+        code: 'invalid_prompt',
+        message: 'Invalid prompt: your prompt was flagged.',
+        param: null,
+      },
+    };
+
+    expect(createOpenAIProviderStreamError(data)).toEqual({
+      message: 'Invalid prompt: your prompt was flagged.',
+      type: 'invalid_request_error',
+      code: 'invalid_prompt',
+      statusCode: 400,
+      isRetryable: false,
+      data,
+    });
+  });
+
+  it('flattens a top-level error event', () => {
+    const data = {
+      type: 'error',
+      code: 'rate_limit_exceeded',
+      message: 'Rate limit reached',
+      param: null,
+    };
+
+    expect(createOpenAIProviderStreamError(data)).toEqual({
+      message: 'Rate limit reached',
+      type: 'error',
+      code: 'rate_limit_exceeded',
+      statusCode: 429,
+      isRetryable: true,
+      data,
+    });
+  });
+
+  it('classifies insufficient quota as non-retryable', () => {
+    const data = {
+      type: 'error',
+      code: 'insufficient_quota',
+      message: 'You exceeded your current quota.',
+      param: null,
+    };
+
+    expect(createOpenAIProviderStreamError(data)).toMatchObject({
+      statusCode: 429,
+      isRetryable: false,
+    });
+  });
+
+  it('flattens a response.failed event', () => {
+    const data = {
+      type: 'response.failed',
+      sequence_number: 3,
+      response: {
+        error: { code: 'server_error', message: 'Response failed' },
+        incomplete_details: null,
+        service_tier: null,
+      },
+    };
+
+    expect(createOpenAIProviderStreamError(data)).toEqual({
+      message: 'Response failed',
+      type: 'response.failed',
+      code: 'server_error',
+      statusCode: 500,
+      isRetryable: true,
+      data,
+    });
+  });
+
+  it('returns undefined for frames without a message', () => {
+    expect(
+      createOpenAIProviderStreamError({ type: 'error', error: {} }),
+    ).toBeUndefined();
+    expect(createOpenAIProviderStreamError('boom')).toBeUndefined();
+  });
+});

--- a/packages/openai/src/openai-stream-error.ts
+++ b/packages/openai/src/openai-stream-error.ts
@@ -5,8 +5,42 @@ type StreamError = {
   message: string;
   code?: string | number | null;
   type?: string | null;
-  frame: unknown;
 };
+
+export type OpenAIProviderStreamError = {
+  readonly message: string;
+  readonly type?: string;
+  readonly code?: string | number;
+  readonly statusCode: number;
+  readonly isRetryable: boolean;
+  readonly data: unknown;
+};
+
+/**
+ * Flattens an OpenAI stream error frame (`{ type: 'error', error: {...} }` or
+ * `response.failed`) so consumers can read `message` and `code` at the top
+ * level. The raw frame is kept in `data`.
+ */
+export function createOpenAIProviderStreamError(
+  frame: unknown,
+): OpenAIProviderStreamError | undefined {
+  const streamError = parseStreamError(frame);
+
+  if (streamError == null) {
+    return undefined;
+  }
+
+  const statusCode = getStatusCode(streamError);
+
+  return {
+    message: streamError.message,
+    type: streamError.type ?? undefined,
+    code: streamError.code ?? undefined,
+    statusCode,
+    isRetryable: isRetryableStreamError(streamError, statusCode),
+    data: frame,
+  };
+}
 
 export async function throwIfOpenAIStreamErrorBeforeOutput<T>({
   stream,
@@ -103,7 +137,6 @@ function parseStreamError(frame: unknown): StreamError | undefined {
           message: responseError.message,
           code: getStringOrNumber(responseError.code),
           type: 'response.failed',
-          frame,
         }
       : undefined;
   }
@@ -119,7 +152,6 @@ function parseStreamError(frame: unknown): StreamError | undefined {
         message: error.message,
         code: getStringOrNumber(error.code),
         type: typeof error.type === 'string' ? error.type : undefined,
-        frame,
       }
     : undefined;
 }
@@ -178,4 +210,27 @@ function getStringOrNumber(value: unknown): string | number | undefined {
 
 function isHttpErrorStatusCode(value: number): boolean {
   return Number.isInteger(value) && value >= 400 && value <= 599;
+}
+
+function isRetryableStatusCode(statusCode: number): boolean {
+  return (
+    statusCode === 408 ||
+    statusCode === 409 ||
+    statusCode === 429 ||
+    statusCode >= 500
+  );
+}
+
+function isRetryableStreamError(
+  error: StreamError,
+  statusCode: number,
+): boolean {
+  if (
+    error.code === 'insufficient_quota' ||
+    error.type === 'insufficient_quota'
+  ) {
+    return false;
+  }
+
+  return isRetryableStatusCode(statusCode);
 }

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -8235,6 +8235,47 @@ describe('OpenAIResponsesLanguageModel', () => {
         });
       });
 
+      it('should flatten a mid-stream error event so message and code are top-level', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'stream-chunks',
+          chunks: [
+            `data:{"type":"response.created","sequence_number":0,"response":{"id":"resp_flagged","created_at":1741269019,"model":"gpt-4o-2024-07-18","service_tier":null}}\n\n`,
+            `data:{"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"id":"msg_flagged","type":"message"}}\n\n`,
+            `data:{"type":"response.output_text.delta","sequence_number":2,"item_id":"msg_flagged","output_index":0,"content_index":0,"delta":"partial"}\n\n`,
+            `data:{"type":"error","sequence_number":3,"error":{"type":"invalid_request_error","code":"invalid_prompt","message":"Invalid prompt: your prompt was flagged.","param":null}}\n\n`,
+          ],
+        };
+
+        const { stream } = await createModel('gpt-4o-mini').doStream({
+          prompt: TEST_PROMPT,
+          includeRawChunks: false,
+        });
+
+        const events = await convertReadableStreamToArray(stream);
+        const errorEvent = events.find(event => event.type === 'error');
+
+        expect(errorEvent).toEqual({
+          type: 'error',
+          error: {
+            message: 'Invalid prompt: your prompt was flagged.',
+            type: 'invalid_request_error',
+            code: 'invalid_prompt',
+            statusCode: 400,
+            isRetryable: false,
+            data: {
+              type: 'error',
+              sequence_number: 3,
+              error: {
+                type: 'invalid_request_error',
+                code: 'invalid_prompt',
+                message: 'Invalid prompt: your prompt was flagged.',
+                param: null,
+              },
+            },
+          },
+        });
+      });
+
       it('should expose raw finish reason from late response.failed incomplete details', async () => {
         server.urls['https://api.openai.com/v1/responses'].response = {
           type: 'stream-chunks',
@@ -8276,14 +8317,21 @@ describe('OpenAIResponsesLanguageModel', () => {
             },
             {
               "error": {
-                "error": {
-                  "code": "server_error",
-                  "message": "response failed",
-                  "param": null,
-                  "type": "server_error",
+                "code": "server_error",
+                "data": {
+                  "error": {
+                    "code": "server_error",
+                    "message": "response failed",
+                    "param": null,
+                    "type": "server_error",
+                  },
+                  "sequence_number": 2,
+                  "type": "error",
                 },
-                "sequence_number": 2,
-                "type": "error",
+                "isRetryable": true,
+                "message": "response failed",
+                "statusCode": 500,
+                "type": "server_error",
               },
               "type": "error",
             },

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -29,7 +29,10 @@ import {
 import type { OpenAIConfig } from '../openai-config';
 import { openaiFailedResponseHandler } from '../openai-error';
 import { getOpenAILanguageModelCapabilities } from '../openai-language-model-capabilities';
-import { throwIfOpenAIStreamErrorBeforeOutput } from '../openai-stream-error';
+import {
+  createOpenAIProviderStreamError,
+  throwIfOpenAIStreamErrorBeforeOutput,
+} from '../openai-stream-error';
 import type { applyPatchInputSchema } from '../tool/apply-patch';
 import type {
   codeInterpreterInputSchema,
@@ -2229,17 +2232,18 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
 
               if (!encounteredStreamError && value.response.error != null) {
                 encounteredStreamError = true;
+                const error = {
+                  type: 'response.failed',
+                  sequence_number: value.sequence_number,
+                  response: {
+                    error: value.response.error,
+                    incomplete_details: value.response.incomplete_details,
+                    service_tier: value.response.service_tier,
+                  },
+                };
                 controller.enqueue({
                   type: 'error',
-                  error: {
-                    type: 'response.failed',
-                    sequence_number: value.sequence_number,
-                    response: {
-                      error: value.response.error,
-                      incomplete_details: value.response.incomplete_details,
-                      service_tier: value.response.service_tier,
-                    },
-                  },
+                  error: createOpenAIProviderStreamError(error) ?? error,
                 });
               }
             } else if (isResponseAnnotationAddedChunk(value)) {
@@ -2313,7 +2317,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
             } else if (isErrorChunk(value)) {
               encounteredStreamError = true;
               finishReason = { unified: 'error', raw: 'error' };
-              controller.enqueue({ type: 'error', error: value });
+              controller.enqueue({
+                type: 'error',
+                error: createOpenAIProviderStreamError(value) ?? value,
+              });
             }
           },
 


### PR DESCRIPTION
## Background

When the OpenAI Responses API fails after output has started it emits one of two frames:

```
{ type: 'error', sequence_number, error: { type, code, message, param } }
{ type: 'response.failed', sequence_number, response: { error: { code, message }, ... } }
```

`OpenAIResponsesLanguageModel.doStream` enqueued those frames verbatim as the `error` of the stream part. Neither carries a top-level `message` or `code`, so consumers reading those fields saw nothing usable and fell back to a generic placeholder. Before output starts the same frames are already unwrapped into an `APICallError`, so only the mid-stream path was affected.

The v7 line fixed this in [#18671](https://github.com/vercel/ai/pull/18671) as part of a larger typed-stream-error feature. This ports only the `@ai-sdk/openai` flattening to v6.

## Summary

- `createOpenAIProviderStreamError(frame)` in `openai-stream-error.ts` flattens a frame to `{ message, type, code, statusCode, isRetryable, data }`, with the raw frame kept in `data`. Same shape as the v7 `ProviderStreamError`, minus the provider-utils marker (v6 core does not normalize stream errors).
- Both mid-stream enqueue sites in the Responses model use it, falling back to the raw frame when it cannot be parsed.
- The pre-output `APICallError` path is unchanged.

## Verification

- New `openai-stream-error.test.ts` covers nested, top-level, `response.failed`, insufficient-quota and unparseable frames.
- New Responses test streams a delta and then an `error` event and asserts the flattened part.
- `@ai-sdk/openai` node + edge suites pass, `type-check`, `oxfmt` and `oxlint` clean.
