### PR TITLE
feat(openai): add GPT-6 reasoning configuration updates

### DIFF
--- a/.changeset/tidy-dodos-reason.md
+++ b/.changeset/tidy-dodos-reason.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): add GPT-6 reasoning configuration updates

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -206,8 +206,22 @@ The following provider options are available:
 
 <Note>
   Supported reasoning efforts vary by model. GPT-5.6 supports `'none'`, `'low'`,
-  `'medium'`, `'high'`, `'xhigh'`, and `'max'`.
+  `'medium'`, `'high'`, `'xhigh'`, and `'max'`. GPT-6 and later models support
+  `'low'`, `'medium'`, `'high'`, `'xhigh'`, and `'max'`.
 </Note>
+
+<Note>
+  GPT-6 and later models do not support `temperature`, `topP`, `logprobs`, or
+  the legacy `promptCacheRetention` option. The provider removes these settings
+  and returns a warning. Use the Responses API for GPT-6 tool calling.
+</Note>
+
+- **reasoningEffortUpdate** _'low' | 'medium' | 'high' | 'xhigh' | 'max'_
+  Updates the reasoning effort for GPT-6 and later models starting with the
+  current response without changing the request-level effort. Use this with
+  `previousResponseId` to preserve the original prompt prefix for caching.
+  Configuration updates require standard, single-agent mode and cannot be
+  combined with automatic truncation.
 
 - **reasoningMode** _'standard' | 'pro'_
   Controls how much model work GPT-5.6 performs before returning a final answer. `'standard'` is the default. Use `'pro'` for difficult tasks where quality matters more than latency and token usage.
@@ -307,6 +321,58 @@ The following OpenAI-specific metadata may be returned:
   Service tier information returned by the API.
 - **reasoningContext** _(optional)_
   Effective persisted-reasoning context returned by GPT-5.6 (`'current_turn'` or `'all_turns'`).
+
+#### Changing Reasoning Effort Mid-Conversation
+
+GPT-6 and later models can change reasoning effort between responses without
+changing the request-level `reasoningEffort` setting. The provider sends
+`reasoningEffortUpdate` as an OpenAI `configuration_update` input item before
+the next user message. Keeping the request-level effort unchanged preserves the
+original prompt prefix for prompt caching.
+
+```ts highlight="13,32,34"
+import {
+  openai,
+  type OpenAILanguageModelResponsesOptions,
+  type OpenaiResponsesProviderMetadata,
+} from '@ai-sdk/openai';
+import { generateText } from 'ai';
+
+const first = await generateText({
+  model: openai.responses('gpt-6-astra'),
+  prompt: 'Draft a database migration plan.',
+  providerOptions: {
+    openai: {
+      reasoningEffort: 'low',
+    } satisfies OpenAILanguageModelResponsesOptions,
+  },
+});
+
+const metadata = first.providerMetadata as
+  | OpenaiResponsesProviderMetadata
+  | undefined;
+const previousResponseId = metadata?.openai.responseId;
+
+if (!previousResponseId) {
+  throw new Error('OpenAI did not return a response ID.');
+}
+
+const second = await generateText({
+  model: openai.responses('gpt-6-astra'),
+  prompt: 'Analyze the failure modes and propose rollback steps.',
+  providerOptions: {
+    openai: {
+      previousResponseId,
+      reasoningEffort: 'low',
+      reasoningEffortUpdate: 'high',
+    } satisfies OpenAILanguageModelResponsesOptions,
+  },
+});
+```
+
+The response metadata continues to report the request-level reasoning effort,
+not the effective effort selected by `reasoningEffortUpdate`. Configuration
+updates are not supported with `reasoningMode: 'pro'` or `truncation: 'auto'`.
 
 #### Reasoning Output
 

