### PR TITLE
feat (provider/topaz): add Topaz Labs provider

### DIFF
--- a/.changeset/topaz-provider-package.md
+++ b/.changeset/topaz-provider-package.md
@@ -1,0 +1,12 @@
+---
+'@ai-sdk/topaz': major
+---
+
+feat (provider/topaz): add Topaz Labs provider
+
+Adds `@ai-sdk/topaz` with image and video enhancement support for the Topaz Labs API:
+
+- `topaz.image('wonder-3.5')` — generative image upscaling. The provider submits the async enhance job, polls it, and downloads the result.
+- `topaz.video('proteus')` and `topaz.video('starlight-precise-2.6')` — video enhancement via the spec-v4 async operation protocol, running the Topaz create/accept/upload/complete-upload flow in `doStart` and polling in `doStatus`.
+
+Topaz enhances media the caller supplies: the image is passed through the prompt's `images` and the video through `inputReferences`. Video requests also need source metadata (resolution, duration, frame rate, frame count) up front, which the provider assembles from the standard call options and the `source` provider option.

--- a/content/providers/01-ai-sdk-providers/105-topaz.mdx
+++ b/content/providers/01-ai-sdk-providers/105-topaz.mdx
@@ -1,0 +1,233 @@
+---
+title: Topaz Labs
+description: Learn how to use the Topaz Labs provider for the AI SDK.
+---
+
+# Topaz Labs Provider
+
+The [Topaz Labs](https://www.topazlabs.com/) provider contains support for Topaz Labs' image and video enhancement models.
+
+Topaz models **enhance media you supply** — they upscale, denoise, sharpen and restore an existing image or video. They do not generate media from a text prompt, so the input file is the required part of the request and a text prompt is ignored.
+
+## Setup
+
+The Topaz Labs provider is available in the `@ai-sdk/topaz` module. You can install it with
+
+<InstallPackages packages="@ai-sdk/topaz" />
+
+## Provider Instance
+
+You can import the default provider instance `topaz` from `@ai-sdk/topaz`:
+
+```ts
+import { topaz } from '@ai-sdk/topaz';
+```
+
+If you need a customized setup, you can import `createTopaz` and create a provider instance with your settings:
+
+```ts
+import { createTopaz } from '@ai-sdk/topaz';
+
+const topaz = createTopaz({
+  apiKey: process.env.TOPAZ_API_KEY,
+});
+```
+
+You can use the following optional settings to customize the Topaz Labs provider instance:
+
+- **apiKey** _string_
+
+  API key that is being sent as the `X-API-Key` header.
+  It defaults to the `TOPAZ_API_KEY` environment variable.
+
+- **baseURL** _string_
+
+  Use a different URL prefix for API calls, e.g. to use proxy servers.
+  The default prefix is `https://api.topazlabs.com`.
+
+- **headers** _Record&lt;string, string&gt;_
+
+  Custom headers to include in the requests.
+
+- **fetch** _(input: RequestInfo, init?: RequestInit) => Promise&lt;Response&gt;_
+
+  Custom [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) implementation.
+
+## Image Models
+
+You can create Topaz image models using `topaz.image()`:
+
+```ts
+import { topaz } from '@ai-sdk/topaz';
+import { generateImage } from 'ai';
+
+const { images } = await generateImage({
+  model: topaz.image('wonder-3.5'),
+  prompt: {
+    images: ['https://example.com/photo.jpg'],
+  },
+});
+```
+
+The image to enhance is passed through the prompt's `images`. The Topaz image API is asynchronous: the provider submits the job, polls until it finishes, and downloads the result, so `generateImage` resolves with the enhanced image.
+
+### Model Capabilities
+
+| Model        | Topaz model  | Description                              |
+| ------------ | ------------ | ---------------------------------------- |
+| `wonder-3.5` | `Wonder 3.5` | Generative upscaling and detail recovery |
+
+Passing a raw Topaz model name (for example `Wonder 3.5`) also works — unknown ids are forwarded to the API unchanged.
+
+### Image Provider Options
+
+```ts
+import { topaz, type TopazImageModelOptions } from '@ai-sdk/topaz';
+import { generateImage } from 'ai';
+
+const { images } = await generateImage({
+  model: topaz.image('wonder-3.5'),
+  prompt: {
+    images: ['https://example.com/photo.jpg'],
+  },
+  size: '4096x4096',
+  providerOptions: {
+    topaz: {
+      enhancementStrength: 'high',
+      grain: true,
+      grainDensity: 0.3,
+      outputFormat: 'png',
+    } satisfies TopazImageModelOptions,
+  },
+});
+```
+
+- **enhancementStrength** _'low' | 'medium' | 'high'_ — how aggressively to enhance. Defaults to `high`.
+- **grain** _boolean_ — add grain to the output. Defaults to `false`.
+- **grainDensity** _number_ — grain intensity, 0 to 1. Defaults to 0.5.
+- **grainModel** _'silver' | 'gaussian' | 'grey'_ — grain model. Defaults to `silver`.
+- **grainSize** _number_ — grain particle size, 1 to 5. Defaults to 1.
+- **grainStrength** _number_ — grain effect strength, 0 to 1. Defaults to 0.5.
+- **inputWidth** / **inputHeight** _number_ — input dimensions in pixels. Topaz infers these from the upload when omitted.
+- **outputWidth** / **outputHeight** _number_ — output dimensions in pixels, 1 to 32000. These take precedence over the dimensions derived from `size`.
+- **outputFormat** _'jpeg' | 'jpg' | 'png' | 'tiff' | 'tif'_ — output format.
+- **cropToFill** _boolean_ — crop the output to fill the requested dimensions. Defaults to `false`.
+- **webhookUrl** _string_ — URL to receive job-status webhooks.
+- **pollIntervalMillis** _number_ — status poll interval. Defaults to 2000.
+- **pollTimeoutMillis** _number_ — maximum time to wait for the job. Defaults to 600000.
+
+`aspectRatio`, `seed`, `mask` and `n` greater than 1 are not supported and produce warnings.
+
+## Video Models
+
+You can create Topaz video models using `topaz.video()`:
+
+```ts
+import { topaz } from '@ai-sdk/topaz';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { videos } = await generateVideo({
+  model: topaz.video('starlight-precise-2.6'),
+  inputReferences: ['https://example.com/clip.mp4'],
+  providerOptions: {
+    topaz: {
+      source: {
+        width: 1920,
+        height: 1080,
+        duration: 10,
+        frameRate: 30,
+        frameCount: 300,
+      },
+      output: { width: 3840, height: 2160 },
+    },
+  },
+});
+```
+
+The video to enhance is passed through `inputReferences`.
+
+### Model Capabilities
+
+| Model                   | Topaz model | Description                                   |
+| ----------------------- | ----------- | --------------------------------------------- |
+| `proteus`               | `prob-4`    | Detail-preserving upscaling with fine control |
+| `starlight-precise-2.6` | `slp-2.6`   | Generative upscaling with high fidelity       |
+
+### Source Metadata
+
+Topaz creates the video request before the upload begins, and that request has to describe the input video. The AI SDK does not inspect media files, so this metadata comes from your side. The provider fills in what it can:
+
+| Field        | Where it comes from                                                 |
+| ------------ | ------------------------------------------------------------------- |
+| `size`       | Derived from the input bytes.                                       |
+| `container`  | Derived from the input's media type or URL extension.               |
+| `resolution` | The `resolution` call option, or `source.width` / `source.height`.  |
+| `duration`   | The `duration` call option, or `source.duration`.                   |
+| `frameRate`  | The `fps` call option, or `source.frameRate`.                       |
+| `frameCount` | `source.frameCount`, or `duration * frameRate` when both are known. |
+
+`source.*` always takes precedence over the corresponding call option. If anything is still missing, the provider throws an error naming the fields it needs.
+
+<Note>
+  Set `source.frameCount` explicitly for variable-frame-rate input, where
+  `duration * frameRate` is not exact.
+</Note>
+
+So the example above can also be written using the standard call options:
+
+```ts
+const { videos } = await generateVideo({
+  model: topaz.video('proteus'),
+  inputReferences: ['https://example.com/clip.mp4'],
+  resolution: '1920x1080',
+  duration: 10,
+  fps: 30,
+  providerOptions: {
+    topaz: {
+      source: { frameCount: 300 },
+    },
+  },
+});
+```
+
+### Video Provider Options
+
+Structural options:
+
+- **source** _object_ — input video metadata: `width`, `height`, `duration`, `frameRate`, `frameCount`, `container`.
+- **output** _object_ — `width`, `height`, `frameRate`, `audioCodec` (`'AAC' | 'AC3' | 'PCM'`), `audioTransfer` (`'Copy' | 'Convert' | 'None'`), `container` (`'mp4' | 'mov' | 'mkv'`), `dynamicCompressionLevel`. Each dimension and the frame rate default to the source value; audio defaults to `AAC` / `Copy`.
+- **additionalFilters** _Array&lt;Record&lt;string, unknown&gt;&gt;_ — extra `filters[]` entries, e.g. a frame-interpolation filter. Each entry must include a `model` key.
+- **filter** _Record&lt;string, unknown&gt;_ — escape hatch merged into the model's filter entry, overriding the typed options below.
+
+Proteus filter settings: `videoType`, `auto`, `fieldOrder`, `focusFixLevel`, `compression`, `details`, `prenoise`, `noise`, `halo`, `preblur`, `blur`, `grain`, `grainSigma`, `grainSize`, `grainType`, `recoverOriginalDetailValue`.
+
+Starlight Precise filter settings: `sharpness`, `videoBitDepth`, `videoCodec`, `videoProfile`, `watermark`.
+
+See the [Proteus](https://developer.topazlabs.com/video-models/proteus/proteus-1) and [Starlight Precise 2.6](https://developer.topazlabs.com/video-models/starlight/starlight-precise-2.6) references for the accepted ranges.
+
+`prompt`, `aspectRatio`, `seed`, `generateAudio`, `frameImages` and `n` greater than 1 are not supported and produce warnings.
+
+### Long-Running Operations
+
+Video enhancement takes minutes, so Topaz video models implement the AI SDK's async operation protocol. `generateVideo` polls to completion. Use `experimental_startVideo` when you would rather persist the operation and check its status later:
+
+```ts
+import { topaz } from '@ai-sdk/topaz';
+import { experimental_startVideo as startVideo } from 'ai';
+
+const operation = await startVideo({
+  model: topaz.video('starlight-precise-2.6'),
+  inputReferences: ['https://example.com/clip.mp4'],
+  providerOptions: {
+    topaz: {
+      source: {
+        width: 1920,
+        height: 1080,
+        duration: 10,
+        frameRate: 30,
+        frameCount: 300,
+      },
+    },
+  },
+});
+```

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -66,6 +66,7 @@
     "@ai-sdk/sandbox-just-bash": "workspace:*",
     "@ai-sdk/sandbox-vercel": "workspace:*",
     "@ai-sdk/togetherai": "workspace:*",
+    "@ai-sdk/topaz": "workspace:*",
     "@ai-sdk/tui": "workspace:*",
     "@ai-sdk/valibot": "workspace:*",
     "@ai-sdk/voyage": "workspace:*",

--- a/examples/ai-functions/src/generate-image/topaz/basic.ts
+++ b/examples/ai-functions/src/generate-image/topaz/basic.ts
@@ -1,0 +1,25 @@
+import { topaz, type TopazImageModelOptions } from '@ai-sdk/topaz';
+import { generateImage } from 'ai';
+import { presentImages } from '../../lib/present-image';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateImage({
+    model: topaz.image('wonder-3.5'),
+    // Topaz enhances an image you supply, so the input image is the prompt.
+    prompt: {
+      images: [
+        'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/comic-cat.png',
+      ],
+    },
+    providerOptions: {
+      topaz: {
+        enhancementStrength: 'high',
+        outputWidth: 2048,
+        outputHeight: 2048,
+      } satisfies TopazImageModelOptions,
+    },
+  });
+
+  await presentImages(result.images);
+});

--- a/examples/ai-functions/src/generate-video/topaz/basic.ts
+++ b/examples/ai-functions/src/generate-video/topaz/basic.ts
@@ -1,0 +1,36 @@
+import { topaz, type TopazVideoModelOptions } from '@ai-sdk/topaz';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner(
+    'Enhancing video with Starlight Precise 2.6...',
+    () =>
+      generateVideo({
+        model: topaz.video('starlight-precise-2.6'),
+        // Topaz enhances a video you supply; pass it as an input reference.
+        inputReferences: [
+          'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/prudence.mp4',
+        ],
+        providerOptions: {
+          topaz: {
+            // Topaz needs the input video's properties before the upload
+            // starts, and the AI SDK does not inspect media files.
+            source: {
+              width: 1920,
+              height: 1080,
+              duration: 10,
+              frameRate: 30,
+              frameCount: 300,
+            },
+            output: { width: 3840, height: 2160 },
+            sharpness: 4,
+          } satisfies TopazVideoModelOptions,
+        },
+      }),
+  );
+
+  await presentVideos(videos);
+});

