### PR TITLE
feat(openai): add async tool calling

### DIFF
--- a/.changeset/quick-tools-wait.md
+++ b/.changeset/quick-tools-wait.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Add async function tool calling support for OpenAI Responses models.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -617,6 +617,55 @@ const result = await generateText({
   specification and cannot be customized. The model can only be
 </Note>
 
+#### Async Tool Calling
+
+GPT-6 Astra and later Responses models support
+[async tool calling](https://developers.openai.com/api/docs/guides/async-tool-calling).
+An async tool lets the model continue generating independent output after issuing
+the call instead of waiting for its result. Your application still executes the
+tool and sends its result in a later request using the original tool call ID.
+
+Enable async calling on a function tool with `providerOptions.openai.async`:
+
+```ts
+import { openai, type OpenAIToolOptions } from '@ai-sdk/openai';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+const result = await generateText({
+  model: openai.responses('gpt-6-astra'),
+  tools: {
+    getWeather: tool({
+      description: 'Get the weather for a city.',
+      inputSchema: z.object({ city: z.string() }),
+      outputSchema: z.object({
+        city: z.string(),
+        temperatureC: z.number(),
+      }),
+      providerOptions: {
+        openai: { async: true } satisfies OpenAIToolOptions,
+      },
+    }),
+  },
+  prompt:
+    'Start the weather lookup for Paris, then list three general packing essentials without waiting.',
+});
+```
+
+The generated tool call exposes the provider marker as
+`providerMetadata.openai.async`. Use `providerMetadata.openai.responseId` as the
+next request's `previousResponseId`, and submit the result in a tool message with
+the original `toolCallId`.
+
+With `streamText`, OpenAI can continue streaming text after the completed
+`tool-call` part. Use the tool's `onInputAvailable` callback to start work as soon
+as that part arrives. If `execute` returns the same already-running promise, tool
+execution overlaps the rest of the model stream. Omit `execute` when the job
+should outlive the current generation and submit its result in a later request.
+
+Async calling applies to directly called function tools. It does not apply to
+hosted tools such as web search or code interpreter.
+
 #### Image Inputs
 
 The OpenAI Responses API supports Image inputs for appropriate models.

--- a/examples/ai-core/src/generate-text/openai-responses-async-tool-calling.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-async-tool-calling.ts
@@ -69,8 +69,9 @@ run(async () => {
     throw new Error('The response did not include the expected weather call.');
   }
 
-  const previousResponseId = firstResult.providerMetadata?.openai
-    ?.responseId as string | undefined;
+  const previousResponseId = firstResult.providerMetadata?.openai?.responseId as
+    | string
+    | undefined;
   if (previousResponseId == null) {
     throw new Error('OpenAI did not return a response ID.');
   }

--- a/examples/ai-core/src/generate-text/openai-responses-async-tool-calling.ts
+++ b/examples/ai-core/src/generate-text/openai-responses-async-tool-calling.ts
@@ -1,0 +1,107 @@
+import {
+  openai,
+  type OpenAIResponsesProviderOptions,
+  type OpenAIToolOptions,
+} from '@ai-sdk/openai';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../lib/run';
+
+const model = openai.responses('gpt-6-astra');
+
+const tools = {
+  get_weather: tool({
+    description: 'Read a demo weather snapshot for a city.',
+    inputSchema: z.object({
+      city: z.string(),
+    }),
+    outputSchema: z.object({
+      city: z.string(),
+      temperatureC: z.number(),
+      condition: z.string(),
+      source: z.string(),
+    }),
+    providerOptions: {
+      openai: {
+        async: true,
+      } satisfies OpenAIToolOptions,
+    },
+  }),
+};
+
+async function getWeather(city: string) {
+  // Simulate an application-managed background job.
+  await new Promise(resolve => setTimeout(resolve, 3_000));
+
+  if (city !== 'Paris') {
+    throw new Error(`No demo weather snapshot for ${city}.`);
+  }
+
+  return {
+    city,
+    temperatureC: 22,
+    condition: 'Clear',
+    source: 'demo weather snapshot',
+  };
+}
+
+run(async () => {
+  const firstResult = await generateText({
+    model,
+    tools,
+    system:
+      'Start the weather lookup and answer the independent packing question ' +
+      'without waiting. Use the demo weather result when it arrives; never invent it.',
+    prompt:
+      'Check the demo weather snapshot for Paris. Meanwhile, list three essentials for any city trip.',
+  });
+
+  console.log('First response content:');
+  console.log(JSON.stringify(firstResult.content, null, 2));
+
+  const call = firstResult.toolCalls[0];
+  if (
+    call == null ||
+    call.dynamic ||
+    call.toolName !== 'get_weather' ||
+    call.input.city !== 'Paris'
+  ) {
+    throw new Error('The response did not include the expected weather call.');
+  }
+
+  const previousResponseId = firstResult.providerMetadata?.openai
+    ?.responseId as string | undefined;
+  if (previousResponseId == null) {
+    throw new Error('OpenAI did not return a response ID.');
+  }
+
+  // The application owns and executes the job. Other conversation turns could
+  // happen before this promise resolves.
+  const weather = await getWeather(call.input.city);
+
+  const finalResult = await generateText({
+    model,
+    tools,
+    messages: [
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: call.toolCallId,
+            toolName: call.toolName,
+            output: { type: 'json', value: weather },
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      openai: {
+        previousResponseId,
+      } satisfies OpenAIResponsesProviderOptions,
+    },
+  });
+
+  console.log('\nFinal response content:');
+  console.log(JSON.stringify(finalResult.content, null, 2));
+});

--- a/examples/ai-core/src/stream-text/openai-responses-async-tool-calling.ts
+++ b/examples/ai-core/src/stream-text/openai-responses-async-tool-calling.ts
@@ -1,0 +1,117 @@
+import {
+  openai,
+  type OpenAIResponsesProviderOptions,
+  type OpenAIToolOptions,
+} from '@ai-sdk/openai';
+import { streamText, tool } from 'ai';
+import { z } from 'zod';
+import { printFullStream } from '../lib/print-full-stream';
+import { run } from '../lib/run';
+
+const model = openai.responses('gpt-6-astra');
+
+async function getWeather(city: string) {
+  // Simulate an application-managed background job.
+  await new Promise(resolve => setTimeout(resolve, 3_000));
+
+  if (city !== 'Paris') {
+    throw new Error(`No demo weather snapshot for ${city}.`);
+  }
+
+  return {
+    city,
+    temperatureC: 22,
+    condition: 'Clear',
+    source: 'demo weather snapshot',
+  };
+}
+
+const weatherJobs = new Map<string, ReturnType<typeof getWeather>>();
+
+const tools = {
+  get_weather: tool({
+    description: 'Read a demo weather snapshot for a city.',
+    inputSchema: z.object({
+      city: z.string(),
+    }),
+    outputSchema: z.object({
+      city: z.string(),
+      temperatureC: z.number(),
+      condition: z.string(),
+      source: z.string(),
+    }),
+    providerOptions: {
+      openai: {
+        async: true,
+      } satisfies OpenAIToolOptions,
+    },
+    onInputAvailable({ input, toolCallId }) {
+      // This runs as soon as the complete streamed tool call arrives. Starting
+      // the promise here lets the job overlap subsequent model output.
+      weatherJobs.set(toolCallId, getWeather(input.city));
+    },
+  }),
+};
+
+run(async () => {
+  const firstResult = streamText({
+    model,
+    tools,
+    system:
+      'Start the weather lookup and answer the independent packing question ' +
+      'without waiting. Use the demo weather result when it arrives; never invent it.',
+    prompt:
+      'Check the demo weather snapshot for Paris. Meanwhile, list three essentials for any city trip.',
+  });
+
+  console.log('First response:');
+  await printFullStream({ result: firstResult });
+
+  const call = (await firstResult.toolCalls)[0];
+  if (
+    call == null ||
+    call.dynamic ||
+    call.toolName !== 'get_weather' ||
+    call.input.city !== 'Paris'
+  ) {
+    throw new Error('The response did not include the expected weather call.');
+  }
+
+  const previousResponseId = (await firstResult.providerMetadata)?.openai
+    ?.responseId as string | undefined;
+  if (previousResponseId == null) {
+    throw new Error('OpenAI did not return a response ID.');
+  }
+
+  const weatherJob = weatherJobs.get(call.toolCallId);
+  if (weatherJob == null) {
+    throw new Error('The weather job was not started.');
+  }
+  const weather = await weatherJob;
+
+  const finalResult = streamText({
+    model,
+    tools,
+    messages: [
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: call.toolCallId,
+            toolName: call.toolName,
+            output: { type: 'json', value: weather },
+          },
+        ],
+      },
+    ],
+    providerOptions: {
+      openai: {
+        previousResponseId,
+      } satisfies OpenAIResponsesProviderOptions,
+    },
+  });
+
+  console.log('\nResponse after the weather job completes:');
+  await printFullStream({ result: finalResult });
+});

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -1,6 +1,11 @@
 export { createOpenAI, openai } from './openai-provider';
 export type { OpenAIProvider, OpenAIProviderSettings } from './openai-provider';
 export type { OpenAIResponsesProviderOptions } from './responses/openai-responses-options';
+export type { OpenAIToolOptions } from './responses/openai-responses-prepare-tools';
+export type {
+  OpenaiResponsesProviderMetadata,
+  OpenaiResponsesToolCallProviderMetadata,
+} from './responses/openai-responses-provider-metadata';
 export type { OpenAIChatLanguageModelOptions } from './chat/openai-chat-options';
 export type {
   OpenAIImageModelOptions,

--- a/packages/openai/src/openai-language-model-capabilities.test.ts
+++ b/packages/openai/src/openai-language-model-capabilities.test.ts
@@ -133,6 +133,22 @@ describe('getOpenAILanguageModelCapabilities', () => {
       ['gpt-5.6', false],
       ['gpt-6-astra', true],
       ['gpt-6.1', true],
+      ['gpt-7', true],
+      ['gpt-99', true],
+      ['custom-model', false],
+    ])(
+      '%s supports async tool calling: %s',
+      (modelId, expectedCapabilities) => {
+        expect(
+          getOpenAILanguageModelCapabilities(modelId).supportsAsyncToolCalling,
+        ).toEqual(expectedCapabilities);
+      },
+    );
+
+    it.each([
+      ['gpt-5.6', false],
+      ['gpt-6-astra', true],
+      ['gpt-6.1', true],
       ['gpt-99', true],
     ])(
       '%s supports configuration updates: %s',

--- a/packages/openai/src/openai-language-model-capabilities.ts
+++ b/packages/openai/src/openai-language-model-capabilities.ts
@@ -4,6 +4,7 @@ export type OpenAILanguageModelCapabilities = {
   supportsFlexProcessing: boolean;
   supportsPriorityProcessing: boolean;
   supportsConfigurationUpdate: boolean;
+  supportsAsyncToolCalling: boolean;
   supportedReasoningEfforts: readonly string[] | undefined;
 
   /**
@@ -57,6 +58,7 @@ export function getOpenAILanguageModelCapabilities(
     supportsFlexProcessing,
     supportsPriorityProcessing,
     supportsConfigurationUpdate: isGpt6OrLaterModel,
+    supportsAsyncToolCalling: isGpt6OrLaterModel,
     supportedReasoningEfforts: isGpt6OrLaterModel
       ? ['low', 'medium', 'high', 'xhigh', 'max']
       : undefined,

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -829,6 +829,43 @@ describe('convertToOpenAIResponsesInput', () => {
       ]);
     });
 
+    it('should round-trip async mode on function tool calls', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool-call',
+                toolCallId: 'call_async',
+                toolName: 'get_weather',
+                input: { location: 'Berlin' },
+                providerOptions: {
+                  openai: {
+                    itemId: 'fc_async',
+                    async: true,
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        systemMessageMode: 'system',
+        store: false,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'function_call',
+          call_id: 'call_async',
+          name: 'get_weather',
+          arguments: JSON.stringify({ location: 'Berlin' }),
+          async: true,
+          id: 'fc_async',
+        },
+      ]);
+    });
+
     it('should convert messages with tool call parts that have ids', async () => {
       const result = await convertToOpenAIResponsesInput({
         prompt: [

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -236,6 +236,9 @@ export async function convertToOpenAIResponsesInput({
               const id = part.providerOptions?.openai?.itemId as
                 | string
                 | undefined;
+              const isAsync = part.providerOptions?.openai?.async as
+                | boolean
+                | undefined;
 
               // item references reduce the payload size
               if (store && id != null) {
@@ -270,6 +273,7 @@ export async function convertToOpenAIResponsesInput({
                 call_id: part.toolCallId,
                 name: part.toolName,
                 arguments: JSON.stringify(part.input),
+                ...(isAsync != null && { async: isAsync }),
                 id,
               });
               break;

--- a/packages/openai/src/responses/openai-responses-api.test.ts
+++ b/packages/openai/src/responses/openai-responses-api.test.ts
@@ -90,6 +90,26 @@ describe('openaiResponses schema alignment', () => {
     expectTypeOf<DoneChunkPhase>().toEqualTypeOf<ResponsePhase>();
   });
 
+  it('aligns async mode between function call schemas', () => {
+    type AddedAsync = Extract<
+      Extract<Chunk, { type: 'response.output_item.added' }>['item'],
+      { type: 'function_call' }
+    >['async'];
+
+    type DoneAsync = Extract<
+      Extract<Chunk, { type: 'response.output_item.done' }>['item'],
+      { type: 'function_call' }
+    >['async'];
+
+    type ResponseAsync = Extract<
+      NonNullable<Response['output']>[number],
+      { type: 'function_call' }
+    >['async'];
+
+    expectTypeOf<AddedAsync>().toEqualTypeOf<DoneAsync>();
+    expectTypeOf<DoneAsync>().toEqualTypeOf<ResponseAsync>();
+  });
+
   it('aligns output_text logprobs', () => {
     type ChunkLogprobs = Extract<
       Chunk,

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -95,6 +95,7 @@ export type OpenAIResponsesFunctionCall = {
   call_id: string;
   name: string;
   arguments: string;
+  async?: boolean;
   id?: string;
 };
 
@@ -205,6 +206,7 @@ export type OpenAIResponsesTool =
       name: string;
       description: string | undefined;
       parameters: JSONSchema7;
+      async?: boolean;
       strict: boolean | undefined;
     }
   | {
@@ -368,6 +370,7 @@ export const openaiResponsesChunkSchema = lazyValidator(() =>
             call_id: z.string(),
             name: z.string(),
             arguments: z.string(),
+            async: z.boolean().nullish(),
           }),
           z.object({
             type: z.literal('web_search_call'),
@@ -424,6 +427,7 @@ export const openaiResponsesChunkSchema = lazyValidator(() =>
             call_id: z.string(),
             name: z.string(),
             arguments: z.string(),
+            async: z.boolean().nullish(),
             status: z.literal('completed'),
           }),
           z.object({
@@ -778,6 +782,7 @@ export const openaiResponsesResponseSchema = lazyValidator(() =>
               name: z.string(),
               arguments: z.string(),
               id: z.string(),
+              async: z.boolean().nullish(),
             }),
             z.object({
               type: z.literal('computer_call'),

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2668,6 +2668,77 @@ describe('OpenAIResponsesLanguageModel', () => {
 
         expect(result.finishReason).toStrictEqual('tool-calls');
       });
+
+      it('should gate async tools to GPT-6 and later models', async () => {
+        const asyncTools: Array<LanguageModelV2FunctionTool> = [
+          {
+            ...TEST_TOOLS[0],
+            providerOptions: {
+              openai: { async: true },
+            },
+          },
+        ];
+
+        const unsupportedResult = await createModel('gpt-5.6').doGenerate({
+          prompt: TEST_PROMPT,
+          tools: asyncTools,
+        });
+        const unsupportedBody = (await server.calls[0].requestBodyJson) as {
+          tools: Array<{ async?: boolean }>;
+        };
+
+        expect(unsupportedBody.tools[0].async).toBeUndefined();
+        expect(unsupportedResult.warnings).toContainEqual({
+          type: 'unsupported-tool',
+          tool: asyncTools[0],
+          details:
+            'Async tool calling is only supported by GPT-6 and later models.',
+        });
+
+        await createModel('gpt-99').doGenerate({
+          prompt: TEST_PROMPT,
+          tools: asyncTools,
+        });
+        const supportedBody = (await server.calls[1].requestBodyJson) as {
+          tools: Array<{ async?: boolean }>;
+        };
+
+        expect(supportedBody.tools[0].async).toBe(true);
+      });
+
+      it('should preserve async mode on function_call output', async () => {
+        server.urls['https://api.openai.com/v1/responses'].response = {
+          type: 'json-value',
+          body: {
+            id: 'resp_async',
+            created_at: 1,
+            model: 'gpt-6-astra',
+            output: [
+              {
+                type: 'function_call',
+                id: 'fc_async_1',
+                call_id: 'call_async_1',
+                name: 'weather',
+                arguments: '{"location":"NYC"}',
+                status: 'completed',
+                async: true,
+              },
+            ],
+            usage: { input_tokens: 1, output_tokens: 2 },
+          },
+        };
+
+        const result = await createModel('gpt-6-astra').doGenerate({
+          prompt: TEST_PROMPT,
+          tools: TEST_TOOLS,
+        });
+
+        const toolCall = result.content.find(p => p.type === 'tool-call');
+        expect(toolCall?.providerMetadata?.openai).toMatchObject({
+          itemId: 'fc_async_1',
+          async: true,
+        });
+      });
     });
 
     describe('code interpreter tool', () => {
@@ -3849,6 +3920,69 @@ describe('OpenAIResponsesLanguageModel', () => {
           },
         ]
       `);
+    });
+
+    it('should preserve async mode on streamed function calls', async () => {
+      const functionCall = {
+        id: 'fc_async',
+        type: 'function_call',
+        name: 'weather',
+        call_id: 'call_async',
+        arguments: '{"location":"Berlin"}',
+        status: 'completed',
+        async: true,
+      };
+
+      server.urls['https://api.openai.com/v1/responses'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: ${JSON.stringify({
+            type: 'response.created',
+            response: {
+              id: 'response_async',
+              created_at: 1,
+              model: 'gpt-6-astra',
+            },
+          })}\n\n`,
+          `data: ${JSON.stringify({
+            type: 'response.output_item.added',
+            output_index: 0,
+            item: { ...functionCall, arguments: '', status: 'in_progress' },
+          })}\n\n`,
+          `data: ${JSON.stringify({
+            type: 'response.output_item.done',
+            output_index: 0,
+            item: functionCall,
+          })}\n\n`,
+          `data: ${JSON.stringify({
+            type: 'response.completed',
+            response: {
+              incomplete_details: null,
+              output: [functionCall],
+              usage: { input_tokens: 1, output_tokens: 2 },
+            },
+          })}\n\n`,
+        ],
+      };
+
+      const { stream } = await createModel('gpt-6-astra').doStream({
+        prompt: TEST_PROMPT,
+        tools: TEST_TOOLS,
+      });
+
+      const events = await convertReadableStreamToArray(stream);
+      expect(events.find(event => event.type === 'tool-call')).toMatchObject({
+        type: 'tool-call',
+        toolCallId: 'call_async',
+        toolName: 'weather',
+        input: '{"location":"Berlin"}',
+        providerMetadata: {
+          openai: {
+            itemId: 'fc_async',
+            async: true,
+          },
+        },
+      });
     });
 
     it('Should handle service tier', async () => {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -47,7 +47,10 @@ import {
 } from './openai-responses-options';
 import { prepareResponsesTools } from './openai-responses-prepare-tools';
 import { getOpenAILanguageModelCapabilities } from '../openai-language-model-capabilities';
-import type { ResponsesUsageProviderMetadata } from './openai-responses-provider-metadata';
+import type {
+  ResponsesToolCallProviderMetadata,
+  ResponsesUsageProviderMetadata,
+} from './openai-responses-provider-metadata';
 
 export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
   readonly specificationVersion = 'v2';
@@ -438,6 +441,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       tools,
       toolChoice,
       strictJsonSchema,
+      supportsAsyncToolCalling: modelCapabilities.supportsAsyncToolCalling,
     });
 
     return {
@@ -666,7 +670,8 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
             providerMetadata: {
               [providerKey]: {
                 itemId: part.id,
-              },
+                ...(part.async != null && { async: part.async }),
+              } satisfies ResponsesToolCallProviderMetadata,
             },
           });
           break;
@@ -867,6 +872,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       | {
           toolName: string;
           toolCallId: string;
+          async?: boolean | null;
           codeInterpreter?: {
             containerId: string;
           };
@@ -930,6 +936,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                 ongoingToolCalls[value.output_index] = {
                   toolName: value.item.name,
                   toolCallId: value.item.call_id,
+                  async: value.item.async,
                 };
 
                 controller.enqueue({
@@ -1065,6 +1072,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                   },
                 });
               } else if (value.item.type === 'function_call') {
+                const ongoingToolCall = ongoingToolCalls[value.output_index];
                 ongoingToolCalls[value.output_index] = undefined;
                 hasFunctionCall = true;
 
@@ -1081,7 +1089,12 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                   providerMetadata: {
                     [providerKey]: {
                       itemId: value.item.id,
-                    },
+                      ...(value.item.async != null
+                        ? { async: value.item.async }
+                        : ongoingToolCall?.async != null
+                          ? { async: ongoingToolCall.async }
+                          : {}),
+                    } satisfies ResponsesToolCallProviderMetadata,
                   },
                 });
               } else if (value.item.type === 'web_search_call') {

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -2,6 +2,83 @@ import { prepareResponsesTools } from './openai-responses-prepare-tools';
 import { describe, it, expect } from 'vitest';
 
 describe('prepareResponsesTools', () => {
+  describe('async tools', () => {
+    it('should pass through async mode for function tools', async () => {
+      const result = await prepareResponsesTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'get_weather',
+            description: 'Get the weather',
+            inputSchema: {
+              type: 'object',
+              properties: { city: { type: 'string' } },
+              required: ['city'],
+              additionalProperties: false,
+            },
+            providerOptions: {
+              openai: { async: true },
+            },
+          },
+        ],
+        toolChoice: undefined,
+        strictJsonSchema: false,
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: 'Get the weather',
+          parameters: {
+            type: 'object',
+            properties: { city: { type: 'string' } },
+            required: ['city'],
+            additionalProperties: false,
+          },
+          strict: false,
+          async: true,
+        },
+      ]);
+    });
+
+    it('should omit async mode and warn for unsupported models', async () => {
+      const functionTool = {
+        type: 'function' as const,
+        name: 'get_weather',
+        inputSchema: { type: 'object' as const, properties: {} },
+        providerOptions: {
+          openai: { async: true },
+        },
+      };
+
+      const result = await prepareResponsesTools({
+        tools: [functionTool],
+        toolChoice: undefined,
+        strictJsonSchema: false,
+        supportsAsyncToolCalling: false,
+      });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: undefined,
+          parameters: { type: 'object', properties: {} },
+          strict: false,
+        },
+      ]);
+      expect(result.toolWarnings).toEqual([
+        {
+          type: 'unsupported-tool',
+          tool: functionTool,
+          details:
+            'Async tool calling is only supported by GPT-6 and later models.',
+        },
+      ]);
+    });
+  });
+
   describe('code interpreter', () => {
     it('should prepare code interpreter tool with no container (auto mode)', async () => {
       const result = await prepareResponsesTools({

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -1,6 +1,7 @@
 import {
   type LanguageModelV2CallOptions,
   type LanguageModelV2CallWarning,
+  type LanguageModelV2FunctionTool,
   UnsupportedFunctionalityError,
 } from '@ai-sdk/provider';
 import { codeInterpreterArgsSchema } from '../tool/code-interpreter';
@@ -11,14 +12,24 @@ import { imageGenerationArgsSchema } from '../tool/image-generation';
 import type { OpenAIResponsesTool } from './openai-responses-api';
 import { validateTypes } from '@ai-sdk/provider-utils';
 
+export type OpenAIToolOptions = {
+  /**
+   * Whether the model can continue generating after calling this tool without
+   * waiting for its result.
+   */
+  async?: boolean;
+};
+
 export async function prepareResponsesTools({
   tools,
   toolChoice,
   strictJsonSchema,
+  supportsAsyncToolCalling = true,
 }: {
   tools: LanguageModelV2CallOptions['tools'];
   toolChoice?: LanguageModelV2CallOptions['toolChoice'];
   strictJsonSchema: boolean;
+  supportsAsyncToolCalling?: boolean;
 }): Promise<{
   tools?: Array<OpenAIResponsesTool>;
   toolChoice?:
@@ -46,15 +57,27 @@ export async function prepareResponsesTools({
 
   for (const tool of tools) {
     switch (tool.type) {
-      case 'function':
+      case 'function': {
+        const openaiOptions = tool.providerOptions?.openai as
+          | OpenAIToolOptions
+          | undefined;
+        const async = resolveAsyncToolOption({
+          value: openaiOptions?.async,
+          supportsAsyncToolCalling,
+          tool,
+          toolWarnings,
+        });
+
         openaiTools.push({
           type: 'function',
           name: tool.name,
           description: tool.description,
           parameters: tool.inputSchema,
           strict: strictJsonSchema,
+          ...(async != null ? { async } : {}),
         });
         break;
+      }
       case 'provider-defined': {
         switch (tool.id) {
           case 'openai.file_search': {
@@ -198,4 +221,27 @@ export async function prepareResponsesTools({
       });
     }
   }
+}
+
+function resolveAsyncToolOption({
+  value,
+  supportsAsyncToolCalling,
+  tool,
+  toolWarnings,
+}: {
+  value: boolean | undefined;
+  supportsAsyncToolCalling: boolean;
+  tool: LanguageModelV2FunctionTool;
+  toolWarnings: LanguageModelV2CallWarning[];
+}): boolean | undefined {
+  if (value !== true || supportsAsyncToolCalling) {
+    return value;
+  }
+
+  toolWarnings.push({
+    type: 'unsupported-tool',
+    tool,
+    details: 'Async tool calling is only supported by GPT-6 and later models.',
+  });
+  return undefined;
 }

--- a/packages/openai/src/responses/openai-responses-provider-metadata.ts
+++ b/packages/openai/src/responses/openai-responses-provider-metadata.ts
@@ -43,6 +43,15 @@ export type OpenaiResponsesProviderMetadata = {
   openai: ResponsesProviderMetadata;
 };
 
+export type ResponsesToolCallProviderMetadata = {
+  itemId: string;
+  async?: boolean;
+};
+
+export type OpenaiResponsesToolCallProviderMetadata = {
+  openai: ResponsesToolCallProviderMetadata;
+};
+
 export type ResponsesTextProviderMetadata = {
   itemId: string;
   phase?: 'commentary' | 'final_answer' | null;


### PR DESCRIPTION
## Background

OpenAI recently added the capability to support async tool calls. After the model sends a tool call object, it can continue sending text response or reasoning, while the application sends the tool result back to the model.

Backport for https://github.com/vercel/ai/pull/20449 and https://github.com/vercel/ai/pull/20450

## Summary

- support the async parameter on providerOptions for openai tool defs
- added for both function calls and custom tools

## End-to-End Verification

verified by running the examples:
- `examples/ai-functions/src/generate-text/openai/responses-async-tool-calling.ts`
- `examples/ai-functions/src/stream-text/openai/responses-async-tool-calling.ts`

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)