### PR TITLE
fix(openai): accept non-completed function_call items in Responses output_item.done (v6)

### DIFF
--- a/.changeset/quiet-otters-finish.md
+++ b/.changeset/quiet-otters-finish.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): accept non-completed function_call and custom_tool_call items in Responses `output_item.done` events (tool calls truncated by `max_output_tokens`)

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -917,7 +917,9 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
             call_id: z.string(),
             name: z.string(),
             arguments: z.string(),
-            status: z.literal('completed'),
+            // A tool call cut off by max_output_tokens is closed with a
+            // non-completed status; the stream then ends with response.incomplete.
+            status: z.enum(['in_progress', 'completed', 'incomplete']),
             namespace: z.string().nullish(),
           }),
           z.object({
@@ -926,7 +928,7 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
             call_id: z.string(),
             name: z.string(),
             input: z.string(),
-            status: z.literal('completed'),
+            status: z.enum(['in_progress', 'completed', 'incomplete']),
           }),
           z.object({
             type: z.literal('code_interpreter_call'),

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -6499,6 +6499,53 @@ describe('OpenAIResponsesLanguageModel', () => {
       `);
     });
 
+    it('should not fail when a tool call is cut off by max_output_tokens', async () => {
+      // Repro from a gpt-6-astra run: the model degenerated mid-arguments,
+      // hit max_output_tokens, and the item was closed with status
+      // "in_progress" followed by response.incomplete.
+      server.urls['https://api.openai.com/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data:{"type":"response.created","response":{"id":"resp_truncated_tool_call","object":"response","created_at":1741362087,"status":"in_progress","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":100,"model":"gpt-6-astra","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":true,"temperature":null,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":null,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}\n\n`,
+          `data:{"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_truncated","call_id":"call_truncated","name":"weather","arguments":"","status":"in_progress"}}\n\n`,
+          `data:{"type":"response.function_call_arguments.delta","item_id":"fc_truncated","output_index":0,"delta":"{\\"location\\":\\"Ro"}\n\n`,
+          `data:{"type":"response.function_call_arguments.delta","item_id":"fc_truncated","output_index":0,"delta":"me\\"       \\t   "}\n\n`,
+          `data:{"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_truncated","call_id":"call_truncated","name":"weather","arguments":"{\\"location\\":\\"Rome\\"       \\t   ","status":"in_progress"}}\n\n`,
+          `data:{"type":"response.incomplete","response":{"id":"resp_truncated_tool_call","object":"response","created_at":1741362087,"status":"incomplete","error":null,"incomplete_details":{"reason":"max_output_tokens"},"instructions":null,"max_output_tokens":100,"model":"gpt-6-astra","output":[{"type":"function_call","id":"fc_truncated","call_id":"call_truncated","name":"weather","arguments":"{\\"location\\":\\"Rome\\"       \\t   ","status":"in_progress"}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":true,"temperature":null,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":null,"truncation":"disabled","usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":100,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":110},"user":null,"metadata":{}}}\n\n`,
+        ],
+      };
+
+      const { stream } = await createModel('gpt-6-astra').doStream({
+        tools: TEST_TOOLS,
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+
+      expect(parts.filter(part => part.type === 'error')).toStrictEqual([]);
+      expect(parts.filter(part => part.type === 'tool-call'))
+        .toMatchInlineSnapshot(`
+          [
+            {
+              "input": "{"location":"Rome"       	   ",
+              "providerMetadata": {
+                "openai": {
+                  "itemId": "fc_truncated",
+                },
+              },
+              "toolCallId": "call_truncated",
+              "toolName": "weather",
+              "type": "tool-call",
+            },
+          ]
+        `);
+      expect(parts.at(-1)).toMatchObject({
+        type: 'finish',
+        finishReason: { raw: 'max_output_tokens', unified: 'length' },
+      });
+    });
+
     it('should send streaming tool calls', async () => {
       server.urls['https://api.openai.com/v1/responses'].response = {
         type: 'stream-chunks',


### PR DESCRIPTION
## Background

When a Responses API tool call is cut off by `max_output_tokens`, OpenAI closes the item with `response.output_item.done` carrying `status: "in_progress"` (or `"incomplete"`) and then ends the stream with `response.incomplete`. The v6 `@ai-sdk/openai` chunk schema required `status: "completed"` on `function_call` / `custom_tool_call` items in `output_item.done`, so the whole stream failed with `AI_TypeValidationError` instead of finishing with `finishReason: "length"`.

Observed on `gpt-6-astra` (a degenerate tool-call argument string that hit the output cap), but any truncated tool call on any Responses model hits the same path. `main` already accepts these statuses since #17790; this backports that relaxation.

## Summary

- `function_call` and `custom_tool_call` items in `response.output_item.done` accept `status: 'in_progress' | 'completed' | 'incomplete'`.
- Adds a streaming test that reproduces the truncated tool call and asserts no `error` part, a `tool-call` part with the partial arguments, and `finishReason: length`. The test fails on `release-v6.0` with the exact `AI_TypeValidationError` seen in production.

## End-to-End Verification

`pnpm vitest --config vitest.node.config.js --run src/responses/` in `packages/openai` (524 passed).

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (n/a — no API surface change)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)