### PR TITLE
feat(openai): support additional tools after function results

### DIFF
--- a/.changeset/ordered-openai-function-tools.md
+++ b/.changeset/ordered-openai-function-tools.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Support additionalTools provider options on ordinary Responses tool results. Preserve the result and append function definitions at that history position, omitting matching request-level declarations without changing local tool execution availability.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -1394,6 +1394,63 @@ In client mode, the flow spans two steps:
 
 For more details, see the [OpenAI Tool Search documentation](https://platform.openai.com/docs/guides/tools-tool-search).
 
+#### Additional Tools After a Function Result
+
+When your application loads tools through an ordinary function such as
+`readSkill`, attach `providerOptions.openai.additionalTools` to its successful
+tool-result part. The Responses provider emits the normal `function_call_output`
+followed immediately by an `additional_tools` item with `role: 'developer'`.
+
+```ts
+import type { OpenAIResponsesToolResultOptions } from '@ai-sdk/openai';
+import type { ToolModelMessage } from 'ai';
+
+const message: ToolModelMessage = {
+  role: 'tool',
+  content: [
+    {
+      type: 'tool-result',
+      toolCallId: 'call_read_skill',
+      toolName: 'readSkill',
+      output: { type: 'text', value: 'Use getExampleNumber to get the number.' },
+      providerOptions: {
+        openai: {
+          additionalTools: [
+            {
+              type: 'function',
+              name: 'getExampleNumber',
+              parameters: {
+                type: 'object',
+                properties: {},
+                additionalProperties: false,
+              },
+            },
+          ],
+        } satisfies OpenAIResponsesToolResultOptions,
+      },
+    },
+  ],
+};
+```
+
+Keep the implementations in `tools` and enable the loaded functions through
+`prepareStep.activeTools` on the next step. The provider options do not change
+which tools the SDK may execute in the current step.
+
+Matching definitions are omitted from request-level `tools`. Their name,
+description, parameters, and optional `strict` setting must match the SDK tool
+definition; conflicting definitions throw an error.
+
+For later turns, save all `responseMessages` with the tool-result options and
+replay them in order. If you attach the options in `prepareStep`, also attach them
+to the messages you save. The [generateText example](https://github.com/vercel/ai/blob/main/examples/ai-functions/src/generate-text/openai/additional-tools.ts)
+and [streamText example](https://github.com/vercel/ai/blob/main/examples/ai-functions/src/stream-text/openai/additional-tools.ts)
+demonstrate this with `store: false`.
+
+Only successful ordinary function results and flat function definitions with
+object parameters are supported. For details on the OpenAI transport, see
+[Add tools at a specific point in the input](https://developers.openai.com/api/docs/guides/tools-tool-search#add-tools-at-a-specific-point-in-the-input).
+
 #### Custom Tool
 
 The OpenAI Responses API supports

--- a/examples/ai-functions/src/generate-text/openai/additional-tools.ts
+++ b/examples/ai-functions/src/generate-text/openai/additional-tools.ts
@@ -1,0 +1,23 @@
+import { generateText, type ModelMessage } from 'ai';
+import { options, project } from '../../lib/openai-additional-tools';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const messages: ModelMessage[] = [
+    { role: 'user', content: 'Read the skill, then get the example number.' },
+  ];
+  const first = await generateText({ ...options, messages });
+  console.log(first.text);
+  // Persist all steps, including the original tool-result options.
+  const saved: ModelMessage[] = JSON.parse(
+    JSON.stringify(project([...messages, ...first.responseMessages])),
+  );
+  const second = await generateText({
+    ...options,
+    messages: [
+      ...saved,
+      { role: 'user', content: 'Get the example number again.' },
+    ],
+  });
+  console.log(second.text);
+});

--- a/examples/ai-functions/src/lib/openai-additional-tools.ts
+++ b/examples/ai-functions/src/lib/openai-additional-tools.ts
@@ -1,0 +1,81 @@
+import { openai, type OpenAIResponsesToolResultOptions } from '@ai-sdk/openai';
+import {
+  isStepCount,
+  jsonSchema,
+  type ModelMessage,
+  type PrepareStepFunction,
+  type ToolModelMessage,
+} from 'ai';
+
+const parameters = {
+  type: 'object',
+  properties: {},
+  additionalProperties: false,
+} as const;
+const instructions =
+  'The getExampleNumber tool returns the example number. Call it to answer the user.';
+const resultOptions = {
+  additionalTools: [{ type: 'function', name: 'getExampleNumber', parameters }],
+} satisfies OpenAIResponsesToolResultOptions;
+
+export const tools = {
+  readSkill: {
+    description: 'Read instructions and load the example number tool.',
+    inputSchema: jsonSchema<Record<string, never>>(parameters),
+    execute: async () => instructions,
+  },
+  getExampleNumber: {
+    inputSchema: jsonSchema<Record<string, never>>(parameters),
+    execute: async () => 42,
+  },
+};
+
+// This demo has one immutable skill. A real application should resolve saved
+// successful receipts against its trusted, version-pinned catalog.
+function isSkillResult(part: ToolModelMessage['content'][number]) {
+  return (
+    part.type === 'tool-result' &&
+    part.toolName === 'readSkill' &&
+    part.output.type === 'text' &&
+    part.output.value === instructions
+  );
+}
+
+export function project(messages: ModelMessage[]): ModelMessage[] {
+  return messages.map(message => {
+    if (message.role !== 'tool') return message;
+    return {
+      ...message,
+      content: message.content.map(part => {
+        if (part.type !== 'tool-result' || !isSkillResult(part)) return part;
+        return {
+          ...part,
+          providerOptions: {
+            ...part.providerOptions,
+            openai: { ...part.providerOptions?.openai, ...resultOptions },
+          },
+        };
+      }),
+    };
+  });
+}
+
+const prepareStep: PrepareStepFunction<typeof tools> = ({ messages }) => {
+  const projected = project(messages);
+  const loaded = projected.some(
+    message => message.role === 'tool' && message.content.some(isSkillResult),
+  );
+  return {
+    messages: projected,
+    activeTools: loaded ? ['readSkill', 'getExampleNumber'] : ['readSkill'],
+  };
+};
+
+export const options = {
+  model: openai.responses('gpt-5.6-luna'),
+  tools,
+  prepareStep,
+  stopWhen: isStepCount(4),
+  maxRetries: 0,
+  providerOptions: { openai: { store: false } },
+};

--- a/examples/ai-functions/src/stream-text/openai/additional-tools.ts
+++ b/examples/ai-functions/src/stream-text/openai/additional-tools.ts
@@ -1,0 +1,22 @@
+import { streamText, type ModelMessage } from 'ai';
+import { options, project } from '../../lib/openai-additional-tools';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const messages: ModelMessage[] = [
+    { role: 'user', content: 'Read the skill, then get the example number.' },
+  ];
+  const first = streamText({ ...options, messages });
+  for await (const text of first.textStream) process.stdout.write(text);
+  const saved: ModelMessage[] = JSON.parse(
+    JSON.stringify(project([...messages, ...(await first.responseMessages)])),
+  );
+  const second = streamText({
+    ...options,
+    messages: [
+      ...saved,
+      { role: 'user', content: 'Get the example number again.' },
+    ],
+  });
+  for await (const text of second.textStream) process.stdout.write(text);
+});

