### PR TITLE
fix: prevent empty tool-call deltas from fragmenting OpenAI-compatible reasoning streams

### DIFF
--- a/.changeset/fresh-cats-think.md
+++ b/.changeset/fresh-cats-think.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/openai-compatible": patch
+---
+
+fix(openai-compatible): keep reasoning streams contiguous when deltas include empty tool call arrays

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.test.ts
@@ -2032,6 +2032,37 @@ describe('doStream', () => {
     `);
   });
 
+  it('should keep reasoning active when deltas include empty tool calls', async () => {
+    server.urls['https://my.api.com/v1/chat/completions'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        `data: {"id":"chatcmpl-test","object":"chat.completion.chunk","model":"test-model",` +
+          `"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_content":"Think ","tool_calls":[]},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-test","object":"chat.completion.chunk","model":"test-model",` +
+          `"choices":[{"index":0,"delta":{"content":"","reasoning_content":"more...","tool_calls":[]},"finish_reason":null}]}\n\n`,
+        `data: {"id":"chatcmpl-test","object":"chat.completion.chunk","model":"test-model",` +
+          `"choices":[{"index":0,"delta":{"content":"Hello","reasoning_content":"","tool_calls":[]},"finish_reason":"stop"}]}\n\n`,
+        'data: [DONE]\n\n',
+      ],
+    };
+
+    const { stream } = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    });
+
+    const events = await convertReadableStreamToArray(stream);
+
+    expect(
+      events.filter(({ type }) => type.startsWith('reasoning-')),
+    ).toStrictEqual([
+      { type: 'reasoning-start', id: 'reasoning-0' },
+      { type: 'reasoning-delta', id: 'reasoning-0', delta: 'Think ' },
+      { type: 'reasoning-delta', id: 'reasoning-0', delta: 'more...' },
+      { type: 'reasoning-end', id: 'reasoning-0' },
+    ]);
+  });
+
   it('should stream reasoning from reasoning field when reasoning_content is not provided', async () => {
     server.urls['https://my.api.com/v1/chat/completions'].response = {
       type: 'stream-chunks',

--- a/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
+++ b/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts
@@ -562,7 +562,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
               }
             }
 
-            if (delta.tool_calls != null) {
+            if (delta.tool_calls != null && delta.tool_calls.length > 0) {
               // end active reasoning block before tool calls start
               if (isActiveReasoning) {
                 controller.enqueue({


### PR DESCRIPTION
## Background

OpenAI-compatible gateways that attach `tool_calls: []` to reasoning deltas caused one logical reasoning span to be emitted as multiple user-visible reasoning blocks.

## Root Cause

The stream transform treated any non-null `tool_calls` array as active tool output. The immutable reproduction and regression test confirmed that empty arrays closed reasoning after each delta, producing two start/end cycles instead of one.

## Summary

Reasoning now ends for tool calls only when the streamed `tool_calls` array contains entries. Added a patch changeset and removed reproduction-only artifacts.

## Testing

Added a regression test verifying consecutive reasoning deltas with empty tool-call arrays remain within one reasoning lifecycle.

## End-to-end Validation

- `pnpm -C packages/openai-compatible build` completed successfully.
- Immutable reproduction replay completed successfully with one contiguous reasoning block and no original failure signal.

## Related Issues

Fixes #20203

Closes #20251
