### PR TITLE
feat: add batch cancel and list APIs

### DIFF
--- a/.changeset/calm-batches-list.md
+++ b/.changeset/calm-batches-list.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/provider': patch
+'ai': patch
+---
+
+feat: add batch cancel and list APIs

--- a/content/docs/03-ai-sdk-core/42-batch.mdx
+++ b/content/docs/03-ai-sdk-core/42-batch.mdx
@@ -18,7 +18,7 @@ summarization, and content generation that do not need an immediate response.
 The batch API is designed to support multiple request types. Currently, only
 `type: 'text'` is supported.
 
-The AI SDK provides three functions for the batch lifecycle:
+The AI SDK provides five functions for the batch lifecycle:
 
 - [`experimental_startBatch`](/docs/reference/ai-sdk-core/start-batch)
   submits a batch and returns its initial status and a serializable reference.
@@ -26,17 +26,29 @@ The AI SDK provides three functions for the batch lifecycle:
   retrieves the latest status and request counts.
 - [`experimental_getBatchResults`](/docs/reference/ai-sdk-core/get-batch-results)
   asynchronously iterates over the terminal result for each request.
+- [`experimental_cancelBatch`](/docs/reference/ai-sdk-core/cancel-batch)
+  requests cancellation of a batch.
+- [`experimental_listBatches`](/docs/reference/ai-sdk-core/list-batches)
+  lists batches and their latest statuses.
 
-All three functions are exported from `ai`. The examples below use aliases so
+All five functions are exported from `ai`. The examples below use aliases so
 the shorter names can be used in application code:
 
 ```ts
 import {
+  experimental_cancelBatch as cancelBatch,
   experimental_getBatchResults as getBatchResults,
   experimental_getBatchStatus as getBatchStatus,
+  experimental_listBatches as listBatches,
   experimental_startBatch as startBatch,
 } from 'ai';
 ```
+
+Cancellation and listing are optional provider capabilities. Calling either
+function with a provider that does not implement it throws an
+`UnsupportedFunctionalityError`. In the cancellation and listing examples
+below, `provider` represents a batch provider that implements the respective
+capability.
 
 ## Supported providers
 
@@ -218,6 +230,55 @@ support and payloads are provider-specific. The provider pages linked above
 describe their webhook behavior; providers that do not support webhooks return
 an unsupported warning and continue without one.
 
+## Cancelling a batch
+
+Use `cancelBatch` to ask the provider to stop processing a batch:
+
+```ts
+const result = await cancelBatch({
+  provider,
+  batch,
+});
+
+console.log(result.providerMetadata);
+```
+
+A successful call means that the provider accepted the cancellation request.
+It does not guarantee that cancellation has finished or that every pending
+request will be cancelled. Use `getBatchStatus` to retrieve the latest status
+after requesting cancellation.
+
+The result can include provider metadata with additional information from the
+cancellation response.
+
+## Listing batches
+
+Use `listBatches` to retrieve batches from the provider. Results are paginated.
+Pass the returned `nextCursor` as `cursor` to retrieve the next page:
+
+```ts
+let cursor: string | undefined;
+
+do {
+  const page = await listBatches({
+    provider,
+    limit: 20,
+    cursor,
+  });
+
+  for (const batch of page.batches) {
+    console.log(batch.id, batch.status);
+  }
+
+  cursor = page.nextCursor;
+} while (cursor != null);
+```
+
+Each item is a serializable batch reference with its latest normalized status,
+so it can be passed directly to `getBatchStatus`, `getBatchResults`, or
+`cancelBatch`. Cursors are opaque and provider-specific; applications should
+store or pass them unchanged rather than inspect their contents.
+
 ## Retrieving results
 
 After the batch is complete, `getBatchResults` returns an async iterable. Each
@@ -257,14 +318,14 @@ sensitive data.
 
 ## Request controls
 
-`getBatchStatus` and `getBatchResults` accept `providerOptions`, `headers`,
-`timeout`, `abortSignal`, and `maxRetries` for the current status or result
-retrieval operation:
+All batch lifecycle functions accept `providerOptions`, `headers`, `timeout`,
+and `abortSignal` for the current operation. `getBatchStatus`,
+`getBatchResults`, and `listBatches` also accept `maxRetries`:
 
