### PR TITLE
docs(agents): clarify needsApproval scope in tool approvals

### DIFF
--- a/content/docs/03-agents/06-tool-approvals.mdx
+++ b/content/docs/03-agents/06-tool-approvals.mdx
@@ -334,5 +334,5 @@ Every serverless instance that might handle a request needs the same secret, sin
 
 - Use `toolApproval` with `ToolLoopAgent`, `generateText`, and `streamText`.
 - Author approval rules as code with [Policy-Based Tool Approvals](/docs/agents/policy-tool-approvals) (`@ai-sdk/policy-opa`).
-- Use `needsApproval` only with [`WorkflowAgent`](/docs/agents/workflow-agent), where approvals suspend and resume durable workflow execution.
+- `needsApproval` is deprecated for `generateText`, `streamText`, and `ToolLoopAgent` in favor of `toolApproval` — though it is still honored as a fallback when no `toolApproval` rule applies to a tool. Use `needsApproval` for [`WorkflowAgent`](/docs/agents/workflow-agent), where it remains the primary approval mechanism and approvals suspend and resume durable workflow execution.
 - Subagent tools cannot use `toolApproval`; see [Subagents](/docs/agents/subagents#no-tool-approvals-in-subagents).


### PR DESCRIPTION
## What

`needsApproval` is deprecated on the core `Tool` type (`packages/provider-utils/src/types/tool.ts`) in favor of `toolApproval`, but the docs' "Related APIs" line said to use it "only with `WorkflowAgent`" - which reads as if it has no effect elsewhere. It's actually still an active fallback for `generateText`/`streamText`/`ToolLoopAgent`: `resolveToolApproval()` (`packages/ai/src/generate-text/resolve-tool-approval.ts`) falls back to a tool's own `needsApproval` whenever no `toolApproval` rule applies to that tool, and `ToolLoopAgent`'s own class doc already says as much ("A tool call needs approval via `toolApproval` or tool-level `needsApproval`").

## Change

One line in `content/docs/03-agents/06-tool-approvals.mdx`'s "Related APIs" section. Keeps the existing recommendation (use `toolApproval` for `generateText`/`streamText`/`ToolLoopAgent`, use `needsApproval` for `WorkflowAgent`) unchanged - just states the deprecated-fallback behavior explicitly instead of implying `needsApproval` is inert outside `WorkflowAgent`.

## Scope

Docs-only, one file, one line. No code changes.