--- a/packages/ai/src/generate-text/openai-additional-tools.test.ts
+++ b/packages/ai/src/generate-text/openai-additional-tools.test.ts
@@ -1,0 +1,271 @@
+import {
+  createOpenAI,
+  type OpenAIResponsesToolResultOptions,
+} from '@ai-sdk/openai';
+import { jsonSchema, type ModelMessage } from '@ai-sdk/provider-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { generateText } from './generate-text';
+import { streamText } from './stream-text';
+import { isStepCount } from './stop-condition';
+
+const parameters = {
+  type: 'object',
+  properties: {},
+  additionalProperties: false,
+} as const;
+const activation = {
+  additionalTools: [{ type: 'function', name: 'specialist', parameters }],
+} satisfies OpenAIResponsesToolResultOptions;
+
+// Application-owned projection from a successful, durable result, not mutable
+// execution state. The same projection is applied after loading saved messages.
+function project(messages: ModelMessage[]): ModelMessage[] {
+  return messages.map(message =>
+    message.role !== 'tool'
+      ? message
+      : {
+          ...message,
+          content: message.content.map(part =>
+            part.type === 'tool-result' &&
+            part.toolName === 'readSkill' &&
+            part.output.type === 'text' &&
+            part.output.value === 'loaded'
+              ? {
+                  ...part,
+                  providerOptions: {
+                    ...part.providerOptions,
+                    openai: { ...part.providerOptions?.openai, ...activation },
+                  },
+                }
+              : part,
+          ),
+        },
+  );
+}
+
+function isLoaded(messages: ModelMessage[]) {
+  return messages.some(
+    message =>
+      message.role === 'tool' &&
+      message.content.some(
+        part =>
+          part.type === 'tool-result' &&
+          part.toolName === 'readSkill' &&
+          part.output.type === 'text' &&
+          part.output.value === 'loaded',
+      ),
+  );
+}
+
+describe.each(['generate', 'stream'] as const)(
+  'OpenAI additional tools with %sText',
+  mode => {
+    function setup(script: string[][]) {
+      const requests: Array<{
+        input: Array<Record<string, unknown>>;
+        tools: Array<{ name: string }>;
+        tool_choice: unknown;
+      }> = [];
+      const specialist = vi.fn(async () => 'specialist result');
+      const readSkill = vi.fn(async () => 'loaded');
+      const model = createOpenAI({
+        apiKey: 'test',
+        fetch: async (_url, init) => {
+          const request = JSON.parse(String(init?.body));
+          requests.push(request);
+          const names = script.shift();
+          if (!names) throw new Error('Unexpected model request');
+          const output = names.map((name, index) => ({
+            type: 'function_call',
+            id: `fc_${requests.length}_${index}`,
+            call_id: `call_${requests.length}_${index}`,
+            name,
+            arguments: '{}',
+            status: 'completed',
+          }));
+          const response = {
+            id: 'resp_test',
+            created_at: 0,
+            model: 'gpt-5.4',
+            output,
+            usage: { input_tokens: 1, output_tokens: 1 },
+          };
+          if (!request.stream) return Response.json(response);
+          const events: unknown[] = [{ type: 'response.created', response }];
+          for (const [output_index, item] of output.entries()) {
+            events.push(
+              {
+                type: 'response.output_item.added',
+                output_index,
+                item: { ...item, arguments: '' },
+              },
+              {
+                type: 'response.function_call_arguments.delta',
+                output_index,
+                item_id: item.id,
+                delta: '{}',
+              },
+              { type: 'response.output_item.done', output_index, item },
+            );
+          }
+          events.push({ type: 'response.completed', response });
+          return new Response(
+            events.map(event => `data: ${JSON.stringify(event)}\n\n`).join(''),
+            { headers: { 'content-type': 'text/event-stream' } },
+          );
+        },
+      }).responses('gpt-5.4');
+      const tools = {
+        readSkill: {
+          inputSchema: jsonSchema<Record<string, never>>(parameters),
+          execute: readSkill,
+        },
+        specialist: {
+          inputSchema: jsonSchema<Record<string, never>>(parameters),
+          execute: specialist,
+        },
+      };
+      async function run(
+        messages: ModelMessage[],
+        maxSteps = 3,
+        toolChoice:
+          | 'auto'
+          | 'none'
+          | 'required'
+          | { type: 'tool'; toolName: 'specialist' } = 'auto',
+      ) {
+        const options = {
+          model,
+          tools,
+          toolChoice,
+          messages,
+          maxRetries: 0,
+          stopWhen: isStepCount(maxSteps),
+          providerOptions: { openai: { store: false } },
+          prepareStep: ({ messages }: { messages: ModelMessage[] }) => ({
+            messages: project(messages),
+            activeTools: isLoaded(messages)
+              ? (['readSkill', 'specialist'] as Array<keyof typeof tools>)
+              : (['readSkill'] as Array<keyof typeof tools>),
+          }),
+        };
+        if (mode === 'generate')
+          return (await generateText(options)).responseMessages;
+        const result = streamText(options);
+        await result.consumeStream({
+          onError: error => {
+            throw error;
+          },
+        });
+        return await result.responseMessages;
+      }
+      return { requests, specialist, readSkill, run };
+    }
+
+    it('executes on the next step, saves/reloads a multi-step response, and replays the original position', async () => {
+      const test = setup([
+        ['readSkill'],
+        ['specialist'],
+        [],
+        ['specialist'],
+        [],
+      ]);
+      const initial: ModelMessage[] = [
+        { role: 'user', content: 'Load the skill and use it.' },
+      ];
+      const response = await test.run(initial);
+      const saved: ModelMessage[] = JSON.parse(
+        JSON.stringify([...initial, ...project(response)]),
+      );
+      await test.run([...saved, { role: 'user', content: 'Use it again.' }]);
+      expect(test.specialist).toHaveBeenCalledTimes(2);
+      expect(test.readSkill).toHaveBeenCalledTimes(1);
+      for (const request of test.requests)
+        expect(request.tools.map(tool => tool.name)).toEqual(['readSkill']);
+      expect(
+        test.requests[0].input.some(item => item.type === 'additional_tools'),
+      ).toBe(false);
+      const second = test.requests[1].input;
+      const index = second.findIndex(item => item.type === 'additional_tools');
+      expect(second[index - 1]).toMatchObject({
+        type: 'function_call_output',
+        output: 'loaded',
+      });
+      expect(test.requests[3].input.slice(0, index + 1)).toEqual(
+        second.slice(0, index + 1),
+      );
+      expect(
+        test.requests[3].input.filter(item => item.type === 'additional_tools'),
+      ).toHaveLength(1);
+    });
+
+    it.each(['auto', 'none', 'required', 'specialist'] as const)(
+      'preserves %s tool choice after omitting the loaded declaration',
+      async choice => {
+        const test = setup([
+          choice === 'required' || choice === 'specialist'
+            ? ['specialist']
+            : [],
+        ]);
+        await test.run(
+          [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'read',
+                  toolName: 'readSkill',
+                  input: {},
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolCallId: 'read',
+                  toolName: 'readSkill',
+                  output: { type: 'text', value: 'loaded' },
+                },
+              ],
+            },
+          ],
+          1,
+          choice === 'specialist'
+            ? { type: 'tool', toolName: 'specialist' }
+            : choice,
+        );
+        expect(test.requests[0].tools.map(tool => tool.name)).toEqual([
+          'readSkill',
+        ]);
+        expect(test.requests[0].tool_choice).toEqual(
+          choice === 'specialist'
+            ? { type: 'function', name: 'specialist' }
+            : choice,
+        );
+      },
+    );
+
+    it.each([['specialist'], ['readSkill', 'specialist']])(
+      'does not execute an unavailable call in %j',
+      async (...names) => {
+        const test = setup([names]);
+        await test.run(
+          [
+            {
+              role: 'user',
+              content: 'Try calling the unavailable specialist.',
+            },
+          ],
+          1,
+        );
+        expect(test.specialist).not.toHaveBeenCalled();
+        expect(test.readSkill).toHaveBeenCalledTimes(
+          names.includes('readSkill') ? 1 : 0,
+        );
+      },
+    );
+  },
+);

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -8,6 +8,7 @@ export type {
   OpenAILanguageModelResponsesOptions as OpenAIResponsesProviderOptions,
 } from './responses/openai-responses-language-model-options';
 export type { OpenAIToolOptions } from './responses/openai-responses-prepare-tools';
