### PR TITLE
feat(nebul): add Nebul provider package (@ai-sdk/nebul) (#20445)

### DIFF
--- a/.changeset/add-nebul-provider.md
+++ b/.changeset/add-nebul-provider.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/nebul': patch
+---
+
+Add Nebul provider package (`@ai-sdk/nebul`) for sovereign open-weight model inference.

--- a/content/providers/01-ai-sdk-providers/110-nebul.mdx
+++ b/content/providers/01-ai-sdk-providers/110-nebul.mdx
@@ -1,0 +1,68 @@
+---
+title: Nebul
+description: Learn how to use Nebul models with the AI SDK.
+---
+
+# Nebul Provider
+
+The [Nebul](https://nebul.io) provider offers access to open-weight language models through Nebul's sovereign GPU inference platform over an OpenAI-compatible API.
+
+API keys can be obtained from your [Nebul console](https://nebul.io).
+
+## Setup
+
+The Nebul provider is available via the `@ai-sdk/nebul` module. You can install it with:
+
+<InstallPackages packages="@ai-sdk/nebul" />
+
+## Provider Instance
+
+You can import the default provider instance `nebul` from `@ai-sdk/nebul`:
+
+```ts
+import { nebul } from '@ai-sdk/nebul';
+```
+
+For custom configuration, you can import `createNebul` and create a provider instance with your settings:
+
+```ts
+import { createNebul } from '@ai-sdk/nebul';
+
+const nebul = createNebul({
+  apiKey: process.env.NEBUL_API_KEY ?? '',
+});
+```
+
+You can use the following optional settings to customize the Nebul provider instance:
+
+- **baseURL** _string_
+
+  Use a different URL prefix for API calls.
+  The default prefix is `https://api.inference.nebul.io/v1`.
+
+- **apiKey** _string_
+
+  API key that is being sent using the `Authorization` header. It defaults to
+  the `NEBUL_API_KEY` environment variable.
+
+- **headers** _Record&lt;string,string&gt;_
+
+  Custom headers to include in the requests.
+
+- **fetch** _FetchFunction_
+
+  Custom fetch implementation.
+
+## Language Models
+
+```ts
+import { nebul } from '@ai-sdk/nebul';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: nebul('mistralai/Mistral-7B-Instruct-v0.3'),
+  prompt: 'What is the capital of France?',
+});
+```
+
+Nebul serves an evolving catalog of open-weight models over chat completions, so model ids are typed as `string`. Embedding and image models are not supported.

--- a/contributing/packages.md
+++ b/contributing/packages.md
@@ -31,6 +31,7 @@ When adding new packages under `packages`, please ensure they are added to `/tsc
 | `perplexity`        | `@ai-sdk/perplexity`        | Perplexity                  |
 | `replicate`         | `@ai-sdk/replicate`         | Replicate                   |
 | `togetherai`        | `@ai-sdk/togetherai`        | Together AI                 |
+| `nebul`             | `@ai-sdk/nebul`             | Nebul                       |
 | `xai`               | `@ai-sdk/xai`               | xAI (Grok)                  |
 | `gateway`           | `@ai-sdk/gateway`           | AI Gateway                  |
 | `openai-compatible` | `@ai-sdk/openai-compatible` | OpenAI-compatible providers |

--- a/examples/ai-functions/package.json
+++ b/examples/ai-functions/package.json
@@ -52,6 +52,7 @@
     "@ai-sdk/minimax": "workspace:*",
     "@ai-sdk/mistral": "workspace:*",
     "@ai-sdk/moonshotai": "workspace:*",
+    "@ai-sdk/nebul": "workspace:*",
     "@ai-sdk/open-responses": "workspace:*",
     "@ai-sdk/openai": "workspace:*",
     "@ai-sdk/openai-compatible": "workspace:*",

--- a/examples/ai-functions/src/generate-text/nebul/basic.ts
+++ b/examples/ai-functions/src/generate-text/nebul/basic.ts
@@ -1,0 +1,14 @@
+import { nebul } from '@ai-sdk/nebul';
+import { generateText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { text, usage } = await generateText({
+    model: nebul('mistralai/Mistral-7B-Instruct-v0.3'),
+    prompt: 'What is notable about Sonoran food? Answer in a few sentences.',
+  });
+
+  console.log(text);
+  console.log();
+  console.log('Token usage:', usage);
+});

--- a/examples/ai-functions/src/stream-text/nebul/basic.ts
+++ b/examples/ai-functions/src/stream-text/nebul/basic.ts
@@ -1,0 +1,14 @@
+import { nebul } from '@ai-sdk/nebul';
+import { streamText } from 'ai';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = streamText({
+    model: nebul('mistralai/Mistral-7B-Instruct-v0.3'),
+    prompt: 'Invent a new holiday and describe its traditions.',
+  });
+
+  for await (const textPart of result.textStream) {
+    process.stdout.write(textPart);
+  }
+});

--- a/examples/ai-functions/tsconfig.json
+++ b/examples/ai-functions/tsconfig.json
@@ -166,6 +166,9 @@
       "path": "../../packages/moonshotai"
     },
     {
+      "path": "../../packages/nebul"
+    },
+    {
       "path": "../../packages/open-responses"
     },
     {

--- a/packages/nebul/CHANGELOG.md
+++ b/packages/nebul/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ai-sdk/nebul
+
+## 1.0.0
+
+### Major Changes
+
+- Initial release of `@ai-sdk/nebul` provider package.

--- a/packages/nebul/README.md
+++ b/packages/nebul/README.md
@@ -1,0 +1,43 @@
+# AI SDK - Nebul Provider
+
+The **Nebul provider** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for [Nebul](https://nebul.io), offering sovereign GPU inference for open-weight models over an OpenAI-compatible API.
+
+## Setup
+
+The Nebul provider is available in the `@ai-sdk/nebul` module. You can install it with:
+
+```bash
+npm i @ai-sdk/nebul
+```
+
+## Provider Instance
+
+You can import the default provider instance `nebul` from `@ai-sdk/nebul`:
+
+```ts
+import { nebul } from '@ai-sdk/nebul';
+```
+
+The Nebul API key is read from the `NEBUL_API_KEY` environment variable by default. For custom configuration, use `createNebul`:
+
+```ts
+import { createNebul } from '@ai-sdk/nebul';
+
+const nebul = createNebul({
+  apiKey: process.env.NEBUL_API_KEY ?? '',
+});
+```
+
+## Language Models
+
+```ts
+import { nebul } from '@ai-sdk/nebul';
+import { generateText } from 'ai';
+
+const { text } = await generateText({
+  model: nebul('mistralai/Mistral-7B-Instruct-v0.3'),
+  prompt: 'What is the capital of France?',
+});
+```
+
+Nebul serves an evolving catalog of open-weight models over chat completions, so model ids are typed as `string`. Embedding and image models are not supported.

--- a/packages/nebul/package.json
+++ b/packages/nebul/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "@ai-sdk/nebul",
+  "version": "1.0.0",
+  "type": "module",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "docs/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "!src/**/__snapshots__",
+    "!src/**/__fixtures__",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "directories": {
+    "doc": "./docs"
+  },
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist docs *.tsbuildinfo",
+    "prepack": "mkdir -p docs && cp ../../content/providers/01-ai-sdk-providers/110-nebul.mdx ./docs/",
+    "postpack": "del-cli docs",
+    "type-check": "tsc --build",
+    "test": "pnpm test:node && pnpm test:edge",
+    "test:update": "pnpm test:node -u",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:edge": "vitest --config vitest.edge.config.js --run",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ai-sdk/openai-compatible": "workspace:*",
+    "@ai-sdk/provider": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.19",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "5.8.3",
+    "zod": "3.25.76"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/nebul"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai"
+  ],
+  "description": "The **Nebul provider** for the [AI SDK](https://ai-sdk.dev/docs) contains language model support for [Nebul](https://nebul.io), offering sovereign AI inference for open-weight models over an OpenAI-compatible API."
+}

--- a/packages/nebul/src/index.ts
+++ b/packages/nebul/src/index.ts
@@ -1,0 +1,4 @@
+export { createNebul, nebul } from './nebul-provider';
+export type { NebulProvider, NebulProviderSettings } from './nebul-provider';
+export type { NebulChatModelId } from './nebul-chat-options';
+export { VERSION } from './version';

--- a/packages/nebul/src/nebul-chat-language-model.test.ts
+++ b/packages/nebul/src/nebul-chat-language-model.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createNebul } from './nebul-provider';
+
+describe('NebulChatLanguageModel', () => {
+  it('passes expected configuration to chat completions', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'chatcmpl-123',
+          object: 'chat.completion',
+          created: 1677652288,
+          model: 'mistralai/Mistral-7B-Instruct-v0.3',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: 'Hello World',
+              },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: {
+            prompt_tokens: 9,
+            completion_tokens: 12,
+            total_tokens: 21,
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+
+    const model = createNebul({ apiKey: 'test-key', fetch: fetchMock })(
+      'mistralai/Mistral-7B-Instruct-v0.3',
+    );
+
+    const result = await model.doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+    });
+
+    expect(result.content[0]).toEqual({ type: 'text', text: 'Hello World' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.inference.nebul.io/v1/chat/completions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          authorization: 'Bearer test-key',
+        }),
+      }),
+    );
+  });
+});

--- a/packages/nebul/src/nebul-chat-language-model.ts
+++ b/packages/nebul/src/nebul-chat-language-model.ts
@@ -1,0 +1,31 @@
+import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
+import type { LanguageModelV4 } from '@ai-sdk/provider';
+import {
+  serializeModelOptions,
+  WORKFLOW_DESERIALIZE,
+  WORKFLOW_SERIALIZE,
+} from '@ai-sdk/provider-utils';
+import type { NebulChatModelId } from './nebul-chat-options';
+
+type NebulChatConfig = ConstructorParameters<
+  typeof OpenAICompatibleChatLanguageModel
+>[1];
+
+export class NebulChatLanguageModel
+  extends OpenAICompatibleChatLanguageModel
+  implements LanguageModelV4
+{
+  static [WORKFLOW_SERIALIZE](model: NebulChatLanguageModel) {
+    return serializeModelOptions({
+      modelId: model.modelId,
+      config: model.config,
+    });
+  }
+
+  static [WORKFLOW_DESERIALIZE](options: {
+    modelId: NebulChatModelId;
+    config: NebulChatConfig;
+  }) {
+    return new NebulChatLanguageModel(options.modelId, options.config);
+  }
+}

--- a/packages/nebul/src/nebul-chat-options.ts
+++ b/packages/nebul/src/nebul-chat-options.ts
@@ -1,0 +1,6 @@
+export type NebulChatModelId =
+  | 'mistralai/Mistral-7B-Instruct-v0.3'
+  | 'meta-llama/Meta-Llama-3.1-8B-Instruct'
+  | 'Qwen/Qwen2.5-72B-Instruct'
+  | 'deepseek-ai/DeepSeek-R1'
+  | (string & {});

--- a/packages/nebul/src/nebul-provider.test.ts
+++ b/packages/nebul/src/nebul-provider.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { createNebul } from './nebul-provider';
+import { loadApiKey } from '@ai-sdk/provider-utils';
+import { OpenAICompatibleChatLanguageModel } from '@ai-sdk/openai-compatible';
+
+const OpenAICompatibleChatLanguageModelMock =
+  OpenAICompatibleChatLanguageModel as unknown as Mock;
+
+vi.mock('@ai-sdk/openai-compatible', () => ({
+  OpenAICompatibleChatLanguageModel: vi.fn(),
+}));
+
+vi.mock('./version', () => ({
+  VERSION: '0.0.0-test',
+}));
+
+vi.mock('@ai-sdk/provider-utils', async () => {
+  const actual = await vi.importActual('@ai-sdk/provider-utils');
+  return {
+    ...actual,
+    loadApiKey: vi.fn().mockReturnValue('mock-api-key'),
+    withoutTrailingSlash: vi.fn(url => url),
+  };
+});
+
+describe('createNebul', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults to the Nebul endpoint and NEBUL_API_KEY', () => {
+    const provider = createNebul();
+    provider('mistralai/Mistral-7B-Instruct-v0.3');
+
+    const config = OpenAICompatibleChatLanguageModelMock.mock.calls[0][1];
+    const headers = config.headers!();
+
+    expect(config.provider).toBe('nebul.chat');
+    expect(config.url({ path: '/chat/completions' })).toBe(
+      'https://api.inference.nebul.io/v1/chat/completions',
+    );
+    expect(loadApiKey).toHaveBeenCalledWith(
+      expect.objectContaining({ environmentVariableName: 'NEBUL_API_KEY' }),
+    );
+    expect(headers).toEqual(
+      expect.objectContaining({
+        authorization: 'Bearer mock-api-key',
+        'user-agent': 'ai-sdk/nebul/0.0.0-test',
+      }),
+    );
+  });
+
+  it('respects a custom baseURL', () => {
+    const provider = createNebul({
+      baseURL: 'https://custom.nebul.endpoint/v1',
+    });
+    provider('model');
+
+    const config = OpenAICompatibleChatLanguageModelMock.mock.calls[0][1];
+    expect(config.url({ path: '/chat/completions' })).toBe(
+      'https://custom.nebul.endpoint/v1/chat/completions',
+    );
+  });
+
+  it('throws NoSuchModelError for embedding and image models', () => {
+    const provider = createNebul();
+    expect(() => provider.embeddingModel('model')).toThrow(/embeddingModel/);
+    expect(() => provider.imageModel('model')).toThrow(/imageModel/);
+  });
+});

--- a/packages/nebul/src/nebul-provider.ts
+++ b/packages/nebul/src/nebul-provider.ts
@@ -1,0 +1,105 @@
+import {
+  NoSuchModelError,
+  type LanguageModelV4,
+  type ProviderV4,
+} from '@ai-sdk/provider';
+import {
+  loadApiKey,
+  withoutTrailingSlash,
+  withUserAgentSuffix,
+  type FetchFunction,
+} from '@ai-sdk/provider-utils';
+import { NebulChatLanguageModel } from './nebul-chat-language-model';
+import type { NebulChatModelId } from './nebul-chat-options';
+import { VERSION } from './version';
+
+export interface NebulProviderSettings {
+  /**
+   * Nebul API key. Defaults to the `NEBUL_API_KEY` environment variable.
+   */
+  apiKey?: string;
+  /**
+   * Base URL for the API calls. Defaults to
+   * `https://api.inference.nebul.io/v1`.
+   */
+  baseURL?: string;
+  /**
+   * Custom headers to include in the requests.
+   */
+  headers?: Record<string, string>;
+  /**
+   * Custom fetch implementation. You can use it as a middleware to intercept
+   * requests, or to provide a custom fetch implementation for e.g. testing.
+   */
+  fetch?: FetchFunction;
+}
+
+export interface NebulProvider extends ProviderV4 {
+  /**
+   * Creates a Nebul model for text generation.
+   */
+  (modelId: NebulChatModelId): LanguageModelV4;
+
+  /**
+   * Creates a Nebul model for text generation.
+   */
+  languageModel(modelId: NebulChatModelId): LanguageModelV4;
+
+  /**
+   * Creates a Nebul chat model for text generation.
+   */
+  chat(modelId: NebulChatModelId): LanguageModelV4;
+
+  /**
+   * @deprecated Use `embeddingModel` instead.
+   */
+  textEmbeddingModel(modelId: string): never;
+}
+
+export function createNebul(
+  options: NebulProviderSettings = {},
+): NebulProvider {
+  const baseURL = withoutTrailingSlash(
+    options.baseURL ?? 'https://api.inference.nebul.io/v1',
+  );
+  const getHeaders = () =>
+    withUserAgentSuffix(
+      {
+        Authorization: `Bearer ${loadApiKey({
+          apiKey: options.apiKey,
+          environmentVariableName: 'NEBUL_API_KEY',
+          description: 'Nebul API key',
+        })}`,
+        ...options.headers,
+      },
+      `ai-sdk/nebul/${VERSION}`,
+    );
+
+  const createLanguageModel = (modelId: NebulChatModelId) => {
+    return new NebulChatLanguageModel(modelId, {
+      provider: `nebul.chat`,
+      url: ({ path }) => `${baseURL}${path}`,
+      headers: getHeaders,
+      fetch: options.fetch,
+      supportsStructuredOutputs: true,
+    });
+  };
+
+  const provider = (modelId: NebulChatModelId) => createLanguageModel(modelId);
+
+  provider.specificationVersion = 'v4' as const;
+  provider.languageModel = createLanguageModel;
+  provider.chat = createLanguageModel;
+
+  provider.embeddingModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
+  };
+  provider.textEmbeddingModel = provider.embeddingModel;
+  provider.imageModel = (modelId: string) => {
+    throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
+  };
+
+  return provider;
+}
+
+export const nebul = createNebul();

--- a/packages/nebul/src/version.ts
+++ b/packages/nebul/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/nebul/tsconfig.build.json
+++ b/packages/nebul/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Disable project configuration for tsup builds
+    "composite": false
+  }
+}

