### PR TITLE
feat(openai): support xhigh and max image quality

### DIFF
--- a/.changeset/tidy-images-shine.md
+++ b/.changeset/tidy-images-shine.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+Add `xhigh` and `max` quality support for GPT Image 2.5 Flare and Sunburst in image generation, image editing, and the Responses API image generation tool.

--- a/content/providers/01-ai-sdk-providers/03-openai.mdx
+++ b/content/providers/01-ai-sdk-providers/03-openai.mdx
@@ -827,6 +827,16 @@ for await (const part of result.stream) {
   setting `store: false`.
 </Note>
 
+To use `xhigh` or `max` quality, select `gpt-image-2.5-flare` or
+`gpt-image-2.5-sunburst` as the image generation tool's model:
+
+```ts
+openai.tools.imageGeneration({
+  model: 'gpt-image-2.5-flare',
+  quality: 'xhigh',
+});
+```
+
 For complete details on model availability, image quality controls, supported sizes, and tool-specific parameters,
 refer to the OpenAI documentation:
 
@@ -3086,6 +3096,19 @@ const { image, providerMetadata } = await generateImage({
 });
 ```
 
+The `gpt-image-2.5-flare` and `gpt-image-2.5-sunburst` models also support
+`quality: 'xhigh'` and `quality: 'max'` for both image generation and editing:
+
+```ts
+const { image } = await generateImage({
+  model: openai.image('gpt-image-2.5-sunburst'),
+  prompt: 'A salamander at sunrise in a forest pond in the Seychelles.',
+  providerOptions: {
+    openai: { quality: 'max' } satisfies OpenAIImageModelGenerationOptions,
+  },
+});
+```
+
 For more on `generateImage()` see [Image Generation](/docs/ai-sdk-core/image-generation).
 
 OpenAI's image models return additional metadata in the response that can be
@@ -3098,7 +3121,7 @@ is available:
   - `revisedPrompt` _string_ - The revised prompt that was actually used to generate the image (OpenAI may modify your prompt for safety or clarity)
   - `created` _number_ - The Unix timestamp (in seconds) of when the image was created
   - `size` _string_ - The size of the generated image. One of `1024x1024`, `1024x1536`, or `1536x1024`
-  - `quality` _string_ - The quality of the generated image. One of `low`, `medium`, or `high`
+  - `quality` _string_ - The quality of the generated image. One of `low`, `medium`, `high`, `xhigh`, or `max`
   - `background` _string_ - The background parameter used for the image generation. Either `transparent` or `opaque`
   - `outputFormat` _string_ - The output format of the generated image. One of `png`, `webp`, or `jpeg`
 

--- a/examples/ai-functions/src/generate-image/openai/gpt-image-2-5-quality.ts
+++ b/examples/ai-functions/src/generate-image/openai/gpt-image-2-5-quality.ts
@@ -1,0 +1,18 @@
+import { openai, type OpenAIImageModelGenerationOptions } from '@ai-sdk/openai';
+import { generateImage } from 'ai';
+import { presentImages } from '../../lib/present-image';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const { image } = await generateImage({
+    model: openai.image('gpt-image-2.5-sunburst'),
+    prompt: 'A red panda barista pouring latte art in a cozy Tokyo cafe',
+    providerOptions: {
+      openai: {
+        quality: 'max',
+      } satisfies OpenAIImageModelGenerationOptions,
+    },
+  });
+
+  await presentImages([image]);
+});

--- a/packages/openai/src/image/openai-image-model-options.ts
+++ b/packages/openai/src/image/openai-image-model-options.ts
@@ -45,10 +45,11 @@ const baseImageModelOptionsObject = z.object({
   /**
    * Quality of the generated image(s).
    *
-   * Valid values: `standard`, `hd`, `low`, `medium`, `high`, `auto`.
+   * Valid values: `standard`, `hd`, `low`, `medium`, `high`, `xhigh`, `max`, `auto`.
+   * `xhigh` and `max` are supported by GPT Image 2.5 models.
    */
   quality: z
-    .enum(['standard', 'hd', 'low', 'medium', 'high', 'auto'])
+    .enum(['standard', 'hd', 'low', 'medium', 'high', 'xhigh', 'max', 'auto'])
     .optional(),
 
   /**

--- a/packages/openai/src/image/openai-image-model.test.ts
+++ b/packages/openai/src/image/openai-image-model.test.ts
@@ -3,6 +3,10 @@ import fs from 'node:fs';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { createOpenAI } from '../openai-provider';
 import { OpenAIImageModel } from './openai-image-model';
+import type {
+  OpenAIImageModelEditOptions,
+  OpenAIImageModelGenerationOptions,
+} from './openai-image-model-options';
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('../version', () => ({
@@ -46,6 +50,39 @@ function prepareEditFixtureResponse(
 }
 
 describe('doGenerate', () => {
+  describe.each(['gpt-image-2.5-flare', 'gpt-image-2.5-sunburst'])(
+    '%s quality',
+    modelId => {
+      it.each(['xhigh', 'max'] as const)(
+        'should pass %s quality',
+        async quality => {
+          prepareJsonFixtureResponse('openai-image');
+
+          await provider.image(modelId).doGenerate({
+            prompt,
+            files: undefined,
+            mask: undefined,
+            n: 1,
+            size: '1024x1024',
+            aspectRatio: undefined,
+            seed: undefined,
+            providerOptions: {
+              openai: { quality } satisfies OpenAIImageModelGenerationOptions,
+            },
+          });
+
+          expect(await server.calls[0].requestBodyJson).toStrictEqual({
+            model: modelId,
+            prompt,
+            n: 1,
+            size: '1024x1024',
+            quality,
+          });
+        },
+      );
+    },
+  );
+
   it('should pass the model and the settings', async () => {
     prepareJsonFixtureResponse('openai-image');
 
@@ -601,6 +638,42 @@ describe('doGenerate', () => {
 });
 
 describe('doGenerate - image editing', () => {
+  describe.each(['gpt-image-2.5-flare', 'gpt-image-2.5-sunburst'])(
+    '%s quality',
+    modelId => {
+      it.each(['xhigh', 'max'] as const)(
+        'should pass %s quality',
+        async quality => {
+          prepareEditFixtureResponse('openai-image-edit');
+
+          await provider.image(modelId).doGenerate({
+            prompt,
+            files: [
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                data: new Uint8Array([137, 80, 78, 71]),
+              },
+            ],
+            mask: undefined,
+            n: 1,
+            size: '1024x1024',
+            aspectRatio: undefined,
+            seed: undefined,
+            providerOptions: {
+              openai: { quality } satisfies OpenAIImageModelEditOptions,
+            },
+          });
+
+          expect(await server.calls[0].requestBodyMultipart).toMatchObject({
+            model: modelId,
+            quality,
+          });
+        },
+      );
+    },
+  );
+
   it('should call /images/edits endpoint when files are provided', async () => {
     prepareEditFixtureResponse('openai-image-edit');
 

--- a/packages/openai/src/openai-tools.ts
+++ b/packages/openai/src/openai-tools.ts
@@ -77,7 +77,7 @@ export const openaiTools = {
    * @param outputCompression - Compression level for the output image (0-100).
    * @param outputFormat - The output format of the generated image. One of 'png', 'jpeg', or 'webp'.
    * @param partialImages - Number of partial images to generate in streaming mode (0-3).
-   * @param quality - The quality of the generated image. One of 'auto', 'low', 'medium', or 'high'.
+   * @param quality - The quality of the generated image. One of 'auto', 'low', 'medium', 'high', 'xhigh', or 'max'. 'xhigh' and 'max' require a GPT Image 2.5 model.
    * @param size - The size of the generated image. One of 'auto', '1024x1024', '1024x1536', or '1536x1024'.
    */
   imageGeneration,

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -626,7 +626,7 @@ export type OpenAIResponsesTool =
       output_compression: number | undefined;
       output_format: 'png' | 'jpeg' | 'webp' | undefined;
       partial_images: number | undefined;
-      quality: 'auto' | 'low' | 'medium' | 'high' | undefined;
+      quality: 'auto' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | undefined;
       size:
         | 'auto'
         | '1024x1024'

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -1,4 +1,5 @@
 import { NoSuchProviderReferenceError } from '@ai-sdk/provider';
+import { imageGeneration } from '../tool/image-generation';
 import { prepareResponsesTools } from './openai-responses-prepare-tools';
 import { describe, it, expect } from 'vitest';
 
@@ -548,6 +549,34 @@ describe('prepareResponsesTools', () => {
   });
 
   describe('image generation', () => {
+    describe.each(['gpt-image-2.5-flare', 'gpt-image-2.5-sunburst'])(
+      '%s quality',
+      model => {
+        it.each(['xhigh', 'max'] as const)(
+          'should pass %s quality',
+          async quality => {
+            const tool = imageGeneration({ model, quality });
+            const result = await prepareResponsesTools({
+              tools: [
+                {
+                  type: 'provider',
+                  id: 'openai.image_generation',
+                  name: 'image_generation',
+                  args: tool.args,
+                },
+              ],
+              toolChoice: undefined,
+            });
+
+            expect(result.toolWarnings).toEqual([]);
+            expect(result.tools).toMatchObject([
+              { type: 'image_generation', model, quality },
+            ]);
+          },
+        );
+      },
+    );
+
     it('should prepare image_generation tool with all options', async () => {
       const result = await prepareResponsesTools({
         tools: [

--- a/packages/openai/src/tool/image-generation.ts
+++ b/packages/openai/src/tool/image-generation.ts
@@ -23,7 +23,9 @@ export const imageGenerationArgsSchema = lazySchema(() =>
         outputCompression: z.number().int().min(0).max(100).optional(),
         outputFormat: z.enum(['png', 'jpeg', 'webp']).optional(),
         partialImages: z.number().int().min(0).max(3).optional(),
-        quality: z.enum(['auto', 'low', 'medium', 'high']).optional(),
+        quality: z
+          .enum(['auto', 'low', 'medium', 'high', 'xhigh', 'max'])
+          .optional(),
         size: z
           .union([
             z.enum(['1024x1024', '1024x1536', '1536x1024', 'auto']),
@@ -101,9 +103,10 @@ type ImageGenerationArgs = {
 
   /**
    * The quality of the generated image.
-   * One of low, medium, high, or auto. Default: auto.
+   * One of low, medium, high, xhigh, max, or auto. Default: auto.
+   * xhigh and max are supported by GPT Image 2.5 models.
    */
-  quality?: 'auto' | 'low' | 'medium' | 'high';
+  quality?: 'auto' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
   /**
    * The size of the generated image.


### PR DESCRIPTION
## Background

GPT Image 2.5 [Flare](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare) and [Sunburst](https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst) support `xhigh` and `max` quality. The OpenAI provider currently rejects both values during validation before sending a request.

## Summary

- Accept `xhigh` and `max` in the image generation/editing options and the Responses image generation tool, including its public and request types.
- Add regression coverage for both qualities on both models across JSON generation requests, multipart editing requests, and Responses tool preparation.
- Update provider documentation and add a usage example and patch changeset.

Validation: all 12 new regression cases failed before the fix. The two focused suites now pass in Node and Edge (120 tests per runtime). Full workspace type checking, changed-code lint/format checks, and `git diff --check` passed.

## End-to-End Verification

Live OpenAI API calls were not run. A runnable image generation example is included at `examples/ai-functions/src/generate-image/openai/gpt-image-2-5-quality.ts`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
