### PR TITLE
docs: add The Grid to the OpenAI-compatible providers documentation

### DIFF
--- a/content/providers/04-openai-compatible-providers/60-thegrid.mdx
+++ b/content/providers/04-openai-compatible-providers/60-thegrid.mdx
@@ -1,0 +1,100 @@
+---
+title: The Grid
+description: Use The Grid OpenAI compatible API with the AI SDK.
+---
+
+# The Grid Provider
+
+[The Grid](https://thegrid.ai) is a spot market for AI inference that provides access to models from competing suppliers through an OpenAI-compatible API. You can use its Chat Completions endpoint with the AI SDK through the `@ai-sdk/openai-compatible` module.
+
+## Setup
+
+The Grid provider is available via the `@ai-sdk/openai-compatible` module as it is compatible with the OpenAI API. You can install it with:
+
+<InstallPackages packages="@ai-sdk/openai-compatible" />
+
+## Provider Instance
+
+To use The Grid, create a custom provider instance with the `createOpenAICompatible` function from `@ai-sdk/openai-compatible`:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+
+const thegrid = createOpenAICompatible({
+  name: 'thegrid',
+  baseURL: 'https://api.thegrid.ai/v1',
+  apiKey: process.env.THEGRID_API_KEY,
+});
+```
+
+<Note>
+  Follow the [The Grid quickstart](https://thegrid.ai/docs/start-here/quickstart)
+  to create an API key. Make sure to set the `THEGRID_API_KEY` environment
+  variable with your API key.
+</Note>
+
+## Language Models
+
+You can create The Grid models using the provider instance. The first argument is a model ID from the [instrument catalog](https://thegrid.ai/docs/instrument-specifications/current-instruments), for example `text-standard`.
+
+```ts
+const model = thegrid('text-standard');
+```
+
+The Grid's model IDs are market instruments rather than fixed models. You choose a task type (`text`, `code`, or `agent`) and a quality tier (`standard`, `prime`, or `max`) — such as `text-standard`, `code-prime`, or `agent-max` — and the request is filled by a qualifying supplier at the current market price. Lab-scoped instruments such as `claude-opus-latest` and `gemini-pro-latest` stay within one model family. Because of this, the `model` field of a response names the model that actually served the request, which will differ from the instrument you requested.
+
+### Example
+
+You can use The Grid language models to generate text with the `generateText` function:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { generateText } from 'ai';
+
+const thegrid = createOpenAICompatible({
+  name: 'thegrid',
+  baseURL: 'https://api.thegrid.ai/v1',
+  apiKey: process.env.THEGRID_API_KEY,
+});
+
+const { text } = await generateText({
+  model: thegrid('text-standard'),
+  prompt: 'Tell me about yourself in one sentence.',
+});
+
+console.log(text);
+```
+
+The Grid language models can also generate text in a streaming fashion with the `streamText` function:
+
+```ts
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { streamText } from 'ai';
+
+const thegrid = createOpenAICompatible({
+  name: 'thegrid',
+  baseURL: 'https://api.thegrid.ai/v1',
+  apiKey: process.env.THEGRID_API_KEY,
+});
+
+const result = streamText({
+  model: thegrid('code-prime'),
+  prompt: 'Write a one-line JavaScript function that adds two numbers.',
+});
+
+for await (const textPart of result.textStream) {
+  process.stdout.write(textPart);
+}
+```
+
+<Note>
+  The Grid answers inference requests with a `307` redirect to its routing
+  layer on the same host. The AI SDK's default `fetch` follows this
+  transparently, so no configuration is needed. If you pass a custom `fetch`,
+  make sure it forwards its `init` argument to a redirect-following
+  implementation, otherwise the request surfaces as a `307` error. See
+  [request routing and
+  redirects](https://thegrid.ai/docs/api-reference/request-routing-and-redirects).
+</Note>
+
+See [The Grid documentation](https://thegrid.ai/docs) for endpoint details and instrument-specific capabilities.

--- a/content/providers/04-openai-compatible-providers/index.mdx
+++ b/content/providers/04-openai-compatible-providers/index.mdx
@@ -17,6 +17,7 @@ We provide detailed documentation for the following OpenAI compatible providers:
 - [Clarifai](/providers/openai-compatible-providers/clarifai)
 - [NEAR AI Cloud](/providers/openai-compatible-providers/nearai)
 - [Synthorai](/providers/openai-compatible-providers/synthorai)
+- [The Grid](/providers/openai-compatible-providers/thegrid)
 
 The general setup and provider instance creation is the same for all of these providers.
 


### PR DESCRIPTION
Adds [The Grid](https://thegrid.ai) to the OpenAI-compatible providers documentation.

**Disclosure:** I work on The Grid. I've kept this to the two files the section's own convention calls for, and separated what I verified from what I didn't below.

The Grid is a spot market for AI inference. Its model IDs are market instruments rather than fixed models — a task type (`text`, `code`, `agent`) and a quality tier (`standard`, `prime`, `max`), plus lab-scoped instruments like `claude-opus-latest` — and requests are filled by whichever supplier is competitive at the time. It's OpenAI-compatible, so `@ai-sdk/openai-compatible` covers it with no package of our own.

### Files

| File | Change |
|---|---|
| `content/providers/04-openai-compatible-providers/60-thegrid.mdx` | new page |
| `content/providers/04-openai-compatible-providers/index.mdx` | one line appended |

`60-thegrid.mdx` follows `55-synthorai.mdx` section for section — frontmatter, `# … Provider`, `## Setup`, `<InstallPackages>`, `## Provider Instance`, `<Note>`, `## Language Models`, `### Example`. The number sorts after `55-`, and the index entry is appended last.

### Verified

Every snippet on the page was run against the live API with `ai@7.0.93` and `@ai-sdk/openai-compatible@3.0.44`, not written from the template and assumed:

```
generateText  -> "OK"
                 usage: { inputTokens: 77, outputTokens: 45, totalTokens: 122 }
streamText    -> "```javascript\nconst add = (a, b) => a + b;\n```"
                 usage: { inputTokens: 142, outputTokens: 37, totalTokens: 179 }
```

Every `thegrid.ai` URL on the page returns `200` (checked with redirects followed).

### One thing worth flagging to reviewers

The Grid answers inference requests with a documented `307` to its routing layer on the same host. I traced this through `packages/provider-utils/src/post-to-api.ts`: it calls `fetch` with no `redirect` key, so the platform default `'follow'` applies, and the body is a JSON string that replays cleanly across a 307. Since the hop is same-origin, `Authorization` survives. So the default path needs no special handling — confirmed by the run above.

It only bites if a user supplies a custom `fetch` that doesn't follow redirects, because `if (!response.ok)` turns the 307 into a non-retryable `APICallError`. The page has a short `<Note>` about forwarding `init`. Happy to drop that note if you'd rather keep these pages minimal.

### Not included

`/v1/responses` is also served on the same key and base URL, but I've left it out — it looked out of scope for an OpenAI-*compatible* page, matching the feedback on #19678. Glad to add it if you'd prefer otherwise.

### Checks

Commits are signed. I did not run `pnpm fix` or `pnpm validate:docs` against a full install — `validate-properties-tables.mjs` needs the workspace deps, and this page uses no `<PropertiesTable>`. Worth noting the repo has no prettier config and MDX isn't covered by `lint-staged`, so I matched the sibling pages' formatting rather than reformatting; default prettier flags `55-synthorai.mdx` and `50-nearai.mdx` too.
