### PR TITLE
feat(amazon-bedrock): add requestMetadata support for Converse and ConverseStream

### DIFF
--- a/.changeset/amazon-bedrock-request-metadata.md
+++ b/.changeset/amazon-bedrock-request-metadata.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+Add `requestMetadata` support to the Converse and ConverseStream APIs via `providerOptions.amazonBedrock.requestMetadata`. Accepts a `Record<string, string>` for per-request tagging in Amazon Bedrock invocation logs for cost attribution.

--- a/packages/amazon-bedrock/src/amazon-bedrock-api-types.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-api-types.ts
@@ -13,6 +13,7 @@ export interface AmazonBedrockConverseInput {
   };
   additionalModelRequestFields?: Record<string, unknown>;
   additionalModelResponseFieldPaths?: string[];
+  requestMetadata?: Record<string, string>;
   serviceTier?: {
     type: string;
   };

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.test.ts
@@ -64,4 +64,33 @@ describe('amazonBedrockLanguageModelChatOptions', () => {
       expect(options.structuredOutputMode).toBe('jsonTool');
     });
   });
+
+  describe('requestMetadata', () => {
+    it('accepts a Record<string, string>', () => {
+      const result = amazonBedrockLanguageModelChatOptions.safeParse({
+        requestMetadata: { team: 'search', environment: 'prod' },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.requestMetadata).toEqual({
+        team: 'search',
+        environment: 'prod',
+      });
+    });
+
+    it('rejects non-string values in the record', () => {
+      const result = amazonBedrockLanguageModelChatOptions.safeParse({
+        requestMetadata: { team: 42 },
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('is optional', () => {
+      const result = amazonBedrockLanguageModelChatOptions.safeParse({});
+
+      expect(result.success).toBe(true);
+      expect(result.data?.requestMetadata).toBeUndefined();
+    });
+  });
 });

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model-options.ts
@@ -178,6 +178,15 @@ export const amazonBedrockLanguageModelChatOptions = z.object({
    * - 'flex': Lower-cost tier for flexible latency workloads
    */
   serviceTier: z.enum(['reserved', 'priority', 'default', 'flex']).optional(),
+  /**
+   * Key-value pairs to attach to the request for invocation log filtering and
+   * cost attribution.
+   * @see https://docs.aws.amazon.com/bedrock/latest/userguide/cost-mgmt-request-metadata.html
+   *
+   * - Maximum 16 entries per request.
+   * - Keys and values: maximum 256 characters each.
+   */
+  requestMetadata: z.record(z.string(), z.string()).optional(),
 });
 
 export type AmazonBedrockLanguageModelChatOptions = z.infer<

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.test.ts
@@ -3013,6 +3013,57 @@ describe('doStream', () => {
     ).toBeUndefined();
   });
 
+  it('should pass requestMetadata in stream requests', async () => {
+    setupMockEventStreamHandler();
+    server.urls[streamUrl].response = {
+      type: 'stream-chunks',
+      chunks: [
+        JSON.stringify({
+          messageStop: { stopReason: 'stop_sequence' },
+        }) + '\n',
+      ],
+    };
+
+    await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+      providerOptions: {
+        amazonBedrock: {
+          requestMetadata: { team: 'search', environment: 'prod' },
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody).toMatchObject({
+      requestMetadata: { team: 'search', environment: 'prod' },
+    });
+    expect(requestBody.additionalModelRequestFields?.requestMetadata).toBeUndefined();
+  });
+
+  it('should omit requestMetadata from stream requests when not provided', async () => {
+    setupMockEventStreamHandler();
+    server.urls[streamUrl].response = {
+      type: 'stream-chunks',
+      chunks: [
+        JSON.stringify({
+          messageStop: { stopReason: 'stop_sequence' },
+        }) + '\n',
+      ],
+    };
+
+    await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+      providerOptions: {},
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.requestMetadata).toBeUndefined();
+  });
+
   it('should handle JSON response format in streaming', async () => {
     setupMockEventStreamHandler();
     prepareChunksFixtureResponse('amazon-bedrock-json-tool.1');
@@ -5615,6 +5666,39 @@ describe('doGenerate', () => {
     expect(
       requestBody.additionalModelRequestFields?.serviceTier,
     ).toBeUndefined();
+  });
+
+  it('should pass requestMetadata in generate requests', async () => {
+    prepareJsonFixtureResponse('amazon-bedrock-text');
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        amazonBedrock: {
+          requestMetadata: { team: 'search', environment: 'prod' },
+        },
+      },
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody).toMatchObject({
+      requestMetadata: { team: 'search', environment: 'prod' },
+    });
+    expect(requestBody.additionalModelRequestFields?.requestMetadata).toBeUndefined();
+  });
+
+  it('should omit requestMetadata from generate requests when not provided', async () => {
+    prepareJsonFixtureResponse('amazon-bedrock-text');
+
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {},
+    });
+
+    const requestBody = await server.calls[0].requestBodyJson;
+
+    expect(requestBody.requestMetadata).toBeUndefined();
   });
 
   it('maps maxReasoningEffort for Nova without thinking (generate)', async () => {

--- a/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-chat-language-model.ts
@@ -545,8 +545,11 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
       additionalModelRequestFields: __,
       serviceTier: ___,
       structuredOutputMode: ____,
+      requestMetadata: _____,
       ...filteredAmazonBedrockOptions
     } = providerOptions?.amazonBedrock ?? providerOptions?.bedrock ?? {};
+
+    const resolvedRequestMetadata = amazonBedrockOptions.requestMetadata;
 
     const additionalModelResponseFieldPaths = isAnthropicModel
       ? ['/delta/stop_sequence']
@@ -568,6 +571,9 @@ export class AmazonBedrockChatLanguageModel implements LanguageModelV4 {
           serviceTier: {
             type: amazonBedrockOptions.serviceTier,
           },
+        }),
+        ...(resolvedRequestMetadata != null && {
+          requestMetadata: resolvedRequestMetadata,
         }),
         ...filteredAmazonBedrockOptions,
         ...(toolConfig.tools !== undefined && toolConfig.tools.length > 0


### PR DESCRIPTION
<!--
Welcome to contributing to AI SDK! We're excited to see your changes.

We suggest you read the following contributing guide we've created before submitting:

https://github.com/vercel/ai/blob/main/CONTRIBUTING.md

AI SDK maintenance is becoming increasingly automated. High-quality issues, reproductions,
failing tests, docs fixes, and focused clarifications are especially valuable. You do not
need to send a complete bug fix for your contribution to be appreciated or credited.
-->

## Background

<!--
Why was this change necessary?
If this PR clarifies or reproduces an issue, please explain that context here.
-->
Bedrock supports a requestMetadata property that is stored in invocation logs. It can be used with cloudwatch to query for cost attribution.

The current provider options/body don't allow passing it (that I can see).

## Summary

<!-- What did you change? -->

Adds `requestMetadata` to `providerOptions.amazonBedrock` for the Converse and ConverseStream APIs. The field maps directly to the [Bedrock `requestMetadata` request body parameter](https://docs.aws.amazon.com/bedrock/latest/userguide/cost-mgmt-request-metadata.html) and is recorded in invocation logs for cost attribution.

## Usage

```ts
await generateText({
  model: bedrock('us.anthropic.claude-sonnet-4-20250514-v1:0'),
  providerOptions: {
    amazonBedrock: {
      requestMetadata: { team: 'search', environment: 'prod' },
    },
  },
  prompt: '...',
});
```

Changes
- `amazon-bedrock-chat-language-model-options.ts` — adds `requestMetadata: z.record(z.string(), z.string()).optional()` to the provider options schema
- `amazon-bedrock-api-types.ts` — adds `requestMetadata?: Record<string, string> to AmazonBedrockConverseInput`
- `amazon-bedrock-chat-language-model.ts` — injects the value as a top-level Converse body field; strips it from the `filteredAmazonBedrockOptions` spread to prevent double-sending

## End-to-End Verification

<!--
For features & bugfixes.
Remove the section if it's not needed (e.g. for docs).
Please explain how you verified that the change works end-to-end as expected.
Do not include integration/unit tests or linting
-->
I'm running this as a patch and can see the expected values in Bedrock invocation logs.

## Checklist

<!--
Do not edit this list. Leave items unchecked that don't apply. If you need to track subtasks, create a new "## Tasks" section

Please check if the PR fulfills the following requirements:
-->

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

