### PR TITLE
feat(xai): add batch cancellation and listing

### DIFF
--- a/.changeset/tidy-xai-batches.md
+++ b/.changeset/tidy-xai-batches.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+feat(xai): add batch cancellation and listing

--- a/examples/ai-functions/src/start-batch/xai/cancel-and-list.ts
+++ b/examples/ai-functions/src/start-batch/xai/cancel-and-list.ts
@@ -1,0 +1,39 @@
+import { xai } from '@ai-sdk/xai';
+import {
+  experimental_cancelBatch as cancelBatch,
+  experimental_getBatchStatus as getBatchStatus,
+  experimental_listBatches as listBatches,
+  experimental_startBatch as startBatch,
+} from 'ai';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const provider = xai;
+  const batch = await startBatch({
+    provider,
+    requests: [
+      {
+        id: 'capital-france',
+        type: 'text',
+        model: 'grok-4.3',
+        prompt: 'What is the capital of France?',
+      },
+    ],
+  });
+
+  print('Started batch:', batch);
+
+  const page = await listBatches({ provider, limit: 20 });
+  print(
+    'Listed batch:',
+    page.batches.find(item => item.id === batch.id),
+  );
+  print('Next cursor:', page.nextCursor);
+
+  await cancelBatch({ provider, batch });
+  print('Cancellation requested for:', batch.id);
+
+  const status = await getBatchStatus({ provider, batch });
+  print('Batch status:', status);
+});

