### PR TITLE
fix(ai): use new message ID when replacing a message in `sendMessage`

### DIFF
--- a/.changeset/bright-edits-id.md
+++ b/.changeset/bright-edits-id.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(ai): use new message ID when replacing a message in `sendMessage`

--- a/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
+++ b/content/docs/07-reference/02-ai-sdk-ui/01-use-chat.mdx
@@ -408,7 +408,7 @@ Allows you to easily create a conversational user interface for your chatbot app
       name: 'sendMessage',
       type: '(message?: { text: string; files?: FileList | FileUIPart[]; metadata?; messageId?: string } | CreateUIMessage, options?: ChatRequestOptions) => Promise<void>',
       description:
-        'Function to send a new message to the chat. This will trigger an API call to generate the assistant response. If a messageId is provided, the message will be replaced (useful for editing). If no message is provided, resubmits the current messages (useful after adding tool outputs).',
+        'Function to send a new message to the chat. This will trigger an API call to generate the assistant response. If a messageId is provided, the message will be replaced (useful for editing). When replacing with a CreateUIMessage, provide its id to assign a new ID to the replacement. If no message is provided, resubmits the current messages (useful after adding tool outputs).',
       properties: [
         {
           type: 'ChatRequestOptions',

--- a/examples/ai-e2e-next/app/api/chat/message-replacement/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/message-replacement/route.ts
@@ -1,0 +1,29 @@
+import { createUIMessageStreamResponse, simulateReadableStream } from 'ai';
+
+export async function POST(req: Request) {
+  const { messageId, messages } = (await req.json()) as {
+    messageId: string | undefined;
+    messages: Array<{ id: string }>;
+  };
+  const replacementId = messages.at(-1)?.id ?? 'missing';
+
+  return createUIMessageStreamResponse({
+    stream: simulateReadableStream({
+      initialDelayInMs: 0,
+      chunkDelayInMs: 0,
+      chunks: [
+        { type: 'start' },
+        { type: 'start-step' },
+        { type: 'text-start', id: '0' },
+        {
+          type: 'text-delta',
+          id: '0',
+          delta: `Replaced ${messageId} with ${replacementId}`,
+        },
+        { type: 'text-end', id: '0' },
+        { type: 'finish-step' },
+        { type: 'finish' },
+      ],
+    }),
+  });
+}

--- a/examples/ai-e2e-next/app/api/chat/message-replacement/route.ts
+++ b/examples/ai-e2e-next/app/api/chat/message-replacement/route.ts
@@ -1,12 +1,6 @@
 import { createUIMessageStreamResponse, simulateReadableStream } from 'ai';
 
-export async function POST(req: Request) {
-  const { messageId, messages } = (await req.json()) as {
-    messageId: string | undefined;
-    messages: Array<{ id: string }>;
-  };
-  const replacementId = messages.at(-1)?.id ?? 'missing';
-
+export function POST() {
   return createUIMessageStreamResponse({
     stream: simulateReadableStream({
       initialDelayInMs: 0,
@@ -18,7 +12,7 @@ export async function POST(req: Request) {
         {
           type: 'text-delta',
           id: '0',
-          delta: `Replaced ${messageId} with ${replacementId}`,
+          delta: 'Replacement request completed.',
         },
         { type: 'text-end', id: '0' },
         { type: 'finish-step' },

--- a/examples/ai-e2e-next/app/chat/message-replacement/page.tsx
+++ b/examples/ai-e2e-next/app/chat/message-replacement/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport, type UIMessage } from 'ai';
+import { memo } from 'react';
+
+const originalMessageId = 'original-message-id';
+const replacementMessageId = 'replacement-message-id';
+
+const Message = memo(
+  function Message({ message }: { message: UIMessage }) {
+    return (
+      <div data-testid={`message-${message.id}`}>
+        <div data-testid={`message-id-${message.id}`}>{message.id}</div>
+        <div>
+          {message.parts
+            .map(part => (part.type === 'text' ? part.text : ''))
+            .join('')}
+        </div>
+      </div>
+    );
+  },
+  (previous, next) =>
+    previous.message.role === 'user' &&
+    next.message.role === 'user' &&
+    previous.message.id === next.message.id,
+);
+
+export default function Page() {
+  const { messages, sendMessage, status } = useChat({
+    messages: [
+      {
+        id: originalMessageId,
+        role: 'user',
+        parts: [{ type: 'text', text: 'Original message' }],
+      },
+    ],
+    transport: new DefaultChatTransport({
+      api: '/api/chat/message-replacement',
+    }),
+  });
+
+  return (
+    <div className="flex flex-col w-full max-w-lg py-12 mx-auto gap-4">
+      <h4 className="text-xl font-bold">useChat message replacement</h4>
+      <p>
+        The memoized user message view only rerenders when its message ID
+        changes.
+      </p>
+
+      <button
+        className="px-3 py-1 text-white bg-black rounded disabled:opacity-50"
+        data-testid="replace-message"
+        disabled={status !== 'ready'}
+        onClick={() => {
+          sendMessage({
+            id: replacementMessageId,
+            parts: [{ type: 'text', text: 'Replacement message' }],
+            messageId: originalMessageId,
+          });
+        }}
+      >
+        Replace message
+      </button>
+
+      <div className="flex flex-col gap-2">
+        {messages.map(message => (
+          <Message key={message.id} message={message} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/ai/src/ui/chat.test.ts
+++ b/packages/ai/src/ui/chat.test.ts
@@ -1717,6 +1717,54 @@ describe('Chat', () => {
     `);
   });
 
+  it('should use an explicitly provided ID when replacing a user message', async () => {
+    server.urls['http://localhost:3000/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        formatChunk({ type: 'start' }),
+        formatChunk({ type: 'start-step' }),
+        formatChunk({ type: 'finish-step' }),
+        formatChunk({ type: 'finish' }),
+      ],
+    };
+
+    const finishPromise = createResolvablePromise<void>();
+    const chat = new TestChat({
+      id: '123',
+      transport: new DefaultChatTransport({
+        api: 'http://localhost:3000/api/chat',
+      }),
+      onFinish: () => finishPromise.resolve(),
+      messages: [
+        {
+          id: 'id-0',
+          role: 'user',
+          parts: [{ text: 'Hi!', type: 'text' }],
+        },
+      ],
+    });
+
+    chat.sendMessage({
+      id: 'replacement-id',
+      parts: [{ text: 'Hello, world!', type: 'text' }],
+      messageId: 'id-0',
+    });
+
+    await finishPromise.promise;
+
+    expect(await server.calls[0].requestBodyJson).toMatchObject({
+      messageId: 'id-0',
+      messages: [
+        {
+          id: 'replacement-id',
+          role: 'user',
+          parts: [{ text: 'Hello, world!', type: 'text' }],
+        },
+      ],
+    });
+    expect(chat.messages[0].id).toBe('replacement-id');
+  });
+
   it('should reject when onFinish throws', async () => {
     const onFinishError = new Error('onFinish failed');
     const chat = new TestChat({

--- a/packages/ai/src/ui/chat.ts
+++ b/packages/ai/src/ui/chat.ts
@@ -420,8 +420,8 @@ export abstract class AbstractChat<UI_MESSAGE extends UIMessage> {
 
       // update the message with the new content
       this.state.replaceMessage(messageIndex, {
-        ...uiMessage,
         id: message.messageId,
+        ...uiMessage,
         role: uiMessage.role ?? 'user',
         metadata: message.metadata,
       } as UI_MESSAGE);


### PR DESCRIPTION
## Background

Editing a message with `sendMessage` always used the existing message ID, even when a new message ID was explicitly passed in.

## Summary

Move the object spread to *after* the message ID is set to the old message ID, so that the spread can overwrite it if the user supplies it. 

## End-to-End Verification

added an example to ai-e2e-next to verify message editing works

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Related Issues

Fixes https://github.com/vercel/ai/issues/10993
