### PR TITLE
fix(provider/google): strip $ref and $defs from tool response content

### DIFF
--- a/.changeset/fix-google-sanitize-ref-in-function-response.md
+++ b/.changeset/fix-google-sanitize-ref-in-function-response.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(provider/google): strip $ref and $defs from tool response content

--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -658,6 +658,76 @@ describe('tool messages', () => {
     });
   });
 
+  it('should strip $ref and $defs from function response content', async () => {
+    const result = convertToGoogleMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolName: 'get_schema',
+            toolCallId: 'testCallId',
+            output: {
+              type: 'json',
+              value: {
+                tools: [
+                  {
+                    name: 'find_records',
+                    inputSchema: {
+                      type: 'object',
+                      properties: {
+                        filter: { $ref: '#/$defs/__schema0' },
+                      },
+                      $defs: {
+                        __schema0: {
+                          type: 'object',
+                          properties: { field: { type: 'string' } },
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual({
+      systemInstruction: undefined,
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'testCallId',
+                name: 'get_schema',
+                response: {
+                  name: 'get_schema',
+                  content: {
+                    tools: [
+                      {
+                        name: 'find_records',
+                        inputSchema: {
+                          type: 'object',
+                          properties: {
+                            filter: {},
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it('should convert tool result content with image-data into functionResponse parts', async () => {
     const result = convertToGoogleMessages([
       {

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -198,6 +198,35 @@ function appendLegacyToolResultParts(
   }
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) return false;
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function sanitizeFunctionResponseContent(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeFunctionResponseContent);
+  }
+
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, item] of Object.entries(value)) {
+    if (key === '$ref' || key === '$defs') {
+      continue;
+    }
+
+    sanitized[key] = sanitizeFunctionResponseContent(item);
+  }
+
+  return sanitized;
+}
+
 export function convertToGoogleMessages(
   prompt: LanguageModelV4Prompt,
   options?: {
@@ -622,7 +651,7 @@ export function convertToGoogleMessages(
                   content:
                     output.type === 'execution-denied'
                       ? (output.reason ?? 'Tool call execution denied.')
-                      : output.value,
+                      : sanitizeFunctionResponseContent(output.value),
                 },
               },
             });


### PR DESCRIPTION
## Summary

- strip `$ref` and `$defs` recursively from plain-object tool response content in the Google message converter
- add a focused regression test and a patch changeset

## Related Issues

Closes #14369