### PR TITLE
fix(harness-acp): remove problematic condition that leads to errors when using `stopWhen`

### DIFF
--- a/.changeset/modern-jokes-reflect.md
+++ b/.changeset/modern-jokes-reflect.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness-acp": patch
+---
+
+fix(harness-acp): remove problematic condition that leads to errors when using `stopWhen`

--- a/packages/harness-acp/src/v1/acp-v1-harness.ts
+++ b/packages/harness-acp/src/v1/acp-v1-harness.ts
@@ -1781,11 +1781,6 @@ function createSession({
           `${harnessId} ACP session ${sessionId} is stopped; cannot suspend.`,
         );
       }
-      if (!turnInFlight) {
-        throw new Error(
-          `${harnessId} ACP session ${sessionId} has no in-flight turn to suspend.`,
-        );
-      }
       stopped = true;
       const lastSeenEventId = await channel.suspend();
       return {


### PR DESCRIPTION
## Background

The ACP-backed harness adapters all failed any `stopWhen` mid-turn suspend with `... has no in-flight turn to suspend`. It happened whenever the underlying ACP agent finished the whole turn on its own before the host got around to calling `doSuspendTurn`, a very common outcome since ACP agents run their tool-calling loop autonomously once started.

## Summary

`doSuspendTurn` guarded on a `turnInFlight` flag that gets cleared as soon as the bridge's `finish` frame arrives, which can race ahead of the host's own step-boundary bookkeeping. The `codex` and `claude-code` adapters never had this guard: they suspend unconditionally and let `channel.suspend()` handle the "nothing left to suspend" case on its own. This PR removes the same, now clearly unnecessary, check from the ACP v1 adapter.

## End-to-End Verification

Reran all `examples/ai-functions/src/harness-agent/*/stop-when.ts` examples.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
