### PR TITLE
docs(generate-video): match the getVideoStatus JSDoc param to the signature

### DIFF
--- a/packages/ai/src/generate-video/get-video-status.ts
+++ b/packages/ai/src/generate-video/get-video-status.ts
@@ -23,7 +23,7 @@ export type GetVideoStatusResult =
  * schedule, or skip polling entirely when the start used `webhookUrl` and
  * your receiver fetches the result after the terminal notification arrives.
  *
- * @param model - The video model the operation was started on.
+ * @param modelArg - The video model the operation was started on.
  * @param operation - The opaque reference returned by `experimental_startVideo`.
  * @param headers - Additional HTTP headers to be sent with the request. Only applicable for HTTP-based providers.
  * @param abortSignal - An optional abort signal that can be used to cancel the call.


### PR DESCRIPTION
`getVideoStatus`'s JSDoc documents `@param model`; the parameter is named `modelArg`. One-line doc fix.