### PR TITLE
feat(provider/gateway): add Browserbase Search and Fetch tools

### DIFF
--- a/.changeset/browserbase-gateway-tools.md
+++ b/.changeset/browserbase-gateway-tools.md
@@ -2,4 +2,4 @@
 '@ai-sdk/gateway': patch
 ---
 
-feat(provider/gateway): add Browserbase Search and Fetch tools
+feat (provider/gateway): add Browserbase Search and Fetch tool support

--- a/.changeset/browserbase-gateway-tools.md
+++ b/.changeset/browserbase-gateway-tools.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(provider/gateway): add Browserbase Search and Fetch tools

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -959,6 +959,132 @@ token-efficient content controls. Deep synthesis modes and generated summaries
 are intentionally not exposed yet because they have separate pricing from
 standard Search.
 
+#### Browserbase Search
+
+The Browserbase Search tool enables models to search the web using [Browserbase's Search API](https://docs.browserbase.com/reference/api/web-search). It is executed by AI Gateway and returns fast, structured search results without opening a browser session.
+
+```ts
+import { gateway, generateText } from 'ai';
+
+const result = await generateText({
+  model: 'openai/gpt-5.6-luna',
+  prompt:
+    'Find official guidance on traveling with power banks on U.S. flights. Return the most relevant page titles and URLs.',
+  tools: {
+    browserbase_search: gateway.tools.browserbaseSearch(),
+  },
+});
+
+console.log(result.text);
+console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+```
+
+You can configure the maximum number of results returned by each search:
+
+```ts
+import { gateway, generateText } from 'ai';
+
+const result = await generateText({
+  model: 'openai/gpt-5.6-luna',
+  prompt:
+    'Find three recent reviews comparing e-readers for outdoor reading. Return their titles and URLs.',
+  tools: {
+    browserbase_search: gateway.tools.browserbaseSearch({
+      numResults: 3,
+    }),
+  },
+});
+
+console.log(result.text);
+```
+
+The Browserbase Search tool supports this optional configuration option:
+
+- **numResults** _number_
+
+  Maximum number of search results to return (1-25, default: 10).
+
+The tool works with both `generateText` and `streamText`.
+
+#### Browserbase Fetch
+
+The Browserbase Fetch tool enables models to retrieve page content using [Browserbase's Fetch API](https://docs.browserbase.com/platform/fetch/overview). It is a lightweight option for pages that do not require JavaScript execution or browser interaction, and it supports raw, Markdown, and schema-driven JSON output.
+
+```ts
+import { gateway, generateText } from 'ai';
+
+const result = await generateText({
+  model: 'openai/gpt-5.6-luna',
+  prompt:
+    'Fetch https://www.nps.gov/yose/planyourvisit/halfdome.htm and summarize the permit requirements and main safety warnings.',
+  tools: {
+    browserbase_fetch: gateway.tools.browserbaseFetch(),
+  },
+});
+
+console.log(result.text);
+console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+```
+
+You can configure the output format and request behavior. For example, use JSON extraction to return content matching a JSON Schema:
+
+```ts
+import { gateway, generateText } from 'ai';
+
+const result = await generateText({
+  model: 'openai/gpt-5.6-luna',
+  prompt:
+    'Fetch https://www.nps.gov/yose/planyourvisit/halfdome.htm and extract its page title, whether a permit is required, and three safety tips.',
+  tools: {
+    browserbase_fetch: gateway.tools.browserbaseFetch({
+      allowRedirects: true,
+      format: 'json',
+      schema: {
+        type: 'object',
+        properties: {
+          pageTitle: { type: 'string' },
+          permitRequired: { type: 'boolean' },
+          safetyTips: {
+            type: 'array',
+            items: { type: 'string' },
+            maxItems: 3,
+          },
+        },
+        required: ['pageTitle', 'permitRequired', 'safetyTips'],
+      },
+    }),
+  },
+});
+
+console.log(result.text);
+```
+
+The Browserbase Fetch tool supports these optional configuration options:
+
+- **format** _'raw' | 'markdown' | 'json'_
+
+  Output format for the fetched content. `raw` returns the upstream response body unchanged and is the default. `markdown` converts the page to Markdown. `json` performs structured extraction and requires `schema`.
+
+- **schema** _object_
+
+  JSON Schema describing the desired structured content. Only used when `format` is `json`.
+
+- **allowRedirects** _boolean_
+
+  Follow HTTP redirects. Defaults to `false`.
+
+- **proxies** _boolean_
+
+  Route the request through Browserbase's proxy network. Defaults to `false`.
+
+- **allowInsecureSsl** _boolean_
+
+  Bypass TLS certificate verification. Defaults to `false`; only enable it for trusted hosts.
+
+The Fetch API does not execute JavaScript. Use a browser session for interactive or JavaScript-rendered pages. The tool works with both `generateText` and `streamText`.
+
 #### Tako Search
 
 The Tako Search tool enables models to search the web and Tako's curated knowledge graph in a single call using [Tako's Search API](https://docs.tako.com/documentation/integrating-tako/search/overview). This tool is executed by the AI Gateway and returns token-efficient web excerpts, plus knowledge-graph results that carry structured data, premium source attribution, and an embed-ready visualization.

--- a/examples/ai-functions/src/generate-text/gateway/tool-browserbase-fetch-params.ts
+++ b/examples/ai-functions/src/generate-text/gateway/tool-browserbase-fetch-params.ts
@@ -1,0 +1,39 @@
+import { gateway, generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: 'openai/gpt-5.6-luna',
+    prompt:
+      'Use Browserbase Fetch to extract the page title, whether a permit is required, and three safety tips from https://www.nps.gov/yose/planyourvisit/halfdome.htm.',
+    tools: {
+      browserbase_fetch: gateway.tools.browserbaseFetch({
+        allowRedirects: true,
+        format: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            pageTitle: { type: 'string' },
+            permitRequired: { type: 'boolean' },
+            safetyTips: {
+              type: 'array',
+              items: { type: 'string' },
+              maxItems: 3,
+            },
+          },
+          required: ['pageTitle', 'permitRequired', 'safetyTips'],
+        },
+      }),
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+  console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/generate-text/gateway/tool-browserbase-fetch.ts
+++ b/examples/ai-functions/src/generate-text/gateway/tool-browserbase-fetch.ts
@@ -1,0 +1,23 @@
+import { gateway, generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: 'openai/gpt-5.6-luna',
+    prompt:
+      'Use Browserbase Fetch to read https://www.nps.gov/yose/planyourvisit/halfdome.htm and summarize the permit requirements and main safety warnings.',
+    tools: {
+      browserbase_fetch: gateway.tools.browserbaseFetch(),
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+  console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/generate-text/gateway/tool-browserbase-search-params.ts
+++ b/examples/ai-functions/src/generate-text/gateway/tool-browserbase-search-params.ts
@@ -1,0 +1,25 @@
+import { gateway, generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: 'openai/gpt-5.6-luna',
+    prompt:
+      'Use Browserbase Search to find three recent reviews comparing e-readers for outdoor reading. Return their titles and URLs.',
+    tools: {
+      browserbase_search: gateway.tools.browserbaseSearch({
+        numResults: 3,
+      }),
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+  console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/generate-text/gateway/tool-browserbase-search.ts
+++ b/examples/ai-functions/src/generate-text/gateway/tool-browserbase-search.ts
@@ -1,0 +1,23 @@
+import { gateway, generateText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = await generateText({
+    model: 'openai/gpt-5.6-luna',
+    prompt:
+      'Use Browserbase Search to find official guidance on traveling with power banks on U.S. flights. Return the most relevant page titles and URLs.',
+    tools: {
+      browserbase_search: gateway.tools.browserbaseSearch(),
+    },
+  });
+
+  console.log('Text:', result.text);
+  console.log();
+  console.log('Tool calls:', JSON.stringify(result.toolCalls, null, 2));
+  console.log('Tool results:', JSON.stringify(result.toolResults, null, 2));
+  console.log();
+  console.log('Token usage:', result.usage);
+  console.log('Finish reason:', result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/stream-text/gateway/tool-browserbase-fetch-params.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-browserbase-fetch-params.ts
@@ -1,0 +1,52 @@
+import { gateway, streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: 'openai/gpt-5.6-luna',
+    prompt:
+      'Use Browserbase Fetch to extract the page title, whether a permit is required, and three safety tips from https://www.nps.gov/yose/planyourvisit/halfdome.htm.',
+    tools: {
+      browserbase_fetch: gateway.tools.browserbaseFetch({
+        allowRedirects: true,
+        format: 'json',
+        schema: {
+          type: 'object',
+          properties: {
+            pageTitle: { type: 'string' },
+            permitRequired: { type: 'boolean' },
+            safetyTips: {
+              type: 'array',
+              items: { type: 'string' },
+              maxItems: 3,
+            },
+          },
+          required: ['pageTitle', 'permitRequired', 'safetyTips'],
+        },
+      }),
+    },
+  });
+
+  for await (const part of result.stream) {
+    switch (part.type) {
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'tool-call':
+        console.log('\nTool call:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-result':
+        console.log('\nTool result:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-error':
+        console.log('\nTool error:', JSON.stringify(part, null, 2));
+        break;
+    }
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/stream-text/gateway/tool-browserbase-fetch.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-browserbase-fetch.ts
@@ -1,0 +1,36 @@
+import { gateway, streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: 'openai/gpt-5.6-luna',
+    prompt:
+      'Use Browserbase Fetch to read https://www.nps.gov/yose/planyourvisit/halfdome.htm and summarize the permit requirements and main safety warnings.',
+    tools: {
+      browserbase_fetch: gateway.tools.browserbaseFetch(),
+    },
+  });
+
+  for await (const part of result.stream) {
+    switch (part.type) {
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'tool-call':
+        console.log('\nTool call:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-result':
+        console.log('\nTool result:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-error':
+        console.log('\nTool error:', JSON.stringify(part, null, 2));
+        break;
+    }
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/stream-text/gateway/tool-browserbase-search-params.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-browserbase-search-params.ts
@@ -1,0 +1,38 @@
+import { gateway, streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: 'openai/gpt-5.6-luna',
+    prompt:
+      'Use Browserbase Search to find three recent reviews comparing e-readers for outdoor reading. Return their titles and URLs.',
+    tools: {
+      browserbase_search: gateway.tools.browserbaseSearch({
+        numResults: 3,
+      }),
+    },
+  });
+
+  for await (const part of result.stream) {
+    switch (part.type) {
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'tool-call':
+        console.log('\nTool call:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-result':
+        console.log('\nTool result:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-error':
+        console.log('\nTool error:', JSON.stringify(part, null, 2));
+        break;
+    }
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/examples/ai-functions/src/stream-text/gateway/tool-browserbase-search.ts
+++ b/examples/ai-functions/src/stream-text/gateway/tool-browserbase-search.ts
@@ -1,0 +1,36 @@
+import { gateway, streamText } from 'ai';
+import 'dotenv/config';
+
+async function main() {
+  const result = streamText({
+    model: 'openai/gpt-5.6-luna',
+    prompt:
+      'Use Browserbase Search to find official guidance on traveling with power banks on U.S. flights. Return the most relevant page titles and URLs.',
+    tools: {
+      browserbase_search: gateway.tools.browserbaseSearch(),
+    },
+  });
+
+  for await (const part of result.stream) {
+    switch (part.type) {
+      case 'text-delta':
+        process.stdout.write(part.text);
+        break;
+      case 'tool-call':
+        console.log('\nTool call:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-result':
+        console.log('\nTool result:', JSON.stringify(part, null, 2));
+        break;
+      case 'tool-error':
+        console.log('\nTool error:', JSON.stringify(part, null, 2));
+        break;
+    }
+  }
+
+  console.log();
+  console.log('Token usage:', await result.usage);
+  console.log('Finish reason:', await result.finishReason);
+}
+
+main().catch(console.error);

--- a/packages/gateway/src/gateway-tools.ts
+++ b/packages/gateway/src/gateway-tools.ts
@@ -1,3 +1,5 @@
+import { browserbaseFetch } from './tool/browserbase-fetch';
+import { browserbaseSearch } from './tool/browserbase-search';
 import { exaSearch } from './tool/exa-search';
 import { parallelSearch } from './tool/parallel-search';
 import { perplexitySearch } from './tool/perplexity-search';
@@ -7,6 +9,22 @@ import { takoSearch } from './tool/tako-search';
  * Gateway-specific provider-defined tools.
  */
 export const gatewayTools = {
+  /**
+   * Fetch page content using Browserbase's lightweight Fetch API.
+   *
+   * Supports raw, Markdown, and schema-driven JSON output as well as redirects,
+   * proxy routing, and TLS controls.
+   */
+  browserbaseFetch,
+
+  /**
+   * Search the web using Browserbase's Search API for fast, structured results.
+   *
+   * Returns titles, URLs, and available publication metadata without requiring
+   * a browser session.
+   */
+  browserbaseSearch,
+
   /**
    * Search the web using Exa for current information and token-efficient
    * excerpts optimized for agent workflows.

--- a/packages/gateway/src/tool/browserbase-fetch.test.ts
+++ b/packages/gateway/src/tool/browserbase-fetch.test.ts
@@ -1,4 +1,4 @@
-import { asSchema } from '@ai-sdk/provider-utils';
+import { asSchema, safeValidateTypes } from '@ai-sdk/provider-utils';
 import { describe, expect, it } from 'vitest';
 import { browserbaseFetch } from './browserbase-fetch';
 
@@ -37,5 +37,68 @@ describe('browserbaseFetch', () => {
         schema: { type: 'object' },
       },
     });
+  });
+
+  it('validates a Browserbase Fetch API success response', async () => {
+    const result = await safeValidateTypes({
+      value: {
+        id: 'fetch_9f8e7d6c5b4a',
+        statusCode: 200,
+        headers: {
+          'content-type': 'text/html; charset=utf-8',
+          'cache-control': 'max-age=0',
+        },
+        content: '<!DOCTYPE html><html><body>Example</body></html>',
+        contentType: 'text/html; charset=utf-8',
+        encoding: 'utf-8',
+      },
+      schema: asSchema(browserbaseFetch().outputSchema),
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('validates a JSON-extraction success response', async () => {
+    const result = await safeValidateTypes({
+      value: {
+        id: 'fetch_1a2b3c4d5e6f',
+        statusCode: 200,
+        headers: { 'content-type': 'text/html' },
+        content: { title: 'Example Domain', price: 42 },
+        contentType: 'text/html',
+        encoding: 'utf-8',
+      },
+      schema: asSchema(browserbaseFetch().outputSchema),
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('validates a Browserbase Fetch API error response', async () => {
+    const result = await safeValidateTypes({
+      value: {
+        error: 'rate_limit',
+        statusCode: 429,
+        message: 'Rate limit exceeded',
+      },
+      schema: asSchema(browserbaseFetch().outputSchema),
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a success response missing id', async () => {
+    const result = await safeValidateTypes({
+      value: {
+        statusCode: 200,
+        headers: { 'content-type': 'text/html' },
+        content: '<!DOCTYPE html><html><body>Example</body></html>',
+        contentType: 'text/html; charset=utf-8',
+        encoding: 'utf-8',
+      },
+      schema: asSchema(browserbaseFetch().outputSchema),
+    });
+
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/gateway/src/tool/browserbase-fetch.test.ts
+++ b/packages/gateway/src/tool/browserbase-fetch.test.ts
@@ -1,0 +1,41 @@
+import { asSchema } from '@ai-sdk/provider-utils';
+import { describe, expect, it } from 'vitest';
+import { browserbaseFetch } from './browserbase-fetch';
+
+describe('browserbaseFetch', () => {
+  it('creates a provider-executed Browserbase Fetch tool', () => {
+    expect(
+      browserbaseFetch({
+        allowRedirects: true,
+        format: 'markdown',
+        proxies: true,
+      }),
+    ).toMatchObject({
+      type: 'provider',
+      id: 'gateway.browserbase_fetch',
+      args: {
+        allowRedirects: true,
+        format: 'markdown',
+        proxies: true,
+      },
+      isProviderExecuted: true,
+    });
+  });
+
+  it('describes all Browserbase Fetch API inputs', async () => {
+    const inputSchema = await asSchema(browserbaseFetch().inputSchema)
+      .jsonSchema;
+
+    expect(inputSchema).toMatchObject({
+      required: ['url'],
+      properties: {
+        url: { type: 'string' },
+        allow_redirects: { type: 'boolean' },
+        allow_insecure_ssl: { type: 'boolean' },
+        proxies: { type: 'boolean' },
+        format: { enum: ['raw', 'json', 'markdown'] },
+        schema: { type: 'object' },
+      },
+    });
+  });
+});

--- a/packages/gateway/src/tool/browserbase-fetch.ts
+++ b/packages/gateway/src/tool/browserbase-fetch.ts
@@ -1,0 +1,157 @@
+import {
+  createProviderExecutedToolFactory,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from '../zod';
+
+export type BrowserbaseFetchFormat = 'raw' | 'json' | 'markdown';
+
+export interface BrowserbaseFetchConfig {
+  /** Whether to follow HTTP redirects (default: false). */
+  allowRedirects?: boolean;
+  /** Whether to bypass TLS certificate verification (default: false). */
+  allowInsecureSsl?: boolean;
+  /** Whether to route the request through Browserbase proxies (default: false). */
+  proxies?: boolean;
+  /** Output format for the response content (default: raw). */
+  format?: BrowserbaseFetchFormat;
+  /**
+   * JSON Schema describing the desired response content. Only used when format
+   * is json.
+   */
+  schema?: Record<string, unknown>;
+}
+
+export interface BrowserbaseFetchInput {
+  /** URL of the page to fetch. */
+  url: string;
+  /** Whether to follow HTTP redirects. */
+  allow_redirects?: boolean;
+  /** Whether to bypass TLS certificate verification. */
+  allow_insecure_ssl?: boolean;
+  /** Whether to route the request through Browserbase proxies. */
+  proxies?: boolean;
+  /** Output format for the response content. */
+  format?: BrowserbaseFetchFormat;
+  /**
+   * JSON Schema describing the desired response content. Only used when format
+   * is json.
+   */
+  schema?: Record<string, unknown>;
+}
+
+export interface BrowserbaseFetchResponse {
+  /** Unique identifier for the fetch request. */
+  id: string;
+  /**
+   * Response body. Raw and markdown responses return strings; JSON extraction
+   * returns an object matching the requested schema.
+   */
+  content: string | Record<string, unknown>;
+  /** MIME type of the response. */
+  contentType: string;
+  /** Character encoding of the response. */
+  encoding: string;
+  /** Response headers from the fetched page. */
+  headers: Record<string, string>;
+  /** HTTP status code returned by the fetched page. */
+  statusCode: number;
+}
+
+export interface BrowserbaseFetchError {
+  error:
+    | 'api_error'
+    | 'configuration_error'
+    | 'execution_error'
+    | 'invalid_input'
+    | 'rate_limit'
+    | 'timeout'
+    | 'unknown';
+  statusCode?: number;
+  message: string;
+}
+
+export type BrowserbaseFetchOutput =
+  | BrowserbaseFetchError
+  | BrowserbaseFetchResponse;
+
+const jsonObjectSchema = z.record(z.string(), z.unknown());
+
+const browserbaseFetchInputSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      url: z.string().url().describe('URL of the page to fetch.'),
+      allow_redirects: z
+        .boolean()
+        .optional()
+        .describe('Whether to follow HTTP redirects (default: false).'),
+      allow_insecure_ssl: z
+        .boolean()
+        .optional()
+        .describe(
+          'Whether to bypass TLS certificate verification (default: false). Only use for trusted hosts.',
+        ),
+      proxies: z
+        .boolean()
+        .optional()
+        .describe(
+          'Whether to route the request through Browserbase proxies (default: false).',
+        ),
+      format: z
+        .enum(['raw', 'json', 'markdown'])
+        .optional()
+        .describe(
+          'Output format. raw returns the response body unchanged, markdown returns page content as Markdown, and json returns structured content using schema.',
+        ),
+      schema: jsonObjectSchema
+        .optional()
+        .describe(
+          'JSON Schema for structured extraction. Only use with format set to json.',
+        ),
+    }),
+  ),
+);
+
+const browserbaseFetchOutputSchema = lazySchema(() =>
+  zodSchema(
+    z.union([
+      z.object({
+        id: z.string(),
+        content: z.union([z.string(), jsonObjectSchema]),
+        contentType: z.string(),
+        encoding: z.string(),
+        headers: z.record(z.string(), z.string()),
+        statusCode: z.number(),
+      }),
+      z.object({
+        error: z.enum([
+          'api_error',
+          'configuration_error',
+          'execution_error',
+          'invalid_input',
+          'rate_limit',
+          'timeout',
+          'unknown',
+        ]),
+        statusCode: z.number().optional(),
+        message: z.string(),
+      }),
+    ]),
+  ),
+);
+
+export const browserbaseFetchToolFactory = createProviderExecutedToolFactory<
+  BrowserbaseFetchInput,
+  BrowserbaseFetchOutput,
+  BrowserbaseFetchConfig
+>({
+  id: 'gateway.browserbase_fetch',
+  inputSchema: browserbaseFetchInputSchema,
+  outputSchema: browserbaseFetchOutputSchema,
+});
+
+export const browserbaseFetch = (
+  config: BrowserbaseFetchConfig = {},
+): ReturnType<typeof browserbaseFetchToolFactory> =>
+  browserbaseFetchToolFactory(config);

--- a/packages/gateway/src/tool/browserbase-search.test.ts
+++ b/packages/gateway/src/tool/browserbase-search.test.ts
@@ -1,4 +1,4 @@
-import { asSchema } from '@ai-sdk/provider-utils';
+import { asSchema, safeValidateTypes } from '@ai-sdk/provider-utils';
 import { describe, expect, it } from 'vitest';
 import { browserbaseSearch } from './browserbase-search';
 
@@ -29,5 +29,58 @@ describe('browserbaseSearch', () => {
         },
       },
     });
+  });
+
+  it('validates a Browserbase Search API success response', async () => {
+    const result = await safeValidateTypes({
+      value: {
+        requestId: 'req_9f8e7d6c5b4a',
+        query: 'half dome permit',
+        results: [
+          {
+            id: 'result_1',
+            url: 'https://www.nps.gov/yose/planyourvisit/halfdome.htm',
+            title: 'Half Dome - Yosemite National Park',
+            author: 'National Park Service',
+            favicon: 'https://www.nps.gov/favicon.ico',
+            image: 'https://www.nps.gov/halfdome.jpg',
+            publishedDate: '2026-01-15T00:00:00Z',
+          },
+          {
+            id: 'result_2',
+            url: 'https://www.recreation.gov/permits/234652',
+            title: 'Half Dome Permits',
+          },
+        ],
+      },
+      schema: asSchema(browserbaseSearch().outputSchema),
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('validates a Browserbase Search API error response', async () => {
+    const result = await safeValidateTypes({
+      value: {
+        error: 'timeout',
+        statusCode: 504,
+        message: 'Search request timed out',
+      },
+      schema: asSchema(browserbaseSearch().outputSchema),
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a success response missing requestId', async () => {
+    const result = await safeValidateTypes({
+      value: {
+        query: 'half dome permit',
+        results: [],
+      },
+      schema: asSchema(browserbaseSearch().outputSchema),
+    });
+
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/gateway/src/tool/browserbase-search.test.ts
+++ b/packages/gateway/src/tool/browserbase-search.test.ts
@@ -1,0 +1,33 @@
+import { asSchema } from '@ai-sdk/provider-utils';
+import { describe, expect, it } from 'vitest';
+import { browserbaseSearch } from './browserbase-search';
+
+describe('browserbaseSearch', () => {
+  it('creates a provider-executed Browserbase Search tool', () => {
+    expect(browserbaseSearch({ numResults: 5 })).toMatchObject({
+      type: 'provider',
+      id: 'gateway.browserbase_search',
+      args: { numResults: 5 },
+      isProviderExecuted: true,
+    });
+  });
+
+  it('describes the Browserbase Search API input constraints', async () => {
+    const inputSchema = await asSchema(browserbaseSearch().inputSchema)
+      .jsonSchema;
+
+    expect(inputSchema).toMatchObject({
+      required: ['query'],
+      properties: {
+        query: {
+          minLength: 1,
+          maxLength: 200,
+        },
+        num_results: {
+          minimum: 1,
+          maximum: 25,
+        },
+      },
+    });
+  });
+});

--- a/packages/gateway/src/tool/browserbase-search.ts
+++ b/packages/gateway/src/tool/browserbase-search.ts
@@ -1,0 +1,137 @@
+import {
+  createProviderExecutedToolFactory,
+  lazySchema,
+  zodSchema,
+} from '@ai-sdk/provider-utils';
+import { z } from '../zod';
+
+export interface BrowserbaseSearchConfig {
+  /**
+   * Default maximum number of results to return (1-25, default: 10).
+   */
+  numResults?: number;
+}
+
+export interface BrowserbaseSearchInput {
+  /**
+   * Web search query (1-200 characters).
+   */
+  query: string;
+
+  /**
+   * Maximum number of results to return (1-25, default: 10).
+   */
+  num_results?: number;
+}
+
+export interface BrowserbaseSearchResult {
+  /** Unique identifier for the result. */
+  id: string;
+  /** Title of the search result. */
+  title: string;
+  /** URL of the search result. */
+  url: string;
+  /** Author of the content, when available. */
+  author?: string;
+  /** Favicon URL, when available. */
+  favicon?: string;
+  /** Image URL, when available. */
+  image?: string;
+  /** Publication date in ISO 8601 format, when available. */
+  publishedDate?: string;
+}
+
+export interface BrowserbaseSearchResponse {
+  /** The search query that was executed. */
+  query: string;
+  /** Unique identifier for the request. */
+  requestId: string;
+  /** Search results. */
+  results: BrowserbaseSearchResult[];
+}
+
+export interface BrowserbaseSearchError {
+  error:
+    | 'api_error'
+    | 'configuration_error'
+    | 'execution_error'
+    | 'invalid_input'
+    | 'rate_limit'
+    | 'timeout'
+    | 'unknown';
+  statusCode?: number;
+  message: string;
+}
+
+export type BrowserbaseSearchOutput =
+  | BrowserbaseSearchError
+  | BrowserbaseSearchResponse;
+
+const browserbaseSearchInputSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      query: z
+        .string()
+        .min(1)
+        .max(200)
+        .describe('Web search query. Must be between 1 and 200 characters.'),
+      num_results: z
+        .number()
+        .int()
+        .min(1)
+        .max(25)
+        .optional()
+        .describe('Maximum number of results to return (1-25, default: 10).'),
+    }),
+  ),
+);
+
+const browserbaseSearchOutputSchema = lazySchema(() =>
+  zodSchema(
+    z.union([
+      z.object({
+        query: z.string(),
+        requestId: z.string(),
+        results: z.array(
+          z.object({
+            id: z.string(),
+            title: z.string(),
+            url: z.string(),
+            author: z.string().optional(),
+            favicon: z.string().optional(),
+            image: z.string().optional(),
+            publishedDate: z.string().optional(),
+          }),
+        ),
+      }),
+      z.object({
+        error: z.enum([
+          'api_error',
+          'configuration_error',
+          'execution_error',
+          'invalid_input',
+          'rate_limit',
+          'timeout',
+          'unknown',
+        ]),
+        statusCode: z.number().optional(),
+        message: z.string(),
+      }),
+    ]),
+  ),
+);
+
+export const browserbaseSearchToolFactory = createProviderExecutedToolFactory<
+  BrowserbaseSearchInput,
+  BrowserbaseSearchOutput,
+  BrowserbaseSearchConfig
+>({
+  id: 'gateway.browserbase_search',
+  inputSchema: browserbaseSearchInputSchema,
+  outputSchema: browserbaseSearchOutputSchema,
+});
+
+export const browserbaseSearch = (
+  config: BrowserbaseSearchConfig = {},
+): ReturnType<typeof browserbaseSearchToolFactory> =>
+  browserbaseSearchToolFactory(config);


### PR DESCRIPTION
## Background

Browserbase provides a Search API for fast, structured web discovery and a Fetch API for retrieving raw, Markdown, or schema-driven JSON content without opening a browser session. This change exposes both as first-party, provider-executed AI Gateway tools.

This PR defines the public SDK surface and wire contract. Production execution requires corresponding support in Vercel's private `ai-gateway` service.

## Summary

- Add `gateway.tools.browserbaseSearch()` with optional result-count configuration.
- Add `gateway.tools.browserbaseFetch()` with output format, JSON schema, redirects, proxy, and TLS configuration.
- Add request and response types, input/output schemas, and provider-executed tool factory wiring.
- Add `generateText` and `streamText` examples using `openai/gpt-5.6-luna` and practical external-site tasks.
- Add AI Gateway provider documentation and a patch changeset.

## End-to-End Verification

Full Browserbase execution through AI Gateway is pending the companion private-service implementation. The built public `ai` package was exercised through `generateText` with an injected Gateway transport, verifying that both tools are exported, their provider IDs and configuration are serialized to the Gateway request, `openai/gpt-5.6-luna` reaches the model header, and a Gateway response completes through the public API.

## Validation

- `pnpm --filter @ai-sdk/gateway test:node` (23 files, 544 tests)
- `pnpm type-check:full`
- `pnpm check`
- `pnpm validate:docs`
- `git diff --check upstream/main...HEAD`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Register and execute `gateway.browserbase_search` and `gateway.browserbase_fetch` in the private `ai-gateway` service, including managed authentication, error mapping, telemetry, and billing.
