### PR TITLE
fix(google): map code execution tool name

### DIFF
--- a/.changeset/smart-mangos-mate.md
+++ b/.changeset/smart-mangos-mate.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(google): map code execution tool name- #20260

--- a/packages/google/src/google-language-model.test.ts
+++ b/packages/google/src/google-language-model.test.ts
@@ -364,7 +364,7 @@ describe('urlContextMetadata', () => {
 });
 
 describe('doGenerate', () => {
-  it('should associate multiple generated and streamed code execution results with the same tool call', async () => {
+  it('should use the custom code execution tool name for generated and streamed results', async () => {
     const response = {
       candidates: [
         {
@@ -422,7 +422,7 @@ describe('doGenerate', () => {
           {
             type: 'provider',
             id: 'google.code_execution',
-            name: 'code_execution',
+            name: 'CodeExecutionTool',
             args: {},
           },
         ],
@@ -436,7 +436,7 @@ describe('doGenerate', () => {
           "input": "{"language":"PYTHON","code":"print('ok')\\nprint(1/0)"}",
           "providerExecuted": true,
           "toolCallId": "test-id",
-          "toolName": "code_execution",
+          "toolName": "CodeExecutionTool",
           "type": "tool-call",
         },
         {
@@ -446,7 +446,7 @@ describe('doGenerate', () => {
       ",
           },
           "toolCallId": "test-id",
-          "toolName": "code_execution",
+          "toolName": "CodeExecutionTool",
           "type": "tool-result",
         },
         {
@@ -456,7 +456,7 @@ describe('doGenerate', () => {
       ",
           },
           "toolCallId": "test-id",
-          "toolName": "code_execution",
+          "toolName": "CodeExecutionTool",
           "type": "tool-result",
         },
       ]
@@ -469,7 +469,7 @@ describe('doGenerate', () => {
           {
             type: 'provider',
             id: 'google.code_execution',
-            name: 'code_execution',
+            name: 'CodeExecutionTool',
             args: {},
           },
         ],
@@ -488,7 +488,7 @@ describe('doGenerate', () => {
           "input": "{"language":"PYTHON","code":"print('ok')\\nprint(1/0)"}",
           "providerExecuted": true,
           "toolCallId": "test-id",
-          "toolName": "code_execution",
+          "toolName": "CodeExecutionTool",
           "type": "tool-call",
         },
         {
@@ -498,7 +498,7 @@ describe('doGenerate', () => {
       ",
           },
           "toolCallId": "test-id",
-          "toolName": "code_execution",
+          "toolName": "CodeExecutionTool",
           "type": "tool-result",
         },
         {
@@ -508,7 +508,7 @@ describe('doGenerate', () => {
       ",
           },
           "toolCallId": "test-id",
-          "toolName": "code_execution",
+          "toolName": "CodeExecutionTool",
           "type": "tool-result",
         },
       ]

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -414,7 +414,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
     response: InferSchema<typeof responseSchema>;
     warnings: SharedV4Warning[];
     providerOptionsNames: readonly string[];
-    toolNameMapping: ReturnType<typeof createToolNameMapping>;
+    toolNameMapping?: ReturnType<typeof createToolNameMapping>;
   }): LanguageModelV4GenerateResult {
     const wrapProviderMetadata = (payload: Record<string, unknown>) =>
       Object.fromEntries(
@@ -447,7 +447,9 @@ export class GoogleLanguageModel implements LanguageModelV4 {
         content.push({
           type: 'tool-call',
           toolCallId,
-          toolName: toolNameMapping.toCustomToolName('code_execution'),
+          toolName:
+            toolNameMapping?.toCustomToolName('code_execution') ??
+            'code_execution',
           input: JSON.stringify(part.executableCode),
           providerExecuted: true,
         });
@@ -456,7 +458,9 @@ export class GoogleLanguageModel implements LanguageModelV4 {
           type: 'tool-result',
           // Results correspond to the most recent executable code part.
           toolCallId: lastCodeExecutionToolCallId!,
-          toolName: toolNameMapping.toCustomToolName('code_execution'),
+          toolName:
+            toolNameMapping?.toCustomToolName('code_execution') ??
+            'code_execution',
           result: {
             outcome: part.codeExecutionResult.outcome,
             output: part.codeExecutionResult.output ?? '',

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -13,6 +13,7 @@ import type {
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
+  createToolNameMapping,
   createEventSourceResponseHandler,
   createJsonResponseHandler,
   generateId,
@@ -297,6 +298,12 @@ export class GoogleLanguageModel implements LanguageModelV4 {
       modelId: this.modelId,
       isVertexProvider,
     });
+    const toolNameMapping = createToolNameMapping({
+      tools,
+      providerToolNames: {
+        'google.code_execution': 'code_execution',
+      },
+    });
 
     const resolvedThinking = resolveThinkingConfig({
       reasoning,
@@ -394,6 +401,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
       warnings: [...warnings, ...toolWarnings],
       providerOptionsNames,
       extraHeaders: vertexPaygoHeaders,
+      toolNameMapping,
     };
   }
 
@@ -401,10 +409,12 @@ export class GoogleLanguageModel implements LanguageModelV4 {
     response,
     warnings,
     providerOptionsNames,
+    toolNameMapping,
   }: {
     response: InferSchema<typeof responseSchema>;
     warnings: SharedV4Warning[];
     providerOptionsNames: readonly string[];
+    toolNameMapping: ReturnType<typeof createToolNameMapping>;
   }): LanguageModelV4GenerateResult {
     const wrapProviderMetadata = (payload: Record<string, unknown>) =>
       Object.fromEntries(
@@ -437,7 +447,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
         content.push({
           type: 'tool-call',
           toolCallId,
-          toolName: 'code_execution',
+          toolName: toolNameMapping.toCustomToolName('code_execution'),
           input: JSON.stringify(part.executableCode),
           providerExecuted: true,
         });
@@ -446,7 +456,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
           type: 'tool-result',
           // Results correspond to the most recent executable code part.
           toolCallId: lastCodeExecutionToolCallId!,
-          toolName: 'code_execution',
+          toolName: toolNameMapping.toCustomToolName('code_execution'),
           result: {
             outcome: part.codeExecutionResult.outcome,
             output: part.codeExecutionResult.output ?? '',
@@ -586,8 +596,13 @@ export class GoogleLanguageModel implements LanguageModelV4 {
   async doGenerate(
     options: LanguageModelV4CallOptions,
   ): Promise<LanguageModelV4GenerateResult> {
-    const { args, warnings, providerOptionsNames, extraHeaders } =
-      await this.getArgs(options);
+    const {
+      args,
+      warnings,
+      providerOptionsNames,
+      extraHeaders,
+      toolNameMapping,
+    } = await this.getArgs(options);
 
     const mergedHeaders = combineHeaders(
       this.config.headers ? await resolve(this.config.headers) : undefined,
@@ -615,6 +630,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
       response,
       warnings,
       providerOptionsNames,
+      toolNameMapping,
     });
 
     return {
@@ -631,8 +647,13 @@ export class GoogleLanguageModel implements LanguageModelV4 {
   async doStream(
     options: LanguageModelV4CallOptions,
   ): Promise<LanguageModelV4StreamResult> {
-    const { args, warnings, providerOptionsNames, extraHeaders } =
-      await this.getArgs(options, { isStreaming: true });
+    const {
+      args,
+      warnings,
+      providerOptionsNames,
+      extraHeaders,
+      toolNameMapping,
+    } = await this.getArgs(options, { isStreaming: true });
     const wrapProviderMetadata = (payload: Record<string, unknown>) =>
       Object.fromEntries(
         providerOptionsNames.map(name => [name, payload]),
@@ -820,7 +841,8 @@ export class GoogleLanguageModel implements LanguageModelV4 {
                   controller.enqueue({
                     type: 'tool-call',
                     toolCallId,
-                    toolName: 'code_execution',
+                    toolName:
+                      toolNameMapping.toCustomToolName('code_execution'),
                     input: JSON.stringify(part.executableCode),
                     providerExecuted: true,
                   });
@@ -835,7 +857,8 @@ export class GoogleLanguageModel implements LanguageModelV4 {
                     controller.enqueue({
                       type: 'tool-result',
                       toolCallId,
-                      toolName: 'code_execution',
+                      toolName:
+                        toolNameMapping.toCustomToolName('code_execution'),
                       result: {
                         outcome: part.codeExecutionResult.outcome,
                         output: part.codeExecutionResult.output ?? '',


### PR DESCRIPTION
## Background

Vertex code execution uses fixed `code_execution`, but users can register it under a custom AI SDK tool key. When the model called the tool, it caused Core to reject the response with `AI_NoSuchToolError`.

## Summary

Map Vertex’s native `code_execution` response name back to the caller-defined tool key. This is the same solution already used by the OpenAI provider for `code_interpreter`.

## End-to-End Verification

Verified with `googleVertex('gemini-2.5-pro')`. A custom `CodeExecutionTool` key now receives valid tool-call and tool-result parts with no `AI_NoSuchToolError`.

```ts
tools: {
  CodeExecutionTool: googleVertex.tools.codeExecution({}),
}
```

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

Fixes https://github.com/vercel/ai/issues/9280