### PR TITLE
feat(gateway): support provider timeouts for system credentials

### DIFF
--- a/.changeset/tidy-gateways-wait.md
+++ b/.changeset/tidy-gateways-wait.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+feat(gateway): support provider timeouts for system credentials

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -1376,9 +1376,11 @@ The following gateway provider options are available:
 
 - **providerTimeouts** _object_
 
-  Per-provider timeouts for BYOK credentials in milliseconds. Controls how long to wait for a provider to start responding before falling back to the next available provider.
+  Per-provider timeouts in milliseconds. Use `byok` for your own credentials and `system` for AI Gateway's system credentials. Both maps are optional and use provider slugs as keys. Values in both maps must be between 1,000 and 789,000 milliseconds.
 
-  Example: `providerTimeouts: { byok: { openai: 5000, anthropic: 2000 } }`
+  For streaming requests, the timeout ends when the first stream chunk arrives. For non-streaming requests, it runs until the provider returns the complete response. A timeout allows fallback to the next available provider before streaming starts. After streaming starts, a timeout may terminate the stream without falling back.
+
+  Example: `providerTimeouts: { byok: { openai: 5000, anthropic: 2000 }, system: { openai: 1000, anthropic: 10000 } }`
 
   For full details, see [Provider Timeouts](https://vercel.com/docs/ai-gateway/models-and-providers/provider-timeouts).
 

--- a/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
+++ b/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx
@@ -1376,9 +1376,9 @@ The following gateway provider options are available:
 
 - **providerTimeouts** _object_
 
-  Per-provider timeouts in milliseconds. Use `byok` for your own credentials and `system` for AI Gateway's system credentials. Both maps are optional and use provider slugs as keys. Values in both maps must be between 1,000 and 789,000 milliseconds.
+  Per-provider timeouts in milliseconds. Use `byok` for your own credentials and `system` for AI Gateway's system credentials. Both maps are optional and use provider slugs as keys. Values in both maps must be integers of at least 1,000 milliseconds.
 
-  For streaming requests, the timeout ends when the first stream chunk arrives. For non-streaming requests, it runs until the provider returns the complete response. A timeout allows fallback to the next available provider before streaming starts. After streaming starts, a timeout may terminate the stream without falling back.
+  For streaming requests, the timeout is cleared when the first provider stream chunk arrives. For non-streaming requests, it runs until the provider returns the complete response. AI Gateway's overall request deadline still applies.
 
   Example: `providerTimeouts: { byok: { openai: 5000, anthropic: 2000 }, system: { openai: 1000, anthropic: 10000 } }`
 

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -7,6 +7,7 @@ import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 import { GatewayLanguageModel } from './gateway-language-model';
 import type { GatewayConfig } from './gateway-config';
+import type { GatewayProviderOptions } from './index';
 import {
   GatewayAuthenticationError,
   GatewayRateLimitError,
@@ -1584,8 +1585,9 @@ describe('GatewayLanguageModel', () => {
           gateway: {
             providerTimeouts: {
               byok: { openai: 5000, anthropic: 2000 },
+              system: { openai: 1000, anthropic: 10000 },
             },
-          },
+          } satisfies GatewayProviderOptions,
         },
       });
 
@@ -1594,6 +1596,7 @@ describe('GatewayLanguageModel', () => {
         gateway: {
           providerTimeouts: {
             byok: { openai: 5000, anthropic: 2000 },
+            system: { openai: 1000, anthropic: 10000 },
           },
         },
       });
@@ -1610,8 +1613,9 @@ describe('GatewayLanguageModel', () => {
           gateway: {
             providerTimeouts: {
               byok: { anthropic: 3000 },
+              system: { anthropic: 6000 },
             },
-          },
+          } satisfies GatewayProviderOptions,
         },
       });
 
@@ -1622,6 +1626,7 @@ describe('GatewayLanguageModel', () => {
         gateway: {
           providerTimeouts: {
             byok: { anthropic: 3000 },
+            system: { anthropic: 6000 },
           },
         },
       });

--- a/packages/gateway/src/gateway-provider-options.ts
+++ b/packages/gateway/src/gateway-provider-options.ts
@@ -36,9 +36,10 @@ export type GatewayProviderOptions = {
   /** Array of provider slugs specifying the provider attempt order. */
   order?: string[];
 
-  /** Per-provider timeouts for BYOK credentials in milliseconds. */
+  /** Per-provider timeouts for BYOK and system credentials in milliseconds. */
   providerTimeouts?: {
     byok?: Record<string, number>;
+    system?: Record<string, number>;
   };
 
   /** Entity identifier against which quota is tracked. */


### PR DESCRIPTION
## Summary

Add `providerTimeouts.system` to `GatewayProviderOptions` so applications can configure timeouts for AI Gateway-managed credentials. The existing `byok` map remains independent and unchanged.

Update the Gateway provider documentation and cover both maps in typed generate/stream forwarding tests. Includes a patch changeset for `@ai-sdk/gateway`.

## Validation

Gateway tests passed: 540 Node tests and 532 Edge tests, with 8 existing Edge skips. Gateway build, typecheck, lint, formatting, and documentation validation passed.

Backport to AI SDK 6 and then AI SDK 5 for their Gateway public types.

Related: [AIG-824](https://linear.app/vercel/issue/AIG-824/support-provider-timeouts-with-system-credentials)