-- `maxRetries` controls retries for status and result retrieval. It does not
-  retry batch creation, which could create a duplicate batch. It defaults to 2;
-  set it to 0 to disable retries.
-- `abortSignal` cancels the current status or result request.
+- `maxRetries` controls retries for status, result retrieval, and listing. It
+  does not retry batch creation or cancellation. It defaults to 2; set it to 0
+  to disable retries.
+- `abortSignal` cancels the current API request.
 - `timeout` limits the current HTTP operation.
 
 These controls affect communication with the provider. They do not change the

--- a/content/docs/07-reference/01-ai-sdk-core/23-cancel-batch.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/23-cancel-batch.mdx
@@ -1,0 +1,96 @@
+---
+title: experimental_cancelBatch
+description: API Reference for experimental_cancelBatch.
+---
+
+# `experimental_cancelBatch()`
+
+<Note type="warning">
+  Batch support is experimental and the API may change in patch releases.
+</Note>
+
+Requests cancellation of an asynchronous batch. A successful call means that
+the provider accepted the cancellation request, not that cancellation has
+finished. For a complete guide to the batch lifecycle, see
+[Batch](/docs/ai-sdk-core/batch).
+
+```ts
+import { experimental_cancelBatch as cancelBatch } from 'ai';
+
+const result = await cancelBatch({
+  provider,
+  batch,
+});
+
+console.log(result.providerMetadata);
+```
+
+## Import
+
+<Snippet
+  text={`import { experimental_cancelBatch } from "ai"`}
+  prompt={false}
+/>
+
+## API Signature
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'provider',
+      type: 'Experimental_BatchProvider',
+      isOptional: true,
+      description:
+        'The provider used to access the batch. Defaults to the global provider, or the AI Gateway when no global provider is configured.',
+    },
+    {
+      name: 'batch',
+      type: 'Experimental_BatchReference',
+      description:
+        'The serializable reference returned by experimental_startBatch.',
+    },
+    {
+      name: 'providerOptions',
+      type: 'ProviderOptions',
+      isOptional: true,
+      description:
+        'Additional provider-specific options for the cancellation request.',
+    },
+    {
+      name: 'abortSignal',
+      type: 'AbortSignal',
+      isOptional: true,
+      description: 'An optional abort signal to cancel the API request.',
+    },
+    {
+      name: 'timeout',
+      type: 'number | { totalMs?: number }',
+      isOptional: true,
+      description: 'Maximum time allowed for the cancellation request.',
+    },
+    {
+      name: 'headers',
+      type: 'Record<string, string | undefined>',
+      isOptional: true,
+      description: 'Additional HTTP headers for the request.',
+    },
+  ]}
+/>
+
+### Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: 'providerMetadata',
+      type: 'ProviderMetadata',
+      isOptional: true,
+      description: 'Provider-specific metadata from the cancellation response.',
+    },
+  ]}
+/>
+
+Calling this function with a provider that does not support batch cancellation
+throws an `UnsupportedFunctionalityError`.