--- a/packages/nebul/tsconfig.json
+++ b/packages/nebul/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": ["dist", "build", "node_modules", "tsup.config.ts"],
+  "references": [
+    {
+      "path": "../openai-compatible"
+    },
+    {
+      "path": "../provider"
+    },
+    {
+      "path": "../provider-utils"
+    }
+  ]
+}

--- a/packages/nebul/tsup.config.ts
+++ b/packages/nebul/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(
+        (await import('./package.json', { with: { type: 'json' } })).default
+          .version,
+      ),
+    },
+  },
+]);

--- a/packages/nebul/turbo.json
+++ b/packages/nebul/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["**/dist/**"]
+    }
+  }
+}

--- a/packages/nebul/vitest.edge.config.js
+++ b/packages/nebul/vitest.edge.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'edge-runtime',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/packages/nebul/vitest.node.config.js
+++ b/packages/nebul/vitest.node.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import packageJson from './package.json';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,6 +456,9 @@ importers:
       '@ai-sdk/moonshotai':
         specifier: workspace:*
         version: link:../../packages/moonshotai
+      '@ai-sdk/nebul':
+        specifier: workspace:*
+        version: link:../../packages/nebul
       '@ai-sdk/open-responses':
         specifier: workspace:*
         version: link:../../packages/open-responses
