### PR TITLE
feat(openai): support action, moderation low, and gpt-image-2 sizes in the image generation tool

### DIFF
--- a/.changeset/openai-image-generation-tool-options.md
+++ b/.changeset/openai-image-generation-tool-options.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+feat(openai): support action, moderation low, and gpt-image-2 sizes in the image generation tool

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -601,6 +601,7 @@ export type OpenAIResponsesTool =
     }
   | {
       type: 'image_generation';
+      action: 'generate' | 'edit' | 'auto' | undefined;
       background: 'auto' | 'opaque' | 'transparent' | undefined;
       input_fidelity: 'low' | 'high' | undefined;
       input_image_mask:
@@ -610,12 +611,18 @@ export type OpenAIResponsesTool =
           }
         | undefined;
       model: string | undefined;
-      moderation: 'auto' | undefined;
+      moderation: 'auto' | 'low' | undefined;
       output_compression: number | undefined;
       output_format: 'png' | 'jpeg' | 'webp' | undefined;
       partial_images: number | undefined;
       quality: 'auto' | 'low' | 'medium' | 'high' | undefined;
-      size: 'auto' | '1024x1024' | '1024x1536' | '1536x1024' | undefined;
+      size:
+        | 'auto'
+        | '1024x1024'
+        | '1024x1536'
+        | '1536x1024'
+        | (string & {})
+        | undefined;
     }
 
   /**

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -453,6 +453,7 @@ describe('prepareResponsesTools', () => {
           "toolWarnings": [],
           "tools": [
             {
+              "action": undefined,
               "background": "opaque",
               "input_fidelity": undefined,
               "input_image_mask": undefined,
@@ -468,6 +469,61 @@ describe('prepareResponsesTools', () => {
           ],
         }
       `);
+    });
+
+    it('should pass action, low moderation and a gpt-image-2 size', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'openai.image_generation',
+            name: 'image_generation',
+            args: {
+              action: 'edit',
+              model: 'gpt-image-2',
+              moderation: 'low',
+              size: '1536x864',
+            },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result.toolWarnings).toEqual([]);
+      expect(result.tools).toMatchInlineSnapshot(`
+        [
+          {
+            "action": "edit",
+            "background": undefined,
+            "input_fidelity": undefined,
+            "input_image_mask": undefined,
+            "model": "gpt-image-2",
+            "moderation": "low",
+            "output_compression": undefined,
+            "output_format": undefined,
+            "partial_images": undefined,
+            "quality": undefined,
+            "size": "1536x864",
+            "type": "image_generation",
+          },
+        ]
+      `);
+    });
+
+    it('should reject a size that is not WIDTHxHEIGHT', async () => {
+      await expect(
+        prepareResponsesTools({
+          tools: [
+            {
+              type: 'provider',
+              id: 'openai.image_generation',
+              name: 'image_generation',
+              args: { size: 'large' },
+            },
+          ],
+          toolChoice: undefined,
+        }),
+      ).rejects.toThrow();
     });
 
     it('should support tool choice selection for image_generation', async () => {
@@ -486,6 +542,7 @@ describe('prepareResponsesTools', () => {
       expect(result.tools).toMatchInlineSnapshot(`
         [
           {
+            "action": undefined,
             "background": undefined,
             "input_fidelity": undefined,
             "input_image_mask": undefined,

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -302,6 +302,7 @@ export async function prepareResponsesTools({
 
             openaiTools.push({
               type: 'image_generation',
+              action: args.action,
               background: args.background,
               input_fidelity: args.inputFidelity,
               input_image_mask: args.inputImageMask

--- a/packages/openai/src/tool/image-generation.ts
+++ b/packages/openai/src/tool/image-generation.ts
@@ -9,6 +9,7 @@ export const imageGenerationArgsSchema = lazySchema(() =>
   zodSchema(
     z
       .object({
+        action: z.enum(['generate', 'edit', 'auto']).optional(),
         background: z.enum(['auto', 'opaque', 'transparent']).optional(),
         inputFidelity: z.enum(['low', 'high']).optional(),
         inputImageMask: z
@@ -18,13 +19,16 @@ export const imageGenerationArgsSchema = lazySchema(() =>
           })
           .optional(),
         model: z.string().optional(),
-        moderation: z.enum(['auto']).optional(),
+        moderation: z.enum(['auto', 'low']).optional(),
         outputCompression: z.number().int().min(0).max(100).optional(),
         outputFormat: z.enum(['png', 'jpeg', 'webp']).optional(),
         partialImages: z.number().int().min(0).max(3).optional(),
         quality: z.enum(['auto', 'low', 'medium', 'high']).optional(),
         size: z
-          .enum(['1024x1024', '1024x1536', '1536x1024', 'auto'])
+          .union([
+            z.enum(['1024x1024', '1024x1536', '1536x1024', 'auto']),
+            z.string().regex(/^\d+x\d+$/),
+          ])
           .optional(),
       })
       .strict(),
@@ -38,6 +42,11 @@ export const imageGenerationOutputSchema = lazySchema(() =>
 );
 
 type ImageGenerationArgs = {
+  /**
+   * Whether to generate a new image or edit an existing image. Default: auto.
+   */
+  action?: 'generate' | 'edit' | 'auto';
+
   /**
    * Background type for the generated image. Default is 'auto'.
    */
