### PR TITLE
fix: retry empty image results in generateImage

### DIFF
--- a/packages/ai/src/generate-image/generate-image.ts
+++ b/packages/ai/src/generate-image/generate-image.ts
@@ -162,7 +162,7 @@ export async function generateImage({
     `ai/${VERSION}`,
   );
 
-  const { retry } = prepareRetries({
+  const { retry, getDelay } = prepareRetries({
     maxRetries: maxRetriesArg,
     abortSignal,
   });
@@ -184,12 +184,15 @@ export async function generateImage({
   });
 
   const results = await Promise.all(
-    callImageCounts.map(
-      async callImageCount =>
-        await retry(() => {
+    callImageCounts.map(async callImageCount => {
+      let lastResult: any;
+      let lastError: unknown;
+
+      for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        try {
           const { prompt, files, mask } = normalizePrompt(promptArg);
 
-          return model.doGenerate({
+          const result = await model.doGenerate({
             prompt,
             files,
             mask,
@@ -201,8 +204,35 @@ export async function generateImage({
             seed,
             providerOptions: providerOptions ?? {},
           });
-        }),
-    ),
+
+          if (result.images.length > 0) {
+            return result;
+          }
+
+          lastResult = result;
+          lastError = new NoImageGeneratedError({
+            responses: [result.response],
+            calls: [
+              {
+                images: [],
+                providerMetadata: result.providerMetadata,
+                response: result.response,
+                warnings: result.warnings,
+                usage: result.usage,
+              },
+            ],
+          });
+        } catch (error) {
+          lastError = error;
+        }
+
+        if (attempt < maxRetries) {
+          await new Promise(resolve => setTimeout(resolve, getDelay(attempt)));
+        }
+      }
+
+      throw lastError;
+    }),
   );
 
   // collect result images, warnings, and response metadata

--- a/packages/ai/src/util/prepare-retries.ts
+++ b/packages/ai/src/util/prepare-retries.ts
@@ -1,6 +1,10 @@
 import { InvalidArgumentError } from '../error/invalid-argument-error';
 import type { RetryFunction } from '@ai-sdk/provider-utils';
 import { retryWithExponentialBackoffRespectingRetryHeaders } from '../util/retry-with-exponential-backoff';
+
+const DEFAULT_INITIAL_DELAY_MS = 2000;
+const DEFAULT_BACKOFF_FACTOR = 2;
+
 /**
  * Validate and prepare retries.
  */
@@ -17,6 +21,7 @@ export function prepareRetries({
 }): {
   maxRetries: number;
   retry: RetryFunction;
+  getDelay: (attempt: number) => number;
 } {
   if (maxRetries != null) {
     if (!Number.isInteger(maxRetries)) {
@@ -44,5 +49,10 @@ export function prepareRetries({
       maxRetries: maxRetriesResult,
       abortSignal,
     }),
+    getDelay: (attempt: number) =>
+      Math.min(
+        DEFAULT_INITIAL_DELAY_MS * Math.pow(DEFAULT_BACKOFF_FACTOR, attempt),
+        60000,
+      ),
   };
 }


### PR DESCRIPTION
## Summary

Fixes #20156

maxRetries now applies to empty image results, not just errors. This enables recovery from transient empty responses.

## Changes

- Wrapped model.doGenerate and empty image check in a single retry loop
- Added getDelay helper to prepare-retries utility

## Test plan

- [x] Existing tests still pass