--- a/packages/xai/src/xai-batch.test.ts
+++ b/packages/xai/src/xai-batch.test.ts
@@ -12,6 +12,7 @@ const urls = {
   files: 'https://api.x.ai/v1/files',
   batches: 'https://api.x.ai/v1/batches',
   batch: 'https://api.x.ai/v1/batches/batch_123',
+  cancel: 'https://api.x.ai/v1/batches/batch_123:cancel',
   results: 'https://api.x.ai/v1/batches/batch_123/results',
   resultsPage1: 'https://api.x.ai/v1/batches/batch_123/results?limit=1000',
   resultsPage2:
@@ -22,6 +23,7 @@ const server = createTestServer({
   [urls.files]: {},
   [urls.batches]: {},
   [urls.batch]: {},
+  [urls.cancel]: {},
   [urls.results]: {},
 });
 
@@ -321,6 +323,123 @@ describe('xAI batch', () => {
       createdAt: '2026-08-25T12:00:00Z',
       expiresAt: '2099-08-26T12:00:00Z',
     });
+  });
+
+  it('cancels a batch', async () => {
+    server.urls[urls.cancel].response = {
+      type: 'json-value',
+      body: batchResponse({ cancel_time: '2026-08-25T12:30:00Z' }),
+    };
+    const mockFetch = vi.fn().mockImplementation(globalThis.fetch);
+    const abortController = new AbortController();
+    const batch = createXai({
+      apiKey: 'test-api-key',
+      headers: { 'Provider-Header': 'provider' },
+      fetch: mockFetch,
+    }).experimental_batch();
+
+    await expect(
+      batch.doCancelBatch!({
+        batchId: 'batch_123',
+        headers: { 'Operation-Header': 'operation' },
+        abortSignal: abortController.signal,
+      }),
+    ).resolves.toEqual({});
+
+    expect(server.calls[0].requestMethod).toBe('POST');
+    await expect(server.calls[0].requestBodyJson).resolves.toEqual({});
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      authorization: 'Bearer test-api-key',
+      'provider-header': 'provider',
+      'operation-header': 'operation',
+    });
+    expect(mockFetch.mock.calls[0][1].signal).toBe(abortController.signal);
+  });
+
+  it('lists and normalizes a page of batches', async () => {
+    server.urls[urls.batches].response = {
+      type: 'json-value',
+      body: {
+        batches: [
+          batchResponse({
+            batch_id: 'batch_123',
+            state: {
+              num_requests: 3,
+              num_pending: 2,
+              num_success: 1,
+              num_error: 0,
+              num_cancelled: 0,
+            },
+          }),
+          batchResponse({ batch_id: 'batch_122' }),
+        ],
+        pagination_token: 'next/page',
+      },
+    };
+    const mockFetch = vi.fn().mockImplementation(globalThis.fetch);
+    const abortController = new AbortController();
+    const batch = createXai({
+      apiKey: 'test-api-key',
+      headers: { 'Provider-Header': 'provider' },
+      fetch: mockFetch,
+    }).experimental_batch();
+
+    await expect(
+      batch.doListBatches!({
+        limit: 2,
+        cursor: 'previous/page',
+        headers: { 'Operation-Header': 'operation' },
+        abortSignal: abortController.signal,
+      }),
+    ).resolves.toEqual({
+      batches: [
+        {
+          batchId: 'batch_123',
+          status: 'pending',
+          requestCounts: {
+            total: 3,
+            pending: 2,
+            completed: 1,
+            failed: 0,
+          },
+          createdAt: '2026-08-25T12:00:00Z',
+          expiresAt: '2099-08-26T12:00:00Z',
+        },
+        {
+          batchId: 'batch_122',
+          status: 'completed',
+          requestCounts: {
+            total: 2,
+            pending: 0,
+            completed: 2,
+            failed: 0,
+          },
+          createdAt: '2026-08-25T12:00:00Z',
+          expiresAt: '2099-08-26T12:00:00Z',
+        },
+      ],
+      nextCursor: 'next/page',
+    });
+
+    expect(server.calls[0].requestHeaders).toMatchObject({
+      authorization: 'Bearer test-api-key',
+      'provider-header': 'provider',
+      'operation-header': 'operation',
+    });
+    expect(
+      Object.fromEntries(new URL(server.calls[0].requestUrl).searchParams),
+    ).toEqual({ limit: '2', pagination_token: 'previous/page' });
+    expect(mockFetch.mock.calls[0][1].signal).toBe(abortController.signal);
+  });
+
+  it('omits the next cursor when there are no more batches', async () => {
+    server.urls[urls.batches].response = {
+      type: 'json-value',
+      body: { batches: [], pagination_token: null },
+    };
+    const batch = createXai({ apiKey: 'test-api-key' }).experimental_batch();
+
+    await expect(batch.doListBatches!({})).resolves.toEqual({ batches: [] });
   });
 
   it('omits inconsistent request counts', async () => {
@@ -744,6 +863,8 @@ describe('xAI batch', () => {
     expect(batch.doStartBatch).toBeTypeOf('function');
     expect(batch.doGetBatchStatus).toBeTypeOf('function');
     expect(batch.doGetBatchResults).toBeTypeOf('function');
+    expect(batch.doCancelBatch).toBeTypeOf('function');
+    expect(batch.doListBatches).toBeTypeOf('function');
 
     for (const model of [
       provider('grok-4.3'),

--- a/packages/xai/src/xai-batch.ts
+++ b/packages/xai/src/xai-batch.ts
@@ -1,8 +1,11 @@
 import {
   InvalidArgumentError,
   type Experimental_BatchV4 as BatchV4,
+  type Experimental_BatchV4CancelResult as BatchV4CancelResult,
   type Experimental_BatchV4Error as BatchV4Error,
   type Experimental_BatchV4ItemResult as BatchV4ItemResult,
+  type Experimental_BatchV4ListOptions as BatchV4ListOptions,
+  type Experimental_BatchV4ListResult as BatchV4ListResult,
   type Experimental_BatchV4OperationOptions as BatchV4OperationOptions,
   type Experimental_BatchV4StartResult as BatchV4StartResult,
   type Experimental_BatchV4Status as BatchV4Status,
@@ -80,26 +83,27 @@ type XaiBatchResponseConversion =
   | { success: true; result: LanguageModelV4GenerateResult }
   | { success: false; error: BatchV4Error };
 
+const xaiBatchResponseZodSchema = () =>
+  z.object({
+    batch_id: z.string(),
+    name: z.string().nullish(),
+    create_time: z.string().nullish(),
+    expire_time: z.string().nullish(),
+    cancel_time: z.string().nullish(),
+    cancel_by_xai_message: z.string().nullish(),
+    state: z
+      .object({
+        num_requests: z.number().nullish(),
+        num_pending: z.number().nullish(),
+        num_success: z.number().nullish(),
+        num_error: z.number().nullish(),
+        num_cancelled: z.number().nullish(),
+      })
+      .nullish(),
+  });
+
 const xaiBatchResponseSchema = lazySchema(() =>
-  zodSchema(
-    z.object({
-      batch_id: z.string(),
-      name: z.string().nullish(),
-      create_time: z.string().nullish(),
-      expire_time: z.string().nullish(),
-      cancel_time: z.string().nullish(),
-      cancel_by_xai_message: z.string().nullish(),
-      state: z
-        .object({
-          num_requests: z.number().nullish(),
-          num_pending: z.number().nullish(),
-          num_success: z.number().nullish(),
-          num_error: z.number().nullish(),
-          num_cancelled: z.number().nullish(),
-        })
-        .nullish(),
-    }),
-  ),
+  zodSchema(xaiBatchResponseZodSchema()),
 );
 
 type XaiBatchResponse = InferSchema<typeof xaiBatchResponseSchema>;
@@ -130,6 +134,15 @@ const xaiBatchResultsPageSchema = lazySchema(() =>
   zodSchema(
     z.object({
       results: z.array(xaiBatchResultSchema),
+      pagination_token: z.string().nullish(),
+    }),
+  ),
+);
+
+const xaiBatchListResponseSchema = lazySchema(() =>
+  zodSchema(
+    z.object({
+      batches: z.array(xaiBatchResponseZodSchema()),
       pagination_token: z.string().nullish(),
     }),
   ),
@@ -260,6 +273,58 @@ export class XaiBatch implements BatchV4<XaiBatchModelIds> {
     options: BatchV4OperationOptions,
   ): Promise<BatchV4Status> {
     return convertXaiBatchStatus(await this.retrieveBatch(options));
+  }
+
+  async doCancelBatch(
+    options: BatchV4OperationOptions,
+  ): Promise<BatchV4CancelResult> {
+    await postJsonToApi({
+      url: this.getUrl(
+        `/batches/${encodeURIComponent(options.batchId)}:cancel`,
+      ),
+      headers: combineHeaders(this.options.config.headers?.(), options.headers),
+      body: {},
+      failedResponseHandler: xaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        xaiBatchResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.options.config.fetch,
+    });
+
+    return {};
+  }
+
+  async doListBatches(options: BatchV4ListOptions): Promise<BatchV4ListResult> {
+    const url = new URL(this.getUrl('/batches'));
+    if (options.limit != null) {
+      url.searchParams.set('limit', String(options.limit));
+    }
+    if (options.cursor != null) {
+      url.searchParams.set('pagination_token', options.cursor);
+    }
+
+    const { value: page } = await getFromApi({
+      url: url.toString(),
+      headers: combineHeaders(this.options.config.headers?.(), options.headers),
+      failedResponseHandler: xaiFailedResponseHandler,
+      successfulResponseHandler: createJsonResponseHandler(
+        xaiBatchListResponseSchema,
+      ),
+      abortSignal: options.abortSignal,
+      fetch: this.options.config.fetch,
+      validateUrl: false,
+    });
+
+    return {
+      batches: page.batches.map(batch => ({
+        batchId: batch.batch_id,
+        ...convertXaiBatchStatus(batch),
+      })),
+      ...(page.pagination_token != null
+        ? { nextCursor: page.pagination_token }
+        : {}),
+    };
   }
 
   async doGetBatchResults(


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/pull/20543 added batch cancel and list APIs

## Summary

add support for batch cancel and list to xai provider

## End-to-End Verification

added an example that creates a batch, lists it, and cancels the batch

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)
