### PR TITLE
feat(openai): accept serviceTier 'ultrafast'

### DIFF
--- a/.changeset/openai-service-tier-ultrafast.md
+++ b/.changeset/openai-service-tier-ultrafast.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/openai': patch
+'@ai-sdk/azure': patch
+---
+
+Accept `serviceTier: 'ultrafast'` on OpenAI chat and responses models. OpenAI published Ultrafast as `service_tier: 'ultrafast'` (currently `gpt-5.6-sol`) in the official Responses API reference and in openai-node `ServiceTier` since v7.5.0. It is a separate access-controlled tier, so `'ultrafast'` is passed through as `service_tier: 'ultrafast'` and is not gated on priority processing. `@ai-sdk/azure` re-exports the same option type and will forward the value; Azure OpenAI does not document this tier.

--- a/content/providers/01-ai-sdk-providers/04-azure.mdx
+++ b/content/providers/01-ai-sdk-providers/04-azure.mdx
@@ -191,6 +191,8 @@ and support structured data generation with [`Output`](/docs/reference/ai-sdk-co
 
 When using OpenAI language models on Azure, you can configure provider-specific options using `providerOptions.openai`. More information on available configuration options are on [the OpenAI provider page](/providers/ai-sdk-providers/openai#language-models).
 
+`serviceTier: 'ultrafast'` is an OpenAI-only preview tier (currently `gpt-5.6-sol`). Azure OpenAI does not document it. The shared option type accepts the value and forwards `service_tier` as-is.
+
 ```ts highlight="12-14,24-26"
 import { azure, type OpenAILanguageModelResponsesOptions } from '@ai-sdk/azure';
 

--- a/packages/openai/src/chat/openai-chat-language-model-options.ts
+++ b/packages/openai/src/chat/openai-chat-language-model-options.ts
@@ -139,12 +139,20 @@ export const openaiLanguageModelChatOptions = lazySchema(() =>
        * - 'flex': 50% cheaper processing at the cost of increased latency. Only available for o3 and o4-mini models.
        * - 'priority': Higher-speed processing with predictably low latency at premium cost. Available for Enterprise customers.
        * - 'fast': OpenAI's newer name for the 'priority' tier. Interchangeable with it.
+       * - 'ultrafast': Access-controlled Ultrafast processing. Currently available for gpt-5.6-sol;
+       *                a response served through it reports service_tier=ultrafast.
+       *                Published on the Responses `service_tier` parameter and openai-node `ServiceTier`
+       *                (v7.5.0+). This is an OpenAI-only preview tier, not Azure OpenAI.
        * - 'default': The request will be processed with the standard pricing and performance for the selected model.
+       *
+       * @see https://developers.openai.com/api/reference/resources/responses/methods/create
+       * @see https://developers.openai.com/api/docs/changelog
+       * @see https://openai.com/index/previewing-ultrafast/
        *
        * @default 'auto'
        */
       serviceTier: z
-        .enum(['auto', 'flex', 'priority', 'fast', 'default'])
+        .enum(['auto', 'flex', 'priority', 'fast', 'ultrafast', 'default'])
         .optional(),
 
       /**

--- a/packages/openai/src/openai-service-tier-ultrafast.test.ts
+++ b/packages/openai/src/openai-service-tier-ultrafast.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import { createOpenAI } from './openai-provider';
+
+const prompt: LanguageModelV4Prompt = [
+  { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+];
+
+function successfulChatResponse(model: string) {
+  return {
+    id: 'chatcmpl_test',
+    object: 'chat.completion',
+    created: 1,
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: 'ok' },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: {
+      prompt_tokens: 1,
+      completion_tokens: 1,
+      total_tokens: 2,
+    },
+  };
+}
+
+function successfulResponsesResponse(model: string) {
+  return {
+    id: 'resp_test',
+    object: 'response',
+    created_at: 1,
+    status: 'completed',
+    model,
+    output: [
+      {
+        id: 'msg_test',
+        type: 'message',
+        status: 'completed',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'ok' }],
+      },
+    ],
+    usage: {
+      input_tokens: 1,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens: 1,
+      output_tokens_details: { reasoning_tokens: 0 },
+      total_tokens: 2,
+    },
+  };
+}
+
+function sseChatChunk(model: string) {
+  return [
+    `data: ${JSON.stringify({
+      id: 'chatcmpl_test',
+      object: 'chat.completion.chunk',
+      created: 1,
+      model,
+      choices: [
+        {
+          index: 0,
+          delta: { role: 'assistant', content: 'ok' },
+          finish_reason: null,
+        },
+      ],
+    })}\n\n`,
+    `data: ${JSON.stringify({
+      id: 'chatcmpl_test',
+      object: 'chat.completion.chunk',
+      created: 1,
+      model,
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+    })}\n\n`,
+    'data: [DONE]\n\n',
+  ].join('');
+}
+
+describe('OpenAI serviceTier ultrafast', () => {
+  it('sends service_tier ultrafast on Chat Completions for gpt-5.6-sol', async () => {
+    let requestBody: { service_tier?: string; model?: string } | undefined;
+
+    const provider = createOpenAI({
+      apiKey: 'test-api-key',
+      fetch: async (_input, init) => {
+        requestBody = JSON.parse(String(init?.body));
+        return Response.json(successfulChatResponse(requestBody!.model!));
+      },
+    });
+
+    const result = await provider.chat('gpt-5.6-sol').doGenerate({
+      prompt,
+      providerOptions: {
+        openai: {
+          serviceTier: 'ultrafast',
+        },
+      },
+    });
+
+    expect(requestBody).toMatchObject({
+      model: 'gpt-5.6-sol',
+      service_tier: 'ultrafast',
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('sends service_tier ultrafast on Chat Completions streaming', async () => {
+    let requestBody:
+      | { service_tier?: string; model?: string; stream?: boolean }
+      | undefined;
+
+    const provider = createOpenAI({
+      apiKey: 'test-api-key',
+      fetch: async (_input, init) => {
+        requestBody = JSON.parse(String(init?.body));
+        return new Response(sseChatChunk(requestBody!.model!), {
+          headers: { 'Content-Type': 'text/event-stream' },
+        });
+      },
+    });
+
+    await provider.chat('gpt-5.6-sol').doStream({
+      prompt,
+      providerOptions: {
+        openai: {
+          serviceTier: 'ultrafast',
+        },
+      },
+    });
+
+    expect(requestBody).toMatchObject({
+      model: 'gpt-5.6-sol',
+      service_tier: 'ultrafast',
+      stream: true,
+    });
+  });
+
+  it('sends service_tier ultrafast on Responses for gpt-5.6-sol', async () => {
+    let requestBody: { service_tier?: string; model?: string } | undefined;
+
+    const provider = createOpenAI({
+      apiKey: 'test-api-key',
+      fetch: async (_input, init) => {
+        requestBody = JSON.parse(String(init?.body));
+        return Response.json(successfulResponsesResponse(requestBody!.model!));
+      },
+    });
+
+    const result = await provider.responses('gpt-5.6-sol').doGenerate({
+      prompt,
+      providerOptions: {
+        openai: {
+          serviceTier: 'ultrafast',
+        },
+      },
+    });
+
+    expect(requestBody).toMatchObject({
+      model: 'gpt-5.6-sol',
+      service_tier: 'ultrafast',
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('does not gate ultrafast on priority-processing support', async () => {
+    let requestBody: { service_tier?: string } | undefined;
+
+    const provider = createOpenAI({
+      apiKey: 'test-api-key',
+      fetch: async (_input, init) => {
+        requestBody = JSON.parse(String(init?.body));
+        return Response.json(successfulChatResponse('gpt-3.5-turbo'));
+      },
+    });
+
+    const result = await provider.chat('gpt-3.5-turbo').doGenerate({
+      prompt,
+      providerOptions: {
+        openai: {
+          serviceTier: 'ultrafast',
+        },
+      },
+    });
+
+    expect(requestBody?.service_tier).toBe('ultrafast');
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/packages/openai/src/responses/openai-responses-language-model-options.ts
+++ b/packages/openai/src/responses/openai-responses-language-model-options.ts
@@ -294,11 +294,18 @@ export const openaiLanguageModelResponsesOptionsSchema = lazySchema(() =>
        * Set to 'flex' for 50% cheaper processing at the cost of increased latency (available for o3, o4-mini, and gpt-5 models).
        * Set to 'priority' for faster processing with Enterprise access (available for gpt-4, gpt-5, gpt-5-mini, o3, o4-mini; gpt-5-nano is not supported).
        * Set to 'fast' for the same tier as 'priority' (OpenAI's newer name for it).
+       * Set to 'ultrafast' for access-controlled Ultrafast processing (currently gpt-5.6-sol).
+       * Published on the Responses `service_tier` parameter and openai-node `ServiceTier`
+       * (v7.5.0+). This is an OpenAI-only preview tier, not Azure OpenAI.
+       *
+       * @see https://developers.openai.com/api/reference/resources/responses/methods/create
+       * @see https://developers.openai.com/api/docs/changelog
+       * @see https://openai.com/index/previewing-ultrafast/
        *
        * Defaults to 'auto'.
        */
       serviceTier: z
-        .enum(['auto', 'flex', 'priority', 'fast', 'default'])
+        .enum(['auto', 'flex', 'priority', 'fast', 'ultrafast', 'default'])
         .nullish(),
 
       /**


### PR DESCRIPTION
## Background

OpenAI published Ultrafast as `service_tier: "ultrafast"` for `gpt-5.6-sol`. `@ai-sdk/openai` still Zod-validates `providerOptions.openai.serviceTier` without that value, so the request never reaches the API.

Same shape as #18589 (`'fast'`), but Ultrafast is a **separate** Cerebras-backed tier, not a rename of priority/fast.

This supersedes #20151 (that branch accidentally truncated `03-openai.mdx` during a docs upload).

## Evidence that Ultrafast is published

The official Responses `service_tier` parameter lists `"ultrafast"` and documents the wire value:

- [Responses create — `service_tier`](https://developers.openai.com/api/reference/resources/responses/methods/create): *If set to 'ultrafast', then the request will be processed with the access-controlled Ultrafast Processing service tier. This tier is currently available for `gpt-5.6-sol`; a response served through it will show `service_tier=ultrafast`.* The enum on that page is `auto | default | flex | scale | priority | fast | ultrafast`.
- [API changelog, 13 Aug 2026](https://developers.openai.com/api/docs/changelog): *Announced Ultrafast mode, a new API service tier for GPT-5.6 Sol*
- [Previewing Ultrafast](https://openai.com/index/previewing-ultrafast/)
- [openai-node `ServiceTier`](https://github.com/openai/openai-node/blob/master/src/resources/responses/responses.ts) since [v7.5.0 (17 Aug 2026)](https://github.com/openai/openai-node/releases/tag/v7.5.0): `'auto' | 'default' | 'flex' | 'scale' | 'priority' | 'fast' | 'ultrafast' | null`

Chat Completions types in openai-node still use an older inline union without `ultrafast`. That is SDK lag on the chat resource, not the API contract. AI SDK Responses (the default since v5) should follow the Responses `ServiceTier` type.

## Summary

- add `'ultrafast'` to the chat and responses `serviceTier` enums; forwarded as `service_tier: "ultrafast"`
- do **not** gate on `supportsPriorityProcessing`
- tests: chat generate/stream, responses generate, no-gating case
- `@ai-sdk/azure` re-exports the same option type (same as `'fast'` in #18589). Documented on the Azure provider page: Ultrafast is OpenAI-only; Azure forwards the value and does not document the tier
- patch changeset for `@ai-sdk/openai` and `@ai-sdk/azure`

## End-to-End Verification

Unit tests only. I do not have Ultrafast preview access, so this was not smoked against `api.openai.com`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

`content/providers/01-ai-sdk-providers/03-openai.mdx` still needs the two `serviceTier` unions updated to include `'ultrafast'` (Responses + Chat sections). That file is ~112KB and a previous upload truncated it, which is why #20151 was closed. Suggested copy is in the JSDoc on the option schemas. Happy to add the mdx hunks if a maintainer applies them or I get a path that will not clobber the file.
