### PR TITLE
feat(openai): add async tool calling

### DIFF
--- a/.changeset/quick-tools-wait.md
+++ b/.changeset/quick-tools-wait.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+feat(openai): add async tool calling

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -548,6 +548,55 @@ metadata on tool-call parts. The SDK uses `providerMetadata.openai.namespace` or
 `providerOptions.openai.namespace` to round-trip the namespace back to OpenAI on
 subsequent requests.
 
+#### Async Tool Calling
+
+GPT-6 Astra and later Responses models support
+[async tool calling](https://developers.openai.com/api/docs/guides/async-tool-calling).
+An async tool lets the model continue generating independent output after issuing
+the call instead of waiting for its result. Your application still executes the
+tool and sends its result in a later request using the original tool call ID.
+
+Enable async calling on a function tool with `providerOptions.openai.async`:
+
+```ts
+import { openai, type OpenAIToolOptions } from '@ai-sdk/openai';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+const result = await generateText({
+  model: openai.responses('gpt-6-astra'),
+  tools: {
+    getWeather: tool({
+      description: 'Get the weather for a city.',
+      inputSchema: z.object({ city: z.string() }),
+      outputSchema: z.object({
+        city: z.string(),
+        temperatureC: z.number(),
+      }),
+      providerOptions: {
+        openai: { async: true } satisfies OpenAIToolOptions,
+      },
+    }),
+  },
+  prompt:
+    'Start the weather lookup for Paris, then list three general packing essentials without waiting.',
+});
+```
+
+The generated tool call exposes the provider marker as
+`providerMetadata.openai.async`. Use `providerMetadata.openai.responseId` as the
+next request's `previousResponseId`, and submit the result in a tool message with
+the original `toolCallId`.
+
+With `streamText`, OpenAI can continue streaming text after the completed
+`tool-call` part. Use the tool's `onInputAvailable` callback to start work as soon
+as that part arrives. If `execute` returns the same already-running promise, tool
+execution overlaps the rest of the model stream. Omit `execute` when the job
+should outlive the current generation and submit its result in a later request.
+
+Async calling applies to directly called function and custom tools. It does not
+apply to hosted tools.
+
 #### Web Search Tool
 
 The OpenAI responses API supports web search through the `openai.tools.webSearch` tool.

--- a/examples/ai-functions/src/generate-text/openai/responses-async-tool-calling.ts
+++ b/examples/ai-functions/src/generate-text/openai/responses-async-tool-calling.ts
@@ -1,0 +1,111 @@
+import {
+  openai,
+  type OpenaiResponsesProviderMetadata,
+  type OpenAILanguageModelResponsesOptions,
+  type OpenAIToolOptions,
+} from '@ai-sdk/openai';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+const model = openai.responses('gpt-6-astra');
+
+const tools = {
+  get_weather: tool({
+    description: 'Read a demo weather snapshot for a city.',
+    inputSchema: z.object({
+      city: z.string(),
+    }),
+    outputSchema: z.object({
+      city: z.string(),
+      temperatureC: z.number(),
+      condition: z.string(),
+      source: z.string(),
+    }),
+    strict: true,
+    providerOptions: {
+      openai: {
+        async: true,
+      } satisfies OpenAIToolOptions,
+    },
+  }),
+};
+
+async function getWeather(city: string) {
+  // Simulate an application-managed background job.
+  await new Promise(resolve => setTimeout(resolve, 3_000));
+
+  if (city !== 'Paris') {
+    throw new Error(`No demo weather snapshot for ${city}.`);
+  }
+
+  return {
+    city,
+    temperatureC: 22,
+    condition: 'Clear',
+    source: 'demo weather snapshot',
+  };
+}
+
+run(async () => {
+  const firstResult = await generateText({
+    model,
+    tools,
+    system:
+      'Start the weather lookup and answer the independent packing question ' +
+      'without waiting. Use the demo weather result when it arrives; never invent it.',
+    prompt:
+      'Check the demo weather snapshot for Paris. Meanwhile, list three essentials for any city trip.',
+  });
+
+  console.log('First response content:');
+  console.log(JSON.stringify(firstResult.content, null, 2));
+
+  const call = firstResult.toolCalls[0];
+  if (
+    call == null ||
+    call.dynamic ||
+    call.toolName !== 'get_weather' ||
+    call.input.city !== 'Paris'
+  ) {
+    throw new Error('The response did not include the expected weather call.');
+  }
+
+  const responseMetadata = firstResult.providerMetadata as
+    | OpenaiResponsesProviderMetadata
+    | undefined;
+  const previousResponseId = responseMetadata?.openai.responseId;
+  if (previousResponseId == null) {
+    throw new Error('OpenAI did not return a response ID.');
+  }
+
+  // The application owns and executes the job. Other conversation turns could
+  // happen before this promise resolves.
+  const weather = await getWeather(call.input.city);
+
+  const finalResult = await generateText({
+    model,
+    tools,
+    messages: [
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: call.toolCallId,
+            toolName: call.toolName,
+            output: { type: 'json', value: weather },
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      openai: {
+        previousResponseId,
+      } satisfies OpenAILanguageModelResponsesOptions,
+    },
+  });
+
+  console.log('\nFinal response content:');
+  console.log(JSON.stringify(finalResult.content, null, 2));
+});

--- a/examples/ai-functions/src/stream-text/openai/responses-async-tool-calling.ts
+++ b/examples/ai-functions/src/stream-text/openai/responses-async-tool-calling.ts
@@ -1,0 +1,121 @@
+import {
+  openai,
+  type OpenaiResponsesProviderMetadata,
+  type OpenAILanguageModelResponsesOptions,
+  type OpenAIToolOptions,
+} from '@ai-sdk/openai';
+import { streamText, tool } from 'ai';
+import { z } from 'zod';
+import { printFullStream } from '../../lib/print-full-stream';
+import { run } from '../../lib/run';
+
+const model = openai.responses('gpt-6-astra');
+
+async function getWeather(city: string) {
+  // Simulate an application-managed background job.
+  await new Promise(resolve => setTimeout(resolve, 3_000));
+
+  if (city !== 'Paris') {
+    throw new Error(`No demo weather snapshot for ${city}.`);
+  }
+
+  return {
+    city,
+    temperatureC: 22,
+    condition: 'Clear',
+    source: 'demo weather snapshot',
+  };
+}
+
+const weatherJobs = new Map<string, ReturnType<typeof getWeather>>();
+
+const tools = {
+  get_weather: tool({
+    description: 'Read a demo weather snapshot for a city.',
+    inputSchema: z.object({
+      city: z.string(),
+    }),
+    outputSchema: z.object({
+      city: z.string(),
+      temperatureC: z.number(),
+      condition: z.string(),
+      source: z.string(),
+    }),
+    strict: true,
+    providerOptions: {
+      openai: {
+        async: true,
+      } satisfies OpenAIToolOptions,
+    },
+    onInputAvailable({ input, toolCallId }) {
+      // This runs as soon as the complete streamed tool call arrives. Starting
+      // the promise here lets the job overlap subsequent model output.
+      weatherJobs.set(toolCallId, getWeather(input.city));
+    },
+  }),
+};
+
+run(async () => {
+  const firstResult = streamText({
+    model,
+    tools,
+    system:
+      'Start the weather lookup and answer the independent packing question ' +
+      'without waiting. Use the demo weather result when it arrives; never invent it.',
+    prompt:
+      'Check the demo weather snapshot for Paris. Meanwhile, list three essentials for any city trip.',
+  });
+
+  console.log('First response:');
+  await printFullStream({ result: firstResult });
+
+  const call = (await firstResult.toolCalls)[0];
+  if (
+    call == null ||
+    call.dynamic ||
+    call.toolName !== 'get_weather' ||
+    call.input.city !== 'Paris'
+  ) {
+    throw new Error('The response did not include the expected weather call.');
+  }
+
+  const responseMetadata = (await firstResult.providerMetadata) as
+    | OpenaiResponsesProviderMetadata
+    | undefined;
+  const previousResponseId = responseMetadata?.openai.responseId;
+  if (previousResponseId == null) {
+    throw new Error('OpenAI did not return a response ID.');
+  }
+
+  const weatherJob = weatherJobs.get(call.toolCallId);
+  if (weatherJob == null) {
+    throw new Error('The weather job was not started.');
+  }
+  const weather = await weatherJob;
+
+  const finalResult = streamText({
+    model,
+    tools,
+    messages: [
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: call.toolCallId,
+            toolName: call.toolName,
+            output: { type: 'json', value: weather },
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      openai: {
+        previousResponseId,
+      } satisfies OpenAILanguageModelResponsesOptions,
+    },
+  });
+
+  console.log('\nResponse after the weather job completes:');
+  await printFullStream({ result: finalResult });
+});

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -19,9 +19,11 @@ export type { OpenAILanguageModelCompletionOptions } from './completion/openai-c
 export type { OpenAIEmbeddingModelOptions } from './embedding/openai-embedding-options';
 export type { OpenAISpeechModelOptions } from './speech/openai-speech-options';
 export type { OpenAITranscriptionModelOptions } from './transcription/openai-transcription-options';
+export type { OpenAIToolOptions } from './responses/openai-responses-prepare-tools';
 export type {
   OpenaiResponsesProviderMetadata,
   OpenaiResponsesReasoningProviderMetadata,
+  OpenaiResponsesToolCallProviderMetadata,
   OpenaiResponsesTextProviderMetadata,
   OpenaiResponsesSourceDocumentProviderMetadata,
 } from './responses/openai-responses-provider-metadata';

--- a/packages/openai/src/openai-language-model-capabilities.test.ts
+++ b/packages/openai/src/openai-language-model-capabilities.test.ts
@@ -124,6 +124,22 @@ describe('getOpenAILanguageModelCapabilities', () => {
       ['gpt-5.6', false],
       ['gpt-6-astra', true],
       ['gpt-6.1', true],
+      ['gpt-7', true],
+      ['gpt-99', true],
+      ['custom-model', false],
+    ])(
+      '%s supports async tool calling: %s',
+      (modelId, expectedCapabilities) => {
+        expect(
+          getOpenAILanguageModelCapabilities(modelId).supportsAsyncToolCalling,
+        ).toEqual(expectedCapabilities);
+      },
+    );
+
+    it.each([
+      ['gpt-5.6', false],
+      ['gpt-6-astra', true],
+      ['gpt-6.1', true],
       ['gpt-99', true],
     ])(
       '%s supports configuration updates: %s',

--- a/packages/openai/src/openai-language-model-capabilities.ts
+++ b/packages/openai/src/openai-language-model-capabilities.ts
@@ -4,6 +4,7 @@ export type OpenAILanguageModelCapabilities = {
   supportsFlexProcessing: boolean;
   supportsPriorityProcessing: boolean;
   supportsConfigurationUpdate: boolean;
+  supportsAsyncToolCalling: boolean;
   supportedReasoningEfforts: readonly string[] | undefined;
 
   /**
@@ -55,6 +56,7 @@ export function getOpenAILanguageModelCapabilities(
     supportsFlexProcessing,
     supportsPriorityProcessing,
     supportsConfigurationUpdate: isGpt6OrLaterModel,
+    supportsAsyncToolCalling: isGpt6OrLaterModel,
     supportedReasoningEfforts: isGpt6OrLaterModel
       ? ['low', 'medium', 'high', 'xhigh', 'max']
       : undefined,

--- a/packages/openai/src/openai-tools.ts
+++ b/packages/openai/src/openai-tools.ts
@@ -27,6 +27,7 @@ export const openaiTools = {
    *
    * @param name - The name of the custom tool.
    * @param description - An optional description of the tool.
+   * @param async - Whether the model can continue without waiting for the tool result.
    * @param format - The output format constraint (grammar type, syntax, and definition).
    */
   customTool,

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -1418,6 +1418,84 @@ describe('convertToOpenAIResponsesInput', () => {
       ]);
     });
 
+    it('should round-trip async mode on function tool calls', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call_async',
+                toolName: 'get_weather',
+                input: { location: 'Berlin' },
+                providerOptions: {
+                  openai: {
+                    itemId: 'fc_async',
+                    async: true,
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: false,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call',
+          call_id: 'call_async',
+          name: 'get_weather',
+          arguments: JSON.stringify({ location: 'Berlin' }),
+          async: true,
+        },
+      ]);
+    });
+
+    it('should round-trip async mode on custom tool calls', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        toolNameMapping: testToolNameMapping,
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call_custom_async',
+                toolName: 'write_sql',
+                input: 'SELECT 1',
+                providerOptions: {
+                  openai: {
+                    itemId: 'ctc_async',
+                    async: true,
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        providerOptionsName: 'openai',
+        store: false,
+        customProviderToolNames: new Set(['write_sql']),
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'custom_tool_call',
+          call_id: 'call_custom_async',
+          name: 'write_sql',
+          input: 'SELECT 1',
+          async: true,
+          id: 'ctc_async',
+        },
+      ]);
+    });
+
     describe('reasoning messages (store: false)', () => {
       describe('single summary part', () => {
         it('should convert single reasoning part with text', async () => {

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -589,6 +589,18 @@ export async function convertToOpenAIResponsesInput({
                 | string
                 | undefined;
 
+              const isAsync = (part.providerOptions?.[providerOptionsName]
+                ?.async ??
+                (
+                  part as {
+                    providerMetadata?: {
+                      [providerOptionsName]?: { async?: boolean };
+                    };
+                  }
+                ).providerMetadata?.[providerOptionsName]?.async) as
+                | boolean
+                | undefined;
+
               if (hasConversation && id != null) {
                 break;
               }
@@ -739,6 +751,7 @@ export async function convertToOpenAIResponsesInput({
                     typeof part.input === 'string'
                       ? part.input
                       : JSON.stringify(part.input),
+                  ...(isAsync != null && { async: isAsync }),
                   id,
                 });
                 break;
@@ -749,6 +762,7 @@ export async function convertToOpenAIResponsesInput({
                 call_id: part.toolCallId,
                 name: resolvedToolName,
                 arguments: serializeToolCallArguments(part.input),
+                ...(isAsync != null && { async: isAsync }),
                 ...(namespace != null && { namespace }),
               });
               break;

--- a/packages/openai/src/responses/openai-responses-api.test.ts
+++ b/packages/openai/src/responses/openai-responses-api.test.ts
@@ -90,6 +90,26 @@ describe('openaiResponses schema alignment', () => {
     expectTypeOf<DoneChunkPhase>().toEqualTypeOf<ResponsePhase>();
   });
 
+  it('aligns async mode between function call schemas', () => {
+    type AddedAsync = Extract<
+      Extract<Chunk, { type: 'response.output_item.added' }>['item'],
+      { type: 'function_call' }
+    >['async'];
+
+    type DoneAsync = Extract<
+      Extract<Chunk, { type: 'response.output_item.done' }>['item'],
+      { type: 'function_call' }
+    >['async'];
+
+    type ResponseAsync = Extract<
+      NonNullable<Response['output']>[number],
+      { type: 'function_call' }
+    >['async'];
+
+    expectTypeOf<AddedAsync>().toEqualTypeOf<DoneAsync>();
+    expectTypeOf<DoneAsync>().toEqualTypeOf<ResponseAsync>();
+  });
+
   it('aligns output_text logprobs', () => {
     type ChunkLogprobs = Extract<
       Chunk,

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -180,6 +180,7 @@ export type OpenAIResponsesFunctionCall = {
   call_id: string;
   name: string;
   arguments: string;
+  async?: boolean;
   id?: string;
   namespace?: string;
 };
@@ -220,6 +221,7 @@ export type OpenAIResponsesCustomToolCall = {
   call_id: string;
   name: string;
   input: string;
+  async?: boolean;
 };
 
 export type OpenAIResponsesCustomToolCallOutput = {
@@ -373,6 +375,7 @@ export type OpenAIResponsesFunctionTool = {
   name: string;
   description: string | undefined;
   parameters: JSONSchema7;
+  async?: boolean;
   strict?: boolean;
   defer_loading?: boolean;
 };
@@ -501,6 +504,7 @@ export type OpenAIResponsesTool =
       type: 'custom';
       name: string;
       description?: string;
+      async?: boolean;
       format?:
         | {
             type: 'grammar';
@@ -772,6 +776,7 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
             call_id: z.string(),
             name: z.string(),
             arguments: z.string(),
+            async: z.boolean().nullish(),
             namespace: z.string().nullish(),
           }),
           z.object({
@@ -850,6 +855,7 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
             call_id: z.string(),
             name: z.string(),
             input: z.string(),
+            async: z.boolean().nullish(),
           }),
           z.object({
             type: z.literal('shell_call'),
@@ -917,6 +923,7 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
             call_id: z.string(),
             name: z.string(),
             arguments: z.string(),
+            async: z.boolean().nullish(),
             status: z.literal('completed'),
             namespace: z.string().nullish(),
           }),
@@ -926,6 +933,7 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
             call_id: z.string(),
             name: z.string(),
             input: z.string(),
+            async: z.boolean().nullish(),
             status: z.literal('completed'),
           }),
           z.object({
@@ -1410,6 +1418,7 @@ export const openaiResponsesResponseSchema = lazySchema(() =>
               name: z.string(),
               arguments: z.string(),
               id: z.string(),
+              async: z.boolean().nullish(),
               namespace: z.string().nullish(),
             }),
             z.object({
@@ -1418,6 +1427,7 @@ export const openaiResponsesResponseSchema = lazySchema(() =>
               name: z.string(),
               input: z.string(),
               id: z.string(),
+              async: z.boolean().nullish(),
             }),
             z.object({
               type: z.literal('computer_call'),

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -3101,6 +3101,43 @@ describe('OpenAIResponsesLanguageModel', () => {
         `);
       });
 
+      it('should gate async tools to GPT-6 and later models', async () => {
+        const asyncTools: Array<LanguageModelV3FunctionTool> = [
+          {
+            ...TEST_TOOLS[0],
+            providerOptions: {
+              openai: { async: true },
+            },
+          },
+        ];
+
+        const unsupportedResult = await createModel('gpt-5.6').doGenerate({
+          prompt: TEST_PROMPT,
+          tools: asyncTools,
+        });
+        const unsupportedBody = (await server.calls[0].requestBodyJson) as {
+          tools: Array<{ async?: boolean }>;
+        };
+
+        expect(unsupportedBody.tools[0].async).toBeUndefined();
+        expect(unsupportedResult.warnings).toContainEqual({
+          type: 'unsupported',
+          feature: 'async tool calling for "weather"',
+          details:
+            'Async tool calling is only supported by GPT-6 and later models.',
+        });
+
+        await createModel('gpt-99').doGenerate({
+          prompt: TEST_PROMPT,
+          tools: asyncTools,
+        });
+        const supportedBody = (await server.calls[1].requestBodyJson) as {
+          tools: Array<{ async?: boolean }>;
+        };
+
+        expect(supportedBody.tools[0].async).toBe(true);
+      });
+
       it('should expand an internal parallel tool call wrapper', async () => {
         prepareJsonFixtureResponse('parallel-tool-call-wrapper.1');
 
@@ -3141,7 +3178,7 @@ describe('OpenAIResponsesLanguageModel', () => {
         `);
       });
 
-      it('should preserve namespace on function_call output', async () => {
+      it('should preserve async mode and namespace on function_call output', async () => {
         server.urls['https://api.openai.com/v1/responses'].response = {
           type: 'json-value',
           body: {
@@ -3163,6 +3200,7 @@ describe('OpenAIResponsesLanguageModel', () => {
                 name: 'get_weather',
                 arguments: '{"location":"NYC"}',
                 status: 'completed',
+                async: true,
                 namespace: 'weather_ns',
               },
             ],
@@ -3195,6 +3233,7 @@ describe('OpenAIResponsesLanguageModel', () => {
         const toolCall = result.content.find(p => p.type === 'tool-call');
         expect(toolCall?.providerMetadata?.openai).toMatchObject({
           itemId: 'fc_ns_1',
+          async: true,
           namespace: 'weather_ns',
         });
       });
@@ -6067,6 +6106,69 @@ describe('OpenAIResponsesLanguageModel', () => {
           'You can also use @ai-sdk/openai-compatible for OpenAI-compatible providers.',
         responseBody:
           '{"choices":[],"created":0,"id":"","model":"","object":"","prompt_filter_results":[{"prompt_index":0,"content_filter_results":{}}]}',
+      });
+    });
+
+    it('should preserve async mode on streamed function calls', async () => {
+      const functionCall = {
+        id: 'fc_async',
+        type: 'function_call',
+        name: 'weather',
+        call_id: 'call_async',
+        arguments: '{"location":"Berlin"}',
+        status: 'completed',
+        async: true,
+      };
+
+      server.urls['https://api.openai.com/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: ${JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'response_async',
+              created_at: 1,
+              model: 'gpt-6-astra',
+            },
+          })}\n\n`,
+          `data: ${JSON.stringify({
+            type: 'response.output_item.added',
+            output_index: 0,
+            item: { ...functionCall, arguments: '', status: 'in_progress' },
+          })}\n\n`,
+          `data: ${JSON.stringify({
+            type: 'response.output_item.done',
+            output_index: 0,
+            item: functionCall,
+          })}\n\n`,
+          `data: ${JSON.stringify({
+            type: 'response.completed',
+            response: {
+              incomplete_details: null,
+              output: [functionCall],
+              usage: { input_tokens: 1, output_tokens: 2 },
+            },
+          })}\n\n`,
+        ],
+      };
+
+      const { stream } = await createModel('gpt-6-astra').doStream({
+        prompt: TEST_PROMPT,
+        tools: TEST_TOOLS,
+      });
+
+      const events = await convertReadableStreamToArray(stream);
+      expect(events.find(event => event.type === 'tool-call')).toMatchObject({
+        type: 'tool-call',
+        toolCallId: 'call_async',
+        toolName: 'weather',
+        input: '{"location":"Berlin"}',
+        providerMetadata: {
+          openai: {
+            itemId: 'fc_async',
+            async: true,
+          },
+        },
       });
     });
 

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -80,6 +80,7 @@ import type {
   ResponsesReasoningProviderMetadata,
   ResponsesSourceDocumentProviderMetadata,
   ResponsesTextProviderMetadata,
+  ResponsesToolCallProviderMetadata,
 } from './openai-responses-provider-metadata';
 
 /**
@@ -242,6 +243,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       allowedTools: openaiOptions?.allowedTools ?? undefined,
       toolNameMapping,
       customProviderToolNames,
+      supportsAsyncToolCalling: modelCapabilities.supportsAsyncToolCalling,
     });
 
     const { input, warnings: inputWarnings } =
@@ -910,8 +912,9 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
             providerMetadata: {
               [providerOptionsName]: {
                 itemId: part.id,
+                ...(part.async != null && { async: part.async }),
                 ...(part.namespace != null && { namespace: part.namespace }),
-              },
+              } satisfies ResponsesToolCallProviderMetadata,
             },
           });
           break;
@@ -929,7 +932,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
             providerMetadata: {
               [providerOptionsName]: {
                 itemId: part.id,
-              },
+                ...(part.async != null && { async: part.async }),
+              } satisfies ResponsesToolCallProviderMetadata,
             },
           });
           break;
@@ -1242,6 +1246,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
           toolSearchExecution?: 'server' | 'client';
           suppressInputStreaming?: boolean;
           bufferedInputDeltas?: string[];
+          async?: boolean | null;
         }
       | undefined
     > = {};
@@ -1321,6 +1326,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                   toolCallId: value.item.call_id,
                   suppressInputStreaming,
                   bufferedInputDeltas: suppressInputStreaming ? [] : undefined,
+                  async: value.item.async,
                 };
 
                 if (!suppressInputStreaming) {
@@ -1337,6 +1343,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 ongoingToolCalls[value.output_index] = {
                   toolName,
                   toolCallId: value.item.call_id,
+                  async: value.item.async,
                 };
 
                 controller.enqueue({
@@ -1620,10 +1627,15 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                     providerMetadata: {
                       [providerOptionsName]: {
                         itemId: item.id,
+                        ...(item.async != null
+                          ? { async: item.async }
+                          : ongoingToolCall?.async != null
+                            ? { async: ongoingToolCall.async }
+                            : {}),
                         ...(item.namespace != null && {
                           namespace: item.namespace,
                         }),
-                      },
+                      } satisfies ResponsesToolCallProviderMetadata,
                     },
                   });
                 };
@@ -1667,6 +1679,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                   }
                 });
               } else if (value.item.type === 'custom_tool_call') {
+                const ongoingToolCall = ongoingToolCalls[value.output_index];
                 ongoingToolCalls[value.output_index] = undefined;
                 hasFunctionCall = true;
                 const toolName = toolNameMapping.toCustomToolName(
@@ -1686,7 +1699,12 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                   providerMetadata: {
                     [providerOptionsName]: {
                       itemId: value.item.id,
-                    },
+                      ...(value.item.async != null
+                        ? { async: value.item.async }
+                        : ongoingToolCall?.async != null
+                          ? { async: ongoingToolCall.async }
+                          : {}),
+                    } satisfies ResponsesToolCallProviderMetadata,
                   },
                 });
               } else if (value.item.type === 'web_search_call') {

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -3,6 +3,129 @@ import { prepareResponsesTools } from './openai-responses-prepare-tools';
 import { describe, it, expect } from 'vitest';
 
 describe('prepareResponsesTools', () => {
+  describe('async tools', () => {
+    it('should pass through async mode for function tools', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'get_weather',
+            description: 'Get the weather',
+            inputSchema: {
+              type: 'object',
+              properties: { city: { type: 'string' } },
+              required: ['city'],
+              additionalProperties: false,
+            },
+            providerOptions: {
+              openai: { async: true },
+            },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: 'Get the weather',
+          parameters: {
+            type: 'object',
+            properties: { city: { type: 'string' } },
+            required: ['city'],
+            additionalProperties: false,
+          },
+          async: true,
+        },
+      ]);
+    });
+
+    it('should pass through async mode for custom tools', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'provider',
+            id: 'openai.custom',
+            name: 'write_sql',
+            args: {
+              name: 'write_sql',
+              description: 'Write a SQL query',
+              async: true,
+              format: { type: 'text' },
+            },
+          },
+        ],
+        toolChoice: undefined,
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'custom',
+          name: 'write_sql',
+          description: 'Write a SQL query',
+          async: true,
+          format: { type: 'text' },
+        },
+      ]);
+    });
+
+    it('should omit async mode and warn for unsupported models', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'get_weather',
+            inputSchema: { type: 'object', properties: {} },
+            providerOptions: {
+              openai: { async: true },
+            },
+          },
+          {
+            type: 'provider',
+            id: 'openai.custom',
+            name: 'write_sql',
+            args: {
+              name: 'write_sql',
+              async: true,
+            },
+          },
+        ],
+        toolChoice: undefined,
+        supportsAsyncToolCalling: false,
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: undefined,
+          parameters: { type: 'object', properties: {} },
+        },
+        {
+          type: 'custom',
+          name: 'write_sql',
+          description: undefined,
+          format: undefined,
+        },
+      ]);
+      expect(result.toolWarnings).toEqual([
+        {
+          type: 'unsupported',
+          feature: 'async tool calling for "get_weather"',
+          details:
+            'Async tool calling is only supported by GPT-6 and later models.',
+        },
+        {
+          type: 'unsupported',
+          feature: 'async tool calling for "write_sql"',
+          details:
+            'Async tool calling is only supported by GPT-6 and later models.',
+        },
+      ]);
+    });
+  });
+
   describe('function tools strict mode', () => {
     it('should pass through strict mode when strict is true', async () => {
       const result = await prepareResponsesTools({

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -24,7 +24,12 @@ type AllowedToolResolution =
   | { supported: true; entry: OpenAIResponsesAllowedTool }
   | { supported: false; reason: string };
 
-type OpenAIToolOptions = {
+export type OpenAIToolOptions = {
+  /**
+   * Whether the model can continue generating after calling this tool without
+   * waiting for its result.
+   */
+  async?: boolean;
   deferLoading?: boolean;
   namespace?: {
     name: string;
@@ -38,6 +43,7 @@ export async function prepareResponsesTools({
   allowedTools,
   toolNameMapping,
   customProviderToolNames,
+  supportsAsyncToolCalling = true,
 }: {
   tools: LanguageModelV3CallOptions['tools'];
   toolChoice: LanguageModelV3CallOptions['toolChoice'] | undefined;
@@ -47,6 +53,7 @@ export async function prepareResponsesTools({
   };
   toolNameMapping?: ToolNameMapping;
   customProviderToolNames?: Set<string>;
+  supportsAsyncToolCalling?: boolean;
 }): Promise<{
   tools?: Array<OpenAIResponsesTool>;
   toolChoice?:
@@ -124,6 +131,12 @@ export async function prepareResponsesTools({
         const openaiFunctionTool = prepareFunctionTool({
           tool,
           options: openaiOptions,
+          async: resolveAsyncToolOption({
+            value: openaiOptions?.async,
+            supportsAsyncToolCalling,
+            toolName: tool.name,
+            toolWarnings,
+          }),
         });
         const namespace = openaiOptions?.namespace;
 
@@ -355,6 +368,14 @@ export async function prepareResponsesTools({
               type: 'custom',
               name: args.name,
               description: args.description,
+              ...(resolveAsyncToolOption({
+                value: args.async,
+                supportsAsyncToolCalling,
+                toolName: args.name,
+                toolWarnings,
+              }) != null
+                ? { async: args.async }
+                : {}),
               format: args.format,
             });
             resolvedCustomProviderToolNames.add(args.name);
@@ -573,9 +594,11 @@ function toAllowedToolResolution(
 function prepareFunctionTool({
   tool,
   options,
+  async,
 }: {
   tool: LanguageModelV3FunctionTool;
   options: OpenAIToolOptions | undefined;
+  async: boolean | undefined;
 }): OpenAIResponsesFunctionTool {
   const deferLoading = options?.deferLoading;
 
@@ -584,9 +607,33 @@ function prepareFunctionTool({
     name: tool.name,
     description: tool.description,
     parameters: tool.inputSchema,
+    ...(async != null ? { async } : {}),
     ...(tool.strict != null ? { strict: tool.strict } : {}),
     ...(deferLoading != null ? { defer_loading: deferLoading } : {}),
   };
+}
+
+function resolveAsyncToolOption({
+  value,
+  supportsAsyncToolCalling,
+  toolName,
+  toolWarnings,
+}: {
+  value: boolean | undefined;
+  supportsAsyncToolCalling: boolean;
+  toolName: string;
+  toolWarnings: SharedV3Warning[];
+}): boolean | undefined {
+  if (value !== true || supportsAsyncToolCalling) {
+    return value;
+  }
+
+  toolWarnings.push({
+    type: 'unsupported',
+    feature: `async tool calling for "${toolName}"`,
+    details: 'Async tool calling is only supported by GPT-6 and later models.',
+  });
+  return undefined;
 }
 
 function mapShellEnvironment(environment: {

--- a/packages/openai/src/responses/openai-responses-provider-metadata.ts
+++ b/packages/openai/src/responses/openai-responses-provider-metadata.ts
@@ -31,6 +31,16 @@ export type OpenaiResponsesProviderMetadata = {
   openai: ResponsesProviderMetadata;
 };
 
+export type ResponsesToolCallProviderMetadata = {
+  itemId: string;
+  async?: boolean;
+  namespace?: string;
+};
+
+export type OpenaiResponsesToolCallProviderMetadata = {
+  openai: ResponsesToolCallProviderMetadata;
+};
+
 export type ResponsesTextProviderMetadata = {
   itemId: string;
   phase?: 'commentary' | 'final_answer' | null;

--- a/packages/openai/src/tool/custom.ts
+++ b/packages/openai/src/tool/custom.ts
@@ -10,6 +10,7 @@ export const customArgsSchema = lazySchema(() =>
     z.object({
       name: z.string(),
       description: z.string().optional(),
+      async: z.boolean().optional(),
       format: z
         .union([
           z.object({
@@ -40,6 +41,12 @@ export const customToolFactory = createProviderToolFactory<
      * An optional description of what the tool does.
      */
     description?: string;
+
+    /**
+     * Whether the model can continue generating after calling this tool
+     * without waiting for its result.
+     */
+    async?: boolean;
 
     /**
      * The output format specification for the tool.


### PR DESCRIPTION
## Background

OpenAI recently added the capability to support async tool calls. After the model sends a tool call object, it can continue sending text response or reasoning, while the application sends the tool result back to the model.

Backport for https://github.com/vercel/ai/pull/20449

## Summary

- support the async parameter on providerOptions for openai tool defs
- added for both function calls and custom tools

## End-to-End Verification

verified by running the examples:
- `examples/ai-functions/src/generate-text/openai/responses-async-tool-calling.ts`
- `examples/ai-functions/src/stream-text/openai/responses-async-tool-calling.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)