### PR TITLE
fix(harness-acp): fix stream translator to match most appropriate tool based on input shape when no name is present and multiple candidates would match the required arguments

### DIFF
--- a/.changeset/chilled-gifts-sort.md
+++ b/.changeset/chilled-gifts-sort.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-acp": patch
+---
+
+fix(harness-acp): fix stream translator to match most appropriate tool based on input shape when no name is present and multiple candidates would match the required arguments

--- a/packages/harness-acp/src/v1/bridge/stream-translator.test.ts
+++ b/packages/harness-acp/src/v1/bridge/stream-translator.test.ts
@@ -637,6 +637,90 @@ describe('createACPStreamTranslator', () => {
     `);
   });
 
+  it('prefers the schema that declares the most of an ambiguous rawInput', () => {
+    const events: HarnessV1StreamPart[] = [];
+    const translator = createACPStreamTranslator({
+      emit: event => events.push(event),
+      builtinTools: [
+        {
+          toolName: 'bash',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              command: { type: 'string' },
+              shellId: { type: 'string' },
+              mode: { type: 'string', enum: ['sync', 'async'] },
+            },
+            required: ['command'],
+          },
+        },
+        {
+          toolName: 'stop_bash',
+          inputSchema: {
+            type: 'object',
+            properties: { shellId: { type: 'string' } },
+            required: ['shellId'],
+          },
+        },
+      ],
+    });
+
+    translator.update({
+      sessionUpdate: 'tool_call',
+      toolCallId: 'call-async-bash',
+      title: 'Print READY after delay',
+      status: 'completed',
+      rawInput: {
+        command: 'sleep 2; echo READY',
+        shellId: 'ready-check',
+        mode: 'async',
+      },
+    });
+
+    expect(toolEvents({ events })[0]).toMatchObject({
+      type: 'tool-call',
+      toolName: 'bash',
+    });
+  });
+
+  it('keeps equally specific schema matches dynamic', () => {
+    const events: HarnessV1StreamPart[] = [];
+    const translator = createACPStreamTranslator({
+      emit: event => events.push(event),
+      builtinTools: [
+        {
+          toolName: 'first',
+          inputSchema: {
+            type: 'object',
+            properties: { id: { type: 'string' }, extra: { type: 'string' } },
+            required: ['id'],
+          },
+        },
+        {
+          toolName: 'second',
+          inputSchema: {
+            type: 'object',
+            properties: { id: { type: 'string' }, other: { type: 'string' } },
+            required: ['id'],
+          },
+        },
+      ],
+    });
+
+    translator.update({
+      sessionUpdate: 'tool_call',
+      toolCallId: 'call-tied',
+      title: 'Operation',
+      status: 'completed',
+      rawInput: { id: 'task-1' },
+    });
+
+    expect(toolEvents({ events })[0]).toMatchObject({
+      type: 'tool-call',
+      toolName: 'acp_tool_call-tied',
+    });
+  });
+
   it('does not override an unknown programmatic metadata name by schema', () => {
     const events: HarnessV1StreamPart[] = [];
     const translator = createACPStreamTranslator({

--- a/packages/harness-acp/src/v1/bridge/stream-translator.ts
+++ b/packages/harness-acp/src/v1/bridge/stream-translator.ts
@@ -526,7 +526,41 @@ function resolveBuiltinTool({
   const schemaMatches = builtinTools.filter(tool =>
     matchesBuiltinToolInput({ rawInput, inputSchema: tool.inputSchema }),
   );
-  return schemaMatches.length === 1 ? schemaMatches[0] : undefined;
+  if (schemaMatches.length <= 1) return schemaMatches[0];
+  return findMostSpecificSchemaMatch({ rawInput, schemaMatches });
+}
+
+/*
+ * Multiple schemas can pass `matchesBuiltinToolInput` at once: a tool whose
+ * only required field is optional on a richer sibling tool (e.g. `bash`'s
+ * optional `shellId` versus `stop_bash`'s required `shellId`) matches any
+ * rawInput the richer tool also matches. Preferring whichever candidate
+ * declares the most of rawInput's own keys resolves that in favor of the
+ * richer, more specific schema, while two equally specific schemas (e.g.
+ * identical schemas under different names) still resolve to `undefined`.
+ */
+function findMostSpecificSchemaMatch({
+  rawInput,
+  schemaMatches,
+}: {
+  rawInput: unknown;
+  schemaMatches: ReadonlyArray<ACPBuiltinToolMapping>;
+}): ACPBuiltinToolMapping | undefined {
+  if (!isRecord(rawInput)) return undefined;
+  const rawInputKeys = Object.keys(rawInput);
+  const coverageOf = (tool: ACPBuiltinToolMapping): number => {
+    const properties = isRecord(tool.inputSchema)
+      ? isRecord(tool.inputSchema.properties)
+        ? tool.inputSchema.properties
+        : {}
+      : {};
+    return rawInputKeys.filter(key => key in properties).length;
+  };
+  const highestCoverage = Math.max(...schemaMatches.map(coverageOf));
+  const mostSpecificMatches = schemaMatches.filter(
+    tool => coverageOf(tool) === highestCoverage,
+  );
+  return mostSpecificMatches.length === 1 ? mostSpecificMatches[0] : undefined;
 }
 
 function findBuiltinToolByTitle({


### PR DESCRIPTION
## Background

When an ACP agent emits a tool call without providing a tool name, the stream translator attempts to infer the intended tool by matching the input shape against candidate built-in tool schemas. When an input matches multiple schemas (such as a tool whose arguments are a subset of another candidate tool's schema), the stream translator previously discarded either match and fell back to a generic dynamic tool name.

## Summary

This PR updates the ACP stream translator to pick the most specific candidate schema when resolving unnamed tool calls with multiple matching schemas.

- Implemented `findMostSpecificSchemaMatch` to score candidate schemas based on input property coverage and choose the most specific match.
- Preserved dynamic fallback behavior when candidates remain tied in specificity.
- Added unit tests in `harness-acp` for ambiguous input resolution and tie handling.

## End-to-End Verification

Verified end-to-end via #20342, where this flaw was discovered.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