--- a/examples/ai-functions/src/generate-text/openai/responses-reasoning-effort-update.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-reasoning-effort-update.ts
@@ -1,0 +1,50 @@
+import {
+  openai,
+  type OpenAILanguageModelResponsesOptions,
+  type OpenaiResponsesProviderMetadata,
+} from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const firstResult = await generateText({
+    model: openai.responses('gpt-6-astra'),
+    prompt: 'Draft a concise database migration plan.',
+    providerOptions: {
+      openai: {
+        reasoningEffort: 'low',
+        promptCacheOptions: { ttl: '30m' },
+      } satisfies OpenAILanguageModelResponsesOptions,
+    },
+  });
+
+  const firstMetadata = firstResult.providerMetadata as
+    | OpenaiResponsesProviderMetadata
+    | undefined;
+  const previousResponseId = firstMetadata?.openai.responseId;
+
+  if (!previousResponseId) {
+    throw new Error('OpenAI did not return a response ID.');
+  }
+
+  console.log('Low-effort response:');
+  console.log(firstResult.text);
+  console.log();
+
+  const secondResult = await generateText({
+    model: openai.responses('gpt-6-astra'),
+    // Keep the request-level effort unchanged to preserve the cached prefix.
+    prompt: 'Analyze its failure modes and add detailed rollback steps.',
+    providerOptions: {
+      openai: {
+        previousResponseId,
+        reasoningEffort: 'low',
+        reasoningEffortUpdate: 'high',
+        promptCacheOptions: { ttl: '30m' },
+      } satisfies OpenAILanguageModelResponsesOptions,
+    },
+  });
+
+  console.log('High-effort continuation:');
+  console.log(secondResult.text);
+});

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -1566,6 +1566,75 @@ describe('doGenerate', () => {
     expect(result.warnings).toStrictEqual([]);
   });
 