--- a/content/docs/07-reference/01-ai-sdk-core/24-list-batches.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/24-list-batches.mdx
@@ -1,0 +1,121 @@
+---
+title: experimental_listBatches
+description: API Reference for experimental_listBatches.
+---
+
+# `experimental_listBatches()`
+
+<Note type="warning">
+  Batch support is experimental and the API may change in patch releases.
+</Note>
+
+Lists a page of asynchronous batches and their latest normalized statuses. For
+a complete guide to the batch lifecycle, see [Batch](/docs/ai-sdk-core/batch).
+
+```ts
+import { experimental_listBatches as listBatches } from 'ai';
+
+const page = await listBatches({
+  provider,
+  limit: 20,
+  cursor,
+});
+
+console.log(page.batches, page.nextCursor);
+```
+
+## Import
+
+<Snippet
+  text={`import { experimental_listBatches } from "ai"`}
+  prompt={false}
+/>
+
+## API Signature
+
+### Parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: 'provider',
+      type: 'Experimental_BatchProvider',
+      isOptional: true,
+      description:
+        'The provider whose batches should be listed. Defaults to the global provider, or the AI Gateway when no global provider is configured.',
+    },
+    {
+      name: 'limit',
+      type: 'number',
+      isOptional: true,
+      description: 'Maximum number of batches to return in this page.',
+    },
+    {
+      name: 'cursor',
+      type: 'string',
+      isOptional: true,
+      description:
+        'Opaque cursor returned as nextCursor by the previous list operation.',
+    },
+    {
+      name: 'providerOptions',
+      type: 'ProviderOptions',
+      isOptional: true,
+      description: 'Additional provider-specific options for listing batches.',
+    },
+    {
+      name: 'maxRetries',
+      type: 'number',
+      isOptional: true,
+      description:
+        'Maximum number of retries for listing batches. Set to 0 to disable retries. Default: 2.',
+    },
+    {
+      name: 'abortSignal',
+      type: 'AbortSignal',
+      isOptional: true,
+      description: 'An optional abort signal to cancel the request.',
+    },
+    {
+      name: 'timeout',
+      type: 'number | { totalMs?: number }',
+      isOptional: true,
+      description: 'Maximum time allowed for the list request.',
+    },
+    {
+      name: 'headers',
+      type: 'Record<string, string | undefined>',
+      isOptional: true,
+      description: 'Additional HTTP headers for the request.',
+    },
+  ]}
+/>
+
+### Returns
+
+<PropertiesTable
+  content={[
+    {
+      name: 'batches',
+      type: 'Array<Experimental_Batch>',
+      description:
+        'The batches in this page. Each item contains a serializable batch reference and its latest normalized status.',
+    },
+    {
+      name: 'nextCursor',
+      type: 'string',
+      isOptional: true,
+      description:
+        'Opaque cursor to pass as cursor to retrieve the next page. Omitted when there are no more batches.',
+    },
+    {
+      name: 'providerMetadata',
+      type: 'ProviderMetadata',
+      isOptional: true,
+      description: 'Provider-specific metadata for the list operation.',
+    },
+  ]}
+/>
+
+Calling this function with a provider that does not support listing batches
+throws an `UnsupportedFunctionalityError`.

