### PR TITLE
fix(anthropic): recognize Vertex Claude 4 model IDs

### DIFF
--- a/.changeset/calm-taxis-smile.md
+++ b/.changeset/calm-taxis-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+fix(anthropic): recognize dated Google Vertex Claude 4 model IDs when selecting model capabilities

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -11484,6 +11484,16 @@ describe('getModelCapabilities', () => {
     `);
   });
 
+  it.each([
+    ['claude-sonnet-4@20250514', 64000],
+    ['claude-opus-4@20250514', 32000],
+  ])('should recognize the Vertex model ID %s', (modelId, maxOutputTokens) => {
+    expect(getModelCapabilities(modelId)).toMatchObject({
+      isKnownModel: true,
+      maxOutputTokens,
+    });
+  });
+
   it('should return conservative capabilities for an unknown non-Claude model', () => {
     expect(getModelCapabilities('third-party-future-model'))
       .toMatchInlineSnapshot(`

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -2887,7 +2887,7 @@ export function getModelCapabilities(modelId: string): {
       rejectsThinkingDisabledAboveHighEffort: false,
       isKnownModel: true,
     };
-  } else if (modelId.includes('claude-sonnet-4-')) {
+  } else if (/claude-sonnet-4(?:-|@)/.test(modelId)) {
     return {
       maxOutputTokens: 64000,
       supportsStructuredOutput: false,
@@ -2897,7 +2897,7 @@ export function getModelCapabilities(modelId: string): {
       rejectsThinkingDisabledAboveHighEffort: false,
       isKnownModel: true,
     };
-  } else if (modelId.includes('claude-opus-4-')) {
+  } else if (/claude-opus-4(?:-|@)/.test(modelId)) {
     return {
       maxOutputTokens: 32000,
       supportsStructuredOutput: false,


### PR DESCRIPTION
## Background

Google Vertex model IDs such as `claude-sonnet-4@20250514` missed the known Claude 4 capability checks and fell through to the future-Claude defaults. With no explicit `maxOutputTokens`, this sent `128000` instead of the model's supported limit and Vertex rejected the request.

## Summary

Recognizes the `@YYYYMMDD` Vertex spelling for Claude Sonnet 4 and Opus 4, preserving their existing 64k and 32k output limits.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

🤖
