### PR TITLE
test(provider-utils): cover base64 encoding memory regression

### DIFF
--- a/packages/provider-utils/src/uint8-utils.node.test.ts
+++ b/packages/provider-utils/src/uint8-utils.node.test.ts
@@ -1,0 +1,34 @@
+import { execFileSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+import { convertUint8ArrayToBase64 } from './uint8-utils';
+
+const reproductionByteLength = 14_078_689;
+const expectedBase64Length = Math.ceil(reproductionByteLength / 3) * 4;
+
+describe('convertUint8ArrayToBase64 memory regression', () => {
+  it('encodes the reproduction-size array within a 128 MiB heap', () => {
+    const output = execFileSync(
+      process.execPath,
+      [
+        '--max-old-space-size=128',
+        '--input-type=module',
+        '--eval',
+        `
+            ${convertUint8ArrayToBase64.toString()}
+
+            const byteLength = ${reproductionByteLength};
+            const bytes = new Uint8Array(byteLength);
+
+            for (let index = 0; index < byteLength; index++) {
+              bytes[index] = index % 256;
+            }
+
+            process.stdout.write(String(convertUint8ArrayToBase64(bytes).length));
+          `,
+      ],
+      { encoding: 'utf8', timeout: 30_000 },
+    );
+
+    expect(output).toBe(String(expectedBase64Length));
+  }, 30_000);
+});

--- a/packages/provider-utils/vitest.edge.config.js
+++ b/packages/provider-utils/vitest.edge.config.js
@@ -1,9 +1,10 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   test: {
     environment: 'edge-runtime',
     include: ['**/*.test.ts', '**/*.test.tsx'],
+    exclude: [...configDefaults.exclude, '**/*.node.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary

- add a Node-only constrained-heap regression test for the base64 encoder
- exclude the Node-specific test from the Edge suite

The test executes the loaded encoder implementation in a 128 MiB subprocess using the original 14,078,689-byte reproduction size. The previous per-byte concatenation implementation exits with an OOM; the chunked implementation succeeds.

## Verification

- 
 RUN  v4.1.6 /Users/gr2m/.codex/worktrees/110a/ai


 Test Files  2 passed (2)
      Tests  9 passed (9)
   Start at  08:17:50
   Duration  372ms (transform 31ms, setup 0ms, import 43ms, tests 295ms, environment 0ms)
- Checking formatting...

All matched files use the correct format.
Finished in 2446ms on 7377 files using 12 threads.
Found 0 warnings and 0 errors.
Finished in 4.3s on 6501 files with 286 rules using 12 threads.
- 