### PR TITLE
feat(anthropic): add batch cancellation and listing

### DIFF
--- a/.changeset/tidy-anthropic-batches.md
+++ b/.changeset/tidy-anthropic-batches.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/anthropic': patch
+---
+
+feat(anthropic): add batch cancellation and listing

--- a/examples/ai-functions/src/start-batch/anthropic/cancel-and-list.ts
+++ b/examples/ai-functions/src/start-batch/anthropic/cancel-and-list.ts
@@ -1,0 +1,39 @@
+import { anthropic } from '@ai-sdk/anthropic';
+import {
+  experimental_cancelBatch as cancelBatch,
+  experimental_getBatchStatus as getBatchStatus,
+  experimental_listBatches as listBatches,
+  experimental_startBatch as startBatch,
+} from 'ai';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const provider = anthropic;
+  const batch = await startBatch({
+    provider,
+    requests: [
+      {
+        id: 'capital-france',
+        type: 'text',
+        model: 'claude-haiku-4-5',
+        prompt: 'What is the capital of France?',
+      },
+    ],
+  });
+
+  print('Started batch:', batch);
+
+  const page = await listBatches({ provider, limit: 20 });
+  print(
+    'Listed batch:',
+    page.batches.find(item => item.id === batch.id),
+  );
+  print('Next cursor:', page.nextCursor);
+
+  await cancelBatch({ provider, batch });
+  print('Cancellation requested for:', batch.id);
+
+  const status = await getBatchStatus({ provider, batch });
+  print('Batch status:', status);
+});

