### PR TITLE
feat(google): support agentic video processing in the Interactions API

### DIFF
--- a/.changeset/agentic-videos-explore.md
+++ b/.changeset/agentic-videos-explore.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(google): support agentic video processing in the Interactions API

--- a/content/providers/01-ai-sdk-providers/15-google.mdx
+++ b/content/providers/01-ai-sdk-providers/15-google.mdx
@@ -1453,7 +1453,20 @@ exposes:
 - **signature** _string_
 
   Per-block signature hash, set by the SDK on output reasoning and
-  tool-call parts. Round-tripped automatically on the next turn.
+  tool-call or agentic video processing parts. Round-tripped automatically on
+  the next turn.
+
+Agentic video custom parts additionally expose:
+
+- **processingId** _string_
+
+  ID of an agentic video `processing_call`. Present on
+  `google.processing_call` custom parts.
+
+- **processingCallId** _string_
+
+  ID of the matching agentic video processing call. Present on
+  `google.processing_result` custom parts.
 
 ### Stateful chaining
 
@@ -1524,6 +1537,97 @@ const turn2 = await generateText({
   },
 });
 ```
+
+### Agentic video understanding
+
+Gemini 3.7 Flash, 3.6 Flash, and 3.5 Flash Lite support agentic video
+understanding through the Interactions API. Instead of sampling the entire
+video at a fixed frame rate, the model dynamically navigates the timeline and
+loads the transcripts, frames, or audio needed for the prompt.
+
+Set `processing: 'agentic'` in the Google provider options of an individual
+video file part. You can validate the per-file options with
+`GoogleInteractionsVideoOptions`:
+
+```ts
+import { google, type GoogleInteractionsVideoOptions } from '@ai-sdk/google';
+import { generateText } from 'ai';
+
+const result = await generateText({
+  model: google.interactions('gemini-3.7-flash'),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'file',
+          data: 'https://www.youtube.com/watch?v=9hE5-98ZeCg',
+          mediaType: 'video',
+          providerOptions: {
+            google: {
+              processing: 'agentic',
+            } satisfies GoogleInteractionsVideoOptions,
+          },
+        },
+        {
+          type: 'text',
+          text: 'Identify the three most important moments and include timestamps.',
+        },
+      ],
+    },
+  ],
+  providerOptions: {
+    google: {
+      thinkingSummaries: 'auto',
+    },
+  },
+});
+
+const processingSteps = result.content.filter(
+  part =>
+    part.type === 'custom' &&
+    (part.kind === 'google.processing_call' ||
+      part.kind === 'google.processing_result'),
+);
+```
+
+Agentic navigation is exposed as `custom` content parts:
+
+- `google.processing_call` marks a request by the model to inspect part of the
+  video. Its `providerMetadata.google.processingId` contains the processing ID.
+- `google.processing_result` marks completion of that request. Its
+  `providerMetadata.google.processingCallId` links it to the processing call.
+
+These parts are informational and do not require a tool response. They are
+available from both `generateText` and `streamText`.
+
+For static processing, use `'static'` or provide clipping and frame-rate
+options:
+
+```ts
+const video = {
+  type: 'file' as const,
+  data: videoBytes,
+  mediaType: 'video/mp4',
+  providerOptions: {
+    google: {
+      processing: {
+        type: 'static',
+        startOffset: 1200,
+        endOffset: 1500,
+        fps: 0.5,
+      },
+    } satisfies GoogleInteractionsVideoOptions,
+  },
+};
+```
+
+With stateful conversations, pass the returned `interactionId` as
+`previousInteractionId`; Gemini retains the video context server-side. With
+`store: false`, append `result.responseMessages` and re-send the full history.
+The processing custom parts and their signatures are then round-tripped as
+native `processing_call` and `processing_result` steps so the video context is
+preserved.
 
 ### Built-in Tools
 

--- a/examples/ai-e2e-next/app/api/chat/google-interactions-agentic-video/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/google-interactions-agentic-video/route.ts
@@ -1,0 +1,87 @@
+import {
+  google,
+  type GoogleLanguageModelInteractionsOptions,
+  type GoogleInteractionsVideoOptions,
+} from '@ai-sdk/google';
+import {
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  streamText,
+  toUIMessageStream,
+  type UIMessage,
+} from 'ai';
+
+export const maxDuration = 300;
+
+function findLatestInteractionId(messages: UIMessage[]): string | undefined {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message.role !== 'assistant') {
+      continue;
+    }
+    for (const part of message.parts) {
+      const interactionId = (
+        part as {
+          providerMetadata?: { google?: { interactionId?: unknown } };
+        }
+      ).providerMetadata?.google?.interactionId;
+      if (typeof interactionId === 'string') {
+        return interactionId;
+      }
+    }
+  }
+  return undefined;
+}
+
+function addAgenticVideoProcessing(messages: UIMessage[]): UIMessage[] {
+  return messages.map(message => ({
+    ...message,
+    parts: message.parts.map(part => {
+      if (part.type !== 'file' || !part.mediaType.startsWith('video/')) {
+        return part;
+      }
+
+      return {
+        ...part,
+        providerMetadata: {
+          ...part.providerMetadata,
+          google: {
+            ...part.providerMetadata?.google,
+            processing: 'agentic',
+          } satisfies GoogleInteractionsVideoOptions,
+        },
+      };
+    }),
+  }));
+}
+
+export async function POST(req: Request) {
+  const { messages }: { messages: UIMessage[] } = await req.json();
+  const previousInteractionId = findLatestInteractionId(messages);
+  const modelMessages = await convertToModelMessages(
+    addAgenticVideoProcessing(messages),
+  );
+  const latestUserMessage = modelMessages.findLast(
+    message => message.role === 'user',
+  );
+
+  const result = streamText({
+    model: google.interactions('gemini-3.7-flash'),
+    messages:
+      previousInteractionId != null && latestUserMessage != null
+        ? [latestUserMessage]
+        : modelMessages,
+    abortSignal: req.signal,
+    providerOptions: {
+      google: {
+        store: true,
+        thinkingSummaries: 'auto',
+        ...(previousInteractionId != null ? { previousInteractionId } : {}),
+      } satisfies GoogleLanguageModelInteractionsOptions,
+    },
+  });
+
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({ stream: result.stream }),
+  });
+}

--- a/examples/ai-e2e-next/app/chat/google-interactions-agentic-video/page.tsx
+++ b/examples/ai-e2e-next/app/chat/google-interactions-agentic-video/page.tsx
@@ -68,6 +68,7 @@ export default function Chat() {
                 ) {
                   return (
                     <div key={index}>
+                      {/* eslint-disable-next-line jsx-a11y/media-has-caption -- User-provided videos do not include a captions track. */}
                       <video
                         className="w-full rounded-md"
                         src={part.url}

--- a/examples/ai-e2e-next/app/chat/google-interactions-agentic-video/page.tsx
+++ b/examples/ai-e2e-next/app/chat/google-interactions-agentic-video/page.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { Response } from '@/components/ai-elements/response';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
+import { useRef, useState, type FormEvent } from 'react';
+
+const MAX_VIDEO_SIZE = 15 * 1024 * 1024;
+const transport = new DefaultChatTransport({
+  api: '/api/chat/google-interactions-agentic-video',
+});
+
+export default function Chat() {
+  const [input, setInput] = useState('');
+  const [files, setFiles] = useState<FileList>();
+  const [fileError, setFileError] = useState<string>();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { error, messages, sendMessage, status, stop } = useChat({
+    transport,
+  });
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const text = input.trim();
+    if (text.length === 0 || status !== 'ready') {
+      return;
+    }
+
+    sendMessage({ text, files });
+    setInput('');
+    setFiles(undefined);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }
+
+  return (
+    <main className="flex flex-col w-full max-w-2xl min-h-screen gap-6 px-4 py-12 mx-auto">
+      <header>
+        <h1 className="text-2xl font-bold">
+          Google Interactions agentic video
+        </h1>
+        <p className="mt-2 text-sm text-zinc-600">
+          Attach a short video (up to 15 MB), ask a question, then continue the
+          conversation without attaching it again. Follow-up turns reference the
+          stored Gemini interaction, so the video is not uploaded again.
+        </p>
+      </header>
+
+      <section className="flex flex-col flex-1 gap-4">
+        {messages.map(message => (
+          <article
+            key={message.id}
+            className="p-4 border rounded-lg border-zinc-200"
+          >
+            <div className="mb-2 text-xs font-semibold uppercase text-zinc-500">
+              {message.role}
+            </div>
+            <div className="flex flex-col gap-3">
+              {message.parts.map((part, index) => {
+                if (part.type === 'text') {
+                  return <Response key={index}>{part.text}</Response>;
+                }
+
+                if (
+                  part.type === 'file' &&
+                  part.mediaType.startsWith('video/')
+                ) {
+                  return (
+                    <div key={index}>
+                      <video
+                        className="w-full rounded-md"
+                        src={part.url}
+                        controls
+                      />
+                      <div className="mt-1 text-xs text-zinc-500">
+                        {part.filename ?? part.mediaType}
+                      </div>
+                    </div>
+                  );
+                }
+
+                if (
+                  part.type === 'custom' &&
+                  (part.kind === 'google.processing_call' ||
+                    part.kind === 'google.processing_result')
+                ) {
+                  const google = part.providerMetadata?.google as
+                    | {
+                        processingId?: string;
+                        processingCallId?: string;
+                      }
+                    | undefined;
+                  const id =
+                    part.kind === 'google.processing_call'
+                      ? google?.processingId
+                      : google?.processingCallId;
+
+                  return (
+                    <div
+                      key={index}
+                      className="px-3 py-2 font-mono text-xs rounded bg-blue-50 text-blue-700"
+                    >
+                      {part.kind}
+                      {id ? ` · ${id}` : ''}
+                    </div>
+                  );
+                }
+
+                if (part.type === 'reasoning' && part.text.length > 0) {
+                  return (
+                    <details key={index} className="text-sm text-zinc-500">
+                      <summary>Reasoning</summary>
+                      <div className="mt-2 whitespace-pre-wrap">
+                        {part.text}
+                      </div>
+                    </details>
+                  );
+                }
+
+                return null;
+              })}
+            </div>
+          </article>
+        ))}
+      </section>
+
+      {error ? (
+        <div className="text-sm text-red-600">{error.message}</div>
+      ) : null}
+
+      <form
+        onSubmit={handleSubmit}
+        className="sticky bottom-0 flex flex-col gap-3 p-4 bg-white border rounded-lg shadow-sm border-zinc-200"
+      >
+        <label className="text-sm font-medium">
+          Video
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="video/*"
+            className="block w-full mt-1 text-sm"
+            disabled={status !== 'ready'}
+            onChange={event => {
+              const selectedFiles = event.target.files;
+              const video = selectedFiles?.item(0);
+              if (video != null && video.size > MAX_VIDEO_SIZE) {
+                setFiles(undefined);
+                setFileError('Choose a video smaller than 15 MB.');
+                event.target.value = '';
+                return;
+              }
+              setFiles(selectedFiles ?? undefined);
+              setFileError(undefined);
+            }}
+          />
+        </label>
+        {fileError ? (
+          <div className="text-sm text-red-600">{fileError}</div>
+        ) : null}
+        {files?.item(0) ? (
+          <div className="text-xs text-zinc-500">
+            Attached: {files.item(0)?.name}
+          </div>
+        ) : null}
+        <div className="flex gap-2">
+          <input
+            value={input}
+            placeholder="Ask about the video..."
+            onChange={event => setInput(event.target.value)}
+            className="flex-1 px-3 py-2 border rounded-md border-zinc-300"
+            disabled={status !== 'ready'}
+          />
+          {status === 'submitted' || status === 'streaming' ? (
+            <button
+              type="button"
+              onClick={stop}
+              className="px-4 py-2 border rounded-md border-zinc-300"
+            >
+              Stop
+            </button>
+          ) : (
+            <button
+              type="submit"
+              disabled={input.trim().length === 0}
+              className="px-4 py-2 text-white bg-black rounded-md disabled:opacity-50"
+            >
+              Send
+            </button>
+          )}
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/examples/ai-functions/src/generate-text/google/interactions-agentic-video.ts
+++ b/examples/ai-functions/src/generate-text/google/interactions-agentic-video.ts
@@ -1,0 +1,41 @@
+import { google, type GoogleInteractionsVideoOptions } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: google.interactions('gemini-3.7-flash'),
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            mediaType: 'video',
+            data: 'https://youtu.be/yxKA0NnNJeo?si=fRyOkgoCH8Va0wJL',
+            providerOptions: {
+              google: {
+                processing: 'agentic',
+              } satisfies GoogleInteractionsVideoOptions,
+            },
+          },
+          {
+            type: 'text',
+            text: 'Identify the three most important moments in this video. Explain why each matters and include timestamps.',
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      google: {
+        thinkingSummaries: 'auto',
+      },
+    },
+  });
+
+  console.log('RESULT CONTENT:');
+  console.log(JSON.stringify(result.content, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+});

--- a/packages/google/src/index.ts
+++ b/packages/google/src/index.ts
@@ -37,6 +37,7 @@ export type { GoogleFilesUploadOptions } from './google-files';
 export type {
   GoogleLanguageModelInteractionsOptions,
   GoogleInteractionsModelId,
+  GoogleInteractionsVideoOptions,
 } from './interactions/google-interactions-language-model-options';
 export type { GoogleInteractionsProviderMetadata } from './interactions/google-interactions-provider-metadata';
 export type { GoogleInteractionsAgentName } from './interactions/google-interactions-agent';

--- a/packages/google/src/interactions/build-google-interactions-stream-transform.test.ts
+++ b/packages/google/src/interactions/build-google-interactions-stream-transform.test.ts
@@ -130,6 +130,68 @@ describe('buildGoogleInteractionsStreamTransform — usage modality', () => {
   });
 });
 
+describe('buildGoogleInteractionsStreamTransform — agentic video', () => {
+  it('emits processing steps as custom parts', async () => {
+    const parts = await runTransform([
+      {
+        event_type: 'interaction.created',
+        interaction: { id: 'interaction-1', status: 'in_progress' },
+      },
+      {
+        event_type: 'step.start',
+        index: 0,
+        step: {
+          type: 'processing_call',
+          id: 'processing-1',
+          signature: 'call-signature',
+        },
+      },
+      { event_type: 'step.stop', index: 0 },
+      {
+        event_type: 'step.start',
+        index: 1,
+        step: {
+          type: 'processing_result',
+          call_id: 'processing-1',
+          signature: 'result-signature',
+        },
+      },
+      { event_type: 'step.stop', index: 1 },
+      {
+        event_type: 'interaction.completed',
+        interaction: { id: 'interaction-1', status: 'completed' },
+      },
+    ]);
+
+    expect(parts).toEqual(
+      expect.arrayContaining([
+        {
+          type: 'custom',
+          kind: 'google.processing_call',
+          providerMetadata: {
+            google: {
+              signature: 'call-signature',
+              interactionId: 'interaction-1',
+              processingId: 'processing-1',
+            },
+          },
+        },
+        {
+          type: 'custom',
+          kind: 'google.processing_result',
+          providerMetadata: {
+            google: {
+              signature: 'result-signature',
+              interactionId: 'interaction-1',
+              processingCallId: 'processing-1',
+            },
+          },
+        },
+      ]),
+    );
+  });
+});
+
 describe('buildGoogleInteractionsStreamTransform — tool call IDs', () => {
   it('uses the generated block ID when a function call ID is empty', async () => {
     const parts = await runTransform([

--- a/packages/google/src/interactions/build-google-interactions-stream-transform.ts
+++ b/packages/google/src/interactions/build-google-interactions-stream-transform.ts
@@ -103,6 +103,12 @@ type OpenBlockState =
       isError?: boolean;
       resultEmitted: boolean;
     }
+  | {
+      kind: 'custom';
+      id: string;
+      customKind: 'google.processing_call' | 'google.processing_result';
+      google: Record<string, string>;
+    }
   /**
    * A `model_output` step whose inner content-block kind has not yet been
    * disambiguated. `step.start` may arrive bare (`{type: 'model_output'}`,
@@ -337,6 +343,24 @@ export function buildGoogleInteractionsStreamTransform({
                 }
               }
             }
+          } else if (
+            stepType === 'processing_call' ||
+            stepType === 'processing_result'
+          ) {
+            const google: Record<string, string> = {};
+            if (step?.signature != null) google.signature = step.signature;
+            if (interactionId != null) google.interactionId = interactionId;
+            if (stepType === 'processing_call') {
+              google.processingId = step?.id || blockId;
+            } else {
+              google.processingCallId = step?.call_id || blockId;
+            }
+            openBlocks.set(index, {
+              kind: 'custom',
+              id: blockId,
+              customKind: `google.${stepType}`,
+              google,
+            });
           } else if (stepType === 'function_call') {
             const toolCallId = step?.id || blockId;
             const toolName = step?.name ?? 'unknown';
@@ -544,7 +568,28 @@ export function buildGoogleInteractionsStreamTransform({
               }
             | undefined;
 
-          if (open.kind === 'text' && delta?.type === 'text') {
+          if (
+            open.kind === 'custom' &&
+            (delta?.type === 'processing_call' ||
+              delta?.type === 'processing_result')
+          ) {
+            if (delta.signature != null)
+              open.google.signature = delta.signature;
+            if (
+              delta.type === 'processing_call' &&
+              delta.id != null &&
+              delta.id.length > 0
+            ) {
+              open.google.processingId = delta.id;
+            }
+            if (
+              delta.type === 'processing_result' &&
+              delta.call_id != null &&
+              delta.call_id.length > 0
+            ) {
+              open.google.processingCallId = delta.call_id;
+            }
+          } else if (open.kind === 'text' && delta?.type === 'text') {
             const text = delta.text ?? '';
             if (text.length > 0) {
               controller.enqueue({
@@ -723,6 +768,12 @@ export function buildGoogleInteractionsStreamTransform({
               toolName: open.toolName,
               input: accumulated,
               ...(providerMetadata ? { providerMetadata } : {}),
+            });
+          } else if (open.kind === 'custom') {
+            controller.enqueue({
+              type: 'custom',
+              kind: open.customKind,
+              providerMetadata: { google: open.google },
             });
           } else if (open.kind === 'builtin_tool_call' && !open.callEmitted) {
             controller.enqueue({

--- a/packages/google/src/interactions/convert-to-google-interactions-input.test.ts
+++ b/packages/google/src/interactions/convert-to-google-interactions-input.test.ts
@@ -633,6 +633,88 @@ describe('convertToGoogleInteractionsInput', () => {
         ]
       `);
     });
