### PR TITLE
fix(google-vertex): forward includeUsage in Vertex MaaS provider

### DIFF
--- a/.changeset/spotty-pandas-switch.md
+++ b/.changeset/spotty-pandas-switch.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google-vertex': patch
+---
+
+fix(google-vertex): forward includeUsage in Vertex MaaS provider

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.test.ts
@@ -63,6 +63,7 @@ describe('google-vertex-maas-provider', () => {
         {
           "baseURL": "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi",
           "fetch": undefined,
+          "includeUsage": undefined,
           "name": "vertex.maas",
           "transformRequestBody": [Function],
         }
@@ -82,6 +83,7 @@ describe('google-vertex-maas-provider', () => {
         {
           "baseURL": "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi",
           "fetch": undefined,
+          "includeUsage": undefined,
           "name": "vertex.maas",
           "transformRequestBody": [Function],
         }
@@ -101,6 +103,7 @@ describe('google-vertex-maas-provider', () => {
         {
           "baseURL": "https://aiplatform.eu.rep.googleapis.com/v1/projects/test-project/locations/eu/endpoints/openapi",
           "fetch": undefined,
+          "includeUsage": undefined,
           "name": "vertex.maas",
           "transformRequestBody": [Function],
         }
@@ -267,5 +270,19 @@ describe('google-vertex-maas-provider', () => {
     provider('model-2');
 
     expect(createOpenAICompatible).toHaveBeenCalledTimes(1);
+  });
+
+  it('should forward includeUsage to createOpenAICompatible', () => {
+    const provider = createGoogleVertexMaas({
+      project: 'test-project',
+      location: 'global',
+      includeUsage: true,
+    });
+
+    provider('test-model');
+
+    expect(createOpenAICompatible).toHaveBeenCalledWith(
+      expect.objectContaining({ includeUsage: true }),
+    );
   });
 });

--- a/packages/google-vertex/src/maas/google-vertex-maas-provider.ts
+++ b/packages/google-vertex/src/maas/google-vertex-maas-provider.ts
@@ -62,6 +62,12 @@ export interface GoogleVertexMaasProviderSettings {
    * or to provide a custom fetch implementation for e.g. testing.
    */
   fetch?: FetchFunction;
+
+  /**
+   * Include usage information in streaming responses.
+   * Forwarded to the underlying OpenAI-compatible provider.
+   */
+  includeUsage?: boolean;
 }
 
 /**
@@ -114,6 +120,7 @@ export function createGoogleVertexMaas(
       name: 'vertex.maas',
       baseURL: loadBaseURL(),
       fetch: options.fetch,
+      includeUsage: options.includeUsage,
       transformRequestBody: transformGoogleVertexMaasRequestBody,
     }));
 


### PR DESCRIPTION
Fixes #20520

`createGoogleVertexMaas` never forwarded `includeUsage` to the underlying `createOpenAICompatible()` call, so streaming token usage was impossible for all Vertex MaaS partner models. Non-streaming usage worked — only the streaming path was affected.

This adds the option to `GoogleVertexMaasProviderSettings` and forwards it. The edge/node wrappers spread `...options` through, so they pick it up automatically.

## Testing

- New test asserting `createOpenAICompatible` receives `includeUsage: true`.
- Full maas suite: 32 passed (node) + 9 passed (edge); `tsc --noEmit` clean on the package.