@@ -3524,6 +3527,34 @@ importers:
       '@ai-sdk/test-server':
         specifier: workspace:*
         version: link:../test-server
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.26)(supports-color@10.2.2)(tsx@4.23.12)(typescript@5.8.3)(yaml@2.9.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
+  packages/nebul:
+    dependencies:
+      '@ai-sdk/openai-compatible':
+        specifier: workspace:*
+        version: link:../openai-compatible
+      '@ai-sdk/provider':
+        specifier: workspace:*
+        version: link:../provider
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+    devDependencies:
       '@types/node':
         specifier: 22.19.19
         version: 22.19.19

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -157,6 +157,9 @@
       "path": "packages/moonshotai"
     },
     {
+      "path": "packages/nebul"
+    },
+    {
       "path": "packages/open-responses"
     },
     {


### PR DESCRIPTION
## Background

Users requested out-of-the-box support for Nebul ([nebul.io](https://nebul.io)) to easily run sovereign open-weight language models via standard AI SDK functions without needing to manually construct an OpenAI-compatible provider.

## Summary

This PR adds a dedicated `@ai-sdk/nebul` first-party provider package:

- **`packages/nebul`**:
  - Implemented `createNebul` provider factory and default `nebul` instance in `nebul-provider.ts`.
  - Configured default base URL `https://api.inference.nebul.io/v1` and environment variable `NEBUL_API_KEY`.
  - Implemented `NebulChatLanguageModel` extending `OpenAICompatibleChatLanguageModel` with workflow serialization (`WORKFLOW_SERIALIZE` / `WORKFLOW_DESERIALIZE`).
  - Added `NebulChatModelId` type for common open-weight models (`mistralai/Mistral-7B-Instruct-v0.3`, `meta-llama/Meta-Llama-3.1-8B-Instruct`, `Qwen/Qwen2.5-72B-Instruct`, `deepseek-ai/DeepSeek-R1`, etc.) as well as `(string & {})`.
  - Added unit test suites covering default endpoints, authentication header formatting, custom settings, and error handling for unsupported model types (`embeddingModel`, `imageModel`).
- **Documentation**:
  - Added official provider documentation at `content/providers/01-ai-sdk-providers/110-nebul.mdx`.
  - Updated AI/LLM Providers matrix table in `contributing/packages.md`.
- **Examples & Tooling**:
  - Added `generateText` and `streamText` example scripts in `examples/ai-functions`.
  - Added `packages/nebul` reference to `/tsconfig.json` and `examples/ai-functions/tsconfig.json`.
  - Added changeset for `@ai-sdk/nebul` patch release.

## Contributor Credit

- `@wynandhuizinga` for reporting issue #20445.

## End-to-End Verification

- **Unit Tests**: Verified with Vitest in both Node.js (`pnpm test:node`) and Edge Runtime (`pnpm test:edge`) environments (`4/4` tests passing).
- **Type Check**: Verified workspace type-checking (`pnpm --filter @ai-sdk/nebul type-check`).
- **Build**: Verified ESM and declaration generation via `tsup` (`pnpm --filter @ai-sdk/nebul build`).

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #20445