+
+    it('maps per-file agentic processing onto a video block', () => {
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'video',
+              data: {
+                type: 'url',
+                url: new URL('https://www.youtube.com/watch?v=abc123'),
+              },
+              providerOptions: {
+                google: { processing: 'agentic' },
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToGoogleInteractionsInput({ prompt });
+
+      expect(result.input).toEqual([
+        {
+          type: 'user_input',
+          content: [
+            {
+              type: 'video',
+              uri: 'https://www.youtube.com/watch?v=abc123',
+              processing: 'agentic',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('maps camel-case static processing options onto the wire format', () => {
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'file',
+              mediaType: 'video/mp4',
+              data: { type: 'data', data: 'AAAA' },
+              providerOptions: {
+                google: {
+                  processing: {
+                    type: 'static',
+                    startOffset: 1200,
+                    endOffset: 1500,
+                    fps: 0.5,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToGoogleInteractionsInput({ prompt });
+
+      expect(result.input).toEqual([
+        {
+          type: 'user_input',
+          content: [
+            {
+              type: 'video',
+              data: 'AAAA',
+              mime_type: 'video/mp4',
+              processing: {
+                type: 'static',
+                start_offset: 1200,
+                end_offset: 1500,
+                fps: 0.5,
+              },
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   describe('text file parts', () => {
@@ -918,6 +1000,51 @@ describe('convertToGoogleInteractionsInput', () => {
       }>;
       const fnCall = steps.find(step => step.type === 'function_call');
       expect(fnCall?.signature).toBe('sig-xyz');
+    });
+
+    it('round-trips custom video processing parts', () => {
+      const prompt: LanguageModelV4Prompt = [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'custom',
+              kind: 'google.processing_call',
+              providerOptions: {
+                google: {
+                  processingId: 'processing-1',
+                  signature: 'call-signature',
+                },
+              },
+            },
+            {
+              type: 'custom',
+              kind: 'google.processing_result',
+              providerOptions: {
+                google: {
+                  processingCallId: 'processing-1',
+                  signature: 'result-signature',
+                },
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToGoogleInteractionsInput({ prompt });
+
+      expect(result.input).toEqual([
+        {
+          type: 'processing_call',
+          id: 'processing-1',
+          signature: 'call-signature',
+        },
+        {
+          type: 'processing_result',
+          call_id: 'processing-1',
+          signature: 'result-signature',
+        },
+      ]);
     });
   });
 

--- a/packages/google/src/interactions/convert-to-google-interactions-input.ts
+++ b/packages/google/src/interactions/convert-to-google-interactions-input.ts
@@ -20,6 +20,7 @@ import type {
   GoogleInteractionsInput,
   GoogleInteractionsStep,
   GoogleInteractionsTextContent,
+  GoogleInteractionsVideoProcessing,
 } from './google-interactions-prompt';
 
 export type GoogleInteractionsMediaResolution =
@@ -163,6 +164,44 @@ export function convertToGoogleInteractionsInput({
             if (fileBlock != null) {
               pendingModelOutput.push(fileBlock);
             }
+          } else if (part.type === 'custom') {
+            flushModelOutput();
+            const google = part.providerOptions?.google as
+              | {
+                  processingId?: unknown;
+                  processingCallId?: unknown;
+                  signature?: unknown;
+                }
+              | undefined;
+            const signature =
+              typeof google?.signature === 'string'
+                ? google.signature
+                : undefined;
+
+            if (
+              part.kind === 'google.processing_call' &&
+              typeof google?.processingId === 'string'
+            ) {
+              steps.push({
+                type: 'processing_call',
+                id: google.processingId,
+                ...(signature != null ? { signature } : {}),
+              });
+            } else if (
+              part.kind === 'google.processing_result' &&
+              typeof google?.processingCallId === 'string'
+            ) {
+              steps.push({
+                type: 'processing_result',
+                call_id: google.processingCallId,
+                ...(signature != null ? { signature } : {}),
+              });
+            } else {
+              warnings.push({
+                type: 'other',
+                message: `google.interactions: unsupported or invalid custom assistant content part "${part.kind}"; part dropped.`,
+              });
+            }
           } else if (part.type === 'tool-call') {
             flushModelOutput();
             const signature = part.providerOptions?.google?.signature as
@@ -282,6 +321,8 @@ function convertFilePartToContent({
     mediaResolution != null && (kind === 'image' || kind === 'video')
       ? { resolution: mediaResolution }
       : {};
+  const processingField =
+    kind === 'video' ? getVideoProcessingField({ part, warnings }) : {};
 
   switch (part.data.type) {
     case 'data': {
@@ -291,6 +332,7 @@ function convertFilePartToContent({
         data: convertToBase64(part.data.data),
         mime_type: mimeType,
         ...resolutionField,
+        ...processingField,
       };
     }
     case 'url': {
@@ -301,6 +343,7 @@ function convertFilePartToContent({
           ? { mime_type: part.mediaType }
           : {}),
         ...resolutionField,
+        ...processingField,
       };
     }
     case 'reference': {
@@ -315,9 +358,65 @@ function convertFilePartToContent({
           ? { mime_type: part.mediaType }
           : {}),
         ...resolutionField,
+        ...processingField,
       };
     }
   }
+}
+
+function getVideoProcessingField({
+  part,
+  warnings,
+}: {
+  part: LanguageModelV4FilePart;
+  warnings: Array<SharedV4Warning>;
+}): { processing?: GoogleInteractionsVideoProcessing } {
+  const processing = (
+    part.providerOptions?.google as
+      | {
+          processing?: unknown;
+        }
+      | undefined
+  )?.processing;
+
+  if (processing == null) {
+    return {};
+  }
+
+  if (processing === 'agentic' || processing === 'static') {
+    return { processing };
+  }
+
+  if (
+    typeof processing === 'object' &&
+    !Array.isArray(processing) &&
+    (processing as { type?: unknown }).type === 'static'
+  ) {
+    const config = processing as {
+      startOffset?: unknown;
+      endOffset?: unknown;
+      fps?: unknown;
+    };
+    return {
+      processing: {
+        type: 'static',
+        ...(typeof config.startOffset === 'number'
+          ? { start_offset: config.startOffset }
+          : {}),
+        ...(typeof config.endOffset === 'number'
+          ? { end_offset: config.endOffset }
+          : {}),
+        ...(typeof config.fps === 'number' ? { fps: config.fps } : {}),
+      },
+    };
+  }
+
+  warnings.push({
+    type: 'other',
+    message:
+      'google.interactions: invalid providerOptions.google.processing on video file part; expected "agentic", "static", or a static processing configuration. Option dropped.',
+  });
+  return {};
 }
 
 /*

--- a/packages/google/src/interactions/google-interactions-api.ts
+++ b/packages/google/src/interactions/google-interactions-api.ts
@@ -222,6 +222,22 @@ const stepSchema = () => {
     })
     .loose();
 
+  const processingCallStep = z
+    .object({
+      type: z.literal('processing_call'),
+      id: z.string(),
+      signature: z.string().nullish(),
+    })
+    .loose();
+
+  const processingResultStep = z
+    .object({
+      type: z.literal('processing_result'),
+      call_id: z.string(),
+      signature: z.string().nullish(),
+    })
+    .loose();
+
   const builtinToolCallStep = z
     .object({
       type: z.enum(BUILTIN_TOOL_CALL_STEP_TYPES),
@@ -251,6 +267,8 @@ const stepSchema = () => {
     modelOutputStep,
     functionCallStep,
     thoughtStep,
+    processingCallStep,
+    processingResultStep,
     builtinToolCallStep,
     builtinToolResultStep,
     z.object({ type: z.string() }).loose(),

--- a/packages/google/src/interactions/google-interactions-language-model-options.ts
+++ b/packages/google/src/interactions/google-interactions-language-model-options.ts
@@ -42,6 +42,29 @@ export type GoogleInteractionsModelId =
   | (string & {});
 
 /**
+ * Provider options for an individual video file part sent to the Gemini
+ * Interactions API.
+ */
+export type GoogleInteractionsVideoOptions = {
+  /**
+   * Controls how Gemini processes this video.
+   *
+   * Agentic processing dynamically explores the video timeline. Static
+   * processing samples frames at a fixed rate and optionally supports clipping
+   * and custom frame rates.
+   */
+  processing?:
+    | 'agentic'
+    | 'static'
+    | {
+        type: 'static';
+        startOffset?: number;
+        endOffset?: number;
+        fps?: number;
+      };
+};
+
+/**
  * Provider-options schema for `google.interactions(...)` calls. Read from the
  * shared `providerOptions.google.*` namespace (per PRD); per-call options that
  * the AI SDK doesn't natively expose live here.

--- a/packages/google/src/interactions/google-interactions-prompt.ts
+++ b/packages/google/src/interactions/google-interactions-prompt.ts
@@ -35,12 +35,23 @@ export type GoogleInteractionsDocumentContent = {
   uri?: string;
 };
 
+export type GoogleInteractionsVideoProcessing =
+  | 'agentic'
+  | 'static'
+  | {
+      type: 'static';
+      start_offset?: number;
+      end_offset?: number;
+      fps?: number;
+    };
+
 export type GoogleInteractionsVideoContent = {
   type: 'video';
   data?: string;
   mime_type?: string;
   uri?: string;
   resolution?: 'low' | 'medium' | 'high' | 'ultra_high';
+  processing?: GoogleInteractionsVideoProcessing;
 };
 
 export type GoogleInteractionsThoughtSummaryItem =
@@ -125,6 +136,16 @@ export type GoogleInteractionsFunctionCallStepPayload = {
 export type GoogleInteractionsThoughtStepPayload = {
   signature?: string;
   summary?: Array<GoogleInteractionsThoughtSummaryItem>;
+};
+
+export type GoogleInteractionsProcessingCallStepPayload = {
+  id: string;
+  signature?: string;
+};
+
+export type GoogleInteractionsProcessingResultStepPayload = {
+  call_id: string;
+  signature?: string;
 };
 
 export type GoogleInteractionsCodeExecutionCallStepPayload = {
@@ -255,6 +276,14 @@ export type GoogleInteractionsThoughtStep = {
   type: 'thought';
 } & GoogleInteractionsThoughtStepPayload;
 
+export type GoogleInteractionsProcessingCallStep = {
+  type: 'processing_call';
+} & GoogleInteractionsProcessingCallStepPayload;
+
+export type GoogleInteractionsProcessingResultStep = {
+  type: 'processing_result';
+} & GoogleInteractionsProcessingResultStepPayload;
+
 export type GoogleInteractionsBuiltinToolCallStep =
   | ({
       type: 'google_search_call';
@@ -294,6 +323,8 @@ export type GoogleInteractionsStep =
   | GoogleInteractionsModelOutputStep
   | GoogleInteractionsFunctionCallStep
   | GoogleInteractionsThoughtStep
+  | GoogleInteractionsProcessingCallStep
+  | GoogleInteractionsProcessingResultStep
   | GoogleInteractionsBuiltinToolCallStep
   | GoogleInteractionsBuiltinToolResultStep
   | { type: string; [k: string]: unknown };

--- a/packages/google/src/interactions/google-interactions-provider-metadata.ts
+++ b/packages/google/src/interactions/google-interactions-provider-metadata.ts
@@ -28,4 +28,16 @@ export type GoogleInteractionsProviderMetadata = {
    * reasoning / tool-call parts and round-tripped on input parts.
    */
   signature?: string;
+
+  /**
+   * ID of an agentic video `processing_call` step. Present on
+   * `google.processing_call` custom parts.
+   */
+  processingId?: string;
+
+  /**
+   * ID of the corresponding agentic video processing call. Present on
+   * `google.processing_result` custom parts.
+   */
+  processingCallId?: string;
 };

--- a/packages/google/src/interactions/parse-google-interactions-outputs.test.ts
+++ b/packages/google/src/interactions/parse-google-interactions-outputs.test.ts
@@ -176,6 +176,52 @@ describe('parseGoogleInteractionsOutputs', () => {
     });
   });
 
+  describe('agentic video processing steps', () => {
+    it('emits custom parts with IDs and signatures', () => {
+      const { content } = parseGoogleInteractionsOutputs({
+        steps: [
+          {
+            type: 'processing_call',
+            id: 'processing-1',
+            signature: 'call-signature',
+          },
+          {
+            type: 'processing_result',
+            call_id: 'processing-1',
+            signature: 'result-signature',
+          },
+        ],
+        generateId,
+        interactionId: 'interaction-1',
+      });
+
+      expect(content).toEqual([
+        {
+          type: 'custom',
+          kind: 'google.processing_call',
+          providerMetadata: {
+            google: {
+              signature: 'call-signature',
+              interactionId: 'interaction-1',
+              processingId: 'processing-1',
+            },
+          },
+        },
+        {
+          type: 'custom',
+          kind: 'google.processing_result',
+          providerMetadata: {
+            google: {
+              signature: 'result-signature',
+              interactionId: 'interaction-1',
+              processingCallId: 'processing-1',
+            },
+          },
+        },
+      ]);
+    });
+  });
+
   describe('image content in model_output steps', () => {
     it('emits a file content part with mediaType + base64 data when an image block carries inline data', () => {
       const steps = [

--- a/packages/google/src/interactions/parse-google-interactions-outputs.ts
+++ b/packages/google/src/interactions/parse-google-interactions-outputs.ts
@@ -23,9 +23,13 @@ export type ParseGoogleInteractionsOutputsResult = {
 function googleProviderMetadata({
   signature,
   interactionId,
+  processingId,
+  processingCallId,
 }: {
   signature?: string | null;
   interactionId?: string;
+  processingId?: string;
+  processingCallId?: string;
 }): { providerMetadata: { google: Record<string, string> } } | object {
   const google: Record<string, string> = {};
   if (signature != null) {
@@ -33,6 +37,12 @@ function googleProviderMetadata({
   }
   if (interactionId != null) {
     google.interactionId = interactionId;
+  }
+  if (processingId != null) {
+    google.processingId = processingId;
+  }
+  if (processingCallId != null) {
+    google.processingCallId = processingCallId;
   }
   return Object.keys(google).length > 0 ? { providerMetadata: { google } } : {};
 }
@@ -194,6 +204,40 @@ export function parseGoogleInteractionsOutputs({
           ...googleProviderMetadata({
             signature: thought.signature,
             interactionId,
+          }),
+        });
+        break;
+      }
+      case 'processing_call': {
+        const call = step as {
+          id?: string;
+          signature?: string | null;
+        };
+        const processingId = call.id || generateId();
+        content.push({
+          type: 'custom',
+          kind: 'google.processing_call',
+          ...googleProviderMetadata({
+            signature: call.signature,
+            interactionId,
+            processingId,
+          }),
+        });
+        break;
+      }
+      case 'processing_result': {
+        const result = step as {
+          call_id?: string;
+          signature?: string | null;
+        };
+        const processingCallId = result.call_id || generateId();
+        content.push({
+          type: 'custom',
+          kind: 'google.processing_result',
+          ...googleProviderMetadata({
+            signature: result.signature,
+            interactionId,
+            processingCallId,
           }),
         });
         break;


### PR DESCRIPTION
## Background

Gemini interactions API now has the capability to agentically understand videos: https://aistudio.google.com/docs/video-understanding#agentic-video-understanding

we previously only supported `static` understanding. but now `agentic` is also available

## Summary

- video file parts now accept `processing: agentic` along with `static` - which are translated into the Gemini Interactions request format
- gemini’s `processing_call` and `processing_result` steps are exposed as observable custom parts and preserved across stateless multi-turn requests

## End-to-End Verification

verified by running the example `http://localhost:3000/chat/google-interactions-agentic-video` with a multiturn convo

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)