@@ -70,9 +79,9 @@ type ImageGenerationArgs = {
   model?: string;
 
   /**
-   * Moderation level for the generated image. Default: auto.
+   * Moderation level for the generated image. One of auto or low. Default: auto.
    */
-  moderation?: 'auto';
+  moderation?: 'auto' | 'low';
 
   /**
    * Compression level for the output image. Default: 100.
@@ -98,10 +107,11 @@ type ImageGenerationArgs = {
 
   /**
    * The size of the generated image.
-   * One of 1024x1024, 1024x1536, 1536x1024, or auto.
+   * One of 1024x1024, 1024x1536, 1536x1024, or auto. gpt-image-2 also accepts
+   * arbitrary WIDTHxHEIGHT sizes where both are divisible by 16, e.g. 1536x864.
    * Default: auto.
    */
-  size?: 'auto' | '1024x1024' | '1024x1536' | '1536x1024';
+  size?: 'auto' | '1024x1024' | '1024x1536' | '1536x1024' | (string & {});
 };
 
 const imageGenerationToolFactory = createProviderExecutedToolFactory<


### PR DESCRIPTION
## Background

the responses api `image_generation` tool takes `action`, `moderation: 'low'`, and for gpt-image-2 any `WIDTHxHEIGHT` size divisible by 16. `openai.tools.imageGeneration` rejects all three before a request is sent, because the args schema is `.strict()` with narrower enums than the api. details and a fetch-stubbed reproduction in #20206.

## Summary

widened the tool to match the api reference:

- `packages/openai/src/tool/image-generation.ts`: added `action` (`generate | edit | auto`), `moderation` now `auto | low`, `size` accepts the four known values or any `\d+x\d+` string. types and jsdoc updated to match.
- `packages/openai/src/responses/openai-responses-prepare-tools.ts`: passes `action` through.
- `packages/openai/src/responses/openai-responses-api.ts`: widened the request types the same way.

`size` keeps the enum for the four documented values and adds a `\d+x\d+` regex rather than plain `z.string()`, so a typo like `'large'` still fails early and only the shape openai actually documents gets through.

no docs change. the tool section in `03-openai.mdx` points at openai's own tool options page rather than listing parameters.

## End-to-End Verification

ran `generateText` with a fetch stub that captures the request body, against the published `@ai-sdk/openai@4.0.56` and then against this branch's build.

before, three of four throw `AI_TypeValidationError` client side and nothing is sent:

```
moderation: 'auto'                     -> request sent
moderation: 'low'                      -> AI_TypeValidationError
action: 'edit'                         -> AI_TypeValidationError
model: 'gpt-image-2', size: '1536x864' -> AI_TypeValidationError
```

after, all four send, and the tool object in the body carries the new fields:

```
moderation: 'low'   -> {"type":"image_generation","moderation":"low"}
action: 'edit'      -> {"type":"image_generation","action":"edit"}
size: '1536x864'    -> {"type":"image_generation","model":"gpt-image-2","size":"1536x864"}
```

`@ai-sdk/openai` suite is green, 27 files, 1007 tests.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #20206
