### PR TITLE
fix(vertex): default Llama 4 output tokens

### DIFF
--- a/.changeset/bright-mice-sleep.md
+++ b/.changeset/bright-mice-sleep.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+fix(vertex): default Llama 4 output tokens

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -2156,6 +2156,12 @@ The following models are available through the MaaS provider. You can also pass 
 | `moonshotai/kimi-k2-thinking-maas`             | Moonshot |
 
 <Note>
+  Llama 4 MaaS models default to their 8,192-token output limit when
+  `maxOutputTokens` is not specified. An explicit `maxOutputTokens` value takes
+  precedence.
+</Note>
+
+<Note>
   Model availability depends on your Google Cloud project and region. Check the
   [Vertex AI Model
   Garden](https://console.cloud.google.com/vertex-ai/model-garden) for the

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
@@ -64,6 +64,7 @@ describe('google-vertex-maas-provider', () => {
           "baseURL": "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi",
           "fetch": undefined,
           "name": "vertex.maas",
+          "transformRequestBody": [Function],
         }
       `);
   });
@@ -82,6 +83,7 @@ describe('google-vertex-maas-provider', () => {
           "baseURL": "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi",
           "fetch": undefined,
           "name": "vertex.maas",
+          "transformRequestBody": [Function],
         }
       `);
   });
@@ -100,6 +102,7 @@ describe('google-vertex-maas-provider', () => {
           "baseURL": "https://aiplatform.eu.rep.googleapis.com/v1/projects/test-project/locations/eu/endpoints/openapi",
           "fetch": undefined,
           "name": "vertex.maas",
+          "transformRequestBody": [Function],
         }
       `);
   });
@@ -174,6 +177,53 @@ describe('google-vertex-maas-provider', () => {
         fetch: customFetch,
       }),
     );
+  });
+
+  it('should default Llama 4 max tokens without overriding explicit or other model settings', () => {
+    const provider = createGoogleVertexMaas({
+      project: 'test-project',
+    });
+
+    provider('meta/llama-4-scout-17b-16e-instruct-maas');
+
+    const [{ transformRequestBody }] = vi.mocked(createOpenAICompatible).mock
+      .calls[0];
+
+    expect(
+      transformRequestBody?.({
+        model: 'meta/llama-4-scout-17b-16e-instruct-maas',
+        messages: [],
+        max_tokens: undefined,
+      }),
+    ).toEqual({
+      model: 'meta/llama-4-scout-17b-16e-instruct-maas',
+      messages: [],
+      max_tokens: 8192,
+    });
+
+    expect(
+      transformRequestBody?.({
+        model: 'meta/llama-4-maverick-17b-128e-instruct-maas',
+        messages: [],
+        max_tokens: 64,
+      }),
+    ).toEqual({
+      model: 'meta/llama-4-maverick-17b-128e-instruct-maas',
+      messages: [],
+      max_tokens: 64,
+    });
+
+    expect(
+      transformRequestBody?.({
+        model: 'openai/gpt-oss-20b-maas',
+        messages: [],
+        max_tokens: undefined,
+      }),
+    ).toEqual({
+      model: 'openai/gpt-oss-20b-maas',
+      messages: [],
+      max_tokens: undefined,
+    });
   });
 
   it('should construct correct URL with trailing slash removed from baseURL', () => {

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.ts
@@ -11,6 +11,19 @@ import {
 } from '@ai-sdk/provider-utils';
 import type { GoogleVertexMaasModelId } from './google-vertex-maas-options';
 
+const maxOutputTokensByModel: Record<string, number | undefined> = {
+  'meta/llama-4-maverick-17b-128e-instruct-maas': 8192,
+  'meta/llama-4-scout-17b-16e-instruct-maas': 8192,
+};
+
+function transformGoogleVertexMaasRequestBody(args: Record<string, any>) {
+  const maxOutputTokens = maxOutputTokensByModel[args.model];
+
+  return maxOutputTokens != null && args.max_tokens === undefined
+    ? { ...args, max_tokens: maxOutputTokens }
+    : args;
+}
+
 export interface GoogleVertexMaasProvider extends OpenAICompatibleProvider<
   GoogleVertexMaasModelId,
   string,
@@ -101,6 +114,7 @@ export function createGoogleVertexMaas(
       name: 'vertex.maas',
       baseURL: loadBaseURL(),
       fetch: options.fetch,
+      transformRequestBody: transformGoogleVertexMaasRequestBody,
     }));
 
   const provider = (modelId: GoogleVertexMaasModelId) => getProvider()(modelId);


### PR DESCRIPTION
## Background

On Vertex MaaS, Llama 4 returns empty text when `max_tokens` is omitted. The models require an explicit output-token limit.

## Summary

Default `max_tokens` to 8192 for the supported Llama 4 Scout and Maverick MaaS model IDs

## End-to-End Verification

Against MaaS Llama 4 Scout, a request without `max_tokens` returned `text: ''`. Same request with `max_tokens: 8192` returned `text: 'ok'`.

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

Fixes https://github.com/vercel/ai/issues/15685