### PR TITLE
fix(harness): avoid warning about lack of credential brokering support when `credentialForwarding` callback is used to replace all credentials with ephemeral fake secrets

### DIFF
--- a/.changeset/soft-colts-hug.md
+++ b/.changeset/soft-colts-hug.md
@@ -1,0 +1,10 @@
+---
+"@ai-sdk/harness-claude-code": patch
+"@ai-sdk/harness-deepagents": patch
+"@ai-sdk/harness-opencode": patch
+"@ai-sdk/harness-codex": patch
+"@ai-sdk/harness-acp": patch
+"@ai-sdk/harness": patch
+---
+
+fix(harness): avoid warning about lack of credential brokering support when `credentialForwarding` callback is used to replace all credentials with ephemeral fake secrets

--- a/packages/harness-acp/src/acp-harness.test.ts
+++ b/packages/harness-acp/src/acp-harness.test.ts
@@ -1017,6 +1017,7 @@ describe('createACP', () => {
   });
 
   it('preserves real credential forwarding when additive transformations are unavailable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.stubEnv('PROVIDER_API_KEY', 'legacy-secret');
     const credentialBrokering = vi.fn(() => []);
     const spawns: Array<{
@@ -1043,11 +1044,16 @@ describe('createACP', () => {
 
     expect(credentialBrokering).not.toHaveBeenCalled();
     expect(spawns[0]!.env.PROVIDER_API_KEY).toBe('legacy-secret');
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      'The sandbox implementation does not support configuring request transformations, so credential brokering does not work. Falling back to less secure credential forwarding.',
+    );
 
     await session.doDestroy();
+    warn.mockRestore();
   });
 
   it('customizes direct and Gateway credentials under their sandbox environment names', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.stubEnv('PROVIDER_API_KEY', 'direct-secret');
     vi.stubEnv('AI_GATEWAY_API_KEY', 'gateway-secret');
     const credentialBrokering = vi.fn(() => []);
@@ -1112,8 +1118,10 @@ describe('createACP', () => {
         providerEnvironment: {},
       },
     });
+    expect(warn).not.toHaveBeenCalled();
 
     await session.doDestroy();
+    warn.mockRestore();
   });
 
   it('aborts before spawning when credential forwarding fails', async () => {

--- a/packages/harness-acp/src/v1/acp-v1-harness.ts
+++ b/packages/harness-acp/src/v1/acp-v1-harness.ts
@@ -333,8 +333,6 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
           'ai-gateway'
             ? {}
             : undefined;
-      } else if (settings.credentialBrokering != null) {
-        warnCredentialBrokeringUnavailable();
       }
       if (
         settings.credentialForwarding != null &&
@@ -561,6 +559,25 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
               credentialForwarding: settings.credentialForwarding,
             })
           : sandboxImplementationEnvironment;
