### PR TITLE
fix: preserve per-call diagnostics in NoImageGeneratedError

### DIFF
--- a/packages/ai/src/error/no-image-generated-error.ts
+++ b/packages/ai/src/error/no-image-generated-error.ts
@@ -1,5 +1,6 @@
 import { AISDKError } from '@ai-sdk/provider';
 import type { ImageModelResponseMetadata } from '../types/image-model-response-metadata';
+import type { GenerateImageCall } from '../generate-image/generate-image-result';
 
 const name = 'AI_NoImageGeneratedError';
 const marker = `vercel.ai.error.${name}`;
@@ -19,18 +20,26 @@ export class NoImageGeneratedError extends AISDKError {
    */
   readonly responses: Array<ImageModelResponseMetadata> | undefined;
 
+  /**
+   * The complete per-call diagnostics for each call.
+   */
+  readonly calls: Array<GenerateImageCall> | undefined;
+
   constructor({
     message = 'No image generated.',
     cause,
     responses,
+    calls,
   }: {
     message?: string;
     cause?: Error;
     responses?: Array<ImageModelResponseMetadata>;
+    calls?: Array<GenerateImageCall>;
   }) {
     super({ name, message, cause });
 
     this.responses = responses;
+    this.calls = calls;
   }
 
   static isInstance(error: unknown): error is NoImageGeneratedError {

--- a/packages/ai/src/generate-image/generate-image.ts
+++ b/packages/ai/src/generate-image/generate-image.ts
@@ -295,7 +295,7 @@ export async function generateImage({
   logWarnings({ warnings, provider: model.provider, model: model.modelId });
 
   if (!images.length) {
-    throw new NoImageGeneratedError({ responses });
+    throw new NoImageGeneratedError({ responses, calls });
   }
 
   return new DefaultGenerateImageResult({


### PR DESCRIPTION
## Summary

Fixes #20153

Added calls property to NoImageGeneratedError and GenerateImageResult to retain complete per-call diagnostics (providerMetadata, response, warnings, usage) when no images are generated. This enables callers to distinguish moderation blocks from transient failures.

## Changes

- Added GenerateImageCall interface
- Added calls property to GenerateImageResult
- Added calls property to NoImageGeneratedError
- Updated generate-image.ts to track and pass calls

## Test plan

- [x] Existing tests still pass