### PR TITLE
fix(harness-claude-code): treat a `result` flagged `is_error` as a terminal error

### DIFF
--- a/.changeset/lucky-pandas-report.md
+++ b/.changeset/lucky-pandas-report.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-claude-code': patch
+---
+
+fix (harness-claude-code): treat a `result` message flagged `is_error` as a terminal error

--- a/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-claude-code/src/bridge/create-emit-stream-event.ts
@@ -38,6 +38,9 @@ export type ClaudeMessage = {
     usage?: Record<string, unknown>;
   };
   result?: string;
+  /** Result-message error flags; distinct from `error_status` (`api_retry`). */
+  is_error?: boolean;
+  api_error_status?: number | null;
   errors?: ReadonlyArray<string>;
   usage?: Record<string, unknown>;
   total_cost_usd?: number;

--- a/packages/harness-claude-code/src/bridge/index.test.ts
+++ b/packages/harness-claude-code/src/bridge/index.test.ts
@@ -734,4 +734,72 @@ describe('Claude Code bridge configuration', () => {
     expect(emitError).not.toHaveBeenCalled();
     expect(disposed).toHaveBeenCalled();
   });
+  test('reports a result flagged `is_error` as a terminal error, even though its subtype is `success`', async () => {
+    const emitError = vi.fn();
+    state.emitError = emitError;
+    // What the CLI actually sends when the provider rejects the request: the
+    // `success` subtype, `is_error: true`, and the message in `result`.
+    state.messages = [
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: true,
+        api_error_status: 400,
+        result: 'API Error: 400 the request was rejected',
+      },
+    ];
+
+    await import('./index');
+
+    expect(emitError).toHaveBeenCalledWith({
+      error: 'API Error: 400 the request was rejected',
+      message: 'claude-code terminal error',
+    });
+    // The turn must not also settle as a normal finish: that is what made a
+    // hard rejection look like an agent that simply returned nothing.
+    expect(state.emitted).not.toContainEqual(
+      expect.objectContaining({ type: 'finish' }),
+    );
+  });
+
+  test('names the HTTP status when an errored result carries no message', async () => {
+    const emitError = vi.fn();
+    state.emitError = emitError;
+    state.messages = [
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: true,
+        api_error_status: 529,
+        result: '   ',
+      },
+    ];
+
+    await import('./index');
+
+    expect(emitError).toHaveBeenCalledWith({
+      error: 'Claude Code reported an API error (HTTP 529)',
+      message: 'claude-code terminal error',
+    });
+  });
+
+  test('still finishes normally when a `success` result is not flagged as an error', async () => {
+    const emitError = vi.fn();
+    state.emitError = emitError;
+    state.messages = [
+      {
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        result: 'done',
+      },
+    ];
+
+    await import('./index');
+
+    expect(emitError).not.toHaveBeenCalled();
+    expect(state.emitted).toContainEqual(
+      expect.objectContaining({ type: 'finish' }),
+    );
+  });
 });

--- a/packages/harness-claude-code/src/bridge/index.ts
+++ b/packages/harness-claude-code/src/bridge/index.ts
@@ -507,6 +507,19 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
 
       if (type === 'result') {
         if (msg.subtype === 'success') {
+          // `success` does not mean the turn succeeded: the CLI flags a rejected
+          // request with `is_error` and puts the message in `result`, which the
+          // empty-result rescue below cannot catch.
+          if (msg.is_error) {
+            emitTerminalError(
+              msg.result?.trim() ||
+                streamEventState.observedTerminalError ||
+                (typeof msg.api_error_status === 'number'
+                  ? `Claude Code reported an API error (HTTP ${msg.api_error_status})`
+                  : 'Claude Code reported a failed result'),
+            );
+            continue;
+          }
           const emptyResult = !msg.result?.trim?.();
           if (emptyResult && streamEventState.observedTerminalError) {
             emitTerminalError(streamEventState.observedTerminalError);


### PR DESCRIPTION
## Summary

This PR is an exact copy of the diff from #20211. That PR was already approved and good to merge from a code perspective, but it lacked verified commit signatures.

See #20211 for the PR implementation context.

## Contributor Credit

All credit for the implementation goes to @DanOfir.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #20210

Co-Authored-By: Dan Ofir <9513799+DanOfir@users.noreply.github.com>