### PR TITLE
fix(amazon-bedrock): sanitize document names derived from filenames

### DIFF
--- a/.changeset/bedrock-sanitize-document-names.md
+++ b/.changeset/bedrock-sanitize-document-names.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix(amazon-bedrock): sanitize document names derived from filenames

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.test.ts
@@ -375,6 +375,155 @@ describe('user messages', () => {
     `);
   });
 
+  it('should remove characters that Bedrock rejects in document names', async () => {
+    const fileData = new Uint8Array([0, 1, 2, 3]);
+
+    const { messages } = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: {
+              type: 'data' as const,
+              data: Buffer.from(fileData).toString('base64'),
+            },
+            mediaType: 'application/pdf',
+            filename: "John's résumé_v2 (draft) [#2], final.pdf",
+          },
+        ],
+      },
+    ]);
+
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "document": {
+                "format": "pdf",
+                "name": "Johns rsum_v2 (draft) [2] final",
+                "source": {
+                  "bytes": "AAECAw==",
+                },
+              },
+            },
+          ],
+          "role": "user",
+        },
+      ]
+    `);
+  });
+
+  it('should collapse consecutive whitespace in document names', async () => {
+    const fileData = new Uint8Array([0, 1, 2, 3]);
+
+    const { messages } = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: {
+              type: 'data' as const,
+              data: Buffer.from(fileData).toString('base64'),
+            },
+            mediaType: 'application/pdf',
+            filename: 'Report -  Final\tDraft.pdf',
+          },
+        ],
+      },
+    ]);
+
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "document": {
+                "format": "pdf",
+                "name": "Report - Final Draft",
+                "source": {
+                  "bytes": "AAECAw==",
+                },
+              },
+            },
+          ],
+          "role": "user",
+        },
+      ]
+    `);
+  });
+
+  it('should truncate document names to 200 characters', async () => {
+    const fileData = new Uint8Array([0, 1, 2, 3]);
+
+    const { messages } = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: {
+              type: 'data' as const,
+              data: Buffer.from(fileData).toString('base64'),
+            },
+            mediaType: 'application/pdf',
+            filename: `${'a'.repeat(250)}.pdf`,
+          },
+        ],
+      },
+    ]);
+
+    expect(messages[0].content[0]).toEqual({
+      document: {
+        format: 'pdf',
+        name: 'a'.repeat(200),
+        source: { bytes: 'AAECAw==' },
+      },
+    });
+  });
+
+  it('should fall back to a generated document name when no allowed characters remain', async () => {
+    const fileData = new Uint8Array([0, 1, 2, 3]);
+
+    const { messages } = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: {
+              type: 'data' as const,
+              data: Buffer.from(fileData).toString('base64'),
+            },
+            mediaType: 'application/pdf',
+            filename: '분기보고서.pdf',
+          },
+        ],
+      },
+    ]);
+
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        {
+          "content": [
+            {
+              "document": {
+                "format": "pdf",
+                "name": "document-1",
+                "source": {
+                  "bytes": "AAECAw==",
+                },
+              },
+            },
+          ],
+          "role": "user",
+        },
+      ]
+    `);
+  });
+
   it('should use consistent document names for prompt cache effectiveness', async () => {
     const fileData1 = new Uint8Array([0, 1, 2, 3]);
     const fileData2 = new Uint8Array([4, 5, 6, 7]);
@@ -2224,6 +2373,52 @@ describe('tool messages', () => {
                 document: {
                   format: 'pdf',
                   name: 'tool-result',
+                  source: { bytes: 'base64data' },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  it('should sanitize document names in tool result content', async () => {
+    const result = await convertToAmazonBedrockChatMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-123',
+            toolName: 'document-reader',
+            output: {
+              type: 'content',
+              value: [
+                {
+                  type: 'file',
+                  data: { type: 'data', data: 'base64data' },
+                  mediaType: 'application/pdf',
+                  filename: "tool's  result.pdf",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.messages[0]).toEqual({
+      role: 'user',
+      content: [
+        {
+          toolResult: {
+            toolUseId: 'call-123',
+            content: [
+              {
+                document: {
+                  format: 'pdf',
+                  name: 'tools result',
                   source: { bytes: 'base64data' },
                 },
               },

--- a/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
+++ b/packages/amazon-bedrock/src/convert-to-amazon-bedrock-chat-messages.ts
@@ -72,6 +72,18 @@ function sanitizeToolName(toolName: string): string {
   return toolName.replace(/[^a-zA-Z0-9_-]/g, '') || '_';
 }
 
+// Bedrock only accepts alphanumeric characters, single whitespace characters,
+// hyphens, parentheses and square brackets in document names (1-200 chars):
+// https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentBlock.html
+// Underscores are not documented but are accepted by the service.
+function sanitizeDocumentName(name: string): string {
+  return name
+    .replace(/[^a-zA-Z0-9_\s()[\]-]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 200);
+}
+
 function getAmazonBedrockMediaSource({
   data,
   functionality,
@@ -162,6 +174,12 @@ export async function convertToAmazonBedrockChatMessages(
 
   let documentCounter = 0;
   const generateDocumentName = () => `document-${++documentCounter}`;
+  const getDocumentName = (filename: string | undefined) => {
+    const name = filename
+      ? sanitizeDocumentName(stripFileExtension(filename))
+      : '';
+    return name || generateDocumentName();
+  };
 
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i];
@@ -284,9 +302,7 @@ export async function convertToAmazonBedrockChatMessages(
                           document: {
                             format:
                               getAmazonBedrockDocumentFormat(textMediaType),
-                            name: part.filename
-                              ? stripFileExtension(part.filename)
-                              : generateDocumentName(),
+                            name: getDocumentName(part.filename),
                             source: {
                               bytes: convertToBase64(
                                 new TextEncoder().encode(part.data.text),
@@ -350,9 +366,7 @@ export async function convertToAmazonBedrockChatMessages(
                               document: {
                                 format:
                                   getAmazonBedrockDocumentFormat(fullMediaType),
-                                name: part.filename
-                                  ? stripFileExtension(part.filename)
-                                  : generateDocumentName(),
+                                name: getDocumentName(part.filename),
                                 source: {
                                   bytes: convertToBase64(part.data.data),
                                 },
@@ -453,9 +467,7 @@ export async function convertToAmazonBedrockChatMessages(
                                       getAmazonBedrockDocumentFormat(
                                         fullMediaType,
                                       ),
-                                    name: contentPart.filename
-                                      ? stripFileExtension(contentPart.filename)
-                                      : generateDocumentName(),
+                                    name: getDocumentName(contentPart.filename),
                                     source: {
                                       bytes: convertToBase64(
                                         contentPart.data.data,


### PR DESCRIPTION
## Background

Fixes #20365.

Bedrock validates the Converse `document.name` field strictly: alphanumerics, single whitespace, hyphens, parentheses, square brackets, 1–200 characters ([DocumentBlock](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentBlock.html)). Since #9170 the converter uses `part.filename` as that name, and #12971 strips the extension because `.` is rejected. Every other disallowed character (`'`, `#`, `&`, `,`, non-ASCII, tabs, double spaces) still goes through, so a file part named `John's report.pdf` fails the whole request with a 400 `ValidationException` before the model sees it. Same error on Nova, so it is the service validating, not the model.

## Summary

- Add `sanitizeDocumentName` next to `sanitizeToolName` (#17769 did the same for tool names): drop characters Bedrock rejects, collapse whitespace runs to a single space, trim, cap at 200.
- Route the three `document.name` call sites (user file bytes, user text file, tool-result document) through one local `getDocumentName`: `stripFileExtension` → sanitize → fall back to the existing `document-N` when nothing is left (`분기보고서.pdf`, or `.pdf` which currently becomes `""`).
- Underscores are kept on purpose. They are not in the documented list, but Bedrock accepts them (checked live) and they are sent through today, so stripping them would rename documents that currently work.

| `filename` | Before (`document.name` → Bedrock) | After |
|---|---|---|
| `John's report.pdf` | `John's report` → 400 ValidationException | `Johns report` → 200 |
| `Report -  Final\tDraft.pdf` | `Report -  Final\tDraft` → 400 | `Report - Final Draft` |
| `résumé.pdf` / `분기보고서.pdf` | 400 | `rsum` / `document-1` |
| 250-character name | 400 `length less than or equal to 200` | truncated to 200 |
| `.pdf` | `""` → 400 `length greater than or equal to 1` | `document-1` |
| `custom-filename.pdf`, `report (final) [v2].pdf`, `Q3_report.pdf` | sent as-is | Unchanged |
| no `filename` | `document-N` | Unchanged |
| `@ai-sdk/amazon-bedrock/anthropic` | not affected (Anthropic `document.title` has no constraint) | Unchanged |

No warning is emitted when a name is changed, matching how tool-name sanitization behaves today; the converter does not return warnings, so adding one would be a larger change.

## End-to-End Verification

`generateText` with `bedrock('us.anthropic.claude-haiku-4-5-20251001-v1:0')` and a `text/plain` file part named `John's report.txt`, logging the outgoing `document.name` from a `fetch` wrapper.

Before (main @ abb9ebf):

```
document.name sent: "John's report"
APICallError [AI_APICallError]: The document file name can only contain alphanumeric characters, whitespace characters, hyphens, parentheses, and square brackets. The name can't contain more than one consecutive whitespace character. Check that the file name conforms to these restrictions and retry your request.
  statusCode: 400,
  'x-amzn-errortype': 'ValidationException:http://internal.amazon.com/coral/com.amazon.bedrock/'
```

After (this branch, `pnpm -C packages/amazon-bedrock build` then the same script):

```
document.name sent: "Johns report"
Response: The quarterly revenue was 42 million.
```

Also sent the sanitized forms (`Johns resume`, `Report - Final Draft`, `Johns rsum 2 final`, `Q3_report_v2`) directly to the Converse endpoint on `us.anthropic.claude-haiku-4-5-20251001-v1:0` and `us.amazon.nova-lite-v1:0`: all 200.

## Testing

Five converter tests added (rejected characters, whitespace collapsing, 200-char cap, generated-name fallback, tool-result document). With the source change reverted and the tests kept, all five fail on main:

```
× should remove characters that Bedrock rejects in document names
-           "name": "Johns rsum_v2 (draft) [2] final",
+           "name": "John's résumé_v2 (draft) [#2], final",
× should collapse consecutive whitespace in document names
-           "name": "Report - Final Draft",
+           "name": "Report -  Final	Draft",
× should fall back to a generated document name when no allowed characters remain
-           "name": "document-1",
+           "name": "분기보고서",
 Tests  5 failed | 528 passed (533)
```

With the fix: 533 passed in Node and 533 passed in Edge. `ultracite check packages/amazon-bedrock/src` and `tsc --build` are clean.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #20365
