### PR TITLE
feat(harness): allow passing arbitrary headers with inference requests via `headers` property in `HarnessAgentSettings`

### DIFF
--- a/.changeset/sixty-hats-appear.md
+++ b/.changeset/sixty-hats-appear.md
@@ -1,0 +1,15 @@
+---
+"@ai-sdk/harness-claude-code": patch
+"@ai-sdk/harness-deepagents": patch
+"@ai-sdk/harness-grok-build": patch
+"@ai-sdk/harness-opencode": patch
+"@ai-sdk/harness-cursor": patch
+"@ai-sdk/harness-cline": patch
+"@ai-sdk/harness-codex": patch
+"@ai-sdk/harness-acp": patch
+"@ai-sdk/harness-fx": patch
+"@ai-sdk/harness-pi": patch
+"@ai-sdk/harness": patch
+---
+
+feat(harness): allow passing arbitrary headers with inference requests via `headers` property in `HarnessAgentSettings`

--- a/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
+++ b/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
@@ -510,9 +510,9 @@ console.log(preparation.identity);
 - `id`: optional stable agent identifier.
 - `instructions`: instructions appended to the runtime's system or developer
   prompt when supported, or prepended to the user prompt otherwise.
-- `headers`: additional headers sent with AI Gateway model requests. Headers
-  are fixed at construction time. `authorization`, `x-api-key`, `user-agent`,
-  and `x-client-app` are not allowed.
+- `headers`: additional headers sent with model requests. Headers are fixed at
+  construction time. `authorization`, `x-api-key`, `user-agent`, and
+  `x-client-app` are not allowed.
 - `callOptionsSchema` and `prepareCall`: validate custom call options and derive
   model, skills, instructions, and tools for each new turn.
 - `output`: typed output specification applied to every turn.

--- a/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
+++ b/content/docs/03-ai-sdk-harnesses/02-harness-agent.mdx
@@ -510,6 +510,9 @@ console.log(preparation.identity);
 - `id`: optional stable agent identifier.
 - `instructions`: instructions appended to the runtime's system or developer
   prompt when supported, or prepended to the user prompt otherwise.
+- `headers`: additional headers sent with AI Gateway model requests. Headers
+  are fixed at construction time. `authorization`, `x-api-key`, `user-agent`,
+  and `x-client-app` are not allowed.
 - `callOptionsSchema` and `prepareCall`: validate custom call options and derive
   model, skills, instructions, and tools for each new turn.
 - `output`: typed output specification applied to every turn.

--- a/content/providers/02-ai-sdk-harnesses/07-grok-build.mdx
+++ b/content/providers/02-ai-sdk-harnesses/07-grok-build.mdx
@@ -210,6 +210,10 @@ safe built-in operations internally without sending a permission request.
   error.
 - A changed host-tool catalog requires Grok Build to refresh its ACP MCP tool
   list. If the implementation retains stale tools, the turn fails explicitly.
+- Custom `headers` are not natively supported and only applied via
+  sandbox-external request transformations. When a sandbox without that
+  capability is provided, custom `headers` therefore cannot be passed and are
+  ignored.
 
 ## Related
 

--- a/content/providers/02-ai-sdk-harnesses/09-cursor.mdx
+++ b/content/providers/02-ai-sdk-harnesses/09-cursor.mdx
@@ -179,6 +179,10 @@ MCP payload and correlates the call with the host-side tool execution.
   error.
 - Cursor ACP does not expose a structured-output metadata mapping, so schema-backed
   structured output is unsupported.
+- Custom `headers` are not natively supported and only applied via
+  sandbox-external request transformations. When a sandbox without that
+  capability is provided, custom `headers` therefore cannot be passed and are
+  ignored.
 
 ## Related
 

--- a/content/providers/02-ai-sdk-harnesses/10-fx.mdx
+++ b/content/providers/02-ai-sdk-harnesses/10-fx.mdx
@@ -191,6 +191,10 @@ or apply its own permission policy without sending an ACP permission request.
   supported, but filtering fx built-ins throws an unsupported-capability error.
 - fx ACP does not expose a structured-output metadata mapping, so schema-backed
   structured output is unsupported.
+- Custom `headers` are not natively supported and only applied via
+  sandbox-external request transformations. When a sandbox without that
+  capability is provided, custom `headers` therefore cannot be passed and are
+  ignored.
 
 ## Related
 

