### PR TITLE
feat(mcp): surface server-provided tool annotations in tool metadata

### DIFF
--- a/.changeset/brave-tools-wave.md
+++ b/.changeset/brave-tools-wave.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/mcp": patch
+---
+
+feat(mcp): surface server-provided tool annotations in tool metadata

--- a/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
+++ b/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
@@ -320,6 +320,51 @@ const tools = await mcpClient.tools();
 
 This approach is simpler to implement and automatically stays in sync with server changes. However, you won't have TypeScript type safety during development, and all tools from the server will be loaded
 
+### Tool Annotations and Approval
+
+MCP servers can describe tool behavior with annotations such as
+`readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`. The
+MCP client exposes these annotations on each tool's `metadata.annotations` and
+on the resulting tool call's `toolMetadata.annotations`.
+
+Annotations are untrusted, server-provided hints. The MCP client does not turn
+them into an approval policy automatically. Applications should combine them
+with deterministic controls such as tool allowlists, scoped credentials, and
+their own [`toolApproval`](/docs/agents/tool-approvals) policy.
+
+The following conservative policy allows tools to run automatically only when
+the server explicitly marks them as read-only. Tools with `readOnlyHint: false`
+or no `readOnlyHint` require user approval:
+
+```typescript
+import { type McpProviderMetadata } from '@ai-sdk/mcp';
+
+const result = streamText({
+  model: __MODEL__,
+  tools,
+  toolApproval: ({ toolCall }) => {
+    const annotations = (
+      toolCall.toolMetadata as McpProviderMetadata | undefined
+    )?.annotations;
+
+    return annotations?.readOnlyHint === true
+      ? 'not-applicable'
+      : {
+          type: 'user-approval',
+          reason:
+            annotations?.destructiveHint === true
+              ? 'The MCP server marks this tool as destructive.'
+              : 'The MCP server does not mark this tool as read-only.',
+        };
+  },
+  prompt,
+});
+```
+
+See the
+[Shopify MCP example](https://github.com/vercel/ai/blob/main/examples/mcp/src/shopify-mcp/client.ts)
+for a complete application-layer approval configuration.
+
 ### Schema Definition
 
 For better type safety and control, you can define the tools and their input schemas explicitly in your client code:

--- a/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
+++ b/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
@@ -373,13 +373,13 @@ pnpm server:tool-annotations
 
 ```bash
 cd examples/mcp
-pnpm client:tool-annotations read-note
-pnpm client:tool-annotations delete-note
-pnpm client:tool-annotations create-note
+pnpm client:tool-annotations
 ```
 
-The read-only tool executes immediately. The destructive and unannotated tools
-produce approval requests without executing.
+Ask the client to read, delete, or create a note. The read-only tool executes
+immediately. The destructive and unannotated tools prompt for approval; after
+you enter `y` or `n`, the client sends the decision back and prints the model's
+response.
 
 ### Schema Definition
 

--- a/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
+++ b/content/docs/03-ai-sdk-core/16-mcp-tools.mdx
@@ -362,8 +362,24 @@ const result = streamText({
 ```
 
 See the
-[Shopify MCP example](https://github.com/vercel/ai/blob/main/examples/mcp/src/shopify-mcp/client.ts)
-for a complete application-layer approval configuration.
+[local tool annotations example](https://github.com/vercel/ai/tree/main/examples/mcp/src/tool-annotations)
+for a complete annotated MCP server and application-layer approval
+configuration. Start the server and client in separate terminals:
+
+```bash
+cd examples/mcp
+pnpm server:tool-annotations
+```
+
+```bash
+cd examples/mcp
+pnpm client:tool-annotations read-note
+pnpm client:tool-annotations delete-note
+pnpm client:tool-annotations create-note
+```
+
+The read-only tool executes immediately. The destructive and unannotated tools
+produce approval requests without executing.
 
 ### Schema Definition
 

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -24,6 +24,8 @@
     "client:tool-meta": "tsx src/tool-meta/client.ts",
     "server:provider-metadata": "tsx src/provider-metadata/server.ts",
     "client:provider-metadata": "tsx src/provider-metadata/client.ts",
+    "server:tool-annotations": "tsx src/tool-annotations/server.ts",
+    "client:tool-annotations": "tsx src/tool-annotations/client.ts",
     "server:server-instructions": "tsx src/server-instructions/server.ts",
     "client:server-instructions": "tsx src/server-instructions/client.ts",
     "stdio:build": "tsc src/stdio/server.ts --outDir src/stdio/dist --target es2023 --module nodenext",

--- a/examples/mcp/src/tool-annotations/client.ts
+++ b/examples/mcp/src/tool-annotations/client.ts
@@ -1,0 +1,130 @@
+import { createMCPClient, type McpProviderMetadata } from '@ai-sdk/mcp';
+import { openai } from '@ai-sdk/openai';
+import {
+  generateText,
+  isStepCount,
+  type ModelMessage,
+  type ToolApprovalResponse,
+} from 'ai';
+import 'dotenv/config';
+import * as readline from 'node:readline/promises';
+
+const terminal = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+async function main() {
+  const mcpClient = await createMCPClient({
+    transport: {
+      type: 'http',
+      url: 'http://localhost:8086/mcp',
+    },
+  });
+
+  try {
+    const tools = await mcpClient.tools();
+    const messages: ModelMessage[] = [];
+    let approvals: ToolApprovalResponse[] = [];
+
+    console.log('Try one of these prompts:');
+    console.log('- Read note note-1');
+    console.log('- Delete note note-1');
+    console.log('- Create note note-2 with the text "Hello from MCP"');
+
+    while (true) {
+      messages.push(
+        approvals.length > 0
+          ? { role: 'tool', content: approvals }
+          : { role: 'user', content: await terminal.question('\nYou:\n') },
+      );
+      approvals = [];
+
+      const result = await generateText({
+        model: openai('gpt-4o-mini'),
+        tools,
+        toolApproval: ({ toolCall }) => {
+          const annotations = (
+            toolCall.toolMetadata as McpProviderMetadata | undefined
+          )?.annotations;
+
+          // Only an explicit read-only hint bypasses approval. False or missing
+          // hints require approval because server annotations are untrusted.
+          return annotations?.readOnlyHint === true
+            ? 'not-applicable'
+            : {
+                type: 'user-approval',
+                reason:
+                  annotations?.destructiveHint === true
+                    ? 'The MCP server marks this tool as destructive.'
+                    : 'The MCP server does not mark this tool as read-only.',
+              };
+        },
+        messages,
+        stopWhen: isStepCount(5),
+      });
+
+      for (const step of result.steps) {
+        for (const part of step.content) {
+          switch (part.type) {
+            case 'text': {
+              process.stdout.write(`\nAssistant:\n${part.text}\n`);
+              break;
+            }
+
+            case 'tool-approval-request': {
+              if (part.isAutomatic) {
+                break;
+              }
+
+              const metadata = part.toolCall.toolMetadata as
+                | McpProviderMetadata
+                | undefined;
+              console.log(
+                '\nServer annotations:',
+                metadata?.annotations ?? '(none)',
+              );
+              console.log(
+                `Requested ${part.toolCall.toolName}:`,
+                part.toolCall.input,
+              );
+
+              const answer = await terminal.question(
+                `${part.reason ?? 'This tool requires approval.'} Approve? (y/n)\n`,
+              );
+              approvals.push({
+                type: 'tool-approval-response',
+                approvalId: part.approvalId,
+                approved:
+                  answer.toLowerCase() === 'y' ||
+                  answer.toLowerCase() === 'yes',
+              });
+              break;
+            }
+
+            case 'tool-approval-response': {
+              process.stdout.write(
+                `\n${part.toolCall.toolName} was ${
+                  part.approved
+                    ? '\x1b[32mapproved\x1b[0m'
+                    : '\x1b[31mdenied\x1b[0m'
+                }.\n`,
+              );
+              if (part.reason != null) {
+                process.stdout.write(`Reason: ${part.reason}\n`);
+              }
+              break;
+            }
+          }
+        }
+      }
+
+      messages.push(...result.responseMessages);
+    }
+  } finally {
+    terminal.close();
+    await mcpClient.close();
+  }
+}
+
+main().catch(console.error);

--- a/examples/mcp/src/tool-annotations/server.ts
+++ b/examples/mcp/src/tool-annotations/server.ts
@@ -1,0 +1,125 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import express from 'express';
+import { z } from 'zod';
+
+const app = express();
+app.use(express.json());
+
+const notes = new Map([
+  ['note-1', 'MCP annotations are behavioral hints, not security guarantees.'],
+]);
+
+app.post('/mcp', async (request, response) => {
+  const server = new McpServer({
+    name: 'tool-annotations-example-server',
+    version: '1.0.0',
+  });
+
+  server.registerTool(
+    'read-note',
+    {
+      description: 'Read a note without changing it.',
+      inputSchema: {
+        id: z.string().describe('The note ID.'),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ id }) => {
+      console.log(`Executed read-note for ${id}`);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: notes.get(id) ?? `Note ${id} does not exist.`,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'delete-note',
+    {
+      description: 'Permanently delete a note.',
+      inputSchema: {
+        id: z.string().describe('The note ID.'),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ id }) => {
+      console.log(`Executed delete-note for ${id}`);
+      const deleted = notes.delete(id);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: deleted ? `Deleted note ${id}.` : `Note ${id} did not exist.`,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'create-note',
+    {
+      description:
+        'Create a note. This tool intentionally does not provide annotations.',
+      inputSchema: {
+        id: z.string().describe('The note ID.'),
+        text: z.string().describe('The note contents.'),
+      },
+    },
+    async ({ id, text }) => {
+      console.log(`Executed create-note for ${id}`);
+      notes.set(id, text);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Created note ${id}.`,
+          },
+        ],
+      };
+    },
+  );
+
+  try {
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+    await server.connect(transport);
+    await transport.handleRequest(request, response, request.body);
+    response.on('close', () => {
+      transport.close();
+      server.close();
+    });
+  } catch (error) {
+    console.error('Error handling MCP request:', error);
+    if (!response.headersSent) {
+      response.status(500).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32603,
+          message: 'Internal server error',
+        },
+        id: null,
+      });
+    }
+  }
+});
+
+app.listen(8086, () => {
+  console.log('Tool annotations MCP server listening on http://localhost:8086');
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -37,6 +37,7 @@ export type {
   InitializeResult,
   ListToolsResult,
   McpProviderMetadata,
+  McpToolAnnotations,
   ClientCapabilities as MCPClientCapabilities,
 } from './tool/types';
 export { auth, UnauthorizedError } from './tool/oauth';

--- a/packages/mcp/src/tool/mcp-client.test.ts
+++ b/packages/mcp/src/tool/mcp-client.test.ts
@@ -2958,6 +2958,59 @@ describe('MCPClient', () => {
     });
   });
 
