### PR TITLE
fix(ai): throw on empty embeddings in embed

### DIFF
--- a/.changeset/olive-pandas-shout.md
+++ b/.changeset/olive-pandas-shout.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): throw InvalidResponseDataError on empty embeddings in embed

--- a/packages/ai/src/embed/embed.test.ts
+++ b/packages/ai/src/embed/embed.test.ts
@@ -638,6 +638,20 @@ describe('options.onStart and onEnd together', () => {
   });
 });
 
+describe('empty provider response (#20355)', () => {
+  it('should throw InvalidResponseDataError instead of resolving undefined', async () => {
+    await assert.rejects(
+      embed({
+        model: new MockEmbeddingModelV4({
+          doEmbed: mockEmbed([testValue], []),
+        }),
+        value: testValue,
+      }),
+      /Response contained no embeddings/,
+    );
+  });
+});
+
 function mockEmbed(
   expectedValues: Array<string>,
   embeddings: Array<Embedding>,

--- a/packages/ai/src/embed/embed.ts
+++ b/packages/ai/src/embed/embed.ts
@@ -3,6 +3,7 @@ import {
   withUserAgentSuffix,
   type ProviderOptions,
 } from '@ai-sdk/provider-utils';
+import { InvalidResponseDataError } from '@ai-sdk/provider';
 import { logWarnings } from '../logger/log-warnings';
 import { resolveEmbeddingModel } from '../model/resolve-model';
 import { createTelemetryDispatcher } from '../telemetry/create-telemetry-dispatcher';
@@ -205,6 +206,12 @@ export async function embed({
             });
 
             const embedding = modelResponse.embeddings[0];
+            if (embedding == null) {
+              throw new InvalidResponseDataError({
+                data: modelResponse,
+                message: 'Response contained no embeddings.',
+              });
+            }
             const usage = modelResponse.usage ?? { tokens: NaN };
 
             await notify({


### PR DESCRIPTION
## Summary

`embed()` silently resolved with an `undefined` embedding when the provider returned zero embeddings. It now throws `InvalidResponseDataError` with a clear message, matching the empty-choices guard from #20351 and the sibling `NoXGeneratedError` family. Patch changeset included per repo convention.

## How to test

1. Mock a provider `doEmbed` returning `{ embeddings: [], usage: { tokens: 5 } }` and call `embed()`.
2. Observe `InvalidResponseDataError: Response contained no embeddings.` now. Before the fix, it resolved with `embedding: undefined`.
3. Run `vitest run packages/ai/src/embed/`. All 67 tests pass, including the new regression test (red without the fix, green with it).

## Related issues

Fixes #20355