### PR TITLE
fix(providers): throw on empty choices in chat doGenerate

### DIFF
--- a/.changeset/great-pandas-shout.md
+++ b/.changeset/great-pandas-shout.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+fix(openai): throw InvalidResponseDataError on empty choices in chat doGenerate

--- a/.changeset/tidy-geese-cheer.md
+++ b/.changeset/tidy-geese-cheer.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai-compatible": patch
+---
+
+fix(openai-compatible): throw InvalidResponseDataError on empty choices in chat doGenerate

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -4373,3 +4373,25 @@ describe('transformRequestBody', () => {
     expect(requestBody).not.toHaveProperty('custom_field');
   });
 });
+
+describe('doGenerate empty choices (#20351)', () => {
+  it('should throw InvalidResponseDataError instead of TypeError', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'json-value',
+      body: {
+        id: 'chatcmpl-empty',
+        object: 'chat.completion',
+        created: 1711115037,
+        model: 'grok-3',
+        choices: [],
+        usage: { prompt_tokens: 4, total_tokens: 4, completion_tokens: 0 },
+      },
+    };
+
+    await expect(
+      model.doGenerate({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+      }),
+    ).rejects.toThrow('Response contained no choices.');
+  });
+});

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -353,6 +353,12 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV4 {
     });
 
     const choice = responseBody.choices[0];
+    if (choice == null) {
+      throw new InvalidResponseDataError({
+        data: responseBody,
+        message: 'Response contained no choices.',
+      });
+    }
     const content: Array<LanguageModelV4Content> = [];
 
     content.push(...convertOpenAICompatibleContent(choice.message.content));

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -4156,3 +4156,25 @@ describe('doStream', () => {
     });
   });
 });
+
+describe('doGenerate empty choices (#20351)', () => {
+  it('should throw InvalidResponseDataError instead of TypeError', async () => {
+    server.urls['https://api.openai.com/v1/chat/completions'].response = {
+      type: 'json-value',
+      body: {
+        id: 'chatcmpl-empty',
+        object: 'chat.completion',
+        created: 1711115037,
+        model: 'gpt-3.5-turbo-0125',
+        choices: [],
+        usage: { prompt_tokens: 4, total_tokens: 4, completion_tokens: 0 },
+      },
+    };
+
+    await expect(
+      model.doGenerate({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+      }),
+    ).rejects.toThrow('Response contained no choices.');
+  });
+});

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -1,13 +1,14 @@
-import type {
-  LanguageModelV4,
-  LanguageModelV4CallOptions,
-  LanguageModelV4Content,
-  LanguageModelV4FinishReason,
-  LanguageModelV4GenerateResult,
-  LanguageModelV4StreamPart,
-  LanguageModelV4StreamResult,
-  SharedV4ProviderMetadata,
-  SharedV4Warning,
+import {
+  InvalidResponseDataError,
+  type LanguageModelV4,
+  type LanguageModelV4CallOptions,
+  type LanguageModelV4Content,
+  type LanguageModelV4FinishReason,
+  type LanguageModelV4GenerateResult,
+  type LanguageModelV4StreamPart,
+  type LanguageModelV4StreamResult,
+  type SharedV4ProviderMetadata,
+  type SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   StreamingToolCallTracker,
@@ -368,6 +369,12 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
     });
 
     const choice = response.choices[0];
+    if (choice == null) {
+      throw new InvalidResponseDataError({
+        data: response,
+        message: 'Response contained no choices.',
+      });
+    }
     const content: Array<LanguageModelV4Content> = [];
 
     // text content:


### PR DESCRIPTION
## Summary

Non-streaming `doGenerate` in the OpenAI and OpenAI-compatible chat models crashed with a raw `TypeError` on HTTP 200 with an empty `choices` array. Both now throw `InvalidResponseDataError` with a clear message, keeping the AISDKError contract. Patch changesets for both packages included per repo convention.

## How to test

1. Mock a 200 response with `choices: []` for either chat model and call `doGenerate`.
2. Observe `InvalidResponseDataError: Response contained no choices.` now. Before the fix, both threw `TypeError: Cannot read properties of undefined`.
3. Run the chat test files in both packages. All pass (94 + 104), including the new regression tests (red without the fix, green with it).

## Related issues

Fixes #20351