### PR TITLE
ci: detect expired Backport approvals without jobs

### DIFF
--- a/.github/workflows/slack-workflow-failure-notification.yml
+++ b/.github/workflows/slack-workflow-failure-notification.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   actions: read
-  checks: read
   contents: read
 
 jobs:
@@ -37,56 +36,31 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            const approvalExpiredMessage =
-              'This workflow run required approval but was not approved before it expired.';
             const { owner, repo } = context.repo;
             let approvalExpired = false;
 
             try {
+              // An unapproved fork PR run has no jobs. When its PR is closed,
+              // GitHub completes the run as a failure and renders the expiration
+              // message in the UI without creating a job or check annotation.
               const jobs = await github.paginate(
                 github.rest.actions.listJobsForWorkflowRun,
                 {
                   owner,
                   repo,
                   run_id: context.payload.workflow_run.id,
-                  filter: 'latest',
+                  filter: 'all',
                   per_page: 100,
                 },
               );
+              const workflowRun = context.payload.workflow_run;
+              const isForkPullRequest =
+                workflowRun.event === 'pull_request' &&
+                workflowRun.head_repository?.full_name != null &&
+                workflowRun.head_repository.full_name !==
+                  workflowRun.repository.full_name;
 
-              for (const job of jobs) {
-                const checkRunId = Number(job.check_run_url.split('/').at(-1));
-
-                if (!Number.isInteger(checkRunId)) {
-                  core.warning(`Could not determine the check run for ${job.name}.`);
-                  continue;
-                }
-
-                try {
-                  const annotations = await github.paginate(
-                    github.rest.checks.listAnnotations,
-                    {
-                      owner,
-                      repo,
-                      check_run_id: checkRunId,
-                      per_page: 100,
-                    },
-                  );
-
-                  if (
-                    annotations.some(
-                      annotation => annotation.message === approvalExpiredMessage,
-                    )
-                  ) {
-                    approvalExpired = true;
-                    break;
-                  }
-                } catch (error) {
-                  core.warning(
-                    `Could not inspect annotations for ${job.name}: ${error.message}`,
-                  );
-                }
-              }
+              approvalExpired = isForkPullRequest && jobs.length === 0;
             } catch (error) {
               core.warning(
                 `Could not inspect jobs for the Backport workflow: ${error.message}`,


### PR DESCRIPTION
## Background

#20242 tried to suppress Slack notifications for Backport runs whose fork approval expired by looking for GitHub's expiration message in check annotations.

The reported run, https://github.com/vercel/ai/actions/runs/33762482188, has no jobs and its check suite has no check runs. GitHub renders the expiration message in the UI, but there is no job annotation for the detector to inspect, so it returned `false` and sent the notification.

## Summary

- Detect expired Backport approvals using the API state GitHub actually exposes: a completed fork `pull_request` run with zero jobs.
- Query all run attempts so a genuine run with jobs is never misclassified based only on its latest attempt.
- Remove the no-longer-needed `checks: read` permission.

## End-to-End Verification

Compared the detector inputs against live Backport run history:

- Expired fork-approval runs 33762482188 and 33763852243 each have zero jobs and are suppressed.
- A genuine same-repository failure (28251523893), a genuine `main` failure (26643878001), and a genuine approved-fork failure (26790156237) have jobs and still notify.

## Verification

- `pnpm check`
- `pnpm type-check:full`
- Parsed the updated workflow as YAML

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related

- Follow-up to #20242
- Reported run: https://github.com/vercel/ai/actions/runs/33762482188
