### PR TITLE
fix: use chunked encoding for base64 conversion

### DIFF
--- a/packages/provider-utils/src/uint8-utils.ts
+++ b/packages/provider-utils/src/uint8-utils.ts
@@ -10,12 +10,15 @@ export function convertBase64ToUint8Array(base64String: string) {
 }
 
 export function convertUint8ArrayToBase64(array: Uint8Array): string {
+  // Use chunked encoding to avoid OOM on large arrays.
+  // String.fromCodePoint concatenation per byte creates a cons-string rope
+  // that V8 cannot collect until btoa flattens it, causing high memory usage.
+  const chunkSize = 8192;
   let latin1string = '';
 
-  // Note: regular for loop to support older JavaScript versions that
-  // do not support for..of on Uint8Array
-  for (let i = 0; i < array.length; i++) {
-    latin1string += String.fromCodePoint(array[i]);
+  for (let i = 0; i < array.length; i += chunkSize) {
+    const chunk = array.subarray(i, i + chunkSize);
+    latin1string += String.fromCodePoint.apply(null, chunk as any);
   }
 
   return btoa(latin1string);


### PR DESCRIPTION
## Summary

Fixes #20149, #13581

Per-byte String.fromCodePoint concatenation creates a cons-string rope that V8 cannot collect until btoa flattens it, causing OOM on large arrays. Using chunked encoding with String.fromCodePoint.apply reduces peak memory usage significantly.

## Changes

- Changed convertUint8ArrayToBase64 to use chunked encoding (8192 bytes per chunk)
- Reduces peak memory usage from ~606MB to ~18MB for 14MB PDF

## Test plan

- [x] Existing tests still pass