### PR TITLE
fix(openai): remove reference to this.modelId on static method

### DIFF
--- a/.changeset/wise-balloons-decide.md
+++ b/.changeset/wise-balloons-decide.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+chore: fix failing CI

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -321,7 +321,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
       warnings.push({
         type: 'unsupported',
         feature: 'reasoningEffort',
-        details: `${this.modelId} only supports the following reasoning efforts: ${modelCapabilities.supportedReasoningEfforts.join(', ')}`,
+        details: `${modelId} only supports the following reasoning efforts: ${modelCapabilities.supportedReasoningEfforts.join(', ')}`,
       });
       resolvedReasoningEffort = undefined;
     }


### PR DESCRIPTION
Fix a missed this.modelId reference after prepareRequest became static in https://github.com/vercel/ai/pull/20138, restoring OpenAI’s declaration build.