### PR TITLE
[v5.0] fix(azure): include explicit message types for Foundry Responses

### DIFF
--- a/.changeset/curvy-dodos-talk.md
+++ b/.changeset/curvy-dodos-talk.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/azure': patch
+'@ai-sdk/openai': patch
+---
+
+Include explicit message item types in Azure AI Foundry Responses requests.

--- a/packages/azure/src/azure-openai-provider.test.ts
+++ b/packages/azure/src/azure-openai-provider.test.ts
@@ -121,6 +121,8 @@ const server = createTestServer({
     {},
   'https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1/chat/completions':
     {},
+  'https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1/responses':
+    {},
   'https://our-gateway.example.com/azure/chat/completions': {},
   'https://test-resource.openai.azure.com/openai/deployments/whisper-1/audio/transcriptions':
     {},
@@ -1089,17 +1091,18 @@ describe('image', () => {
 
 describe('responses', () => {
   describe('doGenerate', () => {
-    function prepareJsonResponse({
-      content = '',
-      usage = {
-        input_tokens: 4,
-        output_tokens: 30,
-        total_tokens: 34,
-      },
-    } = {}) {
-      server.urls[
-        'https://test-resource.openai.azure.com/openai/v1/responses'
-      ].response = {
+    function prepareJsonResponse(
+      {
+        content = '',
+        usage = {
+          input_tokens: 4,
+          output_tokens: 30,
+          total_tokens: 34,
+        },
+      } = {},
+      url: TestServerURL = 'https://test-resource.openai.azure.com/openai/v1/responses',
+    ) {
+      server.urls[url].response = {
         type: 'json-value',
         body: {
           id: 'resp_67c97c0203188190a025beb4a75242bc',
@@ -1184,6 +1187,54 @@ describe('responses', () => {
       expect(server.calls[0].requestUrl).toStrictEqual(
         'https://test-resource.openai.azure.com/openai/v1/responses?api-version=v1',
       );
+    });
+
+    it('should include explicit message item types for Foundry project endpoints', async () => {
+      const foundryURL =
+        'https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1/responses';
+      prepareJsonResponse({}, foundryURL);
+
+      const foundryProvider = createAzure({
+        baseURL:
+          'https://test-resource.services.ai.azure.com/api/projects/test-project/openai/v1',
+        apiKey: 'test-api-key',
+      });
+
+      await foundryProvider.responses('test-deployment').doGenerate({
+        prompt: [
+          { role: 'system', content: 'You are concise.' },
+          { role: 'user', content: [{ type: 'text', text: 'Say hi.' }] },
+          { role: 'assistant', content: [{ type: 'text', text: 'Hi.' }] },
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Say it again.' }],
+          },
+        ],
+      });
+
+      const requestBody = await server.calls[0].requestBodyJson;
+      expect(requestBody.input).toEqual([
+        {
+          type: 'message',
+          role: 'system',
+          content: 'You are concise.',
+        },
+        {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'Say hi.' }],
+        },
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Hi.' }],
+        },
+        {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'Say it again.' }],
+        },
+      ]);
     });
 
     it('should handle Azure file IDs with assistant- prefix', async () => {

--- a/packages/azure/src/azure-openai-provider.ts
+++ b/packages/azure/src/azure-openai-provider.ts
@@ -298,6 +298,7 @@ export function createAzure(
       url,
       headers: getHeaders,
       fetch,
+      explicitMessageItemType: isFoundryProject,
       fileIdPrefixes: ['assistant-'],
     });
 

--- a/packages/openai/src/openai-config.ts
+++ b/packages/openai/src/openai-config.ts
@@ -7,6 +7,11 @@ export type OpenAIConfig = {
   fetch?: FetchFunction;
   generateId?: () => string;
   /**
+   * Whether Responses API message input items must include an explicit
+   * `type: 'message'` discriminator.
+   */
+  explicitMessageItemType?: boolean;
+  /**
    * File ID prefixes used to identify file IDs in Responses API.
    * When undefined, all file data is treated as base64 content.
    *

--- a/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.test.ts
@@ -2,6 +2,56 @@ import { convertToOpenAIResponsesInput } from './convert-to-openai-responses-inp
 import { describe, it, expect } from 'vitest';
 
 describe('convertToOpenAIResponsesInput', () => {
+  describe('explicit message item types', () => {
+    it('should add the message type to system, user, and assistant messages', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+          { role: 'assistant', content: [{ type: 'text', text: 'Hi!' }] },
+        ],
+        systemMessageMode: 'system',
+        explicitMessageItemType: true,
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'message',
+          role: 'system',
+          content: 'You are helpful.',
+        },
+        {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'Hello' }],
+        },
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Hi!' }],
+        },
+      ]);
+    });
+
+    it('should add the message type to developer messages', async () => {
+      const result = await convertToOpenAIResponsesInput({
+        prompt: [{ role: 'system', content: 'You are helpful.' }],
+        systemMessageMode: 'developer',
+        explicitMessageItemType: true,
+        store: true,
+      });
+
+      expect(result.input).toEqual([
+        {
+          type: 'message',
+          role: 'developer',
+          content: 'You are helpful.',
+        },
+      ]);
+    });
+  });
+
   describe('system messages', () => {
     it('should convert system messages to system role', async () => {
       const result = await convertToOpenAIResponsesInput({

--- a/packages/openai/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/openai/src/responses/convert-to-openai-responses-input.ts
@@ -44,12 +44,14 @@ function isFileId(data: string, prefixes?: readonly string[]): boolean {
 export async function convertToOpenAIResponsesInput({
   prompt,
   systemMessageMode,
+  explicitMessageItemType = false,
   fileIdPrefixes,
   store,
   hasLocalShellTool = false,
 }: {
   prompt: LanguageModelV2Prompt;
   systemMessageMode: 'system' | 'developer' | 'remove';
+  explicitMessageItemType?: boolean;
   fileIdPrefixes?: readonly string[];
   store: boolean;
   hasLocalShellTool?: boolean;
@@ -68,6 +70,7 @@ export async function convertToOpenAIResponsesInput({
             const promptCacheBreakpoint =
               getPromptCacheBreakpoint(providerOptions);
             input.push({
+              ...(explicitMessageItemType && { type: 'message' as const }),
               role: 'system',
               content:
                 promptCacheBreakpoint == null
@@ -86,6 +89,7 @@ export async function convertToOpenAIResponsesInput({
             const promptCacheBreakpoint =
               getPromptCacheBreakpoint(providerOptions);
             input.push({
+              ...(explicitMessageItemType && { type: 'message' as const }),
               role: 'developer',
               content:
                 promptCacheBreakpoint == null
@@ -119,6 +123,7 @@ export async function convertToOpenAIResponsesInput({
 
       case 'user': {
         input.push({
+          ...(explicitMessageItemType && { type: 'message' as const }),
           role: 'user',
           content: content.map((part, index) => {
             switch (part.type) {
@@ -218,6 +223,7 @@ export async function convertToOpenAIResponsesInput({
               }
 
               input.push({
+                ...(explicitMessageItemType && { type: 'message' as const }),
                 role: 'assistant',
                 content: [{ type: 'output_text', text: part.text }],
                 id,

--- a/packages/openai/src/responses/openai-responses-api.ts
+++ b/packages/openai/src/responses/openai-responses-api.ts
@@ -36,6 +36,7 @@ export type OpenAIResponsesIncludeOptions =
   | null;
 
 export type OpenAIResponsesSystemMessage = {
+  type?: 'message';
   role: 'system' | 'developer';
   content:
     | string
@@ -47,6 +48,7 @@ export type OpenAIResponsesSystemMessage = {
 };
 
 export type OpenAIResponsesUserMessage = {
+  type?: 'message';
   role: 'user';
   content: Array<
     | {
@@ -84,6 +86,7 @@ export type OpenAIResponsesUserMessage = {
 };
 
 export type OpenAIResponsesAssistantMessage = {
+  type?: 'message';
   role: 'assistant';
   content: Array<{ type: 'output_text'; text: string }>;
   id?: string;

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -135,6 +135,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       await convertToOpenAIResponsesInput({
         prompt,
         systemMessageMode: modelCapabilities.systemMessageMode,
+        explicitMessageItemType: this.config.explicitMessageItemType,
         fileIdPrefixes: this.config.fileIdPrefixes,
         store: openaiOptions?.store ?? true,
         hasLocalShellTool: hasOpenAITool('openai.local_shell'),


### PR DESCRIPTION
## Summary

Backport of #20487 to `release-v5.0`.

- add an internal OpenAI Responses serialization capability for explicit `type: "message"` discriminators
- enable it only for recognized Azure AI Foundry project URLs
- cover system, developer, user, and assistant message items while preserving existing OpenAI, standard Azure OpenAI, and custom-gateway payloads
- add patch changesets for `@ai-sdk/azure` and `@ai-sdk/openai`

Fixes #20180 for AI SDK 5.

## Test plan

- `pnpm check`
- `pnpm --filter @ai-sdk/openai type-check`
- `pnpm --filter @ai-sdk/azure type-check`
- `pnpm --filter @ai-sdk/openai test`
- `pnpm --filter @ai-sdk/azure test`
- `pnpm --filter @ai-sdk/azure... --filter @ai-sdk/test-server build`

`pnpm type-check:full` currently fails on this release branch in untouched examples because of React type resolution conflicts; both changed packages type-check and build successfully.