### PR TITLE
fix: add type message to Responses input items

### DIFF
--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -398,6 +398,7 @@ export async function convertToOpenAIResponsesInput({
               providerOptionsName,
             );
             input.push({
+              type: 'message',
               role: 'system',
               content:
                 promptCacheBreakpoint == null
@@ -418,6 +419,7 @@ export async function convertToOpenAIResponsesInput({
               providerOptionsName,
             );
             input.push({
+              type: 'message',
               role: 'developer',
               content:
                 promptCacheBreakpoint == null
@@ -451,6 +453,7 @@ export async function convertToOpenAIResponsesInput({
 
       case 'user': {
         input.push({
+          type: 'message',
           role: 'user',
           content: content.map((part, index) => {
             switch (part.type) {
@@ -603,6 +606,7 @@ export async function convertToOpenAIResponsesInput({
               }
 
               input.push({
+                type: 'message',
                 role: 'assistant',
                 content: [{ type: 'output_text', text: part.text }],
                 id,


### PR DESCRIPTION
## Summary

Fixes #20180

Azure AI Foundry project endpoints require type: 'message' on input items with role system/user/assistant/developer. OpenAI's own endpoint infers this, but Foundry rejects items without it.

## Changes

- Added type: 'message' to all role pushes in convertToOpenAIResponsesInput

## Test plan

- [x] Existing tests still pass