### PR TITLE
feat(open-responses): add strict assistant history serialization without synthetic item IDs

### DIFF
--- a/.changeset/calm-responses-smile.md
+++ b/.changeset/calm-responses-smile.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/open-responses': patch
+---
+
+feat(open-responses): add strict assistant history serialization without synthetic item IDs

--- a/content/providers/01-ai-sdk-providers/06-open-responses.mdx
+++ b/content/providers/01-ai-sdk-providers/06-open-responses.mdx
@@ -61,6 +61,13 @@ You can use the following optional settings to customize the Open Responses prov
   Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
   Defaults to the global `fetch` function.
 
+- **strictResponseInput** _boolean_
+
+  Serializes assistant history using strict OpenAI Responses input schemas.
+  Assistant messages without an item ID are sent as easy input messages, while
+  messages with a genuine provider item ID are sent as complete output items.
+  Defaults to `false`.
+
 ### Endpoint Examples
 
 For a local LM Studio server that does not require authentication:

--- a/packages/open-responses/src/open-responses-provider.ts
+++ b/packages/open-responses/src/open-responses-provider.ts
@@ -47,6 +47,15 @@ export interface OpenResponsesProviderSettings {
   fetch?: FetchFunction;
 
   /**
+   * Whether to serialize assistant history using the strict OpenAI Responses
+   * input schemas. Assistant messages without an item ID are sent as easy input
+   * messages, while messages with an item ID are sent as complete output items.
+   *
+   * @default false
+   */
+  strictResponseInput?: boolean;
+
+  /**
    * Codecs for Open Responses extension tools, items, and streaming events.
    *
    * @experimental This API may change in a future release.
@@ -84,6 +93,7 @@ export function createOpenResponses(
       fetch: options.fetch,
       generateId: () => generateId(),
       extensionRegistry,
+      strictResponseInput: options.strictResponseInput,
     });
   };
 

--- a/packages/open-responses/src/responses/convert-to-open-responses-input.test.ts
+++ b/packages/open-responses/src/responses/convert-to-open-responses-input.test.ts
@@ -510,6 +510,66 @@ describe('convertToOpenResponsesInput', () => {
         },
       ]);
     });
+
+    it('should use an easy input message without generating an ID in strict mode', async () => {
+      const result = await convertToOpenResponsesInput({
+        prompt: [
+          {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hello from assistant' }],
+          },
+        ],
+        strictResponseInput: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'message',
+          role: 'assistant',
+          content: 'Hello from assistant',
+        },
+      ]);
+    });
+
+    it('should preserve a genuine item ID as a complete output message in strict mode', async () => {
+      const result = await convertToOpenResponsesInput({
+        providerOptionsName: 'test-provider',
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'text',
+                text: 'Hello from assistant',
+                providerOptions: {
+                  'test-provider': {
+                    itemId: 'msg_123',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        strictResponseInput: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          id: 'msg_123',
+          type: 'message',
+          status: 'completed',
+          role: 'assistant',
+          content: [
+            {
+              type: 'output_text',
+              text: 'Hello from assistant',
+              annotations: [],
+              logprobs: [],
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   describe('assistant messages with tool calls', () => {

--- a/packages/open-responses/src/responses/convert-to-open-responses-input.ts
+++ b/packages/open-responses/src/responses/convert-to-open-responses-input.ts
@@ -31,11 +31,13 @@ export async function convertToOpenResponsesInput({
   providerOptionsName = 'open-responses',
   extensionRegistry,
   providerToolsByName = new Map(),
+  strictResponseInput = false,
 }: {
   prompt: LanguageModelV4Prompt;
   providerOptionsName?: string;
   extensionRegistry?: OpenResponsesExtensionRegistry;
   providerToolsByName?: Map<string, LanguageModelV4ProviderTool>;
+  strictResponseInput?: boolean;
 }): Promise<{
   input: OpenResponsesRequestBody['input'];
   instructions: string | undefined;
@@ -126,12 +128,40 @@ export async function convertToOpenResponsesInput({
             return;
           }
 
-          input.push({
-            type: 'message',
-            role: 'assistant',
-            content: assistantContent,
-            ...(assistantMessageId != null && { id: assistantMessageId }),
-          });
+          if (strictResponseInput && assistantMessageId == null) {
+            input.push({
+              type: 'message',
+              role: 'assistant',
+              content: assistantContent
+                .map(part =>
+                  part.type === 'output_text' ? part.text : part.refusal,
+                )
+                .join(''),
+            });
+          } else if (strictResponseInput) {
+            input.push({
+              id: assistantMessageId,
+              type: 'message',
+              status: 'completed',
+              role: 'assistant',
+              content: assistantContent.map(part =>
+                part.type === 'output_text'
+                  ? {
+                      ...part,
+                      annotations: part.annotations ?? [],
+                      logprobs: part.logprobs ?? [],
+                    }
+                  : part,
+              ),
+            });
+          } else {
+            input.push({
+              type: 'message',
+              role: 'assistant',
+              content: assistantContent,
+              ...(assistantMessageId != null && { id: assistantMessageId }),
+            });
+          }
           assistantContent = [];
           assistantMessageId = undefined;
         };

--- a/packages/open-responses/src/responses/open-responses-api.ts
+++ b/packages/open-responses/src/responses/open-responses-api.ts
@@ -100,6 +100,7 @@ export type OutputTextContentParam = {
   type: 'output_text';
   text: string;
   annotations?: UrlCitationParam[];
+  logprobs?: LogProb[];
 };
 
 /**

--- a/packages/open-responses/src/responses/open-responses-config.ts
+++ b/packages/open-responses/src/responses/open-responses-config.ts
@@ -9,4 +9,5 @@ export type OpenResponsesConfig = {
   fetch?: FetchFunction;
   generateId: () => string;
   extensionRegistry?: OpenResponsesExtensionRegistry;
+  strictResponseInput?: boolean;
 };

--- a/packages/open-responses/src/responses/open-responses-language-model.ts
+++ b/packages/open-responses/src/responses/open-responses-language-model.ts
@@ -146,6 +146,7 @@ export class OpenResponsesLanguageModel implements LanguageModelV4 {
       providerOptionsName: this.config.providerOptionsName,
       extensionRegistry: this.extensionRegistry,
       providerToolsByName,
+      strictResponseInput: this.config.strictResponseInput,
     });
 
     warnings.push(...inputWarnings);


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/12754

there was a solution posed in https://github.com/vercel/ai/pull/20341 that approached this in the wrong way and only targeted `openai` package (whereas the intended fix should've been open-responses)

## Summary

added an opt-in `strictResponseInput` mode serializing ID-less assistant history without synthetic IDs while preserving genuine IDs as complete output messages.

## End-to-End Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #12754