### PR TITLE
fix(harness): preserve host results across turn suspension

### DIFF
--- a/.changeset/preserve-suspended-harness-results.md
+++ b/.changeset/preserve-suspended-harness-results.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness': patch
+---
+
+Preserve host tool results that finish after a turn begins suspending. Wait for dispatched work before returning the continuation, deliver saved results on resume without rerunning tools, and retain the resumed step completion event.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -101,6 +101,13 @@ const agent = new HarnessAgent({
 
 Use `session.detach()` to park a bridge-backed session for later attach, `session.stop()` to save state and stop the sandbox, or `session.destroy()` to clean up without keeping resume state. Bridge-backed adapters such as Claude Code, Codex, OpenCode, and DeepAgents require a network sandbox session that exposes ports — `@ai-sdk/sandbox-vercel` is the supported choice today. `@ai-sdk/sandbox-just-bash` is suitable only for host-runtime or otherwise non-bridge flows, such as Pi.
 
+Use `session.suspendTurn()` to freeze an unfinished turn for another process.
+It waits for dispatched host tools to settle and includes any undelivered results
+in the returned continuation. Persist that entire value, pass it as `continueFrom`
+to a new `agent.createSession()` call, then call `agent.continueStream()` or
+`agent.continueGenerate()`. Saved results are delivered without executing their
+tools again; suspension can therefore take longer than the adapter disconnect.
+
 Set `model` on `HarnessAgent` to select the model used when the harness session
 starts. Model identifiers are harness-specific, so `model` accepts any string.
 

--- a/packages/harness/src/agent/harness-agent-session.ts
+++ b/packages/harness/src/agent/harness-agent-session.ts
@@ -112,6 +112,7 @@ export class HarnessAgentSession {
   private turnState: HarnessAgentTurnState;
   private turnSequence = 0;
   private activeTurnSequence = 0;
+  private activePromptDone: Promise<void> | undefined;
   private activePromptControl: ActivePromptControl | undefined;
   private suspendedTurnState:
     | Promise<HarnessAgentContinueTurnState>
@@ -281,6 +282,7 @@ export class HarnessAgentSession {
         onStopConditionMet: () =>
           this.captureStopConditionBoundary({ session, turnId }),
       });
+      this.activePromptDone = turn.done;
       return {
         ...turn,
         ready: this.waitForPromptControl({ turnId }),
@@ -380,6 +382,7 @@ export class HarnessAgentSession {
         onStopConditionMet: () =>
           this.captureStopConditionBoundary({ session, turnId }),
       });
+      this.activePromptDone = turn.done;
       return {
         ...turn,
         ready: this.waitForPromptControl({ turnId }),
@@ -556,7 +559,10 @@ export class HarnessAgentSession {
     }
     const session = this.underlyingSession;
     try {
-      return await this.suspendCurrentTurn({ session });
+      const state = await this.suspendCurrentTurn({ session });
+      // Freeze ingress first, then include all dispatched host work in the cursor.
+      await this.activePromptDone;
+      return this.addPendingToolState(state);
     } finally {
       this.endLocalHandle({ sessionState: 'detached' });
     }

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -47,6 +47,7 @@ function mockHarness(options: {
   promptDone?: (options: HarnessV1PromptTurnOptions) => Promise<void>;
   supportsSteering?: boolean;
   onSuspendTurn?: () => void | Promise<void>;
+  onSubmitToolResult?: HarnessV1PromptControl['submitToolResult'];
   continueScript?: (
     submitToolResult: (input: {
       toolCallId: string;
@@ -102,6 +103,7 @@ function mockHarness(options: {
   const doContinueTurn = vi.fn(async (opts: HarnessV1ContinueTurnOptions) => {
     const control: HarnessV1PromptControl = {
       submitToolResult: async input => {
+        await options.onSubmitToolResult?.(input);
         toolResults.push(input);
       },
       submitToolApproval: async input => {
@@ -139,6 +141,7 @@ function mockHarness(options: {
       options.onPromptTurn?.(opts);
       const control: HarnessV1PromptControl = {
         submitToolResult: async input => {
+          await options.onSubmitToolResult?.(input);
           toolResults.push(input);
         },
         submitToolApproval: async input => {
@@ -925,6 +928,7 @@ describe('HarnessAgent', () => {
       script: () => [],
       supportsSteering: true,
       promptDone: () => promptDone,
+      onSuspendTurn: () => finishPrompt(),
     });
     const agent = new HarnessAgent({
       harness,
@@ -1474,6 +1478,252 @@ describe('HarnessAgent', () => {
     ).resolves.toBeDefined();
 
     await session.destroy();
+  });
+
+  test.each([
+    { count: 1, error: false, suspendDuringValidation: false },
+    { count: 3, error: true, suspendDuringValidation: false },
+    { count: 1, error: false, suspendDuringValidation: true },
+  ])(
+    'preserves dispatched host results when the adapter suspends ($count calls, error=$error, validation=$suspendDuringValidation)',
+    async ({ count, error, suspendDuringValidation }) => {
+      let releaseWork!: () => void;
+      const work = new Promise<void>(resolve => {
+        releaseWork = resolve;
+      });
+      let resolveStarted!: () => void;
+      const started = new Promise<void>(resolve => {
+        resolveStarted = resolve;
+      });
+      let closeStream!: () => void;
+      const streamDone = new Promise<void>(resolve => {
+        closeStream = resolve;
+      });
+      let resolveClosed!: () => void;
+      const closed = new Promise<void>(resolve => {
+        resolveClosed = resolve;
+      });
+      let channelClosed = false;
+      const completed: string[] = [];
+      const execute = vi.fn(async ({ query }: { query: string }) => {
+        if (execute.mock.calls.length === count) resolveStarted();
+        await work;
+        completed.push(query);
+        if (error && query === '1') throw new Error('tool unavailable');
+        return { answer: query };
+      });
+      const calls: Extract<HarnessV1StreamPart, { type: 'tool-call' }>[] =
+        Array.from({ length: count }, (_, index) => ({
+          type: 'tool-call',
+          toolCallId: `call-${index}`,
+          toolName: 'research',
+          input: JSON.stringify({ query: String(index) }),
+        }));
+      const { harness, toolResults, prompts, doContinueTurn } = mockHarness({
+        script: () => calls,
+        promptDone: () => streamDone,
+        onDoStart: () => {
+          channelClosed = false;
+        },
+        onSuspendTurn: () => {
+          channelClosed = true;
+          closeStream();
+          resolveClosed();
+        },
+        onSubmitToolResult: async () => {
+          if (channelClosed)
+            throw new Error(
+              'SandboxChannel: cannot send tool-result — channel is closed.',
+            );
+        },
+        continueScript: () => [
+          ...calls.map(call => ({
+            type: 'tool-result' as const,
+            toolCallId: call.toolCallId,
+            toolName: call.toolName,
+            result: { answer: call.toolCallId },
+          })),
+          ...finishEvents(),
+        ],
+      });
+      const agent = new HarnessAgent({
+        harness,
+        sandbox: makeSandboxProvider(),
+        tools: {
+          research: tool({
+            inputSchema: z.object({ query: z.string() }).refine(async () => {
+              if (suspendDuringValidation) {
+                resolveStarted();
+                await work;
+              }
+              return true;
+            }),
+            execute,
+          }),
+        },
+      });
+      const session = await agent.createSession();
+      const first = await agent.stream({ session, prompt: 'research' });
+      const firstParts: string[] = [];
+      const firstRead = (async () => {
+        for await (const part of first.fullStream) firstParts.push(part.type);
+      })();
+      await started;
+      const suspension = session.suspendTurn();
+      await closed;
+      releaseWork();
+      const continueFrom = await suspension;
+      await firstRead;
+
+      expect(completed).toHaveLength(count);
+      expect(continueFrom.pendingToolResults).toHaveLength(count);
+      expect(toolResults).toEqual([]);
+      expect(firstParts).not.toContain('error');
+      expect(firstParts.filter(type => type === 'tool-result')).toHaveLength(
+        count - Number(error),
+      );
+      expect(firstParts.filter(type => type === 'tool-error')).toHaveLength(
+        Number(error),
+      );
+      const resumed = await agent.createSession({
+        sessionId: session.sessionId,
+        continueFrom: JSON.parse(JSON.stringify(continueFrom)),
+      });
+      const second = await agent.continueStream({ session: resumed });
+      const secondParts: string[] = [];
+      for await (const part of second.fullStream) secondParts.push(part.type);
+
+      expect(execute).toHaveBeenCalledTimes(count);
+      expect(prompts).toEqual(['research']);
+      expect(doContinueTurn).toHaveBeenCalledOnce();
+      expect(toolResults).toHaveLength(count);
+      expect(toolResults).toEqual(
+        expect.arrayContaining(
+          calls.map((call, index) => ({
+            toolCallId: call.toolCallId,
+            output:
+              error && index === 1
+                ? { error: 'Error: tool unavailable' }
+                : { answer: String(index) },
+            ...(error && index === 1 ? { isError: true } : {}),
+          })),
+        ),
+      );
+      expect(secondParts).not.toContain('tool-result');
+      expect(secondParts).not.toContain('tool-error');
+      expect(secondParts.filter(type => type === 'finish-step')).toHaveLength(
+        1,
+      );
+      await expect(second.steps).resolves.toHaveLength(1);
+      await resumed.destroy();
+    },
+  );
+
+  test('preserves a resumed approved host call across another suspension', async () => {
+    let startWork!: () => void;
+    const started = new Promise<void>(resolve => {
+      startWork = resolve;
+    });
+    let finishWork!: () => void;
+    const work = new Promise<void>(resolve => {
+      finishWork = resolve;
+    });
+    let signalClosed!: () => void;
+    const closed = new Promise<void>(resolve => {
+      signalClosed = resolve;
+    });
+    let channelClosed = false;
+    let continuationCount = 0;
+    const execute = vi.fn(async () => {
+      startWork();
+      await work;
+      return { answer: 'retained' };
+    });
+    const { harness, toolResults } = mockHarness({
+      script: () => [],
+      onDoStart: () => {
+        channelClosed = false;
+      },
+      onSuspendTurn: () => {
+        channelClosed = true;
+        signalClosed();
+      },
+      onSubmitToolResult: async () => {
+        if (channelClosed) throw new Error('channel is closed');
+      },
+      continueScript: () =>
+        ++continuationCount === 1
+          ? []
+          : [
+              {
+                type: 'tool-result',
+                toolCallId: 'call-1',
+                toolName: 'research',
+                result: { answer: 'retained' },
+              },
+              ...finishEvents(),
+            ],
+    });
+    const agent = new HarnessAgent({
+      harness,
+      sandbox: makeSandboxProvider(),
+      tools: {
+        research: tool({ inputSchema: z.object({}), execute }),
+      },
+    });
+    const session = await agent.createSession({
+      continueFrom: {
+        type: 'continue-turn',
+        harnessId: 'mock',
+        specificationVersion: 'harness-v1',
+        data: {},
+        pendingToolApprovals: [
+          {
+            approvalId: 'approval-1',
+            toolCallId: 'call-1',
+            toolName: 'research',
+            input: '{}',
+            kind: 'custom',
+            providerExecuted: false,
+          },
+        ],
+      },
+    });
+    const first = await agent.continueStream({
+      session,
+      toolApprovalContinuations: [
+        {
+          type: 'tool-approval-response',
+          approvalId: 'approval-1',
+          approved: true,
+        },
+      ],
+    });
+    const firstParts: string[] = [];
+    const consume = (async () => {
+      for await (const part of first.fullStream) firstParts.push(part.type);
+    })();
+    await started;
+    const suspension = session.suspendTurn();
+    await closed;
+    finishWork();
+    const continueFrom = await suspension;
+    await consume;
+    expect(firstParts).not.toContain('error');
+    expect(firstParts.filter(type => type === 'tool-result')).toHaveLength(1);
+    expect(continueFrom.pendingToolResults).toHaveLength(1);
+    expect(continueFrom.pendingToolApprovals).toBeUndefined();
+    const resumed = await agent.createSession({
+      sessionId: session.sessionId,
+      continueFrom: JSON.parse(JSON.stringify(continueFrom)),
+    });
+    const second = await agent.continueStream({ session: resumed });
+    await second.consumeStream();
+    expect(execute).toHaveBeenCalledOnce();
+    expect(toolResults).toEqual([
+      { toolCallId: 'call-1', output: { answer: 'retained' } },
+    ]);
+    await resumed.destroy();
   });
 
   test('keeps a turn unfinished when suspension closes its stream mid-step', async () => {

--- a/packages/harness/src/agent/internal/run-prompt.ts
+++ b/packages/harness/src/agent/internal/run-prompt.ts
@@ -269,6 +269,39 @@ export function runPrompt<
     }
 
     const { stream, control } = bridge;
+    const submitToolResult: HarnessV1PromptControl['submitToolResult'] =
+      async submission => {
+        if (!input.isTurnSuspending?.())
+          return control.submitToolResult(submission);
+        const toolCall =
+          rawToolCallsByToolCallId.get(submission.toolCallId) ??
+          pendingResultsByToolCallId.get(submission.toolCallId) ??
+          pendingToolApprovals.find(
+            approval => approval.toolCallId === submission.toolCallId,
+          );
+        if (toolCall == null)
+          throw new Error(
+            `Unknown suspended tool call '${submission.toolCallId}'.`,
+          );
+        const { toolCallId, ...completedResult } = submission;
+        onPendingToolResult({
+          toolCallId,
+          toolName: toolCall.toolName,
+          input: toolCall.input,
+          completedResult,
+        });
+        const parsed = toolCallsByToolCallId.get(toolCallId);
+        if (parsed != null && !settledHostToolCallIds.has(toolCallId)) {
+          bufferedToolOutcomes.push(() =>
+            enqueueHostToolOutcome({
+              toolCall: parsed,
+              outcome: submission.isError
+                ? { ok: false, error: submission.output }
+                : { ok: true, output: submission.output },
+            }),
+          );
+        }
+      };
     input.onPromptControlAvailable?.(control);
     const reader = stream.getReader();
     const stripToolInputWorkDir = createToolInputWorkDirStripper({
@@ -541,25 +574,30 @@ export function runPrompt<
     };
     const processPendingToolResultContinuation = async (
       pendingResult: HarnessV1PendingToolResult,
-      continuation: ToolResultPart,
+      continuation: ToolResultPart | undefined,
     ): Promise<void> => {
-      const result = unwrapToolResultOutput(continuation);
-      onToolResultSettled(pendingResult.toolCallId);
-      pendingResultsByToolCallId.delete(pendingResult.toolCallId);
+      const submission =
+        continuation == null
+          ? pendingResult.completedResult
+          : {
+              ...unwrapToolResultOutput(continuation),
+              toolResult: {
+                ...continuation,
+                toolName: pendingResult.toolName,
+                ...(continuation.providerOptions == null &&
+                pendingResult.providerOptions != null
+                  ? { providerOptions: pendingResult.providerOptions }
+                  : {}),
+              },
+            };
+      if (submission == null) return;
       settledHostToolCallIds.add(pendingResult.toolCallId);
-      await control.submitToolResult({
+      onToolResultSettled(pendingResult.toolCallId);
+      await submitToolResult({
         toolCallId: pendingResult.toolCallId,
-        output: result.output,
-        isError: result.isError,
-        toolResult: {
-          ...continuation,
-          toolName: pendingResult.toolName,
-          ...(continuation.providerOptions == null &&
-          pendingResult.providerOptions != null
-            ? { providerOptions: pendingResult.providerOptions }
-            : {}),
-        },
+        ...submission,
       });
+      pendingResultsByToolCallId.delete(pendingResult.toolCallId);
     };
     const enqueueHostToolOutcome = (options: {
       toolCall: ToolCallTextStreamPart;
@@ -643,7 +681,7 @@ export function runPrompt<
 
       settledHostToolCallIds.add(approval.toolCallId);
       if (!continuation.approved) {
-        await control.submitToolResult({
+        await submitToolResult({
           toolCallId: approval.toolCallId,
           output: {
             type: 'execution-denied',
@@ -664,7 +702,7 @@ export function runPrompt<
         wrappedExecuteTool: lifecycle.executeTool,
         sandboxSession: input.sandboxSession,
         abortSignal: input.abortSignal,
-        control,
+        submitToolResult,
         onPreliminaryResult: preliminaryOutput => {
           const stripped = stripWorkDir(
             {
@@ -727,12 +765,12 @@ export function runPrompt<
         const continuation = continuationsByToolCallId.get(
           pendingResult.toolCallId,
         );
-        if (continuation != null) {
+        if (continuation != null || pendingResult.completedResult != null) {
           await processPendingToolResultContinuation(
             pendingResult,
             continuation,
           );
-          closingResumedStep = true;
+          if (pendingResult.completedResult == null) closingResumedStep = true;
         }
       }
 
@@ -1083,7 +1121,7 @@ export function runPrompt<
                 toolName: toolCall.toolName,
               }),
             };
-            await control.submitToolResult({
+            await submitToolResult({
               toolCallId: toolCall.toolCallId,
               output,
             });
@@ -1130,7 +1168,7 @@ export function runPrompt<
               type: 'execution-denied',
               reason: customToolApprovalDecision.reason,
             };
-            await control.submitToolResult({
+            await submitToolResult({
               toolCallId: toolCall.toolCallId,
               output,
             });
@@ -1223,7 +1261,7 @@ export function runPrompt<
                 wrappedExecuteTool: lifecycle.executeTool,
                 sandboxSession: input.sandboxSession,
                 abortSignal: input.abortSignal,
-                control,
+                submitToolResult,
                 onPreliminaryResult: preliminaryOutput => {
                   /*
                    * Project a `yield`ed value as a preliminary AI SDK
@@ -1277,6 +1315,7 @@ export function runPrompt<
       await waitForOutstandingHostToolExecutions();
       const isTurnSuspending = input.isTurnSuspending?.() === true;
       if (isTurnSuspending) {
+        await publishToolExecutions();
         if (finalFinish == null) {
           /*
            * A timed slice may stop in the middle of a model step. Its partial
@@ -1388,7 +1427,7 @@ async function maybeExecuteHostTool<TOOLS extends ToolSet>(input: {
   wrappedExecuteTool: TurnLifecycle<ToolSet, Context>['executeTool'];
   sandboxSession: SandboxSession;
   abortSignal: AbortSignal | undefined;
-  control: HarnessV1PromptControl;
+  submitToolResult: HarnessV1PromptControl['submitToolResult'];
   /**
    * Called for each value a generator `execute` `yield`s before its last. The
    * caller surfaces these as preliminary `tool-result` parts on the consumer
@@ -1440,13 +1479,13 @@ async function maybeExecuteHostTool<TOOLS extends ToolSet>(input: {
       },
     });
 
-    await input.control.submitToolResult({
+    await input.submitToolResult({
       toolCallId: input.event.toolCallId,
       output,
     });
     return { executed: true, outcome: { ok: true, output } };
   } catch (err) {
-    await input.control.submitToolResult({
+    await input.submitToolResult({
       toolCallId: input.event.toolCallId,
       output: { error: String(err) },
       isError: true,

--- a/packages/harness/src/v1/harness-v1-lifecycle-state.ts
+++ b/packages/harness/src/v1/harness-v1-lifecycle-state.ts
@@ -1,5 +1,5 @@
 import type { JSONValue } from '@ai-sdk/provider';
-import type { ProviderOptions } from '@ai-sdk/provider-utils';
+import type { ProviderOptions, ToolResultPart } from '@ai-sdk/provider-utils';
 import type { HarnessV1Skill } from './harness-v1-skill';
 import type { HarnessV1ToolSpec } from './harness-v1-tool-spec';
 
@@ -18,6 +18,12 @@ export type HarnessV1PendingToolResult = {
   readonly toolName: string;
   readonly input: string;
   readonly providerOptions?: ProviderOptions;
+  /** Executed while suspending; submit on resume without running the tool again. */
+  readonly completedResult?: {
+    readonly output: unknown;
+    readonly isError?: boolean;
+    readonly toolResult?: ToolResultPart;
+  };
 };
 
 /**


### PR DESCRIPTION
## Background

Suspending a bridge-backed harness turn can close the adapter while dispatched host tools are still executing. Their eventual `submitToolResult` calls fail on the closed channel, and the already-captured continuation does not retain the completed work. Workflow time slicing can therefore fail a turn whose host tool succeeded.

The deterministic reproduction uses a promise gate and an adapter that rejects submissions after suspension. Its first three cases fail on the unmodified base.

## Summary

- Capture host results completed during suspension in the framework-owned continuation, including errors and canonical tool results where supplied.
- Wait for dispatched host work before returning the public `suspendTurn()` continuation, then deliver saved results on continuation without re-executing tools.
- Preserve lifecycle tool outcomes and the real resumed step completion; retain existing explicit tool-result and approval continuation behavior.
- Add four regression cases covering one tool, parallel tools with an error, asynchronous validation, and an approved tool suspended while resuming. Document the suspension contract and add a patch changeset.

No dependency, adapter, timeout, retry, or model-policy changes.

## End-to-End Verification

Ran the built current-source packages with OpenCode, Vercel Sandbox, AI Gateway, and Workflow harness. A synthetic 15-second host tool crossed a 3-second slice boundary. The turn completed across five slices in about 53 seconds, the tool executed once, and the final model response contained the saved tool result. The sandbox was deleted afterward.

## Testing

- Harness Node suite: **363 tests passed**.
- Harness Edge suite: **338 tests passed**.
- Workflow harness suite: **15 tests passed**.
- Full workspace `pnpm type-check:full`: passed, including examples.
- Build of the harness / workflow / OpenCode / Vercel Sandbox dependency graph: passed.
- Changed TypeScript lint/format, Markdown format, and `git diff --check`: passed.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #20535.
