### PR TITLE
feat(harness-acp): support control over how host tools are exposed via `hostToolMcpTransport` config

### DIFF
--- a/.changeset/slimy-dryers-brush.md
+++ b/.changeset/slimy-dryers-brush.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-acp": patch
+---
+
+feat(harness-acp): support control over how host tools are exposed via `hostToolMcpTransport` config

--- a/content/providers/02-ai-sdk-harnesses/06-acp.mdx
+++ b/content/providers/02-ai-sdk-harnesses/06-acp.mdx
@@ -87,6 +87,11 @@ try {
 - `builtinTools`: optional native tool definitions for static typing and exact
   name matching.
 - `mcpServers`: MCP server definitions keyed by server name.
+- `hostToolMcpTransport`: transport used for the harness-owned MCP server that
+  exposes host tools to the ACP implementation. It defaults to `'stdio'`. Set
+  this to `'http'` for implementations that only accept HTTP or SSE MCP servers
+  from the client, which requires the implementation to advertise
+  `agentCapabilities.mcpCapabilities.http`.
 - `authentication`: advertised ACP authentication method, metadata, and client
   capabilities.
 - `auth`: downstream provider authentication mode:

--- a/packages/harness-acp/src/acp-harness.ts
+++ b/packages/harness-acp/src/acp-harness.ts
@@ -74,6 +74,14 @@ export type ACPHarnessSettings<
   readonly skillsDirectory?: ACPV1Settings['skillsDirectory'];
   readonly instructionMapping?: ACPV1Settings['instructionMapping'];
   readonly outputSchemaMapping?: ACPV1Settings['outputSchemaMapping'];
+  /**
+   * Transport used for the harness-owned MCP server that exposes host tools to
+   * the ACP implementation. Defaults to `stdio`. Set this to `http` for
+   * implementations that only accept HTTP or SSE MCP servers from the client,
+   * which requires the implementation to advertise
+   * `agentCapabilities.mcpCapabilities.http`.
+   */
+  readonly hostToolMcpTransport?: ACPV1Settings['hostToolMcpTransport'];
   readonly askUserQuestions?: TAskUserQuestions;
   readonly permissionModeMapping?: ACPV1Settings['permissionModeMapping'];
   readonly session?: ACPV1Settings['session'];

--- a/packages/harness-acp/src/index.ts
+++ b/packages/harness-acp/src/index.ts
@@ -23,6 +23,7 @@ export type {
   ACPAskUserQuestionsSettings,
   ACPCredentialBrokering,
   ACPAuthentication,
+  ACPHostToolMCPTransport,
   ACPInstallCommandSource,
   ACPInstructionMapping,
   ACPModelMapping,

--- a/packages/harness-acp/src/v1/acp-v1-harness.ts
+++ b/packages/harness-acp/src/v1/acp-v1-harness.ts
@@ -623,6 +623,7 @@ export function createACPV1<TBuiltinTools extends ToolSet = {}>({
             clientCapabilities: settings.clientCapabilities,
             askUserQuestionsRequestMethod:
               settings.askUserQuestions?.requestMethod,
+            hostToolMcpTransport: settings.hostToolMcpTransport,
           }),
           ...sandboxProviderAuthenticationEnvironment,
           BRIDGE_CHANNEL_TOKEN: token,

--- a/packages/harness-acp/src/v1/acp-v1-settings.ts
+++ b/packages/harness-acp/src/v1/acp-v1-settings.ts
@@ -133,6 +133,12 @@ export type ACPOutputSchemaMapping = {
   readonly path: ReadonlyArray<string>;
 };
 
+/**
+ * Transport used for the harness-owned MCP server that exposes host tools to
+ * an ACP implementation.
+ */
+export type ACPHostToolMCPTransport = 'stdio' | 'http';
+
 export type ACPAskUserQuestionsSettings = {
   readonly requestMethod: string;
   readonly isNativeToolCall?: (options: {
@@ -202,6 +208,14 @@ export type ACPV1Settings = {
    * below the ACP session prompt's `_meta` field.
    */
   readonly outputSchemaMapping?: ACPOutputSchemaMapping;
+  /**
+   * Transport used for the harness-owned MCP server that exposes host tools to
+   * the ACP implementation. Defaults to `stdio`. Set this to `http` for
+   * implementations that only accept HTTP or SSE MCP servers from the client,
+   * which requires the implementation to advertise
+   * `agentCapabilities.mcpCapabilities.http`.
+   */
+  readonly hostToolMcpTransport?: ACPHostToolMCPTransport;
   readonly askUserQuestions?: ACPAskUserQuestionsSettings;
   readonly permissionModeMapping?: ACPPermissionModeMapping;
   readonly session?: {

--- a/packages/harness-acp/src/v1/bridge/acp-v1-bridge-environment.ts
+++ b/packages/harness-acp/src/v1/bridge/acp-v1-bridge-environment.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod/v4';
 import type {
   ACPAuthentication,
+  ACPHostToolMCPTransport,
   ACPProfileValue,
   ACPSerializableValue,
 } from '../acp-v1-settings';
@@ -33,6 +34,11 @@ const profileValueSchema: z.ZodType<ACPProfileValue> = z.lazy(() =>
   ]),
 );
 
+const hostToolMcpTransportSchema: z.ZodType<ACPHostToolMCPTransport> = z.enum([
+  'stdio',
+  'http',
+]);
+
 const serializableRecordSchema = z.record(z.string(), serializableValueSchema);
 const profileRecordSchema = z.record(z.string(), profileValueSchema);
 
@@ -61,6 +67,7 @@ export type ACPBridgeConfiguration = {
   readonly sessionMeta?: Readonly<Record<string, ACPSerializableValue>>;
   readonly clientCapabilities?: Readonly<Record<string, ACPSerializableValue>>;
   readonly askUserQuestionsRequestMethod?: string;
+  readonly hostToolMcpTransport?: ACPHostToolMCPTransport;
 };
 
 const bridgeConfigurationSchema: z.ZodType<ACPBridgeConfiguration> = z.object({
@@ -70,6 +77,7 @@ const bridgeConfigurationSchema: z.ZodType<ACPBridgeConfiguration> = z.object({
   sessionMeta: serializableRecordSchema.optional(),
   clientCapabilities: serializableRecordSchema.optional(),
   askUserQuestionsRequestMethod: z.string().optional(),
+  hostToolMcpTransport: hostToolMcpTransportSchema.optional(),
 });
 
 export function createACPBridgeEnvironment({
@@ -79,6 +87,7 @@ export function createACPBridgeEnvironment({
   sessionMeta,
   clientCapabilities,
   askUserQuestionsRequestMethod,
+  hostToolMcpTransport,
 }: ACPBridgeConfiguration): Record<string, string> {
   return {
     [ACP_BRIDGE_CONFIGURATION_ENV]: JSON.stringify({
@@ -90,6 +99,7 @@ export function createACPBridgeEnvironment({
       ...(askUserQuestionsRequestMethod == null
         ? {}
         : { askUserQuestionsRequestMethod }),
+      ...(hostToolMcpTransport == null ? {} : { hostToolMcpTransport }),
     }),
   };
 }

--- a/packages/harness-acp/src/v1/bridge/host-tool-mcp-definition.test.ts
+++ b/packages/harness-acp/src/v1/bridge/host-tool-mcp-definition.test.ts
@@ -1,0 +1,119 @@
+import { HarnessBridgeCapabilityUnsupportedError } from '@ai-sdk/harness/bridge';
+import { describe, expect, it } from 'vitest';
+import { createHostToolMcpServerDefinition } from './host-tool-mcp-definition';
+
+const relay = {
+  url: 'http://127.0.0.1:5001/invoke',
+  mcpUrl: 'http://127.0.0.1:5001/mcp',
+  credential: 'relay-credential',
+};
+
+describe('createHostToolMcpServerDefinition', () => {
+  it('launches the stdio MCP process for the stdio transport', () => {
+    const definition = createHostToolMcpServerDefinition({
+      mcpTransport: 'stdio',
+      relay,
+      serverName: 'ai-sdk-harness-tools',
+      catalogPath: '/state/host-tools.json',
+      initialization: {},
+      harnessId: 'example-acp',
+    });
+
+    expect(definition).toMatchObject({
+      name: 'ai-sdk-harness-tools',
+      args: [expect.stringContaining('host-tool-mcp.mjs')],
+      env: [
+        {
+          name: 'AI_SDK_ACP_HOST_TOOLS_FILE',
+          value: '/state/host-tools.json',
+        },
+        {
+          name: 'AI_SDK_ACP_HOST_TOOL_RELAY_URL',
+          value: 'http://127.0.0.1:5001/invoke',
+        },
+        {
+          name: 'AI_SDK_ACP_HOST_TOOL_RELAY_CREDENTIAL',
+          value: 'relay-credential',
+        },
+      ],
+    });
+    expect(definition).not.toHaveProperty('type');
+  });
+
+  it('points at the relay MCP endpoint for the http transport', () => {
+    const definition = createHostToolMcpServerDefinition({
+      mcpTransport: 'http',
+      relay,
+      serverName: 'ai-sdk-harness-tools',
+      catalogPath: '/state/host-tools.json',
+      initialization: {
+        agentCapabilities: { mcpCapabilities: { http: true, sse: true } },
+      },
+      harnessId: 'github-copilot',
+    });
+
+    expect(definition).toEqual({
+      type: 'http',
+      name: 'ai-sdk-harness-tools',
+      url: 'http://127.0.0.1:5001/mcp',
+      headers: [{ name: 'Authorization', value: 'Bearer relay-credential' }],
+    });
+  });
+
+  it('reports an unsupported capability when the agent rejects HTTP MCP servers', () => {
+    expect(() =>
+      createHostToolMcpServerDefinition({
+        mcpTransport: 'http',
+        relay,
+        serverName: 'ai-sdk-harness-tools',
+        catalogPath: '/state/host-tools.json',
+        initialization: {
+          agentCapabilities: { mcpCapabilities: { http: false, sse: false } },
+        },
+        harnessId: 'github-copilot',
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        name: 'AI_HarnessBridgeCapabilityUnsupportedError',
+        message: expect.stringContaining(
+          'does not advertise support for HTTP MCP servers',
+        ),
+      }),
+    );
+  });
+
+  it('reports an unsupported capability when the agent omits MCP capabilities', () => {
+    let thrown: unknown;
+    try {
+      createHostToolMcpServerDefinition({
+        mcpTransport: 'http',
+        relay,
+        serverName: 'ai-sdk-harness-tools',
+        catalogPath: '/state/host-tools.json',
+        initialization: {},
+        harnessId: 'github-copilot',
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(HarnessBridgeCapabilityUnsupportedError.isInstance(thrown)).toBe(
+      true,
+    );
+  });
+
+  it('fails when the relay did not start an MCP endpoint', () => {
+    expect(() =>
+      createHostToolMcpServerDefinition({
+        mcpTransport: 'http',
+        relay: { ...relay, mcpUrl: undefined },
+        serverName: 'ai-sdk-harness-tools',
+        catalogPath: '/state/host-tools.json',
+        initialization: {
+          agentCapabilities: { mcpCapabilities: { http: true, sse: true } },
+        },
+        harnessId: 'github-copilot',
+      }),
+    ).toThrowError('The host tool MCP HTTP endpoint is unavailable.');
+  });
+});

--- a/packages/harness-acp/src/v1/bridge/host-tool-mcp-definition.ts
+++ b/packages/harness-acp/src/v1/bridge/host-tool-mcp-definition.ts
@@ -1,0 +1,69 @@
+import { fileURLToPath } from 'node:url';
+import { execPath } from 'node:process';
+import type * as acp from '@agentclientprotocol/sdk';
+import { HarnessBridgeCapabilityUnsupportedError } from '@ai-sdk/harness/bridge';
+import type { ACPHostToolMCPTransport } from '../acp-v1-settings';
+import type { HostToolRelay } from './host-tool-relay';
+
+/*
+ * Builds the ACP `session/new` definition for the harness-owned MCP server
+ * that exposes host tools. The stdio transport launches `host-tool-mcp.mjs`,
+ * which bridges back to the relay over its private HTTP protocol. The http
+ * transport points the ACP implementation straight at the relay's own MCP
+ * endpoint, which is required by implementations that reject client-supplied
+ * stdio MCP servers.
+ */
+export function createHostToolMcpServerDefinition({
+  mcpTransport,
+  relay,
+  serverName,
+  catalogPath,
+  initialization,
+  harnessId,
+}: {
+  mcpTransport: ACPHostToolMCPTransport;
+  relay: Pick<HostToolRelay, 'url' | 'mcpUrl' | 'credential'>;
+  serverName: string;
+  catalogPath: string;
+  initialization: Pick<acp.InitializeResponse, 'agentCapabilities'>;
+  harnessId: string;
+}): acp.McpServer {
+  if (mcpTransport === 'stdio') {
+    return {
+      name: serverName,
+      command: execPath,
+      args: [fileURLToPath(new URL('./host-tool-mcp.mjs', import.meta.url))],
+      env: [
+        {
+          name: 'AI_SDK_ACP_HOST_TOOLS_FILE',
+          value: catalogPath,
+        },
+        {
+          name: 'AI_SDK_ACP_HOST_TOOL_RELAY_URL',
+          value: relay.url,
+        },
+        {
+          name: 'AI_SDK_ACP_HOST_TOOL_RELAY_CREDENTIAL',
+          value: relay.credential,
+        },
+      ],
+    };
+  }
+  if (initialization.agentCapabilities?.mcpCapabilities?.http !== true) {
+    throw new HarnessBridgeCapabilityUnsupportedError({
+      harnessId,
+      message:
+        'This harness exposes host tools through an HTTP MCP server, but ' +
+        'the ACP agent does not advertise support for HTTP MCP servers.',
+    });
+  }
+  if (relay.mcpUrl == null) {
+    throw new Error('The host tool MCP HTTP endpoint is unavailable.');
+  }
+  return {
+    type: 'http',
+    name: serverName,
+    url: relay.mcpUrl,
+    headers: [{ name: 'Authorization', value: `Bearer ${relay.credential}` }],
+  };
+}

--- a/packages/harness-acp/src/v1/bridge/host-tool-mcp-http.test.ts
+++ b/packages/harness-acp/src/v1/bridge/host-tool-mcp-http.test.ts
@@ -1,0 +1,276 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  startHostToolRelay,
+  type HostToolRelay,
+  type HostToolRelayTurn,
+} from './host-tool-relay';
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  const pending = cleanups.splice(0, cleanups.length).reverse();
+  for (const cleanup of pending) await cleanup();
+});
+
+describe('host tool MCP HTTP transport', () => {
+  it('exposes an MCP endpoint alongside the relay endpoint', async () => {
+    const relay = await createRelay({
+      tools: [{ name: 'weather', inputSchema: { type: 'object' } }],
+    });
+
+    expect(relay.mcpUrl).toBe(new URL('/mcp', relay.url).toString());
+  });
+
+  it('omits the MCP endpoint for the stdio transport', async () => {
+    const relay = await createRelay({
+      tools: [{ name: 'weather', inputSchema: { type: 'object' } }],
+      mcpTransport: 'stdio',
+    });
+
+    expect(relay.mcpUrl).toBeUndefined();
+  });
+
+  it('lists host tools, acknowledges the catalog, and invokes through the turn', async () => {
+    const emitToolCall = vi.fn();
+    const emitToolResult = vi.fn();
+    const registerCorrelationInvocation = vi.fn();
+    const relay = await createRelay({
+      tools: [
+        {
+          name: 'weather',
+          description: 'Get the current temperature for a city.',
+          inputSchema: {
+            type: 'object',
+            properties: { city: { type: 'string' } },
+          },
+        },
+      ],
+    });
+    relay.bindTurn({
+      turn: createTurn({
+        emitToolCall,
+        emitToolResult,
+        registerCorrelationInvocation,
+        requestToolResult: async () => ({ output: { celsius: 12 } }),
+      }),
+    });
+    const client = await connect({ relay });
+
+    const listed = await client.listTools();
+    expect(listed.tools).toEqual([
+      {
+        name: 'weather',
+        description: 'Get the current temperature for a city.',
+        inputSchema: {
+          type: 'object',
+          properties: { city: { type: 'string' } },
+        },
+      },
+    ]);
+    await expect(
+      relay.waitForCatalogRefresh({ revision: 1, timeoutMs: 5_000 }),
+    ).resolves.toBe(true);
+
+    const result = await client.callTool({
+      name: 'weather',
+      arguments: { city: 'Paris' },
+    });
+    expect(result).toMatchObject({
+      content: [{ type: 'text', text: '{"celsius":12}' }],
+      _meta: {
+        'ai-sdk-harness-acp-correlation':
+          expect.stringMatching(/^[a-f0-9]{64}$/),
+      },
+    });
+    expect(emitToolCall).toHaveBeenCalledWith({
+      toolCallId: expect.any(String),
+      toolName: 'weather',
+      input: { city: 'Paris' },
+    });
+    expect(emitToolResult).toHaveBeenCalledWith({
+      toolCallId: expect.any(String),
+      toolName: 'weather',
+      output: { celsius: 12 },
+    });
+    expect(registerCorrelationInvocation).toHaveBeenCalledWith({
+      token: expect.stringMatching(/^[a-f0-9]{64}$/),
+      serverName: 'ai-sdk-harness-tools',
+      toolName: 'weather',
+      input: { city: 'Paris' },
+      order: 1,
+    });
+  });
+
+  it('notifies the connected session when the catalog changes', async () => {
+    const relay = await createRelay({
+      tools: [{ name: 'weather', inputSchema: { type: 'object' } }],
+    });
+    const client = await connect({ relay });
+    const listChanged = vi.fn();
+    client.setNotificationHandler(
+      ToolListChangedNotificationSchema,
+      listChanged,
+    );
+    await client.listTools();
+
+    const updated = relay.updateCatalog({
+      tools: [
+        { name: 'weather', inputSchema: { type: 'object' } },
+        { name: 'clock', inputSchema: { type: 'object' } },
+      ],
+    });
+    expect(updated).toEqual({ changed: true, revision: 2 });
+
+    await vi.waitFor(() => {
+      expect(listChanged).toHaveBeenCalled();
+    });
+    const listed = await client.listTools();
+    expect(listed.tools.map(tool => tool.name)).toEqual(['weather', 'clock']);
+    await expect(
+      relay.waitForCatalogRefresh({ revision: 2, timeoutMs: 5_000 }),
+    ).resolves.toBe(true);
+  });
+
+  it('rejects tool invocations from a stale catalog revision', async () => {
+    const relay = await createRelay({
+      tools: [{ name: 'weather', inputSchema: { type: 'object' } }],
+    });
+    relay.bindTurn({
+      turn: createTurn({
+        requestToolResult: async () => ({ output: { celsius: 12 } }),
+      }),
+    });
+    const client = await connect({ relay });
+    await client.listTools();
+    relay.updateCatalog({
+      tools: [{ name: 'clock', inputSchema: { type: 'object' } }],
+    });
+
+    await expect(
+      client.callTool({ name: 'weather', arguments: {} }),
+    ).rejects.toThrow(/Unknown host tool: weather/);
+  });
+
+  it('rejects MCP requests without the relay credential', async () => {
+    const relay = await createRelay({
+      tools: [{ name: 'weather', inputSchema: { type: 'object' } }],
+    });
+
+    const response = await fetch(relay.mcpUrl!, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json, text/event-stream',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '1.0.0' },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Invalid host tool relay credential.',
+    });
+  });
+
+  it('rejects session-less requests that are not an initialize request', async () => {
+    const relay = await createRelay({
+      tools: [{ name: 'weather', inputSchema: { type: 'object' } }],
+    });
+
+    const response = await fetch(relay.mcpUrl!, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json, text/event-stream',
+        authorization: `Bearer ${relay.credential}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        message:
+          'Host tool MCP requests without a session id must be an initialize request.',
+      },
+    });
+  });
+
+  it('rejects requests for an unknown MCP session', async () => {
+    const relay = await createRelay({
+      tools: [{ name: 'weather', inputSchema: { type: 'object' } }],
+    });
+
+    const response = await fetch(relay.mcpUrl!, {
+      method: 'GET',
+      headers: {
+        accept: 'text/event-stream',
+        authorization: `Bearer ${relay.credential}`,
+        'mcp-session-id': 'not-a-live-session',
+      },
+    });
+
+    expect(response.status).toBe(404);
+  });
+});
+
+async function createRelay({
+  tools,
+  mcpTransport = 'http',
+}: {
+  tools: Parameters<typeof startHostToolRelay>[0]['tools'];
+  mcpTransport?: Parameters<typeof startHostToolRelay>[0]['mcpTransport'];
+}): Promise<HostToolRelay> {
+  const relay = await startHostToolRelay({
+    tools,
+    serverName: 'ai-sdk-harness-tools',
+    mcpTransport,
+  });
+  cleanups.push(() => relay.close());
+  return relay;
+}
+
+async function connect({ relay }: { relay: HostToolRelay }): Promise<Client> {
+  const client = new Client({ name: 'host-tool-test', version: '1.0.0' });
+  const transport = new StreamableHTTPClientTransport(new URL(relay.mcpUrl!), {
+    requestInit: {
+      headers: { authorization: `Bearer ${relay.credential}` },
+    },
+  });
+  await client.connect(transport);
+  cleanups.push(() => client.close());
+  return client;
+}
+
+function createTurn({
+  emitToolCall = vi.fn(),
+  emitToolResult = vi.fn(),
+  registerCorrelationInvocation = vi.fn(),
+  removeCorrelationInvocation = vi.fn(),
+  requestToolResult,
+}: {
+  emitToolCall?: HostToolRelayTurn['emitToolCall'];
+  emitToolResult?: HostToolRelayTurn['emitToolResult'];
+  registerCorrelationInvocation?: HostToolRelayTurn['registerCorrelationInvocation'];
+  removeCorrelationInvocation?: HostToolRelayTurn['removeCorrelationInvocation'];
+  requestToolResult: HostToolRelayTurn['requestToolResult'];
+}): HostToolRelayTurn {
+  return {
+    emitToolCall,
+    emitToolResult,
+    registerCorrelationInvocation,
+    removeCorrelationInvocation,
+    requestToolResult,
+  };
+}

--- a/packages/harness-acp/src/v1/bridge/host-tool-mcp-http.ts
+++ b/packages/harness-acp/src/v1/bridge/host-tool-mcp-http.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import type { HarnessV1BridgeToolWire } from '@ai-sdk/harness';
+import {
+  createHostToolMCPServer,
+  type HostToolMCPInvocationResult,
+  type HostToolMCPServer,
+} from './host-tool-mcp-server';
+
+export const HOST_TOOL_MCP_ENDPOINT_PATH = '/mcp';
+
+export type HostToolMCPHttpEndpoint = {
+  handleRequest(options: {
+    request: IncomingMessage;
+    response: ServerResponse;
+    body?: unknown;
+  }): Promise<void>;
+  updateCatalog(options: {
+    revision: number;
+    tools: ReadonlyArray<HarnessV1BridgeToolWire>;
+  }): Promise<void>;
+  close(): Promise<void>;
+};
+
+type EndpointSession = {
+  readonly transport: StreamableHTTPServerTransport;
+  readonly hostToolServer: HostToolMCPServer;
+};
+
+/*
+ * The ACP host tool catalog is shared by every MCP session opened against this
+ * endpoint. Each session needs its own MCP `Server` instance because a server
+ * can be connected to a single transport at a time, so catalog updates are
+ * fanned out to all live sessions and also retained for sessions opened later.
+ */
+export function createHostToolMCPHttpEndpoint({
+  tools,
+  revision,
+  invoke,
+  onListTools,
+}: {
+  tools: ReadonlyArray<HarnessV1BridgeToolWire>;
+  revision: number;
+  invoke: (options: {
+    toolName: string;
+    input: Readonly<Record<string, unknown>>;
+    catalogRevision: number;
+  }) => Promise<HostToolMCPInvocationResult>;
+  onListTools: (options: { revision: number }) => Promise<void>;
+}): HostToolMCPHttpEndpoint {
+  let catalog: {
+    revision: number;
+    tools: ReadonlyArray<HarnessV1BridgeToolWire>;
+  } = { revision, tools: [...tools] };
+  const sessions = new Map<string, EndpointSession>();
+  let closed = false;
+
+  async function openSession({
+    request,
+    response,
+    body,
+  }: {
+    request: IncomingMessage;
+    response: ServerResponse;
+    body: unknown;
+  }): Promise<void> {
+    const hostToolServer = createHostToolMCPServer({
+      tools: catalog.tools,
+      revision: catalog.revision,
+      invoke,
+      onListTools,
+    });
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: sessionId => {
+        sessions.set(sessionId, { transport, hostToolServer });
+      },
+      onsessionclosed: sessionId => {
+        sessions.delete(sessionId);
+      },
+    });
+    transport.onclose = () => {
+      const { sessionId } = transport;
+      if (sessionId != null) sessions.delete(sessionId);
+    };
+    await hostToolServer.server.connect(transport);
+    await transport.handleRequest(request, response, body);
+  }
+
+  return {
+    handleRequest: async ({ request, response, body }) => {
+      if (closed) {
+        respondWithJSONRPCError({
+          response,
+          status: 503,
+          code: -32000,
+          message: 'The host tool MCP endpoint is closed.',
+        });
+        return;
+      }
+      const sessionId = readSessionId({ request });
+      if (sessionId != null) {
+        const session = sessions.get(sessionId);
+        if (session == null) {
+          respondWithJSONRPCError({
+            response,
+            status: 404,
+            code: -32001,
+            message: 'Unknown host tool MCP session.',
+          });
+          return;
+        }
+        await session.transport.handleRequest(request, response, body);
+        return;
+      }
+      if (request.method !== 'POST' || !isInitializeRequest(body)) {
+        respondWithJSONRPCError({
+          response,
+          status: 400,
+          code: -32000,
+          message:
+            'Host tool MCP requests without a session id must be an initialize request.',
+        });
+        return;
+      }
+      await openSession({ request, response, body });
+    },
+    updateCatalog: async ({ revision: nextRevision, tools: nextTools }) => {
+      catalog = { revision: nextRevision, tools: [...nextTools] };
+      await Promise.all(
+        [...sessions.values()].map(session =>
+          session.hostToolServer.updateCatalog({
+            revision: nextRevision,
+            tools: nextTools,
+          }),
+        ),
+      );
+    },
+    close: async () => {
+      if (closed) return;
+      closed = true;
+      const live = [...sessions.values()];
+      sessions.clear();
+      await Promise.all(
+        live.map(session => session.hostToolServer.server.close()),
+      );
+    },
+  };
+}
+
+function readSessionId({
+  request,
+}: {
+  request: IncomingMessage;
+}): string | undefined {
+  const value = request.headers['mcp-session-id'];
+  const sessionId = Array.isArray(value) ? value[0] : value;
+  return sessionId == null || sessionId.length === 0 ? undefined : sessionId;
+}
+
+function respondWithJSONRPCError({
+  response,
+  status,
+  code,
+  message,
+}: {
+  response: ServerResponse;
+  status: number;
+  code: number;
+  message: string;
+}): void {
+  response.writeHead(status, { 'content-type': 'application/json' });
+  response.end(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      error: { code, message },
+      id: null,
+    }),
+  );
+}

--- a/packages/harness-acp/src/v1/bridge/host-tool-relay.ts
+++ b/packages/harness-acp/src/v1/bridge/host-tool-relay.ts
@@ -1,7 +1,13 @@
-import { randomBytes, timingSafeEqual } from 'node:crypto';
+import { randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
 import { createServer, type IncomingMessage, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import type { HarnessV1BridgeToolWire } from '@ai-sdk/harness';
+import type { ACPHostToolMCPTransport } from '../acp-v1-settings';
+import {
+  createHostToolMCPHttpEndpoint,
+  HOST_TOOL_MCP_ENDPOINT_PATH,
+  type HostToolMCPHttpEndpoint,
+} from './host-tool-mcp-http';
 
 export type HostToolCorrelationInvocation = {
   readonly token: string;
@@ -34,6 +40,11 @@ export type HostToolRelayTurn = {
 
 export type HostToolRelay = {
   readonly url: string;
+  /**
+   * MCP endpoint that exposes the host tool catalog over Streamable HTTP.
+   * Only present when the relay was started with the `http` MCP transport.
+   */
+  readonly mcpUrl?: string;
   readonly credential: string;
   bindTurn(options: { turn: HostToolRelayTurn }): void;
   unbindTurn(options: { turn: HostToolRelayTurn }): void;
@@ -64,9 +75,11 @@ type CatalogState = {
 export async function startHostToolRelay({
   tools,
   serverName,
+  mcpTransport = 'stdio',
 }: {
   tools: ReadonlyArray<HarnessV1BridgeToolWire>;
   serverName: string;
+  mcpTransport?: ACPHostToolMCPTransport;
 }): Promise<HostToolRelay> {
   const state: CatalogState = {
     tools: [...tools],
@@ -81,8 +94,52 @@ export async function startHostToolRelay({
   let activeTurn: HostToolRelayTurn | undefined;
   let invocationOrder = 0;
   let closePromise: Promise<void> | undefined;
+  const mcpEndpoint: HostToolMCPHttpEndpoint | undefined =
+    mcpTransport === 'http'
+      ? createHostToolMCPHttpEndpoint({
+          tools: state.tools,
+          revision: state.revision,
+          invoke: ({ toolName, input, catalogRevision }) =>
+            handleInvocation({
+              body: {
+                requestId: randomUUID(),
+                toolName,
+                input,
+                catalogRevision,
+              },
+              state,
+              serverName,
+              turn: activeTurn,
+              nextInvocationOrder: () => ++invocationOrder,
+            }),
+          onListTools: async ({ revision }) => {
+            acknowledgeCatalog({ state, revision });
+          },
+        })
+      : undefined;
   const server = createServer(async (request, response) => {
     try {
+      if (mcpEndpoint != null && request.url === HOST_TOOL_MCP_ENDPOINT_PATH) {
+        if (
+          !credentialsMatch({
+            expected: credential,
+            actual: request.headers.authorization,
+          })
+        ) {
+          throw new RelayRequestError({
+            status: 401,
+            message: 'Invalid host tool relay credential.',
+          });
+        }
+        await mcpEndpoint.handleRequest({
+          request,
+          response,
+          ...(request.method === 'POST'
+            ? { body: await readJSONBody({ request }) }
+            : {}),
+        });
+        return;
+      }
       const result = await handleRequest({
         request,
         credential,
@@ -94,6 +151,10 @@ export async function startHostToolRelay({
       response.writeHead(200, { 'content-type': 'application/json' });
       response.end(JSON.stringify(result));
     } catch (error) {
+      if (response.headersSent) {
+        response.end();
+        return;
+      }
       const status = error instanceof RelayRequestError ? error.status : 500;
       response.writeHead(status, { 'content-type': 'application/json' });
       response.end(
@@ -108,6 +169,11 @@ export async function startHostToolRelay({
 
   return {
     url: `http://127.0.0.1:${address.port}/invoke`,
+    ...(mcpEndpoint == null
+      ? {}
+      : {
+          mcpUrl: `http://127.0.0.1:${address.port}${HOST_TOOL_MCP_ENDPOINT_PATH}`,
+        }),
     credential,
     bindTurn: ({ turn }) => {
       if (activeTurn != null && activeTurn !== turn) {
@@ -127,6 +193,10 @@ export async function startHostToolRelay({
       state.fingerprint = fingerprint;
       state.revision += 1;
       resolveCatalogChanges({ state });
+      void mcpEndpoint?.updateCatalog({
+        revision: state.revision,
+        tools: state.tools,
+      });
       return { changed: true, revision: state.revision };
     },
     waitForCatalogRefresh: ({ revision, timeoutMs }) =>
@@ -136,7 +206,10 @@ export async function startHostToolRelay({
       state.closed = true;
       resolveCatalogChanges({ state });
       resolveRefreshWaiters({ state, closing: true });
-      closePromise = closeServer({ server });
+      closePromise = (async () => {
+        await mcpEndpoint?.close();
+        await closeServer({ server });
+      })();
       return closePromise;
     },
   };
@@ -243,12 +316,19 @@ function handleCatalogSeen({
       message: 'Invalid host tool catalog acknowledgment.',
     });
   }
-  state.servedRevision = Math.max(
-    state.servedRevision,
-    body.revision as number,
-  );
-  resolveRefreshWaiters({ state, closing: false });
+  acknowledgeCatalog({ state, revision: body.revision as number });
   return { acknowledged: true };
+}
+
+function acknowledgeCatalog({
+  state,
+  revision,
+}: {
+  state: CatalogState;
+  revision: number;
+}): void {
+  state.servedRevision = Math.max(state.servedRevision, revision);
+  resolveRefreshWaiters({ state, closing: false });
 }
 
 async function handleInvocation({

--- a/packages/harness-acp/src/v1/bridge/index.ts
+++ b/packages/harness-acp/src/v1/bridge/index.ts
@@ -7,7 +7,6 @@ import {
 import * as acp from '@agentclientprotocol/sdk';
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { readFile, writeFile } from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
 import { Readable, Writable } from 'node:stream';
 import { argv, env as processEnv } from 'node:process';
 import {
@@ -38,6 +37,7 @@ import {
   type HostToolRelay,
   type HostToolRelayTurn,
 } from './host-tool-relay';
+import { createHostToolMcpServerDefinition } from './host-tool-mcp-definition';
 import {
   promptAndRefreshInitialHostToolCatalog,
   refreshHostToolCatalog,
@@ -593,34 +593,27 @@ async function ensureSession({
     initialization,
   });
   const tools = start.tools ?? [];
+  const mcpTransport = bridgeConfiguration.hostToolMcpTransport ?? 'stdio';
   const catalogPath = `${bridgeStateDir}/host-tools.json`;
-  await writeFile(catalogPath, JSON.stringify(tools), { mode: 0o600 });
+  if (mcpTransport === 'stdio') {
+    await writeFile(catalogPath, JSON.stringify(tools), { mode: 0o600 });
+  }
   hostToolRelay = await startHostToolRelay({
     tools,
     serverName: HOST_TOOL_MCP_SERVER_NAME,
+    mcpTransport,
   });
 
   const mcpServers: acp.McpServer[] = [
     ...externalMcpServers,
-    {
-      name: HOST_TOOL_MCP_SERVER_NAME,
-      command: process.execPath,
-      args: [fileURLToPath(new URL('./host-tool-mcp.mjs', import.meta.url))],
-      env: [
-        {
-          name: 'AI_SDK_ACP_HOST_TOOLS_FILE',
-          value: catalogPath,
-        },
-        {
-          name: 'AI_SDK_ACP_HOST_TOOL_RELAY_URL',
-          value: hostToolRelay.url,
-        },
-        {
-          name: 'AI_SDK_ACP_HOST_TOOL_RELAY_CREDENTIAL',
-          value: hostToolRelay.credential,
-        },
-      ],
-    },
+    createHostToolMcpServerDefinition({
+      mcpTransport,
+      relay: hostToolRelay,
+      serverName: HOST_TOOL_MCP_SERVER_NAME,
+      catalogPath,
+      initialization,
+      harnessId: bridgeType,
+    }),
   ];
   let createdSession: ACPActiveSession;
   if (start.recoveryMode?.type === 'lossy-rerun') {

--- a/packages/harness-acp/src/v1/index.ts
+++ b/packages/harness-acp/src/v1/index.ts
@@ -4,6 +4,7 @@ export type {
   ACPCredentialBrokering,
   ACPAuthentication,
   ACPAuthenticationMode,
+  ACPHostToolMCPTransport,
   ACPInstallCommandSource,
   ACPInstructionMapping,
   ACPModelMapping,


### PR DESCRIPTION
## Background

ACP harness implementations historically exposed host tools to the runtime exclusively over a stdio-based MCP server. However, some harness adapters (such as GitHub Copilot, see #20342) do not support stdio-based MCP servers and only accept HTTP or SSE MCP servers, requiring a mechanism to indicate this to the ACP meta harness.

## Summary

This adds a `hostToolMcpTransport` configuration option to `createACP` that allows ACP-based harness adapters to expose host tools over Streamable HTTP instead of stdio.

- Add `hostToolMcpTransport` setting (`'stdio' | 'http'`, defaulting to `'stdio'`) to `createACP` and forward it through the ACP bridge configuration.
- Expose a Streamable HTTP MCP endpoint directly on the host tool relay when `http` transport is configured.
- Configure the ACP `session/new` MCP server definition as an HTTP server when `http` is selected, verifying that the implementation advertises `agentCapabilities.mcpCapabilities.http`.
- Document `hostToolMcpTransport` in the ACP harness documentation.

## End-to-End Verification

Verified via e2e tests in #20342.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
