### PR TITLE
feat(batch): surface the uploaded input file on the batch start result

### DIFF
--- a/.changeset/batch-input-file-metadata.md
+++ b/.changeset/batch-input-file-metadata.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/openai': patch
+'@ai-sdk/xai': patch
+'@ai-sdk/google': patch
+---
+
+feat(batch): surface the uploaded input file on the batch start result (`providerMetadata.<provider>.inputFileId` / `inputFileExpiresAt`) and accept an `inputFileExpiresAfter` provider option on the OpenAI and xAI batch input file upload

--- a/packages/google/src/google-batch.test.ts
+++ b/packages/google/src/google-batch.test.ts
@@ -102,6 +102,7 @@ function prepareUpload() {
         sizeBytes: '256',
         uri: 'https://generativelanguage.googleapis.com/v1beta/files/batch-input',
         state: 'ACTIVE',
+        expirationTime: '2026-08-27T12:00:00Z',
       },
     },
   };
@@ -228,6 +229,7 @@ describe('GoogleBatchLanguageModel', () => {
       abortSignal: abortController.signal,
     });
 
+    expect(result.providerMetadata).toBeUndefined();
     expect(result).toMatchObject({
       batchId: 'batches/batch-123',
       status: 'pending',
@@ -378,6 +380,12 @@ describe('GoogleBatchLanguageModel', () => {
     });
 
     expect(result.warnings).toEqual([]);
+    expect(result.providerMetadata).toEqual({
+      google: {
+        inputFileId: 'files/batch-input',
+        inputFileExpiresAt: '2026-08-27T12:00:00Z',
+      },
+    });
 
     expect(server.calls.map(call => call.requestUrl)).toEqual([
       urls.uploadStart,

--- a/packages/google/src/google-batch.ts
+++ b/packages/google/src/google-batch.ts
@@ -105,6 +105,7 @@ const googleFileUploadResponseSchema = lazySchema(() =>
     z.object({
       file: z.object({
         name: z.string(),
+        expirationTime: z.string().nullish(),
       }),
     }),
   ),
@@ -244,6 +245,7 @@ export class GoogleBatchLanguageModel
       this.modelId,
     )}:batchGenerateContent`;
     let operation: GoogleBatchOperation;
+    let inputFileMetadata: Record<string, string> | undefined;
 
     if (fileParts == null) {
       const { value } = await postJsonToApi({
@@ -310,6 +312,13 @@ export class GoogleBatchLanguageModel
         fetch: this.batchConfig.fetch,
       });
 
+      inputFileMetadata = {
+        inputFileId: uploadedFile.file.name,
+        ...(uploadedFile.file.expirationTime != null
+          ? { inputFileExpiresAt: uploadedFile.file.expirationTime }
+          : {}),
+      };
+
       const { value } = await postJsonToApi({
         url: createUrl,
         headers,
@@ -337,6 +346,9 @@ export class GoogleBatchLanguageModel
     return {
       batchId: operation.name,
       ...convertGoogleBatchStatus(operation),
+      ...(inputFileMetadata != null
+        ? { providerMetadata: { google: inputFileMetadata } }
+        : {}),
       warnings,
     };
   }

--- a/packages/google/src/google-batch.ts
+++ b/packages/google/src/google-batch.ts
@@ -244,11 +244,9 @@ export class GoogleBatchLanguageModel
     const createUrl = `${this.batchConfig.baseURL}/${getModelPath(
       this.modelId,
     )}:batchGenerateContent`;
-    let operation: GoogleBatchOperation;
-    let inputFileMetadata: Record<string, string> | undefined;
 
     if (fileParts == null) {
-      const { value } = await postJsonToApi({
+      const { value: operation } = await postJsonToApi({
         url: createUrl,
         headers,
         body: inlineBatchBody,
@@ -259,96 +257,98 @@ export class GoogleBatchLanguageModel
         abortSignal: options.abortSignal,
         fetch: this.batchConfig.fetch,
       });
-      operation = value;
-    } else {
-      const inputFile = new Blob(fileParts, { type: 'application/jsonl' });
-      // Blob snapshots the strings, so release the potentially large input array.
-      fileParts.length = 0;
-      if (inputFile.size > googleBatchInputFileMaxBytes) {
-        throw new InvalidArgumentError({
-          argument: 'requests',
-          message: 'Google batch input files must not exceed 2 GB.',
-        });
-      }
 
-      const { value: uploadUrl } = await postJsonToApi({
-        url: `${this.getBaseOrigin()}/upload/v1beta/files`,
-        headers: combineHeaders(headers, {
-          'X-Goog-Upload-Protocol': 'resumable',
-          'X-Goog-Upload-Command': 'start',
-          'X-Goog-Upload-Header-Content-Length': String(inputFile.size),
-          'X-Goog-Upload-Header-Content-Type': 'application/jsonl',
-        }),
-        body: {
-          file: {
-            display_name: `${displayName}-input`,
-          },
-        },
-        failedResponseHandler: googleFailedResponseHandler,
-        successfulResponseHandler: googleUploadUrlResponseHandler,
-        abortSignal: options.abortSignal,
-        fetch: this.batchConfig.fetch,
-      });
-
-      const { value: uploadedFile } = await postToApi({
-        url: uploadUrl,
-        headers: {
-          'X-Goog-Upload-Offset': '0',
-          'X-Goog-Upload-Command': 'upload, finalize',
-          'Content-Type': 'application/jsonl',
-        },
-        body: {
-          content: inputFile,
-          values: {
-            byteLength: inputFile.size,
-            mediaType: 'application/jsonl',
-          },
-        },
-        failedResponseHandler: googleFailedResponseHandler,
-        successfulResponseHandler: createJsonResponseHandler(
-          googleFileUploadResponseSchema,
-        ),
-        abortSignal: options.abortSignal,
-        fetch: this.batchConfig.fetch,
-      });
-
-      inputFileMetadata = {
-        inputFileId: uploadedFile.file.name,
-        ...(uploadedFile.file.expirationTime != null
-          ? { inputFileExpiresAt: uploadedFile.file.expirationTime }
-          : {}),
+      return {
+        batchId: operation.name,
+        ...convertGoogleBatchStatus(operation),
+        warnings,
       };
+    }
 
-      const { value } = await postJsonToApi({
-        url: createUrl,
-        headers,
-        body: {
-          batch: {
-            displayName,
-            ...(options.webhookUrl != null && {
-              webhookConfig: { uris: [options.webhookUrl] },
-            }),
-            inputConfig: {
-              fileName: uploadedFile.file.name,
-            },
+    const inputFile = new Blob(fileParts, { type: 'application/jsonl' });
+    // Blob snapshots the strings, so release the potentially large input array.
+    fileParts.length = 0;
+    if (inputFile.size > googleBatchInputFileMaxBytes) {
+      throw new InvalidArgumentError({
+        argument: 'requests',
+        message: 'Google batch input files must not exceed 2 GB.',
+      });
+    }
+
+    const { value: uploadUrl } = await postJsonToApi({
+      url: `${this.getBaseOrigin()}/upload/v1beta/files`,
+      headers: combineHeaders(headers, {
+        'X-Goog-Upload-Protocol': 'resumable',
+        'X-Goog-Upload-Command': 'start',
+        'X-Goog-Upload-Header-Content-Length': String(inputFile.size),
+        'X-Goog-Upload-Header-Content-Type': 'application/jsonl',
+      }),
+      body: {
+        file: {
+          display_name: `${displayName}-input`,
+        },
+      },
+      failedResponseHandler: googleFailedResponseHandler,
+      successfulResponseHandler: googleUploadUrlResponseHandler,
+      abortSignal: options.abortSignal,
+      fetch: this.batchConfig.fetch,
+    });
+
+    const { value: uploadedFile } = await postToApi({
+      url: uploadUrl,
+      headers: {
+        'X-Goog-Upload-Offset': '0',
+        'X-Goog-Upload-Command': 'upload, finalize',
+        'Content-Type': 'application/jsonl',
+      },
+      body: {
+        content: inputFile,
+        values: {
+          byteLength: inputFile.size,
+          mediaType: 'application/jsonl',
+        },
+      },
+      failedResponseHandler: googleFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        googleFileUploadResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.batchConfig.fetch,
+    });
+
+    const { value: operation } = await postJsonToApi({
+      url: createUrl,
+      headers,
+      body: {
+        batch: {
+          displayName,
+          ...(options.webhookUrl != null && {
+            webhookConfig: { uris: [options.webhookUrl] },
+          }),
+          inputConfig: {
+            fileName: uploadedFile.file.name,
           },
         },
-        failedResponseHandler: googleFailedResponseHandler,
-        successfulResponseHandler: createJsonResponseHandler(
-          googleBatchOperationSchema,
-        ),
-        abortSignal: options.abortSignal,
-        fetch: this.batchConfig.fetch,
-      });
-      operation = value;
-    }
+      },
+      failedResponseHandler: googleFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        googleBatchOperationSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.batchConfig.fetch,
+    });
 
     return {
       batchId: operation.name,
       ...convertGoogleBatchStatus(operation),
-      ...(inputFileMetadata != null
-        ? { providerMetadata: { google: inputFileMetadata } }
-        : {}),
+      providerMetadata: {
+        google: {
+          inputFileId: uploadedFile.file.name,
+          ...(uploadedFile.file.expirationTime != null
+            ? { inputFileExpiresAt: uploadedFile.file.expirationTime }
+            : {}),
+        },
+      },
       warnings,
     };
   }

--- a/packages/harness-pi/src/pi-workspace-mirror.test.ts
+++ b/packages/harness-pi/src/pi-workspace-mirror.test.ts
@@ -530,7 +530,7 @@ describe('syncHostWorkspaceFromSandbox', () => {
         'utf8',
       ),
     ).toBe('# skill 699');
-  });
+  }, 30_000);
 
   it('mirrors members whose path exceeds the 100-character tar name field', async () => {
     const longName =

--- a/packages/openai/src/openai-responses-batch.test.ts
+++ b/packages/openai/src/openai-responses-batch.test.ts
@@ -81,6 +81,7 @@ function prepareCreateResponse(overrides: Record<string, unknown> = {}) {
       object: 'file',
       filename: 'batch.jsonl',
       purpose: 'batch',
+      expires_at: 1_700_172_800,
     },
   };
   server.urls[urls.batches].response = {
@@ -169,6 +170,12 @@ describe('OpenAI batch language models', () => {
       },
       createdAt: '2023-11-14T22:13:20.000Z',
       expiresAt: '2023-11-15T22:13:20.000Z',
+      providerMetadata: {
+        openai: {
+          inputFileId: 'file-input',
+          inputFileExpiresAt: '2023-11-16T22:13:20.000Z',
+        },
+      },
       warnings: [
         {
           warning: {
@@ -231,6 +238,41 @@ describe('OpenAI batch language models', () => {
       authorization: 'Bearer test-api-key',
       'provider-header': 'provider',
       'operation-header': 'operation',
+    });
+  });
+
+  it('applies the inputFileExpiresAfter provider option to the input file upload', async () => {
+    prepareCreateResponse();
+    const model = createOpenAI({ apiKey: 'test-api-key' }).responses('gpt-5.6');
+
+    await model.experimental_doStartBatch({
+      requests: [
+        { id: 'france', ...request('What is the capital of France?') },
+      ],
+      providerOptions: { openai: { inputFileExpiresAfter: 3600 } },
+    });
+
+    const multipart = await server.calls[0].requestBodyMultipart;
+    expect(multipart?.['expires_after[anchor]']).toBe('created_at');
+    expect(multipart?.['expires_after[seconds]']).toBe('3600');
+  });
+
+  it('omits inputFileExpiresAt when the upload response carries no expiry', async () => {
+    prepareCreateResponse();
+    server.urls[urls.files].response = {
+      type: 'json-value',
+      body: { id: 'file-input', object: 'file' },
+    };
+    const model = createOpenAI({ apiKey: 'test-api-key' }).responses('gpt-5.6');
+
+    const result = await model.experimental_doStartBatch({
+      requests: [
+        { id: 'france', ...request('What is the capital of France?') },
+      ],
+    });
+
+    expect(result.providerMetadata).toEqual({
+      openai: { inputFileId: 'file-input' },
     });
   });
 

--- a/packages/openai/src/openai-responses-batch.ts
+++ b/packages/openai/src/openai-responses-batch.ts
@@ -20,6 +20,7 @@ import {
   getFromApi,
   lazySchema,
   normalizeBatchRequestCounts,
+  parseProviderOptions,
   postJsonToApi,
   postToApi,
   safeValidateTypes,
@@ -52,7 +53,25 @@ import type { OpenAIResponsesModelId } from './responses/openai-responses-langua
 import type { ResponsesReasoningProviderMetadata } from './responses/openai-responses-provider-metadata';
 
 const openaiBatchEndpoint = '/v1/responses';
-const openaiBatchInputFileExpiresAfterSeconds = 48 * 60 * 60;
+const openaiBatchInputFileDefaultExpiresAfterSeconds = 48 * 60 * 60;
+
+const openaiBatchProviderOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      /**
+       * TTL in seconds for the uploaded batch input file, measured from
+       * upload time. OpenAI accepts integers between 3600 (1 hour) and
+       * 2592000 (30 days) inclusive. Defaults to 48 hours.
+       */
+      inputFileExpiresAfter: z
+        .number()
+        .int()
+        .min(3600)
+        .max(2_592_000)
+        .optional(),
+    }),
+  ),
+);
 
 type OpenAIBatchRequest = Parameters<
   BatchLanguageModelV4['experimental_doStartBatch']
@@ -153,6 +172,13 @@ class OpenAIResponsesBatch {
             },
           ];
 
+    const batchOptions = await this.parseBatchProviderOptions(
+      options.providerOptions,
+    );
+    const inputFileExpiresAfterSeconds =
+      batchOptions?.inputFileExpiresAfter ??
+      openaiBatchInputFileDefaultExpiresAfterSeconds;
+
     for (const request of options.requests) {
       const preparedRequest = await this.options.prepareRequest(request);
 
@@ -200,7 +226,7 @@ class OpenAIResponsesBatch {
     formData.append('expires_after[anchor]', 'created_at');
     formData.append(
       'expires_after[seconds]',
-      String(openaiBatchInputFileExpiresAfterSeconds),
+      String(inputFileExpiresAfterSeconds),
     );
 
     const { value: uploadedFile } = await postToApi({
@@ -211,9 +237,7 @@ class OpenAIResponsesBatch {
         values: {
           purpose: 'batch',
           'expires_after[anchor]': 'created_at',
-          'expires_after[seconds]': String(
-            openaiBatchInputFileExpiresAfterSeconds,
-          ),
+          'expires_after[seconds]': String(inputFileExpiresAfterSeconds),
           file: {
             name: filename,
             type: file.type,
@@ -245,11 +269,42 @@ class OpenAIResponsesBatch {
       fetch: this.options.config.fetch,
     });
 
+    const inputFileExpiresAt = convertUnixTimestamp(uploadedFile.expires_at);
+
     return {
       batchId: batch.id,
       ...convertOpenAIBatchStatus(batch),
+      providerMetadata: {
+        openai: {
+          inputFileId: uploadedFile.id,
+          ...(inputFileExpiresAt != null ? { inputFileExpiresAt } : {}),
+        },
+      },
       warnings,
     };
+  }
+
+  private async parseBatchProviderOptions(
+    providerOptions: BatchV4StartOptions<OpenAIBatchRequest>['providerOptions'],
+  ) {
+    const providerOptionsName = this.options.config.provider.includes('azure')
+      ? 'azure'
+      : 'openai';
+    let batchOptions = await parseProviderOptions({
+      provider: providerOptionsName,
+      providerOptions,
+      schema: openaiBatchProviderOptionsSchema,
+    });
+
+    if (batchOptions == null && providerOptionsName !== 'openai') {
+      batchOptions = await parseProviderOptions({
+        provider: 'openai',
+        providerOptions,
+        schema: openaiBatchProviderOptionsSchema,
+      });
+    }
+
+    return batchOptions;
   }
 
   async getBatchStatus(

--- a/packages/xai/src/responses/xai-responses-batch.test.ts
+++ b/packages/xai/src/responses/xai-responses-batch.test.ts
@@ -114,7 +114,11 @@ describe('xAI Responses batch language model', () => {
   it('uploads prepared JSONL requests and creates a file-backed batch', async () => {
     server.urls[urls.files].response = {
       type: 'json-value',
-      body: { id: 'file_123', filename: 'batch.jsonl' },
+      body: {
+        id: 'file_123',
+        filename: 'batch.jsonl',
+        expires_at: 1_700_172_800,
+      },
     };
     server.urls[urls.batches].response = {
       type: 'json-value',
@@ -156,6 +160,12 @@ describe('xAI Responses batch language model', () => {
       },
       createdAt: '2026-08-25T12:00:00Z',
       expiresAt: '2099-08-26T12:00:00Z',
+      providerMetadata: {
+        xai: {
+          inputFileId: 'file_123',
+          inputFileExpiresAt: '2023-11-16T22:13:20.000Z',
+        },
+      },
       warnings: [
         {
           warning: {
@@ -176,6 +186,7 @@ describe('xAI Responses batch language model', () => {
     const file = multipart?.file as File;
     expect(file.name).toBe('batch.jsonl');
     expect(file.type).toBe('application/jsonl');
+    expect(multipart?.expires_after).toBeUndefined();
     const lines = (await file.text())
       .trim()
       .split('\n')
@@ -231,6 +242,37 @@ describe('xAI Responses batch language model', () => {
         'operation-header': 'operation',
       });
     }
+  });
+
+  it('appends inputFileExpiresAfter as expires_after before the file part', async () => {
+    server.urls[urls.files].response = {
+      type: 'json-value',
+      body: { id: 'file_123', filename: 'batch.jsonl' },
+    };
+    server.urls[urls.batches].response = {
+      type: 'json-value',
+      body: batchResponse(),
+    };
+    const model = createXai({ apiKey: 'test-api-key' }).responses('grok-4.3');
+
+    const result = await model.experimental_doStartBatch({
+      requests: [
+        { id: 'france', ...request('What is the capital of France?') },
+      ],
+      providerOptions: { xai: { inputFileExpiresAfter: 172_800 } },
+    });
+
+    const multipart = await server.calls[0].requestBodyMultipart;
+    expect(multipart?.expires_after).toBe('172800');
+    // xAI rejects uploads where expires_after arrives after the file part
+    expect(Object.keys(multipart ?? {})).toEqual(['expires_after', 'file']);
+    expect(await server.calls[1].requestBodyJson).toEqual({
+      name: 'ai-sdk-text-batch',
+      input_file_id: 'file_123',
+    });
+    expect(result.providerMetadata).toEqual({
+      xai: { inputFileId: 'file_123' },
+    });
   });
 
   it('maps xAI state counters and cancellation metadata', async () => {

--- a/packages/xai/src/responses/xai-responses-batch.ts
+++ b/packages/xai/src/responses/xai-responses-batch.ts
@@ -20,6 +20,7 @@ import {
   getFromApi,
   lazySchema,
   normalizeBatchRequestCounts,
+  parseProviderOptions,
   postFormDataToApi,
   postJsonToApi,
   safeValidateTypes,
@@ -47,6 +48,24 @@ import type { XaiResponsesModelId } from './xai-responses-language-model-options
 const xaiBatchEndpoint = '/v1/responses';
 const xaiBatchName = 'ai-sdk-text-batch';
 const xaiBatchResultsPageSize = 1000;
+
+const xaiBatchProviderOptionsSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      /**
+       * TTL in seconds for the uploaded batch input file, measured from
+       * upload time. xAI accepts integers between 3600 (1 hour) and
+       * 2592000 (30 days) inclusive. Without it the file has no expiry.
+       */
+      inputFileExpiresAfter: z
+        .number()
+        .int()
+        .min(3600)
+        .max(2_592_000)
+        .optional(),
+    }),
+  ),
+);
 
 type XaiBatchRequest = Parameters<
   BatchLanguageModelV4['experimental_doStartBatch']
@@ -144,6 +163,12 @@ class XaiResponsesBatch {
             },
           ];
 
+    const batchOptions = await parseProviderOptions({
+      provider: 'xai',
+      providerOptions: options.providerOptions,
+      schema: xaiBatchProviderOptionsSchema,
+    });
+
     for (const request of options.requests) {
       const preparedRequest = await this.options.prepareRequest(request);
 
@@ -166,6 +191,14 @@ class XaiResponsesBatch {
     const file = new Blob(fileParts, { type: 'application/jsonl' });
     fileParts.length = 0;
     const formData = new FormData();
+    // xAI rejects uploads where expires_after arrives after the file part,
+    // so all fields precede the file.
+    if (batchOptions?.inputFileExpiresAfter != null) {
+      formData.append(
+        'expires_after',
+        String(batchOptions.inputFileExpiresAfter),
+      );
+    }
     formData.append('file', file, filename);
 
     const headers = combineHeaders(
@@ -203,6 +236,18 @@ class XaiResponsesBatch {
     return {
       batchId: batch.batch_id,
       ...convertXaiBatchStatus(batch),
+      providerMetadata: {
+        xai: {
+          inputFileId: uploadedFile.id,
+          ...(uploadedFile.expires_at != null
+            ? {
+                inputFileExpiresAt: new Date(
+                  uploadedFile.expires_at * 1000,
+                ).toISOString(),
+              }
+            : {}),
+        },
+      },
       warnings,
     };
   }


### PR DESCRIPTION
## Background

The OpenAI, xAI, and Google batch adapters upload the JSONL input file inside `experimental_doStartBatch` and then drop its id — `uploadedFile.id` is used once for `input_file_id` and never surfaced. A caller that owns retention for that file (the AI Gateway ledgers system-credential batch inputs and deletes them at batch terminal) has no way to learn which file was created or when the provider will expire it. xAI additionally uploaded with no `expires_after`, so the file lived indefinitely.

`Experimental_BatchV4Status` already carries `providerMetadata`, and `Experimental_BatchV4StartResult` inherits it, so this needs no `@ai-sdk/provider` change.

Tracking: Linear KDA-490 (AI Gateway async-files-service).

## Summary

- **OpenAI, xAI, Google**: the start result now carries `providerMetadata.<provider>.inputFileId` and, when the upload response reports one, `inputFileExpiresAt` (ISO string). Google only surfaces on its Files API path (inline creation under 20MB has no file).
- **OpenAI, xAI**: new `inputFileExpiresAfter` provider option (seconds, 3600–2592000) applied to the input file upload. OpenAI keeps its existing 48h default and is byte-identical when the option is absent. xAI sends `expires_after` only when asked, appended before the `file` part (xAI rejects the reverse order). Google's Files API has a fixed TTL, so no option there.
- The adapters keep their one-call upload+create shape; nothing about how requests are prepared or how batches are created changes.

## End-to-End Verification

Unit-tested against the recorded provider response shapes (OpenAI `/files` returns `expires_at`; xAI `/files` returns `expires_at`; Google's resumable upload returns `file.expirationTime`). Live verification against the three providers will happen from the AI Gateway consumer (KDA-490) once this is released and bumped.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- OpenAI adapter starting a batch from a pre-uploaded `input_file_id` (KDA-492) — a separate, OpenAI-compat-only flow.
