### PR TITLE
chore: fix flaky Pi adapter test

### DIFF
--- a/packages/harness-pi/src/pi-workspace-mirror.test.ts
+++ b/packages/harness-pi/src/pi-workspace-mirror.test.ts
@@ -12,7 +12,10 @@ import { gzipSync } from 'node:zlib';
 import { createJustBashSandbox } from '@ai-sdk/sandbox-just-bash';
 import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { syncHostWorkspaceFromSandbox } from './pi-workspace-mirror';
+import {
+  ARCHIVE_BATCH_SIZE,
+  syncHostWorkspaceFromSandbox,
+} from './pi-workspace-mirror';
 
 const sandboxWorkDir = '/sandbox/work';
 
@@ -506,8 +509,12 @@ describe('syncHostWorkspaceFromSandbox', () => {
   });
 
   it('transfers files as batched archives instead of one request per file', async () => {
+    // One file past the 300-file batch boundary — enough to prove a second
+    // archive request happens and that the last file isn't dropped at the
+    // split, without paying for hundreds of unnecessary tar entries.
+    const fileCount = ARCHIVE_BATCH_SIZE + 1;
     const files: Record<string, string> = {};
-    for (let index = 0; index < 700; index++) {
+    for (let index = 0; index < fileCount; index++) {
       files[`.agents/skills/skill-${index}/SKILL.md`] = `# skill ${index}`;
     }
     const { sandbox, run, readBinaryFile } = makeSandbox({
@@ -522,14 +529,17 @@ describe('syncHostWorkspaceFromSandbox', () => {
     });
 
     expect(readBinaryFile).not.toHaveBeenCalled();
-    // One listing plus ceil(700 / 300) archives — not 700 requests.
-    expect(run).toHaveBeenCalledTimes(4);
+    // One listing plus ceil(fileCount / 300) archives — not fileCount requests.
+    expect(run).toHaveBeenCalledTimes(3);
     expect(
       readFileSync(
-        path.join(hostWorkDir, '.agents/skills/skill-699/SKILL.md'),
+        path.join(
+          hostWorkDir,
+          `.agents/skills/skill-${fileCount - 1}/SKILL.md`,
+        ),
         'utf8',
       ),
-    ).toBe('# skill 699');
+    ).toBe(`# skill ${fileCount - 1}`);
   });
 
   it('mirrors members whose path exceeds the 100-character tar name field', async () => {

--- a/packages/harness-pi/src/pi-workspace-mirror.ts
+++ b/packages/harness-pi/src/pi-workspace-mirror.ts
@@ -45,7 +45,7 @@ const PI_CONTEXT_FILENAMES = ['AGENTS.md', 'AGENTS.MD'] as const;
  * few hundred files instead of one request per file. Sandboxes without `tar`,
  * `gzip`, or `base64` fall back to per-file reads.
  */
-const ARCHIVE_BATCH_SIZE = 300;
+export const ARCHIVE_BATCH_SIZE = 300;
 const TAR_BLOCK_SIZE = 512;
 
 function normalizeRelativePath(inputPath: string): string {


### PR DESCRIPTION
## Background

Follow-up to #20204: This test was simply excessive because it would TAR 700 files into 2 archives, which would often exceed the 5s per-test threshold.

## Summary

We can simply reduce it while still covering the same behavior.

**Note:** This exports a `const` from a production code file, but it remains package-internal still. So no changeset is required for this PR.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

See #20118