### PR TITLE
fix(openai-compatible): preserve multimodal tool result content

### DIFF
--- a/.changeset/bright-tools-share.md
+++ b/.changeset/bright-tools-share.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai-compatible': patch
+---
+
+preserve multimodal content returned by tools when converting chat messages

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.test.ts
@@ -699,6 +699,47 @@ describe('tool calls', () => {
       },
     ]);
   });
+
+  it('should preserve media content in tool results instead of stringifying it', () => {
+    const result = convertToOpenAICompatibleChatMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'getImage',
+            output: {
+              type: 'content',
+              value: [
+                {
+                  type: 'file',
+                  data: {
+                    type: 'data' as const,
+                    data: new Uint8Array([0, 1, 2, 3]),
+                  },
+                  mediaType: 'image/png',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,AAECAw==' },
+          },
+        ],
+        tool_call_id: 'call-1',
+      },
+    ]);
+  });
 });
 
 describe('provider-specific metadata merging', () => {

--- a/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts
@@ -1,9 +1,13 @@
 import {
   UnsupportedFunctionalityError,
   type LanguageModelV4Prompt,
+  type LanguageModelV4ToolResultOutput,
   type SharedV4ProviderMetadata,
 } from '@ai-sdk/provider';
-import type { OpenAICompatibleChatPrompt } from './openai-compatible-api-types';
+import type {
+  OpenAICompatibleChatPrompt,
+  OpenAICompatibleContentPart,
+} from './openai-compatible-api-types';
 import {
   convertBase64ToUint8Array,
   convertToBase64,
@@ -27,6 +31,89 @@ function getAudioFormat(mediaType: string): 'wav' | 'mp3' | null {
     default:
       return null;
   }
+}
+
+function convertToolContent(
+  value: Extract<LanguageModelV4ToolResultOutput, { type: 'content' }>['value'],
+): Array<OpenAICompatibleContentPart> {
+  return value.map(part => {
+    if (part.type === 'text') {
+      return { type: 'text', text: part.text };
+    }
+    if (part.type !== 'file') {
+      throw new UnsupportedFunctionalityError({
+        functionality: 'custom tool result content',
+      });
+    }
+    if (part.data.type !== 'data' && part.data.type !== 'url') {
+      throw new UnsupportedFunctionalityError({
+        functionality: 'tool result file references',
+      });
+    }
+    const topLevel = getTopLevelMediaType(part.mediaType);
+    if (topLevel === 'image' || topLevel === 'video') {
+      const url =
+        part.data.type === 'url'
+          ? part.data.url.toString()
+          : `data:${resolveFullMediaType({ part })};base64,${convertToBase64(part.data.data)}`;
+      return topLevel === 'image'
+        ? { type: 'image_url', image_url: { url } }
+        : { type: 'video_url', video_url: { url } };
+    }
+    if (topLevel === 'audio') {
+      if (part.data.type === 'url') {
+        throw new UnsupportedFunctionalityError({
+          functionality: 'tool result audio URLs',
+        });
+      }
+      const format = getAudioFormat(resolveFullMediaType({ part }));
+      if (format === null) {
+        throw new UnsupportedFunctionalityError({
+          functionality: `tool result audio media type ${part.mediaType}`,
+        });
+      }
+      return {
+        type: 'input_audio',
+        input_audio: {
+          data: convertToBase64(part.data.data),
+          format,
+        },
+      };
+    }
+    if (topLevel === 'application') {
+      if (part.data.type === 'url') {
+        throw new UnsupportedFunctionalityError({
+          functionality: 'tool result PDF URLs',
+        });
+      }
+      if (resolveFullMediaType({ part }) !== 'application/pdf') {
+        throw new UnsupportedFunctionalityError({
+          functionality: `tool result file media type ${part.mediaType}`,
+        });
+      }
+      return {
+        type: 'file',
+        file: {
+          filename: part.filename ?? 'document.pdf',
+          file_data: `data:application/pdf;base64,${convertToBase64(part.data.data)}`,
+        },
+      };
+    }
+    if (topLevel === 'text') {
+      const text =
+        part.data.type === 'url'
+          ? part.data.url.toString()
+          : typeof part.data.data === 'string'
+            ? new TextDecoder().decode(
+                convertBase64ToUint8Array(part.data.data),
+              )
+            : new TextDecoder().decode(part.data.data);
+      return { type: 'text', text };
+    }
+    throw new UnsupportedFunctionalityError({
+      functionality: `tool result media type ${part.mediaType}`,
+    });
+  });
 }
 
 export function convertToOpenAICompatibleChatMessages(
@@ -255,7 +342,7 @@ export function convertToOpenAICompatibleChatMessages(
 
           const output = toolResponse.output;
 
-          let contentValue: string;
+          let contentValue: string | Array<OpenAICompatibleContentPart>;
           switch (output.type) {
             case 'text':
             case 'error-text':
@@ -265,6 +352,8 @@ export function convertToOpenAICompatibleChatMessages(
               contentValue = output.reason ?? 'Tool call execution denied.';
               break;
             case 'content':
+              contentValue = convertToolContent(output.value);
+              break;
             case 'json':
             case 'error-json':
               contentValue = JSON.stringify(output.value);

--- a/packages/openai-compatible/src/chat/openai-compatible-api-types.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-api-types.ts
@@ -87,6 +87,6 @@ export interface OpenAICompatibleMessageToolCall extends JsonRecord {
 
 export interface OpenAICompatibleToolMessage extends JsonRecord {
   role: 'tool';
-  content: string;
+  content: string | Array<OpenAICompatibleContentPart>;
   tool_call_id: string;
 }


### PR DESCRIPTION
## Summary

Fixes #10850 by preserving multimodal content returned by tools when converting prompts for OpenAI-compatible chat APIs.

Previously, `content` tool outputs were always serialized with `JSON.stringify`, which turned image/video/audio/PDF parts into a plain string. This change converts supported file and text parts into OpenAI-compatible content parts while preserving the existing string behavior for `text`, `json`, and `error-json` outputs.

Supported content parts:

- text → `text`
- image → `image_url`
- video → `video_url`
- audio → `input_audio`
- PDF → `file`

The tool message type now allows `string | OpenAICompatibleContentPart[]`.

## Risk / protocol note

This is a runnable but high-risk proposal that requires maintainer confirmation of the protocol direction. OpenAI-compatible providers differ in whether they accept array-based multimodal tool content. The change is intentionally isolated to `content` tool outputs; JSON and text outputs retain their existing behavior. Feedback on whether this should instead be guarded by a provider capability or option is welcome.

## Validation

- `pnpm --filter @ai-sdk/openai-compatible type-check`
- `pnpm --filter @ai-sdk/openai-compatible test`
  - Node: 262 passed
  - Edge: 262 passed
- `git diff --check`

## Related issue

Closes #10850
