### PR TITLE
fix(angular): don't let Completion.handleSubmit track input as a reactive dependency

### DIFF
--- a/.changeset/angular-untracked-handle-submit.md
+++ b/.changeset/angular-untracked-handle-submit.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk/angular": patch
+---
+
+fix(angular): don't let `Completion.handleSubmit` register `input` as a reactive dependency
+
+`handleSubmit` read the `input` signal directly. Calling it from inside an `effect` or `computed` (for example, an auto-send effect) would subscribe that reactive context to `input`, so it re-ran on every keystroke. It now reads the value with `untracked`. Nothing changes for the normal form-submit path.

--- a/packages/angular/src/lib/completion.ng.test.ts
+++ b/packages/angular/src/lib/completion.ng.test.ts
@@ -2,6 +2,7 @@ import {
   createTestServer,
   TestResponseController,
 } from '@ai-sdk/test-server/with-vitest';
+import { computed } from '@angular/core';
 import { describe, expect, it, vi } from 'vitest';
 import { Completion } from './completion.ng';
 
@@ -87,6 +88,29 @@ describe('Completion', () => {
     controller.close();
     await completionOperation;
     expect(completion.loading).toBe(false);
+  });
+
+  describe('handleSubmit', () => {
+    it('does not subscribe the calling reactive context to input', () => {
+      const completion = new Completion();
+      // keep a reactive re-run (the bug) from making a real request
+      completion.complete = async () => '';
+      let runs = 0;
+
+      const tracker = computed(() => {
+        runs++;
+        void completion.handleSubmit();
+        return runs;
+      });
+
+      tracker();
+      const runsAfterFirstRead = runs;
+
+      completion.input = 'hello';
+      tracker();
+
+      expect(runs).toBe(runsAfterFirstRead);
+    });
   });
 
   describe('stop', () => {

--- a/packages/angular/src/lib/completion.ng.ts
+++ b/packages/angular/src/lib/completion.ng.ts
@@ -1,4 +1,4 @@
-import { signal } from '@angular/core';
+import { signal, untracked } from '@angular/core';
 import {
   callCompletionApi,
   generateId,
@@ -81,8 +81,9 @@ export class Completion<BODY extends object = object> {
   /** Form submission handler to automatically reset input and call the completion API */
   handleSubmit = async (event?: { preventDefault?: () => void }) => {
     event?.preventDefault?.();
-    if (this.#input()) {
-      await this.complete(this.#input());
+    const input = untracked(this.#input);
+    if (input) {
+      await this.complete(input);
     }
   };
 


### PR DESCRIPTION
handleSubmit read the #input signal directly before its first await, so calling it from a reactive context (effect/computed/afterRenderEffect) subscribed that context to #input and re-ran it on every keystroke. Read the value with untracked instead. No change for the normal DOM form-submit path.

The state getters (get input(), etc.) are left tracked on purpose: they are the reactive read surface for templates and effects.