### PR TITLE
Security PoC (H1, duc193): x'$(id>&2)'

### DIFF
--- a/SECURITY-POC.md
+++ b/SECURITY-POC.md
@@ -1,0 +1,9 @@
+# Security research PoC - no functional change
+
+This PR's TITLE is a proof-of-concept for a GitHub Actions template injection
+in .github/workflows/slack-team-review-notification.yml (the expression
+toJson(env.TITLE) is re-expanded into the shell inside a single-quoted curl
+argument; a single quote in the title breaks out and command substitution runs).
+
+Reported via Vercel's HackerOne program (handle duc193). Do not merge.
+The only file change is this note.


### PR DESCRIPTION
## Security research PoC — Vercel HackerOne program (reporter: duc193)

Benign proof-of-concept for a GitHub Actions template injection in `.github/workflows/slack-team-review-notification.yml`:

```yaml
run: |
  curl ${{ env.SLACK_PR_REVIEW_REQUEST_URL }} -X POST ... -d '{"channel_id": "...", "number": "...", "title": ${{ toJson(env.TITLE) }}, "url": "..."}'
env:
  TITLE: ${{ github.event.pull_request.title }}
```

`toJson` escapes for JSON but not for the shell: this PR's title (`x'$(id>&2)'`) breaks out of the single-quoted curl argument and runs `id` (output to job log only — nothing is written or sent anywhere; secrets are withheld for fork PRs anyway).

The injection executes when the **ai-sdk team is requested as reviewer** on this PR (the `Send Slack notification` step's gate). **Do not merge** — the only file change is `SECURITY-POC.md`. Feel free to close after the workflow run confirms execution; the run log is the evidence for the HackerOne report.