### PR TITLE
feat(mcp): add AuthorizationServerMismatchError for OAuth pin mismatches

### DIFF
--- a/.changeset/lazy-rivers-argue.md
+++ b/.changeset/lazy-rivers-argue.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/mcp': patch
+---
+
+feat(mcp): add AuthorizationServerMismatchError for OAuth authorization server pin mismatches

--- a/packages/mcp/src/error/oauth-error.ts
+++ b/packages/mcp/src/error/oauth-error.ts
@@ -42,8 +42,22 @@ export class UnauthorizedClientError extends MCPClientOAuthError {
   static errorCode = 'unauthorized_client';
 }
 
+const mismatchName = 'AI_AuthorizationServerMismatchError';
+const mismatchMarker = `vercel.ai.error.${mismatchName}`;
+const mismatchSymbol = Symbol.for(mismatchMarker);
+
 export class AuthorizationServerMismatchError extends MCPClientOAuthError {
+  private readonly [mismatchSymbol] = true;
+
   static errorCode = 'authorization_server_mismatch';
+
+  constructor({ message, cause }: { message: string; cause?: unknown }) {
+    super({ name: 'AuthorizationServerMismatchError', message, cause });
+  }
+
+  static isInstance(error: unknown): error is AuthorizationServerMismatchError {
+    return AISDKError.hasMarker(error, mismatchMarker);
+  }
 }
 
 export const OAUTH_ERRORS = {

--- a/packages/mcp/src/error/oauth-error.ts
+++ b/packages/mcp/src/error/oauth-error.ts
@@ -42,6 +42,10 @@ export class UnauthorizedClientError extends MCPClientOAuthError {
   static errorCode = 'unauthorized_client';
 }
 
+export class AuthorizationServerMismatchError extends MCPClientOAuthError {
+  static errorCode = 'authorization_server_mismatch';
+}
+
 export const OAUTH_ERRORS = {
   [ServerError.errorCode]: ServerError,
   [InvalidClientError.errorCode]: InvalidClientError,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -41,6 +41,10 @@ export type {
   ClientCapabilities as MCPClientCapabilities,
 } from './tool/types';
 export { auth, UnauthorizedError } from './tool/oauth';
+export {
+  MCPClientOAuthError,
+  AuthorizationServerMismatchError,
+} from './error/oauth-error';
 export type {
   OAuthAuthorizationServerInformation,
   OAuthClientProvider,

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -2468,6 +2468,14 @@ describe('auth function', () => {
 
     await expect(authPromise).rejects.toThrow(/does not match/);
     await expect(authPromise).rejects.toThrow(AuthorizationServerMismatchError);
+    await expect(authPromise).rejects.toSatisfy((error: unknown) =>
+      AuthorizationServerMismatchError.isInstance(error),
+    );
+    expect(
+      AuthorizationServerMismatchError.isInstance(
+        new ServerError({ message: 'other oauth failure' }),
+      ),
+    ).toBe(false);
 
     expect(evilTokenRequests).toHaveLength(0);
   });

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -14,7 +14,10 @@ import {
   type AuthResult,
 } from './oauth';
 import type { AuthorizationServerMetadata } from './oauth-types';
-import { ServerError } from '../error/oauth-error';
+import {
+  ServerError,
+  AuthorizationServerMismatchError,
+} from '../error/oauth-error';
 import { LATEST_PROTOCOL_VERSION } from './types';
 
 // Mock the pkce-challenge module
@@ -2459,11 +2462,12 @@ describe('auth function', () => {
       token_endpoint: 'https://auth.example.com/token',
     });
 
-    await expect(
-      auth(mockProvider, {
-        serverUrl: 'https://api.example.com/mcp-server',
-      }),
-    ).rejects.toThrow(/does not match/);
+    const authPromise = auth(mockProvider, {
+      serverUrl: 'https://api.example.com/mcp-server',
+    });
+
+    await expect(authPromise).rejects.toThrow(/does not match/);
+    await expect(authPromise).rejects.toThrow(AuthorizationServerMismatchError);
 
     expect(evilTokenRequests).toHaveLength(0);
   });

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -20,6 +20,7 @@ import {
   InvalidClientError,
   InvalidGrantError,
   UnauthorizedClientError,
+  AuthorizationServerMismatchError,
 } from '../error/oauth-error';
 import {
   resourceUrlFromServerUrl,
@@ -331,7 +332,7 @@ function assertAuthorizationServerInformationMatches({
     storedAuthorizationServerInformation.tokenEndpoint !==
       currentAuthorizationServerInformation.tokenEndpoint
   ) {
-    throw new MCPClientOAuthError({
+    throw new AuthorizationServerMismatchError({
       message:
         'OAuth authorization server metadata does not match the metadata that issued the stored credentials',
     });


### PR DESCRIPTION
## Background

`assertAuthorizationServerInformationMatches` throws a bare `MCPClientOAuthError` when stored credentials were issued by a different authorization server. Consumers need to treat this case as permanent (drop credentials, reconnect) rather than retry, but the only handle today is matching the message string — every other case in `oauth-error.ts` has a subclass with a `static errorCode`.

## Summary

- Add `AuthorizationServerMismatchError` (`errorCode: 'authorization_server_mismatch'`), following the existing subclass pattern, and throw it at the mismatch site. Message unchanged. Not added to `OAUTH_ERRORS`, which maps server-reported wire codes; this is a client-side check.
- Export it and `MCPClientOAuthError` from the entrypoint so `isInstance` is reachable (neither was exported).
- The existing end-to-end mismatch test in `oauth.test.ts` now asserts the subclass, not just the message. Patch changeset added.

## Verification

`pnpm --filter @ai-sdk/mcp test`: 319 passed, 3 skipped (unchanged) on both node and edge configs. `type-check` clean.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
