### PR TITLE
docs: start composed UI message streams once

### DIFF
--- a/content/docs/04-ai-sdk-ui/20-streaming-data.mdx
+++ b/content/docs/04-ai-sdk-ui/20-streaming-data.mdx
@@ -63,14 +63,17 @@ export async function POST(req: Request) {
 
   const stream = createUIMessageStream<MyUIMessage>({
     execute: ({ writer }) => {
-      // 1. Send initial status (transient - won't be added to message history)
+      // 1. Start the assistant message before writing any message parts.
+      writer.write({ type: 'start' });
+
+      // 2. Send initial status (transient - won't be added to message history)
       writer.write({
         type: 'data-notification',
         data: { message: 'Processing your request...', level: 'info' },
         transient: true, // This part won't be added to message history
       });
 
-      // 2. Send sources (useful for RAG use cases)
+      // 3. Send sources (useful for RAG use cases)
       writer.write({
         type: 'source',
         value: {
@@ -82,7 +85,7 @@ export async function POST(req: Request) {
         },
       });
 
-      // 3. Send data parts with loading state
+      // 4. Send data parts with loading state
       writer.write({
         type: 'data-weather',
         id: 'weather-1',
@@ -93,7 +96,7 @@ export async function POST(req: Request) {
         model: __MODEL__,
         messages: await convertToModelMessages(messages),
         onEnd() {
-          // 4. Update the same data part (reconciliation)
+          // 5. Update the same data part (reconciliation)
           writer.write({
             type: 'data-weather',
             id: 'weather-1', // Same ID = update existing part
@@ -104,7 +107,7 @@ export async function POST(req: Request) {
             },
           });
 
-          // 5. Send completion notification (transient)
+          // 6. Send completion notification (transient)
           writer.write({
             type: 'data-notification',
             data: { message: 'Request completed', level: 'info' },
@@ -113,7 +116,9 @@ export async function POST(req: Request) {
         },
       });
 
-      writer.merge(toUIMessageStream({ stream: result.stream }));
+      writer.merge(
+        toUIMessageStream({ stream: result.stream, sendStart: false }),
+      );
     },
   });
 

--- a/content/docs/07-reference/02-ai-sdk-ui/40-create-ui-message-stream.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/40-create-ui-message-stream.mdx
@@ -20,6 +20,9 @@ const existingMessages: UIMessage[] = [
 
 const stream = createUIMessageStream({
   async execute({ writer }) {
+    // The outer stream owns the assistant message lifecycle.
+    writer.write({ type: 'start' });
+
     // Start a text message
     // Note: The id must be consistent across text-start, text-delta, and text-end steps
     // This allows the system to correctly identify they belong to the same text block
@@ -50,6 +53,7 @@ const stream = createUIMessageStream({
     writer.merge(
       toUIMessageStream({
         stream: result.stream,
+        sendStart: false,
         onEnd: ({ outcome }) => {
           // The composer decides that the model stream outcome is also the
           // aggregate stream outcome.

--- a/content/docs/07-reference/02-ai-sdk-ui/41-create-ui-message-stream-response.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/41-create-ui-message-stream-response.mdx
@@ -33,6 +33,9 @@ const response = createUIMessageStreamResponse({
   },
   stream: createUIMessageStream({
     execute({ writer }) {
+      // The outer stream owns the assistant message lifecycle.
+      writer.write({ type: 'start' });
+
       // Write custom data (type must be 'data-<name>')
       writer.write({
         type: 'data-message',
@@ -68,7 +71,9 @@ const response = createUIMessageStreamResponse({
         prompt: 'Say hello',
       });
 
-      writer.merge(toUIMessageStream({ stream: result.stream }));
+      writer.merge(
+        toUIMessageStream({ stream: result.stream, sendStart: false }),
+      );
     },
   }),
 });


### PR DESCRIPTION
## Background

A composed UI message stream must emit one `start` before persistent data or text. The affected examples wrote parts first, then merged a model stream that emitted `start`; the late server message ID made the client append a second assistant message.

## Summary

- Start the outer UI message stream before writing custom parts.
- Suppress the merged model stream start with `sendStart: false`.

## Contributor Credit

Reported in #8734 by @raju-stuvio.

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

Related to #8734