### PR TITLE
fix(smooth-stream): preserve providerMetadata on chunked parts without cross-delta leaks

### DIFF
--- a/.changeset/smooth-stream-metadata.md
+++ b/.changeset/smooth-stream-metadata.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+fix(smooth-stream): preserve providerMetadata on chunked stream parts without leaking across deltas

--- a/packages/ai/src/generate-text/smooth-stream.test.ts
+++ b/packages/ai/src/generate-text/smooth-stream.test.ts
@@ -1680,6 +1680,117 @@ describe('smoothStream', () => {
         anthropic: { redactedData: 'redacted-thinking-data' },
       });
     });
+
+    it('should preserve providerMetadata on word-chunked deltas with text (#14373)', async () => {
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'reasoning-start', id: 'r1' },
+        {
+          text: 'First ',
+          type: 'reasoning-delta',
+          id: 'r1',
+          providerMetadata: { anthropic: { signature: 'sig_first' } },
+        },
+        {
+          text: 'second ',
+          type: 'reasoning-delta',
+          id: 'r1',
+          providerMetadata: { anthropic: { signature: 'sig_second' } },
+        },
+        { type: 'reasoning-end', id: 'r1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      const deltas = events.filter((e: any) => e.type === 'reasoning-delta');
+      expect(deltas).toHaveLength(2);
+      expect(deltas[0]).toEqual({
+        text: 'First ',
+        type: 'reasoning-delta',
+        id: 'r1',
+        providerMetadata: { anthropic: { signature: 'sig_first' } },
+      });
+      expect(deltas[1]).toEqual({
+        text: 'second ',
+        type: 'reasoning-delta',
+        id: 'r1',
+        providerMetadata: { anthropic: { signature: 'sig_second' } },
+      });
+    });
+
+    it('should not leak providerMetadata onto later deltas without metadata', async () => {
+      const metadata = { anthropic: { signature: 'sig_only_first' } };
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'text-start', id: 't1' },
+        {
+          text: 'Hello ',
+          type: 'text-delta',
+          id: 't1',
+          providerMetadata: metadata,
+        },
+        { text: 'world!', type: 'text-delta', id: 't1' },
+        { type: 'text-end', id: 't1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      const deltas = events.filter((e: any) => e.type === 'text-delta');
+      expect(deltas).toHaveLength(2);
+      expect(deltas[0]).toEqual({
+        text: 'Hello ',
+        type: 'text-delta',
+        id: 't1',
+        providerMetadata: metadata,
+      });
+      expect(deltas[1]).toEqual({
+        text: 'world!',
+        type: 'text-delta',
+        id: 't1',
+      });
+      expect(deltas[1]).not.toHaveProperty('providerMetadata');
+    });
+
+    it('should not merge metadata-only deltas into earlier buffered text', async () => {
+      const metadata = { anthropic: { signature: 'sig_trailing' } };
+      const stream = convertArrayToReadableStream<TextStreamPart<ToolSet>>([
+        { type: 'text-start', id: 't1' },
+        { text: 'Hello worl', type: 'text-delta', id: 't1' },
+        { text: '', type: 'text-delta', id: 't1', providerMetadata: metadata },
+        { type: 'text-end', id: 't1' },
+      ]).pipeThrough(
+        smoothStream({
+          delayInMs: 10,
+          _internal: { delay },
+        })({ tools: {} }),
+      );
+
+      await consumeStream(stream);
+
+      const deltas = events.filter((e: any) => e.type === 'text-delta');
+      expect(deltas).toHaveLength(3);
+      expect(deltas[0]).toEqual({
+        text: 'Hello ',
+        type: 'text-delta',
+        id: 't1',
+      });
+      expect(deltas[1]).toEqual({ text: 'worl', type: 'text-delta', id: 't1' });
+      expect(deltas[1]).not.toHaveProperty('providerMetadata');
+      expect(deltas[2]).toEqual({
+        text: '',
+        type: 'text-delta',
+        id: 't1',
+        providerMetadata: metadata,
+      });
+    });
   });
 
   describe('Intl.Segmenter chunking', () => {

--- a/packages/ai/src/generate-text/smooth-stream.ts
+++ b/packages/ai/src/generate-text/smooth-stream.ts
@@ -159,10 +159,23 @@ export function smoothStream<TOOLS extends ToolSet>({
           return;
         }
 
-        // Flush buffer when type or id changes
+        // Empty deltas that only carry metadata (e.g. Anthropic thinking
+        // signatures) pass through untouched, so the metadata is neither
+        // merged into surrounding text nor dropped from the stream.
+        if (chunk.text.length === 0 && chunk.providerMetadata != null) {
+          flushBuffer(controller);
+          controller.enqueue(chunk);
+          return;
+        }
+
+        // Flush at metadata boundaries: one output part must not merge
+        // metadata from multiple input deltas.
         if (
-          (chunk.type !== type || chunk.id !== id) &&
-          (buffer.length > 0 || providerMetadata != null)
+          buffer.length > 0 &&
+          (chunk.type !== type ||
+            chunk.id !== id ||
+            providerMetadata != null ||
+            chunk.providerMetadata != null)
         ) {
           flushBuffer(controller);
         }
@@ -170,19 +183,26 @@ export function smoothStream<TOOLS extends ToolSet>({
         buffer += chunk.text;
         id = chunk.id;
         type = chunk.type;
-
-        // Preserve providerMetadata (e.g., Anthropic thinking signatures)
-        if (chunk.providerMetadata != null) {
-          providerMetadata = chunk.providerMetadata;
-        }
+        providerMetadata = chunk.providerMetadata;
 
         let match;
 
         while ((match = detectChunk(buffer)) != null) {
-          controller.enqueue({ type, text: match, id });
+          controller.enqueue({
+            type,
+            text: match,
+            id,
+            ...(providerMetadata != null ? { providerMetadata } : {}),
+          });
           buffer = buffer.slice(match.length);
 
           await delay(isDocumentHidden() ? null : delayInMs);
+        }
+
+        // The buffered metadata has been fully emitted with the chunked
+        // text above: clear it so it cannot leak onto later deltas.
+        if (buffer.length === 0) {
+          providerMetadata = undefined;
         }
       },
     });


### PR DESCRIPTION
## Background

Fixes #14373. When `smoothStream` splits buffered text at word/line boundaries, the re-emitted chunks dropped `providerMetadata` — only the final flush remainder kept it. With Anthropic extended thinking, that silently strips thinking signatures from intermediate stream parts.

Approaches were previously explored in #14374 and #19561 (both open; #19561 is conflicted against current main). This rebases the boundary-flush approach onto current main.

## Summary

In `packages/ai/src/generate-text/smooth-stream.ts`:

- word/line-chunked `text-delta` / `reasoning-delta` parts now carry the `providerMetadata` of the input delta they were smoothed from
- empty metadata-only deltas (e.g. thinking signatures) pass through untouched instead of merging into surrounding text
- buffered text flushes at metadata boundaries so one output part never merges metadata from two input deltas
- consumed metadata is cleared once fully emitted so it cannot leak onto later deltas

Also adds a patch changeset and 3 regression tests (preserve on chunked deltas, no forward leak, no backward merge).

## Contributor Credit

- Bug report: @kuishou68 (#14373, plus fix attempt #14374)
- Prior approach: ai-sdk-factory #19561

## End-to-End Verification

Unit-level (no live provider needed — same shape as the factory repro in #19532):

- new tests FAIL on unpatched code (3 failed, 40 passed) and PASS with the fix
- `smooth-stream.test.ts`: 43/43 node + 43/43 edge
- consumer `stream-text.test.ts`: 451/451 node
- `tsc --build`, oxlint, oxfmt clean