### PR TITLE
docs: add ZeroSignal to the OpenAI-compatible providers documentation

### DIFF
--- a/content/providers/04-openai-compatible-providers/60-zerosignal.mdx
+++ b/content/providers/04-openai-compatible-providers/60-zerosignal.mdx
@@ -1,0 +1,83 @@
+---
+title: ZeroSignal
+description: Use the ZeroSignal OpenAI compatible API with the AI SDK.
+---
+
+# ZeroSignal Provider
+
+[ZeroSignal](https://zerosignal.ai) is a private, pay-per-use inference network.
+Its `zs-proxy` daemon runs on your machine and exposes the network as an OpenAI compatible API on `http://127.0.0.1:9376/v1`.
+Every request is encrypted end to end and paid from your ZeroSignal wallet, so there is no API key: the proxy ignores the `Authorization` header.
+
+## Setup
+
+The ZeroSignal provider is available via the `@ai-sdk/openai-compatible` module as it is compatible with the OpenAI API.
+You can install it with
+
+<InstallPackages packages="@ai-sdk/openai-compatible" />
+
+Then install and start the proxy. See the [ZeroSignal proxy quick start](https://docs.zerosignal.ai/using-the-proxy/quick-start) for Windows and Linux installs.
+
+```bash
+brew install txnlab/tap/zs-proxy
+zs-proxy wallet login
+zs-proxy proxy start
+```
+
+## Provider Instance
+
+To use ZeroSignal, you can create a custom provider instance with the `createOpenAICompatible` function from `@ai-sdk/openai-compatible`:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+
+const zerosignal = createOpenAICompatible({
+  name: 'zerosignal',
+  baseURL: 'http://127.0.0.1:9376/v1',
+});
+```
+
+<Note>
+  `zs-proxy` listens on port `9376` by default. Pass `--port` to `zs-proxy
+  proxy start` to change it, and update `baseURL` to match.
+</Note>
+
+## Language Models
+
+You can interact with the models served on the ZeroSignal network using a provider instance.
+The first argument is the model id as returned by `GET /v1/models`, e.g. `moonshotai/kimi-k2.7-code`.
+
+```ts
+const model = zerosignal('moonshotai/kimi-k2.7-code');
+```
+
+Models are served by independent operators, so the catalog changes over time.
+Run `curl http://127.0.0.1:9376/v1/models` for the current list, including each model's context window and price.
+
+### Example
+
+You can use ZeroSignal language models to generate text with the `generateText` function:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { generateText } from 'ai';
+
+const zerosignal = createOpenAICompatible({
+  name: 'zerosignal',
+  baseURL: 'http://127.0.0.1:9376/v1',
+});
+
+const { text } = await generateText({
+  model: zerosignal('moonshotai/kimi-k2.7-code'),
+  prompt: 'Write a vegetarian lasagna recipe for 4 people.',
+  maxRetries: 1, // immediately error if the proxy is not running
+});
+```
+
+ZeroSignal language models can also be used with `streamText`.
+Pass `includeUsage: true` to `createOpenAICompatible` to receive token usage on streamed responses.
+
+## Cost
+
+Each response carries the amount charged for the request in the `X-Zs-Inference-Amount` response header.
+See the [ZeroSignal pricing docs](https://docs.zerosignal.ai/pricing) for how requests are priced.

--- a/content/providers/04-openai-compatible-providers/index.mdx
+++ b/content/providers/04-openai-compatible-providers/index.mdx
@@ -17,6 +17,7 @@ We provide detailed documentation for the following OpenAI compatible providers:
 - [Clarifai](/providers/openai-compatible-providers/clarifai)
 - [NEAR AI Cloud](/providers/openai-compatible-providers/nearai)
 - [Synthorai](/providers/openai-compatible-providers/synthorai)
+- [ZeroSignal](/providers/openai-compatible-providers/zerosignal)
 
 The general setup and provider instance creation is the same for all of these providers.
 


### PR DESCRIPTION
## Background

[ZeroSignal](https://zerosignal.ai) is a private, pay-per-use inference network. Its `zs-proxy` daemon runs on the user's machine and exposes the network as an OpenAI-compatible API on `http://127.0.0.1:9376/v1`. There is no API key (the proxy ignores `Authorization`; admission comes from the user's wallet), so it works with `createOpenAICompatible` with only a `baseURL`. Users have been asking how to wire it into the AI SDK, and a dedicated page under OpenAI Compatible Providers is the documented path for that.

## Summary

- Add `content/providers/04-openai-compatible-providers/60-zerosignal.mdx`, following the LM Studio page (another local OpenAI-compatible server): setup, provider instance, language models, `generateText` example, and a short cost note.
- Link the page from the section index.

Docs only. The example was run against zs-proxy v0.21.0 with `@ai-sdk/openai-compatible`; `curl http://127.0.0.1:9376/v1/models` returns the model id used.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)