### PR TITLE
fix(ai): validate response embeddings count in embedMany

### DIFF
--- a/.changeset/witty-pandas-shout.md
+++ b/.changeset/witty-pandas-shout.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): validate response embeddings count in embedMany

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -341,7 +341,7 @@ describe('result.responses', () => {
             case 0:
               assert.deepStrictEqual(values, [testValues[0]]);
               return {
-                embeddings: dummyEmbeddings,
+                embeddings: dummyEmbeddings.slice(0, 1),
                 response: {
                   body: { first: true },
                 },
@@ -350,7 +350,7 @@ describe('result.responses', () => {
             case 1:
               assert.deepStrictEqual(values, [testValues[1]]);
               return {
-                embeddings: dummyEmbeddings,
+                embeddings: dummyEmbeddings.slice(1, 2),
                 response: {
                   body: { second: true },
                 },
@@ -359,7 +359,7 @@ describe('result.responses', () => {
             case 2:
               assert.deepStrictEqual(values, [testValues[2]]);
               return {
-                embeddings: dummyEmbeddings,
+                embeddings: dummyEmbeddings.slice(2, 3),
                 response: {
                   body: { third: true },
                 },

--- a/packages/ai/src/embed/embed-many.test.ts
+++ b/packages/ai/src/embed/embed-many.test.ts
@@ -1104,6 +1104,37 @@ describe('options.onStart and onEnd together', () => {
   });
 });
 
+describe('response length validation (#20359)', () => {
+  it('should throw on empty embeddings (fast path)', async () => {
+    await assert.rejects(
+      embedMany({
+        model: new MockEmbeddingModelV4({
+          maxEmbeddingsPerCall: null,
+          doEmbed: mockEmbed(testValues, []),
+        }),
+        values: testValues,
+      }),
+      /does not match values count/,
+    );
+  });
+
+  it('should throw on short chunk embeddings (chunked path)', async () => {
+    await assert.rejects(
+      embedMany({
+        model: new MockEmbeddingModelV4({
+          maxEmbeddingsPerCall: 2,
+          doEmbed: (async () => ({
+            embeddings: dummyEmbeddings.slice(0, 1),
+            warnings: [],
+          })) as never,
+        }),
+        values: testValues,
+      }),
+      /does not match values count/,
+    );
+  });
+});
+
 function mockEmbed(
   expectedValues: Array<string>,
   embeddings: Array<Embedding>,

--- a/packages/ai/src/embed/embed-many.ts
+++ b/packages/ai/src/embed/embed-many.ts
@@ -3,6 +3,7 @@ import {
   withUserAgentSuffix,
   type ProviderOptions,
 } from '@ai-sdk/provider-utils';
+import { InvalidResponseDataError } from '@ai-sdk/provider';
 import { logWarnings } from '../logger/log-warnings';
 import { getEmbeddingModelMaxInputBytesPerCall } from '../model/get-embedding-model-max-input-bytes-per-call';
 import { resolveEmbeddingModel } from '../model/resolve-model';
@@ -239,6 +240,12 @@ export async function embedMany({
               });
 
               const embeddings = modelResponse.embeddings;
+              if (embeddings.length !== values.length) {
+                throw new InvalidResponseDataError({
+                  data: modelResponse,
+                  message: `Response embeddings count (${embeddings.length}) does not match values count (${values.length}).`,
+                });
+              }
               const usage = modelResponse.usage ?? { tokens: NaN };
 
               await notify({
@@ -349,6 +356,12 @@ export async function embedMany({
                 });
 
                 const chunkEmbeddings = modelResponse.embeddings;
+                if (chunkEmbeddings.length !== chunk.length) {
+                  throw new InvalidResponseDataError({
+                    data: modelResponse,
+                    message: `Response embeddings count (${chunkEmbeddings.length}) does not match values count (${chunk.length}).`,
+                  });
+                }
                 const usage = modelResponse.usage ?? { tokens: NaN };
 
                 await notify({


### PR DESCRIPTION
## Summary

`embedMany()` silently accepted provider responses whose embeddings array didn't match the values array, misaligning value→vector mapping downstream. Both the fast path and the chunked path now throw `InvalidResponseDataError` on a count mismatch, matching the single-value `embed()` guard from #20355. Also fixed one existing test mock that returned 3 embeddings for 1-value chunks (the exact mismatch now forbidden). Patch changeset included per repo convention.

## How to test

1. Mock `doEmbed` returning fewer embeddings than values and call `embedMany()`.
2. Observe `InvalidResponseDataError` now. Before the fix, it resolved with mismatched arrays.
3. Run `vitest run packages/ai/src/embed/`. All 68 tests pass, including the 2 new regression tests (red without the fix, green with it).

## Related issues

Fixes #20359