### PR TITLE
fix: tolerate structuredContent-only MCP tool results

### DIFF
--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -591,6 +591,24 @@ class DefaultMCPClient implements MCPClient {
         }
 
         try {
+          // Normalize structuredContent-only results for backwards compatibility.
+          // Some MCP servers return structuredContent without content.
+          if (
+            response.result != null &&
+            typeof response.result === 'object' &&
+            'structuredContent' in response.result &&
+            !('content' in response.result)
+          ) {
+            response.result = {
+              ...response.result,
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(response.result.structuredContent),
+                },
+              ],
+            };
+          }
           const result = resultSchema.parse(response.result);
           cleanup();
           resolve(result);


### PR DESCRIPTION
## Summary

Fixes #20171

MCP servers may return structuredContent without content. The client now normalizes these results to include a text content mirror for backwards compatibility.

## Changes

- Added normalization in request handler for structuredContent-only results

## Test plan

- [x] Existing tests still pass