--- a/content/docs/07-reference/01-ai-sdk-core/index.mdx
+++ b/content/docs/07-reference/01-ai-sdk-core/index.mdx
@@ -69,6 +69,16 @@ AI SDK Core contains the following main functions:
       href: '/docs/reference/ai-sdk-core/get-batch-results',
     },
     {
+      title: 'experimental_cancelBatch()',
+      description: 'Request cancellation of an asynchronous batch.',
+      href: '/docs/reference/ai-sdk-core/cancel-batch',
+    },
+    {
+      title: 'experimental_listBatches()',
+      description: 'List asynchronous batches and their latest statuses.',
+      href: '/docs/reference/ai-sdk-core/list-batches',
+    },
+    {
       title: 'transcribe()',
       description: 'Generate a transcript from an audio file.',
       href: '/docs/reference/ai-sdk-core/transcribe',

--- a/packages/ai/src/batch/batch-types.test-d.ts
+++ b/packages/ai/src/batch/batch-types.test-d.ts
@@ -2,6 +2,8 @@ import type {
   Experimental_BatchV4 as BatchV4,
   Experimental_BatchV4Error as BatchV4Error,
   Experimental_BatchV4ItemResult as BatchV4ItemResult,
+  Experimental_BatchV4ListOptions as BatchV4ListOptions,
+  Experimental_BatchV4ListResult as BatchV4ListResult,
   Experimental_BatchV4OperationOptions as BatchV4OperationOptions,
   Experimental_BatchV4Request as BatchV4Request,
   Experimental_BatchV4Status as BatchV4Status,
@@ -14,16 +16,20 @@ import type {
 } from '@ai-sdk/provider';
 import { expectTypeOf, it } from 'vitest';
 import {
+  experimental_cancelBatch as cancelBatch,
   experimental_getBatchResults as getBatchResults,
   experimental_getBatchStatus as getBatchStatus,
   experimental_startBatch as startBatch,
+  experimental_listBatches as listBatches,
   type GatewayProviderMetadata,
   type Experimental_BatchError as BatchError,
   type Experimental_BatchProvider as BatchProvider,
   type Experimental_BatchReference as BatchReference,
   type Experimental_BatchStatus as BatchStatus,
+  type Experimental_CancelBatchResult as CancelBatchResult,
   type Experimental_GetBatchResultsOptions as GetBatchResultsOptions,
   type Experimental_GetBatchStatusOptions as GetBatchStatusOptions,
+  type Experimental_ListBatchesResult as ListBatchesResult,
   type Experimental_StartBatchOptions as StartBatchOptions,
   type Experimental_StartBatchResult as StartBatchResult,
   type Experimental_Batch as Batch,
@@ -181,6 +187,12 @@ it('defines batch support as a standalone provider service', () => {
   expectTypeOf<ReturnType<TestBatchApi['doGetBatchResults']>>().toEqualTypeOf<
     PromiseLike<ReadableStream<BatchV4ItemResult>>
   >();
+  expectTypeOf<
+    NonNullable<TestBatchApi['doListBatches']>
+  >().parameters.toEqualTypeOf<[BatchV4ListOptions]>();
+  expectTypeOf<
+    ReturnType<NonNullable<TestBatchApi['doListBatches']>>
+  >().toEqualTypeOf<PromiseLike<BatchV4ListResult>>();
   expectTypeOf<BatchV4ItemResult>().toEqualTypeOf<TextBatchV4ItemResult>();
   expectTypeOf<
     Extract<TextBatchV4ItemResult, { status: 'succeeded' }>['result']
@@ -233,11 +245,15 @@ it('allows the default provider to be omitted', () => {
 
   getBatchStatus({ batch: {} as BatchReference });
   getBatchResults({ batch: {} as BatchReference });
+  cancelBatch({ batch: {} as BatchReference });
+  listBatches();
 });
 
 it('exports the experimental batch functions with the public result types', () => {
   expectTypeOf(startBatch).returns.resolves.toEqualTypeOf<StartBatchResult>();
   expectTypeOf(getBatchStatus).returns.resolves.toEqualTypeOf<BatchStatus>();
+  expectTypeOf(cancelBatch).returns.resolves.toEqualTypeOf<CancelBatchResult>();
+  expectTypeOf(listBatches).returns.resolves.toEqualTypeOf<ListBatchesResult>();
   getBatchStatus({
     provider: {} as BatchV4,
     batch: {} as BatchReference,

--- a/packages/ai/src/batch/batch-types.ts
+++ b/packages/ai/src/batch/batch-types.ts
@@ -119,6 +119,42 @@ export type StartBatchResult = Batch & {
 };
 
 /**
+ * Options for requesting cancellation of a batch.
+ */
+export type CancelBatchOptions = {
+  provider?: BatchProvider;
+  batch: BatchReference;
+  providerOptions?: ProviderOptions;
+} & BatchCallOptions;
+
+/**
+ * Result of requesting cancellation of a batch.
+ */
+export type CancelBatchResult = {
+  readonly providerMetadata?: ProviderMetadata;
+};
+
+/**
+ * Options for listing batches.
+ */
+export type ListBatchesOptions = {
+  provider?: BatchProvider;
+  providerOptions?: ProviderOptions;
+  limit?: number;
+  cursor?: string;
+  maxRetries?: number;
+} & BatchCallOptions;
+
+/**
+ * One page of listed batches.
+ */
+export type ListBatchesResult = {
+  readonly batches: Array<Batch>;
+  readonly nextCursor?: string;
+  readonly providerMetadata?: ProviderMetadata;
+};
+
+/**
  * Options for retrieving batch status.
  */
 export type GetBatchStatusOptions = {

--- a/packages/ai/src/batch/batch.test.ts
+++ b/packages/ai/src/batch/batch.test.ts
@@ -10,7 +10,13 @@ import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
 import { describe, expect, it, vi } from 'vitest';
 import { InvalidArgumentError } from '../error/invalid-argument-error';
 import { MockProviderV4 } from '../test/mock-provider-v4';
-import { getBatchResults, getBatchStatus, startBatch } from './batch';
+import {
+  cancelBatch,
+  getBatchResults,
+  getBatchStatus,
+  listBatches,
+  startBatch,
+} from './batch';
 import type { BatchReference } from './batch-types';
 
 vi.mock('../version', () => ({ VERSION: '0.0.0-test' }));
@@ -43,10 +49,14 @@ function createMockBatchApi({
   }),
   doGetBatchStatus = async () => ({ status: 'pending' as const }),
   doGetBatchResults = async () => convertArrayToReadableStream([]),
+  doCancelBatch,
+  doListBatches,
 }: {
   doStartBatch?: BatchV4['doStartBatch'];
   doGetBatchStatus?: BatchV4['doGetBatchStatus'];
   doGetBatchResults?: BatchV4['doGetBatchResults'];
+  doCancelBatch?: BatchV4['doCancelBatch'];
+  doListBatches?: BatchV4['doListBatches'];
 } = {}): BatchV4 {
   return {
     specificationVersion: 'v4',
@@ -55,8 +65,96 @@ function createMockBatchApi({
     doStartBatch: doStartBatch,
     doGetBatchStatus: doGetBatchStatus,
     doGetBatchResults: doGetBatchResults,
+    doCancelBatch,
+    doListBatches,
   };
 }
+
+describe('cancelBatch', () => {
+  it('requests cancellation and returns provider metadata', async () => {
+    const calls: BatchV4OperationOptions[] = [];
+    const batchApi = createMockBatchApi({
+      doCancelBatch: async options => {
+        calls.push(options);
+        return { providerMetadata: { mock: { cancellation: 'requested' } } };
+      },
+    });
+
+    await expect(
+      cancelBatch({ provider: batchApi, batch: batchReference }),
+    ).resolves.toEqual({
+      providerMetadata: { mock: { cancellation: 'requested' } },
+    });
+    expect(calls).toEqual([
+      {
+        batchId: 'batch-123',
+        providerOptions: undefined,
+        abortSignal: undefined,
+        headers: { 'user-agent': 'ai/0.0.0-test' },
+      },
+    ]);
+  });
+
+  it('throws when cancellation is unsupported', async () => {
+    await expect(
+      cancelBatch({ provider: createMockBatchApi(), batch: batchReference }),
+    ).rejects.toMatchObject({ functionality: 'batch cancellation' });
+  });
+});
+
+describe('listBatches', () => {
+  it('returns normalized batch references and the next cursor', async () => {
+    const batchApi = createMockBatchApi({
+      doListBatches: async options => {
+        expect(options).toEqual({
+          providerOptions: undefined,
+          abortSignal: undefined,
+          headers: { 'user-agent': 'ai/0.0.0-test' },
+          limit: 20,
+          cursor: 'cursor-1',
+        });
+        return {
+          batches: [
+            {
+              batchId: 'batch-456',
+              status: 'completed',
+              rawStatus: 'done',
+            },
+          ],
+          nextCursor: 'cursor-2',
+          providerMetadata: { mock: { page: 1 } },
+        };
+      },
+    });
+
+    await expect(
+      listBatches({
+        provider: batchApi,
+        limit: 20,
+        cursor: 'cursor-1',
+        maxRetries: 0,
+      }),
+    ).resolves.toEqual({
+      batches: [
+        {
+          version: 2,
+          id: 'batch-456',
+          provider: 'mock-provider',
+          status: 'completed',
+          rawStatus: 'done',
+        },
+      ],
+      nextCursor: 'cursor-2',
+      providerMetadata: { mock: { page: 1 } },
+    });
+  });
+
+  it('throws when listing is unsupported', async () => {
+    await expect(
+      listBatches({ provider: createMockBatchApi() }),
+    ).rejects.toMatchObject({ functionality: 'batch listing' });
+  });
+});
 
 describe('startBatch', () => {
   it('uses the global default provider when provider is omitted', async () => {

--- a/packages/ai/src/batch/batch.test.ts
+++ b/packages/ai/src/batch/batch.test.ts
@@ -103,6 +103,18 @@ describe('cancelBatch', () => {
 });
 
 describe('listBatches', () => {
+  it('preserves the batch API as the method receiver', async () => {
+    const batchApi = createMockBatchApi();
+    batchApi.doListBatches = async function () {
+      expect(this).toBe(batchApi);
+      return { batches: [] };
+    };
+
+    await expect(
+      listBatches({ provider: batchApi, maxRetries: 0 }),
+    ).resolves.toEqual({ batches: [] });
+  });
+
   it('returns normalized batch references and the next cursor', async () => {
     const batchApi = createMockBatchApi({
       doListBatches: async options => {

--- a/packages/ai/src/batch/batch.ts
+++ b/packages/ai/src/batch/batch.ts
@@ -96,7 +96,7 @@ export async function listBatches({
 }: ListBatchesOptions = {}): Promise<ListBatchesResult> {
   const batchApi = resolveBatchApi(provider);
 
-  const doListBatches = batchApi.doListBatches;
+  const doListBatches = batchApi.doListBatches?.bind(batchApi);
   if (doListBatches == null) {
     throw new UnsupportedFunctionalityError({
       functionality: 'batch listing',

--- a/packages/ai/src/batch/batch.ts
+++ b/packages/ai/src/batch/batch.ts
@@ -31,13 +31,113 @@ import type {
   BatchProvider,
   BatchReference,
   BatchStatus,
+  CancelBatchOptions,
+  CancelBatchResult,
   GetBatchResultsOptions,
   GetBatchStatusOptions,
+  ListBatchesOptions,
+  ListBatchesResult,
   StartBatchOptions,
   StartBatchResult,
   TextBatchGenerationResult,
   TextBatchItemResult,
 } from './batch-types';
+
+/**
+ * Requests cancellation of a batch.
+ */
+export async function cancelBatch({
+  provider,
+  batch,
+  providerOptions,
+  abortSignal,
+  headers,
+  timeout,
+}: CancelBatchOptions): Promise<CancelBatchResult> {
+  const batchApi = resolveBatchApi(provider);
+  validateBatchReference({ batchApi, batch });
+
+  if (batchApi.doCancelBatch == null) {
+    throw new UnsupportedFunctionalityError({
+      functionality: 'batch cancellation',
+      message: 'The provider does not support batch cancellation.',
+    });
+  }
+
+  const operationAbortSignal = mergeAbortSignals(
+    abortSignal,
+    getTotalTimeoutMs(timeout),
+  );
+
+  try {
+    return await batchApi.doCancelBatch({
+      batchId: batch.id,
+      providerOptions,
+      abortSignal: operationAbortSignal,
+      headers: withUserAgentSuffix(headers ?? {}, `ai/${VERSION}`),
+    });
+  } catch (error) {
+    throw wrapGatewayError(error);
+  }
+}
+
+/**
+ * Lists a page of batches.
+ */
+export async function listBatches({
+  provider,
+  providerOptions,
+  limit,
+  cursor,
+  maxRetries,
+  abortSignal,
+  headers,
+  timeout,
+}: ListBatchesOptions = {}): Promise<ListBatchesResult> {
+  const batchApi = resolveBatchApi(provider);
+
+  const doListBatches = batchApi.doListBatches;
+  if (doListBatches == null) {
+    throw new UnsupportedFunctionalityError({
+      functionality: 'batch listing',
+      message: 'The provider does not support listing batches.',
+    });
+  }
+
+  const operationAbortSignal = mergeAbortSignals(
+    abortSignal,
+    getTotalTimeoutMs(timeout),
+  );
+  const { retry } = prepareRetries({
+    maxRetries,
+    abortSignal: operationAbortSignal,
+  });
+
+  try {
+    const { batches, nextCursor, providerMetadata } = await retry(() =>
+      doListBatches({
+        providerOptions,
+        abortSignal: operationAbortSignal,
+        headers: withUserAgentSuffix(headers ?? {}, `ai/${VERSION}`),
+        ...(limit != null && { limit }),
+        ...(cursor != null && { cursor }),
+      }),
+    );
+
+    return {
+      batches: batches.map(({ batchId, ...status }) => ({
+        version: 2,
+        id: batchId,
+        provider: batchApi.provider,
+        ...status,
+      })),
+      ...(nextCursor != null && { nextCursor }),
+      ...(providerMetadata != null && { providerMetadata }),
+    };
+  } catch (error) {
+    throw wrapGatewayError(error);
+  }
+}
 
 /**
  * Starts a batch.

--- a/packages/ai/src/batch/index.ts
+++ b/packages/ai/src/batch/index.ts
@@ -1,15 +1,21 @@
 export {
+  cancelBatch as experimental_cancelBatch,
   startBatch as experimental_startBatch,
   getBatchResults as experimental_getBatchResults,
   getBatchStatus as experimental_getBatchStatus,
+  listBatches as experimental_listBatches,
 } from './batch';
 export type {
   BatchError as Experimental_BatchError,
   BatchProvider as Experimental_BatchProvider,
   BatchReference as Experimental_BatchReference,
   BatchStatus as Experimental_BatchStatus,
+  CancelBatchOptions as Experimental_CancelBatchOptions,
+  CancelBatchResult as Experimental_CancelBatchResult,
   GetBatchResultsOptions as Experimental_GetBatchResultsOptions,
   GetBatchStatusOptions as Experimental_GetBatchStatusOptions,
+  ListBatchesOptions as Experimental_ListBatchesOptions,
+  ListBatchesResult as Experimental_ListBatchesResult,
   StartBatchOptions as Experimental_StartBatchOptions,
   StartBatchResult as Experimental_StartBatchResult,
   Batch as Experimental_Batch,

--- a/packages/provider/src/batch/v4/batch-v4.ts
+++ b/packages/provider/src/batch/v4/batch-v4.ts
@@ -91,6 +91,37 @@ export type BatchV4OperationOptions = {
   readonly batchId: string;
 } & BatchV4CallOptions;
 
+/**
+ * Result of requesting cancellation of a batch.
+ */
+export type BatchV4CancelResult = {
+  readonly providerMetadata?: SharedV4ProviderMetadata;
+};
+
+/**
+ * Options for listing batches.
+ */
+export type BatchV4ListOptions = BatchV4CallOptions & {
+  readonly limit?: number;
+  readonly cursor?: string;
+};
+
+/**
+ * A batch returned by a list operation.
+ */
+export type BatchV4ListItem = BatchV4Status & {
+  readonly batchId: string;
+};
+
+/**
+ * Result of listing batches.
+ */
+export type BatchV4ListResult = {
+  readonly batches: Array<BatchV4ListItem>;
+  readonly nextCursor?: string;
+  readonly providerMetadata?: SharedV4ProviderMetadata;
+};
+
 type BatchV4ItemResultBase<RESULT> =
   | {
       readonly id: string;
@@ -157,4 +188,10 @@ export type BatchV4<ModelIds extends BatchV4ModelIds = BatchV4ModelIds> = {
   doGetBatchResults(
     options: BatchV4OperationOptions,
   ): PromiseLike<ReadableStream<BatchV4ItemResult>>;
+
+  doCancelBatch?(
+    options: BatchV4OperationOptions,
+  ): PromiseLike<BatchV4CancelResult>;
+
+  doListBatches?(options: BatchV4ListOptions): PromiseLike<BatchV4ListResult>;
 };

--- a/packages/provider/src/batch/v4/index.ts
+++ b/packages/provider/src/batch/v4/index.ts
@@ -1,7 +1,11 @@
 export type {
   BatchV4 as Experimental_BatchV4,
+  BatchV4CancelResult as Experimental_BatchV4CancelResult,
   BatchV4Error as Experimental_BatchV4Error,
   BatchV4ItemResult as Experimental_BatchV4ItemResult,
+  BatchV4ListItem as Experimental_BatchV4ListItem,
+  BatchV4ListOptions as Experimental_BatchV4ListOptions,
+  BatchV4ListResult as Experimental_BatchV4ListResult,
   BatchV4ModelIds as Experimental_BatchV4ModelIds,
   BatchV4OperationOptions as Experimental_BatchV4OperationOptions,
   BatchV4Request as Experimental_BatchV4Request,


### PR DESCRIPTION
## Background

Batch provider APIs support listing and canceling batches. AI SDK's Batch API didn't support them.

## Summary

- Add optional `doCancelBatch?` and `doListBatches?` methods to the provider `BatchV4` interface
- Add `cancelBatch` and `listBatches` APIs

## End-to-End Verification

Cannot end to end verify because the APIs haven't been implemented in provider packages

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [X] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)

## Future Work

Add support in provider packages
