### PR TITLE
chore(provider-utils): fix test that can timeout

### DIFF
--- a/.changeset/selfish-phones-allow.md
+++ b/.changeset/selfish-phones-allow.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/provider-utils": patch
+---
+
+chore(provider-utils): fix test that can timeout

--- a/packages/provider-utils/src/uint8-utils.test.ts
+++ b/packages/provider-utils/src/uint8-utils.test.ts
@@ -23,9 +23,12 @@ describe('convertUint8ArrayToBase64', () => {
   it('round-trips arrays larger than a single conversion chunk', () => {
     const bytes = createBytes(100_000);
 
-    expect(convertBase64ToUint8Array(convertUint8ArrayToBase64(bytes))).toEqual(
-      bytes,
+    const result = convertBase64ToUint8Array(
+      convertUint8ArrayToBase64(bytes),
     );
+
+    expect(result).toHaveLength(bytes.length);
+    expect(result.every((byte, index) => byte === bytes[index])).toBe(true);
   });
 });
 

--- a/packages/provider-utils/src/uint8-utils.test.ts
+++ b/packages/provider-utils/src/uint8-utils.test.ts
@@ -23,9 +23,7 @@ describe('convertUint8ArrayToBase64', () => {
   it('round-trips arrays larger than a single conversion chunk', () => {
     const bytes = createBytes(100_000);
 
-    const result = convertBase64ToUint8Array(
-      convertUint8ArrayToBase64(bytes),
-    );
+    const result = convertBase64ToUint8Array(convertUint8ArrayToBase64(bytes));
 
     expect(result).toHaveLength(bytes.length);
     expect(result.every((byte, index) => byte === bytes[index])).toBe(true);


### PR DESCRIPTION
Fixes a flaky timeout introduced in https://github.com/vercel/ai/pull/20152 by replacing an expensive deep comparison of a large `Uint8Array` with a more efficient check.