### PR TITLE
fix(openai): reject denied programmatic tool calls

### DIFF
--- a/.changeset/perfect-cups-swim.md
+++ b/.changeset/perfect-cups-swim.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai": patch
+---
+
+fix(openai): reject denied programmatic tool calls

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -1,10 +1,10 @@
-import { UnsupportedFunctionalityError } from '@ai-sdk/provider';
-import type { ToolNameMapping } from '@ai-sdk/provider-utils';
-import type {
-  LanguageModelV4Prompt,
-  LanguageModelV4ToolResultOutput,
-  LanguageModelV4ToolResultPart,
+import {
+  UnsupportedFunctionalityError,
+  type LanguageModelV4Prompt,
+  type LanguageModelV4ToolResultOutput,
+  type LanguageModelV4ToolResultPart,
 } from '@ai-sdk/provider';
+import type { ToolNameMapping } from '@ai-sdk/provider-utils';
 import { describe, it, expect } from 'vitest';
 import { convertToOpenAIResponsesInput as convertToOpenAIResponsesInputBase } from './convert-to-openai-responses-input';
 

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -1,3 +1,4 @@
+import { UnsupportedFunctionalityError } from '@ai-sdk/provider';
 import type { ToolNameMapping } from '@ai-sdk/provider-utils';
 import type {
   LanguageModelV4Prompt,
@@ -3152,6 +3153,52 @@ describe('convertToOpenAIResponsesInput', () => {
           output: 'User denied the tool execution',
         },
       ]);
+    });
+
+    it('should reject execution-denied programmatic tool results', async () => {
+      await expect(
+        convertToOpenAIResponsesInput({
+          toolNameMapping: testToolNameMapping,
+          prompt: [
+            {
+              role: 'assistant',
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call_denied_123',
+                  toolName: 'search',
+                  input: { query: 'test' },
+                  providerOptions: {
+                    openai: {
+                      caller: {
+                        type: 'program',
+                        callerId: 'program_call_123',
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              role: 'tool',
+              content: [
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call_denied_123',
+                  toolName: 'search',
+                  output: {
+                    type: 'execution-denied',
+                    reason: 'User denied the tool execution',
+                  },
+                },
+              ],
+            },
+          ],
+          systemMessageMode: 'system',
+          providerOptionsName: 'openai',
+          store: true,
+        }),
+      ).rejects.toBeInstanceOf(UnsupportedFunctionalityError);
     });
 
     it('should convert single tool result part with multipart that contains text', async () => {

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -378,6 +378,7 @@ export async function convertToOpenAIResponsesInput({
   let input: OpenAIResponsesInput = [];
   const warnings: Array<SharedV4Warning> = [];
   const processedApprovalIds = new Set<string>();
+  const programmaticToolCallIds = new Set<string>();
   const parallelToolResultGroups =
     hasConversation || hasPreviousResponseId
       ? collectCompleteParallelToolResultGroups({
@@ -693,6 +694,10 @@ export async function convertToOpenAIResponsesInput({
                 | { type: 'direct' }
                 | { type: 'program'; callerId: string }
                 | undefined;
+
+              if (caller?.type === 'program') {
+                programmaticToolCallIds.add(part.toolCallId);
+              }
 
               if (hasConversation && id != null) {
                 break;
@@ -1568,6 +1573,23 @@ export async function convertToOpenAIResponsesInput({
             continue;
           }
 
+          const resultCaller = part.providerOptions?.[providerOptionsName]
+            ?.caller as
+            | { type: 'direct' }
+            | { type: 'program'; callerId: string }
+            | undefined;
+
+          if (
+            output.type === 'execution-denied' &&
+            (resultCaller?.type === 'program' ||
+              programmaticToolCallIds.has(part.toolCallId))
+          ) {
+            throw new UnsupportedFunctionalityError({
+              functionality:
+                'execution-denied results for programmatic tool calls',
+            });
+          }
+
           const contentValue = await convertFunctionToolResultOutput({
             output,
             toolName: part.toolName,
@@ -1581,12 +1603,7 @@ export async function convertToOpenAIResponsesInput({
             warnings,
           });
 
-          const caller = mapToolCaller(
-            part.providerOptions?.[providerOptionsName]?.caller as
-              | { type: 'direct' }
-              | { type: 'program'; callerId: string }
-              | undefined,
-          );
+          const caller = mapToolCaller(resultCaller);
 
           input.push({
             type: 'function_call_output',


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/20263

denied programmatic tool calls resolved successfully with the denial reason; but users had the request for the request to be denied completely. 

## Summary

AI SDK aborts generation to prevent the denial from being consumed as valid tool output
- we abort generateText because OpenAI cannot reject the hosted tool Promise, and aborting prevents a denied call from being treated as successful data. 

## End-to-End Verification

verified by running the script: 
<details>

```ts
import { openai } from '@ai-sdk/openai';
import { parseJSON } from '@ai-sdk/provider-utils';
import { generateText, isStepCount, tool } from 'ai';
import { z } from 'zod';
import { run } from '../../lib/run';

const denialReason = 'ACCESS_DENIED_SENTINEL';

run(async () => {
  let executeCalled = false;

  const result = await generateText({
    model: openai('gpt-5.6-terra'),
    prompt: `Use programmatic_tool_calling and run this JavaScript logic exactly once:

let rejected = false;
let value;
try {
  value = await tools.get_secret({});
} catch (error) {
  rejected = true;
  value = error instanceof Error ? error.message : String(error);
}
text(JSON.stringify({ rejected, value, valueType: typeof value }));

Do not call get_secret directly. After the program finishes, briefly report its JSON output.`,
    providerOptions: {
      openai: {
        parallelToolCalls: false,
        store: false,
      },
    },
    stopWhen: isStepCount(10),
    toolApproval: {
      get_secret: {
        type: 'denied',
        reason: denialReason,
      },
    },
    tools: {
      get_secret: tool({
        description:
          'Returns a secret. This tool is denied by the application access policy.',
        execute: async () => {
          executeCalled = true;
          return { secret: 'execute should never run' };
        },
        inputSchema: z.object({}),
        outputSchema: z.object({ secret: z.string() }),
        providerOptions: {
          openai: {
            allowedCallers: ['programmatic'],
          },
        },
      }),
      programmatic_tool_calling: openai.tools.programmaticToolCalling(),
    },
  });

  const programResult = result.steps
    .flatMap(step => step.toolResults)
    .find(toolResult => toolResult.toolName === 'programmatic_tool_calling');

  if (
    programResult == null ||
    typeof programResult.output !== 'object' ||
    programResult.output === null ||
    !('result' in programResult.output) ||
    typeof programResult.output.result !== 'string'
  ) {
    throw new Error('The model did not produce the expected program result.');
  }

  const observation = await parseJSON({ text: programResult.output.result });

  console.log('Tool execute callback called:', executeCalled);
  console.log('Program observed:', observation);
  console.log('Final model response:', result.text);

  if (
    executeCalled === false &&
    typeof observation === 'object' &&
    observation !== null &&
    'rejected' in observation &&
    observation.rejected === false &&
    'value' in observation &&
    observation.value === denialReason &&
    'valueType' in observation &&
    observation.valueType === 'string'
  ) {
    console.log(
      '\nBUG REPRODUCED: a denied program-owned tool call resolved as a string.',
    );
  } else {
    console.log(
      '\nBug not reproduced: the denied call did not resolve with the denial string.',
    );
  }
});
```
</details>

the observed behaviour after the fix is that the AISDK will reject the request completely. 

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #20263

closes #20264 