### PR TITLE
fix(ai): prevent NoOutputGeneratedError telemetry leaks in non-Node environments

### DIFF
--- a/.changeset/little-items-greet.md
+++ b/.changeset/little-items-greet.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+Fix unhandled promise rejections from internal telemetry completion promises in non-Node runtimes when streamed output fails.

--- a/packages/ai/src/telemetry/tracing-channel-publisher.test.ts
+++ b/packages/ai/src/telemetry/tracing-channel-publisher.test.ts
@@ -1,7 +1,10 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AI_SDK_TELEMETRY_TRACING_CHANNEL } from './tracing-channel';
-import { runWithTracingChannelSpan } from './tracing-channel-publisher';
+import {
+  openTelemetryChannelSpanContext,
+  runWithTracingChannelSpan,
+} from './tracing-channel-publisher';
 import { isNodeRuntime } from '../util/is-node-runtime';
 
 // Mock the runtime guard so we can drive both branches deterministically,
@@ -62,6 +65,24 @@ describe.runIf(runningOnNode)(
       } finally {
         unsubscribe();
       }
+    });
+
+    it('observes completion when not running on Node', async () => {
+      vi.mocked(isNodeRuntime).mockReturnValue(false);
+
+      const completion = Promise.reject(new Error('completion failed'));
+      const catchSpy = vi.spyOn(completion, 'catch');
+
+      const context = openTelemetryChannelSpanContext({
+        message,
+        completion,
+      });
+
+      expect(context).toBeUndefined();
+      expect(catchSpy).toHaveBeenCalledOnce();
+
+      // Prevent the intentionally rejected test promise from leaking
+      await completion.catch(() => {});
     });
 
     it('traces through the diagnostics channel when running on Node', async () => {

--- a/packages/ai/src/telemetry/tracing-channel-publisher.ts
+++ b/packages/ai/src/telemetry/tracing-channel-publisher.ts
@@ -136,6 +136,7 @@ export function openTelemetryChannelSpanContext({
   completion: PromiseLike<unknown>;
 }): TracingChannelContext | undefined {
   if (!isNodeRuntime()) {
+    Promise.resolve(completion).catch(() => {});
     return undefined;
   }
 


### PR DESCRIPTION
## Background

Hi friends! We use AI SDK in a Tauri desktop app (sth like Electron.js), where it runs in a browser context.
With telemetry enabled, a locally handled `streamText()` failure can leak through
`window.unhandledrejection`. This can trigger error reporting, development
overlays, or fatal-error handling even though the application already handled
the stream error.

The issue reproduces with a globally registered `@ai-sdk/otel` `OpenTelemetry`
integration and an empty model stream. A minimal browser reproduction is
available for manual testing in [c3d2a5f](https://github.com/vercel/ai/commit/c3d2a5fc7e581bc4a2e24507ccf31afd3ef4917a).

For a short reproduction:

```ts
registerTelemetry(new OpenTelemetry());
window.addEventListener('unhandledrejection', capture);

const result = streamText({
  model: modelWhoseStreamClosesWithoutChunks,
  prompt: 'Hello',
  telemetry: { isEnabled: true },
});

await consume(result.stream);

// Expected: result.stream contains NoOutputGeneratedError.
// Before this fix: capture also receives the same error as an unhandled rejection.
```

The global rejection is therefore a leak from a separate SDK-created telemetry
promise, not an application failure to handle the normal `streamText()` error.

## Summary

`streamText()` creates an internal telemetry completion promise from
`_totalUsage`:

```ts
completion: self._totalUsage.promise.then(() => undefined),
```

When no output is generated, `_totalUsage` rejects with
`NoOutputGeneratedError`, so this derived promise rejects too. In non-Node
runtimes, `openTelemetryChannelSpanContext()` returned before attaching a
rejection handler, leaving this SDK-owned promise unhandled.

This change handles that internal completion promise before the non-Node early
return:

```ts
if (!isNodeRuntime()) {
  // Prevent the internal telemetry completion promise from leaking globally.
  Promise.resolve(completion).catch(() => {});
  return undefined;
}
```

This matches the existing fallback for unavailable Node tracing channels. It does
not suppress the public error: the stream still emits `NoOutputGeneratedError`,
and explicitly accessed result promises continue to reject as before. It only
prevents an inaccessible telemetry bookkeeping promise from reaching global
browser error handling.

## End-to-End Verification

Using the browser reproduction with globally registered OpenTelemetry and an
empty model stream:

- The consumed stream still contains `NoOutputGeneratedError`.
- With the fix, no `unhandledrejection` event is dispatched.
- Removing the new handler reproduces the global
  `AI_NoOutputGeneratedError` rejection.

Built a local `ai` package containing the fix and verified it in our real Tauri application; the unhandled rejection no longer occurs.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