+      if (
+        settings.credentialBrokering != null &&
+        sandboxCredentialEnvironment == null
+      ) {
+        warnCredentialBrokeringUnavailable({
+          environment: {
+            ...sandboxImplementationEnvironment,
+            ...resolvedProviderAuthentication.env,
+          },
+          forwardedEnvironment: {
+            ...forwardedImplementationEnvironment,
+            ...sandboxProviderAuthenticationEnvironment,
+          },
+          credentialEnvironmentVariables: [
+            ...credentialForwardingEnvironmentVariables,
+            'AI_SDK_ACP_GATEWAY_API_KEY',
+          ],
+        });
+      }
       const port = resolveBridgePort({
         sandboxSession,
         override: portOverride,

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -556,6 +556,7 @@ describe('createClaudeCode adapter', () => {
   });
 
   it('customizes real credentials when request transformations are unavailable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const spawnEnvs: Array<Record<string, string | undefined>> = [];
     const forwardedCredentials: Array<{
       credential: string;
@@ -598,8 +599,30 @@ describe('createClaudeCode adapter', () => {
       env: { ANTHROPIC_API_KEY: 'caller-managed-credential' },
     });
     expect(JSON.stringify(spawnEnvs.at(0))).not.toContain('anthropic-secret');
+    expect(warn).not.toHaveBeenCalled();
 
     await session.doDestroy();
+
+    const identityHarness = createClaudeCode({
+      auth: { ANTHROPIC_API_KEY: 'anthropic-secret' },
+      credentialForwarding: ({ credential }) => credential,
+    });
+    const identitySession = await identityHarness.doStart({
+      sessionId: 's2',
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        spawnEnvs: [],
+        writes: [],
+        runs: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/claude-code-s2',
+    });
+
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      'The sandbox implementation does not support configuring request transformations, so credential brokering does not work. Falling back to less secure credential forwarding.',
+    );
+
+    await identitySession.doDestroy();
   });
 
   it('customizes credentials forwarded through the Claude process environment', async () => {

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -921,12 +921,17 @@ export function createClaudeCode(
           );
         }
       } else {
-        warnCredentialBrokeringUnavailable();
         sandboxClaudeEnvironment = await applyCredentialForwarding({
           environment: sandboxClaudeEnvironment,
           credentialEnvironmentVariables:
             CLAUDE_CODE_CREDENTIAL_ENVIRONMENT_VARIABLES,
           credentialForwarding: settings.credentialForwarding,
+        });
+        warnCredentialBrokeringUnavailable({
+          environment: claudeEnvironment,
+          forwardedEnvironment: sandboxClaudeEnvironment,
+          credentialEnvironmentVariables:
+            CLAUDE_CODE_CREDENTIAL_ENVIRONMENT_VARIABLES,
         });
       }
       const bootstrapDir = posix.resolve(

--- a/packages/harness-codex/src/codex-harness.test.ts
+++ b/packages/harness-codex/src/codex-harness.test.ts
@@ -475,6 +475,7 @@ describe('createCodex adapter', () => {
   });
 
   it('customizes real credentials when request transformations are unavailable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const spawnEnvs: Array<Record<string, string | undefined>> = [];
     const forwardedCredentials: Array<{
       credential: string;
@@ -510,8 +511,36 @@ describe('createCodex adapter', () => {
     ]);
     expect(spawnEnvs.at(0)?.CODEX_API_KEY).toBe('caller-managed-credential');
     expect(JSON.stringify(spawnEnvs.at(0))).not.toContain('openai-secret');
+    expect(warn).not.toHaveBeenCalled();
 
     await session.doDestroy();
+
+    const identityHarness = createCodex({
+      auth: { OPENAI_API_KEY: 'openai-secret' },
+      credentialForwarding: ({ credential }) => credential,
+    });
+    const identitySandboxSession = fakeNetworkSandboxSessionForStartupSuccess({
+      bridgePortUrl: 'ws://127.0.0.1:1',
+      runs: [],
+      spawns: [],
+      spawnEnvs: [],
+      writes: [],
+    });
+    Object.assign(identitySandboxSession, {
+      addRequestTransformations: undefined,
+    });
+    const identitySession = await identityHarness.doStart({
+      sessionId: 's2',
+      sandboxSession: identitySandboxSession,
+      sessionWorkDir: '/vercel/sandbox/codex-s2',
+    });
+
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      'The sandbox implementation does not support configuring request transformations, so credential brokering does not work. Falling back to less secure credential forwarding.',
+    );
+
+    await identitySession.doDestroy();
+    warn.mockRestore();
   });
 
   it('configures the standard OpenAI URL for brokered direct auth', async () => {

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -313,8 +313,6 @@ export function createCodex(
            */
           sandboxAuthEnvironment.OPENAI_BASE_URL = DEFAULT_OPENAI_BASE_URL;
         }
-      } else {
-        warnCredentialBrokeringUnavailable();
       }
       const bootstrapDir = path.posix.resolve(
         defaultWorkingDirectory,
@@ -446,6 +444,14 @@ export function createCodex(
               CODEX_CREDENTIAL_ENVIRONMENT_VARIABLES,
             credentialForwarding: settings.credentialForwarding,
           });
+      if (!credentialsBrokered) {
+        warnCredentialBrokeringUnavailable({
+          environment: resolvedAuthEnvironment,
+          forwardedEnvironment: forwardedAuthEnvironment,
+          credentialEnvironmentVariables:
+            CODEX_CREDENTIAL_ENVIRONMENT_VARIABLES,
+        });
+      }
       const env = {
         ...forwardedAuthEnvironment,
         AI_SDK_HARNESS_CLIENT_APP: CODEX_CLIENT_APP,

--- a/packages/harness-deepagents/src/deepagents-harness.test.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.test.ts
@@ -343,6 +343,7 @@ describe('createDeepAgents', () => {
   });
 
   it('customizes real credentials when request transformations are unavailable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const spawnEnvs: Array<Record<string, string | undefined>> = [];
     const forwardedCredentials: Array<{
       credential: string;
@@ -372,8 +373,26 @@ describe('createDeepAgents', () => {
       'caller-managed-credential',
     );
     expect(JSON.stringify(spawnEnvs.at(0))).not.toContain('anthropic-secret');
+    expect(warn).not.toHaveBeenCalled();
 
     await session.doDestroy();
+
+    const identityHarness = createDeepAgents({
+      auth: { ANTHROPIC_API_KEY: 'anthropic-secret' },
+      credentialForwarding: ({ credential }) => credential,
+    });
+    const identitySession = await identityHarness.doStart({
+      sessionId: 'identity-session',
+      sessionWorkDir: '/vercel/sandbox/deepagents-identity-session',
+      sandboxSession: fakeSandboxSession(),
+    } as unknown as Parameters<typeof identityHarness.doStart>[0]);
+
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      'The sandbox implementation does not support configuring request transformations, so credential brokering does not work. Falling back to less secure credential forwarding.',
+    );
+
+    await identitySession.doDestroy();
+    warn.mockRestore();
   });
 
   it('passes configured MCP servers to the bridge', async () => {

--- a/packages/harness-deepagents/src/deepagents-harness.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.ts
@@ -292,8 +292,6 @@ export function createDeepAgents(
           );
         }
         credentialsBrokered = true;
-      } else {
-        warnCredentialBrokeringUnavailable();
       }
       const bootstrapDir = posix.resolve(
         defaultWorkingDirectory,
@@ -393,6 +391,14 @@ export function createDeepAgents(
               DEEPAGENTS_CREDENTIAL_ENVIRONMENT_VARIABLES,
             credentialForwarding: settings.credentialForwarding,
           });
+      if (!credentialsBrokered) {
+        warnCredentialBrokeringUnavailable({
+          environment: resolvedAuthEnvironment,
+          forwardedEnvironment: forwardedAuthEnvironment,
+          credentialEnvironmentVariables:
+            DEEPAGENTS_CREDENTIAL_ENVIRONMENT_VARIABLES,
+        });
+      }
       const env = {
         ...forwardedAuthEnvironment,
         AI_SDK_HARNESS_CLIENT_APP: DEEPAGENTS_CLIENT_APP,

--- a/packages/harness-opencode/src/opencode-harness.test.ts
+++ b/packages/harness-opencode/src/opencode-harness.test.ts
@@ -436,6 +436,7 @@ describe('createOpenCode adapter', () => {
   });
 
   it('customizes real credentials when request transformations are unavailable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     harnessUtilsMocks.waitForBridgeReady.mockResolvedValueOnce({ port: 4000 });
     const spawnEnvs: Array<Record<string, string | undefined>> = [];
     const forwardedCredentials: Array<{
@@ -503,8 +504,28 @@ describe('createOpenCode adapter', () => {
     ]);
     expect(spawnEnvs.at(0)?.OPENAI_API_KEY).toBe('caller-managed-credential');
     expect(JSON.stringify(spawnEnvs.at(0))).not.toContain('openai-secret');
+    expect(warn).not.toHaveBeenCalled();
 
     await session.doDetach();
+
+    const identityHarness = createOpenCode({
+      provider: 'openai',
+      auth: { OPENAI_API_KEY: 'openai-secret' },
+      credentialForwarding: ({ credential }) => credential,
+    });
+    harnessUtilsMocks.waitForBridgeReady.mockResolvedValueOnce({ port: 4000 });
+    const identitySession = await identityHarness.doStart({
+      sessionId: 's2',
+      sandboxSession,
+      sessionWorkDir: '/workspace/project-2',
+    });
+
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      'The sandbox implementation does not support configuring request transformations, so credential brokering does not work. Falling back to less secure credential forwarding.',
+    );
+
+    await identitySession.doDetach();
+    warn.mockRestore();
   });
 
   it('writes skills under sandbox HOME and starts OpenCode with that HOME', async () => {

--- a/packages/harness-opencode/src/opencode-harness.ts
+++ b/packages/harness-opencode/src/opencode-harness.ts
@@ -336,8 +336,6 @@ export function createOpenCode(
           );
         }
         credentialsBrokered = true;
-      } else {
-        warnCredentialBrokeringUnavailable();
       }
       const bootstrapDir = path.posix.resolve(
         defaultWorkingDirectory,
@@ -457,6 +455,14 @@ export function createOpenCode(
               OPENCODE_CREDENTIAL_ENVIRONMENT_VARIABLES,
             credentialForwarding: settings.credentialForwarding,
           });
+      if (!credentialsBrokered) {
+        warnCredentialBrokeringUnavailable({
+          environment: resolvedAuthEnvironment,
+          forwardedEnvironment: forwardedAuthEnvironment,
+          credentialEnvironmentVariables:
+            OPENCODE_CREDENTIAL_ENVIRONMENT_VARIABLES,
+        });
+      }
       const env = {
         ...forwardedAuthEnvironment,
         AI_SDK_HARNESS_CLIENT_APP: OPENCODE_CLIENT_APP,

--- a/packages/harness/src/utils/sandbox-credential-brokering.test.ts
+++ b/packages/harness/src/utils/sandbox-credential-brokering.test.ts
@@ -18,14 +18,68 @@ afterEach(() => {
 });
 
 describe('warnCredentialBrokeringUnavailable', () => {
-  it('warns that credential forwarding is less secure', () => {
+  it('does not warn when credential forwarding replaces all credentials', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    warnCredentialBrokeringUnavailable();
+    warnCredentialBrokeringUnavailable({
+      environment: {
+        API_KEY: 'real-secret',
+        SECOND_API_KEY: 'second-real-secret',
+      },
+      forwardedEnvironment: {
+        API_KEY: 'caller-managed-credential',
+        SECOND_API_KEY: 'second-caller-managed-credential',
+      },
+      credentialEnvironmentVariables: ['API_KEY', 'SECOND_API_KEY'],
+    });
 
-    expect(warn).toHaveBeenCalledWith(
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns when credential forwarding preserves a credential', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    warnCredentialBrokeringUnavailable({
+      environment: {
+        API_KEY: 'real-secret',
+        SECOND_API_KEY: 'second-real-secret',
+      },
+      forwardedEnvironment: {
+        API_KEY: 'caller-managed-credential',
+        SECOND_API_KEY: 'second-real-secret',
+      },
+      credentialEnvironmentVariables: ['API_KEY', 'SECOND_API_KEY'],
+    });
+
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
       'The sandbox implementation does not support configuring request transformations, so credential brokering does not work. Falling back to less secure credential forwarding.',
     );
+  });
+
+  it('warns when a forwarded credential contains an original credential', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    warnCredentialBrokeringUnavailable({
+      environment: { API_KEY: 'real-secret' },
+      forwardedEnvironment: { API_KEY: 'wrapped-real-secret' },
+      credentialEnvironmentVariables: ['API_KEY'],
+    });
+
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      'The sandbox implementation does not support configuring request transformations, so credential brokering does not work. Falling back to less secure credential forwarding.',
+    );
+  });
+
+  it('does not warn when no original credentials are present', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    warnCredentialBrokeringUnavailable({
+      environment: {},
+      forwardedEnvironment: {},
+      credentialEnvironmentVariables: ['API_KEY'],
+    });
+
+    expect(warn).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/harness/src/utils/sandbox-credential-brokering.ts
+++ b/packages/harness/src/utils/sandbox-credential-brokering.ts
@@ -11,7 +11,38 @@ export function isSandboxCredentialPlaceholder(value: string): boolean {
   return /^aisdkhc_[A-Za-z0-9_-]{43}$/.test(value);
 }
 
-export function warnCredentialBrokeringUnavailable(): void {
+/**
+ * Warns when credential brokering is unavailable, but only if real credentials
+ * remain among the credentials forwarded into the sandbox.
+ */
+export function warnCredentialBrokeringUnavailable(options: {
+  environment: Readonly<Record<string, string>>;
+  forwardedEnvironment: Readonly<Record<string, string>>;
+  credentialEnvironmentVariables: ReadonlyArray<string>;
+}): void {
+  const credentialEnvironmentVariables = [
+    ...new Set(options.credentialEnvironmentVariables),
+  ];
+  const credentials = credentialEnvironmentVariables
+    .map(name => options.environment[name])
+    .filter(
+      (credential): credential is string =>
+        credential != null && credential.length > 0,
+    );
+  const forwardedCredentials = credentialEnvironmentVariables
+    .map(name => options.forwardedEnvironment[name])
+    .filter((credential): credential is string => credential != null);
+
+  if (
+    !credentials.some(credential =>
+      forwardedCredentials.some(forwardedCredential =>
+        forwardedCredential.includes(credential),
+      ),
+    )
+  ) {
+    return;
+  }
+
   console.warn(
     'The sandbox implementation does not support configuring request transformations, so credential brokering does not work. Falling back to less secure credential forwarding.',
   );


### PR DESCRIPTION
## Background

Harness adapters warn that credential forwarding is insecure whenever the sandbox cannot broker credentials, even when `credentialForwarding` replaces every real credential with an ephemeral fake secret.

## Summary

- Check the final forwarded credential values before emitting the warning.
- Suppress the warning when no real credential remains in the sandbox environment.
- Preserve the warning for unchanged or wrapped real credentials.
- Cover the shared behavior and affected harness adapters with regression tests.

## End-to-End Verification

Tested with a temporary `credential-forwarding` e2e example.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
