### PR TITLE
chore(ai): formally include already supported `onLanguageModelCallStart` and `onLanguageModelCallEnd` in `ToolLoopAgentSettings` type

### DIFF
--- a/.changeset/green-walls-lick.md
+++ b/.changeset/green-walls-lick.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+chore(ai): formally include already supported `onLanguageModelCallStart` and `onLanguageModelCallEnd` in `ToolLoopAgentSettings` type

--- a/packages/ai/src/agent/tool-loop-agent-settings.ts
+++ b/packages/ai/src/agent/tool-loop-agent-settings.ts
@@ -17,6 +17,10 @@ import type {
   GenerateTextOnStepStartCallback,
 } from '../generate-text/generate-text-events';
 import type { GenerateTextInclude } from '../generate-text/generate-text';
+import type {
+  OnLanguageModelCallEndCallback,
+  OnLanguageModelCallStartCallback,
+} from '../generate-text/language-model-events';
 import type { Output } from '../generate-text/output';
 import type { PrepareStepFunction } from '../generate-text/prepare-step';
 import type { StopCondition } from '../generate-text/stop-condition';
@@ -211,6 +215,17 @@ export type ToolLoopAgentSettings<
       NoInfer<RUNTIME_CONTEXT>,
       NoInfer<OUTPUT>
     >;
+
+    /**
+     * Callback that is called immediately before the provider model call begins.
+     */
+    onLanguageModelCallStart?: OnLanguageModelCallStartCallback;
+
+    /**
+     * Callback that is called after the model response has been normalized and parsed,
+     * but before any client-side tool execution begins.
+     */
+    onLanguageModelCallEnd?: OnLanguageModelCallEndCallback<NoInfer<TOOLS>>;
 
     /**
      * Callback that is called before each tool execution begins.

--- a/packages/ai/src/agent/tool-loop-agent.test-d.ts
+++ b/packages/ai/src/agent/tool-loop-agent.test-d.ts
@@ -9,6 +9,7 @@ import {
   Output,
   type GenerateTextOnEndCallback,
   type Experimental_ToolCallers,
+  type LanguageModelCallEndEvent,
   type ToolApprovalConfiguration,
   type ToolInputRefinement,
 } from '../generate-text';
@@ -243,6 +244,27 @@ describe('ToolLoopAgent', () => {
         },
         onStepStart: event => {
           expectTypeOf(event.runtimeContext).toEqualTypeOf<Context>();
+        },
+      });
+    });
+
+    it('should support language model call callbacks in settings', () => {
+      const tools = {
+        calculator: tool({
+          inputSchema: z.object({ expression: z.string() }),
+        }),
+      };
+
+      new ToolLoopAgent({
+        model: new MockLanguageModelV4(),
+        tools,
+        onLanguageModelCallStart: event => {
+          expectTypeOf(event.callId).toEqualTypeOf<string>();
+        },
+        onLanguageModelCallEnd: event => {
+          expectTypeOf(event.content).toEqualTypeOf<
+            LanguageModelCallEndEvent<typeof tools>['content']
+          >();
         },
       });
     });


### PR DESCRIPTION
## Background

`ToolLoopAgent` already forwards `onLanguageModelCallStart` and `onLanguageModelCallEnd` to `generateText` and `streamText`, but `ToolLoopAgentSettings` did not declare them. This appears to be an oversight, given the other lifecycle callbacks were already explicitly included in the `ToolLoopAgentSettings` type.

## Summary

- Add both language model lifecycle callbacks to `ToolLoopAgentSettings`.
- Add type regression coverage for both callbacks.

## End-to-End Verification

N/A. This change formalizes existing runtime behavior.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
