### PR TITLE
feat: add runtimeContext to embed, embedMany, and rerank

### DIFF
--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -2,6 +2,7 @@ import { InvalidResponseDataError } from '@ai-sdk/provider';
 import {
   createIdGenerator,
   withUserAgentSuffix,
+  type Context,
   type ProviderOptions,
 } from '@ai-sdk/provider-utils';
 import { logWarnings } from '../logger/log-warnings';
@@ -49,7 +50,7 @@ const originalGenerateCallId = createIdGenerator({
  *
  * @returns A result object that contains the embeddings, the value, and additional information.
  */
-export async function embedMany({
+export async function embedMany<RUNTIME_CONTEXT extends Context = Context>({
   model: modelArg,
   values,
   maxParallelCalls = Infinity,
@@ -59,6 +60,7 @@ export async function embedMany({
   providerOptions,
   experimental_telemetry,
   telemetry = experimental_telemetry,
+  runtimeContext,
   onStart,
   experimental_onStart,
   onEnd,
@@ -74,6 +76,11 @@ export async function embedMany({
    * The values that should be embedded.
    */
   values: Array<string>;
+
+  /**
+   * User-defined runtime context that flows through the entire embedding lifecycle.
+   */
+  runtimeContext?: RUNTIME_CONTEXT;
 
   /**
    * Maximum number of retries per embedding model call. Set to 0 to disable retries.
@@ -188,6 +195,7 @@ export async function embedMany({
     maxRetries,
     headers: headersWithUserAgent,
     providerOptions,
+    runtimeContext,
   };
 
   return await runInTracingChannelSpan({
@@ -228,6 +236,7 @@ export async function embedMany({
                   provider: model.provider,
                   modelId: model.modelId,
                   values,
+                  runtimeContext,
                 },
                 callbacks: [telemetryDispatcher.onEmbedStart],
               });
@@ -252,6 +261,7 @@ export async function embedMany({
                   values,
                   embeddings,
                   usage,
+                  runtimeContext,
                 },
                 callbacks: [telemetryDispatcher.onEmbedEnd],
               });
@@ -285,6 +295,7 @@ export async function embedMany({
               warnings,
               providerMetadata,
               response: [response],
+              runtimeContext,
             },
             callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
           });
@@ -340,6 +351,7 @@ export async function embedMany({
                     provider: model.provider,
                     modelId: model.modelId,
                     values: chunk,
+                    runtimeContext,
                   },
                   callbacks: [telemetryDispatcher.onEmbedStart],
                 });
@@ -364,6 +376,7 @@ export async function embedMany({
                     values: chunk,
                     embeddings: chunkEmbeddings,
                     usage,
+                    runtimeContext,
                   },
                   callbacks: [telemetryDispatcher.onEmbedEnd],
                 });
@@ -426,6 +439,7 @@ export async function embedMany({
             warnings,
             providerMetadata,
             response: responses,
+            runtimeContext,
           },
           callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
         });
@@ -439,7 +453,7 @@ export async function embedMany({
           responses,
         });
       } catch (error) {
-        await telemetryDispatcher.onError?.({ callId, error });
+        await telemetryDispatcher.onError?.({ callId, error, runtimeContext });
         throw error;
       }
     },

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -1,6 +1,7 @@
 import {
   createIdGenerator,
   withUserAgentSuffix,
+  type Context,
   type ProviderOptions,
 } from '@ai-sdk/provider-utils';
 import { logWarnings } from '../logger/log-warnings';
@@ -38,7 +39,7 @@ const originalGenerateCallId = createIdGenerator({
  *
  * @returns A result object that contains the embedding, the value, and additional information.
  */
-export async function embed({
+export async function embed<RUNTIME_CONTEXT extends Context = Context>({
   model: modelArg,
   value,
   providerOptions,
@@ -47,6 +48,7 @@ export async function embed({
   headers,
   experimental_telemetry,
   telemetry = experimental_telemetry,
+  runtimeContext,
   onStart,
   experimental_onStart,
   onEnd,
@@ -62,6 +64,11 @@ export async function embed({
    * The value that should be embedded.
    */
   value: string;
+
+  /**
+   * User-defined runtime context that flows through the entire embedding lifecycle.
+   */
+  runtimeContext?: RUNTIME_CONTEXT;
 
   /**
    * Maximum number of retries per embedding model call. Set to 0 to disable retries.
@@ -169,6 +176,7 @@ export async function embed({
     maxRetries,
     headers: headersWithUserAgent,
     providerOptions,
+    runtimeContext,
   };
 
   return await runInTracingChannelSpan({
@@ -193,6 +201,7 @@ export async function embed({
                 provider: model.provider,
                 modelId: model.modelId,
                 values: [value],
+                runtimeContext,
               },
               callbacks: [telemetryDispatcher.onEmbedStart],
             });
@@ -217,6 +226,7 @@ export async function embed({
                 values: [value],
                 embeddings: modelResponse.embeddings,
                 usage,
+                runtimeContext,
               },
               callbacks: [telemetryDispatcher.onEmbedEnd],
             });
@@ -248,6 +258,7 @@ export async function embed({
             warnings,
             providerMetadata,
             response,
+            runtimeContext,
           },
           callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
         });
@@ -261,7 +272,7 @@ export async function embed({
           response,
         });
       } catch (error) {
-        await telemetryDispatcher.onError?.({ callId, error });
+        await telemetryDispatcher.onError?.({ callId, error, runtimeContext });
         throw error;
       }
     },

--- a/packages/ai/src/rerank/rerank.ts
+++ b/packages/ai/src/rerank/rerank.ts
@@ -1,6 +1,7 @@
 import type { JSONObject, RerankingModelV4CallOptions } from '@ai-sdk/provider';
 import {
   createIdGenerator,
+  type Context,
   type ProviderOptions,
 } from '@ai-sdk/provider-utils';
 import { prepareRetries } from '../../src/util/prepare-retries';
@@ -35,7 +36,10 @@ const originalGenerateCallId = createIdGenerator({
  *
  * @returns A result object that contains the reranked documents, the reranked indices, and additional information.
  */
-export async function rerank<VALUE extends JSONObject | string>({
+export async function rerank<
+  VALUE extends JSONObject | string,
+  RUNTIME_CONTEXT extends Context = Context,
+>({
   model: modelArg,
   documents,
   query,
@@ -46,6 +50,7 @@ export async function rerank<VALUE extends JSONObject | string>({
   providerOptions,
   experimental_telemetry,
   telemetry = experimental_telemetry,
+  runtimeContext,
   onStart,
   experimental_onStart,
   onEnd,
@@ -71,6 +76,11 @@ export async function rerank<VALUE extends JSONObject | string>({
    * Number of top documents to return.
    */
   topN?: number;
+
+  /**
+   * User-defined runtime context that flows through the entire reranking lifecycle.
+   */
+  runtimeContext?: RUNTIME_CONTEXT;
 
   /**
    * Maximum number of retries per reranking model call. Set to 0 to disable retries.
@@ -171,6 +181,7 @@ export async function rerank<VALUE extends JSONObject | string>({
         maxRetries: maxRetriesArg ?? 2,
         headers,
         providerOptions,
+        runtimeContext,
       },
       callbacks: [resolvedOnStart, telemetryDispatcher.onStart],
     });
@@ -190,6 +201,7 @@ export async function rerank<VALUE extends JSONObject | string>({
           timestamp: new Date(),
           modelId: model.modelId,
         },
+        runtimeContext,
       },
       callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
     });
@@ -226,6 +238,7 @@ export async function rerank<VALUE extends JSONObject | string>({
     maxRetries,
     headers,
     providerOptions,
+    runtimeContext,
   };
 
   return await runInTracingChannelSpan({
@@ -250,6 +263,7 @@ export async function rerank<VALUE extends JSONObject | string>({
                 documentsType: documentsToSend.type,
                 query,
                 topN,
+                runtimeContext,
               },
               callbacks: [telemetryDispatcher.onRerankStart],
             });
@@ -273,6 +287,7 @@ export async function rerank<VALUE extends JSONObject | string>({
                 modelId: model.modelId,
                 documentsType: documentsToSend.type,
                 ranking,
+                runtimeContext,
               },
               callbacks: [telemetryDispatcher.onRerankEnd],
             });
@@ -314,6 +329,7 @@ export async function rerank<VALUE extends JSONObject | string>({
               headers: response?.headers,
               body: response?.body,
             },
+            runtimeContext,
           },
           callbacks: [resolvedOnEnd, telemetryDispatcher.onEnd],
         });
@@ -335,7 +351,7 @@ export async function rerank<VALUE extends JSONObject | string>({
           },
         });
       } catch (error) {
-        await telemetryDispatcher.onError?.({ callId, error });
+        await telemetryDispatcher.onError?.({ callId, error, runtimeContext });
         throw error;
       }
     },


### PR DESCRIPTION
## Summary

Fixes #20155

Added runtimeContext option to embed, embedMany, and rerank functions. This enables telemetry attribution for embedding and reranking operations, matching the existing capability in generateText.

## Changes

- Added runtimeContext parameter to embed, embedMany, and rerank
- Propagated runtimeContext through all telemetry events (onStart, onEnd, onError, onEmbedStart, onEmbedEnd, onRerankStart, onRerankEnd)

## Test plan

- [x] Existing tests still pass