### PR TITLE
fix(open-responses): include default image detail

### DIFF
--- a/.changeset/quiet-images-default.md
+++ b/.changeset/quiet-images-default.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/open-responses': patch
+---
+
+Include the documented `auto` detail level when serializing image inputs.

--- a/packages/open-responses/src/responses/convert-to-open-responses-input.test.ts
+++ b/packages/open-responses/src/responses/convert-to-open-responses-input.test.ts
@@ -144,6 +144,7 @@ describe('convertToOpenResponsesInput', () => {
           {
             "content": [
               {
+                "detail": "auto",
                 "image_url": "data:image/png;base64,ZmFrZS1kYXRh",
                 "type": "input_image",
               },
@@ -179,6 +180,7 @@ describe('convertToOpenResponsesInput', () => {
           {
             "content": [
               {
+                "detail": "auto",
                 "image_url": "https://example.com/image.png",
                 "type": "input_image",
               },
@@ -916,6 +918,7 @@ describe('convertToOpenResponsesInput', () => {
             "call_id": "call_image",
             "output": [
               {
+                "detail": "auto",
                 "image_url": "https://example.com/image.png",
                 "type": "input_image",
               },
@@ -1214,6 +1217,7 @@ describe('convertToOpenResponsesInput', () => {
 
       expect((result.input[0] as { content: unknown[] }).content[0]).toEqual({
         type: 'input_image',
+        detail: 'auto',
         image_url: `data:image/png;base64,${pngBase64}`,
       });
     });
@@ -1236,6 +1240,7 @@ describe('convertToOpenResponsesInput', () => {
 
       expect((result.input[0] as { content: unknown[] }).content[0]).toEqual({
         type: 'input_image',
+        detail: 'auto',
         image_url: `data:image/png;base64,${pngBase64}`,
       });
     });
@@ -1261,6 +1266,7 @@ describe('convertToOpenResponsesInput', () => {
 
       expect((result.input[0] as { content: unknown[] }).content[0]).toEqual({
         type: 'input_image',
+        detail: 'auto',
         image_url: 'https://example.com/x.png',
       });
     });
@@ -1283,6 +1289,7 @@ describe('convertToOpenResponsesInput', () => {
 
       expect((result.input[0] as { content: unknown[] }).content[0]).toEqual({
         type: 'input_image',
+        detail: 'auto',
         image_url: `data:image/png;base64,${pngBase64}`,
       });
     });

--- a/packages/open-responses/src/responses/convert-to-open-responses-input.ts
+++ b/packages/open-responses/src/responses/convert-to-open-responses-input.ts
@@ -85,6 +85,7 @@ export async function convertToOpenResponsesInput({
                   if (topLevel === 'image') {
                     userContent.push({
                       type: 'input_image',
+                      detail: 'auto',
                       ...(part.data.type === 'url'
                         ? { image_url: part.data.url.toString() }
                         : {
@@ -413,6 +414,7 @@ export async function convertToOpenResponsesInput({
                         if (topLevel === 'image') {
                           contentParts.push({
                             type: 'input_image',
+                            detail: 'auto',
                             image_url: `data:${fullMediaType};base64,${convertToBase64(item.data.data)}`,
                           });
                         } else {
@@ -426,6 +428,7 @@ export async function convertToOpenResponsesInput({
                         if (topLevel === 'image') {
                           contentParts.push({
                             type: 'input_image',
+                            detail: 'auto',
                             image_url: item.data.url.toString(),
                           });
                         } else {


### PR DESCRIPTION
## Background

`@ai-sdk/open-responses` currently omits `input_image.detail` when converting image inputs. Strict Open Responses consumers such as vLLM reject the resulting request, even though the protocol defines `auto` as the default detail value. This addresses [#20300](https://github.com/vercel/ai/issues/20300).

## Summary

- Emit `detail: 'auto'` for user and tool-result image data/URL inputs.
- Leave non-image file serialization and transport behavior unchanged.
- Add focused assertions and a patch changeset for `@ai-sdk/open-responses`.

## Contributor Credit

The issue report and strict-consumer reproduction are credited to the reporter. The patch was prepared by `zfaustk` with Codex assistance and independently cross-reviewed before submission.

## End-to-End Verification

The converter now emits the protocol-defined `detail: 'auto'` field for every image input path covered by the package. Node and Edge focused suites both pass.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (not needed for this serializer fix)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #20300
