### PR TITLE
feat(google): add batch cancellation and listing

### DIFF
--- a/.changeset/fresh-google-batches.md
+++ b/.changeset/fresh-google-batches.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/google': patch
+---
+
+feat(google): add batch cancellation and listing

--- a/examples/ai-functions/src/start-batch/google/cancel-and-list.ts
+++ b/examples/ai-functions/src/start-batch/google/cancel-and-list.ts
@@ -1,0 +1,39 @@
+import { google } from '@ai-sdk/google';
+import {
+  experimental_cancelBatch as cancelBatch,
+  experimental_getBatchStatus as getBatchStatus,
+  experimental_listBatches as listBatches,
+  experimental_startBatch as startBatch,
+} from 'ai';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const provider = google;
+  const batch = await startBatch({
+    provider,
+    requests: [
+      {
+        id: 'capital-france',
+        type: 'text',
+        model: 'gemini-3.6-flash',
+        prompt: 'What is the capital of France?',
+      },
+    ],
+  });
+
+  print('Started batch:', batch);
+
+  const page = await listBatches({ provider, limit: 20 });
+  print(
+    'Listed batch:',
+    page.batches.find(item => item.id === batch.id),
+  );
+  print('Next cursor:', page.nextCursor);
+
+  await cancelBatch({ provider, batch });
+  print('Cancellation requested for:', batch.id);
+
+  const status = await getBatchStatus({ provider, batch });
+  print('Batch status:', status);
+});

--- a/packages/google/src/google-batch.test.ts
+++ b/packages/google/src/google-batch.test.ts
@@ -14,7 +14,10 @@ const urls = {
     'https://generativelanguage.googleapis.com/upload/v1beta/files/session-123',
   create:
     'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:batchGenerateContent',
+  batches: 'https://generativelanguage.googleapis.com/v1beta/batches',
   batch: 'https://generativelanguage.googleapis.com/v1beta/batches/batch-123',
+  cancel:
+    'https://generativelanguage.googleapis.com/v1beta/batches/batch-123:cancel',
   output:
     'https://generativelanguage.googleapis.com/download/v1beta/files/batch-output:download?alt=media',
 } as const;
@@ -23,7 +26,9 @@ const server = createTestServer({
   [urls.uploadStart]: {},
   [urls.uploadSession]: {},
   [urls.create]: {},
+  [urls.batches]: {},
   [urls.batch]: {},
+  [urls.cancel]: {},
   [urls.output]: {},
 });
 
@@ -326,6 +331,137 @@ describe('GoogleBatch', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch.mock.calls[0][1]?.signal).toBe(abortController.signal);
   });
