### PR TITLE
fix(openai): return an AI SDK error for empty completion choices

### DIFF
--- a/.changeset/tidy-pandas-shout.md
+++ b/.changeset/tidy-pandas-shout.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/openai': patch
+'@ai-sdk/openai-compatible': patch
+---
+
+fix(openai): return an AI SDK error for empty completion choices

--- a/packages/openai-compatible/src/completion/openai-compatible-completion-language-model.test.ts
+++ b/packages/openai-compatible/src/completion/openai-compatible-completion-language-model.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import {
+  InvalidResponseDataError,
+  type LanguageModelV4Prompt,
+} from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 import { createOpenAICompatible } from '../openai-compatible-provider';
@@ -120,6 +123,34 @@ describe('doGenerate', () => {
         },
       ]
     `);
+  });
+
+  it('should reject a response without choices', async () => {
+    server.urls['https://my.api.com/v1/completions'].response = {
+      type: 'json-value',
+      body: {
+        id: 'cmpl-empty',
+        object: 'text_completion',
+        created: 1711363706,
+        model: 'gpt-3.5-turbo-instruct',
+        choices: [],
+        usage: {
+          prompt_tokens: 4,
+          total_tokens: 4,
+          completion_tokens: 0,
+        },
+      },
+    };
+
+    await expect(
+      model.doGenerate({
+        prompt: TEST_PROMPT,
+      }),
+    ).rejects.toSatisfy(
+      error =>
+        InvalidResponseDataError.isInstance(error) &&
+        error.message === 'Response did not contain any choices.',
+    );
   });
 
   it('should extract usage', async () => {

--- a/packages/openai-compatible/src/completion/openai-compatible-completion-language-model.ts
+++ b/packages/openai-compatible/src/completion/openai-compatible-completion-language-model.ts
@@ -1,13 +1,14 @@
-import type {
-  APICallError,
-  LanguageModelV4,
-  LanguageModelV4CallOptions,
-  LanguageModelV4Content,
-  LanguageModelV4FinishReason,
-  LanguageModelV4GenerateResult,
-  LanguageModelV4StreamPart,
-  LanguageModelV4StreamResult,
-  SharedV4Warning,
+import {
+  InvalidResponseDataError,
+  type APICallError,
+  type LanguageModelV4,
+  type LanguageModelV4CallOptions,
+  type LanguageModelV4Content,
+  type LanguageModelV4FinishReason,
+  type LanguageModelV4GenerateResult,
+  type LanguageModelV4StreamPart,
+  type LanguageModelV4StreamResult,
+  type SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -226,6 +227,12 @@ export class OpenAICompatibleCompletionLanguageModel implements LanguageModelV4 
     });
 
     const choice = response.choices[0];
+    if (choice == null) {
+      throw new InvalidResponseDataError({
+        data: rawResponse,
+        message: 'Response did not contain any choices.',
+      });
+    }
     const content: Array<LanguageModelV4Content> = [];
 
     // text content:

--- a/packages/openai/src/completion/openai-completion-language-model.test.ts
+++ b/packages/openai/src/completion/openai-completion-language-model.test.ts
@@ -1,6 +1,9 @@
 import fs from 'node:fs';
 
-import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import {
+  InvalidResponseDataError,
+  type LanguageModelV4Prompt,
+} from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 import { createOpenAI } from '../openai-provider';
@@ -110,6 +113,34 @@ describe('doGenerate', () => {
         },
       ]
     `);
+  });
+
+  it('should reject a response without choices', async () => {
+    server.urls['https://api.openai.com/v1/completions'].response = {
+      type: 'json-value',
+      body: {
+        id: 'cmpl-empty',
+        object: 'text_completion',
+        created: 1711363706,
+        model: 'gpt-3.5-turbo-instruct',
+        choices: [],
+        usage: {
+          prompt_tokens: 4,
+          total_tokens: 4,
+          completion_tokens: 0,
+        },
+      },
+    };
+
+    await expect(
+      model.doGenerate({
+        prompt: TEST_PROMPT,
+      }),
+    ).rejects.toSatisfy(
+      error =>
+        InvalidResponseDataError.isInstance(error) &&
+        error.message === 'Response did not contain any choices.',
+    );
   });
 
   it('should extract usage', async () => {

--- a/packages/openai/src/completion/openai-completion-language-model.ts
+++ b/packages/openai/src/completion/openai-completion-language-model.ts
@@ -1,12 +1,13 @@
-import type {
-  LanguageModelV4,
-  LanguageModelV4CallOptions,
-  LanguageModelV4FinishReason,
-  LanguageModelV4GenerateResult,
-  LanguageModelV4StreamPart,
-  LanguageModelV4StreamResult,
-  SharedV4ProviderMetadata,
-  SharedV4Warning,
+import {
+  InvalidResponseDataError,
+  type LanguageModelV4,
+  type LanguageModelV4CallOptions,
+  type LanguageModelV4FinishReason,
+  type LanguageModelV4GenerateResult,
+  type LanguageModelV4StreamPart,
+  type LanguageModelV4StreamResult,
+  type SharedV4ProviderMetadata,
+  type SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -205,6 +206,12 @@ export class OpenAICompletionLanguageModel implements LanguageModelV4 {
     });
 
     const choice = response.choices[0];
+    if (choice == null) {
+      throw new InvalidResponseDataError({
+        data: rawResponse,
+        message: 'Response did not contain any choices.',
+      });
+    }
 
     const providerMetadata: SharedV4ProviderMetadata = { openai: {} };
 


### PR DESCRIPTION
The completion adapters (`@ai-sdk/openai` and `@ai-sdk/openai-compatible`) threw a raw `TypeError` on `choices: []` responses (`choices[0]` with no guard), bypassing normal AI SDK error handling. The chat adapters got the same guard in #20513, but these two files were missed.

This adds the same `InvalidResponseDataError` ("Response did not contain any choices.") guard to both completion `doGenerate` paths, matching the chat fix scope exactly.

## Testing

- 2 new regression tests (one per package): verified red before the fix (`TypeError`), green after.
- Completion suites: 19 passed (openai, node+edge) and 30 passed (openai-compatible, node+edge); type-check, oxlint, and oxfmt clean.