+  describe('tool annotations support', () => {
+    it('should expose MCP tool annotations on dynamic and typed tools', async () => {
+      const mockTransport = new MockMCPTransport({
+        overrideTools: [
+          {
+            name: 'annotated-tool',
+            description: 'A tool with behavioral annotations',
+            inputSchema: {
+              type: 'object',
+              properties: {},
+            },
+            annotations: {
+              title: 'Annotated Tool',
+              readOnlyHint: false,
+              destructiveHint: true,
+              idempotentHint: false,
+              openWorldHint: true,
+            },
+          },
+        ],
+      });
+
+      client = await createMCPClient({
+        transport: mockTransport,
+      });
+
+      const dynamicTools = await client.tools();
+      const typedTools = await client.tools({
+        schemas: {
+          'annotated-tool': {
+            inputSchema: z.object({}),
+          },
+        },
+      });
+
+      expect(dynamicTools['annotated-tool'].metadata).toEqual({
+        clientName: 'ai-sdk-mcp-client',
+        toolName: 'annotated-tool',
+        title: 'Annotated Tool',
+        annotations: {
+          title: 'Annotated Tool',
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: false,
+          openWorldHint: true,
+        },
+      });
+      expect(typedTools['annotated-tool'].metadata).toEqual(
+        dynamicTools['annotated-tool'].metadata,
+      );
+    });
+  });
+
   describe('tool title support', () => {
     it('should use top-level title when provided (MCP spec-compliant)', async () => {
       const mockTransport = new MockMCPTransport({

--- a/packages/mcp/src/tool/mcp-client.ts
+++ b/packages/mcp/src/tool/mcp-client.ts
@@ -1217,6 +1217,27 @@ class DefaultMCPClient implements MCPClient {
         clientName: this.clientInfo.name,
         toolName: name,
         ...(resolvedTitle != null ? { title: resolvedTitle } : {}),
+        ...(annotations != null
+          ? {
+              annotations: {
+                ...(annotations.title != null
+                  ? { title: annotations.title }
+                  : {}),
+                ...(annotations.readOnlyHint != null
+                  ? { readOnlyHint: annotations.readOnlyHint }
+                  : {}),
+                ...(annotations.destructiveHint != null
+                  ? { destructiveHint: annotations.destructiveHint }
+                  : {}),
+                ...(annotations.idempotentHint != null
+                  ? { idempotentHint: annotations.idempotentHint }
+                  : {}),
+                ...(annotations.openWorldHint != null
+                  ? { openWorldHint: annotations.openWorldHint }
+                  : {}),
+              },
+            }
+          : {}),
         ...(appMeta?.resourceUri != null
           ? {
               app: {

--- a/packages/mcp/src/tool/types.ts
+++ b/packages/mcp/src/tool/types.ts
@@ -16,7 +16,23 @@ export type McpProviderMetadata = {
   clientName?: string;
   title?: string;
   toolName?: string;
+  annotations?: McpToolAnnotations;
   app?: JSONObject;
+};
+
+/**
+ * Behavioral hints reported by an MCP server for a tool.
+ *
+ * These annotations are untrusted unless the server itself is trusted.
+ *
+ * @see https://modelcontextprotocol.io/specification/2026-07-28/schema#toolannotations
+ */
+export type McpToolAnnotations = {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
 };
 
 /** MCP tool metadata - keys should follow MCP _meta key format specification */
@@ -179,6 +195,10 @@ const ToolSchema = z
       z
         .object({
           title: z.optional(z.string()),
+          readOnlyHint: z.optional(z.boolean()),
+          destructiveHint: z.optional(z.boolean()),
+          idempotentHint: z.optional(z.boolean()),
+          openWorldHint: z.optional(z.boolean()),
         })
         .loose(),
     ),


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/20184

the aisdk dropped mapping tool annotations, that could be used to gate tool calls behind approvals.

the pattern and solution suggested in the issue and the factory created PR are incorrect. the AI SDK should just surface the metadata, and the application should be responsible for implementing the approvals

## Summary

map the annotations returned by the server to tool metadata

## End-to-End Verification

verified by running the example `examples/mcp/src/tool-annotations`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #20184