+
+  it('cancels a batch', async () => {
+    server.urls[urls.cancel].response = {
+      type: 'json-value',
+      body: {},
+    };
+    const mockFetch = vi.fn().mockImplementation(globalThis.fetch);
+    const abortController = new AbortController();
+    const batch = createGoogle({
+      apiKey: 'test-api-key',
+      headers: { 'Provider-Header': 'provider' },
+      fetch: mockFetch,
+    }).experimental_batch();
+
+    await expect(
+      batch.doCancelBatch!({
+        batchId: 'batches/batch-123',
+        headers: { 'Operation-Header': 'operation' },
+        abortSignal: abortController.signal,
+      }),
+    ).resolves.toEqual({});
+
+    expect(server.calls[0].requestMethod).toBe('POST');
+    await expect(server.calls[0].requestBodyJson).resolves.toEqual({});
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      'x-goog-api-key': 'test-api-key',
+      'provider-header': 'provider',
+      'operation-header': 'operation',
+    });
+    expect(mockFetch.mock.calls[0][1]?.signal).toBe(abortController.signal);
+  });
+
+  it('lists and normalizes a page of batches', async () => {
+    server.urls[urls.batches].response = {
+      type: 'json-value',
+      body: {
+        operations: [
+          operation({
+            state: 'BATCH_STATE_RUNNING',
+            batchStats: {
+              requestCount: '3',
+              successfulRequestCount: '1',
+              failedRequestCount: '0',
+              pendingRequestCount: '2',
+            },
+          }),
+          operation(
+            {
+              state: 'BATCH_STATE_SUCCEEDED',
+              batchStats: {
+                requestCount: '2',
+                successfulRequestCount: '2',
+                failedRequestCount: '0',
+              },
+            },
+            { name: 'batches/batch-122' },
+          ),
+        ],
+        nextPageToken: 'page-token-2',
+      },
+    };
+    const mockFetch = vi.fn().mockImplementation(globalThis.fetch);
+    const abortController = new AbortController();
+    const batch = createGoogle({
+      apiKey: 'test-api-key',
+      headers: { 'Provider-Header': 'provider' },
+      fetch: mockFetch,
+    }).experimental_batch();
+
+    await expect(
+      batch.doListBatches!({
+        limit: 2,
+        cursor: 'page-token-1',
+        headers: { 'Operation-Header': 'operation' },
+        abortSignal: abortController.signal,
+      }),
+    ).resolves.toEqual({
+      batches: [
+        {
+          batchId: 'batches/batch-123',
+          status: 'pending',
+          rawStatus: 'BATCH_STATE_RUNNING',
+          requestCounts: {
+            total: 3,
+            pending: 2,
+            completed: 1,
+            failed: 0,
+          },
+          createdAt: '2026-08-04T12:34:56.123Z',
+        },
+        {
+          batchId: 'batches/batch-122',
+          status: 'completed',
+          rawStatus: 'BATCH_STATE_SUCCEEDED',
+          requestCounts: {
+            total: 2,
+            pending: 0,
+            completed: 2,
+            failed: 0,
+          },
+          createdAt: '2026-08-04T12:34:56.123Z',
+        },
+      ],
+      nextCursor: 'page-token-2',
+    });
+
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      'x-goog-api-key': 'test-api-key',
+      'provider-header': 'provider',
+      'operation-header': 'operation',
+    });
+    expect(
+      Object.fromEntries(new URL(server.calls[0].requestUrl).searchParams),
+    ).toEqual({ pageSize: '2', pageToken: 'page-token-1' });
+    expect(mockFetch.mock.calls[0][1]?.signal).toBe(abortController.signal);
+  });
+
+  it.each([{}, { operations: [], nextPageToken: null }])(
+    'returns an empty terminal page for %j',
+    async response => {
+      server.urls[urls.batches].response = {
+        type: 'json-value',
+        body: response,
+      };
+      const batch = createGoogle({
+        apiKey: 'test-api-key',
+      }).experimental_batch();
+
+      await expect(batch.doListBatches!({})).resolves.toEqual({ batches: [] });
+    },
+  );
 
   it('uses a resumable file upload when the creation body reaches 20 MB', async () => {
     prepareUpload();

--- a/packages/google/src/google-batch.ts
+++ b/packages/google/src/google-batch.ts
@@ -2,8 +2,11 @@ import {
   InvalidArgumentError,
   InvalidResponseDataError,
   type Experimental_BatchV4 as BatchV4,
+  type Experimental_BatchV4CancelResult as BatchV4CancelResult,
   type Experimental_BatchV4Error as BatchV4Error,
   type Experimental_BatchV4ItemResult as BatchV4ItemResult,
+  type Experimental_BatchV4ListOptions as BatchV4ListOptions,
+  type Experimental_BatchV4ListResult as BatchV4ListResult,
   type Experimental_BatchV4OperationOptions as BatchV4OperationOptions,
   type Experimental_BatchV4StartResult as BatchV4StartResult,
   type Experimental_BatchV4Status as BatchV4Status,
@@ -76,26 +79,40 @@ const googleBatchOutputSchema = z.object({
     .nullish(),
 });
 
+const googleBatchOperationZodSchema = () =>
+  z.object({
+    name: z.string(),
+    metadata: z
+      .object({
+        state: z.string().nullish(),
+        createTime: z.string().nullish(),
+        batchStats: googleBatchStatsSchema.nullish(),
+        output: googleBatchOutputSchema.nullish(),
+      })
+      .nullish(),
+    done: z.boolean().nullish(),
+    error: googleRpcStatusSchema.nullish(),
+    response: googleBatchOutputSchema.nullish(),
+  });
+
 const googleBatchOperationSchema = lazySchema(() =>
+  zodSchema(googleBatchOperationZodSchema()),
+);
+
+type GoogleBatchOperation = InferSchema<typeof googleBatchOperationSchema>;
+
+const googleBatchListResponseSchema = lazySchema(() =>
   zodSchema(
     z.object({
-      name: z.string(),
-      metadata: z
-        .object({
-          state: z.string().nullish(),
-          createTime: z.string().nullish(),
-          batchStats: googleBatchStatsSchema.nullish(),
-          output: googleBatchOutputSchema.nullish(),
-        })
-        .nullish(),
-      done: z.boolean().nullish(),
-      error: googleRpcStatusSchema.nullish(),
-      response: googleBatchOutputSchema.nullish(),
+      operations: z.array(googleBatchOperationZodSchema()).nullish(),
+      nextPageToken: z.string().nullish(),
     }),
   ),
 );
 
-type GoogleBatchOperation = InferSchema<typeof googleBatchOperationSchema>;
+const googleBatchCancelResponseSchema = lazySchema(() =>
+  zodSchema(z.object({})),
+);
 
 const googleFileUploadResponseSchema = lazySchema(() =>
   zodSchema(
@@ -353,6 +370,54 @@ export class GoogleBatch implements BatchV4<{ readonly text: GoogleModelId }> {
     options: BatchV4OperationOptions,
   ): Promise<BatchV4Status> {
     return convertGoogleBatchStatus(await this.retrieveBatch(options));
+  }
+
+  async doCancelBatch(
+    options: BatchV4OperationOptions,
+  ): Promise<BatchV4CancelResult> {
+    await postJsonToApi({
+      url: `${this.batchConfig.baseURL}/${options.batchId}:cancel`,
+      headers: await this.getHeaders(options.headers),
+      body: {},
+      failedResponseHandler: googleFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        googleBatchCancelResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.batchConfig.fetch,
+    });
+
+    return {};
+  }
+
+  async doListBatches(options: BatchV4ListOptions): Promise<BatchV4ListResult> {
+    const url = new URL(`${this.batchConfig.baseURL}/batches`);
+    if (options.limit != null) {
+      url.searchParams.set('pageSize', String(options.limit));
+    }
+    if (options.cursor != null) {
+      url.searchParams.set('pageToken', options.cursor);
+    }
+
+    const { value: page } = await getFromApi({
+      url: url.toString(),
+      headers: await this.getHeaders(options.headers),
+      failedResponseHandler: googleFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        googleBatchListResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.batchConfig.fetch,
+      validateUrl: false,
+    });
+
+    return {
+      batches: (page.operations ?? []).map(operation => ({
+        batchId: operation.name,
+        ...convertGoogleBatchStatus(operation),
+      })),
+      ...(page.nextPageToken != null ? { nextCursor: page.nextPageToken } : {}),
+    };
   }
 
   async doGetBatchResults(


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/pull/20543 added batch cancel and list APIs

## Summary

add support for batch cancel and list to google provider

## End-to-End Verification

added an example that creates a batch, lists it, and cancels the batch

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)