--- a/packages/harness-acp/src/acp-harness.test.ts
+++ b/packages/harness-acp/src/acp-harness.test.ts
@@ -869,6 +869,7 @@ describe('createACP', () => {
 
     const session = await harness.doStart({
       sessionId: 'session-1',
+      headers: { 'x-tenant': 'acme' },
       sandboxSession: fakeSandbox({
         runs: [],
         spawns,
@@ -887,6 +888,8 @@ describe('createACP', () => {
         PROVIDER_API_KEY: 'ephemeral-PROVIDER_API_KEY',
         PROVIDER_BASE_URL: 'https://gateway.example/v1',
       },
+      headers: { 'x-tenant': 'acme' },
+      isAiGateway: true,
     });
     expect(addRequestTransformations).toHaveBeenCalledWith([
       {

--- a/packages/harness-acp/src/acp-harness.test.ts
+++ b/packages/harness-acp/src/acp-harness.test.ts
@@ -889,7 +889,6 @@ describe('createACP', () => {
         PROVIDER_BASE_URL: 'https://gateway.example/v1',
       },
       headers: { 'x-tenant': 'acme' },
-      isAiGateway: true,
     });
     expect(addRequestTransformations).toHaveBeenCalledWith([
       {

--- a/packages/harness-acp/src/v1/acp-v1-harness.ts
+++ b/packages/harness-acp/src/v1/acp-v1-harness.ts
@@ -324,6 +324,14 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
         const requestTransformations = settings.credentialBrokering({
           env: brokeringEnvironment,
           sandboxEnv: sandboxImplementationEnvironment,
+          ...(startOptions.headers == null
+            ? {}
+            : {
+                headers: startOptions.headers,
+                isAiGateway:
+                  resolvedProviderAuthentication.providerAuthentication
+                    ?.type === 'ai-gateway',
+              }),
         });
         if (requestTransformations.length > 0) {
           await sandboxSession.addRequestTransformations(

--- a/packages/harness-acp/src/v1/acp-v1-harness.ts
+++ b/packages/harness-acp/src/v1/acp-v1-harness.ts
@@ -326,12 +326,7 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
           sandboxEnv: sandboxImplementationEnvironment,
           ...(startOptions.headers == null
             ? {}
-            : {
-                headers: startOptions.headers,
-                isAiGateway:
-                  resolvedProviderAuthentication.providerAuthentication
-                    ?.type === 'ai-gateway',
-              }),
+            : { headers: startOptions.headers }),
         });
         if (requestTransformations.length > 0) {
           await sandboxSession.addRequestTransformations(

--- a/packages/harness-acp/src/v1/acp-v1-settings.ts
+++ b/packages/harness-acp/src/v1/acp-v1-settings.ts
@@ -90,9 +90,13 @@ export type ACPModelMapping =
 export type ACPCredentialBrokering = ({
   env,
   sandboxEnv,
+  headers,
+  isAiGateway,
 }: {
   env: Readonly<Record<string, string>>;
   sandboxEnv?: Readonly<Record<string, string>>;
+  headers?: Readonly<Record<string, string>>;
+  isAiGateway?: boolean;
 }) => ReadonlyArray<HarnessV1RequestTransformation>;
 
 export type ACPPermissionModeTarget =

--- a/packages/harness-acp/src/v1/acp-v1-settings.ts
+++ b/packages/harness-acp/src/v1/acp-v1-settings.ts
@@ -91,12 +91,10 @@ export type ACPCredentialBrokering = ({
   env,
   sandboxEnv,
   headers,
-  isAiGateway,
 }: {
   env: Readonly<Record<string, string>>;
   sandboxEnv?: Readonly<Record<string, string>>;
   headers?: Readonly<Record<string, string>>;
-  isAiGateway?: boolean;
 }) => ReadonlyArray<HarnessV1RequestTransformation>;
 
 export type ACPPermissionModeTarget =

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -487,6 +487,56 @@ describe('createClaudeCode adapter', () => {
     await session.doDestroy();
   });
 
+  it('sets custom headers only for AI Gateway auth', async () => {
+    const gateway = createClaudeCode({
+      auth: { AI_GATEWAY_API_KEY: 'gateway-key' },
+    });
+    const gatewaySession = await gateway.doStart({
+      sessionId: 'gateway',
+      headers: { 'x-tenant': 'acme' },
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        writes: [],
+        runs: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/claude-code-gateway',
+    });
+    await gatewaySession.doPromptTurn({
+      skills: [],
+      tools: [],
+      prompt: 'Hello',
+      emit: () => {},
+    });
+    expect(sentMessages.at(-1)).toMatchObject({
+      env: { ANTHROPIC_CUSTOM_HEADERS: 'x-tenant: acme' },
+    });
+    await gatewaySession.doDestroy();
+
+    const direct = createClaudeCode({
+      auth: { ANTHROPIC_API_KEY: 'anthropic-key' },
+    });
+    const directSession = await direct.doStart({
+      sessionId: 'direct',
+      headers: { 'x-tenant': 'acme' },
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        writes: [],
+        runs: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/claude-code-direct',
+    });
+    await directSession.doPromptTurn({
+      skills: [],
+      tools: [],
+      prompt: 'Hello',
+      emit: () => {},
+    });
+    expect(sentMessages.at(-1)).not.toHaveProperty(
+      'env.ANTHROPIC_CUSTOM_HEADERS',
+    );
+    await directSession.doDestroy();
+  });
+
   it('brokers credentials when the sandbox supports additive request transformations', async () => {
     const spawnEnvs: Array<Record<string, string | undefined>> = [];
     const forwardedCredentials: Array<{

--- a/packages/harness-claude-code/src/claude-code-harness.test.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.test.ts
@@ -487,7 +487,7 @@ describe('createClaudeCode adapter', () => {
     await session.doDestroy();
   });
 
-  it('sets custom headers only for AI Gateway auth', async () => {
+  it('sets custom headers for Gateway and direct auth', async () => {
     const gateway = createClaudeCode({
       auth: { AI_GATEWAY_API_KEY: 'gateway-key' },
     });
@@ -531,9 +531,9 @@ describe('createClaudeCode adapter', () => {
       prompt: 'Hello',
       emit: () => {},
     });
-    expect(sentMessages.at(-1)).not.toHaveProperty(
-      'env.ANTHROPIC_CUSTOM_HEADERS',
-    );
+    expect(sentMessages.at(-1)).toMatchObject({
+      env: { ANTHROPIC_CUSTOM_HEADERS: 'x-tenant: acme' },
+    });
     await directSession.doDestroy();
   });
 

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -867,6 +867,13 @@ export function createClaudeCode(
           ? { CLAUDE_AGENT_SDK_CLIENT_APP: CLAUDE_CODE_CLIENT_APP }
           : {}),
         ...settings.env,
+        ...(authenticationMode === 'ai-gateway' && startOpts.headers != null
+          ? {
+              ANTHROPIC_CUSTOM_HEADERS: Object.entries(startOpts.headers)
+                .map(([name, value]) => `${name}: ${value}`)
+                .join('\n'),
+            }
+          : {}),
       };
       let sandboxClaudeEnvironment = claudeEnvironment;
       let sandboxCredentialEnvironment: Record<string, string> | undefined;

--- a/packages/harness-claude-code/src/claude-code-harness.ts
+++ b/packages/harness-claude-code/src/claude-code-harness.ts
@@ -867,7 +867,7 @@ export function createClaudeCode(
           ? { CLAUDE_AGENT_SDK_CLIENT_APP: CLAUDE_CODE_CLIENT_APP }
           : {}),
         ...settings.env,
-        ...(authenticationMode === 'ai-gateway' && startOpts.headers != null
+        ...(startOpts.headers != null
           ? {
               ANTHROPIC_CUSTOM_HEADERS: Object.entries(startOpts.headers)
                 .map(([name, value]) => `${name}: ${value}`)

--- a/packages/harness-cline/src/cline-harness.ts
+++ b/packages/harness-cline/src/cline-harness.ts
@@ -193,6 +193,7 @@ export function createCline(
           ...(settings.apiKey ? { apiKey: settings.apiKey } : {}),
           ...(settings.baseUrl ? { baseUrl: settings.baseUrl } : {}),
           ...(settings.headers ? { headers: settings.headers } : {}),
+          ...(startOpts.headers ? { agentHeaders: startOpts.headers } : {}),
           ...(settings.reasoningEffort !== undefined
             ? { reasoningEffort: settings.reasoningEffort }
             : {}),

--- a/packages/harness-cline/src/cline-session.test.ts
+++ b/packages/harness-cline/src/cline-session.test.ts
@@ -663,6 +663,7 @@ describe('createClineSession model configuration', () => {
         apiKey: 'anthropic-key',
         baseUrl: 'https://anthropic.example',
         headers: { 'x-custom': 'custom' },
+        agentHeaders: { 'x-agent-ignored': 'agent' },
       },
     });
 
@@ -695,6 +696,7 @@ describe('createClineSession model configuration', () => {
         apiKey: 'anthropic-key',
         baseUrl: 'https://anthropic.example',
         headers: { 'x-custom': 'custom' },
+        agentHeaders: { 'x-agent': 'agent' },
       },
     });
 
@@ -707,6 +709,7 @@ describe('createClineSession model configuration', () => {
           baseUrl: 'https://gateway.example/v1',
           headers: {
             'x-custom': 'custom',
+            'x-agent': 'agent',
             'User-Agent': 'ai-sdk/harness-cline/0.0.0-test',
             'x-client-app': 'ai-sdk/harness-cline/0.0.0-test',
           },

--- a/packages/harness-cline/src/cline-session.test.ts
+++ b/packages/harness-cline/src/cline-session.test.ts
@@ -663,7 +663,7 @@ describe('createClineSession model configuration', () => {
         apiKey: 'anthropic-key',
         baseUrl: 'https://anthropic.example',
         headers: { 'x-custom': 'custom' },
-        agentHeaders: { 'x-agent-ignored': 'agent' },
+        agentHeaders: { 'x-agent': 'agent' },
       },
     });
 
@@ -673,7 +673,10 @@ describe('createClineSession model configuration', () => {
           providerId: 'anthropic',
           apiKey: 'anthropic-key',
           baseUrl: 'https://anthropic.example',
-          headers: { 'x-custom': 'custom' },
+          headers: {
+            'x-custom': 'custom',
+            'x-agent': 'agent',
+          },
         },
       ]);
       expect(clineMock.modelSelections).toEqual([

--- a/packages/harness-cline/src/cline-session.ts
+++ b/packages/harness-cline/src/cline-session.ts
@@ -97,6 +97,7 @@ export interface ClineSessionSettings {
   readonly apiKey?: string;
   readonly baseUrl?: string;
   readonly headers?: Record<string, string>;
+  readonly agentHeaders?: Readonly<Record<string, string>>;
   readonly reasoningEffort?: ClineReasoningEffort;
   readonly maxIterations?: number;
 }
@@ -203,6 +204,7 @@ function createClineAgentModel({
   const headers = isAiGateway
     ? {
         ...settings.headers,
+        ...settings.agentHeaders,
         'User-Agent': clientApp,
         'x-client-app': clientApp,
       }

--- a/packages/harness-cline/src/cline-session.ts
+++ b/packages/harness-cline/src/cline-session.ts
@@ -208,7 +208,12 @@ function createClineAgentModel({
         'User-Agent': clientApp,
         'x-client-app': clientApp,
       }
-    : settings.headers;
+    : settings.headers != null || settings.agentHeaders != null
+      ? {
+          ...settings.headers,
+          ...settings.agentHeaders,
+        }
+      : undefined;
   const gateway = Llms.createGateway({
     providerConfigs: [
       {

--- a/packages/harness-codex/src/bridge/index.test.ts
+++ b/packages/harness-codex/src/bridge/index.test.ts
@@ -28,6 +28,7 @@ const state = vi.hoisted(() => ({
   startRestartThread: false,
   startCodexConfig: undefined as Record<string, unknown> | undefined,
   startMcpServers: undefined as Record<string, unknown> | undefined,
+  startHeaders: undefined as Record<string, string> | undefined,
   resumeThreadCalls: [] as string[],
   originalArgv: [] as string[],
   originalEnv: {} as Record<
@@ -86,6 +87,7 @@ vi.mock('@ai-sdk/harness/bridge', () => ({
         model: state.startModel,
         codexConfig: state.startCodexConfig,
         mcpServers: state.startMcpServers,
+        headers: state.startHeaders,
         tools: [
           {
             name: 'get_weather',
@@ -121,6 +123,7 @@ describe('Codex bridge config', () => {
     state.startRestartThread = false;
     state.startCodexConfig = undefined;
     state.startMcpServers = undefined;
+    state.startHeaders = undefined;
     state.resumeThreadCalls = [];
     state.originalArgv = [...process.argv];
     state.originalEnv = Object.fromEntries(
@@ -299,6 +302,30 @@ describe('Codex bridge config', () => {
         "model": "openai/gpt-5.5",
         "reasoningSummary": "detailed",
         "supportsReasoningSummaries": true,
+      }
+    `);
+  });
+
+  test('passes headers to the AI Gateway model provider', async () => {
+    state.startHeaders = { 'x-tenant': 'acme' };
+    process.env.AI_GATEWAY_API_KEY = 'gateway-key';
+    process.env.AI_GATEWAY_BASE_URL = 'https://ai-gateway.test/v1';
+
+    await import('./index');
+
+    expect(state.codexOptions[0]?.config?.model_providers)
+      .toMatchInlineSnapshot(`
+      {
+        "agent_bridge_openai": {
+          "base_url": "https://ai-gateway.test/v1",
+          "env_key": "CODEX_API_KEY",
+          "http_headers": {
+            "x-tenant": "acme",
+          },
+          "name": "Agent Bridge OpenAI",
+          "supports_websockets": false,
+          "wire_api": "responses",
+        },
       }
     `);
   });

--- a/packages/harness-codex/src/bridge/index.test.ts
+++ b/packages/harness-codex/src/bridge/index.test.ts
@@ -306,10 +306,9 @@ describe('Codex bridge config', () => {
     `);
   });
 
-  test('passes headers to the AI Gateway model provider', async () => {
+  test('passes headers to a direct model provider', async () => {
     state.startHeaders = { 'x-tenant': 'acme' };
-    process.env.AI_GATEWAY_API_KEY = 'gateway-key';
-    process.env.AI_GATEWAY_BASE_URL = 'https://ai-gateway.test/v1';
+    process.env.CODEX_API_KEY = 'openai-key';
 
     await import('./index');
 
@@ -317,7 +316,7 @@ describe('Codex bridge config', () => {
       .toMatchInlineSnapshot(`
       {
         "agent_bridge_openai": {
-          "base_url": "https://ai-gateway.test/v1",
+          "base_url": "https://api.openai.com/v1",
           "env_key": "CODEX_API_KEY",
           "http_headers": {
             "x-tenant": "acme",

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -140,7 +140,10 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
       'AI Gateway auth was selected but AI_GATEWAY_BASE_URL is missing from the Codex bridge environment.',
     );
   }
-  const apiBaseUrl = hasGatewayAuth ? gatewayBaseUrl : procEnv.OPENAI_BASE_URL;
+  const apiBaseUrl = hasGatewayAuth
+    ? gatewayBaseUrl
+    : (procEnv.OPENAI_BASE_URL ??
+      (start.headers != null ? 'https://api.openai.com/v1' : undefined));
   const codexModel =
     start.model && hasGatewayAuth && !start.model.includes('/')
       ? `openai/${start.model}`
@@ -164,11 +167,11 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
         env_key: 'CODEX_API_KEY',
         wire_api: 'responses',
         supports_websockets: false,
-        ...(hasGatewayAuth && (start.headers != null || HARNESS_CLIENT_APP)
+        ...(start.headers != null || (hasGatewayAuth && HARNESS_CLIENT_APP)
           ? {
               http_headers: {
                 ...start.headers,
-                ...(HARNESS_CLIENT_APP
+                ...(hasGatewayAuth && HARNESS_CLIENT_APP
                   ? {
                       'User-Agent': HARNESS_CLIENT_APP,
                       'x-client-app': HARNESS_CLIENT_APP,

--- a/packages/harness-codex/src/bridge/index.ts
+++ b/packages/harness-codex/src/bridge/index.ts
@@ -164,11 +164,16 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
         env_key: 'CODEX_API_KEY',
         wire_api: 'responses',
         supports_websockets: false,
-        ...(hasGatewayAuth && HARNESS_CLIENT_APP
+        ...(hasGatewayAuth && (start.headers != null || HARNESS_CLIENT_APP)
           ? {
               http_headers: {
-                'User-Agent': HARNESS_CLIENT_APP,
-                'x-client-app': HARNESS_CLIENT_APP,
+                ...start.headers,
+                ...(HARNESS_CLIENT_APP
+                  ? {
+                      'User-Agent': HARNESS_CLIENT_APP,
+                      'x-client-app': HARNESS_CLIENT_APP,
+                    }
+                  : {}),
               },
             }
           : {}),

--- a/packages/harness-codex/src/codex-bridge-protocol.ts
+++ b/packages/harness-codex/src/codex-bridge-protocol.ts
@@ -22,6 +22,7 @@ export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
   webSearch: z.boolean().optional(),
   codexConfig: z.record(z.string(), z.unknown()).optional(),
   mcpServers: z.record(z.string(), z.unknown()).optional(),
+  headers: z.record(z.string(), z.string()).optional(),
   // Resume signal. When supplied, the bridge calls
   // `codex.resumeThread(resumeThreadId, …)` instead of starting a fresh thread.
   // The host sources the id from lifecycle state `data` cached from a prior

--- a/packages/harness-codex/src/codex-harness.test.ts
+++ b/packages/harness-codex/src/codex-harness.test.ts
@@ -413,7 +413,7 @@ describe('createCodex adapter', () => {
     await session.doDestroy();
   });
 
-  it('passes headers to the bridge only for AI Gateway auth', async () => {
+  it('passes headers to the bridge for Gateway and direct auth', async () => {
     const gatewaySession = await createCodex({
       auth: { AI_GATEWAY_API_KEY: 'gateway-key' },
     }).doStart({
@@ -465,7 +465,10 @@ describe('createCodex adapter', () => {
     void Promise.resolve(directControl.done).catch(() => {});
 
     await vi.waitFor(() => {
-      expect(sentMessages.at(-1)).not.toHaveProperty('headers');
+      expect(sentMessages.at(-1)).toMatchObject({
+        type: 'start',
+        headers: { 'x-tenant': 'acme' },
+      });
     });
     await directSession.doDestroy();
   });

--- a/packages/harness-codex/src/codex-harness.test.ts
+++ b/packages/harness-codex/src/codex-harness.test.ts
@@ -413,6 +413,63 @@ describe('createCodex adapter', () => {
     await session.doDestroy();
   });
 
+  it('passes headers to the bridge only for AI Gateway auth', async () => {
+    const gatewaySession = await createCodex({
+      auth: { AI_GATEWAY_API_KEY: 'gateway-key' },
+    }).doStart({
+      sessionId: 'gateway',
+      headers: { 'x-tenant': 'acme' },
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        runs: [],
+        spawns: [],
+        writes: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/codex-gateway',
+    });
+    const gatewayControl = await gatewaySession.doPromptTurn({
+      skills: [],
+      tools: [],
+      prompt: 'Hello',
+      emit: () => {},
+    });
+    void Promise.resolve(gatewayControl.done).catch(() => {});
+
+    await vi.waitFor(() => {
+      expect(sentMessages.at(-1)).toMatchObject({
+        type: 'start',
+        headers: { 'x-tenant': 'acme' },
+      });
+    });
+    await gatewaySession.doDestroy();
+
+    const directSession = await createCodex({
+      auth: { OPENAI_API_KEY: 'openai-key' },
+    }).doStart({
+      sessionId: 'direct',
+      headers: { 'x-tenant': 'acme' },
+      sandboxSession: fakeNetworkSandboxSessionForStartupSuccess({
+        bridgePortUrl: 'ws://127.0.0.1:1',
+        runs: [],
+        spawns: [],
+        writes: [],
+      }),
+      sessionWorkDir: '/vercel/sandbox/codex-direct',
+    });
+    const directControl = await directSession.doPromptTurn({
+      skills: [],
+      tools: [],
+      prompt: 'Hello',
+      emit: () => {},
+    });
+    void Promise.resolve(directControl.done).catch(() => {});
+
+    await vi.waitFor(() => {
+      expect(sentMessages.at(-1)).not.toHaveProperty('headers');
+    });
+    await directSession.doDestroy();
+  });
+
   it('brokers credentials when the sandbox supports additive request transformations', async () => {
     const spawnEnvs: Array<Record<string, string | undefined>> = [];
     const forwardedCredentials: Array<{

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -386,6 +386,10 @@ export function createCodex(
             webSearch: settings.webSearch,
             codexConfig: settings.codexConfig,
             mcpServers: settings.mcpServers,
+            headers:
+              authenticationMode === 'ai-gateway'
+                ? startOpts.headers
+                : undefined,
             resumeThreadId: resumeThreadIdString,
             isResume: true,
             seedResumeThreadOnFirstPrompt: false,
@@ -548,6 +552,8 @@ export function createCodex(
         webSearch: settings.webSearch,
         codexConfig: settings.codexConfig,
         mcpServers: settings.mcpServers,
+        headers:
+          authenticationMode === 'ai-gateway' ? startOpts.headers : undefined,
         resumeThreadId: resumeThreadIdString,
         isResume: respawnStrategy !== undefined,
         seedResumeThreadOnFirstPrompt: respawnStrategy !== undefined,
@@ -685,6 +691,7 @@ function createSession({
   webSearch,
   codexConfig,
   mcpServers,
+  headers,
   resumeThreadId,
   isResume,
   seedResumeThreadOnFirstPrompt,
@@ -709,6 +716,7 @@ function createSession({
   webSearch: boolean | undefined;
   codexConfig: Record<string, unknown> | undefined;
   mcpServers: Record<string, unknown> | undefined;
+  headers: Readonly<Record<string, string>> | undefined;
   resumeThreadId: string | undefined;
   isResume: boolean;
   seedResumeThreadOnFirstPrompt: boolean;
@@ -1011,6 +1019,7 @@ function createSession({
         webSearch,
         ...(codexConfig == null ? {} : { codexConfig }),
         ...(mcpServers == null ? {} : { mcpServers }),
+        ...(headers == null ? {} : { headers }),
         ...(permissionMode ? { permissionMode } : {}),
         ...(pendingResumeThreadId
           ? { resumeThreadId: pendingResumeThreadId }
@@ -1088,6 +1097,7 @@ function createSession({
             webSearch,
             ...(codexConfig == null ? {} : { codexConfig }),
             ...(mcpServers == null ? {} : { mcpServers }),
+            ...(headers == null ? {} : { headers }),
             ...(permissionMode ? { permissionMode } : {}),
             ...(threadId ? { resumeThreadId: threadId } : {}),
             ...(restartThread ? { restartThread: true } : {}),

--- a/packages/harness-codex/src/codex-harness.ts
+++ b/packages/harness-codex/src/codex-harness.ts
@@ -386,10 +386,7 @@ export function createCodex(
             webSearch: settings.webSearch,
             codexConfig: settings.codexConfig,
             mcpServers: settings.mcpServers,
-            headers:
-              authenticationMode === 'ai-gateway'
-                ? startOpts.headers
-                : undefined,
+            headers: startOpts.headers,
             resumeThreadId: resumeThreadIdString,
             isResume: true,
             seedResumeThreadOnFirstPrompt: false,
@@ -552,8 +549,7 @@ export function createCodex(
         webSearch: settings.webSearch,
         codexConfig: settings.codexConfig,
         mcpServers: settings.mcpServers,
-        headers:
-          authenticationMode === 'ai-gateway' ? startOpts.headers : undefined,
+        headers: startOpts.headers,
         resumeThreadId: resumeThreadIdString,
         isResume: respawnStrategy !== undefined,
         seedResumeThreadOnFirstPrompt: respawnStrategy !== undefined,

--- a/packages/harness-cursor/src/cursor-harness.test.ts
+++ b/packages/harness-cursor/src/cursor-harness.test.ts
@@ -158,7 +158,7 @@ describe('createCursor', () => {
     });
   });
 
-  it('applies headers only for explicit AI Gateway routing', () => {
+  it('applies headers to configured model request routes', () => {
     createCursor({ auth: 'ai-gateway' });
     const gatewaySettings = mocks.createACP.mock
       .calls[0]?.[0] as ACPHarnessSettings;
@@ -166,7 +166,6 @@ describe('createCursor', () => {
       gatewaySettings.credentialBrokering?.({
         env: {},
         headers: { 'x-tenant': 'acme' },
-        isAiGateway: true,
       }),
     ).toEqual([
       {
@@ -186,9 +185,13 @@ describe('createCursor', () => {
       autoSettings.credentialBrokering?.({
         env: {},
         headers: { 'x-tenant': 'acme' },
-        isAiGateway: true,
       }),
-    ).toEqual([]);
+    ).toEqual([
+      {
+        match: { host: 'api2.cursor.sh' },
+        transform: { headers: { 'x-tenant': 'acme' } },
+      },
+    ]);
   });
 
   it.each(['direct', 'ai-gateway'] as const)(

--- a/packages/harness-cursor/src/cursor-harness.test.ts
+++ b/packages/harness-cursor/src/cursor-harness.test.ts
@@ -158,6 +158,39 @@ describe('createCursor', () => {
     });
   });
 
+  it('applies headers only for explicit AI Gateway routing', () => {
+    createCursor({ auth: 'ai-gateway' });
+    const gatewaySettings = mocks.createACP.mock
+      .calls[0]?.[0] as ACPHarnessSettings;
+    expect(
+      gatewaySettings.credentialBrokering?.({
+        env: {},
+        headers: { 'x-tenant': 'acme' },
+        isAiGateway: true,
+      }),
+    ).toEqual([
+      {
+        match: {
+          host: 'ai-gateway.vercel.sh',
+          path: { startsWith: '/cursor/v1' },
+        },
+        transform: { headers: { 'x-tenant': 'acme' } },
+      },
+    ]);
+
+    mocks.createACP.mockClear();
+    createCursor();
+    const autoSettings = mocks.createACP.mock
+      .calls[0]?.[0] as ACPHarnessSettings;
+    expect(
+      autoSettings.credentialBrokering?.({
+        env: {},
+        headers: { 'x-tenant': 'acme' },
+        isAiGateway: true,
+      }),
+    ).toEqual([]);
+  });
+
   it.each(['direct', 'ai-gateway'] as const)(
     'accepts %s auth and warns that Cursor configuration controls routing',
     auth => {

--- a/packages/harness-cursor/src/cursor-harness.ts
+++ b/packages/harness-cursor/src/cursor-harness.ts
@@ -388,10 +388,10 @@ export function createCursor(
       _meta: { parameterizedModelPicker: true },
     },
     credentialEnv: ['CURSOR_API_KEY'],
-    credentialBrokering: ({ env, sandboxEnv }) => {
-      if (!env.CURSOR_API_KEY || !sandboxEnv?.CURSOR_API_KEY) return [];
-      return [
-        {
+    credentialBrokering: ({ env, sandboxEnv, headers }) => {
+      const transformations = [];
+      if (env.CURSOR_API_KEY && sandboxEnv?.CURSOR_API_KEY) {
+        transformations.push({
           match: {
             host: 'api2.cursor.sh',
             path: { exact: '/auth/exchange_user_api_key' },
@@ -410,8 +410,23 @@ export function createCursor(
               Authorization: `Bearer ${env.CURSOR_API_KEY}`,
             },
           },
-        },
-      ];
+        });
+      }
+      if (settings.auth === 'ai-gateway' && headers != null) {
+        const safeHeaders = Object.fromEntries(
+          Object.entries(headers).filter(
+            ([name]) => name !== 'authorization' && name !== 'x-api-key',
+          ),
+        );
+        transformations.push({
+          match: {
+            host: 'ai-gateway.vercel.sh',
+            path: { startsWith: '/cursor/v1' },
+          },
+          transform: { headers: safeHeaders },
+        });
+      }
+      return transformations;
     },
   });
 }

--- a/packages/harness-cursor/src/cursor-harness.ts
+++ b/packages/harness-cursor/src/cursor-harness.ts
@@ -412,18 +412,16 @@ export function createCursor(
           },
         });
       }
-      if (settings.auth === 'ai-gateway' && headers != null) {
-        const safeHeaders = Object.fromEntries(
-          Object.entries(headers).filter(
-            ([name]) => name !== 'authorization' && name !== 'x-api-key',
-          ),
-        );
+      if (headers != null) {
         transformations.push({
-          match: {
-            host: 'ai-gateway.vercel.sh',
-            path: { startsWith: '/cursor/v1' },
-          },
-          transform: { headers: safeHeaders },
+          match:
+            settings.auth === 'ai-gateway'
+              ? {
+                  host: 'ai-gateway.vercel.sh',
+                  path: { startsWith: '/cursor/v1' },
+                }
+              : { host: 'api2.cursor.sh' },
+          transform: { headers },
         });
       }
       return transformations;

--- a/packages/harness-deepagents/src/bridge/index.test.ts
+++ b/packages/harness-deepagents/src/bridge/index.test.ts
@@ -175,9 +175,9 @@ describe('Deep Agents bridge instructions', () => {
     expect(handler).toHaveBeenCalledWith({ model: configuredModel });
   });
 
-  it('passes headers to the AI Gateway Anthropic client', async () => {
+  it('passes headers to a direct Anthropic client', async () => {
     state.headers = { 'x-tenant': 'acme' };
-    vi.stubEnv('AI_GATEWAY_API_KEY', 'gateway-key');
+    vi.stubEnv('ANTHROPIC_API_KEY', 'anthropic-key');
 
     await import('./index');
 

--- a/packages/harness-deepagents/src/bridge/index.test.ts
+++ b/packages/harness-deepagents/src/bridge/index.test.ts
@@ -13,6 +13,9 @@ type ChatAnthropicOptions = {
   model?: string;
   thinking?: unknown;
   outputConfig?: unknown;
+  clientOptions?: {
+    defaultHeaders?: Record<string, string>;
+  };
 };
 
 const state = vi.hoisted(() => ({
@@ -21,6 +24,7 @@ const state = vi.hoisted(() => ({
   responseFormat: undefined as
     | { type: 'json'; schema: Record<string, unknown> }
     | undefined,
+  headers: undefined as Record<string, string> | undefined,
 }));
 
 vi.mock('deepagents', () => ({
@@ -48,6 +52,7 @@ vi.mock('@ai-sdk/harness/bridge', () => ({
         effort: 'max',
         tools: [],
         responseFormat: state.responseFormat,
+        headers: state.headers,
       },
       {
         emit: () => {},
@@ -64,11 +69,15 @@ vi.mock('@langchain/anthropic', () => ({
     model?: string;
     outputConfig?: unknown;
     thinking?: unknown;
+    clientOptions?: {
+      defaultHeaders?: Record<string, string>;
+    };
 
     constructor(options: ChatAnthropicOptions) {
       this.model = options.model;
       this.outputConfig = options.outputConfig;
       this.thinking = options.thinking;
+      this.clientOptions = options.clientOptions;
     }
   },
 }));
@@ -106,6 +115,7 @@ describe('Deep Agents bridge instructions', () => {
   beforeEach(() => {
     state.createDeepAgentOptions = [];
     state.responseFormat = undefined;
+    state.headers = undefined;
     state.originalArgv = [...process.argv];
     process.argv.splice(
       0,
@@ -121,6 +131,7 @@ describe('Deep Agents bridge instructions', () => {
 
   afterEach(() => {
     process.argv.splice(0, process.argv.length, ...state.originalArgv);
+    vi.unstubAllEnvs();
     vi.resetModules();
   });
 
@@ -162,6 +173,39 @@ describe('Deep Agents bridge instructions', () => {
       thinking: { type: 'adaptive', display: 'summarized' },
     });
     expect(handler).toHaveBeenCalledWith({ model: configuredModel });
+  });
+
+  it('passes headers to the AI Gateway Anthropic client', async () => {
+    state.headers = { 'x-tenant': 'acme' };
+    vi.stubEnv('AI_GATEWAY_API_KEY', 'gateway-key');
+
+    await import('./index');
+
+    const { ChatAnthropic } = await import('@langchain/anthropic');
+    const resolvedModel = new ChatAnthropic({
+      model: 'upstream-selected-model',
+    });
+    const handler = vi.fn(async request => request.model);
+    const wrapModelCall = state.createDeepAgentOptions[0]?.middleware?.find(
+      middleware => middleware.name === 'harnessModel',
+    )?.wrapModelCall;
+
+    await wrapModelCall!(
+      {
+        model: {
+          _getModelInstance: async () => resolvedModel,
+        },
+      },
+      handler,
+    );
+
+    expect(handler.mock.calls[0]?.[0].model).toMatchObject({
+      clientOptions: {
+        defaultHeaders: {
+          'x-tenant': 'acme',
+        },
+      },
+    });
   });
 
   it('applies the requested JSON schema for the active turn', async () => {

--- a/packages/harness-deepagents/src/bridge/index.ts
+++ b/packages/harness-deepagents/src/bridge/index.ts
@@ -75,12 +75,12 @@ function buildModel({
     ...(effort ? { outputConfig: { effort } } : {}),
     ...(procEnv.ANTHROPIC_API_KEY ? { apiKey: procEnv.ANTHROPIC_API_KEY } : {}),
     ...(baseUrl ? { anthropicApiUrl: baseUrl } : {}),
-    ...(procEnv.AI_GATEWAY_API_KEY
+    ...(headers != null || procEnv.AI_GATEWAY_API_KEY
       ? {
           clientOptions: {
             defaultHeaders: {
               ...headers,
-              ...(HARNESS_CLIENT_APP
+              ...(procEnv.AI_GATEWAY_API_KEY && HARNESS_CLIENT_APP
                 ? {
                     'User-Agent': HARNESS_CLIENT_APP,
                     'x-client-app': HARNESS_CLIENT_APP,

--- a/packages/harness-deepagents/src/bridge/index.ts
+++ b/packages/harness-deepagents/src/bridge/index.ts
@@ -59,10 +59,12 @@ function buildModel({
   rawModel,
   thinking,
   effort,
+  headers,
 }: {
   rawModel: string | undefined;
   thinking: StartMessage['thinking'];
   effort: StartMessage['effort'];
+  headers: StartMessage['headers'];
 }) {
   if (!rawModel) return undefined;
   const baseUrl = procEnv.ANTHROPIC_BASE_URL;
@@ -73,12 +75,17 @@ function buildModel({
     ...(effort ? { outputConfig: { effort } } : {}),
     ...(procEnv.ANTHROPIC_API_KEY ? { apiKey: procEnv.ANTHROPIC_API_KEY } : {}),
     ...(baseUrl ? { anthropicApiUrl: baseUrl } : {}),
-    ...(procEnv.AI_GATEWAY_API_KEY && HARNESS_CLIENT_APP
+    ...(procEnv.AI_GATEWAY_API_KEY
       ? {
           clientOptions: {
             defaultHeaders: {
-              'User-Agent': HARNESS_CLIENT_APP,
-              'x-client-app': HARNESS_CLIENT_APP,
+              ...headers,
+              ...(HARNESS_CLIENT_APP
+                ? {
+                    'User-Agent': HARNESS_CLIENT_APP,
+                    'x-client-app': HARNESS_CLIENT_APP,
+                  }
+                : {}),
             },
           },
         }
@@ -90,7 +97,7 @@ function createModelMiddleware() {
   return createMiddleware({
     name: 'harnessModel',
     wrapModelCall: async (request, handler) => {
-      if (!activeModel && !activeThinking && !activeEffort) {
+      if (!activeModel && !activeThinking && !activeEffort && !activeHeaders) {
         return handler(request);
       }
 
@@ -99,6 +106,7 @@ function createModelMiddleware() {
           rawModel: activeModel,
           thinking: activeThinking,
           effort: activeEffort,
+          headers: activeHeaders,
         });
         if (!configuredModel) throw new Error('Deep Agents model is missing');
         return handler({ ...request, model: configuredModel });
@@ -120,6 +128,7 @@ function createModelMiddleware() {
         rawModel: model.model,
         thinking: activeThinking,
         effort: activeEffort,
+        headers: activeHeaders,
       });
       if (!configuredModel) throw new Error('Deep Agents model is missing');
 
@@ -157,6 +166,7 @@ let agentConfigurationSignature: string | undefined;
 let activeModel: string | undefined;
 let activeThinking: StartMessage['thinking'];
 let activeEffort: StartMessage['effort'];
+let activeHeaders: StartMessage['headers'];
 const modelMiddleware = createModelMiddleware();
 
 type DeepAgentsJsonSchema = Record<string, unknown> & {
@@ -214,6 +224,7 @@ async function runTurn(start: StartMessage, turn: BridgeTurn): Promise<void> {
   if (start.model) activeModel = start.model;
   activeThinking = start.thinking;
   activeEffort = start.effort;
+  activeHeaders = start.headers;
   currentResponseFormat =
     start.responseFormat?.type === 'json' && start.responseFormat.schema != null
       ? toolStrategy(start.responseFormat.schema as DeepAgentsJsonSchema)

--- a/packages/harness-deepagents/src/deepagents-bridge-protocol.ts
+++ b/packages/harness-deepagents/src/deepagents-bridge-protocol.ts
@@ -37,6 +37,7 @@ export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
   skillsChanged: z.boolean().optional(),
   // Max LangGraph super-steps per turn (streamEvents recursionLimit).
   recursionLimit: z.number().optional(),
+  headers: z.record(z.string(), z.string()).optional(),
 });
 
 export type StartMessage = z.infer<typeof startMessageSchema>;

--- a/packages/harness-deepagents/src/deepagents-harness.test.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.test.ts
@@ -288,7 +288,7 @@ describe('createDeepAgents', () => {
     await session.doDestroy();
   });
 
-  it('passes headers to the bridge only for AI Gateway auth', async () => {
+  it('passes headers to the bridge for Gateway and direct auth', async () => {
     sentMessages.length = 0;
     const gatewaySession = await createDeepAgents({
       auth: { AI_GATEWAY_API_KEY: 'gateway-key' },
@@ -331,7 +331,10 @@ describe('createDeepAgents', () => {
       prompt: 'Hello',
       emit: () => {},
     });
-    expect(sentMessages.at(-1)).not.toHaveProperty('headers');
+    expect(sentMessages.at(-1)).toMatchObject({
+      type: 'start',
+      headers: { 'x-tenant': 'acme' },
+    });
     await directSession.doDestroy();
   });
 

--- a/packages/harness-deepagents/src/deepagents-harness.test.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.test.ts
@@ -288,6 +288,53 @@ describe('createDeepAgents', () => {
     await session.doDestroy();
   });
 
+  it('passes headers to the bridge only for AI Gateway auth', async () => {
+    sentMessages.length = 0;
+    const gatewaySession = await createDeepAgents({
+      auth: { AI_GATEWAY_API_KEY: 'gateway-key' },
+    }).doStart({
+      sessionId: 'gateway',
+      headers: { 'x-tenant': 'acme' },
+      sessionWorkDir: '/vercel/sandbox/deepagents-gateway',
+      sandboxSession: fakeSandboxSession(),
+    } as unknown as Parameters<
+      ReturnType<typeof createDeepAgents>['doStart']
+    >[0]);
+
+    await gatewaySession.doPromptTurn({
+      skills: [],
+      tools: [],
+      prompt: 'Hello',
+      emit: () => {},
+    });
+    expect(sentMessages.at(-1)).toMatchObject({
+      type: 'start',
+      headers: { 'x-tenant': 'acme' },
+    });
+    await gatewaySession.doDestroy();
+
+    sentMessages.length = 0;
+    const directSession = await createDeepAgents({
+      auth: { ANTHROPIC_API_KEY: 'anthropic-key' },
+    }).doStart({
+      sessionId: 'direct',
+      headers: { 'x-tenant': 'acme' },
+      sessionWorkDir: '/vercel/sandbox/deepagents-direct',
+      sandboxSession: fakeSandboxSession(),
+    } as unknown as Parameters<
+      ReturnType<typeof createDeepAgents>['doStart']
+    >[0]);
+
+    await directSession.doPromptTurn({
+      skills: [],
+      tools: [],
+      prompt: 'Hello',
+      emit: () => {},
+    });
+    expect(sentMessages.at(-1)).not.toHaveProperty('headers');
+    await directSession.doDestroy();
+  });
+
   it('brokers credentials when the sandbox supports additive request transformations', async () => {
     const spawnEnvs: Array<Record<string, string | undefined>> = [];
     const forwardedCredentials: Array<{

--- a/packages/harness-deepagents/src/deepagents-harness.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.ts
@@ -368,10 +368,7 @@ export function createDeepAgents(
             builtinToolFiltering: startOpts.builtinToolFiltering,
             recursionLimit: settings.recursionLimit,
             mcpServers: settings.mcpServers,
-            headers:
-              authenticationMode === 'ai-gateway'
-                ? startOpts.headers
-                : undefined,
+            headers: startOpts.headers,
           });
         } catch {
           // Bridge no longer reachable — recover by respawning below.
@@ -495,8 +492,7 @@ export function createDeepAgents(
         builtinToolFiltering: startOpts.builtinToolFiltering,
         recursionLimit: settings.recursionLimit,
         mcpServers: settings.mcpServers,
-        headers:
-          authenticationMode === 'ai-gateway' ? startOpts.headers : undefined,
+        headers: startOpts.headers,
       });
     },
   };

--- a/packages/harness-deepagents/src/deepagents-harness.ts
+++ b/packages/harness-deepagents/src/deepagents-harness.ts
@@ -368,6 +368,10 @@ export function createDeepAgents(
             builtinToolFiltering: startOpts.builtinToolFiltering,
             recursionLimit: settings.recursionLimit,
             mcpServers: settings.mcpServers,
+            headers:
+              authenticationMode === 'ai-gateway'
+                ? startOpts.headers
+                : undefined,
           });
         } catch {
           // Bridge no longer reachable — recover by respawning below.
@@ -491,6 +495,8 @@ export function createDeepAgents(
         builtinToolFiltering: startOpts.builtinToolFiltering,
         recursionLimit: settings.recursionLimit,
         mcpServers: settings.mcpServers,
+        headers:
+          authenticationMode === 'ai-gateway' ? startOpts.headers : undefined,
       });
     },
   };
@@ -631,6 +637,7 @@ function createSession({
   builtinToolFiltering,
   recursionLimit,
   mcpServers,
+  headers,
 }: {
   sessionId: string;
   channel: DeepAgentsChannel;
@@ -651,6 +658,7 @@ function createSession({
   builtinToolFiltering?: HarnessV1BuiltinToolFiltering;
   recursionLimit?: number;
   mcpServers?: Record<string, unknown>;
+  headers?: Readonly<Record<string, string>>;
 }): HarnessV1Session {
   let stopped = false;
 
@@ -826,6 +834,7 @@ function createSession({
         ...(builtinToolFiltering ? { builtinToolFiltering } : {}),
         ...(recursionLimit != null ? { recursionLimit } : {}),
         ...(mcpServers == null ? {} : { mcpServers }),
+        ...(headers == null ? {} : { headers }),
       });
 
       return control;

--- a/packages/harness-fx/src/fx-harness.test.ts
+++ b/packages/harness-fx/src/fx-harness.test.ts
@@ -331,7 +331,6 @@ describe('createFx', () => {
           AI_GATEWAY_API_KEY: 'sandbox-gateway-secret',
         },
         headers: { 'x-tenant': 'acme' },
-        isAiGateway: true,
       }),
     ).toEqual([
       {

--- a/packages/harness-fx/src/fx-harness.test.ts
+++ b/packages/harness-fx/src/fx-harness.test.ts
@@ -330,6 +330,8 @@ describe('createFx', () => {
           VERCEL_OIDC_TOKEN: 'sandbox-oidc-secret',
           AI_GATEWAY_API_KEY: 'sandbox-gateway-secret',
         },
+        headers: { 'x-tenant': 'acme' },
+        isAiGateway: true,
       }),
     ).toEqual([
       {
@@ -344,6 +346,7 @@ describe('createFx', () => {
         },
         transform: {
           headers: {
+            'x-tenant': 'acme',
             Authorization: 'Bearer oidc-secret',
             'x-client-app': 'ai-sdk/harness-fx/0.0.0-test',
           },

--- a/packages/harness-fx/src/fx-harness.ts
+++ b/packages/harness-fx/src/fx-harness.ts
@@ -594,7 +594,7 @@ export function createFx(
       path: 'model',
     },
     credentialEnv: ['VERCEL_OIDC_TOKEN', 'AI_GATEWAY_API_KEY'],
-    credentialBrokering: ({ env, sandboxEnv, headers, isAiGateway }) => {
+    credentialBrokering: ({ env, sandboxEnv, headers }) => {
       const environmentVariableName = suppliedAuthenticationEnvironment
         ? env.AI_GATEWAY_API_KEY
           ? 'AI_GATEWAY_API_KEY'
@@ -612,7 +612,7 @@ export function createFx(
             Authorization: `Bearer ${sandboxCredential}`,
           },
           transformHeaders: {
-            ...(isAiGateway ? headers : undefined),
+            ...headers,
             Authorization: `Bearer ${credential}`,
             'x-client-app': FX_CLIENT_APP,
           },

--- a/packages/harness-fx/src/fx-harness.ts
+++ b/packages/harness-fx/src/fx-harness.ts
@@ -594,7 +594,7 @@ export function createFx(
       path: 'model',
     },
     credentialEnv: ['VERCEL_OIDC_TOKEN', 'AI_GATEWAY_API_KEY'],
-    credentialBrokering: ({ env, sandboxEnv }) => {
+    credentialBrokering: ({ env, sandboxEnv, headers, isAiGateway }) => {
       const environmentVariableName = suppliedAuthenticationEnvironment
         ? env.AI_GATEWAY_API_KEY
           ? 'AI_GATEWAY_API_KEY'
@@ -612,6 +612,7 @@ export function createFx(
             Authorization: `Bearer ${sandboxCredential}`,
           },
           transformHeaders: {
+            ...(isAiGateway ? headers : undefined),
             Authorization: `Bearer ${credential}`,
             'x-client-app': FX_CLIENT_APP,
           },

--- a/packages/harness-grok-build/src/grok-build-harness.test.ts
+++ b/packages/harness-grok-build/src/grok-build-harness.test.ts
@@ -157,6 +157,8 @@ describe('createGrokBuild', () => {
           XAI_API_KEY: 'sandbox-xai-secret',
           GROK_XAI_API_BASE_URL: 'https://api.x.ai/v1',
         },
+        headers: { 'x-tenant': 'acme' },
+        isAiGateway: true,
       }),
     ).toEqual([
       {
@@ -171,7 +173,10 @@ describe('createGrokBuild', () => {
           ],
         },
         transform: {
-          headers: { Authorization: 'Bearer xai-secret' },
+          headers: {
+            'x-tenant': 'acme',
+            Authorization: 'Bearer xai-secret',
+          },
         },
       },
     ]);

--- a/packages/harness-grok-build/src/grok-build-harness.test.ts
+++ b/packages/harness-grok-build/src/grok-build-harness.test.ts
@@ -158,7 +158,6 @@ describe('createGrokBuild', () => {
           GROK_XAI_API_BASE_URL: 'https://api.x.ai/v1',
         },
         headers: { 'x-tenant': 'acme' },
-        isAiGateway: true,
       }),
     ).toEqual([
       {

--- a/packages/harness-grok-build/src/grok-build-harness.ts
+++ b/packages/harness-grok-build/src/grok-build-harness.ts
@@ -337,7 +337,7 @@ export function createGrokBuild(
       'stdio',
     ],
     credentialEnv: ['XAI_API_KEY'],
-    credentialBrokering: ({ env, sandboxEnv }) => {
+    credentialBrokering: ({ env, sandboxEnv, headers, isAiGateway }) => {
       if (!env.XAI_API_KEY || !sandboxEnv?.XAI_API_KEY) return [];
       return [
         createCredentialRequestTransformation({
@@ -345,7 +345,10 @@ export function createGrokBuild(
           matchHeaders: {
             Authorization: `Bearer ${sandboxEnv.XAI_API_KEY}`,
           },
-          transformHeaders: { Authorization: `Bearer ${env.XAI_API_KEY}` },
+          transformHeaders: {
+            ...(isAiGateway ? headers : undefined),
+            Authorization: `Bearer ${env.XAI_API_KEY}`,
+          },
         }),
       ];
     },

--- a/packages/harness-grok-build/src/grok-build-harness.ts
+++ b/packages/harness-grok-build/src/grok-build-harness.ts
@@ -337,7 +337,7 @@ export function createGrokBuild(
       'stdio',
     ],
     credentialEnv: ['XAI_API_KEY'],
-    credentialBrokering: ({ env, sandboxEnv, headers, isAiGateway }) => {
+    credentialBrokering: ({ env, sandboxEnv, headers }) => {
       if (!env.XAI_API_KEY || !sandboxEnv?.XAI_API_KEY) return [];
       return [
         createCredentialRequestTransformation({
@@ -346,7 +346,7 @@ export function createGrokBuild(
             Authorization: `Bearer ${sandboxEnv.XAI_API_KEY}`,
           },
           transformHeaders: {
-            ...(isAiGateway ? headers : undefined),
+            ...headers,
             Authorization: `Bearer ${env.XAI_API_KEY}`,
           },
         }),

--- a/packages/harness-opencode/src/bridge/index.test.ts
+++ b/packages/harness-opencode/src/bridge/index.test.ts
@@ -94,6 +94,7 @@ describe('OpenCode bridge turn settlement', () => {
     relayMock.authorizeToolCall.mockReset();
     permissionReplyMock.mockReset();
     createOpencodeServerMock.mockClear();
+    vi.unstubAllEnvs();
   });
 
   it('enables the interactive question tool', async () => {
@@ -155,6 +156,79 @@ describe('OpenCode bridge turn settlement', () => {
         }),
       }),
     );
+  });
+
+  it('passes headers to the AI Gateway provider', async () => {
+    const userMessages = createUserMessages();
+    bridgeMock.start = {
+      type: 'start',
+      operation: 'prompt',
+      prompt: 'Start.',
+      model: 'openai/gpt-5.4-mini',
+      headers: { 'x-tenant': 'acme' },
+    };
+    bridgeMock.turn = {
+      emit: vi.fn(),
+      requestToolResult: vi.fn(),
+      requestToolApproval: vi.fn(),
+      experimental_userMessages: userMessages,
+      abortSignal: new AbortController().signal,
+      firstTurn: true,
+      bridgeLog: vi.fn(),
+      emitWarning: vi.fn(),
+      emitError: vi.fn(),
+    };
+    sdkMock.client = {
+      mcp: { status: vi.fn(async () => ({ data: {} })) },
+      session: {
+        create: vi.fn(async () => ({ data: { id: 'session-1' } })),
+        get: vi.fn(async () => ({ data: {} })),
+        messages: vi.fn(async () => ({ data: [] })),
+        promptAsync: vi.fn(async () => ({ data: {} })),
+      },
+      event: {
+        subscribe: vi.fn(async () => ({
+          stream: {
+            async *[Symbol.asyncIterator]() {
+              yield {
+                type: 'session.next.step.failed',
+                properties: {
+                  sessionID: 'session-1',
+                  error: 'model step failed',
+                },
+              };
+            },
+          },
+        })),
+      },
+      v2: {
+        session: {
+          context: vi.fn(async () => ({ data: [] })),
+          switchModel: vi.fn(async () => ({ data: {} })),
+        },
+      },
+    };
+    vi.stubEnv('AI_GATEWAY_API_KEY', 'gateway-key');
+    vi.stubEnv('AI_GATEWAY_BASE_URL', 'https://ai-gateway.test/v1');
+    setBridgeArgv();
+
+    await import('./index');
+
+    expect(createOpencodeServerMock.mock.calls[0]?.[0]).toMatchObject({
+      config: {
+        provider: {
+          openai: {
+            options: {
+              apiKey: 'gateway-key',
+              baseURL: 'https://ai-gateway.test/v1',
+              headers: {
+                'x-tenant': 'acme',
+              },
+            },
+          },
+        },
+      },
+    });
   });
 
   it('settles when OpenCode emits session.next.step.failed', async () => {

--- a/packages/harness-opencode/src/bridge/index.test.ts
+++ b/packages/harness-opencode/src/bridge/index.test.ts
@@ -158,7 +158,7 @@ describe('OpenCode bridge turn settlement', () => {
     );
   });
 
-  it('passes headers to the AI Gateway provider', async () => {
+  it('passes headers to a direct provider', async () => {
     const userMessages = createUserMessages();
     bridgeMock.start = {
       type: 'start',
@@ -208,8 +208,8 @@ describe('OpenCode bridge turn settlement', () => {
         },
       },
     };
-    vi.stubEnv('AI_GATEWAY_API_KEY', 'gateway-key');
-    vi.stubEnv('AI_GATEWAY_BASE_URL', 'https://ai-gateway.test/v1');
+    vi.stubEnv('OPENAI_API_KEY', 'openai-key');
+    vi.stubEnv('OPENAI_BASE_URL', 'https://api.openai.test/v1');
     setBridgeArgv();
 
     await import('./index');
@@ -219,8 +219,8 @@ describe('OpenCode bridge turn settlement', () => {
         provider: {
           openai: {
             options: {
-              apiKey: 'gateway-key',
-              baseURL: 'https://ai-gateway.test/v1',
+              apiKey: 'openai-key',
+              baseURL: 'https://api.openai.test/v1',
               headers: {
                 'x-tenant': 'acme',
               },

--- a/packages/harness-opencode/src/bridge/index.ts
+++ b/packages/harness-opencode/src/bridge/index.ts
@@ -376,6 +376,7 @@ function buildProviderConfig(
           ...(procEnv.OPENAI_BASE_URL
             ? { baseURL: procEnv.OPENAI_BASE_URL }
             : {}),
+          ...(start.headers ? { headers: start.headers } : {}),
           ...parseOpenAIQueryParams(),
         },
         ...(modelID
@@ -407,6 +408,7 @@ function buildProviderConfig(
           ...(procEnv.ANTHROPIC_BASE_URL
             ? { baseURL: procEnv.ANTHROPIC_BASE_URL }
             : {}),
+          ...(start.headers ? { headers: start.headers } : {}),
         },
       },
     };
@@ -429,6 +431,7 @@ function buildProviderConfig(
           ...(procEnv.OPENAI_PROJECT
             ? { project: procEnv.OPENAI_PROJECT }
             : {}),
+          ...(start.headers ? { headers: start.headers } : {}),
           ...parseOpenAIQueryParams(),
         },
       },

--- a/packages/harness-opencode/src/bridge/index.ts
+++ b/packages/harness-opencode/src/bridge/index.ts
@@ -342,8 +342,15 @@ function buildProviderConfig(
           apiKey: procEnv.AI_GATEWAY_API_KEY,
           baseURL: toOpenCodeGatewayBaseUrl(procEnv.AI_GATEWAY_BASE_URL),
           ...(HARNESS_CLIENT_APP
-            ? { headers: { 'x-client-app': HARNESS_CLIENT_APP } }
-            : {}),
+            ? {
+                headers: {
+                  ...start.headers,
+                  'x-client-app': HARNESS_CLIENT_APP,
+                },
+              }
+            : start.headers
+              ? { headers: start.headers }
+              : {}),
         },
         ...(modelID
           ? {

--- a/packages/harness-opencode/src/opencode-bridge-protocol.ts
+++ b/packages/harness-opencode/src/opencode-bridge-protocol.ts
@@ -18,6 +18,7 @@ export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
   resumeSessionId: z.string().optional(),
   openCodeConfig: z.record(z.string(), z.unknown()).optional(),
   mcpServers: z.record(z.string(), z.unknown()).optional(),
+  headers: z.record(z.string(), z.string()).optional(),
 });
 
 export type StartMessage = z.infer<typeof startMessageSchema>;

--- a/packages/harness-opencode/src/opencode-harness.test.ts
+++ b/packages/harness-opencode/src/opencode-harness.test.ts
@@ -712,6 +712,7 @@ describe('createOpenCode adapter', () => {
       agent: { general: { model: 'openai/gpt-5.4-mini' } },
     };
     const harness = createOpenCode({
+      auth: { AI_GATEWAY_API_KEY: 'gateway-key' },
       model: 'legacy-model',
       openCodeConfig,
       reasoningVariant: 'high',
@@ -719,6 +720,7 @@ describe('createOpenCode adapter', () => {
     });
     const session = await harness.doStart({
       sessionId: 's1',
+      headers: { 'x-tenant': 'acme' },
       sandboxSession,
       sessionWorkDir: '/workspace/project',
     });
@@ -734,6 +736,7 @@ describe('createOpenCode adapter', () => {
       operation: 'compact',
       openCodeConfig,
       mcpServers,
+      headers: { 'x-tenant': 'acme' },
       resumeSessionId: 'opencode-session',
     });
     channel.emit('finish', { type: 'finish' });
@@ -757,6 +760,7 @@ describe('createOpenCode adapter', () => {
       variant: 'high',
       openCodeConfig,
       mcpServers,
+      headers: { 'x-tenant': 'acme' },
       resumeSessionId: 'opencode-session',
     });
     channel.emit('finish', { type: 'finish' });
@@ -765,6 +769,7 @@ describe('createOpenCode adapter', () => {
     const resumeFrom = await session.doDetach();
     const resumedSession = await harness.doStart({
       sessionId: 's1',
+      headers: { 'x-tenant': 'acme' },
       sandboxSession,
       sessionWorkDir: '/workspace/project',
       resumeFrom,
@@ -786,6 +791,7 @@ describe('createOpenCode adapter', () => {
       variant: 'high',
       openCodeConfig,
       mcpServers,
+      headers: { 'x-tenant': 'acme' },
       resumeSessionId: 'opencode-session',
     });
     resumedChannel.emit('finish', { type: 'finish' });

--- a/packages/harness-opencode/src/opencode-harness.ts
+++ b/packages/harness-opencode/src/opencode-harness.ts
@@ -412,10 +412,7 @@ export function createOpenCode(
             reasoningVariant: settings.reasoningVariant,
             openCodeConfig: settings.openCodeConfig,
             mcpServers: settings.mcpServers,
-            headers:
-              authenticationMode === 'ai-gateway'
-                ? startOpts.headers
-                : undefined,
+            headers: startOpts.headers,
             openCodeSessionId: resumeSessionId,
             isResume: true,
             seedResumeSessionOnFirstPrompt: false,
@@ -573,8 +570,7 @@ export function createOpenCode(
         reasoningVariant: settings.reasoningVariant,
         openCodeConfig: settings.openCodeConfig,
         mcpServers: settings.mcpServers,
-        headers:
-          authenticationMode === 'ai-gateway' ? startOpts.headers : undefined,
+        headers: startOpts.headers,
         openCodeSessionId: resumeSessionId,
         isResume: respawnStrategy !== undefined,
         seedResumeSessionOnFirstPrompt: respawnStrategy !== undefined,

--- a/packages/harness-opencode/src/opencode-harness.ts
+++ b/packages/harness-opencode/src/opencode-harness.ts
@@ -412,6 +412,10 @@ export function createOpenCode(
             reasoningVariant: settings.reasoningVariant,
             openCodeConfig: settings.openCodeConfig,
             mcpServers: settings.mcpServers,
+            headers:
+              authenticationMode === 'ai-gateway'
+                ? startOpts.headers
+                : undefined,
             openCodeSessionId: resumeSessionId,
             isResume: true,
             seedResumeSessionOnFirstPrompt: false,
@@ -569,6 +573,8 @@ export function createOpenCode(
         reasoningVariant: settings.reasoningVariant,
         openCodeConfig: settings.openCodeConfig,
         mcpServers: settings.mcpServers,
+        headers:
+          authenticationMode === 'ai-gateway' ? startOpts.headers : undefined,
         openCodeSessionId: resumeSessionId,
         isResume: respawnStrategy !== undefined,
         seedResumeSessionOnFirstPrompt: respawnStrategy !== undefined,
@@ -786,6 +792,7 @@ function createSession({
   reasoningVariant,
   openCodeConfig,
   mcpServers,
+  headers,
   openCodeSessionId,
   isResume,
   seedResumeSessionOnFirstPrompt,
@@ -809,6 +816,7 @@ function createSession({
   reasoningVariant: string | undefined;
   openCodeConfig: Record<string, unknown> | undefined;
   mcpServers: Record<string, unknown> | undefined;
+  headers: Readonly<Record<string, string>> | undefined;
   openCodeSessionId: string | undefined;
   isResume: boolean;
   seedResumeSessionOnFirstPrompt: boolean;
@@ -990,6 +998,7 @@ function createSession({
     ...(reasoningVariant ? { variant: reasoningVariant } : {}),
     ...(openCodeConfig == null ? {} : { openCodeConfig }),
     ...(mcpServers == null ? {} : { mcpServers }),
+    ...(headers == null ? {} : { headers }),
     ...(permissionMode ? { permissionMode } : {}),
     ...(builtinToolFiltering ? { builtinToolFiltering } : {}),
     ...(pendingResumeSessionId
@@ -1116,6 +1125,7 @@ function createSession({
         debug,
         openCodeConfig,
         mcpServers,
+        headers,
         resumeSessionId: latestOpenCodeSessionId,
         onCompaction: part => pendingCompactionParts.push(part),
       });
@@ -1289,6 +1299,7 @@ async function runCompactOperation({
   debug,
   openCodeConfig,
   mcpServers,
+  headers,
   resumeSessionId,
   onCompaction,
 }: {
@@ -1299,6 +1310,7 @@ async function runCompactOperation({
   debug: HarnessV1DebugConfig | undefined;
   openCodeConfig: Record<string, unknown> | undefined;
   mcpServers: Record<string, unknown> | undefined;
+  headers: Readonly<Record<string, string>> | undefined;
   resumeSessionId: string | undefined;
   onCompaction: (part: HarnessV1StreamPart) => void;
 }): Promise<void> {
@@ -1328,6 +1340,7 @@ async function runCompactOperation({
     provider,
     ...(openCodeConfig == null ? {} : { openCodeConfig }),
     ...(mcpServers == null ? {} : { mcpServers }),
+    ...(headers == null ? {} : { headers }),
     ...(permissionMode ? { permissionMode } : {}),
     ...(resumeSessionId ? { resumeSessionId } : {}),
     ...(debug ? { debug } : {}),

--- a/packages/harness-pi/src/pi-auth.test.ts
+++ b/packages/harness-pi/src/pi-auth.test.ts
@@ -50,15 +50,18 @@ async function makeRegistries() {
 async function registerProviders({
   options,
   resolvedEnv,
+  headers,
 }: {
   options: PiAuthenticationMode | undefined;
   resolvedEnv: Record<string, string>;
+  headers?: Readonly<Record<string, string>>;
 }) {
   const registries = await makeRegistries();
   await registerPiProviders({
     options,
     resolvedEnv,
     registries,
+    headers,
   });
   return registries;
 }
@@ -315,7 +318,14 @@ describe('registerPiProviders', () => {
       AI_GATEWAY_BASE_URL: 'https://gw.example',
     } satisfies PiAuthenticationMode;
     const resolvedEnv = resolvePiEnv({ options, env: {} });
-    const registries = await registerProviders({ options, resolvedEnv });
+    const registries = await registerProviders({
+      options,
+      resolvedEnv,
+      headers: {
+        'x-tenant': 'acme',
+        'User-Agent': 'caller-agent',
+      },
+    });
 
     expect(registries.setRuntimeApiKey).toHaveBeenCalledWith(
       'vercel-ai-gateway',
@@ -328,6 +338,7 @@ describe('registerPiProviders', () => {
         baseUrl: 'https://gw.example',
         authHeader: true,
         headers: {
+          'x-tenant': 'acme',
           'User-Agent': 'ai-sdk/harness-pi/0.0.0-test',
           'x-client-app': 'ai-sdk/harness-pi/0.0.0-test',
         },

--- a/packages/harness-pi/src/pi-auth.test.ts
+++ b/packages/harness-pi/src/pi-auth.test.ts
@@ -431,6 +431,7 @@ describe('registerPiProviders', () => {
     const registries = await registerProviders({
       options: 'openai',
       resolvedEnv,
+      headers: { 'x-tenant': 'acme' },
     });
     const providers = registries.registerProvider.mock.calls.map(c => c[0]);
 
@@ -443,6 +444,7 @@ describe('registerPiProviders', () => {
       apiKey: 'sk-oai',
       baseUrl: 'https://api.openai.com/v1',
       authHeader: true,
+      headers: { 'x-tenant': 'acme' },
     });
   });
 
@@ -467,6 +469,7 @@ describe('registerPiProviders', () => {
     const registries = await registerProviders({
       options: 'anthropic',
       resolvedEnv,
+      headers: { 'x-tenant': 'acme' },
     });
     const providers = registries.registerProvider.mock.calls.map(c => c[0]);
 
@@ -474,7 +477,10 @@ describe('registerPiProviders', () => {
     expect(registries.registerProvider).toHaveBeenCalledWith('anthropic', {
       apiKey: 'sk-ant',
       baseUrl: 'https://api.anthropic.com',
-      headers: { authorization: 'Bearer tok' },
+      headers: {
+        'x-tenant': 'acme',
+        authorization: 'Bearer tok',
+      },
     });
   });
 

--- a/packages/harness-pi/src/pi-auth.ts
+++ b/packages/harness-pi/src/pi-auth.ts
@@ -174,16 +174,19 @@ function createGatewayProviderConfig({
   apiKey,
   baseUrl,
   clientApp,
+  headers,
 }: {
   apiKey: string;
   baseUrl: string;
   clientApp: string;
+  headers?: Readonly<Record<string, string>>;
 }): ProviderConfigInput {
   return {
     apiKey,
     baseUrl,
     authHeader: true,
     headers: {
+      ...headers,
       'User-Agent': clientApp,
       'x-client-app': clientApp,
     },
@@ -311,11 +314,13 @@ export async function registerPiProviders({
   resolvedEnv,
   registries,
   clientApp = HARNESS_CLIENT_APP,
+  headers,
 }: {
   options: PiAuthenticationMode | undefined;
   resolvedEnv: Record<string, string>;
   registries: PiRegistries;
   clientApp?: string;
+  headers?: Readonly<Record<string, string>>;
 }): Promise<void> {
   const suppliedEnvironment = isHarnessAuthenticationEnvironment(options);
   const authenticationEnvironment = suppliedEnvironment ? options : process.env;
@@ -328,6 +333,7 @@ export async function registerPiProviders({
         customEnv: { ...pickOpenAIEnv(authenticationEnvironment), ...env },
         registries,
         clientApp,
+        headers,
       });
       return;
     }
@@ -337,6 +343,7 @@ export async function registerPiProviders({
         customEnv: { ...pickAnthropicEnv(authenticationEnvironment), ...env },
         registries,
         clientApp,
+        headers,
       });
       return;
     }
@@ -347,6 +354,7 @@ export async function registerPiProviders({
         customEnv: { ...pickProviderEnv(authenticationEnvironment), ...env },
         registries,
         clientApp,
+        headers,
       });
       return;
     }
@@ -367,6 +375,7 @@ export async function registerPiProviders({
           apiKey: gatewayApiKey,
           baseUrl: gatewayBaseUrl,
           clientApp,
+          headers,
         }),
       });
       return;
@@ -391,6 +400,7 @@ export async function registerPiProviders({
             apiKey: gatewayApiKey,
             baseUrl: gatewayBaseUrl,
             clientApp,
+            headers,
           }),
         });
         return;
@@ -400,6 +410,7 @@ export async function registerPiProviders({
         customEnv: { ...pickProviderEnv(authenticationEnvironment), ...env },
         registries,
         clientApp,
+        headers,
       });
       return;
     }
@@ -455,10 +466,12 @@ async function registerCustomProviders({
   customEnv,
   registries,
   clientApp,
+  headers,
 }: {
   customEnv: Record<string, string>;
   registries: PiRegistries;
   clientApp: string;
+  headers?: Readonly<Record<string, string>>;
 }): Promise<void> {
   const gatewayKey = customEnv.AI_GATEWAY_API_KEY;
   if (gatewayKey) {
@@ -471,6 +484,7 @@ async function registerCustomProviders({
         apiKey: gatewayKey,
         baseUrl,
         clientApp,
+        headers,
       }),
     });
   }

--- a/packages/harness-pi/src/pi-auth.ts
+++ b/packages/harness-pi/src/pi-auth.ts
@@ -499,6 +499,7 @@ async function registerCustomProviders({
         apiKey: customEnv.OPENAI_API_KEY,
         baseUrl,
         authHeader: true,
+        ...(headers ? { headers } : {}),
       },
     });
   }
@@ -512,10 +513,15 @@ async function registerCustomProviders({
       config: {
         apiKey: customEnv.ANTHROPIC_API_KEY,
         baseUrl,
-        ...(customEnv.ANTHROPIC_AUTH_TOKEN
+        ...(headers || customEnv.ANTHROPIC_AUTH_TOKEN
           ? {
               headers: {
-                authorization: `Bearer ${customEnv.ANTHROPIC_AUTH_TOKEN}`,
+                ...headers,
+                ...(customEnv.ANTHROPIC_AUTH_TOKEN
+                  ? {
+                      authorization: `Bearer ${customEnv.ANTHROPIC_AUTH_TOKEN}`,
+                    }
+                  : {}),
               },
             }
           : {}),
@@ -548,6 +554,7 @@ async function registerCustomProviders({
         apiKey,
         baseUrl,
         authHeader: true,
+        ...(headers ? { headers } : {}),
       },
     });
   }

--- a/packages/harness-pi/src/pi-harness.ts
+++ b/packages/harness-pi/src/pi-harness.ts
@@ -161,6 +161,7 @@ export function createPi(
           ...(settings.extensionFactories
             ? { extensionFactories: settings.extensionFactories }
             : {}),
+          ...(startOpts.headers ? { headers: startOpts.headers } : {}),
         },
         clientApp: PI_CLIENT_APP,
         isResume: lifecycleState != null,

--- a/packages/harness-pi/src/pi-session.ts
+++ b/packages/harness-pi/src/pi-session.ts
@@ -217,6 +217,7 @@ export type PiThinkingLevel =
 
 export interface PiSessionSettings {
   readonly auth?: PiAuthenticationMode;
+  readonly headers?: Readonly<Record<string, string>>;
   readonly model?: string;
   readonly thinkingLevel?: PiThinkingLevel;
   readonly mcpServers?: Record<string, unknown>;
@@ -410,6 +411,7 @@ export async function createPiSession(
       modelRuntime,
     },
     clientApp: input.clientApp,
+    headers: input.settings.headers,
   });
   const resolveModel = createPiModelResolver({
     modelRegistry,

--- a/packages/harness/src/agent/harness-agent-settings.test-d.ts
+++ b/packages/harness/src/agent/harness-agent-settings.test-d.ts
@@ -71,6 +71,34 @@ describe('HarnessAgentSettings tool filtering types', () => {
     expectTypeOf(settings.model).toEqualTypeOf<string | undefined>();
   });
 
+  test('headers accept undefined values', () => {
+    const settings: Settings = {
+      harness,
+      headers: {
+        'x-tenant': 'acme',
+        'x-optional': undefined,
+      },
+    };
+
+    expectTypeOf(settings.headers).toEqualTypeOf<
+      Record<string, string | undefined> | undefined
+    >();
+  });
+
+  test('prepareCall cannot modify headers', () => {
+    const settings: Settings = {
+      harness,
+      headers: { 'x-tenant': 'acme' },
+      prepareCall: call => {
+        // @ts-expect-error headers are stable construction-time settings
+        call.headers;
+        return call;
+      },
+    };
+
+    expectTypeOf(settings).toMatchTypeOf<Settings>();
+  });
+
   test('activeTools accepts builtin and user tool names', () => {
     const settings: Settings = {
       harness,

--- a/packages/harness/src/agent/harness-agent-settings.ts
+++ b/packages/harness/src/agent/harness-agent-settings.ts
@@ -154,6 +154,15 @@ export type HarnessAgentSettings<
   readonly instructions?: string;
 
   /**
+   * Additional HTTP headers to be sent with every model request.
+   * Only applied when the harness uses AI Gateway.
+   *
+   * `authorization`, `x-api-key`, `user-agent`, and `x-client-app` are
+   * managed by the harness and are not allowed.
+   */
+  readonly headers?: Record<string, string | undefined>;
+
+  /**
    * Schema for validating the custom options passed to each agent call.
    */
   readonly callOptionsSchema?: FlexibleSchema<CALL_OPTIONS>;

--- a/packages/harness/src/agent/harness-agent-settings.ts
+++ b/packages/harness/src/agent/harness-agent-settings.ts
@@ -155,7 +155,6 @@ export type HarnessAgentSettings<
 
   /**
    * Additional HTTP headers to be sent with every model request.
-   * Only applied when the harness uses AI Gateway.
    *
    * `authorization`, `x-api-key`, `user-agent`, and `x-client-app` are
    * managed by the harness and are not allowed.

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -453,6 +453,100 @@ describe('HarnessAgent', () => {
     await session.destroy();
   });
 
+  test('normalizes and snapshots headers before passing them to doStart', async () => {
+    const { harness, doStart } = mockHarness({
+      script: () => finishEvents(),
+    });
+    const headers: Record<string, string | undefined> = {
+      'X-Tenant': 'acme',
+      'X-Optional': undefined,
+    };
+    const agent = new HarnessAgent({
+      harness,
+      headers,
+      sandbox: makeSandboxProvider(),
+    });
+    headers['X-Tenant'] = 'mutated';
+
+    const session = await agent.createSession();
+
+    expect(doStart.mock.calls[0]?.[0]).toMatchObject({
+      headers: { 'x-tenant': 'acme' },
+    });
+    await session.destroy();
+  });
+
+  test.each([
+    'authorization',
+    'Authorization',
+    'x-api-key',
+    'X-API-Key',
+    'user-agent',
+    'User-Agent',
+    'x-client-app',
+    'X-Client-App',
+  ])('rejects the managed header %s', header => {
+    const { harness } = mockHarness({
+      script: () => finishEvents(),
+    });
+
+    expect(
+      () =>
+        new HarnessAgent({
+          harness,
+          headers: { [header]: 'caller-value' },
+          sandbox: makeSandboxProvider(),
+        }),
+    ).toThrow(
+      `HarnessAgent: \`headers\` must not include the managed header \`${header.toLowerCase()}\`.`,
+    );
+  });
+
+  test('rejects a managed header with an undefined value', () => {
+    const { harness } = mockHarness({
+      script: () => finishEvents(),
+    });
+
+    expect(
+      () =>
+        new HarnessAgent({
+          harness,
+          headers: { Authorization: undefined },
+          sandbox: makeSandboxProvider(),
+        }),
+    ).toThrow(
+      'HarnessAgent: `headers` must not include the managed header `authorization`.',
+    );
+  });
+
+  test('passes stable headers when resuming a session', async () => {
+    const { harness, doStart } = mockHarness({
+      script: () => finishEvents(),
+    });
+    const sandboxSession = makeSandboxSession();
+    const agent = new HarnessAgent({
+      harness,
+      headers: { 'x-tenant': 'acme' },
+      sandbox: makeSandboxProvider(sandboxSession),
+    });
+    const session = await agent.createSession({ sessionId: 'session-1' });
+    const resumeFrom = await session.stop();
+
+    const resumedSession = await agent.createSession({
+      sessionId: 'session-1',
+      resumeFrom,
+    });
+
+    expect(doStart).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        headers: { 'x-tenant': 'acme' },
+        resumeFrom,
+      }),
+    );
+    await resumedSession.destroy();
+  });
+
   test('prepares model, skills, instructions, tools, and the prompt for each fresh turn', async () => {
     const promptOptions: HarnessV1PromptTurnOptions[] = [];
     const { harness, doStart } = mockHarness({

--- a/packages/harness/src/agent/harness-agent.ts
+++ b/packages/harness/src/agent/harness-agent.ts
@@ -10,6 +10,7 @@ import {
   asArray,
   asSchema,
   generateId,
+  normalizeHeaders,
   validateTypes,
   type Context,
   type Experimental_SandboxSession as SandboxSession,
@@ -203,6 +204,7 @@ export class HarnessAgent<
     | HarnessV1BuiltinToolFiltering
     | undefined;
   private readonly permissionMode: HarnessAgentPermissionMode;
+  private readonly headers: Readonly<Record<string, string>> | undefined;
 
   constructor(
     settings: HarnessAgentSettings<
@@ -219,6 +221,22 @@ export class HarnessAgent<
     this.stopConditions =
       settings.stopWhen == null ? [] : asArray(settings.stopWhen);
     this.sandboxConfig = sandboxConfig;
+    const forbiddenHeaders = new Set([
+      'authorization',
+      'x-api-key',
+      'user-agent',
+      'x-client-app',
+    ]);
+    const forbiddenHeader = Object.keys(settings.headers ?? {})
+      .map(name => name.toLowerCase())
+      .find(name => forbiddenHeaders.has(name));
+    if (forbiddenHeader != null) {
+      throw new Error(
+        `HarnessAgent: \`headers\` must not include the managed header \`${forbiddenHeader}\`.`,
+      );
+    }
+    const headers = normalizeHeaders(settings.headers);
+    this.headers = Object.keys(headers).length === 0 ? undefined : headers;
     this.id = settings.id;
     const userTools = settings.tools ?? ({} as TUserTools);
     assertNoReservedQuestionTool({
@@ -502,6 +520,7 @@ export class HarnessAgent<
     try {
       const baseStartOptions = {
         sessionId,
+        ...(this.headers == null ? {} : { headers: this.headers }),
         resumeFrom: validatedResumeFrom,
         continueFrom: effectiveContinueFrom,
         permissionMode: this.permissionMode,

--- a/packages/harness/src/v1/harness-v1-session.ts
+++ b/packages/harness/src/v1/harness-v1-session.ts
@@ -22,6 +22,12 @@ import type { HarnessV1BuiltinToolFiltering } from './harness-v1-tool-filtering'
  */
 export type HarnessV1StartOptions = {
   /**
+   * Additional normalized HTTP headers to send with model requests when the
+   * adapter uses AI Gateway.
+   */
+  readonly headers?: Readonly<Record<string, string>>;
+
+  /**
    * Stable identifier for this harness session. Used as the underlying
    * resource name where the adapter has a notion of a named session
    * (sandbox name, native session id, …).

--- a/packages/harness/src/v1/harness-v1-session.ts
+++ b/packages/harness/src/v1/harness-v1-session.ts
@@ -22,8 +22,7 @@ import type { HarnessV1BuiltinToolFiltering } from './harness-v1-tool-filtering'
  */
 export type HarnessV1StartOptions = {
   /**
-   * Additional normalized HTTP headers to send with model requests when the
-   * adapter uses AI Gateway.
+   * Additional normalized HTTP headers to send with model requests.
    */
   readonly headers?: Readonly<Record<string, string>>;
 


### PR DESCRIPTION
## Background

`ToolLoopAgent` supports custom model request headers, but `HarnessAgent` had no equivalent way to pass them through harness runtimes.

## Summary

Adds a stable `headers` setting to `HarnessAgentSettings` and applies it across all harness adapters.

- Uses native header configuration for harnesses that support it.
- Uses sandbox request transformations at the credential-brokering boundary for other harnesses.
- Rejects managed authentication and client attribution headers.
- Adds adapter and bridge coverage for Gateway-only header propagation.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