+  it.each(['none', 'minimal'] as const)(
+    'should omit unsupported GPT-6 reasoning effort %s',
+    async reasoningEffort => {
+      prepareJsonFixtureResponse('openai-text');
+
+      const result = await provider.chat('gpt-6-astra').doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          openai: { reasoningEffort },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'gpt-6-astra',
+        messages: [{ role: 'user', content: 'Hello' }],
+      });
+      expect(result.warnings).toStrictEqual([
+        {
+          type: 'unsupported',
+          feature: 'reasoningEffort',
+          details:
+            'gpt-6-astra only supports the following reasoning efforts: low, medium, high, xhigh, max',
+        },
+      ]);
+    },
+  );
+
+  it('should strip sampling and logprob settings for GPT-6 models', async () => {
+    prepareJsonFixtureResponse('openai-text');
+
+    const result = await provider.chat('gpt-6-astra').doGenerate({
+      prompt: TEST_PROMPT,
+      temperature: 0.5,
+      topP: 0.7,
+      providerOptions: {
+        openai: {
+          reasoningEffort: 'low',
+          logprobs: 5,
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'gpt-6-astra',
+      messages: [{ role: 'user', content: 'Hello' }],
+      reasoning_effort: 'low',
+    });
+    expect(result.warnings).toStrictEqual([
+      {
+        type: 'unsupported',
+        feature: 'temperature',
+        details: 'temperature is not supported for reasoning models',
+      },
+      {
+        type: 'unsupported',
+        feature: 'topP',
+        details: 'topP is not supported for reasoning models',
+      },
+      {
+        type: 'other',
+        message: 'logprobs is not supported for reasoning models',
+      },
+      {
+        type: 'other',
+        message: 'topLogprobs is not supported for reasoning models',
+      },
+    ]);
+  });
+
   it('should use developer messages for o1', async () => {
     prepareJsonFixtureResponse('openai-text');
 
@@ -1868,6 +1937,32 @@ describe('doGenerate', () => {
         ttl: '30m',
       },
     });
+  });
+
+  it('should omit legacy prompt cache retention for GPT-6 models', async () => {
+    prepareJsonFixtureResponse('openai-text');
+
+    const result = await provider.chat('gpt-6-astra').doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        openai: {
+          promptCacheRetention: '24h',
+        },
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toStrictEqual({
+      model: 'gpt-6-astra',
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+    expect(result.warnings).toStrictEqual([
+      {
+        type: 'unsupported',
+        feature: 'promptCacheRetention',
+        details:
+          'promptCacheRetention is not supported by GPT-6 and later models; use promptCacheOptions instead',
+      },
+    ]);
   });
 
   it('should send safetyIdentifier extension value', async () => {

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -97,6 +97,23 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
     const isReasoningModel =
       openaiOptions.forceReasoning ?? modelCapabilities.isReasoningModel;
 
+    let resolvedReasoningEffort = openaiOptions.reasoningEffort;
+
+    if (
+      resolvedReasoningEffort != null &&
+      modelCapabilities.supportedReasoningEfforts != null &&
+      !modelCapabilities.supportedReasoningEfforts.includes(
+        resolvedReasoningEffort,
+      )
+    ) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'reasoningEffort',
+        details: `${this.modelId} only supports the following reasoning efforts: ${modelCapabilities.supportedReasoningEfforts.join(', ')}`,
+      });
+      resolvedReasoningEffort = undefined;
+    }
+
     if (topK != null) {
       warnings.push({ type: 'unsupported', feature: 'topK' });
     }
@@ -168,7 +185,7 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
       store: openaiOptions.store,
       metadata: openaiOptions.metadata,
       prediction: openaiOptions.prediction,
-      reasoning_effort: openaiOptions.reasoningEffort,
+      reasoning_effort: resolvedReasoningEffort,
       service_tier: openaiOptions.serviceTier,
       prompt_cache_key: openaiOptions.promptCacheKey,
       prompt_cache_options: openaiOptions.promptCacheOptions,
@@ -178,6 +195,19 @@ export class OpenAIChatLanguageModel implements LanguageModelV3 {
       // messages:
       messages,
     };
+
+    if (
+      modelCapabilities.supportedReasoningEfforts != null &&
+      baseArgs.prompt_cache_retention != null
+    ) {
+      baseArgs.prompt_cache_retention = undefined;
+      warnings.push({
+        type: 'unsupported',
+        feature: 'promptCacheRetention',
+        details:
+          'promptCacheRetention is not supported by GPT-6 and later models; use promptCacheOptions instead',
+      });
+    }
 
     // remove unsupported settings for reasoning models
     // see https://platform.openai.com/docs/guides/reasoning#limitations

--- a/packages/openai/src/chat/openai-chat-options.ts
+++ b/packages/openai/src/chat/openai-chat-options.ts
@@ -108,6 +108,7 @@ export const openaiLanguageModelChatOptions = lazySchema(() =>
 
       /**
        * Reasoning effort for reasoning models. Defaults to `medium`.
+       * GPT-6 and later models support 'low' | 'medium' | 'high' | 'xhigh' | 'max'.
        */
       reasoningEffort: z
         .enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'])

--- a/packages/openai/src/openai-language-model-capabilities.test.ts
+++ b/packages/openai/src/openai-language-model-capabilities.test.ts
@@ -96,10 +96,10 @@ describe('getOpenAILanguageModelCapabilities', () => {
       ['gpt-5.6-luna', true],
       ['gpt-5.6-sol', true],
       ['gpt-5.6-terra', true],
-      ['gpt-6-astra', true],
+      ['gpt-6-astra', false],
       ['gpt-5.99', true],
       ['gpt-5.100', true],
-      ['gpt-99', true],
+      ['gpt-99', false],
       ['gpt-5', false],
       ['gpt-5.0', false],
       ['gpt-5-mini', false],
@@ -114,6 +114,36 @@ describe('getOpenAILanguageModelCapabilities', () => {
         expect(
           getOpenAILanguageModelCapabilities(modelId)
             .supportsNonReasoningParameters,
+        ).toEqual(expectedCapabilities);
+      },
+    );
+  });
+
+  describe('GPT-6 and later reasoning capabilities', () => {
+    it.each([
+      ['gpt-5.6', false],
+      ['gpt-6-astra', true],
+      ['gpt-6.1', true],
+      ['gpt-99', true],
+    ])(
+      '%s supports configuration updates: %s',
+      (modelId, expectedCapabilities) => {
+        expect(
+          getOpenAILanguageModelCapabilities(modelId)
+            .supportsConfigurationUpdate,
+        ).toEqual(expectedCapabilities);
+      },
+    );
+
+    it.each([
+      ['gpt-5.6', undefined],
+      ['gpt-6-astra', ['low', 'medium', 'high', 'xhigh', 'max']],
+      ['gpt-99', ['low', 'medium', 'high', 'xhigh', 'max']],
+    ])(
+      '%s supports the expected reasoning efforts',
+      (modelId, expectedCapabilities) => {
+        expect(
+          getOpenAILanguageModelCapabilities(modelId).supportedReasoningEfforts,
         ).toEqual(expectedCapabilities);
       },
     );

--- a/packages/openai/src/openai-language-model-capabilities.ts
+++ b/packages/openai/src/openai-language-model-capabilities.ts
@@ -3,6 +3,8 @@ export type OpenAILanguageModelCapabilities = {
   systemMessageMode: 'remove' | 'system' | 'developer';
   supportsFlexProcessing: boolean;
   supportsPriorityProcessing: boolean;
+  supportsConfigurationUpdate: boolean;
+  supportedReasoningEfforts: readonly string[] | undefined;
 
   /**
    * Allow temperature, topP, logProbs when reasoningEffort is none.
@@ -19,6 +21,7 @@ export function getOpenAILanguageModelCapabilities(
     gptVersion?.minor == null &&
     (gptVersion?.variant?.startsWith('chat') ?? false);
   const isGptNanoModel = gptVersion?.variant?.startsWith('nano') ?? false;
+  const isGpt6OrLaterModel = gptVersion != null && gptVersion.major >= 6;
 
   const supportsFlexProcessing =
     (oSeriesVersion != null && oSeriesVersion >= 3) ||
@@ -41,6 +44,7 @@ export function getOpenAILanguageModelCapabilities(
   // https://platform.openai.com/docs/guides/latest-model#gpt-5-1-parameter-compatibility
   // GPT-5.1 and later model families support temperature, topP, logProbs when reasoningEffort is none.
   const supportsNonReasoningParameters =
+    !isGpt6OrLaterModel &&
     gptVersion != null &&
     (gptVersion.major > 5 ||
       (gptVersion.major === 5 && (gptVersion.minor ?? 0) >= 1));
@@ -50,6 +54,10 @@ export function getOpenAILanguageModelCapabilities(
   return {
     supportsFlexProcessing,
     supportsPriorityProcessing,
+    supportsConfigurationUpdate: isGpt6OrLaterModel,
+    supportedReasoningEfforts: isGpt6OrLaterModel
+      ? ['low', 'medium', 'high', 'xhigh', 'max']
+      : undefined,
     isReasoningModel,
     systemMessageMode,
     supportsNonReasoningParameters,

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -87,7 +87,8 @@ export type OpenAIResponsesInputItem =
   | OpenAIResponsesToolSearchCall
   | OpenAIResponsesToolSearchOutput
   | OpenAIResponsesReasoning
-  | OpenAIResponsesItemReference;
+  | OpenAIResponsesItemReference
+  | OpenAIResponsesConfigurationUpdate;
 
 export type OpenAIResponsesIncludeValue =
   | 'web_search_call.action.sources'
@@ -577,6 +578,13 @@ export type OpenAIResponsesReasoning = {
     type: 'summary_text';
     text: string;
   }>;
+};
+
+export type OpenAIResponsesConfigurationUpdate = {
+  type: 'configuration_update';
+  reasoning: {
+    effort: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+  };
 };
 
 // Captured from the Responses API when OpenAI returned an early

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -1309,6 +1309,83 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it.each(['none', 'minimal'])(
+        'should omit unsupported GPT-6 reasoning effort %s',
+        async reasoningEffort => {
+          const { warnings } = await createModel('gpt-6-astra').doGenerate({
+            prompt: TEST_PROMPT,
+            providerOptions: {
+              openai: {
+                reasoningEffort,
+              } satisfies OpenAILanguageModelResponsesOptions,
+            },
+          });
+
+          expect(await server.calls[0].requestBodyJson).toStrictEqual({
+            model: 'gpt-6-astra',
+            input: [
+              {
+                role: 'user',
+                content: [{ type: 'input_text', text: 'Hello' }],
+              },
+            ],
+          });
+          expect(warnings).toStrictEqual([
+            {
+              type: 'unsupported',
+              feature: 'reasoningEffort',
+              details:
+                'gpt-6-astra only supports the following reasoning efforts: low, medium, high, xhigh, max',
+            },
+          ]);
+        },
+      );
+
+      it('should strip sampling and logprob settings for GPT-6 models', async () => {
+        const { warnings } = await createModel('gpt-6-astra').doGenerate({
+          prompt: TEST_PROMPT,
+          temperature: 0.5,
+          topP: 0.7,
+          providerOptions: {
+            openai: {
+              reasoningEffort: 'low',
+              logprobs: 5,
+              include: ['message.output_text.logprobs'],
+            } satisfies OpenAILanguageModelResponsesOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-6-astra',
+          input: [
+            {
+              role: 'user',
+              content: [{ type: 'input_text', text: 'Hello' }],
+            },
+          ],
+          reasoning: {
+            effort: 'low',
+          },
+        });
+        expect(warnings).toStrictEqual([
+          {
+            type: 'unsupported',
+            feature: 'temperature',
+            details: 'temperature is not supported for reasoning models',
+          },
+          {
+            type: 'unsupported',
+            feature: 'topP',
+            details: 'topP is not supported for reasoning models',
+          },
+          {
+            type: 'unsupported',
+            feature: 'logprobs',
+            details: 'logprobs is not supported for reasoning models',
+          },
+        ]);
+      });
+
       it('should warn about GPT-5.6 reasoning controls on non-reasoning models', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
           prompt: TEST_PROMPT,
@@ -1614,6 +1691,147 @@ describe('OpenAIResponsesLanguageModel', () => {
         });
 
         expect(warnings).toStrictEqual([]);
+      });
+
+      it('should insert a reasoning effort configuration update before the prompt', async () => {
+        const { warnings } = await createModel('gpt-6-astra').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              previousResponseId: 'resp_123',
+              reasoningEffort: 'low',
+              reasoningEffortUpdate: 'high',
+            } satisfies OpenAILanguageModelResponsesOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-6-astra',
+          input: [
+            {
+              type: 'configuration_update',
+              reasoning: { effort: 'high' },
+            },
+            {
+              role: 'user',
+              content: [{ type: 'input_text', text: 'Hello' }],
+            },
+          ],
+          previous_response_id: 'resp_123',
+          reasoning: {
+            effort: 'low',
+          },
+        });
+        expect(warnings).toStrictEqual([]);
+      });
+
+      it('should omit reasoning effort updates for models before GPT-6', async () => {
+        const { warnings } = await createModel('gpt-5.6').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              reasoningEffortUpdate: 'high',
+            } satisfies OpenAILanguageModelResponsesOptions,
+          },
+        });
+
+        expect((await server.calls[0].requestBodyJson).input).toStrictEqual([
+          {
+            role: 'user',
+            content: [{ type: 'input_text', text: 'Hello' }],
+          },
+        ]);
+        expect(warnings).toStrictEqual([
+          {
+            type: 'unsupported',
+            feature: 'reasoningEffortUpdate',
+            details:
+              'reasoningEffortUpdate is only supported by GPT-6 and later models',
+          },
+        ]);
+      });
+
+      it('should omit reasoning effort updates with incompatible automatic truncation', async () => {
+        const { warnings } = await createModel('gpt-6-astra').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              reasoningEffortUpdate: 'high',
+              truncation: 'auto',
+            } satisfies OpenAILanguageModelResponsesOptions,
+          },
+        });
+
+        expect((await server.calls[0].requestBodyJson).input).toStrictEqual([
+          {
+            role: 'user',
+            content: [{ type: 'input_text', text: 'Hello' }],
+          },
+        ]);
+        expect(warnings).toStrictEqual([
+          {
+            type: 'unsupported',
+            feature: 'reasoningEffortUpdate',
+            details:
+              'reasoningEffortUpdate requires standard reasoning mode without automatic truncation',
+          },
+        ]);
+      });
+
+      it('should omit reasoning effort updates with pro reasoning mode', async () => {
+        const { warnings } = await createModel('gpt-6-astra').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              reasoningEffortUpdate: 'high',
+              reasoningMode: 'pro',
+            } satisfies OpenAILanguageModelResponsesOptions,
+          },
+        });
+
+        expect((await server.calls[0].requestBodyJson).input).toStrictEqual([
+          {
+            role: 'user',
+            content: [{ type: 'input_text', text: 'Hello' }],
+          },
+        ]);
+        expect(warnings).toStrictEqual([
+          {
+            type: 'unsupported',
+            feature: 'reasoningEffortUpdate',
+            details:
+              'reasoningEffortUpdate requires standard reasoning mode without automatic truncation',
+          },
+        ]);
+      });
+
+      it('should omit legacy prompt cache retention for GPT-6 models', async () => {
+        const { warnings } = await createModel('gpt-6-astra').doGenerate({
+          prompt: TEST_PROMPT,
+          providerOptions: {
+            openai: {
+              promptCacheRetention: '24h',
+            } satisfies OpenAILanguageModelResponsesOptions,
+          },
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-6-astra',
+          input: [
+            {
+              role: 'user',
+              content: [{ type: 'input_text', text: 'Hello' }],
+            },
+          ],
+        });
+        expect(warnings).toStrictEqual([
+          {
+            type: 'unsupported',
+            feature: 'promptCacheRetention',
+            details:
+              'promptCacheRetention is not supported by GPT-6 and later models; use promptCacheOptions instead',
+          },
+        ]);
       });
 
       it('should send safetyIdentifier provider option', async () => {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -186,6 +186,23 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
     const isReasoningModel =
       openaiOptions?.forceReasoning ?? modelCapabilities.isReasoningModel;
 
+    let resolvedReasoningEffort = openaiOptions?.reasoningEffort;
+
+    if (
+      resolvedReasoningEffort != null &&
+      modelCapabilities.supportedReasoningEfforts != null &&
+      !modelCapabilities.supportedReasoningEfforts.includes(
+        resolvedReasoningEffort,
+      )
+    ) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'reasoningEffort',
+        details: `${this.modelId} only supports the following reasoning efforts: ${modelCapabilities.supportedReasoningEfforts.join(', ')}`,
+      });
+      resolvedReasoningEffort = undefined;
+    }
+
     if (openaiOptions?.conversation && openaiOptions?.previousResponseId) {
       warnings.push({
         type: 'unsupported',
@@ -254,6 +271,28 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       });
 
     warnings.push(...inputWarnings);
+
+    const reasoningEffortUpdate = openaiOptions?.reasoningEffortUpdate;
+    const configurationUpdateIsSupported =
+      reasoningEffortUpdate == null ||
+      (modelCapabilities.supportsConfigurationUpdate &&
+        openaiOptions?.reasoningMode !== 'pro' &&
+        openaiOptions?.truncation !== 'auto');
+
+    if (reasoningEffortUpdate != null && !configurationUpdateIsSupported) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'reasoningEffortUpdate',
+        details: !modelCapabilities.supportsConfigurationUpdate
+          ? 'reasoningEffortUpdate is only supported by GPT-6 and later models'
+          : 'reasoningEffortUpdate requires standard reasoning mode without automatic truncation',
+      });
+    } else if (reasoningEffortUpdate != null) {
+      input.unshift({
+        type: 'configuration_update',
+        reasoning: { effort: reasoningEffortUpdate },
+      });
+    }
 
     const strictJsonSchema = openaiOptions?.strictJsonSchema ?? true;
 
@@ -361,13 +400,13 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
 
       // model-specific settings:
       ...(isReasoningModel &&
-        (openaiOptions?.reasoningEffort != null ||
+        (resolvedReasoningEffort != null ||
           openaiOptions?.reasoningSummary != null ||
           openaiOptions?.reasoningMode != null ||
           openaiOptions?.reasoningContext != null) && {
           reasoning: {
-            ...(openaiOptions?.reasoningEffort != null && {
-              effort: openaiOptions.reasoningEffort,
+            ...(resolvedReasoningEffort != null && {
+              effort: resolvedReasoningEffort,
             }),
             ...(openaiOptions?.reasoningSummary != null && {
               summary: openaiOptions.reasoningSummary,
@@ -381,6 +420,19 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
           },
         }),
     };
+
+    if (
+      modelCapabilities.supportsConfigurationUpdate &&
+      baseArgs.prompt_cache_retention != null
+    ) {
+      baseArgs.prompt_cache_retention = undefined;
+      warnings.push({
+        type: 'unsupported',
+        feature: 'promptCacheRetention',
+        details:
+          'promptCacheRetention is not supported by GPT-6 and later models; use promptCacheOptions instead',
+      });
+    }
 
     // remove unsupported settings for reasoning models
     // see https://platform.openai.com/docs/guides/reasoning#limitations
@@ -410,6 +462,26 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
             details: 'topP is not supported for reasoning models',
           });
         }
+      }
+
+      if (
+        modelCapabilities.supportedReasoningEfforts != null &&
+        (baseArgs.top_logprobs != null ||
+          baseArgs.include?.includes('message.output_text.logprobs'))
+      ) {
+        baseArgs.top_logprobs = undefined;
+        const filteredInclude = baseArgs.include?.filter(
+          value => value !== 'message.output_text.logprobs',
+        );
+        baseArgs.include =
+          filteredInclude != null && filteredInclude.length > 0
+            ? filteredInclude
+            : undefined;
+        warnings.push({
+          type: 'unsupported',
+          feature: 'logprobs',
+          details: 'logprobs is not supported for reasoning models',
+        });
       }
     } else {
       if (openaiOptions?.reasoningEffort != null) {

--- a/packages/openai/src/responses/openai-responses-options.ts
+++ b/packages/openai/src/responses/openai-responses-options.ts
@@ -260,9 +260,22 @@ export const openaiLanguageModelResponsesOptionsSchema = lazySchema(() =>
        * Reasoning effort for reasoning models. Defaults to `medium`. If you use
        * `providerOptions` to set the `reasoningEffort` option, this model setting will be ignored.
        * GPT-5.6 supports 'none' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'.
+       * GPT-6 and later models support 'low' | 'medium' | 'high' | 'xhigh' | 'max'.
        * Supported values vary by model.
        */
       reasoningEffort: z.string().nullish(),
+
+      /**
+       * Updates the reasoning effort for GPT-6 and later models starting with this response
+       * without changing the request-level reasoning effort. This preserves the
+       * request prefix for prompt caching.
+       *
+       * Only supported by GPT-6 and later models in standard, single-agent mode. Cannot be
+       * combined with automatic truncation.
+       */
+      reasoningEffortUpdate: z
+        .enum(['low', 'medium', 'high', 'xhigh', 'max'])
+        .optional(),
 
       /**
        * Controls how much model work GPT-5.6 performs before returning a final answer.


### PR DESCRIPTION
## Background

Backport of https://github.com/vercel/ai/pull/20390 for v6

## Summary

Port the changes from https://github.com/vercel/ai/pull/20390 to v6

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)