+export type { OpenAIResponsesToolResultOptions } from './responses/openai-responses-additional-tools';
 export type {
   OpenAILanguageModelChatOptions,
   /** @deprecated Use `OpenAILanguageModelChatOptions` instead. */

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -19,6 +19,7 @@ import {
   type ToolNameMapping,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
+import { openaiResponsesToolResultOptionsSchema } from './openai-responses-additional-tools';
 import {
   applyPatchInputSchema,
   applyPatchOutputSchema,
@@ -1225,6 +1226,35 @@ export async function convertToOpenAIResponsesInput({
             continue;
           }
 
+          const resolvedToolName = toolNameMapping.toProviderToolName(
+            part.toolName,
+          );
+
+          const additionalOptions = await parseProviderOptions({
+            provider: providerOptionsName,
+            providerOptions: part.providerOptions,
+            schema: openaiResponsesToolResultOptionsSchema,
+          });
+          if (
+            additionalOptions?.additionalTools != null &&
+            (part.output.type === 'error-text' ||
+              part.output.type === 'error-json' ||
+              part.output.type === 'execution-denied' ||
+              part.providerOptions?.[providerOptionsName]?.parallelToolCall !=
+                null ||
+              part.toolName === toolSearchToolName ||
+              customProviderToolNames?.has(resolvedToolName) ||
+              (hasLocalShellTool && resolvedToolName === 'local_shell') ||
+              (hasShellTool && resolvedToolName === 'shell') ||
+              (hasApplyPatchTool && resolvedToolName === 'apply_patch') ||
+              (hasComputerTool && resolvedToolName === 'computer'))
+          ) {
+            throw new UnsupportedFunctionalityError({
+              functionality:
+                'additionalTools requires a successful ordinary function tool result',
+            });
+          }
+
           const parallelToolCallMetadata = getParallelToolCallMetadata({
             providerOptions: part.providerOptions,
             providerOptionsName,
@@ -1313,10 +1343,6 @@ export async function convertToOpenAIResponsesInput({
               continue;
             }
           }
-
-          const resolvedToolName = toolNameMapping.toProviderToolName(
-            part.toolName,
-          );
 
           if (part.toolName === toolSearchToolName && output.type === 'json') {
             const parsedOutput = await validateTypes({
@@ -1581,6 +1607,13 @@ export async function convertToOpenAIResponsesInput({
             output: contentValue,
             ...(caller != null && { caller }),
           });
+          if (additionalOptions?.additionalTools != null) {
+            input.push({
+              type: 'additional_tools',
+              role: 'developer',
+              tools: additionalOptions.additionalTools,
+            });
+          }
         }
 
         break;

--- a/packages/openai/src/responses/openai-responses-additional-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-additional-tools.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  JSONValue,
+  LanguageModelV4Prompt,
+  LanguageModelV4ToolResultOutput,
+} from '@ai-sdk/provider';
+import { convertToOpenAIResponsesInput } from './convert-to-openai-responses-input';
+import {
+  omitHistoricalTools,
+  type OpenAIResponsesToolResultOptions,
+} from './openai-responses-additional-tools';
+
+const definition = {
+  type: 'function',
+  name: 'specialist',
+  parameters: { type: 'object' },
+  strict: true,
+} satisfies NonNullable<
+  OpenAIResponsesToolResultOptions['additionalTools']
+>[number];
+const convert = (
+  additionalTools: JSONValue,
+  output: LanguageModelV4ToolResultOutput = {
+    type: 'json',
+    value: { instructions: 'Use specialist.' },
+  },
+) =>
+  convertToOpenAIResponsesInput({
+    prompt: [
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'read',
+            toolName: 'readSkill',
+            output,
+            providerOptions: {
+              openai: {
+                additionalTools,
+                caller: { type: 'direct' },
+              },
+            },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'other',
+            toolName: 'other',
+            output: { type: 'text', value: 'unchanged' },
+          },
+        ],
+      },
+    ] satisfies LanguageModelV4Prompt,
+    toolNameMapping: {
+      toProviderToolName: name => name,
+      toCustomToolName: name => name,
+    },
+    systemMessageMode: 'developer',
+    providerOptionsName: 'openai',
+    store: false,
+  });
+
+describe('additional tools', () => {
+  it.each(['error-text', 'error-json', 'execution-denied'] as const)(
+    'rejects activation on %s results',
+    async type => {
+      await expect(
+        convert(
+          [definition],
+          type === 'execution-denied' ? { type } : { type, value: 'failed' },
+        ),
+      ).rejects.toThrow('successful ordinary function');
+    },
+  );
+  it('inserts immediately after the ordinary output and preserves caller metadata and siblings', async () => {
+    expect((await convert([definition])).input).toMatchInlineSnapshot(`
+      [
+        {
+          "call_id": "read",
+          "caller": {
+            "type": "direct",
+          },
+          "output": "{\"instructions\":\"Use specialist.\"}",
+          "type": "function_call_output",
+        },
+        {
+          "role": "developer",
+          "tools": [
+            {
+              "name": "specialist",
+              "parameters": {
+                "type": "object",
+              },
+              "strict": true,
+              "type": "function",
+            },
+          ],
+          "type": "additional_tools",
+        },
+        {
+          "call_id": "other",
+          "output": "unchanged",
+          "type": "function_call_output",
+        },
+      ]
+    `);
+  });
+
+  it.each(
+    [
+      [],
+      [{ ...definition, name: '' }],
+      [{ ...definition, parameters: false }],
+      [{ ...definition, parameters: { type: 'array' } }],
+      [{ ...definition, parameters: { type: 'object', required: 'bad' } }],
+      [{ ...definition, parameters: { type: 'object', properties: { x: 3 } } }],
+      [{ ...definition, surprise: true }],
+    ].map(value => ({ value })),
+  )('rejects invalid options %j', async ({ value }) => {
+    await expect(convert(value)).rejects.toThrow();
+  });
+
+  it('omits matching definitions across multiple and repeated activations', async () => {
+    const { input } = await convert([definition]);
+    const secondDefinition = { ...definition, name: 'secondSpecialist' };
+    const second = await convert([secondDefinition]);
+    const core = { ...definition, name: 'readSkill', description: undefined };
+    expect(
+      omitHistoricalTools({
+        input: [...input, ...second.input, ...input],
+        tools: [
+          core,
+          { ...definition, description: undefined },
+          { ...secondDefinition, description: undefined },
+        ],
+      }),
+    ).toEqual([core]);
+  });
+
+  it('compares schemas independently of object property order', async () => {
+    const { input } = await convert([
+      {
+        ...definition,
+        parameters: {
+          type: 'object',
+          properties: { a: { type: 'string' }, b: { type: 'number' } },
+        },
+      },
+    ]);
+    expect(
+      omitHistoricalTools({
+        input,
+        tools: [
+          {
+            ...definition,
+            description: undefined,
+            parameters: {
+              properties: { b: { type: 'number' }, a: { type: 'string' } },
+              type: 'object',
+            },
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it('rejects historical and current definition conflicts', async () => {
+    const { input } = await convert([definition]);
+    expect(() =>
+      omitHistoricalTools({
+        input,
+        tools: [{ ...definition, description: 'different' }],
+      }),
+    ).toThrow('Conflicting');
+    const other = await convert([{ ...definition, strict: false }]);
+    expect(() =>
+      omitHistoricalTools({
+        input: [...input, ...other.input],
+        tools: undefined,
+      }),
+    ).toThrow('Conflicting');
+  });
+});

--- a/packages/openai/src/responses/openai-responses-additional-tools.ts
+++ b/packages/openai/src/responses/openai-responses-additional-tools.ts
@@ -1,0 +1,86 @@
+import { UnsupportedFunctionalityError } from '@ai-sdk/provider';
+import { z } from 'zod/v4';
+import type {
+  OpenAIResponsesInput,
+  OpenAIResponsesTool,
+} from './openai-responses-api';
+
+export const openaiResponsesToolResultOptionsSchema = z.object({
+  additionalTools: z
+    .array(
+      z.strictObject({
+        type: z.literal('function'),
+        name: z.string().regex(/^[a-zA-Z0-9_-]{1,64}$/),
+        description: z.string().optional(),
+        parameters: z
+          .object({
+            type: z.literal('object'),
+            properties: z
+              .record(
+                z.string(),
+                z.union([z.boolean(), z.record(z.string(), z.json())]),
+              )
+              .optional(),
+            required: z.array(z.string()).optional(),
+            additionalProperties: z
+              .union([z.boolean(), z.record(z.string(), z.json())])
+              .optional(),
+          })
+          .catchall(z.json()),
+        strict: z.boolean().optional(),
+      }),
+    )
+    .min(1)
+    .optional(),
+});
+
+/** Options on an ordinary function tool-result part in Responses history. */
+export type OpenAIResponsesToolResultOptions = z.infer<
+  typeof openaiResponsesToolResultOptionsSchema
+>;
+
+// Compare JSON objects independently of their property insertion order.
+function canonicalize(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(',')}]`;
+  if (value != null && typeof value === 'object') {
+    return `{${Object.entries(value)
+      .filter(([, value]) => value !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, value]) => `${JSON.stringify(key)}:${canonicalize(value)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'undefined';
+}
+
+/** Keep declarations at their original history position, never in both lists. */
+export function omitHistoricalTools({
+  input,
+  tools,
+}: {
+  input: OpenAIResponsesInput;
+  tools: OpenAIResponsesTool[] | undefined;
+}): OpenAIResponsesTool[] | undefined {
+  const historical = new Map<string, string>();
+  for (const item of input) {
+    if (!('type' in item) || item.type !== 'additional_tools') continue;
+    for (const tool of item.tools) {
+      const definition = canonicalize(tool);
+      const previous = historical.get(tool.name);
+      if (previous != null && previous !== definition) {
+        throw new UnsupportedFunctionalityError({
+          functionality: `Conflicting additionalTools definition for ${tool.name}`,
+        });
+      }
+      historical.set(tool.name, definition);
+    }
+  }
+  return tools?.filter(tool => {
+    if (tool.type !== 'function' || !historical.has(tool.name)) return true;
+    if (historical.get(tool.name) !== canonicalize(tool)) {
+      throw new UnsupportedFunctionalityError({
+        functionality: `Conflicting additionalTools definition for ${tool.name}`,
+      });
+    }
+    return false;
+  });
+}

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -6,6 +6,7 @@ import {
   type InferSchema,
 } from '@ai-sdk/provider-utils';
 import { z } from 'zod/v4';
+import type { OpenAIResponsesToolResultOptions } from './openai-responses-additional-tools';
 
 const jsonValueSchema: z.ZodType<JSONValue> = z.lazy(() =>
   z.union([
@@ -157,6 +158,11 @@ const openaiResponsesLocalShellCallSchema = z.object({
 export type OpenAIResponsesInput = Array<OpenAIResponsesInputItem>;
 
 export type OpenAIResponsesInputItem =
+  | {
+      type: 'additional_tools';
+      role: 'developer';
+      tools: NonNullable<OpenAIResponsesToolResultOptions['additionalTools']>;
+    }
   | OpenAIResponsesSystemMessage
   | OpenAIResponsesUserMessage
   | OpenAIResponsesAssistantMessage

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -65,6 +65,7 @@ import {
   type OpenAIResponsesUsage,
 } from './convert-openai-responses-usage';
 import { convertToOpenAIResponsesInput } from './convert-to-openai-responses-input';
+import { omitHistoricalTools } from './openai-responses-additional-tools';
 import {
   expandParallelToolCall,
   isUndeclaredParallelToolCall,
@@ -706,7 +707,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
       webSearchToolName,
       args: {
         ...baseArgs,
-        tools: openaiTools,
+        tools: omitHistoricalTools({ input, tools: openaiTools }),
         tool_choice: openaiToolChoice,
       },
       warnings: [...warnings, ...toolWarnings],


### PR DESCRIPTION
## Background

Applications that load tools through an ordinary function result cannot currently send OpenAI's `additional_tools` item at that history position. Adding those definitions to request-level `tools` instead changes the initial request prefix.

This follows #17176 with a provider-only implementation. Current `generateText` and `streamText` already restrict local execution to the step's active tools, so no core runtime changes are needed.

## Summary

- Add typed `providerOptions.openai.additionalTools` for flat function definitions with object parameters. Preserve the successful `function_call_output` and insert the declarations immediately after it.
- Omit matching declarations from request-level `tools` and reject conflicting definitions. Applications activate the registered functions through `prepareStep.activeTools` on the next step.
- Add provider and multi-turn SDK tests, examples for both APIs, documentation, and a patch changeset.

## Contributor Credit

Thanks to @ruiconti for #17155, @gr2m for the implementation and review in #17176, and @lgrammel for the provider-only and multi-turn verification guidance.

## End-to-End Verification

Tested with `ai@7.0.93`, `@ai-sdk/openai@4.0.60`, `gpt-5.6-luna`, and `store: false`:

- Both `generateText` and `streamText` loaded a tool, executed it, and executed it again after JSON save/reload. Captured requests preserved the original declaration position and excluded the loaded tool from request-level `tools`.
- In a local chat application using Convex Agent 0.7.1, sending a message loaded and executed the tool. A page reload preserved the conversation, and a follow-up executed the tool without loading it again.

The included `generate-text/openai/additional-tools.ts` and `stream-text/openai/additional-tools.ts` examples demonstrate the save/reload flow.

## Testing

- OpenAI Node and Edge suites: 1,052 tests passed in each.
- SDK additional-tools tests: 14 passed in each runtime, covering replay, tool choice, and rejection of unavailable calls, including loader/specialist calls in the same step.
- Package builds, full workspace typecheck, changed-code lint/format checks, and `git diff --check` passed.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Related to #17155, #17176, the exploration in #17097, and the broader registry discussion in #18021.