--- a/packages/anthropic/src/anthropic-batch.test.ts
+++ b/packages/anthropic/src/anthropic-batch.test.ts
@@ -13,12 +13,14 @@ vi.mock('./version', () => ({
 const urls = {
   batches: 'https://api.anthropic.com/v1/messages/batches',
   batch: 'https://api.anthropic.com/v1/messages/batches/msgbatch_123',
+  cancel: 'https://api.anthropic.com/v1/messages/batches/msgbatch_123/cancel',
   results: 'https://api.anthropic.com/v1/messages/batches/msgbatch_123/results',
 } as const;
 
 const server = createTestServer({
   [urls.batches]: {},
   [urls.batch]: {},
+  [urls.cancel]: {},
   [urls.results]: {},
 });
 
@@ -582,6 +584,125 @@ describe('Anthropic batch', () => {
         },
       },
     });
+  });
+
+  it('cancels a batch', async () => {
+    server.urls[urls.cancel].response = {
+      type: 'json-value',
+      body: batchResponse({ processing_status: 'canceling' }),
+    };
+    const mockFetch = vi.fn().mockImplementation(globalThis.fetch);
+    const abortController = new AbortController();
+    const batch = createAnthropic({
+      apiKey: 'test-api-key',
+      headers: { 'Provider-Header': 'provider' },
+      fetch: mockFetch,
+    }).experimental_batch();
+
+    await expect(
+      batch.doCancelBatch!({
+        batchId: 'msgbatch_123',
+        headers: { 'Operation-Header': 'operation' },
+        abortSignal: abortController.signal,
+      }),
+    ).resolves.toEqual({});
+
+    expect(server.calls[0].requestMethod).toBe('POST');
+    await expect(server.calls[0].requestBodyJson).resolves.toEqual({});
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      'x-api-key': 'test-api-key',
+      'provider-header': 'provider',
+      'operation-header': 'operation',
+    });
+    expect(mockFetch.mock.calls[0][1].signal).toBe(abortController.signal);
+  });
+
+  it('lists and normalizes a page of batches', async () => {
+    server.urls[urls.batches].response = {
+      type: 'json-value',
+      body: {
+        data: [
+          batchResponse({
+            id: 'msgbatch_123',
+            processing_status: 'in_progress',
+            request_counts: {
+              processing: 2,
+              succeeded: 1,
+              errored: 0,
+              canceled: 0,
+              expired: 0,
+            },
+          }),
+          batchResponse({ id: 'msgbatch_122' }),
+        ],
+        first_id: 'msgbatch_123',
+        last_id: 'msgbatch_122',
+        has_more: true,
+      },
+    };
+    const mockFetch = vi.fn().mockImplementation(globalThis.fetch);
+    const abortController = new AbortController();
+    const batch = createAnthropic({
+      apiKey: 'test-api-key',
+      headers: { 'Provider-Header': 'provider' },
+      fetch: mockFetch,
+    }).experimental_batch();
+
+    await expect(
+      batch.doListBatches!({
+        limit: 2,
+        cursor: 'msgbatch_122',
+        headers: { 'Operation-Header': 'operation' },
+        abortSignal: abortController.signal,
+      }),
+    ).resolves.toMatchObject({
+      batches: [
+        {
+          batchId: 'msgbatch_123',
+          status: 'pending',
+          rawStatus: 'in_progress',
+          requestCounts: {
+            total: 3,
+            pending: 2,
+            completed: 1,
+            failed: 0,
+          },
+        },
+        {
+          batchId: 'msgbatch_122',
+          status: 'completed',
+          rawStatus: 'ended',
+        },
+      ],
+      nextCursor: 'msgbatch_122',
+    });
+
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      'x-api-key': 'test-api-key',
+      'provider-header': 'provider',
+      'operation-header': 'operation',
+    });
+    expect(
+      Object.fromEntries(new URL(server.calls[0].requestUrl).searchParams),
+    ).toEqual({ limit: '2', after_id: 'msgbatch_122' });
+    expect(mockFetch.mock.calls[0][1].signal).toBe(abortController.signal);
+  });
+
+  it('omits the next cursor when there are no more batches', async () => {
+    server.urls[urls.batches].response = {
+      type: 'json-value',
+      body: {
+        data: [],
+        first_id: null,
+        last_id: null,
+        has_more: false,
+      },
+    };
+    const batch = createAnthropic({
+      apiKey: 'test-api-key',
+    }).experimental_batch();
+
+    await expect(batch.doListBatches!({})).resolves.toEqual({ batches: [] });
   });
 
   it('rejects result retrieval after Anthropic archives the result file', async () => {
@@ -1501,6 +1622,8 @@ describe('Anthropic batch', () => {
     expect(batch.doStartBatch).toBeTypeOf('function');
     expect(batch.doGetBatchStatus).toBeTypeOf('function');
     expect(batch.doGetBatchResults).toBeTypeOf('function');
+    expect(batch.doCancelBatch).toBeTypeOf('function');
+    expect(batch.doListBatches).toBeTypeOf('function');
 
     for (const model of [
       provider('claude-3-haiku-20240307'),

--- a/packages/anthropic/src/anthropic-batch.ts
+++ b/packages/anthropic/src/anthropic-batch.ts
@@ -3,7 +3,10 @@ import {
   InvalidResponseDataError,
   UnsupportedFunctionalityError,
   type Experimental_BatchV4 as BatchV4,
+  type Experimental_BatchV4CancelResult as BatchV4CancelResult,
   type Experimental_BatchV4ItemResult as BatchV4ItemResult,
+  type Experimental_BatchV4ListOptions as BatchV4ListOptions,
+  type Experimental_BatchV4ListResult as BatchV4ListResult,
   type Experimental_BatchV4OperationOptions as BatchV4OperationOptions,
   type Experimental_BatchV4StartResult as BatchV4StartResult,
   type Experimental_BatchV4Status as BatchV4Status,
@@ -64,25 +67,36 @@ const anthropicBatchProviderOptionsSchema = anthropicLanguageModelOptions.pick({
 
 type AnthropicBatchRequest = TextBatchV4Request<AnthropicModelId>;
 
+const anthropicBatchResponseZodSchema = () =>
+  z.object({
+    id: z.string(),
+    type: z.literal('message_batch'),
+    processing_status: z.string(),
+    request_counts: z.object({
+      processing: z.number(),
+      succeeded: z.number(),
+      errored: z.number(),
+      canceled: z.number(),
+      expired: z.number(),
+    }),
+    created_at: z.string(),
+    expires_at: z.string(),
+    archived_at: z.string().nullish(),
+    cancel_initiated_at: z.string().nullish(),
+    ended_at: z.string().nullish(),
+    results_url: z.string().nullish(),
+  });
+
 const anthropicBatchResponseSchema = lazySchema(() =>
+  zodSchema(anthropicBatchResponseZodSchema()),
+);
+
+const anthropicBatchListResponseSchema = lazySchema(() =>
   zodSchema(
     z.object({
-      id: z.string(),
-      type: z.literal('message_batch'),
-      processing_status: z.string(),
-      request_counts: z.object({
-        processing: z.number(),
-        succeeded: z.number(),
-        errored: z.number(),
-        canceled: z.number(),
-        expired: z.number(),
-      }),
-      created_at: z.string(),
-      expires_at: z.string(),
-      archived_at: z.string().nullish(),
-      cancel_initiated_at: z.string().nullish(),
-      ended_at: z.string().nullish(),
-      results_url: z.string().nullish(),
+      data: z.array(anthropicBatchResponseZodSchema()),
+      has_more: z.boolean(),
+      last_id: z.string().nullish(),
     }),
   ),
 );
@@ -293,6 +307,56 @@ export class AnthropicBatch implements BatchV4<{
     options: BatchV4OperationOptions,
   ): Promise<BatchV4Status> {
     return convertAnthropicBatchStatus(await this.retrieveBatch(options));
+  }
+
+  async doCancelBatch(
+    options: BatchV4OperationOptions,
+  ): Promise<BatchV4CancelResult> {
+    await postJsonToApi({
+      url: this.getBatchUrl(`/${encodeURIComponent(options.batchId)}/cancel`),
+      headers: await this.getBatchHeaders(options.headers),
+      body: {},
+      failedResponseHandler: anthropicFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        anthropicBatchResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.options.config.fetch,
+    });
+
+    return {};
+  }
+
+  async doListBatches(options: BatchV4ListOptions): Promise<BatchV4ListResult> {
+    const url = new URL(this.getBatchUrl(''));
+    if (options.limit != null) {
+      url.searchParams.set('limit', String(options.limit));
+    }
+    if (options.cursor != null) {
+      url.searchParams.set('after_id', options.cursor);
+    }
+
+    const { value: page } = await getFromApi({
+      url: url.toString(),
+      validateUrl: false,
+      headers: await this.getBatchHeaders(options.headers),
+      failedResponseHandler: anthropicFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        anthropicBatchListResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.options.config.fetch,
+    });
+
+    return {
+      batches: page.data.map(batch => ({
+        batchId: batch.id,
+        ...convertAnthropicBatchStatus(batch),
+      })),
+      ...(page.has_more && page.last_id != null
+        ? { nextCursor: page.last_id }
+        : {}),
+    };
   }
 
   async doGetBatchResults(


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/pull/20543 added batch cancel and list APIs

## Summary

add support for batch cancel and list to anthropic provider

## End-to-End Verification

added an example that creates a batch, lists it, and cancels the batch

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)
