### PR TITLE
feat(openai): support `gpt-4o-transcribe-diarize`

### DIFF
--- a/.changeset/calm-diarists-listen.md
+++ b/.changeset/calm-diarists-listen.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): support `gpt-4o-transcribe-diarize`, including chunking and diarized speaker metadata

--- a/content/docs/03-ai-sdk-core/36-transcription.mdx
+++ b/content/docs/03-ai-sdk-core/36-transcription.mdx
@@ -293,40 +293,41 @@ try {
 
 ## Transcription Models
 
-| Provider                                                                            | Model                    |
-| ----------------------------------------------------------------------------------- | ------------------------ |
-| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)                   | `whisper-1`              |
-| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)                   | `gpt-4o-transcribe`      |
-| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)                   | `gpt-4o-mini-transcribe` |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)           | `scribe_v1`              |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)           | `scribe_v1_experimental` |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)           | `scribe_v2`              |
-| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#streaming-transcription-models) | `scribe_v2_realtime`     |
-| [Groq](/providers/ai-sdk-providers/groq#transcription-models)                       | `whisper-large-v3-turbo` |
-| [Groq](/providers/ai-sdk-providers/groq#transcription-models)                       | `whisper-large-v3`       |
-| [Mistral](/providers/ai-sdk-providers/mistral#transcription-models)                 | `voxtral-mini-latest`    |
-| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)              | `whisper-1`              |
-| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)              | `gpt-4o-transcribe`      |
-| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)              | `gpt-4o-mini-transcribe` |
-| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                    | `machine`                |
-| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                    | `low_cost`               |
-| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                    | `fusion`                 |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `base` (+ variants)      |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `enhanced` (+ variants)  |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `nova` (+ variants)      |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `nova-2` (+ variants)    |
-| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `nova-3` (+ variants)    |
-| [Gladia](/providers/ai-sdk-providers/gladia#transcription-models)                   | `default`                |
-| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models)           | `universal-3-5-pro`      |
-| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models)           | `universal-3-pro`        |
-| [Fal](/providers/ai-sdk-providers/fal#transcription-models)                         | `whisper`                |
-| [Fal](/providers/ai-sdk-providers/fal#transcription-models)                         | `wizper`                 |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models)     | `chirp_2`                |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models)     | `chirp_3`                |
-| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models)     | `telephony`              |
-| [xAI](/providers/ai-sdk-providers/xai#transcription-models)                         | `default`                |
-| [Cartesia](/providers/ai-sdk-providers/cartesia#transcription-models)               | `ink-whisper`            |
-| [Cartesia](/providers/ai-sdk-providers/cartesia#streaming-transcription-models)     | `ink-2`                  |
-| [Fish Audio](/providers/ai-sdk-providers/fish-audio#transcription-models)           | `transcribe-1`           |
+| Provider                                                                            | Model                       |
+| ----------------------------------------------------------------------------------- | --------------------------- |
+| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)                   | `whisper-1`                 |
+| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)                   | `gpt-4o-transcribe`         |
+| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)                   | `gpt-4o-mini-transcribe`    |
+| [OpenAI](/providers/ai-sdk-providers/openai#transcription-models)                   | `gpt-4o-transcribe-diarize` |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)           | `scribe_v1`                 |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)           | `scribe_v1_experimental`    |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#transcription-models)           | `scribe_v2`                 |
+| [ElevenLabs](/providers/ai-sdk-providers/elevenlabs#streaming-transcription-models) | `scribe_v2_realtime`        |
+| [Groq](/providers/ai-sdk-providers/groq#transcription-models)                       | `whisper-large-v3-turbo`    |
+| [Groq](/providers/ai-sdk-providers/groq#transcription-models)                       | `whisper-large-v3`          |
+| [Mistral](/providers/ai-sdk-providers/mistral#transcription-models)                 | `voxtral-mini-latest`       |
+| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)              | `whisper-1`                 |
+| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)              | `gpt-4o-transcribe`         |
+| [Azure OpenAI](/providers/ai-sdk-providers/azure#transcription-models)              | `gpt-4o-mini-transcribe`    |
+| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                    | `machine`                   |
+| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                    | `low_cost`                  |
+| [Rev.ai](/providers/ai-sdk-providers/revai#transcription-models)                    | `fusion`                    |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `base` (+ variants)         |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `enhanced` (+ variants)     |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `nova` (+ variants)         |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `nova-2` (+ variants)       |
+| [Deepgram](/providers/ai-sdk-providers/deepgram#transcription-models)               | `nova-3` (+ variants)       |
+| [Gladia](/providers/ai-sdk-providers/gladia#transcription-models)                   | `default`                   |
+| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models)           | `universal-3-5-pro`         |
+| [AssemblyAI](/providers/ai-sdk-providers/assemblyai#transcription-models)           | `universal-3-pro`           |
+| [Fal](/providers/ai-sdk-providers/fal#transcription-models)                         | `whisper`                   |
+| [Fal](/providers/ai-sdk-providers/fal#transcription-models)                         | `wizper`                    |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models)     | `chirp_2`                   |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models)     | `chirp_3`                   |
+| [Google Vertex](/providers/ai-sdk-providers/google-vertex#transcription-models)     | `telephony`                 |
+| [xAI](/providers/ai-sdk-providers/xai#transcription-models)                         | `default`                   |
+| [Cartesia](/providers/ai-sdk-providers/cartesia#transcription-models)               | `ink-whisper`               |
+| [Cartesia](/providers/ai-sdk-providers/cartesia#streaming-transcription-models)     | `ink-2`                     |
+| [Fish Audio](/providers/ai-sdk-providers/fish-audio#transcription-models)           | `transcribe-1`              |
 
 Above are a small subset of the transcription models supported by the AI SDK providers. For more, see the respective provider documentation.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -3023,21 +3023,15 @@ console.log(result.segments); // Array of segments with startSecond/endSecond
 ```
 
 `gpt-4o-transcribe-diarize` identifies speakers in a recording. It defaults to
-the `diarized_json` response format. For audio longer than 30 seconds, set
-`chunkingStrategy` to `'auto'`:
+the `diarized_json` response format and automatic chunking:
 
-```ts highlight="9"
+```ts
 import { transcribe } from 'ai';
-import { openai, type OpenAITranscriptionModelOptions } from '@ai-sdk/openai';
+import { openai } from '@ai-sdk/openai';
 
 const result = await transcribe({
   model: openai.transcription('gpt-4o-transcribe-diarize'),
   audio: new Uint8Array([1, 2, 3, 4]),
-  providerOptions: {
-    openai: {
-      chunkingStrategy: 'auto',
-    } satisfies OpenAITranscriptionModelOptions,
-  },
 });
 
 console.log(result.providerMetadata.openai.segments);
@@ -3071,7 +3065,7 @@ The following provider options are available:
   The format of the transcription response. `gpt-4o-transcribe-diarize` defaults to `diarized_json`.
 
 - **chunkingStrategy** _'auto' | object_
-  Controls how the audio is split into chunks. `gpt-4o-transcribe-diarize` requires this option for inputs longer than 30 seconds. The object form configures OpenAI server-side VAD with `type: 'server_vad'` and optional `threshold`, `prefixPaddingMs`, and `silenceDurationMs` fields.
+  Controls how the audio is split into chunks. `gpt-4o-transcribe-diarize` defaults to `'auto'`; provide this option to override the default. The object form configures OpenAI server-side VAD with `type: 'server_vad'` and optional `threshold`, `prefixPaddingMs`, and `silenceDurationMs` fields.
 
 - **streaming** _object_
   Options for streaming transcription models such as `gpt-realtime-whisper`.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -3022,6 +3022,27 @@ const result = await transcribe({
 console.log(result.segments); // Array of segments with startSecond/endSecond
 ```
 
+`gpt-4o-transcribe-diarize` identifies speakers in a recording. It defaults to
+the `diarized_json` response format. For audio longer than 30 seconds, set
+`chunkingStrategy` to `'auto'`:
+
+```ts highlight="9"
+import { transcribe } from 'ai';
+import { openai, type OpenAITranscriptionModelOptions } from '@ai-sdk/openai';
+
+const result = await transcribe({
+  model: openai.transcription('gpt-4o-transcribe-diarize'),
+  audio: new Uint8Array([1, 2, 3, 4]),
+  providerOptions: {
+    openai: {
+      chunkingStrategy: 'auto',
+    } satisfies OpenAITranscriptionModelOptions,
+  },
+});
+
+console.log(result.providerMetadata.openai.segments);
+```
+
 The following provider options are available:
 
 - **timestampGranularities** _string[]_
@@ -3046,6 +3067,12 @@ The following provider options are available:
 - **include** _string[]_
   Additional information to include in the transcription response.
 
+- **responseFormat** _'json' | 'verbose_json' | 'diarized_json'_
+  The format of the transcription response. `gpt-4o-transcribe-diarize` defaults to `diarized_json`.
+
+- **chunkingStrategy** _'auto' | object_
+  Controls how the audio is split into chunks. `gpt-4o-transcribe-diarize` requires this option for inputs longer than 30 seconds. The object form configures OpenAI server-side VAD with `type: 'server_vad'` and optional `threshold`, `prefixPaddingMs`, and `silenceDurationMs` fields.
+
 - **streaming** _object_
   Options for streaming transcription models such as `gpt-realtime-whisper`.
   Use with `experimental_streamTranscribe`.
@@ -3057,12 +3084,13 @@ The following provider options are available:
 
 ### Model Capabilities
 
-| Model                    | Transcription | Streaming | Duration  | Segments  | Language  |
-| ------------------------ | ------------- | --------- | --------- | --------- | --------- |
-| `whisper-1`              | <Check />     | <Cross /> | <Check /> | <Check /> | <Check /> |
-| `gpt-4o-mini-transcribe` | <Check />     | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
-| `gpt-4o-transcribe`      | <Check />     | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
-| `gpt-realtime-whisper`   | <Cross />     | <Check /> | <Cross /> | <Cross /> | <Cross /> |
+| Model                       | Transcription | Streaming | Duration  | Segments  | Language  |
+| --------------------------- | ------------- | --------- | --------- | --------- | --------- |
+| `whisper-1`                 | <Check />     | <Cross /> | <Check /> | <Check /> | <Check /> |
+| `gpt-4o-mini-transcribe`    | <Check />     | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+| `gpt-4o-transcribe`         | <Check />     | <Cross /> | <Cross /> | <Cross /> | <Cross /> |
+| `gpt-4o-transcribe-diarize` | <Check />     | <Cross /> | <Check /> | <Check /> | <Cross /> |
+| `gpt-realtime-whisper`      | <Cross />     | <Check /> | <Cross /> | <Cross /> | <Cross /> |
 
 ## Translation Models
 

--- a/packages/openai/src/transcription/__fixtures__/openai-diarized-transcription.json
+++ b/packages/openai/src/transcription/__fixtures__/openai-diarized-transcription.json
@@ -1,0 +1,23 @@
+{
+  "task": "transcribe",
+  "duration": 3.2,
+  "text": "Hello from Alice. Hello from Bob.",
+  "segments": [
+    {
+      "type": "transcript.text.segment",
+      "id": "seg_001",
+      "start": 0,
+      "end": 1.5,
+      "text": "Hello from Alice.",
+      "speaker": "A"
+    },
+    {
+      "type": "transcript.text.segment",
+      "id": "seg_002",
+      "start": 1.5,
+      "end": 3.2,
+      "text": "Hello from Bob.",
+      "speaker": "B"
+    }
+  ]
+}

--- a/packages/openai/src/transcription/openai-transcription-api.ts
+++ b/packages/openai/src/transcription/openai-transcription-api.ts
@@ -18,18 +18,28 @@ export const openaiTranscriptionResponseSchema = lazySchema(() =>
         .nullish(),
       segments: z
         .array(
-          z.object({
-            id: z.number(),
-            seek: z.number(),
-            start: z.number(),
-            end: z.number(),
-            text: z.string(),
-            tokens: z.array(z.number()),
-            temperature: z.number(),
-            avg_logprob: z.number(),
-            compression_ratio: z.number(),
-            no_speech_prob: z.number(),
-          }),
+          z.union([
+            z.object({
+              id: z.number(),
+              seek: z.number(),
+              start: z.number(),
+              end: z.number(),
+              text: z.string(),
+              tokens: z.array(z.number()),
+              temperature: z.number(),
+              avg_logprob: z.number(),
+              compression_ratio: z.number(),
+              no_speech_prob: z.number(),
+            }),
+            z.object({
+              type: z.literal('transcript.text.segment'),
+              id: z.string(),
+              start: z.number(),
+              end: z.number(),
+              text: z.string(),
+              speaker: z.string(),
+            }),
+          ]),
         )
         .nullish(),
     }),

--- a/packages/openai/src/transcription/openai-transcription-model-options.ts
+++ b/packages/openai/src/transcription/openai-transcription-model-options.ts
@@ -51,6 +51,28 @@ export const openAITranscriptionModelOptions = lazySchema(() =>
         .optional(),
 
       /**
+       * The format of the transcription response.
+       */
+      responseFormat: z
+        .enum(['json', 'verbose_json', 'diarized_json'])
+        .optional(),
+
+      /**
+       * Controls how the audio is split into chunks before transcription.
+       */
+      chunkingStrategy: z
+        .union([
+          z.literal('auto'),
+          z.object({
+            type: z.literal('server_vad'),
+            threshold: z.number().min(0).max(1).optional(),
+            prefixPaddingMs: z.number().int().min(0).optional(),
+            silenceDurationMs: z.number().int().min(0).optional(),
+          }),
+        ])
+        .optional(),
+
+      /**
        * Options for streaming transcription models such as `gpt-realtime-whisper`.
        */
       streaming: z

--- a/packages/openai/src/transcription/openai-transcription-model.test.ts
+++ b/packages/openai/src/transcription/openai-transcription-model.test.ts
@@ -283,6 +283,7 @@ describe('doGenerate', () => {
     const { file: _, ...rest } = body!;
     expect(rest).toMatchInlineSnapshot(`
       {
+        "chunking_strategy": "auto",
         "model": "gpt-4o-transcribe-diarize",
         "response_format": "diarized_json",
       }

--- a/packages/openai/src/transcription/openai-transcription-model.test.ts
+++ b/packages/openai/src/transcription/openai-transcription-model.test.ts
@@ -269,6 +269,115 @@ describe('doGenerate', () => {
     `);
   });
 
+  it('should support gpt-4o-transcribe-diarize', async () => {
+    prepareJsonFixtureResponse('openai-diarized-transcription');
+
+    const model = provider.transcription('gpt-4o-transcribe-diarize');
+    const result = await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/mpeg',
+    });
+
+    const body = await server.calls[0].requestBodyMultipart;
+    expect(body!.file).toBeInstanceOf(File);
+    const { file: _, ...rest } = body!;
+    expect(rest).toMatchInlineSnapshot(`
+      {
+        "model": "gpt-4o-transcribe-diarize",
+        "response_format": "diarized_json",
+      }
+    `);
+
+    expect(result).toMatchObject({
+      text: 'Hello from Alice. Hello from Bob.',
+      durationInSeconds: 3.2,
+      segments: [
+        {
+          text: 'Hello from Alice.',
+          startSecond: 0,
+          endSecond: 1.5,
+        },
+        {
+          text: 'Hello from Bob.',
+          startSecond: 1.5,
+          endSecond: 3.2,
+        },
+      ],
+      providerMetadata: {
+        openai: {
+          segments: [
+            {
+              text: 'Hello from Alice.',
+              startSecond: 0,
+              endSecond: 1.5,
+              speaker: 'A',
+            },
+            {
+              text: 'Hello from Bob.',
+              startSecond: 1.5,
+              endSecond: 3.2,
+              speaker: 'B',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('should pass diarization response format and chunking strategy provider options', async () => {
+    prepareJsonFixtureResponse('openai-transcription');
+
+    const model = provider.transcription('gpt-4o-transcribe-diarize');
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/mpeg',
+      providerOptions: {
+        openai: {
+          responseFormat: 'json',
+          chunkingStrategy: 'auto',
+        },
+      },
+    });
+
+    const body = await server.calls[0].requestBodyMultipart;
+    expect(body!.file).toBeInstanceOf(File);
+    const { file: _, ...rest } = body!;
+    expect(rest).toMatchInlineSnapshot(`
+      {
+        "chunking_strategy": "auto",
+        "model": "gpt-4o-transcribe-diarize",
+        "response_format": "json",
+        "temperature": "0",
+        "timestamp_granularities[]": "segment",
+      }
+    `);
+  });
+
+  it('should serialize a server VAD chunking strategy', async () => {
+    prepareJsonFixtureResponse('openai-diarized-transcription');
+
+    const model = provider.transcription('gpt-4o-transcribe-diarize');
+    await model.doGenerate({
+      audio: audioData,
+      mediaType: 'audio/mpeg',
+      providerOptions: {
+        openai: {
+          chunkingStrategy: {
+            type: 'server_vad',
+            threshold: 0.7,
+            prefixPaddingMs: 400,
+            silenceDurationMs: 300,
+          },
+        },
+      },
+    });
+
+    const body = await server.calls[0].requestBodyMultipart;
+    expect(body!.chunking_strategy).toBe(
+      '{"type":"server_vad","threshold":0.7,"prefix_padding_ms":400,"silence_duration_ms":300}',
+    );
+  });
+
   it('should pass timestamp_granularities when specified', async () => {
     prepareJsonFixtureResponse('openai-transcription');
 

--- a/packages/openai/src/transcription/openai-transcription-model.ts
+++ b/packages/openai/src/transcription/openai-transcription-model.ts
@@ -196,6 +196,9 @@ export class OpenAITranscriptionModel implements TranscriptionModelV4 {
     }
 
     const isDiarizationModel = this.modelId === 'gpt-4o-transcribe-diarize';
+    const chunkingStrategy =
+      openAIOptions?.chunkingStrategy ??
+      (isDiarizationModel ? 'auto' : undefined);
 
     // Add provider-specific options
     if (openAIOptions) {
@@ -234,31 +237,28 @@ export class OpenAITranscriptionModel implements TranscriptionModelV4 {
           }
         }
       }
-
-      if (openAIOptions.chunkingStrategy != null) {
-        formData.append(
-          'chunking_strategy',
-          typeof openAIOptions.chunkingStrategy === 'string'
-            ? openAIOptions.chunkingStrategy
-            : JSON.stringify({
-                type: openAIOptions.chunkingStrategy.type,
-                ...(openAIOptions.chunkingStrategy.threshold != null && {
-                  threshold: openAIOptions.chunkingStrategy.threshold,
-                }),
-                ...(openAIOptions.chunkingStrategy.prefixPaddingMs != null && {
-                  prefix_padding_ms:
-                    openAIOptions.chunkingStrategy.prefixPaddingMs,
-                }),
-                ...(openAIOptions.chunkingStrategy.silenceDurationMs !=
-                  null && {
-                  silence_duration_ms:
-                    openAIOptions.chunkingStrategy.silenceDurationMs,
-                }),
-              }),
-        );
-      }
     } else if (isDiarizationModel) {
       formData.append('response_format', 'diarized_json');
+    }
+
+    if (chunkingStrategy != null) {
+      formData.append(
+        'chunking_strategy',
+        typeof chunkingStrategy === 'string'
+          ? chunkingStrategy
+          : JSON.stringify({
+              type: chunkingStrategy.type,
+              ...(chunkingStrategy.threshold != null && {
+                threshold: chunkingStrategy.threshold,
+              }),
+              ...(chunkingStrategy.prefixPaddingMs != null && {
+                prefix_padding_ms: chunkingStrategy.prefixPaddingMs,
+              }),
+              ...(chunkingStrategy.silenceDurationMs != null && {
+                silence_duration_ms: chunkingStrategy.silenceDurationMs,
+              }),
+            }),
+      );
     }
 
     return {

--- a/packages/openai/src/transcription/openai-transcription-model.ts
+++ b/packages/openai/src/transcription/openai-transcription-model.ts
@@ -195,6 +195,8 @@ export class OpenAITranscriptionModel implements TranscriptionModelV4 {
       formData.append('response_format', 'verbose_json');
     }
 
+    const isDiarizationModel = this.modelId === 'gpt-4o-transcribe-diarize';
+
     // Add provider-specific options
     if (openAIOptions) {
       const isGpt4oTranscribeModel = [
@@ -209,7 +211,13 @@ export class OpenAITranscriptionModel implements TranscriptionModelV4 {
         // https://platform.openai.com/docs/api-reference/audio/createTranscription#audio_createtranscription-response_format
         // prefer verbose_json to get segments for models that support it
         ...(this.modelId !== 'whisper-1' && {
-          response_format: isGpt4oTranscribeModel ? 'json' : 'verbose_json',
+          response_format:
+            openAIOptions.responseFormat ??
+            (isDiarizationModel
+              ? 'diarized_json'
+              : isGpt4oTranscribeModel
+                ? 'json'
+                : 'verbose_json'),
         }),
         temperature: openAIOptions.temperature,
         timestamp_granularities: openAIOptions.timestampGranularities,
@@ -226,6 +234,31 @@ export class OpenAITranscriptionModel implements TranscriptionModelV4 {
           }
         }
       }
+
+      if (openAIOptions.chunkingStrategy != null) {
+        formData.append(
+          'chunking_strategy',
+          typeof openAIOptions.chunkingStrategy === 'string'
+            ? openAIOptions.chunkingStrategy
+            : JSON.stringify({
+                type: openAIOptions.chunkingStrategy.type,
+                ...(openAIOptions.chunkingStrategy.threshold != null && {
+                  threshold: openAIOptions.chunkingStrategy.threshold,
+                }),
+                ...(openAIOptions.chunkingStrategy.prefixPaddingMs != null && {
+                  prefix_padding_ms:
+                    openAIOptions.chunkingStrategy.prefixPaddingMs,
+                }),
+                ...(openAIOptions.chunkingStrategy.silenceDurationMs !=
+                  null && {
+                  silence_duration_ms:
+                    openAIOptions.chunkingStrategy.silenceDurationMs,
+                }),
+              }),
+        );
+      }
+    } else if (isDiarizationModel) {
+      formData.append('response_format', 'diarized_json');
     }
 
     return {
@@ -270,6 +303,19 @@ export class OpenAITranscriptionModel implements TranscriptionModelV4 {
         ? languageMap[response.language as keyof typeof languageMap]
         : undefined;
 
+    const diarizedSegments = response.segments?.flatMap(segment =>
+      'speaker' in segment
+        ? [
+            {
+              text: segment.text,
+              startSecond: segment.start,
+              endSecond: segment.end,
+              speaker: segment.speaker,
+            },
+          ]
+        : [],
+    );
+
     return {
       text: response.text,
       segments:
@@ -293,6 +339,14 @@ export class OpenAITranscriptionModel implements TranscriptionModelV4 {
         headers: responseHeaders,
         body: rawResponse,
       },
+      ...(diarizedSegments != null &&
+        diarizedSegments.length > 0 && {
+          providerMetadata: {
+            openai: {
+              segments: diarizedSegments,
+            },
+          },
+        }),
     };
   }
 


### PR DESCRIPTION
## Background

`gpt-4o-transcribe-diarize` was unusable through AI SDK because OpenAI requires a chunking strategy, while the provider’s default response format was incompatible with diarized transcription.

## Summary

- Add support for `gpt-4o-transcribe-diarize`, including OpenAI chunking strategy and response-format options.
- Default diarization requests to automatic chunking and `diarized_json`.
- Surface speaker labels in OpenAI provider metadata alongside normalized transcription segments.

## End-to-End Verification

- ran live OpenAI requests using with no provider options; transcription succeeded and returned nine speaker-labeled segments.
- verified explicit `responseFormat: 'json'` and a configured `server_vad` chunking strategy also complete successfully

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

Fixes https://github.com/vercel/ai/issues/11679