--- a/examples/ai-functions/src/generate-video/topaz/proteus.ts
+++ b/examples/ai-functions/src/generate-video/topaz/proteus.ts
@@ -1,0 +1,33 @@
+import { topaz, type TopazVideoModelOptions } from '@ai-sdk/topaz';
+import { experimental_generateVideo as generateVideo } from 'ai';
+import { presentVideos } from '../../lib/present-video';
+import { run } from '../../lib/run';
+import { withSpinner } from '../../lib/spinner';
+
+run(async () => {
+  const { videos } = await withSpinner('Enhancing video with Proteus...', () =>
+    generateVideo({
+      model: topaz.video('proteus'),
+      inputReferences: [
+        'https://raw.githubusercontent.com/vercel/ai/refs/heads/main/examples/ai-functions/data/prudence.mp4',
+      ],
+      // `resolution`, `duration` and `fps` fill in the corresponding source
+      // fields, so only `frameCount` is left to declare.
+      resolution: '1920x1080',
+      duration: 10,
+      fps: 30,
+      providerOptions: {
+        topaz: {
+          source: { frameCount: 300 },
+          videoType: 'Progressive',
+          auto: 'Auto',
+          compression: 0.2,
+          details: 0.35,
+          noise: -0.1,
+        } satisfies TopazVideoModelOptions,
+      },
+    }),
+  );
+
+  await presentVideos(videos);
+});

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -208,6 +208,9 @@
       "path": "../../packages/togetherai"
     },
     {
+      "path": "../../packages/topaz"
+    },
+    {
       "path": "../../packages/tui"
     },
     {

--- a/packages/topaz/README.md
+++ b/packages/topaz/README.md
@@ -1,0 +1,170 @@
+# AI SDK - Topaz Labs Provider
+
+The **Topaz Labs provider** for the [AI SDK](https://ai-sdk.dev/docs) contains image and video model support for the [Topaz Labs API](https://developer.topazlabs.com).
+
+Topaz models **enhance media you supply** — they upscale, denoise, sharpen and restore an existing image or video. They do not generate media from a text prompt.
+
+> **Deploying to Vercel?** With Vercel's AI Gateway you can access Topaz Labs (and hundreds of models from other providers) — no additional packages, API keys, or extra cost. [Get started with AI Gateway](https://vercel.com/ai-gateway).
+
+## Setup
+
+The Topaz Labs provider is available in the `@ai-sdk/topaz` module. You can install it with:
+
+```bash
+npm i @ai-sdk/topaz
+```
+
+## Skill for Coding Agents
+
+If you use coding agents such as Claude Code or Cursor, we highly recommend adding the AI SDK skill to your repository:
+
+```shell
+npx skills add vercel/ai
+```
+
+## Provider Instance
+
+You can import the default provider instance `topaz` from `@ai-sdk/topaz`:
+
+```ts
+import { topaz } from '@ai-sdk/topaz';
+```
+
+## Image Models
+
+| Model id     | Topaz model  | Description                              |
+| ------------ | ------------ | ---------------------------------------- |
+| `wonder-3.5` | `Wonder 3.5` | Generative upscaling and detail recovery |
+
+The input image is passed as the prompt's `images`:
+
+```ts
+import { topaz } from '@ai-sdk/topaz';
+import { generateImage } from 'ai';
+
+const { images } = await generateImage({
+  model: topaz.image('wonder-3.5'),
+  prompt: {
+    images: ['https://example.com/photo.jpg'],
+  },
+  providerOptions: {
+    topaz: {
+      enhancementStrength: 'high',
+      outputWidth: 4096,
+      outputHeight: 4096,
+    },
+  },
+});
+```
+
+The Topaz image API is asynchronous. The provider submits the job, polls until it finishes, and downloads the result, so `generateImage` resolves with the enhanced image. Use `pollIntervalMillis` and `pollTimeoutMillis` to tune that loop.
+
+### Image provider options
+
+| Option                | Type                                          | Description                                                        |
+| --------------------- | --------------------------------------------- | ------------------------------------------------------------------ |
+| `enhancementStrength` | `'low' \| 'medium' \| 'high'`                 | How aggressively to enhance. Default `high`.                       |
+| `grain`               | `boolean`                                     | Add grain to the output. Default `false`.                          |
+| `grainDensity`        | `number` (0–1)                                | Grain intensity. Default 0.5.                                      |
+| `grainModel`          | `'silver' \| 'gaussian' \| 'grey'`            | Grain model. Default `silver`.                                     |
+| `grainSize`           | `number` (1–5)                                | Grain particle size. Default 1.                                    |
+| `grainStrength`       | `number` (0–1)                                | Grain effect strength. Default 0.5.                                |
+| `inputWidth`          | `number`                                      | Input width in pixels. Inferred from the upload when omitted.      |
+| `inputHeight`         | `number`                                      | Input height in pixels. Inferred from the upload when omitted.     |
+| `outputWidth`         | `number` (1–32000)                            | Output width. Takes precedence over the width from `size`.         |
+| `outputHeight`        | `number` (1–32000)                            | Output height. Takes precedence over the height from `size`.       |
+| `outputFormat`        | `'jpeg' \| 'jpg' \| 'png' \| 'tiff' \| 'tif'` | Output format.                                                     |
+| `cropToFill`          | `boolean`                                     | Crop the output to fill the requested dimensions. Default `false`. |
+| `webhookUrl`          | `string`                                      | URL to receive job-status webhooks.                                |
+| `pollIntervalMillis`  | `number`                                      | Status poll interval. Default 2000.                                |
+| `pollTimeoutMillis`   | `number`                                      | Maximum time to wait for the job. Default 600000.                  |
+
+## Video Models
+
+| Model id                | Topaz model | Description                                   |
+| ----------------------- | ----------- | --------------------------------------------- |
+| `proteus`               | `prob-4`    | Detail-preserving upscaling with fine control |
+| `starlight-precise-2.6` | `slp-2.6`   | Generative upscaling with high fidelity       |
+
+The input video is passed as an input reference:
+
+```ts
+import { topaz } from '@ai-sdk/topaz';
+import { experimental_generateVideo as generateVideo } from 'ai';
+
+const { videos } = await generateVideo({
+  model: topaz.video('starlight-precise-2.6'),
+  inputReferences: ['https://example.com/clip.mp4'],
+  providerOptions: {
+    topaz: {
+      source: {
+        width: 1920,
+        height: 1080,
+        duration: 10,
+        frameRate: 30,
+        frameCount: 300,
+      },
+      output: { width: 3840, height: 2160 },
+      sharpness: 4,
+    },
+  },
+});
+```
+
+### Source metadata is required
+
+Topaz needs the input video's properties when the request is created, before the upload begins. The AI SDK does not inspect media files, so this metadata has to come from your side. The provider fills in what it can:
+
+| Field        | Where it comes from                                                 |
+| ------------ | ------------------------------------------------------------------- |
+| `size`       | Derived from the input bytes.                                       |
+| `container`  | Derived from the input's media type or URL extension.               |
+| `resolution` | The `resolution` call option, or `source.width` / `source.height`.  |
+| `duration`   | The `duration` call option, or `source.duration`.                   |
+| `frameRate`  | The `fps` call option, or `source.frameRate`.                       |
+| `frameCount` | `source.frameCount`, or `duration * frameRate` when both are known. |
+
+`source.*` always takes precedence over the corresponding call option. If anything is still missing, the provider throws an error naming the fields it needs. Set `frameCount` explicitly for variable-frame-rate input, where `duration * frameRate` is not exact.
+
+### Polling
+
+Video enhancement is long-running, so the video models implement the AI SDK's async operation protocol. `generateVideo` polls to completion; use `experimental_startVideo` if you would rather persist the operation and check it later.
+
+### Video provider options
+
+Structural options:
+
+| Option              | Type                             | Description                                                                                                                                                                        |
+| ------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source`            | object                           | Input video metadata (see above).                                                                                                                                                  |
+| `output`            | object                           | Output `width`, `height`, `frameRate`, `audioCodec`, `audioTransfer`, `container`, `dynamicCompressionLevel`. Each defaults to the source value; audio defaults to `AAC` / `Copy`. |
+| `additionalFilters` | `Array<Record<string, unknown>>` | Extra `filters[]` entries, e.g. a frame-interpolation filter.                                                                                                                      |
+| `filter`            | `Record<string, unknown>`        | Escape hatch merged into the model's filter, overriding typed options.                                                                                                             |
+
+Proteus filter settings: `videoType`, `auto`, `fieldOrder`, `focusFixLevel`, `compression`, `details`, `prenoise`, `noise`, `halo`, `preblur`, `blur`, `grain`, `grainSigma`, `grainSize`, `grainType`, `recoverOriginalDetailValue`.
+
+Starlight Precise filter settings: `sharpness`, `videoBitDepth`, `videoCodec`, `videoProfile`, `watermark`.
+
+See the [Proteus](https://developer.topazlabs.com/video-models/proteus/proteus-1) and [Starlight Precise 2.6](https://developer.topazlabs.com/video-models/starlight/starlight-precise-2.6) references for the accepted ranges.
+
+## Authentication
+
+Topaz Labs uses API key authentication. Create a key in your [Topaz Labs account](https://developer.topazlabs.com/getting-started/api-key-setup) and set the following environment variable:
+
+```
+TOPAZ_API_KEY=your-api-key
+```
+
+Or pass it directly:
+
+```ts
+import { createTopaz } from '@ai-sdk/topaz';
+
+const topaz = createTopaz({
+  apiKey: 'your-api-key',
+});
+```
+
+## Documentation
+
+Please check out the [Topaz Labs API documentation](https://developer.topazlabs.com) for more information.

--- a/packages/topaz/package.json
+++ b/packages/topaz/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@ai-sdk/topaz",
+  "version": "0.0.0",
+  "type": "module",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist *.tsbuildinfo",
+    "type-check": "tsc --build",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:update": "pnpm test:node -u",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@ai-sdk/test-server": "workspace:*",
+    "@types/node": "22.19.19",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "5.8.3",
+    "zod": "3.25.76"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/topaz"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai"
+  ]
+}

--- a/packages/topaz/src/index.ts
+++ b/packages/topaz/src/index.ts
@@ -1,0 +1,12 @@
+export { createTopaz, topaz } from './topaz-provider';
+export type { TopazProvider, TopazProviderSettings } from './topaz-provider';
+export type { TopazImageModelId } from './topaz-image-settings';
+export type { TopazVideoModelId } from './topaz-video-settings';
+export type { TopazImageModelOptions } from './topaz-image-model-options';
+export type {
+  TopazVideoModelOptions,
+  TopazVideoOutput,
+  TopazVideoSource,
+} from './topaz-video-model-options';
+export { TopazError } from './topaz-error';
+export { VERSION } from './version';

--- a/packages/topaz/src/topaz-config.ts
+++ b/packages/topaz/src/topaz-config.ts
@@ -1,0 +1,11 @@
+import type { FetchFunction } from '@ai-sdk/provider-utils';
+
+export type TopazConfig = {
+  provider: string;
+  baseURL: string;
+  headers: () => Record<string, string | undefined>;
+  fetch?: FetchFunction;
+  _internal?: {
+    currentDate?: () => Date;
+  };
+};

--- a/packages/topaz/src/topaz-error.ts
+++ b/packages/topaz/src/topaz-error.ts
@@ -1,0 +1,62 @@
+import { AISDKError } from '@ai-sdk/provider';
+import { createJsonErrorResponseHandler } from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+
+/**
+ * Topaz reports errors as `{ "detail": ... }`, where `detail` is either a
+ * message or FastAPI's array of validation issues. `message` and `error` are
+ * accepted as well because a few endpoints use them instead.
+ */
+export const topazErrorDataSchema = z.object({
+  detail: z
+    .union([
+      z.string(),
+      z.array(z.object({ msg: z.string().nullish() }).loose()),
+    ])
+    .nullish(),
+  message: z.string().nullish(),
+  error: z.string().nullish(),
+});
+
+export type TopazErrorData = z.infer<typeof topazErrorDataSchema>;
+
+export function topazErrorToMessage(data: TopazErrorData): string {
+  const { detail } = data;
+
+  if (typeof detail === 'string') {
+    return detail;
+  }
+
+  if (Array.isArray(detail)) {
+    const messages = detail
+      .map(issue => issue.msg)
+      .filter((msg): msg is string => msg != null);
+
+    if (messages.length > 0) {
+      return messages.join('; ');
+    }
+  }
+
+  return data.message ?? data.error ?? 'Unknown Topaz API error';
+}
+
+export const topazFailedResponseHandler = createJsonErrorResponseHandler({
+  errorSchema: topazErrorDataSchema,
+  errorToMessage: topazErrorToMessage,
+});
+
+const name = 'AI_TopazError';
+const marker = `vercel.ai.error.${name}`;
+const symbol = Symbol.for(marker);
+
+export class TopazError extends AISDKError {
+  private readonly [symbol] = true; // used in isInstance
+
+  constructor({ message, cause }: { message: string; cause?: unknown }) {
+    super({ name, message, cause });
+  }
+
+  static isInstance(error: unknown): error is TopazError {
+    return AISDKError.hasMarker(error, marker);
+  }
+}

--- a/packages/topaz/src/topaz-image-model-options.ts
+++ b/packages/topaz/src/topaz-image-model-options.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod/v4';
+
+/**
+ * Provider options for Topaz generative image models (Wonder 3.5).
+ *
+ * The documented request schema fields are sent in snake_case
+ * (`output_width`, `output_format`, ...); model-specific settings are sent in
+ * camelCase, matching the Topaz model reference.
+ *
+ * @see https://developer.topazlabs.com/image-models/wonder/wonder-3.5-new
+ */
+export const topazImageModelOptionsSchema = z.object({
+  /**
+   * How aggressively the model enhances the image. Defaults to `high`.
+   */
+  enhancementStrength: z.enum(['low', 'medium', 'high']).optional(),
+
+  /**
+   * Whether to add grain to the output. Defaults to `false`.
+   */
+  grain: z.boolean().optional(),
+
+  /**
+   * Grain intensity, 0.0 to 1.0. Defaults to 0.5.
+   */
+  grainDensity: z.number().min(0).max(1).optional(),
+
+  /**
+   * Grain model. Defaults to `silver`.
+   */
+  grainModel: z.enum(['silver', 'gaussian', 'grey']).optional(),
+
+  /**
+   * Grain particle size, 1 to 5. Defaults to 1.
+   */
+  grainSize: z.number().min(1).max(5).optional(),
+
+  /**
+   * Grain effect strength, 0.0 to 1.0. Defaults to 0.5.
+   */
+  grainStrength: z.number().min(0).max(1).optional(),
+
+  /**
+   * Width of the input image in pixels. Topaz infers this from the upload when
+   * omitted.
+   */
+  inputWidth: z.number().int().positive().optional(),
+
+  /**
+   * Height of the input image in pixels. Topaz infers this from the upload
+   * when omitted.
+   */
+  inputHeight: z.number().int().positive().optional(),
+
+  /**
+   * Width of the output image in pixels, 1 to 32000. Takes precedence over the
+   * width derived from the `size` call option.
+   */
+  outputWidth: z.number().int().min(1).max(32000).optional(),
+
+  /**
+   * Height of the output image in pixels, 1 to 32000. Takes precedence over
+   * the height derived from the `size` call option.
+   */
+  outputHeight: z.number().int().min(1).max(32000).optional(),
+
+  /**
+   * Output image format. Defaults to the Topaz API default.
+   */
+  outputFormat: z.enum(['jpeg', 'jpg', 'png', 'tiff', 'tif']).optional(),
+
+  /**
+   * Whether to crop the output to fill the requested dimensions. Defaults to
+   * `false`.
+   */
+  cropToFill: z.boolean().optional(),
+
+  /**
+   * URL to receive job-status webhooks.
+   */
+  webhookUrl: z.string().optional(),
+
+  /**
+   * How often to poll the Topaz status endpoint, in milliseconds. Defaults to
+   * 2000.
+   */
+  pollIntervalMillis: z.number().int().positive().optional(),
+
+  /**
+   * How long to wait for the job to finish before failing, in milliseconds.
+   * Defaults to 600000 (10 minutes).
+   */
+  pollTimeoutMillis: z.number().int().positive().optional(),
+});
+
+export type TopazImageModelOptions = z.infer<
+  typeof topazImageModelOptionsSchema
+>;

--- a/packages/topaz/src/topaz-image-model.test.ts
+++ b/packages/topaz/src/topaz-image-model.test.ts
@@ -1,0 +1,307 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it } from 'vitest';
+import { TopazImageModel } from './topaz-image-model';
+
+const TEST_BASE_URL = 'https://api.topazlabs.com';
+const PROCESS_ID = 'proc-123';
+const DOWNLOAD_URL = 'https://cdn.topazlabs.example.com/out.png';
+
+const outputBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x01, 0x02]);
+
+const inputImage = {
+  type: 'file' as const,
+  mediaType: 'image/png',
+  data: new Uint8Array([1, 2, 3, 4]),
+};
+
+const defaultOptions = {
+  prompt: undefined,
+  n: 1,
+  size: undefined,
+  aspectRatio: undefined,
+  seed: undefined,
+  files: [inputImage],
+  mask: undefined,
+  providerOptions: { topaz: { pollIntervalMillis: 1 } },
+} as const;
+
+function createModel(modelId = 'wonder-3.5') {
+  return new TopazImageModel(modelId, {
+    provider: 'topaz.image',
+    baseURL: TEST_BASE_URL,
+    headers: () => ({ 'X-API-Key': 'test-key' }),
+    _internal: { currentDate: () => new Date('2026-01-01T00:00:00Z') },
+  });
+}
+
+describe('TopazImageModel', () => {
+  const server = createTestServer({
+    [`${TEST_BASE_URL}/image/v1/enhance-gen/async`]: {
+      response: {
+        type: 'json-value',
+        body: { process_id: PROCESS_ID, source_id: 'src-1', eta: 5 },
+      },
+    },
+    [`${TEST_BASE_URL}/image/v1/status/${PROCESS_ID}`]: {
+      response: {
+        type: 'json-value',
+        body: {
+          status: 'Completed',
+          progress: 100,
+          credits: 2,
+          output_width: 4000,
+          output_height: 3000,
+          output_format: 'png',
+        },
+      },
+    },
+    [`${TEST_BASE_URL}/image/v1/download/${PROCESS_ID}`]: {
+      response: {
+        type: 'json-value',
+        body: { download_url: DOWNLOAD_URL, expiry: 3600 },
+      },
+    },
+    [DOWNLOAD_URL]: {
+      response: { type: 'binary', body: outputBytes },
+    },
+  });
+
+  describe('constructor', () => {
+    it('exposes provider and model information', () => {
+      const model = createModel();
+
+      expect(model.provider).toBe('topaz.image');
+      expect(model.modelId).toBe('wonder-3.5');
+      expect(model.specificationVersion).toBe('v4');
+      expect(model.maxImagesPerCall).toBe(1);
+    });
+  });
+
+  describe('doGenerate', () => {
+    it('submits, polls, downloads and returns the enhanced image', async () => {
+      const result = await createModel().doGenerate({ ...defaultOptions });
+
+      expect(result.images).toHaveLength(1);
+      expect(new Uint8Array(result.images[0] as Uint8Array)).toEqual(
+        new Uint8Array(outputBytes),
+      );
+      expect(result.warnings).toEqual([]);
+      expect(result.response.modelId).toBe('wonder-3.5');
+      expect(result.response.timestamp).toEqual(
+        new Date('2026-01-01T00:00:00Z'),
+      );
+      expect(result.providerMetadata?.topaz.images).toEqual([
+        {
+          processId: PROCESS_ID,
+          credits: 2,
+          width: 4000,
+          height: 3000,
+          format: 'png',
+        },
+      ]);
+    });
+
+    it('maps the model id onto the Topaz model name and uploads the file', async () => {
+      await createModel().doGenerate({ ...defaultOptions });
+
+      const body = await server.calls[0].requestBodyMultipart;
+
+      expect(body?.model).toBe('Wonder 3.5');
+      expect(body?.image).toBeInstanceOf(File);
+    });
+
+    it('sends the API key on the Topaz endpoints', async () => {
+      await createModel().doGenerate({ ...defaultOptions });
+
+      expect(server.calls[0].requestHeaders['x-api-key']).toBe('test-key');
+    });
+
+    it('derives output dimensions from the size option', async () => {
+      await createModel().doGenerate({ ...defaultOptions, size: '4000x3000' });
+
+      const body = await server.calls[0].requestBodyMultipart;
+
+      expect(body?.output_width).toBe('4000');
+      expect(body?.output_height).toBe('3000');
+    });
+
+    it('prefers explicit output dimensions over the size option', async () => {
+      await createModel().doGenerate({
+        ...defaultOptions,
+        size: '4000x3000',
+        providerOptions: {
+          topaz: {
+            pollIntervalMillis: 1,
+            outputWidth: 8000,
+            outputHeight: 6000,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyMultipart;
+
+      expect(body?.output_width).toBe('8000');
+      expect(body?.output_height).toBe('6000');
+    });
+
+    it('sends schema fields in snake_case and model settings in camelCase', async () => {
+      await createModel().doGenerate({
+        ...defaultOptions,
+        providerOptions: {
+          topaz: {
+            pollIntervalMillis: 1,
+            outputFormat: 'jpeg',
+            cropToFill: true,
+            enhancementStrength: 'medium',
+            grain: true,
+            grainDensity: 0.25,
+            grainModel: 'gaussian',
+            grainSize: 2,
+            grainStrength: 0.75,
+            inputWidth: 1000,
+            inputHeight: 800,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyMultipart;
+
+      expect(body?.output_format).toBe('jpeg');
+      expect(body?.crop_to_fill).toBe('true');
+      expect(body?.enhancementStrength).toBe('medium');
+      expect(body?.grain).toBe('true');
+      expect(body?.grainDensity).toBe('0.25');
+      expect(body?.grainModel).toBe('gaussian');
+      expect(body?.grainSize).toBe('2');
+      expect(body?.grainStrength).toBe('0.75');
+      expect(body?.inputWidth).toBe('1000');
+      expect(body?.inputHeight).toBe('800');
+    });
+
+    it('passes a URL input through as source_url instead of uploading bytes', async () => {
+      await createModel().doGenerate({
+        ...defaultOptions,
+        files: [{ type: 'url', url: 'https://example.com/input.png' }],
+      });
+
+      const body = await server.calls[0].requestBodyMultipart;
+
+      expect(body?.source_url).toBe('https://example.com/input.png');
+      expect(body?.image).toBeUndefined();
+    });
+
+    it('polls until the job completes', async () => {
+      const statuses = ['Pending', 'Processing', 'Completed'];
+      let statusCalls = 0;
+
+      server.urls[`${TEST_BASE_URL}/image/v1/status/${PROCESS_ID}`].response =
+        () => ({
+          type: 'json-value',
+          body: { status: statuses[statusCalls++] ?? 'Completed' },
+        });
+
+      const result = await createModel().doGenerate({ ...defaultOptions });
+
+      expect(result.images).toHaveLength(1);
+      expect(statusCalls).toBe(3);
+    });
+
+    it('warns about options Topaz does not support', async () => {
+      const result = await createModel().doGenerate({
+        ...defaultOptions,
+        prompt: 'make it pretty',
+        aspectRatio: '16:9',
+        seed: 42,
+        n: 2,
+        mask: inputImage,
+      });
+
+      expect(result.warnings.map(warning => warning.feature)).toEqual([
+        'prompt',
+        'aspectRatio',
+        'seed',
+        'mask',
+        'n',
+      ]);
+    });
+
+    it('warns when more than one input file is passed', async () => {
+      const result = await createModel().doGenerate({
+        ...defaultOptions,
+        files: [inputImage, inputImage],
+      });
+
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({ feature: 'files' }),
+      );
+    });
+
+    it('throws when no input image is provided', async () => {
+      await expect(
+        createModel().doGenerate({ ...defaultOptions, files: undefined }),
+      ).rejects.toThrow(/enhance an existing image/);
+    });
+
+    it('throws when the job fails', async () => {
+      server.urls[`${TEST_BASE_URL}/image/v1/status/${PROCESS_ID}`].response = {
+        type: 'json-value',
+        body: { status: 'Failed' },
+      };
+
+      await expect(
+        createModel().doGenerate({ ...defaultOptions }),
+      ).rejects.toThrow(/failed for process proc-123/);
+    });
+
+    it('throws when the job is cancelled', async () => {
+      server.urls[`${TEST_BASE_URL}/image/v1/status/${PROCESS_ID}`].response = {
+        type: 'json-value',
+        body: { status: 'Cancelled' },
+      };
+
+      await expect(
+        createModel().doGenerate({ ...defaultOptions }),
+      ).rejects.toThrow(/cancelled for process proc-123/);
+    });
+
+    it('throws when polling exceeds the timeout', async () => {
+      server.urls[`${TEST_BASE_URL}/image/v1/status/${PROCESS_ID}`].response = {
+        type: 'json-value',
+        body: { status: 'Processing' },
+      };
+
+      await expect(
+        createModel().doGenerate({
+          ...defaultOptions,
+          providerOptions: {
+            topaz: { pollIntervalMillis: 1, pollTimeoutMillis: 1 },
+          },
+        }),
+      ).rejects.toThrow(/did not finish within 1ms/);
+    });
+
+    it('throws when no download URL is returned', async () => {
+      server.urls[`${TEST_BASE_URL}/image/v1/download/${PROCESS_ID}`].response =
+        {
+          type: 'json-value',
+          body: {},
+        };
+
+      await expect(
+        createModel().doGenerate({ ...defaultOptions }),
+      ).rejects.toThrow(/did not return a download URL/);
+    });
+
+    it('surfaces Topaz error details', async () => {
+      server.urls[`${TEST_BASE_URL}/image/v1/enhance-gen/async`].response = {
+        type: 'error',
+        status: 422,
+        body: JSON.stringify({ detail: [{ msg: 'model is required' }] }),
+      };
+
+      await expect(
+        createModel().doGenerate({ ...defaultOptions }),
+      ).rejects.toThrow(/model is required/);
+    });
+  });
+});

--- a/packages/topaz/src/topaz-image-model.ts
+++ b/packages/topaz/src/topaz-image-model.ts
@@ -1,0 +1,432 @@
+import type {
+  ImageModelV4,
+  ImageModelV4CallOptions,
+  ImageModelV4File,
+  ImageModelV4Result,
+  SharedV4Warning,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertBase64ToUint8Array,
+  createBinaryResponseHandler,
+  createJsonResponseHandler,
+  getFromApi,
+  mediaTypeToExtension,
+  parseProviderOptions,
+  postFormDataToApi,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import type { TopazConfig } from './topaz-config';
+import { topazFailedResponseHandler, TopazError } from './topaz-error';
+import {
+  topazImageModelOptionsSchema,
+  type TopazImageModelOptions,
+} from './topaz-image-model-options';
+import {
+  resolveTopazImageApiModelId,
+  type TopazImageModelId,
+} from './topaz-image-settings';
+
+const DEFAULT_POLL_INTERVAL_MILLIS = 2000;
+const DEFAULT_POLL_TIMEOUT_MILLIS = 600_000;
+
+/**
+ * Topaz enhances an image that the caller supplies, so `files` is required and
+ * exactly one image is processed per call.
+ */
+export class TopazImageModel implements ImageModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly maxImagesPerCall = 1;
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: TopazImageModelId,
+    private readonly config: TopazConfig,
+  ) {}
+
+  async doGenerate(
+    options: ImageModelV4CallOptions,
+  ): Promise<ImageModelV4Result> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const warnings: SharedV4Warning[] = [];
+
+    const topazOptions = (await parseProviderOptions({
+      provider: 'topaz',
+      providerOptions: options.providerOptions,
+      schema: topazImageModelOptionsSchema,
+    })) as TopazImageModelOptions | undefined;
+
+    this.addUnsupportedWarnings(options, warnings);
+
+    const formData = await this.buildFormData(options, topazOptions, warnings);
+
+    const { value: submitResponse } = await postFormDataToApi({
+      url: `${this.config.baseURL}/image/v1/enhance-gen/async`,
+      headers: combineHeaders(this.config.headers(), options.headers),
+      formData,
+      successfulResponseHandler: createJsonResponseHandler(
+        topazImageSubmitResponseSchema,
+      ),
+      failedResponseHandler: topazFailedResponseHandler,
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const processId = submitResponse.process_id;
+    if (processId == null) {
+      throw new TopazError({
+        message: 'Topaz did not return a process_id for the enhance request.',
+      });
+    }
+
+    const status = await this.waitForCompletion({
+      processId,
+      headers: options.headers,
+      abortSignal: options.abortSignal,
+      pollIntervalMillis:
+        topazOptions?.pollIntervalMillis ?? DEFAULT_POLL_INTERVAL_MILLIS,
+      pollTimeoutMillis:
+        topazOptions?.pollTimeoutMillis ?? DEFAULT_POLL_TIMEOUT_MILLIS,
+    });
+
+    const { image, responseHeaders } = await this.download({
+      processId,
+      headers: options.headers,
+      abortSignal: options.abortSignal,
+    });
+
+    return {
+      images: [image],
+      warnings,
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+      },
+      providerMetadata: {
+        topaz: {
+          images: [
+            {
+              processId,
+              ...(status.credits != null ? { credits: status.credits } : {}),
+              ...(status.output_width != null
+                ? { width: status.output_width }
+                : {}),
+              ...(status.output_height != null
+                ? { height: status.output_height }
+                : {}),
+              ...(status.output_format != null
+                ? { format: status.output_format }
+                : {}),
+            },
+          ],
+        },
+      },
+    };
+  }
+
+  private addUnsupportedWarnings(
+    options: ImageModelV4CallOptions,
+    warnings: SharedV4Warning[],
+  ): void {
+    if (options.prompt != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'prompt',
+        details:
+          'Topaz image models enhance an existing image and do not take a text prompt. ' +
+          'The prompt was ignored.',
+      });
+    }
+
+    if (options.aspectRatio != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'aspectRatio',
+        details:
+          'Topaz image models do not support aspectRatio. Use `size`, or the ' +
+          '`outputWidth` / `outputHeight` provider options, to set output dimensions.',
+      });
+    }
+
+    if (options.seed != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'seed',
+        details: 'Topaz image models do not support seed.',
+      });
+    }
+
+    if (options.mask != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'mask',
+        details:
+          'Topaz image models do not support masks. The mask was ignored.',
+      });
+    }
+
+    if (options.n > 1) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'n',
+        details:
+          'Topaz image models enhance one image per call. Only 1 image will be returned.',
+      });
+    }
+  }
+
+  private async buildFormData(
+    options: ImageModelV4CallOptions,
+    topazOptions: TopazImageModelOptions | undefined,
+    warnings: SharedV4Warning[],
+  ): Promise<FormData> {
+    const file = options.files?.[0];
+
+    if (file == null) {
+      throw new TopazError({
+        message:
+          'Topaz image models enhance an existing image. Pass the input image via ' +
+          'the `files` option.',
+      });
+    }
+
+    if (options.files != null && options.files.length > 1) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'files',
+        details:
+          'Topaz image models enhance one image per call. Only the first file was used.',
+      });
+    }
+
+    const formData = new FormData();
+    formData.append('model', resolveTopazImageApiModelId(this.modelId));
+
+    if (file.type === 'url') {
+      // Topaz fetches the source itself when given a URL, so the bytes never
+      // need to pass through the SDK.
+      formData.append('source_url', file.url);
+    } else {
+      const bytes =
+        typeof file.data === 'string'
+          ? convertBase64ToUint8Array(file.data)
+          : file.data;
+      const extension = mediaTypeToExtension(file.mediaType) ?? 'png';
+
+      formData.append(
+        'image',
+        new File([bytes as BlobPart], `image.${extension}`, {
+          type: file.mediaType,
+        }),
+      );
+    }
+
+    const { width, height } = parseSize(options.size);
+
+    appendIfDefined(
+      formData,
+      'output_width',
+      topazOptions?.outputWidth ?? width,
+    );
+    appendIfDefined(
+      formData,
+      'output_height',
+      topazOptions?.outputHeight ?? height,
+    );
+    appendIfDefined(formData, 'output_format', topazOptions?.outputFormat);
+    appendIfDefined(formData, 'crop_to_fill', topazOptions?.cropToFill);
+    appendIfDefined(formData, 'webhook_url', topazOptions?.webhookUrl);
+
+    // Model-specific settings use camelCase, unlike the request schema fields
+    // above.
+    appendIfDefined(
+      formData,
+      'enhancementStrength',
+      topazOptions?.enhancementStrength,
+    );
+    appendIfDefined(formData, 'grain', topazOptions?.grain);
+    appendIfDefined(formData, 'grainDensity', topazOptions?.grainDensity);
+    appendIfDefined(formData, 'grainModel', topazOptions?.grainModel);
+    appendIfDefined(formData, 'grainSize', topazOptions?.grainSize);
+    appendIfDefined(formData, 'grainStrength', topazOptions?.grainStrength);
+    appendIfDefined(formData, 'inputWidth', topazOptions?.inputWidth);
+    appendIfDefined(formData, 'inputHeight', topazOptions?.inputHeight);
+
+    return formData;
+  }
+
+  private async waitForCompletion({
+    processId,
+    headers,
+    abortSignal,
+    pollIntervalMillis,
+    pollTimeoutMillis,
+  }: {
+    processId: string;
+    headers: Record<string, string | undefined> | undefined;
+    abortSignal: AbortSignal | undefined;
+    pollIntervalMillis: number;
+    pollTimeoutMillis: number;
+  }): Promise<TopazImageStatusResponse> {
+    const deadline = Date.now() + pollTimeoutMillis;
+
+    while (true) {
+      const { value: status } = await getFromApi({
+        url: `${this.config.baseURL}/image/v1/status/${processId}`,
+        // Built from the configured baseURL, not from response data.
+        validateUrl: false,
+        headers: combineHeaders(this.config.headers(), headers),
+        successfulResponseHandler: createJsonResponseHandler(
+          topazImageStatusResponseSchema,
+        ),
+        failedResponseHandler: topazFailedResponseHandler,
+        abortSignal,
+        fetch: this.config.fetch,
+      });
+
+      if (status.status === 'Completed') {
+        return status;
+      }
+
+      if (status.status === 'Failed' || status.status === 'Cancelled') {
+        throw new TopazError({
+          message: `Topaz image enhancement ${status.status.toLowerCase()} for process ${processId}.`,
+        });
+      }
+
+      if (Date.now() + pollIntervalMillis > deadline) {
+        throw new TopazError({
+          message:
+            `Topaz image enhancement did not finish within ${pollTimeoutMillis}ms ` +
+            `(process ${processId}, last status ${status.status ?? 'unknown'}). ` +
+            'Increase the `pollTimeoutMillis` provider option if the job needs longer.',
+        });
+      }
+
+      await delay(pollIntervalMillis, abortSignal);
+    }
+  }
+
+  private async download({
+    processId,
+    headers,
+    abortSignal,
+  }: {
+    processId: string;
+    headers: Record<string, string | undefined> | undefined;
+    abortSignal: AbortSignal | undefined;
+  }): Promise<{
+    image: Uint8Array;
+    responseHeaders: Record<string, string> | undefined;
+  }> {
+    const { value: downloadResponse } = await getFromApi({
+      url: `${this.config.baseURL}/image/v1/download/${processId}`,
+      // Built from the configured baseURL, not from response data.
+      validateUrl: false,
+      headers: combineHeaders(this.config.headers(), headers),
+      successfulResponseHandler: createJsonResponseHandler(
+        topazImageDownloadResponseSchema,
+      ),
+      failedResponseHandler: topazFailedResponseHandler,
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const downloadUrl = downloadResponse.download_url;
+    if (downloadUrl == null) {
+      throw new TopazError({
+        message: `Topaz did not return a download URL for process ${processId}.`,
+      });
+    }
+
+    const { value: image, responseHeaders } = await getFromApi({
+      url: downloadUrl,
+      // Comes from the Topaz response body and normally points at object
+      // storage, so it is validated and the API key is withheld off-origin.
+      validateUrl: true,
+      credentialedOrigin: this.config.baseURL,
+      trustedOrigin: this.config.baseURL,
+      headers: combineHeaders(this.config.headers(), headers),
+      successfulResponseHandler: createBinaryResponseHandler(),
+      failedResponseHandler: topazFailedResponseHandler,
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return { image, responseHeaders };
+  }
+}
+
+function parseSize(size: `${number}x${number}` | undefined): {
+  width: number | undefined;
+  height: number | undefined;
+} {
+  if (size == null) {
+    return { width: undefined, height: undefined };
+  }
+
+  const [width, height] = size.split('x').map(Number);
+  return { width, height };
+}
+
+function appendIfDefined(
+  formData: FormData,
+  key: string,
+  value: string | number | boolean | undefined,
+): void {
+  if (value !== undefined) {
+    formData.append(key, String(value));
+  }
+}
+
+function delay(millis: number, abortSignal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (abortSignal?.aborted) {
+      reject(abortSignal.reason);
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      abortSignal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, millis);
+
+    function onAbort() {
+      clearTimeout(timeout);
+      reject(abortSignal?.reason);
+    }
+
+    abortSignal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+const topazImageSubmitResponseSchema = z.object({
+  process_id: z.string().nullish(),
+  source_id: z.string().nullish(),
+  eta: z.number().nullish(),
+});
+
+const topazImageStatusResponseSchema = z.object({
+  status: z
+    .enum(['Pending', 'Processing', 'Completed', 'Cancelled', 'Failed'])
+    .nullish(),
+  progress: z.number().nullish(),
+  credits: z.number().nullish(),
+  output_width: z.number().nullish(),
+  output_height: z.number().nullish(),
+  output_format: z.string().nullish(),
+});
+
+type TopazImageStatusResponse = z.infer<typeof topazImageStatusResponseSchema>;
+
+const topazImageDownloadResponseSchema = z.object({
+  download_url: z.string().nullish(),
+  head_url: z.string().nullish(),
+  expiry: z.union([z.string(), z.number()]).nullish(),
+});
+
+export type { ImageModelV4File as TopazImageInputFile };

--- a/packages/topaz/src/topaz-image-settings.ts
+++ b/packages/topaz/src/topaz-image-settings.ts
@@ -1,0 +1,22 @@
+/**
+ * Topaz image model ids.
+ *
+ * The AI SDK exposes a readable id that is mapped onto the name the Topaz API
+ * expects in the `model` form field (see `topazImageApiModelIds`). Passing a
+ * raw Topaz name such as `Wonder 3.5` also works - unknown ids are forwarded
+ * to the API unchanged.
+ */
+export type TopazImageModelId = 'wonder-3.5' | (string & {});
+
+/**
+ * Maps AI SDK image model ids onto Topaz API model names.
+ *
+ * @see https://developer.topazlabs.com/image-models/wonder/wonder-3.5-new
+ */
+export const topazImageApiModelIds: Record<string, string> = {
+  'wonder-3.5': 'Wonder 3.5',
+};
+
+export function resolveTopazImageApiModelId(modelId: string): string {
+  return topazImageApiModelIds[modelId] ?? modelId;
+}

--- a/packages/topaz/src/topaz-provider.test.ts
+++ b/packages/topaz/src/topaz-provider.test.ts
@@ -1,0 +1,65 @@
+import { NoSuchModelError } from '@ai-sdk/provider';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTopaz } from './topaz-provider';
+
+describe('createTopaz', () => {
+  beforeEach(() => {
+    vi.stubEnv('TOPAZ_API_KEY', 'env-key');
+  });
+
+  it('creates image models', () => {
+    const provider = createTopaz({ apiKey: 'test-key' });
+    const model = provider.imageModel('wonder-3.5');
+
+    expect(model.provider).toBe('topaz.image');
+    expect(model.modelId).toBe('wonder-3.5');
+    expect(model.specificationVersion).toBe('v4');
+  });
+
+  it('creates video models', () => {
+    const provider = createTopaz({ apiKey: 'test-key' });
+    const model = provider.videoModel('starlight-precise-2.6');
+
+    expect(model.provider).toBe('topaz.video');
+    expect(model.modelId).toBe('starlight-precise-2.6');
+    expect(model.specificationVersion).toBe('v4');
+  });
+
+  it('exposes short aliases for both model types', () => {
+    const provider = createTopaz({ apiKey: 'test-key' });
+
+    expect(provider.image('wonder-3.5').modelId).toBe('wonder-3.5');
+    expect(provider.video('proteus').modelId).toBe('proteus');
+  });
+
+  it('reports specification version v4', () => {
+    expect(createTopaz({ apiKey: 'test-key' }).specificationVersion).toBe('v4');
+  });
+
+  it('throws NoSuchModelError for unsupported model types', () => {
+    const provider = createTopaz({ apiKey: 'test-key' });
+
+    expect(() => provider.languageModel('anything')).toThrow(NoSuchModelError);
+    expect(() => provider.embeddingModel('anything')).toThrow(NoSuchModelError);
+  });
+
+  it('throws when no API key is configured', async () => {
+    vi.stubEnv('TOPAZ_API_KEY', undefined);
+
+    const provider = createTopaz();
+
+    // The key is loaded lazily, when headers are first resolved.
+    await expect(
+      provider.imageModel('wonder-3.5').doGenerate({
+        prompt: undefined,
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: [{ type: 'url', url: 'https://example.com/input.png' }],
+        mask: undefined,
+        providerOptions: {},
+      }),
+    ).rejects.toThrow(/TOPAZ_API_KEY/);
+  });
+});

--- a/packages/topaz/src/topaz-provider.ts
+++ b/packages/topaz/src/topaz-provider.ts
@@ -1,0 +1,136 @@
+import {
+  NoSuchModelError,
+  type Experimental_VideoModelV4 as VideoModelV4,
+  type ImageModelV4,
+  type ProviderV4,
+} from '@ai-sdk/provider';
+import {
+  loadApiKey,
+  withoutTrailingSlash,
+  withUserAgentSuffix,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { TopazImageModel } from './topaz-image-model';
+import type { TopazImageModelId } from './topaz-image-settings';
+import { TopazVideoModel } from './topaz-video-model';
+import type { TopazVideoModelId } from './topaz-video-settings';
+import { VERSION } from './version';
+
+export interface TopazProviderSettings {
+  /**
+   * Topaz Labs API key. Default value is taken from the `TOPAZ_API_KEY`
+   * environment variable.
+   *
+   * @see https://developer.topazlabs.com/getting-started/api-key-setup
+   */
+  apiKey?: string;
+
+  /**
+   * Base URL for the API calls.
+   */
+  baseURL?: string;
+
+  /**
+   * Custom headers to include in the requests.
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept
+   * requests, or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+}
+
+export interface TopazProvider extends ProviderV4 {
+  /**
+   * Creates a model for image enhancement.
+   */
+  image(modelId: TopazImageModelId): ImageModelV4;
+
+  /**
+   * Creates a model for image enhancement.
+   */
+  imageModel(modelId: TopazImageModelId): ImageModelV4;
+
+  /**
+   * Creates a model for video enhancement.
+   */
+  video(modelId: TopazVideoModelId): VideoModelV4;
+
+  /**
+   * Creates a model for video enhancement.
+   */
+  videoModel(modelId: TopazVideoModelId): VideoModelV4;
+}
+
+const defaultBaseURL = 'https://api.topazlabs.com';
+
+/**
+ * Create a Topaz Labs provider instance.
+ */
+export function createTopaz(
+  options: TopazProviderSettings = {},
+): TopazProvider {
+  const baseURL =
+    withoutTrailingSlash(options.baseURL ?? defaultBaseURL) ?? defaultBaseURL;
+
+  const getHeaders = () =>
+    withUserAgentSuffix(
+      {
+        'X-API-Key': loadApiKey({
+          apiKey: options.apiKey,
+          environmentVariableName: 'TOPAZ_API_KEY',
+          description: 'Topaz Labs',
+        }),
+        accept: 'application/json',
+        ...options.headers,
+      },
+      `ai-sdk/topaz/${VERSION}`,
+    );
+
+  const createImageModel = (modelId: TopazImageModelId): ImageModelV4 =>
+    new TopazImageModel(modelId, {
+      provider: 'topaz.image',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
+  const createVideoModel = (modelId: TopazVideoModelId): VideoModelV4 =>
+    new TopazVideoModel(modelId, {
+      provider: 'topaz.video',
+      baseURL,
+      headers: getHeaders,
+      fetch: options.fetch,
+    });
+
+  const noSuchModel = (
+    modelId: string,
+    modelType:
+      | 'languageModel'
+      | 'embeddingModel'
+      | 'transcriptionModel'
+      | 'speechModel'
+      | 'rerankingModel',
+  ): never => {
+    throw new NoSuchModelError({ modelId, modelType });
+  };
+
+  const provider: TopazProvider = {
+    specificationVersion: 'v4' as const,
+    image: createImageModel,
+    imageModel: createImageModel,
+    video: createVideoModel,
+    videoModel: createVideoModel,
+    languageModel: (modelId: string) => noSuchModel(modelId, 'languageModel'),
+    embeddingModel: (modelId: string) => noSuchModel(modelId, 'embeddingModel'),
+  };
+
+  return provider;
+}
+
+/**
+ * Default Topaz Labs provider instance.
+ */
+export const topaz = createTopaz();

--- a/packages/topaz/src/topaz-video-model-options.ts
+++ b/packages/topaz/src/topaz-video-model-options.ts
@@ -1,0 +1,209 @@
+import { z } from 'zod/v4';
+
+/**
+ * Metadata about the input video.
+ *
+ * Topaz requires this on `POST /video/` before the upload happens, and the AI
+ * SDK does not inspect media files (no provider package ships a demuxer), so
+ * whatever cannot be derived from the bytes has to be supplied here.
+ *
+ * `size` and `container` are derived from the input file and are not part of
+ * this object. `duration`, `frameRate` and the resolution are read from the
+ * `duration`, `fps` and `resolution` call options when those are set, so this
+ * object only needs to cover the gaps.
+ */
+export const topazVideoSourceSchema = z.object({
+  /**
+   * Width of the input video in pixels. Falls back to the width of the
+   * `resolution` call option.
+   */
+  width: z.number().int().positive().optional(),
+
+  /**
+   * Height of the input video in pixels. Falls back to the height of the
+   * `resolution` call option.
+   */
+  height: z.number().int().positive().optional(),
+
+  /**
+   * Duration of the input video in seconds. Falls back to the `duration` call
+   * option.
+   */
+  duration: z.number().positive().optional(),
+
+  /**
+   * Frame rate of the input video. Falls back to the `fps` call option.
+   */
+  frameRate: z.number().positive().optional(),
+
+  /**
+   * Total number of frames in the input video. Derived from
+   * `duration * frameRate` when omitted, which is only correct for
+   * constant-frame-rate input - set it explicitly for variable-frame-rate
+   * sources.
+   */
+  frameCount: z.number().int().positive().optional(),
+
+  /**
+   * Container of the input video. Detected from the input file's media type
+   * when omitted.
+   */
+  container: z.enum(['mp4', 'mov', 'mkv']).optional(),
+});
+
+export type TopazVideoSource = z.infer<typeof topazVideoSourceSchema>;
+
+/**
+ * Output settings for the enhanced video. Anything omitted defaults to the
+ * corresponding source value.
+ */
+export const topazVideoOutputSchema = z.object({
+  /**
+   * Width of the output video in pixels. Defaults to the source width.
+   */
+  width: z.number().int().positive().optional(),
+
+  /**
+   * Height of the output video in pixels. Defaults to the source height.
+   */
+  height: z.number().int().positive().optional(),
+
+  /**
+   * Frame rate of the output video. Defaults to the source frame rate.
+   */
+  frameRate: z.number().positive().optional(),
+
+  /**
+   * Audio codec of the output video. Defaults to `AAC`.
+   */
+  audioCodec: z.enum(['AAC', 'AC3', 'PCM']).optional(),
+
+  /**
+   * How to handle the input audio track. Defaults to `Copy`.
+   */
+  audioTransfer: z.enum(['Copy', 'Convert', 'None']).optional(),
+
+  /**
+   * Container of the output video. Defaults to the source container.
+   */
+  container: z.enum(['mp4', 'mov', 'mkv']).optional(),
+
+  /**
+   * Dynamic compression level applied to the output.
+   */
+  dynamicCompressionLevel: z.string().optional(),
+});
+
+export type TopazVideoOutput = z.infer<typeof topazVideoOutputSchema>;
+
+/**
+ * Provider options for Topaz video models.
+ *
+ * @see https://developer.topazlabs.com/video-models/proteus/proteus-1
+ * @see https://developer.topazlabs.com/video-models/starlight/starlight-precise-2.6
+ */
+export const topazVideoModelOptionsSchema = z.object({
+  source: topazVideoSourceSchema.optional(),
+  output: topazVideoOutputSchema.optional(),
+
+  /**
+   * Extra `filters[]` entries to send alongside the model's own filter, e.g. a
+   * frame-interpolation filter. Each entry must include a `model` key.
+   */
+  additionalFilters: z.array(z.record(z.string(), z.unknown())).optional(),
+
+  /**
+   * Escape hatch for filter settings this package does not model yet. Merged
+   * into the model's filter entry, taking precedence over the typed options
+   * below.
+   */
+  filter: z.record(z.string(), z.unknown()).optional(),
+
+  // ---------------------------------------------------------------------------
+  // Proteus (`proteus`)
+  // ---------------------------------------------------------------------------
+
+  /** Proteus: how the input frames are encoded. */
+  videoType: z
+    .enum(['Progressive', 'Interlaced', 'ProgressiveInterlaced'])
+    .optional(),
+
+  /** Proteus: parameter estimation mode. */
+  auto: z.enum(['Auto', 'Manual', 'Relative']).optional(),
+
+  /** Proteus: field order for interlaced input. */
+  fieldOrder: z.enum(['TopFirst', 'BottomFirst', 'Auto']).optional(),
+
+  /** Proteus: focus-fix strength. */
+  focusFixLevel: z.enum(['None', 'Normal', 'Strong']).optional(),
+
+  /** Proteus: compression artifact removal, -1 to 1. */
+  compression: z.number().min(-1).max(1).optional(),
+
+  /** Proteus: detail recovery, -1 to 1. */
+  details: z.number().min(-1).max(1).optional(),
+
+  /** Proteus: pre-processing noise reduction, 0 to 0.1. */
+  prenoise: z.number().min(0).max(0.1).optional(),
+
+  /** Proteus: noise reduction, -1 to 1. */
+  noise: z.number().min(-1).max(1).optional(),
+
+  /** Proteus: halo suppression, -1 to 1. */
+  halo: z.number().min(-1).max(1).optional(),
+
+  /** Proteus: pre-processing blur, -1 to 1. */
+  preblur: z.number().min(-1).max(1).optional(),
+
+  /** Proteus: sharpening, -1 to 1. */
+  blur: z.number().min(-1).max(1).optional(),
+
+  /** Proteus: grain amount, 0 to 0.1. */
+  grain: z.number().min(0).max(0.1).optional(),
+
+  /** Proteus: grain sigma, 0 to 1. */
+  grainSigma: z.number().min(0).max(1).optional(),
+
+  /** Proteus: grain size, 0 to 5. */
+  grainSize: z.number().min(0).max(5).optional(),
+
+  /** Proteus: grain model. */
+  grainType: z.enum(['silverRich', 'gaussian', 'grey']).optional(),
+
+  /** Proteus: original detail recovery, 0 to 1. */
+  recoverOriginalDetailValue: z.number().min(0).max(1).optional(),
+
+  // ---------------------------------------------------------------------------
+  // Starlight Precise (`starlight-precise-2.6`)
+  // ---------------------------------------------------------------------------
+
+  /** Starlight: sharpening applied to the output, 1.0 to 5.0. Defaults to 5.0. */
+  sharpness: z.number().min(1).max(5).optional(),
+
+  /** Starlight: output bit depth. */
+  videoBitDepth: z.number().int().positive().optional(),
+
+  /** Starlight: output video codec. */
+  videoCodec: z.enum(['ffv1', 'prores', 'vp9']).optional(),
+
+  /** Starlight: output chroma subsampling profile. */
+  videoProfile: z.enum(['420', '422', '444']).optional(),
+
+  /** Starlight: whether to watermark the output. Defaults to `false`. */
+  watermark: z.boolean().optional(),
+});
+
+export type TopazVideoModelOptions = z.infer<
+  typeof topazVideoModelOptionsSchema
+>;
+
+/**
+ * Option keys that are structural rather than filter settings, so they are not
+ * forwarded into the `filters[]` entry.
+ */
+export const TOPAZ_NON_FILTER_OPTION_KEYS = [
+  'source',
+  'output',
+  'additionalFilters',
+  'filter',
+] as const satisfies ReadonlyArray<keyof TopazVideoModelOptions>;

--- a/packages/topaz/src/topaz-video-model.test.ts
+++ b/packages/topaz/src/topaz-video-model.test.ts
@@ -1,0 +1,570 @@
+import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import { describe, expect, it } from 'vitest';
+import { TopazVideoModel } from './topaz-video-model';
+
+const TEST_BASE_URL = 'https://api.topazlabs.com';
+const REQUEST_ID = 'req-abc-123';
+const UPLOAD_URL = 'https://uploads.topazlabs.example.com/part-1';
+const UPLOAD_URL_2 = 'https://uploads.topazlabs.example.com/part-2';
+const DOWNLOAD_URL = 'https://cdn.topazlabs.example.com/out.mp4';
+
+const inputVideo = {
+  type: 'file' as const,
+  mediaType: 'video/mp4',
+  data: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+};
+
+/**
+ * Topaz needs source metadata up front, so the happy-path options carry the
+ * pieces that cannot be derived from the request.
+ */
+const sourceOptions = {
+  source: {
+    width: 1920,
+    height: 1080,
+    duration: 10,
+    frameRate: 30,
+    frameCount: 300,
+  },
+};
+
+const defaultOptions = {
+  prompt: undefined,
+  n: 1,
+  image: undefined,
+  frameImages: undefined,
+  inputReferences: [inputVideo],
+  aspectRatio: undefined,
+  resolution: undefined,
+  duration: undefined,
+  fps: undefined,
+  generateAudio: undefined,
+  seed: undefined,
+  providerOptions: { topaz: sourceOptions },
+} as const;
+
+function createModel(modelId = 'starlight-precise-2.6') {
+  return new TopazVideoModel(modelId, {
+    provider: 'topaz.video',
+    baseURL: TEST_BASE_URL,
+    headers: () => ({ 'X-API-Key': 'test-key' }),
+    _internal: { currentDate: () => new Date('2026-01-01T00:00:00Z') },
+  });
+}
+
+describe('TopazVideoModel', () => {
+  const server = createTestServer({
+    [`${TEST_BASE_URL}/video/`]: {
+      response: {
+        type: 'json-value',
+        body: { requestId: REQUEST_ID, estimates: { cost: [12], time: [60] } },
+      },
+    },
+    [`${TEST_BASE_URL}/video/${REQUEST_ID}/accept`]: {
+      response: {
+        type: 'json-value',
+        body: { uploadId: 'upload-1', urls: [UPLOAD_URL] },
+      },
+    },
+    [UPLOAD_URL]: {
+      response: {
+        // `json-value` rather than `empty` because the test server only
+        // applies custom headers (here, the ETag) on a body-carrying response.
+        type: 'json-value',
+        body: {},
+        headers: { etag: '"etag-part-1"' },
+      },
+    },
+    // Only used by the multipart-upload test; the default accept response
+    // returns a single URL.
+    [UPLOAD_URL_2]: {
+      response: {
+        type: 'json-value',
+        body: {},
+        headers: { etag: '"etag-part-2"' },
+      },
+    },
+    [`${TEST_BASE_URL}/video/${REQUEST_ID}/complete-upload`]: {
+      response: { type: 'json-value', body: { message: 'queued' } },
+    },
+    [`${TEST_BASE_URL}/video/${REQUEST_ID}/status`]: {
+      response: {
+        type: 'json-value',
+        body: {
+          status: 'complete',
+          progress: 100,
+          outputSize: 12345,
+          estimates: { cost: [12], time: [60] },
+          download: { url: DOWNLOAD_URL, expiresIn: 3600 },
+        },
+      },
+    },
+  });
+
+  describe('constructor', () => {
+    it('exposes provider and model information', () => {
+      const model = createModel();
+
+      expect(model.provider).toBe('topaz.video');
+      expect(model.modelId).toBe('starlight-precise-2.6');
+      expect(model.specificationVersion).toBe('v4');
+      expect(model.maxVideosPerCall).toBe(1);
+    });
+  });
+
+  describe('doStart', () => {
+    it('runs create, accept, upload and complete-upload in order', async () => {
+      const result = await createModel().doStart({ ...defaultOptions });
+
+      expect(server.calls.map(call => call.requestUrl)).toEqual([
+        `${TEST_BASE_URL}/video/`,
+        `${TEST_BASE_URL}/video/${REQUEST_ID}/accept`,
+        UPLOAD_URL,
+        `${TEST_BASE_URL}/video/${REQUEST_ID}/complete-upload`,
+      ]);
+      expect(server.calls.map(call => call.requestMethod)).toEqual([
+        'POST',
+        'PATCH',
+        'PUT',
+        'PATCH',
+      ]);
+      expect(result.operation).toEqual({
+        requestId: REQUEST_ID,
+        outputContainer: 'mp4',
+      });
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('maps the model id onto the Topaz filter model name', async () => {
+      await createModel().doStart({ ...defaultOptions });
+
+      const body = await server.calls[0].requestBodyJson;
+
+      expect(body.filters).toEqual([{ model: 'slp-2.6' }]);
+    });
+
+    it('maps proteus onto its Topaz model name', async () => {
+      await createModel('proteus').doStart({ ...defaultOptions });
+
+      const body = await server.calls[0].requestBodyJson;
+
+      expect(body.filters[0].model).toBe('prob-4');
+    });
+
+    it('forwards a raw Topaz model name unchanged', async () => {
+      await createModel('slp-2.5').doStart({ ...defaultOptions });
+
+      const body = await server.calls[0].requestBodyJson;
+
+      expect(body.filters[0].model).toBe('slp-2.5');
+    });
+
+    it('derives the source size from the input bytes and the container from the media type', async () => {
+      await createModel().doStart({ ...defaultOptions });
+
+      const body = await server.calls[0].requestBodyJson;
+
+      expect(body.source).toEqual({
+        container: 'mp4',
+        size: 8,
+        duration: 10,
+        frameCount: 300,
+        frameRate: 30,
+        resolution: { width: 1920, height: 1080 },
+      });
+    });
+
+    it('reads source metadata from the spec call options when available', async () => {
+      await createModel().doStart({
+        ...defaultOptions,
+        resolution: '1280x720',
+        duration: 4,
+        fps: 25,
+        providerOptions: { topaz: {} },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+
+      expect(body.source.resolution).toEqual({ width: 1280, height: 720 });
+      expect(body.source.duration).toBe(4);
+      expect(body.source.frameRate).toBe(25);
+      // frameCount is derived from duration * frameRate.
+      expect(body.source.frameCount).toBe(100);
+    });
+
+    it('prefers the source provider option over the spec call options', async () => {
+      await createModel().doStart({
+        ...defaultOptions,
+        resolution: '1280x720',
+        duration: 4,
+        fps: 25,
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+
+      expect(body.source.resolution).toEqual({ width: 1920, height: 1080 });
+      expect(body.source.duration).toBe(10);
+    });
+
+    it('defaults the output to the source, with AAC/Copy audio', async () => {
+      await createModel().doStart({ ...defaultOptions });
+
+      const body = await server.calls[0].requestBodyJson;
+
+      expect(body.output).toEqual({
+        resolution: { width: 1920, height: 1080 },
+        frameRate: 30,
+        audioCodec: 'AAC',
+        audioTransfer: 'Copy',
+        container: 'mp4',
+      });
+    });
+
+    it('applies output provider options', async () => {
+      await createModel().doStart({
+        ...defaultOptions,
+        providerOptions: {
+          topaz: {
+            ...sourceOptions,
+            output: {
+              width: 3840,
+              height: 2160,
+              frameRate: 60,
+              audioCodec: 'PCM',
+              audioTransfer: 'None',
+              container: 'mov',
+            },
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+
+      expect(body.output).toEqual({
+        resolution: { width: 3840, height: 2160 },
+        frameRate: 60,
+        audioCodec: 'PCM',
+        audioTransfer: 'None',
+        container: 'mov',
+      });
+    });
+
+    it('sends model settings as filter fields', async () => {
+      await createModel().doStart({
+        ...defaultOptions,
+        providerOptions: {
+          topaz: {
+            ...sourceOptions,
+            sharpness: 3.5,
+            videoCodec: 'prores',
+            watermark: false,
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+
+      expect(body.filters[0]).toEqual({
+        model: 'slp-2.6',
+        sharpness: 3.5,
+        videoCodec: 'prores',
+        watermark: false,
+      });
+    });
+
+    it('lets the filter escape hatch override typed options', async () => {
+      await createModel().doStart({
+        ...defaultOptions,
+        providerOptions: {
+          topaz: {
+            ...sourceOptions,
+            sharpness: 3.5,
+            filter: { sharpness: 1, experimentalSetting: 'on' },
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+
+      expect(body.filters[0]).toEqual({
+        model: 'slp-2.6',
+        sharpness: 1,
+        experimentalSetting: 'on',
+      });
+    });
+
+    it('appends additional filters', async () => {
+      await createModel().doStart({
+        ...defaultOptions,
+        providerOptions: {
+          topaz: {
+            ...sourceOptions,
+            additionalFilters: [{ model: 'apo-8', fps: 60 }],
+          },
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+
+      expect(body.filters).toEqual([
+        { model: 'slp-2.6' },
+        { model: 'apo-8', fps: 60 },
+      ]);
+    });
+
+    it('uploads the bytes with the container content type and reports the eTag', async () => {
+      await createModel().doStart({ ...defaultOptions });
+
+      expect(server.calls[2].requestHeaders['content-type']).toBe('video/mp4');
+
+      const completeBody = await server.calls[3].requestBodyJson;
+
+      expect(completeBody).toEqual({
+        uploadResults: [{ partNum: 1, eTag: 'etag-part-1' }],
+      });
+    });
+
+    it('splits the upload across every returned URL', async () => {
+      server.urls[`${TEST_BASE_URL}/video/${REQUEST_ID}/accept`].response = {
+        type: 'json-value',
+        body: { uploadId: 'upload-1', urls: [UPLOAD_URL, UPLOAD_URL_2] },
+      };
+
+      await createModel().doStart({ ...defaultOptions });
+
+      const completeBody = await server.calls[4].requestBodyJson;
+
+      expect(completeBody.uploadResults).toEqual([
+        { partNum: 1, eTag: 'etag-part-1' },
+        { partNum: 2, eTag: 'etag-part-2' },
+      ]);
+    });
+
+    it('does not send the API key to the upload URL', async () => {
+      await createModel().doStart({ ...defaultOptions });
+
+      expect(server.calls[2].requestHeaders['x-api-key']).toBeUndefined();
+    });
+
+    it('sends the API key to the Topaz endpoints', async () => {
+      await createModel().doStart({ ...defaultOptions });
+
+      expect(server.calls[0].requestHeaders['x-api-key']).toBe('test-key');
+      expect(server.calls[1].requestHeaders['x-api-key']).toBe('test-key');
+    });
+
+    it('warns about options Topaz does not support', async () => {
+      const result = await createModel().doStart({
+        ...defaultOptions,
+        prompt: 'make it sharp',
+        aspectRatio: '16:9',
+        seed: 7,
+        generateAudio: true,
+        frameImages: [
+          {
+            type: 'url',
+            url: 'https://example.com/first.png',
+            role: 'first_frame',
+          },
+        ],
+        n: 2,
+      });
+
+      expect(result.warnings.map(warning => warning.feature)).toEqual([
+        'prompt',
+        'aspectRatio',
+        'seed',
+        'generateAudio',
+        'frameImages',
+        'n',
+      ]);
+    });
+
+    it('throws and names the missing metadata', async () => {
+      await expect(
+        createModel().doStart({
+          ...defaultOptions,
+          providerOptions: { topaz: {} },
+        }),
+      ).rejects.toThrow(
+        /Missing: source\.width \/ source\.height .*source\.duration.*source\.frameRate.*source\.frameCount/s,
+      );
+    });
+
+    it('throws when no video reference is passed', async () => {
+      await expect(
+        createModel().doStart({
+          ...defaultOptions,
+          inputReferences: undefined,
+        }),
+      ).rejects.toThrow(/require an input video/);
+    });
+
+    it('throws a targeted error when only a still image is passed', async () => {
+      await expect(
+        createModel().doStart({
+          ...defaultOptions,
+          inputReferences: undefined,
+          image: { type: 'url', url: 'https://example.com/frame.png' },
+        }),
+      ).rejects.toThrow(/not a still image/);
+    });
+
+    it('throws for an unsupported container', async () => {
+      await expect(
+        createModel().doStart({
+          ...defaultOptions,
+          inputReferences: [
+            { type: 'file', mediaType: 'video/webm', data: inputVideo.data },
+          ],
+        }),
+      ).rejects.toThrow(/does not support the media type "video\/webm"/);
+    });
+
+    it('warns when more than one reference is passed', async () => {
+      const result = await createModel().doStart({
+        ...defaultOptions,
+        inputReferences: [inputVideo, inputVideo],
+      });
+
+      expect(result.warnings).toContainEqual(
+        expect.objectContaining({ feature: 'inputReferences' }),
+      );
+    });
+
+    it('surfaces Topaz error details from the create call', async () => {
+      server.urls[`${TEST_BASE_URL}/video/`].response = {
+        type: 'error',
+        status: 400,
+        body: JSON.stringify({ detail: 'frameCount must be positive' }),
+      };
+
+      await expect(
+        createModel().doStart({ ...defaultOptions }),
+      ).rejects.toThrow(/frameCount must be positive/);
+    });
+
+    it('surfaces Topaz error details from the accept call', async () => {
+      server.urls[`${TEST_BASE_URL}/video/${REQUEST_ID}/accept`].response = {
+        type: 'error',
+        status: 409,
+        body: JSON.stringify({ detail: 'request already accepted' }),
+      };
+
+      await expect(
+        createModel().doStart({ ...defaultOptions }),
+      ).rejects.toThrow(/request already accepted/);
+    });
+
+    it('throws when no upload URLs are returned', async () => {
+      server.urls[`${TEST_BASE_URL}/video/${REQUEST_ID}/accept`].response = {
+        type: 'json-value',
+        body: { uploadId: 'upload-1', urls: [] },
+      };
+
+      await expect(
+        createModel().doStart({ ...defaultOptions }),
+      ).rejects.toThrow(/no upload URLs/);
+    });
+
+    it('throws when the upload response has no ETag', async () => {
+      server.urls[UPLOAD_URL].response = { type: 'json-value', body: {} };
+
+      await expect(
+        createModel().doStart({ ...defaultOptions }),
+      ).rejects.toThrow(/did not return an ETag/);
+    });
+  });
+
+  describe('doStatus', () => {
+    const operation = { requestId: REQUEST_ID, outputContainer: 'mp4' };
+
+    it('returns the download URL when the request completes', async () => {
+      const result = await createModel().doStatus({ operation });
+
+      expect(result.status).toBe('completed');
+      expect(result).toMatchObject({
+        videos: [{ type: 'url', url: DOWNLOAD_URL, mediaType: 'video/mp4' }],
+      });
+      expect(result.response.timestamp).toEqual(
+        new Date('2026-01-01T00:00:00Z'),
+      );
+    });
+
+    it('reports the media type of the output container', async () => {
+      const result = await createModel().doStatus({
+        operation: { requestId: REQUEST_ID, outputContainer: 'mov' },
+      });
+
+      expect(result).toMatchObject({
+        videos: [expect.objectContaining({ mediaType: 'video/quicktime' })],
+      });
+    });
+
+    it.each([
+      'requested',
+      'accepted',
+      'initializing',
+      'preprocessing',
+      'processing',
+      'postprocessing',
+      'canceling',
+    ])('reports %s as pending', async status => {
+      server.urls[`${TEST_BASE_URL}/video/${REQUEST_ID}/status`].response = {
+        type: 'json-value',
+        body: { status },
+      };
+
+      const result = await createModel().doStatus({ operation });
+
+      expect(result.status).toBe('pending');
+    });
+
+    it('reports a failed request as an error', async () => {
+      server.urls[`${TEST_BASE_URL}/video/${REQUEST_ID}/status`].response = {
+        type: 'json-value',
+        body: { status: 'failed', message: 'out of credits' },
+      };
+
+      const result = await createModel().doStatus({ operation });
+
+      expect(result.status).toBe('error');
+      expect(result).toMatchObject({
+        error: expect.stringMatching(/out of credits/),
+      });
+    });
+
+    it('reports a canceled request as an error', async () => {
+      server.urls[`${TEST_BASE_URL}/video/${REQUEST_ID}/status`].response = {
+        type: 'json-value',
+        body: { status: 'canceled' },
+      };
+
+      const result = await createModel().doStatus({ operation });
+
+      expect(result.status).toBe('error');
+    });
+
+    it('throws when a completed request has no download URL', async () => {
+      server.urls[`${TEST_BASE_URL}/video/${REQUEST_ID}/status`].response = {
+        type: 'json-value',
+        body: { status: 'complete' },
+      };
+
+      await expect(createModel().doStatus({ operation })).rejects.toThrow(
+        /returned no download URL/,
+      );
+    });
+
+    it('throws on an unrecognized status', async () => {
+      server.urls[`${TEST_BASE_URL}/video/${REQUEST_ID}/status`].response = {
+        type: 'json-value',
+        body: { status: 'sideways' },
+      };
+
+      await expect(createModel().doStatus({ operation })).rejects.toThrow(
+        /unrecognized status "sideways"/,
+      );
+    });
+  });
+});

--- a/packages/topaz/src/topaz-video-model.ts
+++ b/packages/topaz/src/topaz-video-model.ts
@@ -1,0 +1,744 @@
+import {
+  type Experimental_VideoModelV4 as VideoModelV4,
+  type Experimental_VideoModelV4File as VideoModelV4File,
+  type Experimental_VideoModelV4OperationStartResult as VideoModelV4OperationStartResult,
+  type Experimental_VideoModelV4OperationStatusResult as VideoModelV4OperationStatusResult,
+  type SharedV4Warning,
+} from '@ai-sdk/provider';
+import {
+  combineHeaders,
+  convertBase64ToUint8Array,
+  createBinaryResponseHandler,
+  createJsonResponseHandler,
+  getFromApi,
+  isSameOrigin,
+  parseProviderOptions,
+  postJsonToApi,
+  validateDownloadUrl,
+  withUserAgentSuffix,
+} from '@ai-sdk/provider-utils';
+import { z } from 'zod/v4';
+import type { TopazConfig } from './topaz-config';
+import { topazFailedResponseHandler, TopazError } from './topaz-error';
+import {
+  TOPAZ_NON_FILTER_OPTION_KEYS,
+  topazVideoModelOptionsSchema,
+  type TopazVideoModelOptions,
+} from './topaz-video-model-options';
+import {
+  resolveTopazVideoApiModelId,
+  type TopazVideoModelId,
+} from './topaz-video-settings';
+import { VERSION } from './version';
+
+type TopazContainer = 'mp4' | 'mov' | 'mkv';
+
+const mediaTypeContainers: Record<string, TopazContainer> = {
+  'video/mp4': 'mp4',
+  'video/quicktime': 'mov',
+  'video/mov': 'mov',
+  'video/x-matroska': 'mkv',
+  'video/matroska': 'mkv',
+};
+
+const extensionContainers: Record<string, TopazContainer> = {
+  mp4: 'mp4',
+  m4v: 'mp4',
+  mov: 'mov',
+  qt: 'mov',
+  mkv: 'mkv',
+};
+
+const containerMediaTypes: Record<TopazContainer, string> = {
+  mp4: 'video/mp4',
+  mov: 'video/quicktime',
+  mkv: 'video/x-matroska',
+};
+
+/** Status values that mean the request has not settled yet. */
+const pendingStatuses = new Set([
+  'requested',
+  'accepted',
+  'initializing',
+  'preprocessing',
+  'processing',
+  'postprocessing',
+  'canceling',
+]);
+
+/**
+ * Topaz video models enhance a video the caller supplies. The input video is
+ * passed through `inputReferences`, and `doStart` runs the four-step Topaz
+ * submission (create, accept, upload, complete-upload) before handing the
+ * request id to `doStatus` for polling.
+ */
+export class TopazVideoModel implements VideoModelV4 {
+  readonly specificationVersion = 'v4';
+  readonly maxVideosPerCall = 1;
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  constructor(
+    readonly modelId: TopazVideoModelId,
+    private readonly config: TopazConfig,
+  ) {}
+
+  async doStart(
+    options: Parameters<NonNullable<VideoModelV4['doStart']>>[0],
+  ): Promise<VideoModelV4OperationStartResult> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const warnings: SharedV4Warning[] = [];
+
+    const topazOptions = (await parseProviderOptions({
+      provider: 'topaz',
+      providerOptions: options.providerOptions,
+      schema: topazVideoModelOptionsSchema,
+    })) as TopazVideoModelOptions | undefined;
+
+    this.addUnsupportedWarnings(options, warnings);
+
+    const input = this.selectInputVideo(options, warnings);
+    const { bytes, container } = await this.resolveInput({
+      input,
+      declaredContainer: topazOptions?.source?.container,
+      abortSignal: options.abortSignal,
+    });
+
+    const source = resolveSource({
+      options,
+      topazOptions,
+      container,
+      sizeBytes: bytes.byteLength,
+    });
+
+    const output = buildOutput(source, topazOptions);
+
+    const body = {
+      source: {
+        container: source.container,
+        size: source.size,
+        duration: source.duration,
+        frameCount: source.frameCount,
+        frameRate: source.frameRate,
+        resolution: { width: source.width, height: source.height },
+      },
+      output,
+      filters: [
+        buildFilter(this.modelId, topazOptions),
+        ...(topazOptions?.additionalFilters ?? []),
+      ],
+    };
+
+    const { value: createResponse, responseHeaders } = await postJsonToApi({
+      url: `${this.config.baseURL}/video/`,
+      headers: combineHeaders(this.config.headers(), options.headers),
+      body,
+      successfulResponseHandler: createJsonResponseHandler(
+        topazVideoCreateResponseSchema,
+      ),
+      failedResponseHandler: topazFailedResponseHandler,
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const requestId = createResponse.requestId;
+    if (requestId == null) {
+      throw new TopazError({
+        message: 'Topaz did not return a requestId for the video request.',
+      });
+    }
+
+    const accepted = await this.patch({
+      path: `/video/${requestId}/accept`,
+      schema: topazVideoAcceptResponseSchema,
+      headers: options.headers,
+      abortSignal: options.abortSignal,
+    });
+
+    const uploadUrls = accepted.urls ?? [];
+    if (uploadUrls.length === 0) {
+      throw new TopazError({
+        message: `Topaz returned no upload URLs for request ${requestId}.`,
+      });
+    }
+
+    const uploadResults = await this.uploadVideo({
+      bytes,
+      urls: uploadUrls,
+      contentType: containerMediaTypes[source.container],
+      abortSignal: options.abortSignal,
+    });
+
+    await this.patch({
+      path: `/video/${requestId}/complete-upload`,
+      body: { uploadResults },
+      schema: topazVideoCompleteUploadResponseSchema,
+      headers: options.headers,
+      abortSignal: options.abortSignal,
+    });
+
+    return {
+      // The output container travels with the operation so `doStatus` can
+      // report the right media type without re-deriving it.
+      operation: { requestId, outputContainer: output.container },
+      warnings,
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: responseHeaders,
+      },
+    };
+  }
+
+  async doStatus(
+    options: Parameters<NonNullable<VideoModelV4['doStatus']>>[0],
+  ): Promise<VideoModelV4OperationStatusResult> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date();
+    const { requestId, outputContainer } = options.operation as {
+      requestId: string;
+      outputContainer?: TopazContainer;
+    };
+
+    const { value: status, responseHeaders } = await getFromApi({
+      url: `${this.config.baseURL}/video/${requestId}/status`,
+      // Built from the configured baseURL, not from response data.
+      validateUrl: false,
+      headers: combineHeaders(this.config.headers(), options.headers),
+      successfulResponseHandler: createJsonResponseHandler(
+        topazVideoStatusResponseSchema,
+      ),
+      failedResponseHandler: topazFailedResponseHandler,
+      abortSignal: options.abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    const response = {
+      timestamp: currentDate,
+      modelId: this.modelId,
+      headers: responseHeaders,
+    };
+
+    if (status.status === 'complete') {
+      const url = status.download?.url;
+      if (url == null) {
+        throw new TopazError({
+          message: `Topaz reported request ${requestId} complete but returned no download URL.`,
+        });
+      }
+
+      return {
+        status: 'completed',
+        videos: [
+          {
+            type: 'url',
+            url,
+            mediaType:
+              outputContainer != null
+                ? containerMediaTypes[outputContainer]
+                : 'video/mp4',
+          },
+        ],
+        warnings: [],
+        response,
+        providerMetadata: {
+          topaz: {
+            videos: [
+              {
+                requestId,
+                ...(status.outputSize != null
+                  ? { outputSize: status.outputSize }
+                  : {}),
+                ...(status.download?.expiresAt != null
+                  ? { expiresAt: status.download.expiresAt }
+                  : {}),
+              },
+            ],
+            ...(status.estimates?.cost != null
+              ? { cost: status.estimates.cost }
+              : {}),
+          },
+        },
+      };
+    }
+
+    if (status.status === 'failed' || status.status === 'canceled') {
+      return {
+        status: 'error',
+        error:
+          `Topaz video request ${requestId} ${status.status}` +
+          (status.message != null ? `: ${status.message}` : '.'),
+        response,
+      };
+    }
+
+    if (status.status != null && !pendingStatuses.has(status.status)) {
+      throw new TopazError({
+        message: `Topaz returned an unrecognized status "${status.status}" for request ${requestId}.`,
+      });
+    }
+
+    return { status: 'pending', response };
+  }
+
+  private addUnsupportedWarnings(
+    options: Parameters<NonNullable<VideoModelV4['doStart']>>[0],
+    warnings: SharedV4Warning[],
+  ): void {
+    if (options.prompt != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'prompt',
+        details:
+          'Topaz video models enhance an existing video and do not take a text prompt. ' +
+          'The prompt was ignored.',
+      });
+    }
+
+    if (options.aspectRatio != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'aspectRatio',
+        details:
+          'Topaz video models do not support aspectRatio. Use `resolution`, or the ' +
+          '`output` provider option, to set the output dimensions.',
+      });
+    }
+
+    if (options.seed != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'seed',
+        details: 'Topaz video models do not support seed.',
+      });
+    }
+
+    if (options.generateAudio != null) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'generateAudio',
+        details:
+          'Topaz video models do not generate audio. Use the `output.audioTransfer` ' +
+          'provider option to control how the input audio track is carried over.',
+      });
+    }
+
+    if (options.frameImages != null && options.frameImages.length > 0) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'frameImages',
+        details:
+          'Topaz video models do not support first/last frame generation. The frame ' +
+          'images were ignored.',
+      });
+    }
+
+    if (options.n > 1) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'n',
+        details:
+          'Topaz video models enhance one video per call. Only 1 video will be produced.',
+      });
+    }
+  }
+
+  private selectInputVideo(
+    options: Parameters<NonNullable<VideoModelV4['doStart']>>[0],
+    warnings: SharedV4Warning[],
+  ): VideoModelV4File {
+    const references = options.inputReferences ?? [];
+    const videos = references.filter(isVideoReference);
+
+    if (videos.length === 0) {
+      if (options.image != null) {
+        throw new TopazError({
+          message:
+            'Topaz video models enhance an existing video, not a still image. Pass the ' +
+            'input video via `inputReferences`.',
+        });
+      }
+
+      throw new TopazError({
+        message:
+          'Topaz video models require an input video. Pass it via `inputReferences`, ' +
+          'e.g. `inputReferences: [{ type: "file", mediaType: "video/mp4", data: bytes }]`. ' +
+          'For URL references, include `mediaType` so the reference is recognized as a video.',
+      });
+    }
+
+    if (references.length > 1) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'inputReferences',
+        details:
+          'Topaz video models enhance a single video. Only the first video reference was used.',
+      });
+    }
+
+    return videos[0];
+  }
+
+  private async resolveInput({
+    input,
+    declaredContainer,
+    abortSignal,
+  }: {
+    input: VideoModelV4File;
+    declaredContainer: TopazContainer | undefined;
+    abortSignal: AbortSignal | undefined;
+  }): Promise<{ bytes: Uint8Array; container: TopazContainer }> {
+    if (input.type === 'file') {
+      const bytes =
+        typeof input.data === 'string'
+          ? convertBase64ToUint8Array(input.data)
+          : input.data;
+
+      const container =
+        declaredContainer ?? mediaTypeContainers[input.mediaType.toLowerCase()];
+
+      if (container == null) {
+        throw new TopazError({
+          message:
+            `Topaz does not support the media type "${input.mediaType}". Supported ` +
+            'containers are mp4, mov and mkv; set `source.container` explicitly if the ' +
+            'media type is unusual.',
+        });
+      }
+
+      return { bytes, container };
+    }
+
+    const container =
+      declaredContainer ??
+      (input.mediaType != null
+        ? mediaTypeContainers[input.mediaType.toLowerCase()]
+        : undefined) ??
+      containerFromUrl(input.url);
+
+    if (container == null) {
+      throw new TopazError({
+        message:
+          `Could not determine the container of the input video at "${input.url}". Set ` +
+          'the `source.container` provider option, or pass `mediaType` on the reference.',
+      });
+    }
+
+    // Topaz uploads go to presigned object storage, so the bytes have to pass
+    // through the SDK even for URL references.
+    const { value: bytes } = await getFromApi({
+      url: input.url,
+      // A caller-supplied URL, so it is validated like any untrusted target.
+      validateUrl: true,
+      successfulResponseHandler: createBinaryResponseHandler(),
+      failedResponseHandler: topazFailedResponseHandler,
+      abortSignal,
+      fetch: this.config.fetch,
+    });
+
+    return { bytes, container };
+  }
+
+  private async uploadVideo({
+    bytes,
+    urls,
+    contentType,
+    abortSignal,
+  }: {
+    bytes: Uint8Array;
+    urls: string[];
+    contentType: string;
+    abortSignal: AbortSignal | undefined;
+  }): Promise<Array<{ partNum: number; eTag: string }>> {
+    const fetchImpl = this.config.fetch ?? globalThis.fetch;
+    const partSize = Math.ceil(bytes.byteLength / urls.length);
+    const results: Array<{ partNum: number; eTag: string }> = [];
+
+    for (const [index, url] of urls.entries()) {
+      // The upload URL comes from the Topaz response body. `getFromApi` cannot
+      // be used for a PUT, so the same trust decision is made explicitly here:
+      // validate unless the URL points back at the configured base URL, and
+      // never attach the API key (presigned URLs carry their own credentials).
+      if (!isSameOrigin(url, this.config.baseURL)) {
+        validateDownloadUrl(url);
+      }
+
+      const part = bytes.subarray(index * partSize, (index + 1) * partSize);
+
+      const response = await fetchImpl(url, {
+        method: 'PUT',
+        headers: withUserAgentSuffix(
+          { 'Content-Type': contentType },
+          `ai-sdk/topaz/${VERSION}`,
+        ) as HeadersInit,
+        body: part as BodyInit,
+        signal: abortSignal,
+      });
+
+      if (!response.ok) {
+        throw new TopazError({
+          message:
+            `Uploading part ${index + 1} of the input video failed with status ` +
+            `${response.status} ${response.statusText}.`,
+        });
+      }
+
+      const eTag = response.headers.get('etag');
+      if (eTag == null) {
+        throw new TopazError({
+          message: `The upload of part ${index + 1} did not return an ETag header.`,
+        });
+      }
+
+      results.push({ partNum: index + 1, eTag: eTag.replace(/"/g, '') });
+    }
+
+    return results;
+  }
+
+  private async patch<T>({
+    path,
+    body,
+    schema,
+    headers,
+    abortSignal,
+  }: {
+    path: string;
+    body?: unknown;
+    schema: z.ZodType<T>;
+    headers: Record<string, string | undefined> | undefined;
+    abortSignal: AbortSignal | undefined;
+  }): Promise<T> {
+    // provider-utils only ships GET and POST helpers, so the Topaz PATCH steps
+    // are issued directly, reusing the shared error handler for parity.
+    const fetchImpl = this.config.fetch ?? globalThis.fetch;
+    const url = `${this.config.baseURL}${path}`;
+
+    const response = await fetchImpl(url, {
+      method: 'PATCH',
+      headers: withUserAgentSuffix(
+        combineHeaders(
+          this.config.headers(),
+          body != null ? { 'Content-Type': 'application/json' } : {},
+          headers,
+        ),
+        `ai-sdk/topaz/${VERSION}`,
+      ) as HeadersInit,
+      ...(body != null ? { body: JSON.stringify(body) } : {}),
+      signal: abortSignal,
+    });
+
+    if (!response.ok) {
+      const { value: error } = await topazFailedResponseHandler({
+        response,
+        url,
+        requestBodyValues: body ?? {},
+      });
+      throw error;
+    }
+
+    const { value } = await createJsonResponseHandler(schema)({
+      response,
+      url,
+      requestBodyValues: body ?? {},
+    });
+
+    return value;
+  }
+}
+
+function isVideoReference(reference: VideoModelV4File): boolean {
+  if (reference.type === 'file') {
+    return reference.mediaType.toLowerCase().startsWith('video/');
+  }
+
+  if (reference.mediaType != null) {
+    return reference.mediaType.toLowerCase().startsWith('video/');
+  }
+
+  return containerFromUrl(reference.url) != null;
+}
+
+function containerFromUrl(url: string): TopazContainer | undefined {
+  const withoutQuery = url.split(/[?#]/)[0];
+  const extension = withoutQuery.split('.').pop()?.toLowerCase();
+  return extension != null ? extensionContainers[extension] : undefined;
+}
+
+type ResolvedSource = {
+  container: TopazContainer;
+  size: number;
+  duration: number;
+  frameRate: number;
+  frameCount: number;
+  width: number;
+  height: number;
+};
+
+/**
+ * Merges the source metadata Topaz needs from the spec call options and the
+ * `source` provider option. Nothing is read out of the video bytes: no provider
+ * package inspects media files, so anything that cannot be derived from the
+ * request has to be supplied by the caller.
+ */
+function resolveSource({
+  options,
+  topazOptions,
+  container,
+  sizeBytes,
+}: {
+  options: Parameters<NonNullable<VideoModelV4['doStart']>>[0];
+  topazOptions: TopazVideoModelOptions | undefined;
+  container: TopazContainer;
+  sizeBytes: number;
+}): ResolvedSource {
+  const source = topazOptions?.source;
+  const resolution = parseResolution(options.resolution);
+
+  const width = source?.width ?? resolution.width;
+  const height = source?.height ?? resolution.height;
+  const duration = source?.duration ?? options.duration;
+  const frameRate = source?.frameRate ?? options.fps;
+  const frameCount =
+    source?.frameCount ??
+    (duration != null && frameRate != null
+      ? Math.round(duration * frameRate)
+      : undefined);
+
+  const missing: string[] = [];
+  if (width == null || height == null) {
+    missing.push('source.width / source.height (or the `resolution` option)');
+  }
+  if (duration == null) {
+    missing.push('source.duration (or the `duration` option)');
+  }
+  if (frameRate == null) {
+    missing.push('source.frameRate (or the `fps` option)');
+  }
+  if (frameCount == null) {
+    missing.push('source.frameCount');
+  }
+
+  if (missing.length > 0) {
+    throw new TopazError({
+      message:
+        'Topaz needs metadata about the input video before the upload starts, and the ' +
+        'AI SDK does not inspect media files. Missing: ' +
+        `${missing.join(', ')}.`,
+    });
+  }
+
+  return {
+    container,
+    size: sizeBytes,
+    duration: duration!,
+    frameRate: frameRate!,
+    frameCount: frameCount!,
+    width: width!,
+    height: height!,
+  };
+}
+
+function parseResolution(resolution: `${number}x${number}` | undefined): {
+  width: number | undefined;
+  height: number | undefined;
+} {
+  if (resolution == null) {
+    return { width: undefined, height: undefined };
+  }
+
+  const [width, height] = resolution.split('x').map(Number);
+  return { width, height };
+}
+
+function buildOutput(
+  source: ResolvedSource,
+  topazOptions: TopazVideoModelOptions | undefined,
+): {
+  container: TopazContainer;
+  resolution: { width: number; height: number };
+  frameRate: number;
+  audioCodec: string;
+  audioTransfer: string;
+  dynamicCompressionLevel?: string;
+} {
+  const output = topazOptions?.output;
+
+  return {
+    resolution: {
+      width: output?.width ?? source.width,
+      height: output?.height ?? source.height,
+    },
+    frameRate: output?.frameRate ?? source.frameRate,
+    audioCodec: output?.audioCodec ?? 'AAC',
+    audioTransfer: output?.audioTransfer ?? 'Copy',
+    container: output?.container ?? source.container,
+    ...(output?.dynamicCompressionLevel != null
+      ? { dynamicCompressionLevel: output.dynamicCompressionLevel }
+      : {}),
+  };
+}
+
+function buildFilter(
+  modelId: string,
+  topazOptions: TopazVideoModelOptions | undefined,
+): Record<string, unknown> {
+  const filter: Record<string, unknown> = {
+    model: resolveTopazVideoApiModelId(modelId),
+  };
+
+  if (topazOptions != null) {
+    const nonFilterKeys = new Set<string>(TOPAZ_NON_FILTER_OPTION_KEYS);
+
+    for (const [key, value] of Object.entries(topazOptions)) {
+      if (!nonFilterKeys.has(key) && value !== undefined) {
+        filter[key] = value;
+      }
+    }
+
+    Object.assign(filter, topazOptions.filter ?? {});
+  }
+
+  return filter;
+}
+
+const topazVideoCreateResponseSchema = z.object({
+  requestId: z.string().nullish(),
+  estimates: z
+    .object({
+      cost: z.json().nullish(),
+      time: z.json().nullish(),
+    })
+    .nullish(),
+});
+
+const topazVideoAcceptResponseSchema = z.object({
+  uploadId: z.string().nullish(),
+  urls: z.array(z.string()).nullish(),
+  message: z.string().nullish(),
+});
+
+const topazVideoCompleteUploadResponseSchema = z.object({
+  message: z.string().nullish(),
+});
+
+const topazVideoStatusResponseSchema = z.object({
+  status: z.string().nullish(),
+  progress: z.number().nullish(),
+  message: z.string().nullish(),
+  outputSize: z.number().nullish(),
+  estimates: z
+    .object({
+      cost: z.json().nullish(),
+      time: z.json().nullish(),
+    })
+    .nullish(),
+  download: z
+    .object({
+      url: z.string().nullish(),
+      expiresIn: z.number().nullish(),
+      expiresAt: z.union([z.string(), z.number()]).nullish(),
+    })
+    .nullish(),
+});

--- a/packages/topaz/src/topaz-video-settings.ts
+++ b/packages/topaz/src/topaz-video-settings.ts
@@ -1,0 +1,27 @@
+/**
+ * Topaz video model ids.
+ *
+ * The AI SDK exposes readable ids that are mapped onto the short names the
+ * Topaz API expects in the `filters[].model` field (see
+ * `topazVideoApiModelIds`). Passing a raw Topaz name such as `slp-2.6` also
+ * works - unknown ids are forwarded to the API unchanged.
+ */
+export type TopazVideoModelId =
+  | 'proteus'
+  | 'starlight-precise-2.6'
+  | (string & {});
+
+/**
+ * Maps AI SDK video model ids onto Topaz API model names.
+ *
+ * @see https://developer.topazlabs.com/video-models/proteus/proteus-1
+ * @see https://developer.topazlabs.com/video-models/starlight/starlight-precise-2.6
+ */
+export const topazVideoApiModelIds: Record<string, string> = {
+  proteus: 'prob-4',
+  'starlight-precise-2.6': 'slp-2.6',
+};
+
+export function resolveTopazVideoApiModelId(modelId: string): string {
+  return topazVideoApiModelIds[modelId] ?? modelId;
+}

--- a/packages/topaz/src/version.ts
+++ b/packages/topaz/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/topaz/tsconfig.build.json
+++ b/packages/topaz/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Disable project configuration for tsup builds
+    "composite": false
+  }
+}

--- a/packages/topaz/tsconfig.json
+++ b/packages/topaz/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": ["dist", "build", "node_modules", "tsup.config.ts"],
+  "references": [
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    },
+    {
+      "path": "../test-server"
+    }
+  ]
+}

--- a/packages/topaz/tsup.config.ts
+++ b/packages/topaz/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+]);

--- a/packages/topaz/vitest.edge.config.js
+++ b/packages/topaz/vitest.edge.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/packages/topaz/vitest.node.config.js
+++ b/packages/topaz/vitest.node.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,6 +495,9 @@ importers:
       '@ai-sdk/togetherai':
         specifier: workspace:*
         version: link:../../packages/togetherai
+      '@ai-sdk/topaz':
+        specifier: workspace:*
+        version: link:../../packages/topaz
       '@ai-sdk/tui':
         specifier: workspace:*
         version: link:../../packages/tui
@@ -646,7 +649,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: ^20.3.26
-        version: 20.3.26(02e283fc6c6c8a3423566b2037fe8b27)
+        version: 20.3.26(4f46d6f5976868fce36453d80f4f9733)
       '@angular/cli':
         specifier: ^20.3.28
         version: 20.3.28(@cfworker/json-schema@4.1.1)(@types/node@22.19.19)(chokidar@4.0.3)(supports-color@10.2.2)
@@ -726,7 +729,7 @@ importers:
     dependencies:
       '@agentclientprotocol/claude-agent-acp':
         specifier: 0.61.0
-        version: 0.61.0(@anthropic-ai/sdk@0.103.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@3.25.76))
+        version: 0.61.0(@anthropic-ai/sdk@0.103.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76))
       '@agentclientprotocol/codex-acp':
         specifier: 1.1.4
         version: 1.1.4
@@ -777,13 +780,13 @@ importers:
         version: link:../../packages/workflow-harness
       '@cline/agents':
         specifier: ^0.0.79
-        version: 0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       '@cline/core':
         specifier: ^0.0.79
-        version: 0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@cfworker/json-schema@4.1.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@cfworker/json-schema@4.1.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       '@earendil-works/pi-coding-agent':
         specifier: ^0.84.3
-        version: 0.84.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@3.25.76))(supports-color@10.2.2)(ws@8.21.3)(zod@3.25.76)
+        version: 0.84.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76))(supports-color@8.1.1)(ws@8.21.3)(zod@3.25.76)
       '@vercel/sandbox':
         specifier: ^3.0.0
         version: 3.1.0
@@ -798,7 +801,7 @@ importers:
         version: 2.1.1
       next:
         specifier: ^15.5.21
-        version: 15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+        version: 15.5.21(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -807,7 +810,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       streamdown:
         specifier: ^1.6.11
-        version: 1.6.11(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@10.2.2))(react@18.3.1)(supports-color@10.2.2)
+        version: 1.6.11(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(react@18.3.1)(supports-color@8.1.1)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -816,7 +819,7 @@ importers:
         version: 1.0.7(tailwindcss@3.4.19(tsx@4.23.12)(yaml@2.9.0))
       workflow:
         specifier: 4.6.0
-        version: 4.6.0(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.4)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(supports-color@10.2.2)(typescript@5.8.3)(ws@8.21.3)
+        version: 4.6.0(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@8.1.1))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.4)(next@15.5.21(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(supports-color@8.1.1)(typescript@5.8.3)(ws@8.21.3)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -1602,7 +1605,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       workflow:
         specifier: 5.0.0-beta.42
-        version: 5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.76)(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.4)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)(supports-color@10.2.2)(typescript@5.8.3)(ws@8.21.3)
+        version: 5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.49)(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.4)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)(supports-color@10.2.2)(typescript@5.8.3)(ws@8.21.0)
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -2267,7 +2270,7 @@ importers:
         version: 4.4.3(supports-color@8.1.1)
       jscodeshift:
         specifier: ^17.3.0
-        version: 17.3.0(@babel/preset-env@7.28.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 17.3.0(@babel/preset-env@7.28.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2)
     devDependencies:
       '@types/cli-progress':
         specifier: ^3.11.6
@@ -4183,6 +4186,34 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
 
+  packages/topaz:
+    dependencies:
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+    devDependencies:
+      '@ai-sdk/test-server':
+        specifier: workspace:*
+        version: link:../test-server
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.26)(supports-color@10.2.2)(tsx@4.23.12)(typescript@5.8.3)(yaml@2.9.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
   packages/tui:
     dependencies:
       ai:
@@ -4342,19 +4373,19 @@ importers:
         version: link:../../tools/tsconfig
       '@workflow/vitest':
         specifier: 5.0.0-beta.42
-        version: 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.6(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@26.1.0(supports-color@8.1.1))(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(ws@8.21.0)
+        version: 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.6(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@26.1.0(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(ws@8.21.3)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.26)(supports-color@8.1.1)(tsx@4.23.12)(typescript@5.8.3)(yaml@2.9.0)
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.26)(supports-color@10.2.2)(tsx@4.23.12)(typescript@5.8.3)(yaml@2.9.0)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@26.1.0(supports-color@8.1.1))(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.6(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@26.1.0(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       workflow:
         specifier: 5.0.0-beta.42
-        version: 5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.49)(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@8.1.1))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.4)(next@15.5.21(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0))(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@8.1.1)(typescript@5.8.3)(ws@8.21.0)
+        version: 5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.76)(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.4)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0))(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@10.2.2)(typescript@5.8.3)(ws@8.21.3)
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -24830,10 +24861,10 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@agentclientprotocol/claude-agent-acp@0.61.0(@anthropic-ai/sdk@0.103.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@3.25.76))':
+  '@agentclientprotocol/claude-agent-acp@0.61.0(@anthropic-ai/sdk@0.103.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76))':
     dependencies:
       '@agentclientprotocol/sdk': 1.3.0(zod@4.4.3)
-      '@anthropic-ai/claude-agent-sdk': 0.3.217(@anthropic-ai/sdk@0.103.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@3.25.76))(zod@4.4.3)
+      '@anthropic-ai/claude-agent-sdk': 0.3.217(@anthropic-ai/sdk@0.103.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76))(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@anthropic-ai/sdk'
@@ -24906,6 +24937,18 @@ snapshots:
       '@ai-sdk/provider': 4.0.8
       '@ai-sdk/provider-utils': 5.0.32(zod@4.4.3)
       google-auth-library: 10.9.1(supports-color@10.2.2)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ai-sdk/google-vertex@5.0.68(supports-color@8.1.1)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/anthropic': 4.0.44(zod@4.4.3)
+      '@ai-sdk/google': 4.0.56(zod@4.4.3)
+      '@ai-sdk/openai-compatible': 3.0.39(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.8
+      '@ai-sdk/provider-utils': 5.0.32(zod@4.4.3)
+      google-auth-library: 10.9.1(supports-color@8.1.1)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -25125,7 +25168,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@20.3.26(02e283fc6c6c8a3423566b2037fe8b27)':
+  '@angular-devkit/build-angular@20.3.26(4f46d6f5976868fce36453d80f4f9733)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2003.26(chokidar@4.0.3)
@@ -25187,7 +25230,7 @@ snapshots:
       '@angular/core': 20.3.27(@angular/compiler@20.3.27)(rxjs@7.8.2)(zone.js@0.15.1)
       '@angular/platform-browser': 20.3.25(@angular/common@20.3.27(@angular/core@20.3.27(@angular/compiler@20.3.27)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.27(@angular/compiler@20.3.27)(rxjs@7.8.2)(zone.js@0.15.1))
       esbuild: 0.28.0
-      jest: 29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3))
       tailwindcss: 4.3.0
     transitivePeerDependencies:
       - '@angular/compiler'
@@ -25501,10 +25544,10 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.245':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.217(@anthropic-ai/sdk@0.103.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@3.25.76))(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.217(@anthropic-ai/sdk@0.103.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76))(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.103.0(zod@3.25.76)
-      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76)
       zod: 4.4.3
     optionalDependencies:
       '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.217
@@ -26072,9 +26115,9 @@ snapshots:
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.29.7
       regexpu-core: 6.4.0
       semver: 6.3.1
@@ -26091,9 +26134,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       debug: 4.4.3(supports-color@10.2.2)
@@ -26210,9 +26253,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-wrap-function': 7.28.6(supports-color@10.2.2)
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
@@ -26324,9 +26367,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -26338,9 +26381,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26349,9 +26392,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26364,12 +26407,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -26382,9 +26425,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -26395,9 +26438,9 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3(supports-color@10.2.2)
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
     optional: true
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7(supports-color@10.2.2))':
@@ -26430,9 +26473,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26440,6 +26483,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
@@ -26522,10 +26571,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26534,9 +26583,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26549,11 +26598,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
@@ -26568,12 +26617,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -26583,9 +26632,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26594,9 +26643,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26616,15 +26665,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.28.3(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.28.3(supports-color@10.2.2)
@@ -26633,10 +26673,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -26654,14 +26694,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-globals': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
@@ -26673,9 +26713,9 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.29.7
 
-  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.29.7
     optional: true
@@ -26688,9 +26728,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -26703,10 +26743,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26715,9 +26755,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26727,10 +26767,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26739,9 +26779,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26753,11 +26793,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -26767,9 +26807,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26778,9 +26818,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26798,9 +26838,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -26816,9 +26856,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
@@ -26831,9 +26871,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26842,9 +26882,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26853,9 +26893,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26864,9 +26904,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26878,10 +26918,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -26903,15 +26943,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.28.3(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.28.3(supports-color@10.2.2)
@@ -26922,10 +26953,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
@@ -26941,10 +26972,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -26956,10 +26987,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26968,9 +26999,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -26984,20 +27015,14 @@ snapshots:
       '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.29.7
-    optional: true
-
   '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.28.3(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27012,13 +27037,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0(supports-color@10.2.2))
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
@@ -27032,11 +27057,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -27046,9 +27071,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27068,23 +27093,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.3(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27104,15 +27120,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.28.3(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.28.3(supports-color@10.2.2)
@@ -27122,11 +27129,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -27137,9 +27144,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27158,9 +27165,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27170,10 +27177,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27182,9 +27189,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27205,9 +27212,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27219,9 +27226,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -27233,9 +27240,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27244,9 +27251,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27255,9 +27262,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27288,9 +27295,9 @@ snapshots:
       '@babel/core': 7.28.3(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27300,10 +27307,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27313,10 +27320,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27326,10 +27333,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.3(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
 
@@ -27409,77 +27416,77 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-env@7.28.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/preset-env@7.28.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@babel/compat-data': 7.29.7
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7(supports-color@10.2.2))
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0(supports-color@10.2.2))
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
       core-js-compat: 3.49.0
       semver: 6.3.1
     transitivePeerDependencies:
@@ -27500,9 +27507,9 @@ snapshots:
       '@babel/types': 7.29.8
       esutils: 2.0.3
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/types': 7.29.8
       esutils: 2.0.3
@@ -27916,9 +27923,39 @@ snapshots:
       - debug
       - supports-color
 
+  '@cline/agents@0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@cline/llms': 0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@cline/shared': 0.0.79
+      nanoid: 5.1.16
+    transitivePeerDependencies:
+      - '@aws-sdk/client-bedrock-runtime'
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/sdk-trace-base'
+      - ai-sdk-provider-claude-code
+      - ai-sdk-provider-codex-cli
+      - debug
+      - supports-color
+
   '@cline/agents@0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@cline/llms': 0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@cline/shared': 0.0.79
+      nanoid: 5.1.16
+    transitivePeerDependencies:
+      - '@aws-sdk/client-bedrock-runtime'
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/sdk-trace-base'
+      - ai-sdk-provider-claude-code
+      - ai-sdk-provider-codex-cli
+      - debug
+      - supports-color
+
+  '@cline/agents@0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@cline/llms': 0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       '@cline/shared': 0.0.79
       nanoid: 5.1.16
     transitivePeerDependencies:
@@ -27952,6 +27989,41 @@ snapshots:
       nanoid: 5.1.16
       node-machine-id: 1.1.12
       simple-git: 3.36.0(supports-color@10.2.2)
+      ws: 8.21.0
+      yaml: 2.9.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@aws-sdk/client-bedrock-runtime'
+      - '@cfworker/json-schema'
+      - '@opentelemetry/core'
+      - ai-sdk-provider-claude-code
+      - ai-sdk-provider-codex-cli
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@cline/core@0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@cfworker/json-schema@4.1.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@cline/agents': 0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@cline/llms': 0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@cline/shared': 0.0.79
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      jiti: 2.7.0
+      nanoid: 5.1.16
+      node-machine-id: 1.1.12
+      simple-git: 3.36.0(supports-color@8.1.1)
       ws: 8.21.0
       yaml: 2.9.0
       zod: 4.4.3
@@ -28004,6 +28076,44 @@ snapshots:
       - debug
       - supports-color
 
+  '@cline/llms@0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@ai-sdk/amazon-bedrock': 5.0.66(zod@4.4.3)
+      '@ai-sdk/anthropic': 4.0.44(zod@4.4.3)
+      '@ai-sdk/gateway': 4.0.67(zod@4.4.3)
+      '@ai-sdk/google': 4.0.56(zod@4.4.3)
+      '@ai-sdk/google-vertex': 5.0.68(supports-color@8.1.1)(zod@4.4.3)
+      '@ai-sdk/mistral': 4.0.35(zod@4.4.3)
+      '@ai-sdk/openai': 4.0.50(zod@4.4.3)
+      '@ai-sdk/openai-compatible': 3.0.39(zod@4.4.3)
+      '@ai-sdk/otel': 1.0.83(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.8
+      '@ai-sdk/provider-utils': 5.0.32(zod@4.4.3)
+      '@aws-sdk/credential-providers': 3.1117.0
+      '@cline/shared': 0.0.79
+      '@jerome-benoit/sap-ai-provider': 4.8.0(ai@7.0.83(zod@4.4.3))(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@langfuse/core': 5.10.1(@opentelemetry/api@1.9.1)
+      '@langfuse/otel': 5.10.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))
+      '@langfuse/vercel-ai-sdk': 5.9.1(@opentelemetry/api@1.9.1)(ai@7.0.83(zod@4.4.3))(zod@4.4.3)
+      '@openrouter/ai-sdk-provider': 3.0.0(ai@7.0.83(zod@4.4.3))(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/sdk-trace-node': 2.10.0(@opentelemetry/api@1.9.1)
+      '@streamparser/json': 0.0.21
+      ai: 7.0.83(zod@4.4.3)
+      ai-sdk-provider-opencode-sdk: 3.0.6(zod@4.4.3)
+      dify-ai-provider: 1.1.1
+      nanoid: 5.1.16
+      ollama-ai-provider-v2: 4.0.1(ai@7.0.83(zod@4.4.3))(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/sdk-trace-base'
+      - debug
+      - supports-color
+
   '@cline/llms@0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@ai-sdk/amazon-bedrock': 5.0.66(zod@4.4.3)
@@ -28020,6 +28130,44 @@ snapshots:
       '@aws-sdk/credential-providers': 3.1117.0
       '@cline/shared': 0.0.79
       '@jerome-benoit/sap-ai-provider': 4.8.0(ai@7.0.83(zod@4.4.3))(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@langfuse/core': 5.10.1(@opentelemetry/api@1.9.1)
+      '@langfuse/otel': 5.10.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@langfuse/vercel-ai-sdk': 5.9.1(@opentelemetry/api@1.9.1)(ai@7.0.83(zod@4.4.3))(zod@4.4.3)
+      '@openrouter/ai-sdk-provider': 3.0.0(ai@7.0.83(zod@4.4.3))(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/sdk-trace-node': 2.10.0(@opentelemetry/api@1.9.1)
+      '@streamparser/json': 0.0.21
+      ai: 7.0.83(zod@4.4.3)
+      ai-sdk-provider-opencode-sdk: 3.0.6(zod@4.4.3)
+      dify-ai-provider: 1.1.1
+      nanoid: 5.1.16
+      ollama-ai-provider-v2: 4.0.1(ai@7.0.83(zod@4.4.3))(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/sdk-trace-base'
+      - debug
+      - supports-color
+
+  '@cline/llms@0.0.79(@aws-sdk/client-bedrock-runtime@3.1048.0)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@ai-sdk/amazon-bedrock': 5.0.66(zod@4.4.3)
+      '@ai-sdk/anthropic': 4.0.44(zod@4.4.3)
+      '@ai-sdk/gateway': 4.0.67(zod@4.4.3)
+      '@ai-sdk/google': 4.0.56(zod@4.4.3)
+      '@ai-sdk/google-vertex': 5.0.68(supports-color@8.1.1)(zod@4.4.3)
+      '@ai-sdk/mistral': 4.0.35(zod@4.4.3)
+      '@ai-sdk/openai': 4.0.50(zod@4.4.3)
+      '@ai-sdk/openai-compatible': 3.0.39(zod@4.4.3)
+      '@ai-sdk/otel': 1.0.83(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.8
+      '@ai-sdk/provider-utils': 5.0.32(zod@4.4.3)
+      '@aws-sdk/credential-providers': 3.1117.0
+      '@cline/shared': 0.0.79
+      '@jerome-benoit/sap-ai-provider': 4.8.0(ai@7.0.83(zod@4.4.3))(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       '@langfuse/core': 5.10.1(@opentelemetry/api@1.9.1)
       '@langfuse/otel': 5.10.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
       '@langfuse/vercel-ai-sdk': 5.9.1(@opentelemetry/api@1.9.1)(ai@7.0.83(zod@4.4.3))(zod@4.4.3)
@@ -28146,6 +28294,22 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-agent-core@0.84.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76))(supports-color@8.1.1)(ws@8.21.3)(zod@3.25.76)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.84.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76))(supports-color@8.1.1)(ws@8.21.3)(zod@3.25.76)
+      '@earendil-works/pi-telemetry': 0.84.3
+      diff: 8.0.4
+      ignore: 7.0.5
+      typebox: 1.3.7
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-ai@0.74.2(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@3.25.76))(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.3)(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
@@ -28186,6 +28350,26 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-ai@0.84.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76))(supports-color@8.1.1)(ws@8.21.3)(zod@3.25.76)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@earendil-works/pi-telemetry': 0.84.3
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76))(supports-color@8.1.1)
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      openai: 6.40.0(ws@8.21.3)(zod@3.25.76)
+      partial-json: 0.1.7
+      typebox: 1.3.7
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-client@0.84.3':
     dependencies:
       '@earendil-works/pi-protocol': 0.84.3
@@ -28194,6 +28378,38 @@ snapshots:
     dependencies:
       '@earendil-works/pi-agent-core': 0.84.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@3.25.76))(supports-color@10.2.2)(ws@8.21.3)(zod@3.25.76)
       '@earendil-works/pi-ai': 0.84.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@3.25.76))(supports-color@10.2.2)(ws@8.21.3)(zod@3.25.76)
+      '@earendil-works/pi-client': 0.84.3
+      '@earendil-works/pi-protocol': 0.84.3
+      '@earendil-works/pi-tui': 0.84.3
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      grok-mermaid: 0.2.2
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.3.7
+      undici: 8.9.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.84.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76))(supports-color@8.1.1)(ws@8.21.3)(zod@3.25.76)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.84.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76))(supports-color@8.1.1)(ws@8.21.3)(zod@3.25.76)
+      '@earendil-works/pi-ai': 0.84.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76))(supports-color@8.1.1)(ws@8.21.3)(zod@3.25.76)
       '@earendil-works/pi-client': 0.84.3
       '@earendil-works/pi-protocol': 0.84.3
       '@earendil-works/pi-tui': 0.84.3
@@ -28878,6 +29094,19 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76))(supports-color@8.1.1)':
+    dependencies:
+      google-auth-library: 10.9.1(supports-color@8.1.1)
+      p-retry: 4.6.2
+      protobufjs: 7.6.5
+      ws: 8.21.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@google/generative-ai@0.21.0': {}
 
   '@grpc/grpc-js@1.14.4':
@@ -29298,6 +29527,18 @@ snapshots:
       - debug
       - supports-color
 
+  '@jerome-benoit/sap-ai-provider@4.8.0(ai@7.0.83(zod@4.4.3))(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.15
+      '@ai-sdk/provider-utils': 4.0.49(zod@4.4.3)
+      '@sap-ai-sdk/foundation-models': 2.15.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-ai-sdk/orchestration': 2.15.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      ai: 7.0.83(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
@@ -29306,6 +29547,42 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
+
+  '@jest/core@29.7.0(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0(supports-color@10.2.2)
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0(supports-color@10.2.2)
+      '@jest/types': 29.6.3
+      '@types/node': 22.19.19
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0(supports-color@10.2.2)
+      jest-runner: 29.7.0(supports-color@10.2.2)
+      jest-runtime: 29.7.0(supports-color@10.2.2)
+      jest-snapshot: 29.7.0(supports-color@10.2.2)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
 
   '@jest/core@29.7.0(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.9.3))':
     dependencies:
@@ -30158,6 +30435,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@kwsites/file-exists@1.1.1(supports-color@8.1.1)':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@kwsites/promise-deferred@1.1.1': {}
 
   '@langchain/anthropic@1.5.0(@langchain/core@1.2.9(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.40.0(ws@8.21.0)(zod@3.25.76))(ws@8.21.0))':
@@ -30827,6 +31110,54 @@ snapshots:
       eventsource-parser: 3.1.1
       express: 5.2.1(supports-color@10.2.2)
       express-rate-limit: 8.6.2(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2)
+      hono: 4.12.34
+      jose: 6.2.10
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.15(hono@4.12.34)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.6.2(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
+      hono: 4.12.34
+      jose: 6.2.10
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@8.1.1)(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.15(hono@4.12.34)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.6.2(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
       hono: 4.12.34
       jose: 6.2.10
       json-schema-typed: 8.0.2
@@ -35435,12 +35766,31 @@ snapshots:
       - debug
       - supports-color
 
+  '@sap-ai-sdk/ai-api@2.15.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@sap-ai-sdk/core': 2.15.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/connectivity': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/util': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@sap-ai-sdk/core@2.15.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@sap-cloud-sdk/connectivity': 4.9.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       '@sap-cloud-sdk/http-client': 4.9.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       '@sap-cloud-sdk/openapi': 4.9.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       '@sap-cloud-sdk/util': 4.9.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap-ai-sdk/core@2.15.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@sap-cloud-sdk/connectivity': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/http-client': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/openapi': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/util': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -35456,6 +35806,17 @@ snapshots:
       - debug
       - supports-color
 
+  '@sap-ai-sdk/foundation-models@2.15.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@sap-ai-sdk/ai-api': 2.15.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-ai-sdk/core': 2.15.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/connectivity': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/http-client': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/util': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@sap-ai-sdk/orchestration@2.15.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@sap-ai-sdk/ai-api': 2.15.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
@@ -35467,9 +35828,28 @@ snapshots:
       - debug
       - supports-color
 
+  '@sap-ai-sdk/orchestration@2.15.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@sap-ai-sdk/ai-api': 2.15.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-ai-sdk/core': 2.15.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-ai-sdk/prompt-registry': 2.15.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/util': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@sap-ai-sdk/prompt-registry@2.15.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@sap-ai-sdk/core': 2.15.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap-ai-sdk/prompt-registry@2.15.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@sap-ai-sdk/core': 2.15.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       zod: 4.4.3
     transitivePeerDependencies:
       - debug
@@ -35490,12 +35870,37 @@ snapshots:
       - debug
       - supports-color
 
+  '@sap-cloud-sdk/connectivity@4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@sap-cloud-sdk/resilience': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/util': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap/xsenv': 6.2.2(supports-color@8.1.1)
+      '@sap/xssec': 4.15.0(supports-color@8.1.1)
+      async-retry: 1.3.3
+      axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      jks-js: 1.1.7
+      jsonwebtoken: 9.0.3
+      safe-stable-stringify: 2.5.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@sap-cloud-sdk/http-client@4.9.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@sap-cloud-sdk/connectivity': 4.9.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       '@sap-cloud-sdk/resilience': 4.9.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       '@sap-cloud-sdk/util': 4.9.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       axios: 1.19.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap-cloud-sdk/http-client@4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@sap-cloud-sdk/connectivity': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/resilience': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/util': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -35511,11 +35916,32 @@ snapshots:
       - debug
       - supports-color
 
+  '@sap-cloud-sdk/openapi@4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@sap-cloud-sdk/connectivity': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/http-client': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/resilience': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      '@sap-cloud-sdk/util': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@sap-cloud-sdk/resilience@4.9.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@sap-cloud-sdk/util': 4.9.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       async-retry: 1.3.3
       axios: 1.19.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      opossum: 10.0.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@sap-cloud-sdk/resilience@4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@sap-cloud-sdk/util': 4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      async-retry: 1.3.3
+      axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       opossum: 10.0.0
     transitivePeerDependencies:
       - debug
@@ -35532,6 +35958,17 @@ snapshots:
       - debug
       - supports-color
 
+  '@sap-cloud-sdk/util@4.9.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      axios: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      logform: 2.7.0
+      voca: 1.4.1
+      winston: 3.19.0
+      winston-transport: 4.9.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@sap/xsenv@6.2.2(supports-color@10.2.2)':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -35540,9 +35977,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@sap/xsenv@6.2.2(supports-color@8.1.1)':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      node-cache: 5.1.2
+      verror: 1.10.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@sap/xssec@4.15.0(supports-color@10.2.2)':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
+      jwt-decode: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sap/xssec@4.15.0(supports-color@8.1.1)':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
       jwt-decode: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -37770,13 +38222,28 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/astro@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)':
+  '@workflow/astro@4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/rollup': 4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      '@workflow/vite': 4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      exsolve: 1.1.1
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+      - ws
+
+  '@workflow/astro@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)':
+    dependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
+      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
-      '@workflow/vite': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/vite': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
       exsolve: 1.1.1
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -37787,13 +38254,13 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@workflow/astro@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)':
+  '@workflow/astro@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
+      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
-      '@workflow/vite': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
+      '@workflow/vite': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
       exsolve: 1.1.1
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -37824,10 +38291,30 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/builders@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)':
+  '@workflow/builders@4.1.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/core': 4.6.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/errors': 4.1.4
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      '@workflow/utils': 4.1.3
+      builtin-modules: 5.0.0
+      chalk: 5.6.2
+      enhanced-resolve: 5.19.0
+      esbuild: 0.28.2
+      find-up: 7.0.0
+      json5: 2.2.3
+      tinyglobby: 0.2.17
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+      - ws
+
+  '@workflow/builders@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)':
+    dependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.0)
       '@workflow/errors': 5.0.0-beta.17
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
       '@workflow/utils': 5.0.0-beta.8
@@ -37846,10 +38333,10 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@workflow/builders@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)':
+  '@workflow/builders@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.0)
+      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.3)
       '@workflow/errors': 5.0.0-beta.17
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
       '@workflow/utils': 5.0.0-beta.8
@@ -37906,18 +38393,56 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/cli@5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.49)(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@8.1.1)(ws@8.21.0)':
+  '@workflow/cli@4.3.0(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)':
     dependencies:
       '@oclif/core': 4.11.4
       '@oclif/plugin-help': 6.2.37
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
       '@vercel/cli-auth': 0.0.1
-      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.0)
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/core': 4.6.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/errors': 4.1.4
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      '@workflow/utils': 4.1.3
+      '@workflow/web': 4.1.12(supports-color@8.1.1)
+      '@workflow/world': 4.2.1
+      '@workflow/world-local': 4.2.1(@opentelemetry/api@1.9.1)
+      '@workflow/world-vercel': 4.5.0(@opentelemetry/api@1.9.1)
+      boxen: 8.0.1
+      builtin-modules: 5.0.0
+      chalk: 5.6.2
+      chokidar: 4.0.3
+      date-fns: 4.1.0
+      dotenv: 17.4.2
+      easy-table: 1.2.0
+      enhanced-resolve: 5.19.0
+      esbuild: 0.28.2
+      find-up: 7.0.0
+      mixpart: 0.0.4
+      open: 10.2.0
+      ora: 8.2.0
+      terminal-link: 5.0.0
+      tinyglobby: 0.2.17
+      xdg-app-paths: 5.1.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+      - ws
+
+  '@workflow/cli@5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.49)(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@18.3.1)(supports-color@10.2.2)(ws@8.21.0)':
+    dependencies:
+      '@oclif/core': 4.11.4
+      '@oclif/plugin-help': 6.2.37
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@vercel/cli-auth': 0.0.1
+      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
+      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.0)
       '@workflow/errors': 5.0.0-beta.17
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
       '@workflow/utils': 5.0.0-beta.8
-      '@workflow/web': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@8.1.1)
+      '@workflow/web': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(react@18.3.1)(supports-color@10.2.2)
       '@workflow/world': 5.0.0-beta.27
       '@workflow/world-local': 5.0.0-beta.36(@opentelemetry/api@1.9.1)
       '@workflow/world-vercel': 5.0.0-beta.38(@aws-sdk/credential-provider-web-identity@3.972.49)(@opentelemetry/api@1.9.1)
@@ -37948,7 +38473,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@workflow/cli@5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.76)(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@18.3.1)(supports-color@10.2.2)(ws@8.21.3)':
+  '@workflow/cli@5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.76)(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@10.2.2)(ws@8.21.3)':
     dependencies:
       '@oclif/core': 4.11.4
       '@oclif/plugin-help': 6.2.37
@@ -37959,7 +38484,7 @@ snapshots:
       '@workflow/errors': 5.0.0-beta.17
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
       '@workflow/utils': 5.0.0-beta.8
-      '@workflow/web': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(react@18.3.1)(supports-color@10.2.2)
+      '@workflow/web': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@10.2.2)
       '@workflow/world': 5.0.0-beta.27
       '@workflow/world-local': 5.0.0-beta.36(@opentelemetry/api@1.9.1)
       '@workflow/world-vercel': 5.0.0-beta.38(@aws-sdk/credential-provider-web-identity@3.972.76)(@opentelemetry/api@1.9.1)
@@ -38017,13 +38542,40 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/core@5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.3)':
+  '@workflow/core@4.6.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.3)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
       '@jridgewell/trace-mapping': 0.3.31
       '@standard-schema/spec': 1.0.0
       '@types/ms': 2.1.0
-      '@vercel/functions': 3.9.3(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.3)
+      '@vercel/functions': 3.7.5(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.3)
+      '@workflow/errors': 4.1.4
+      '@workflow/serde': 4.1.2
+      '@workflow/utils': 4.1.3
+      '@workflow/world': 4.2.1
+      '@workflow/world-local': 4.2.1(@opentelemetry/api@1.9.1)
+      '@workflow/world-vercel': 4.5.0(@opentelemetry/api@1.9.1)
+      debug: 4.4.3(supports-color@8.1.1)
+      devalue: 5.8.1
+      ms: 2.1.3
+      nanoid: 5.1.6
+      seedrandom: 3.0.5
+      semver: 7.7.4
+      ulid: 3.0.2
+      zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+    transitivePeerDependencies:
+      - supports-color
+      - ws
+
+  '@workflow/core@5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.0)':
+    dependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.972.49
+      '@jridgewell/trace-mapping': 0.3.31
+      '@standard-schema/spec': 1.0.0
+      '@types/ms': 2.1.0
+      '@vercel/functions': 3.9.3(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0)
       '@workflow/errors': 5.0.0-beta.17
       '@workflow/serde': 5.0.0-beta.2
       '@workflow/utils': 5.0.0-beta.8
@@ -38047,20 +38599,20 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@workflow/core@5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.0)':
+  '@workflow/core@5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.3)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
       '@jridgewell/trace-mapping': 0.3.31
       '@standard-schema/spec': 1.0.0
       '@types/ms': 2.1.0
-      '@vercel/functions': 3.9.3(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0)
+      '@vercel/functions': 3.9.3(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.3)
       '@workflow/errors': 5.0.0-beta.17
       '@workflow/serde': 5.0.0-beta.2
       '@workflow/utils': 5.0.0-beta.8
       '@workflow/world': 5.0.0-beta.27
       '@workflow/world-local': 5.0.0-beta.36(@opentelemetry/api@1.9.1)
       '@workflow/world-vercel': 5.0.0-beta.38(@aws-sdk/credential-provider-web-identity@3.972.49)(@opentelemetry/api@1.9.1)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@10.2.2)
       devalue: 5.9.0
       ms: 2.1.3
       nanoid: 5.1.6
@@ -38102,6 +38654,39 @@ snapshots:
       - supports-color
       - ws
 
+  '@workflow/nest@4.0.12(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@8.1.1))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)':
+    dependencies:
+      '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1)
+      '@nestjs/core': 11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@swc/cli': 0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@8.1.1)
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+      - ws
+
+  '@workflow/nest@5.0.0-beta.42(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)':
+    dependencies:
+      '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2)
+      '@nestjs/core': 11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@swc/cli': 0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2)
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      esbuild: 0.28.2
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+
   '@workflow/nest@5.0.0-beta.42(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)':
     dependencies:
       '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2)
@@ -38120,40 +38705,6 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@workflow/nest@5.0.0-beta.42(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@8.1.1))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)':
-    dependencies:
-      '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1)
-      '@nestjs/core': 11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@swc/cli': 0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@8.1.1)
-      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
-      esbuild: 0.28.2
-      pathe: 2.0.3
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@swc/helpers'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-
-  '@workflow/next@4.1.0(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(supports-color@10.2.2)(ws@8.21.3)':
-    dependencies:
-      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/core': 4.6.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
-      semver: 7.7.4
-      watchpack: 2.5.1
-    optionalDependencies:
-      next: 15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@swc/helpers'
-      - supports-color
-      - ws
-
   '@workflow/next@4.1.0(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0))(supports-color@10.2.2)(ws@8.21.3)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
@@ -38170,11 +38721,27 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/next@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(supports-color@10.2.2)(ws@8.21.3)':
+  '@workflow/next@4.1.0(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(supports-color@8.1.1)(ws@8.21.3)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/core': 4.6.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      semver: 7.7.4
+      watchpack: 2.5.1
+    optionalDependencies:
+      next: 15.5.21(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+      - ws
+
+  '@workflow/next@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(supports-color@10.2.2)(ws@8.21.0)':
+    dependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
+      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.0)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
       chokidar: 4.0.3
       ignore: 7.0.5
@@ -38189,17 +38756,17 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@workflow/next@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0))(supports-color@8.1.1)(ws@8.21.0)':
+  '@workflow/next@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0))(supports-color@10.2.2)(ws@8.21.3)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.0)
+      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.3)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
       chokidar: 4.0.3
       ignore: 7.0.5
       semver: 7.7.4
     optionalDependencies:
-      next: 15.5.21(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0)
+      next: 15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -38225,14 +38792,31 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/nitro@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@18.3.1)(supports-color@10.2.2)(ws@8.21.3)':
+  '@workflow/nitro@4.1.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/core': 4.6.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/rollup': 4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      '@workflow/vite': 4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/web': 4.1.12(supports-color@8.1.1)
+      exsolve: 1.0.8
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+      - ws
+
+  '@workflow/nitro@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@18.3.1)(supports-color@10.2.2)(ws@8.21.0)':
+    dependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
+      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.0)
+      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
-      '@workflow/vite': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/vite': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
       '@workflow/web': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(react@18.3.1)(supports-color@10.2.2)
       exsolve: 1.0.8
       pathe: 2.0.3
@@ -38245,15 +38829,15 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@workflow/nitro@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@8.1.1)(ws@8.21.0)':
+  '@workflow/nitro@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@10.2.2)(ws@8.21.3)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
+      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
-      '@workflow/vite': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/web': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@8.1.1)
+      '@workflow/vite': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/web': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@10.2.2)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -38276,10 +38860,21 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/nuxt@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.4)(react@18.3.1)(supports-color@10.2.2)(ws@8.21.3)':
+  '@workflow/nuxt@4.0.12(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.4)(supports-color@8.1.1)(ws@8.21.3)':
+    dependencies:
+      '@nuxt/kit': 4.4.7(magicast@0.5.4)
+      '@workflow/nitro': 4.1.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - magicast
+      - supports-color
+      - ws
+
+  '@workflow/nuxt@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.4)(react@18.3.1)(supports-color@10.2.2)(ws@8.21.0)':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.4)
-      '@workflow/nitro': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@18.3.1)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/nitro': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@18.3.1)(supports-color@10.2.2)(ws@8.21.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -38290,10 +38885,10 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@workflow/nuxt@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.4)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@8.1.1)(ws@8.21.0)':
+  '@workflow/nuxt@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.4)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@10.2.2)(ws@8.21.3)':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.4)
-      '@workflow/nitro': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@8.1.1)(ws@8.21.0)
+      '@workflow/nitro': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@10.2.2)(ws@8.21.3)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -38316,10 +38911,22 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/rollup@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)':
+  '@workflow/rollup@4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      exsolve: 1.0.7
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+      - ws
+
+  '@workflow/rollup@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)':
+    dependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
       exsolve: 1.0.7
     transitivePeerDependencies:
@@ -38330,10 +38937,10 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@workflow/rollup@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)':
+  '@workflow/rollup@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
+      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
       exsolve: 1.0.7
     transitivePeerDependencies:
@@ -38368,13 +38975,29 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/sveltekit@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)':
+  '@workflow/sveltekit@4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/rollup': 4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      '@workflow/vite': 4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      exsolve: 1.1.1
+      fs-extra: 11.3.6
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+      - ws
+
+  '@workflow/sveltekit@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)':
+    dependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
+      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
-      '@workflow/vite': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/vite': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
       exsolve: 1.1.1
       fs-extra: 11.3.6
       pathe: 2.0.3
@@ -38386,13 +39009,13 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@workflow/sveltekit@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)':
+  '@workflow/sveltekit@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
+      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.21))
-      '@workflow/vite': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
+      '@workflow/vite': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
       exsolve: 1.1.1
       fs-extra: 11.3.6
       pathe: 2.0.3
@@ -38437,6 +39060,26 @@ snapshots:
       - supports-color
       - ws
 
+  '@workflow/vite@4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)':
+    dependencies:
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+      - ws
+
+  '@workflow/vite@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)':
+    dependencies:
+      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+
   '@workflow/vite@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)':
     dependencies:
       '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
@@ -38448,25 +39091,14 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@workflow/vite@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)':
+  '@workflow/vitest@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.6(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@26.1.0(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(ws@8.21.3)':
     dependencies:
-      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@swc/helpers'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-
-  '@workflow/vitest@5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.6(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@26.1.0(supports-color@8.1.1))(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(ws@8.21.0)':
-    dependencies:
-      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
+      '@workflow/builders': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
       '@workflow/world': 5.0.0-beta.27
       '@workflow/world-local': 5.0.0-beta.36(@opentelemetry/api@1.9.1)
-      vitest: 4.1.6(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@26.1.0(supports-color@8.1.1))(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.6(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@26.1.0(supports-color@10.2.2))(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
     optionalDependencies:
       vite: 7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -38483,6 +39115,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@workflow/web@4.1.12(supports-color@8.1.1)':
+    dependencies:
+      express: 5.2.1(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@workflow/web@5.0.0-beta.42(@opentelemetry/api@1.9.1)(react@18.3.1)(supports-color@10.2.2)':
     dependencies:
       '@workflow/world-local': 5.0.0-beta.36(@opentelemetry/api@1.9.1)
@@ -38493,10 +39131,10 @@ snapshots:
       - react
       - supports-color
 
-  '@workflow/web@5.0.0-beta.42(@opentelemetry/api@1.9.1)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@8.1.1)':
+  '@workflow/web@5.0.0-beta.42(@opentelemetry/api@1.9.1)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@10.2.2)':
     dependencies:
       '@workflow/world-local': 5.0.0-beta.36(@opentelemetry/api@1.9.1)
-      express: 5.2.1(supports-color@8.1.1)
+      express: 5.2.1(supports-color@10.2.2)
       swr: 2.4.1(react@19.0.0-rc-cc1ec60d0d-20240607)
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -38861,6 +39499,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@6.0.2(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   aggregate-error@4.0.1:
@@ -39201,6 +39845,16 @@ snapshots:
       - debug
       - supports-color
 
+  axios@1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   axobject-query@4.1.0: {}
 
   b4a@1.8.1: {}
@@ -39250,11 +39904,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
       '@babel/compat-data': 7.29.7
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -39268,10 +39922,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2):
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
@@ -39284,10 +39938,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2):
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -40124,6 +40778,22 @@ snapshots:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 4.7.0
+
+  create-jest@29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
 
   create-jest@29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.9.3)):
     dependencies:
@@ -41432,6 +42102,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  express-rate-limit@8.6.2(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      express: 5.2.1(supports-color@8.1.1)
+      ip-address: 10.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   express@4.22.1(supports-color@10.2.2):
     dependencies:
       accepts: 1.3.8
@@ -42204,10 +42882,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  gaxios@7.2.0(supports-color@8.1.1):
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
   gaxios@7.3.0(supports-color@10.2.2):
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gaxios@7.3.0(supports-color@8.1.1):
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       node-fetch: 3.3.2
     transitivePeerDependencies:
       - supports-color
@@ -42224,6 +42918,14 @@ snapshots:
   gcp-metadata@8.1.2(supports-color@10.2.2):
     dependencies:
       gaxios: 7.2.0(supports-color@10.2.2)
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2(supports-color@8.1.1):
+    dependencies:
+      gaxios: 7.2.0(supports-color@8.1.1)
       google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -42413,6 +43115,17 @@ snapshots:
       ecdsa-sig-formatter: 1.0.11
       gaxios: 7.3.0(supports-color@10.2.2)
       gcp-metadata: 8.1.2(supports-color@10.2.2)
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-auth-library@10.9.1(supports-color@8.1.1):
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.0(supports-color@8.1.1)
+      gcp-metadata: 8.1.2(supports-color@8.1.1)
       google-logging-utils: 1.1.3
       jws: 4.0.1
     transitivePeerDependencies:
@@ -42640,6 +43353,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-jsx-runtime@2.3.6(supports-color@8.1.1):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   hast-util-to-parse5@8.0.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -42787,7 +43520,6 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   http-proxy-middleware@2.0.9(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
@@ -42834,6 +43566,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
+    dependencies:
+      agent-base: 6.0.2(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
@@ -42847,7 +43586,6 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   httpxy@0.5.5: {}
 
@@ -43388,6 +44126,26 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-cli@29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3)):
+    dependencies:
+      '@jest/core': 29.7.0(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
   jest-cli@29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.9.3))
@@ -43406,6 +44164,38 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  jest-config@29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3)):
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(supports-color@10.2.2)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0(supports-color@10.2.2)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.19.19
+      ts-node: 10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    optional: true
 
   jest-config@29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.9.3)):
     dependencies:
@@ -43659,6 +44449,19 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
+  jest@29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3)):
+    dependencies:
+      '@jest/core': 29.7.0(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
   jest@29.7.0(@types/node@22.19.19)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.9.3))
@@ -43738,7 +44541,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jscodeshift@17.3.0(@babel/preset-env@7.28.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2):
+  jscodeshift@17.3.0(@babel/preset-env@7.28.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/parser': 7.29.3
@@ -43759,7 +44562,7 @@ snapshots:
       tmp: 0.2.5
       write-file-atomic: 5.0.1
     optionalDependencies:
-      '@babel/preset-env': 7.28.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/preset-env': 7.28.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -43817,34 +44620,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-
-  jsdom@26.1.0(supports-color@8.1.1):
-    dependencies:
-      cssstyle: 4.6.0
-      data-urls: 5.0.0
-      decimal.js: 10.6.0
-      html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
-      is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.23
-      parse5: 7.3.0
-      rrweb-cssom: 0.8.0
-      saxes: 6.0.0
-      symbol-tree: 3.2.4
-      tough-cookie: 5.1.2
-      w3c-xmlserializer: 5.0.0
-      webidl-conversions: 7.0.0
-      whatwg-encoding: 3.1.1
-      whatwg-mimetype: 4.0.0
-      whatwg-url: 14.2.0
-      ws: 8.21.0
-      xml-name-validator: 5.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
 
   jsesc@3.1.0: {}
 
@@ -44593,6 +45368,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-from-markdown@2.0.3(supports-color@8.1.1):
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2(supports-color@8.1.1)
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-frontmatter@2.0.1(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
@@ -44622,10 +45414,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-gfm-footnote@2.1.0(supports-color@8.1.1):
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-gfm-strikethrough@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@8.1.1):
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -44640,11 +45450,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-gfm-table@2.0.0(supports-color@8.1.1):
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-gfm-task-list-item@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@8.1.1):
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -44661,6 +45490,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-gfm@3.1.0(supports-color@8.1.1):
+    dependencies:
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0(supports-color@8.1.1)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@8.1.1)
+      mdast-util-gfm-table: 2.0.0(supports-color@8.1.1)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@8.1.1)
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-math@3.0.0(supports-color@10.2.2):
     dependencies:
       '@types/hast': 3.0.4
@@ -44668,6 +45509,18 @@ snapshots:
       devlop: 1.1.0
       longest-streak: 3.1.0
       mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-to-markdown: 2.1.2
+      unist-util-remove-position: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-math@3.0.0(supports-color@8.1.1):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      longest-streak: 3.1.0
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       unist-util-remove-position: 5.0.0
     transitivePeerDependencies:
@@ -44684,6 +45537,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-mdx-expression@2.0.1(supports-color@8.1.1):
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-mdx-jsx@3.2.0(supports-color@10.2.2):
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -44693,6 +45557,23 @@ snapshots:
       ccount: 2.0.1
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0(supports-color@8.1.1):
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -44718,6 +45599,17 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1(supports-color@8.1.1):
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -44899,6 +45791,19 @@ snapshots:
     optionalDependencies:
       micromark-util-types: 2.0.2
 
+  micromark-extension-cjk-friendly-gfm-strikethrough@1.2.3(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1)):
+    dependencies:
+      devlop: 1.1.0
+      get-east-asian-width: 1.6.0
+      micromark: 4.0.2(supports-color@8.1.1)
+      micromark-extension-cjk-friendly-util: 2.1.1(micromark-util-types@2.0.2)
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
+      micromark-util-types: 2.0.2
+
   micromark-extension-cjk-friendly-gfm-strikethrough@2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@10.2.2)):
     dependencies:
       devlop: 1.1.0
@@ -44932,6 +45837,17 @@ snapshots:
     dependencies:
       devlop: 1.1.0
       micromark: 4.0.2(supports-color@10.2.2)
+      micromark-extension-cjk-friendly-util: 2.1.1(micromark-util-types@2.0.2)
+      micromark-util-chunked: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-cjk-friendly@1.2.3(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1)):
+    dependencies:
+      devlop: 1.1.0
+      micromark: 4.0.2(supports-color@8.1.1)
       micromark-extension-cjk-friendly-util: 2.1.1(micromark-util-types@2.0.2)
       micromark-util-chunked: 2.0.1
       micromark-util-resolve-all: 2.0.1
@@ -45194,6 +46110,28 @@ snapshots:
     dependencies:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@10.2.2)
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  micromark@4.0.2(supports-color@8.1.1):
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -45637,15 +46575,15 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.5.21(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0):
+  next@15.5.21(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0):
     dependencies:
       '@next/env': 15.5.21
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001799
       postcss: 8.4.31
-      react: 19.0.0-rc-cc1ec60d0d-20240607
-      react-dom: 19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607)
-      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@19.0.0-rc-cc1ec60d0d-20240607)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.21
       '@next/swc-darwin-x64': 15.5.21
@@ -45662,7 +46600,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-    optional: true
 
   next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.90.0):
     dependencies:
@@ -48276,6 +49213,16 @@ snapshots:
       - micromark
       - micromark-util-types
 
+  remark-cjk-friendly-gfm-strikethrough@1.2.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(unified@11.0.5):
+    dependencies:
+      micromark-extension-cjk-friendly-gfm-strikethrough: 1.2.3(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))
+      unified: 11.0.5
+    optionalDependencies:
+      '@types/mdast': 4.0.4
+    transitivePeerDependencies:
+      - micromark
+      - micromark-util-types
+
   remark-cjk-friendly-gfm-strikethrough@2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@10.2.2))(supports-color@10.2.2)(unified@11.0.5):
     dependencies:
       mdast-util-to-markdown-cjk-friendly-gfm-strikethrough: 1.0.0(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(supports-color@10.2.2)
@@ -48291,6 +49238,16 @@ snapshots:
   remark-cjk-friendly@1.2.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@10.2.2))(unified@11.0.5):
     dependencies:
       micromark-extension-cjk-friendly: 1.2.3(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@10.2.2))
+      unified: 11.0.5
+    optionalDependencies:
+      '@types/mdast': 4.0.4
+    transitivePeerDependencies:
+      - micromark
+      - micromark-util-types
+
+  remark-cjk-friendly@1.2.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(unified@11.0.5):
+    dependencies:
+      micromark-extension-cjk-friendly: 1.2.3(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))
       unified: 11.0.5
     optionalDependencies:
       '@types/mdast': 4.0.4
@@ -48329,10 +49286,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  remark-gfm@4.0.1(supports-color@8.1.1):
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0(supports-color@8.1.1)
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0(supports-color@8.1.1)
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-math@6.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       mdast-util-math: 3.0.0(supports-color@10.2.2)
+      micromark-extension-math: 3.1.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-math@6.0.0(supports-color@8.1.1):
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-math: 3.0.0(supports-color@8.1.1)
       micromark-extension-math: 3.1.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -48349,6 +49326,15 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0(supports-color@8.1.1):
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -49086,6 +50072,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  simple-git@3.36.0(supports-color@8.1.1):
+    dependencies:
+      '@kwsites/file-exists': 1.1.1(supports-color@8.1.1)
+      '@kwsites/promise-deferred': 1.1.1
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   simple-swizzle@0.2.4:
     dependencies:
       is-arrayish: 0.3.4
@@ -49328,6 +50324,38 @@ snapshots:
       - micromark-util-types
       - supports-color
 
+  streamdown@1.6.11(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(react@18.3.1)(supports-color@8.1.1):
+    dependencies:
+      clsx: 2.1.1
+      hast: 1.0.0
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@8.1.1)
+      html-url-attributes: 3.0.1
+      katex: 0.16.46
+      lucide-react: 0.542.0(react@18.3.1)
+      marked: 16.4.2
+      mermaid: 11.15.0
+      react: 18.3.1
+      rehype-harden: 1.1.8
+      rehype-katex: 7.0.1
+      rehype-raw: 7.0.0
+      rehype-sanitize: 6.0.0
+      remark-cjk-friendly: 1.2.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(unified@11.0.5)
+      remark-cjk-friendly-gfm-strikethrough: 1.2.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2(supports-color@8.1.1))(unified@11.0.5)
+      remark-gfm: 4.0.1(supports-color@8.1.1)
+      remark-math: 6.0.0(supports-color@8.1.1)
+      remark-parse: 11.0.0(supports-color@8.1.1)
+      remark-rehype: 11.1.2
+      remend: 1.0.1
+      shiki: 3.23.0
+      tailwind-merge: 3.6.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+    transitivePeerDependencies:
+      - '@types/mdast'
+      - micromark
+      - micromark-util-types
+      - supports-color
+
   streamdown@2.5.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(supports-color@10.2.2):
     dependencies:
       clsx: 2.1.1
@@ -49512,13 +50540,12 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
 
-  styled-jsx@5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@19.0.0-rc-cc1ec60d0d-20240607):
+  styled-jsx@5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@18.3.1):
     dependencies:
       client-only: 0.0.1
-      react: 19.0.0-rc-cc1ec60d0d-20240607
+      react: 18.3.1
     optionalDependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-    optional: true
 
   stylehacks@7.0.11(postcss@8.5.12):
     dependencies:
@@ -50218,30 +51245,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  tsup@7.2.0(@swc/core@1.15.3(@swc/helpers@0.5.21))(postcss@8.5.26)(supports-color@8.1.1)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3))(typescript@5.8.3):
-    dependencies:
-      bundle-require: 4.2.1(esbuild@0.18.20)
-      cac: 6.7.14
-      chokidar: 3.6.0
-      debug: 4.4.3(supports-color@8.1.1)
-      esbuild: 0.18.20
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.5.26)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.21))(@types/node@22.19.19)(typescript@5.8.3))
-      resolve-from: 5.0.0
-      rollup: 3.30.0
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.1
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      postcss: 8.5.26
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-
   tsup@8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.26)(supports-color@10.2.2)(tsx@4.23.12)(typescript@5.6.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
@@ -50278,35 +51281,6 @@ snapshots:
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3(supports-color@10.2.2)
-      esbuild: 0.27.7
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.12)(yaml@2.9.0)
-      resolve-from: 5.0.0
-      rollup: 4.62.4
-      source-map: 0.7.6
-      sucrase: 3.35.1
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.17
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
-      postcss: 8.5.26
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
-  tsup@8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.26)(supports-color@8.1.1)(tsx@4.23.12)(typescript@5.8.3)(yaml@2.9.0):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.7)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.3(supports-color@8.1.1)
       esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -51238,36 +52212,6 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.6(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@26.1.0(supports-color@8.1.1))(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(msw@2.14.6(@types/node@22.19.19)(typescript@5.8.3))(vite@7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
-      es-module-lexer: 2.1.0
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 7.3.6(@types/node@22.19.19)(jiti@2.7.0)(less@4.4.0)(lightningcss@1.32.0)(sass@1.90.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@edge-runtime/vm': 5.0.0
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 22.19.19
-      jsdom: 26.1.0(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - msw
-
   voca@1.4.1: {}
 
   vscode-jsonrpc@9.0.1: {}
@@ -51718,35 +52662,6 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workflow@4.6.0(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.4)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(supports-color@10.2.2)(typescript@5.8.3)(ws@8.21.3):
-    dependencies:
-      '@workflow/astro': 4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/cli': 4.3.0(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/core': 4.6.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/errors': 4.1.4
-      '@workflow/nest': 4.0.12(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/next': 4.1.0(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/nitro': 4.1.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/nuxt': 4.0.12(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.4)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/rollup': 4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/sveltekit': 4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/typescript-plugin': 4.0.3(typescript@5.8.3)
-      '@workflow/utils': 4.1.3
-      ms: 2.1.3
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-    transitivePeerDependencies:
-      - '@nestjs/common'
-      - '@nestjs/core'
-      - '@swc/cli'
-      - '@swc/core'
-      - '@swc/helpers'
-      - magicast
-      - next
-      - supports-color
-      - typescript
-      - ws
-
   workflow@4.6.0(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.4)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0))(supports-color@10.2.2)(typescript@5.8.3)(ws@8.21.3):
     dependencies:
       '@workflow/astro': 4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
@@ -51776,18 +52691,47 @@ snapshots:
       - typescript
       - ws
 
-  workflow@5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.49)(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@8.1.1))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.4)(next@15.5.21(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0))(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@8.1.1)(typescript@5.8.3)(ws@8.21.0):
+  workflow@4.6.0(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@8.1.1))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.4)(next@15.5.21(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(supports-color@8.1.1)(typescript@5.8.3)(ws@8.21.3):
     dependencies:
-      '@workflow/astro': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/cli': 5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.49)(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.0)
+      '@workflow/astro': 4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/cli': 4.3.0(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/core': 4.6.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/errors': 4.1.4
+      '@workflow/nest': 4.0.12(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@8.1.1))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/next': 4.1.0(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/nitro': 4.1.2(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/nuxt': 4.0.12(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.4)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/rollup': 4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/sveltekit': 4.0.11(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.3)
+      '@workflow/typescript-plugin': 4.0.3(typescript@5.8.3)
+      '@workflow/utils': 4.1.3
+      ms: 2.1.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+    transitivePeerDependencies:
+      - '@nestjs/common'
+      - '@nestjs/core'
+      - '@swc/cli'
+      - '@swc/core'
+      - '@swc/helpers'
+      - magicast
+      - next
+      - supports-color
+      - typescript
+      - ws
+
+  workflow@5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.49)(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.4)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)(supports-color@10.2.2)(typescript@5.8.3)(ws@8.21.0):
+    dependencies:
+      '@workflow/astro': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
+      '@workflow/cli': 5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.49)(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@18.3.1)(supports-color@10.2.2)(ws@8.21.0)
+      '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.0)
       '@workflow/errors': 5.0.0-beta.17
-      '@workflow/nest': 5.0.0-beta.42(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@8.1.1))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/next': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0))(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/nitro': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/nuxt': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.4)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/sveltekit': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@8.1.1)(ws@8.21.0)
+      '@workflow/nest': 5.0.0-beta.42(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
+      '@workflow/next': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(supports-color@10.2.2)(ws@8.21.0)
+      '@workflow/nitro': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@18.3.1)(supports-color@10.2.2)(ws@8.21.0)
+      '@workflow/nuxt': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.4)(react@18.3.1)(supports-color@10.2.2)(ws@8.21.0)
+      '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
+      '@workflow/sveltekit': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.0)
       '@workflow/typescript-plugin': 5.0.0-beta.5(typescript@5.8.3)
       '@workflow/utils': 5.0.0-beta.8
       ms: 2.1.3
@@ -51809,16 +52753,16 @@ snapshots:
       - utf-8-validate
       - ws
 
-  workflow@5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.76)(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.4)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(react@18.3.1)(supports-color@10.2.2)(typescript@5.8.3)(ws@8.21.3):
+  workflow@5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.76)(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.4)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0))(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@10.2.2)(typescript@5.8.3)(ws@8.21.3):
     dependencies:
       '@workflow/astro': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/cli': 5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.76)(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@18.3.1)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/cli': 5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.76)(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@10.2.2)(ws@8.21.3)
       '@workflow/core': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.3)
       '@workflow/errors': 5.0.0-beta.17
       '@workflow/nest': 5.0.0-beta.42(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.18(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/next': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.90.0))(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/nitro': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@18.3.1)(supports-color@10.2.2)(ws@8.21.3)
-      '@workflow/nuxt': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.4)(react@18.3.1)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/next': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(next@15.5.21(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.0.0-rc-cc1ec60d0d-20240607(react@19.0.0-rc-cc1ec60d0d-20240607))(react@19.0.0-rc-cc1ec60d0d-20240607)(sass@1.90.0))(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/nitro': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@10.2.2)(ws@8.21.3)
+      '@workflow/nuxt': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(magicast@0.5.4)(react@19.0.0-rc-cc1ec60d0d-20240607)(supports-color@10.2.2)(ws@8.21.3)
       '@workflow/rollup': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
       '@workflow/sveltekit': 5.0.0-beta.42(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.21)(supports-color@10.2.2)(ws@8.21.3)
       '@workflow/typescript-plugin': 5.0.0-beta.5(typescript@5.8.3)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -214,6 +214,9 @@
       "path": "packages/togetherai"
     },
     {
+      "path": "packages/topaz"
+    },
+    {
       "path": "packages/tui"
     },
     {


### PR DESCRIPTION
### Summary
- Add `@ai-sdk/topaz` for Topaz Labs image and video enhancement. These models enhance media you supply (upscale, denoise, sharpen, restore); they do not generate from a text prompt.
- Image: `topaz.image('wonder-3.5')` submits the async enhance job, polls it, and downloads the result. Input goes through `prompt.images`.
- Video: `topaz.video('proteus')` and `topaz.video('starlight-precise-2.6')` use the spec-v4 async operation protocol. `doStart` runs Topaz’s create/accept/upload/complete-upload flow; `doStatus` polls. Input goes through `inputReferences`. Source metadata (resolution, duration, frame rate, frame count) is required up front and is assembled from call options plus the `source` provider option.

Includes docs, examples (`generate-image/topaz`, `generate-video/topaz`), and unit tests.