### PR TITLE
fix: forward video callback URLs for caller-managed receivers

### DIFF
--- a/.changeset/ai-video-webhook-rejections.md
+++ b/.changeset/ai-video-webhook-rejections.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Observe video webhook receiver rejections before generation starts to prevent unhandled rejections during or after a failed start. Preserve start error precedence and assimilate custom receivers only once.

--- a/.changeset/bytedance-video-webhook-callbacks.md
+++ b/.changeset/bytedance-video-webhook-callbacks.md
@@ -1,0 +1,7 @@
+---
+'@ai-sdk/bytedance': patch
+---
+
+Forward `webhookUrl` as `callback_url` in `doStart`, taking precedence over raw provider callback URLs. Callers provide a progress-aware receiver; `generateVideo({ webhook })` continues to fall back to polling.
+
+Treat expired video generation tasks as terminal errors, preserving the provider's diagnostic details.

--- a/.changeset/klingai-video-webhook-callbacks.md
+++ b/.changeset/klingai-video-webhook-callbacks.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/klingai': patch
+---
+
+Forward `webhookUrl` as `callback_url` in `doStart` for text-to-video, image-to-video, multi-image-to-video, and motion control. Explicit URLs take precedence over raw provider callback URLs. Callers provide a progress-aware receiver; `generateVideo({ webhook })` continues to fall back to polling.

--- a/.changeset/minimax-video-webhooks.md
+++ b/.changeset/minimax-video-webhooks.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/minimax': patch
+---
+
+Forward `webhookUrl` as `callback_url` in `doStart` for application-owned receivers. Document challenge verification and terminal-status handling requirements. `generateVideo({ webhook })` continues to fall back to SDK polling without invoking the webhook factory.

--- a/content/providers/01-ai-sdk-providers/33-minimax.mdx
+++ b/content/providers/01-ai-sdk-providers/33-minimax.mdx
@@ -160,8 +160,9 @@ const { video } = await generateVideo({
 });
 ```
 
-Both models generate one video per call. Generation is asynchronous — the model
-creates a task and polls until it completes, then returns the resulting MP4 URL.
+Both models generate one video per call. Generation is asynchronous — by default,
+the model creates a task and polls until it completes, then returns the resulting
+MP4 URL.
 Status polls trust the configured MiniMax API origin for the first request and
 validate every redirect to another origin before following it.
 
@@ -212,8 +213,12 @@ const { video } = await generateVideo({
 
 Without `poll` or `webhook`, generation continues to use the provider's
 `pollIntervalMs` and `pollTimeoutMs` options. With `poll`, the SDK's polling
-settings apply instead. This provider does not register upstream webhooks;
-supplying `webhook` falls back to SDK polling without invoking the factory.
+settings apply instead.
+
+MiniMax does not implement the generic webhook hook. Passing `webhook` to
+`generateVideo` falls back to SDK polling without invoking the factory. MiniMax's
+challenge handshake and progress notifications require a protocol-aware receiver
+and are incompatible with the generic SDK and Workflow webhook receivers.
 
 For caller-managed scheduling, use `experimental_startVideo` to submit one task
 without polling and `experimental_getVideoStatus` to check it once, returning
@@ -229,6 +234,37 @@ Status metadata uses these indices instead of `referenceVideoUrls`; ordinary
 `generateVideo` calls without `poll` or `webhook` retain the existing URL metadata.
 See the
 [start/status example](https://github.com/vercel/ai/blob/main/examples/ai-functions/src/generate-video/minimax/start-status.ts).
+
+For application-managed callbacks, pass an explicit `webhookUrl` to
+`experimental_startVideo`:
+
+```ts
+import { minimax } from '@ai-sdk/minimax';
+import {
+  experimental_startVideo as startVideo,
+  experimental_getVideoStatus as getVideoStatus,
+} from 'ai';
+
+const model = minimax.video('MiniMax-H3');
+const { operation } = await startVideo({
+  model,
+  prompt: 'A white kitten chases a butterfly across a sunlit garden.',
+  webhookUrl: 'https://example.com/api/minimax/callback',
+});
+
+// Persist operation, then check it from your application's callback handler.
+const status = await getVideoStatus(model, { operation });
+```
+
+Your application hosts the callback endpoint and handles MiniMax's callback
+protocol; the adapter only forwards `webhookUrl` as MiniMax's `callback_url`.
+The endpoint must echo the verification `challenge` unchanged within 3 seconds
+and filter out `queued`/`running` progress updates. Handle terminal notifications
+when `task.status` is `succeeded`, `failed`, or `cancelled`, then use
+`getVideoStatus` with the persisted operation to retrieve the outcome. Neither
+the challenge nor a progress update signals completion. See the
+[MiniMax V2 API reference](https://platform.minimax.io/docs/api-reference/video-generation-v2-create.md)
+for the callback contract.
 
 ### Generation modes
 

--- a/content/providers/01-ai-sdk-providers/85-bytedance.mdx
+++ b/content/providers/01-ai-sdk-providers/85-bytedance.mdx
@@ -383,6 +383,30 @@ const { video } = await generateVideo({
 });
 ```
 
+### Caller-Managed Callbacks
+
+Use `experimental_startVideo({ model, prompt, webhookUrl })` to register an
+application-owned callback receiver. The SDK forwards `webhookUrl` as
+`callback_url`, taking precedence over `providerOptions.bytedance.callback_url`.
+When `webhookUrl` is omitted, a raw `callback_url` is passed through unchanged.
+
+The [BytePlus callback protocol](https://docs.byteplus.com/en/docs/ModelArk/1520757)
+sends progress notifications (`'queued'` or `'running'`) as well as terminal
+notifications (`'succeeded'`, `'failed'`, or `'expired'`). Your receiver must
+filter progress notifications and correlate callbacks with the task. Use
+`experimental_getVideoStatus(model, { operation })` with the operation returned
+by `experimental_startVideo` to check status and retrieve the result after a
+terminal notification. Expired tasks return an error status with the provider's
+diagnostic details.
+
+These models deliberately do not expose `handleWebhookOption` because their
+callback protocol requires a progress-aware receiver. Core
+[`generateVideo({ webhook })`](/docs/reference/ai-sdk-core/generate-video)
+falls back to polling without calling the webhook factory. Plain
+`generateVideo()` also polls. Workflow's existing native webhook capability
+check rejects these direct provider models for webhook-based generation;
+use the explicit start/status flow for caller-managed callbacks.
+
 ### Video Model Options
 
 The following options are available via `providerOptions.bytedance`. You can

--- a/content/providers/01-ai-sdk-providers/85-klingai.mdx
+++ b/content/providers/01-ai-sdk-providers/85-klingai.mdx
@@ -237,6 +237,29 @@ const { videos } = await generateVideo({
 });
 ```
 
+### Caller-Managed Callbacks
+
+For text-to-video, image-to-video, multi-image-to-video, and motion control,
+use `experimental_startVideo({ model, prompt, webhookUrl })` to register an
+application-owned callback receiver. The SDK forwards `webhookUrl` as
+`callback_url`, taking precedence over `providerOptions.klingai.callback_url`.
+When `webhookUrl` is omitted, a raw `callback_url` is passed through unchanged.
+
+KlingAI sends progress notifications (`task_status: 'submitted'` or
+`'processing'`) as well as terminal notifications (`'succeed'` or `'failed'`).
+Your receiver must filter progress notifications and correlate callbacks with
+the task. Use `experimental_getVideoStatus(model, { operation })` with the
+operation returned by `experimental_startVideo` to check status and retrieve
+the result after a terminal notification.
+
+These models deliberately do not expose `handleWebhookOption` because their
+callback protocol requires a progress-aware receiver. Core
+[`generateVideo({ webhook })`](/docs/reference/ai-sdk-core/generate-video)
+falls back to polling without calling the webhook factory. Plain
+`generateVideo()` also polls. Workflow's existing native webhook capability
+check rejects these direct provider models for webhook-based generation;
+use the explicit start/status flow for caller-managed callbacks.
+
 ### Video Provider Options
 
 The following provider options are available via `providerOptions.klingai`. Options vary by mode — see the

--- a/examples/ai-functions/src/generate-video/klingai/webhook-options.ts
+++ b/examples/ai-functions/src/generate-video/klingai/webhook-options.ts
@@ -4,8 +4,8 @@ import { presentVideos } from '../../lib/present-video';
 import { run } from '../../lib/run';
 import { withSpinner } from '../../lib/spinner';
 
-// Note: KlingAI does not support webhooks natively. The SDK will log an
-// unsupported-webhook warning and automatically fall back to polling.
+// KlingAI callbacks need a progress-aware receiver. This example demonstrates
+// the generic webhook option falling back to polling without calling the factory.
 run(async () => {
   const { videos, warnings } = await withSpinner('Generating video...', () =>
     generateVideo({
@@ -21,7 +21,7 @@ run(async () => {
       },
       webhook: async () => {
         throw new Error(
-          'Webhooks are not supported by KlingAI. This callback should not be invoked',
+          'KlingAI requires a progress-aware receiver. This factory should not be invoked.',
         );
       },
     }),

--- a/packages/ai/src/generate-video/generate-video.test.ts
+++ b/packages/ai/src/generate-video/generate-video.test.ts
@@ -1638,6 +1638,199 @@ describe('experimental_generateVideo', () => {
       expect(result.videos.length).toBe(1);
     });
 
+    describe('webhook receiver rejection', () => {
+      let unhandledRejections: unknown[];
+      const onUnhandledRejection = (reason: unknown) => {
+        unhandledRejections.push(reason);
+      };
+
+      beforeEach(() => {
+        unhandledRejections = [];
+        process.on('unhandledRejection', onUnhandledRejection);
+      });
+
+      afterEach(async () => {
+        try {
+          await new Promise(resolve => setTimeout(resolve, 0));
+          expect(unhandledRejections).toStrictEqual([]);
+        } finally {
+          process.off('unhandledRejection', onUnhandledRejection);
+        }
+      });
+
+      it.each([
+        { timing: 'during start', startFails: false },
+        { timing: 'at factory handoff', startFails: false },
+        { timing: 'during start', startFails: true },
+        { timing: 'at factory handoff', startFails: true },
+      ])(
+        'should observe rejection $timing while preserving start precedence (startFails: $startFails)',
+        async ({ timing, startFails }) => {
+          const webhookError = new Error('webhook delivery failed');
+          const startError = new Error('start failed');
+          let rejectWebhook!: (reason: unknown) => void;
+          const received = new Promise<VideoModelV4OperationWebhook>(
+            (_, reject) => {
+              rejectWebhook = reject;
+            },
+          );
+          let signalStarted!: () => void;
+          const started = new Promise<void>(resolve => {
+            signalStarted = resolve;
+          });
+          let releaseStart!: () => void;
+          const startGate = new Promise<void>(resolve => {
+            releaseStart = resolve;
+          });
+          const doStatus = vi.fn(async () => {
+            throw new Error('doStatus should not be called');
+          });
+          const settled = vi.fn();
+          const result = experimental_generateVideo({
+            model: new MockVideoModelV4({
+              doGenerate: undefined,
+              handleWebhookOption: async ({ webhook }) => {
+                const { url, received } = await webhook();
+                return { webhookUrl: url, received };
+              },
+              doStart: async () => {
+                signalStarted();
+                await startGate;
+                if (startFails) {
+                  throw startError;
+                }
+                return {
+                  operation: 'op-webhook',
+                  warnings: [],
+                  response: {
+                    timestamp: testDate,
+                    modelId: 'test-model-id',
+                    headers: {},
+                  },
+                };
+              },
+              doStatus,
+            }),
+            prompt,
+            maxRetries: 0,
+            webhook: async () => {
+              if (timing === 'at factory handoff') {
+                rejectWebhook(webhookError);
+              }
+              return { url: 'https://example.com/webhook', received };
+            },
+          });
+          void result.then(settled, settled);
+
+          try {
+            await started;
+            if (timing === 'during start') {
+              rejectWebhook(webhookError);
+            }
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(settled).not.toHaveBeenCalled();
+          } finally {
+            releaseStart();
+          }
+
+          await expect(result).rejects.toBe(
+            startFails ? startError : webhookError,
+          );
+          expect(doStatus).not.toHaveBeenCalled();
+        },
+      );
+
+      it('should observe late webhook rejection after start fails', async () => {
+        const startError = new Error('start failed');
+        let rejectWebhook!: (reason: unknown) => void;
+        const received = new Promise<VideoModelV4OperationWebhook>(
+          (_, reject) => {
+            rejectWebhook = reject;
+          },
+        );
+        const doStatus = vi.fn(async () => {
+          throw new Error('doStatus should not be called');
+        });
+        const result = experimental_generateVideo({
+          model: new MockVideoModelV4({
+            doGenerate: undefined,
+            handleWebhookOption: async ({ webhook }) => {
+              const { url, received } = await webhook();
+              return { webhookUrl: url, received };
+            },
+            doStart: async () => {
+              throw startError;
+            },
+            doStatus,
+          }),
+          prompt,
+          maxRetries: 0,
+          webhook: async () => ({
+            url: 'https://example.com/webhook',
+            received,
+          }),
+        });
+
+        await expect(result).rejects.toBe(startError);
+        rejectWebhook(new Error('late webhook delivery failure'));
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await expect(result).rejects.toBe(startError);
+        expect(doStatus).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should assimilate a then-only webhook receiver once before start completes', async () => {
+      const notification = Promise.resolve<VideoModelV4OperationWebhook>({
+        headers: {},
+        body: {},
+      });
+      const received: PromiseLike<VideoModelV4OperationWebhook> = {
+        // oxlint-disable-next-line unicorn/no-thenable -- Test a PromiseLike receiver.
+        then: notification.then.bind(notification),
+      };
+      const then = vi.spyOn(received, 'then');
+      const doStatus = vi.fn(async () => ({
+        status: 'completed' as const,
+        ...createMockResponse({
+          videos: [{ type: 'base64', data: mp4Base64, mediaType: 'video/mp4' }],
+        }),
+      }));
+
+      const result = await experimental_generateVideo({
+        model: new MockVideoModelV4({
+          doGenerate: undefined,
+          handleWebhookOption: async ({ webhook }) => {
+            const { url, received } = await webhook();
+            return { webhookUrl: url, received };
+          },
+          doStart: async () => {
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(then).toHaveBeenCalledTimes(1);
+            return {
+              operation: 'op-webhook',
+              warnings: [],
+              response: {
+                timestamp: testDate,
+                modelId: 'test-model-id',
+                headers: {},
+              },
+            };
+          },
+          doStatus,
+        }),
+        prompt,
+        maxRetries: 0,
+        webhook: async () => ({
+          url: 'https://example.com/webhook',
+          received,
+        }),
+      });
+
+      expect(then).toHaveBeenCalledTimes(1);
+      expect(doStatus).toHaveBeenCalledTimes(1);
+      expect(result.video.base64).toBe(mp4Base64);
+    });
+
     it('should use a custom delay for the webhook timeout', async () => {
       const delay = vi.fn(() => new Promise<void>(() => {}));
 

--- a/packages/ai/src/generate-video/generate-video.ts
+++ b/packages/ai/src/generate-video/generate-video.ts
@@ -489,7 +489,7 @@ async function executeStartStatusFlow({
   const earlyWarnings: Experimental_VideoModelV4Result['warnings'] = [];
   let webhookUrl: string | undefined;
   let webhookReceived:
-    | PromiseLike<Experimental_VideoModelV4OperationWebhook>
+    | Promise<Experimental_VideoModelV4OperationWebhook>
     | undefined;
 
   if (webhookFactory != null) {
@@ -497,8 +497,10 @@ async function executeStartStatusFlow({
       const result = await model.handleWebhookOption({
         webhook: webhookFactory,
       });
+      webhookReceived = Promise.resolve(result.received);
+      // Observe early failures without changing the error awaited after doStart.
+      webhookReceived.catch(() => {});
       webhookUrl = result.webhookUrl;
-      webhookReceived = result.received;
     } else {
       earlyWarnings.push({
         type: 'unsupported',

--- a/packages/bytedance/src/bytedance-video-model.test.ts
+++ b/packages/bytedance/src/bytedance-video-model.test.ts
@@ -1,3 +1,4 @@
+import type { Experimental_VideoModelV4 as VideoModelV4 } from '@ai-sdk/provider';
 import { DownloadError, type FetchFunction } from '@ai-sdk/provider-utils';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { describe, expect, it } from 'vitest';
@@ -100,6 +101,55 @@ describe('ByteDanceVideoModel', () => {
       });
 
       expect(model.modelId).toBe('custom-model-id');
+    });
+  });
+
+  describe('webhooks', () => {
+    it('should leave the generic webhook hook undefined', () => {
+      const model: VideoModelV4 = createBasicModel();
+      expect(model.handleWebhookOption).toBeUndefined();
+    });
+
+    it.each([
+      {
+        name: 'explicit URL',
+        webhookUrl: 'https://example.com/webhook',
+        rawUrl: undefined,
+        expected: 'https://example.com/webhook',
+      },
+      {
+        name: 'no callback',
+        webhookUrl: undefined,
+        rawUrl: undefined,
+        expected: undefined,
+      },
+      {
+        name: 'raw passthrough',
+        webhookUrl: undefined,
+        rawUrl: 'https://example.com/raw',
+        expected: 'https://example.com/raw',
+      },
+      {
+        name: 'explicit URL overrides raw',
+        webhookUrl: 'https://example.com/webhook',
+        rawUrl: 'https://example.com/raw',
+        expected: 'https://example.com/webhook',
+      },
+    ])('should submit $name', async ({ webhookUrl, rawUrl, expected }) => {
+      await createBasicModel().doStart({
+        ...defaultOptions,
+        webhookUrl,
+        providerOptions: {
+          bytedance: rawUrl != null ? { callback_url: rawUrl } : {},
+        },
+      });
+
+      const body = await server.calls[0].requestBodyJson;
+      if (expected == null) {
+        expect(body).not.toHaveProperty('callback_url');
+      } else {
+        expect(body).toHaveProperty('callback_url', expected);
+      }
     });
   });
 
@@ -1488,6 +1538,38 @@ describe('ByteDanceVideoModel', () => {
         'Video generation canceled',
       );
     });
+
+    it.each([
+      {
+        name: 'structured message',
+        error: { code: 'TaskExpired', message: 'The task has expired.' },
+        expected: 'The task has expired.',
+      },
+      {
+        name: 'missing-error fallback',
+        error: undefined,
+        expected: '{"id":"test-task-id-123","status":"expired"}',
+      },
+    ])(
+      'should return an expired error with $name',
+      async ({ error, expected }) => {
+        server.urls[
+          'https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks/test-task-id-123'
+        ].response = {
+          type: 'json-value',
+          body: { id: 'test-task-id-123', status: 'expired', error },
+        };
+
+        const result = await createBasicModel().doStatus({
+          operation: { taskId: 'test-task-id-123' },
+        });
+
+        expect(result.status).toBe('error');
+        expect(result.status === 'error' ? result.error : undefined).toBe(
+          `Video generation expired. Task ID: test-task-id-123. ${expected}`,
+        );
+      },
+    );
 
     it('should throw error when no video URL in response', async () => {
       server.urls[

--- a/packages/bytedance/src/bytedance-video-model.ts
+++ b/packages/bytedance/src/bytedance-video-model.ts
@@ -349,6 +349,12 @@ export class ByteDanceVideoModel implements VideoModelV4 {
     const currentDate = this.config._internal?.currentDate?.() ?? new Date();
     const { body, warnings } = await this.buildRequestBody(options);
 
+    // Progress notifications require a protocol-aware receiver, so omit handleWebhookOption.
+    // Forward webhookUrl for a caller-owned receiver that filters progress notifications.
+    if (options.webhookUrl != null) {
+      body.callback_url = options.webhookUrl;
+    }
+
     const { value: createResponse, responseHeaders } = await postJsonToApi({
       url: `${this.config.baseURL}/contents/generations/tasks`,
       headers: combineHeaders(
@@ -446,6 +452,7 @@ export class ByteDanceVideoModel implements VideoModelV4 {
     // ModelArk documents `cancelled`; `canceled` is handled defensively.
     if (
       statusResponse.status === 'failed' ||
+      statusResponse.status === 'expired' ||
       statusResponse.status === 'cancelled' ||
       statusResponse.status === 'canceled'
     ) {

--- a/packages/google/src/google-batch.test.ts
+++ b/packages/google/src/google-batch.test.ts
@@ -454,6 +454,37 @@ describe('GoogleBatch', () => {
     }
   });
 
+  it.each(['inline', 'file'] as const)(
+    'omits webhook configuration for %s input when no webhook URL is provided',
+    async inputType => {
+      prepareUpload();
+      server.urls[urls.create].response = {
+        type: 'json-value',
+        body: operation(),
+      };
+
+      await createGoogle({ apiKey: 'test-api-key' })
+        .experimental_batch()
+        .doStartBatch({
+          requests: [
+            request(
+              'request-1',
+              inputType === 'file' ? 'a'.repeat(20_000_000) : 'Hello',
+            ),
+          ],
+        });
+
+      expect(server.calls.map(call => call.requestUrl)).toEqual(
+        inputType === 'file'
+          ? [urls.uploadStart, urls.uploadSession, urls.create]
+          : [urls.create],
+      );
+      const body =
+        await server.calls[inputType === 'file' ? 2 : 0].requestBodyJson;
+      expect(body.batch).not.toHaveProperty('webhookConfig');
+    },
+  );
+
   it.each([
     ['JOB_STATE_PENDING', 'pending'],
     ['JOB_STATE_RUNNING', 'pending'],

--- a/packages/klingai/src/klingai-video-model.test.ts
+++ b/packages/klingai/src/klingai-video-model.test.ts
@@ -1,3 +1,4 @@
+import type { Experimental_VideoModelV4 as VideoModelV4 } from '@ai-sdk/provider';
 import { DownloadError, type FetchFunction } from '@ai-sdk/provider-utils';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { describe, expect, it } from 'vitest';
@@ -178,6 +179,12 @@ describe('KlingAIVideoModel', () => {
       response: {
         type: 'json-value',
         body: successfulTaskResponse,
+      },
+    },
+    [`${TEST_BASE_URL}/v1/videos/multi-image2video`]: {
+      response: {
+        type: 'json-value',
+        body: createTaskResponse,
       },
     },
   });
@@ -1224,6 +1231,103 @@ describe('KlingAIVideoModel', () => {
       expect(result.warnings).toContainEqual(
         expect.objectContaining({ type: 'unsupported', feature: 'n' }),
       );
+    });
+  });
+
+  describe('webhooks', () => {
+    it('should leave the generic webhook hook undefined', () => {
+      const model: VideoModelV4 = createBasicModel();
+      expect(model.handleWebhookOption).toBeUndefined();
+    });
+
+    describe.each([
+      {
+        endpoint: 'text2video',
+        modelId: 'kling-v2.6-t2v',
+        options: t2vDefaultOptions,
+      },
+      {
+        endpoint: 'image2video',
+        modelId: 'kling-v2.6-i2v',
+        options: i2vDefaultOptions,
+      },
+      {
+        endpoint: 'multi-image2video',
+        modelId: 'kling-v1.6-i2v',
+        options: {
+          ...t2vDefaultOptions,
+          inputReferences: [
+            {
+              type: 'url' as const,
+              url: 'https://example.com/character-1.png',
+            },
+            {
+              type: 'url' as const,
+              url: 'https://example.com/character-2.png',
+            },
+          ],
+        },
+      },
+      {
+        endpoint: 'motion-control',
+        modelId: 'kling-v2.6-motion-control',
+        options: defaultOptions,
+      },
+    ])('$endpoint', ({ endpoint, modelId, options }) => {
+      it.each([
+        {
+          name: 'explicit URL',
+          webhookUrl: 'https://example.com/webhook',
+          rawUrl: undefined,
+          expected: 'https://example.com/webhook',
+        },
+        {
+          name: 'no callback',
+          webhookUrl: undefined,
+          rawUrl: undefined,
+          expected: undefined,
+        },
+        {
+          name: 'raw passthrough',
+          webhookUrl: undefined,
+          rawUrl: 'https://example.com/raw',
+          expected: 'https://example.com/raw',
+        },
+        {
+          name: 'explicit URL overrides raw',
+          webhookUrl: 'https://example.com/webhook',
+          rawUrl: 'https://example.com/raw',
+          expected: 'https://example.com/webhook',
+        },
+      ])('should submit $name', async ({ webhookUrl, rawUrl, expected }) => {
+        const result = await createBasicModel({ modelId }).doStart({
+          ...options,
+          webhookUrl,
+          providerOptions: {
+            klingai: {
+              ...options.providerOptions.klingai,
+              ...(rawUrl != null ? { callback_url: rawUrl } : {}),
+            },
+          },
+        });
+
+        expect(result.operation).toStrictEqual({
+          taskId: 'task-abc-123',
+          endpointPath: `/v1/videos/${endpoint}`,
+        });
+        const body = await server.calls[0].requestBodyJson;
+        if (expected == null) {
+          expect(body).not.toHaveProperty('callback_url');
+        } else {
+          expect(body).toHaveProperty('callback_url', expected);
+        }
+        if (endpoint === 'multi-image2video') {
+          expect(body.image_list).toStrictEqual([
+            { image: 'https://example.com/character-1.png' },
+            { image: 'https://example.com/character-2.png' },
+          ]);
+        }
+      });
     });
   });
 

--- a/packages/klingai/src/klingai-video-model.ts
+++ b/packages/klingai/src/klingai-video-model.ts
@@ -260,6 +260,12 @@ export class KlingAIVideoModel implements VideoModelV4 {
       });
     }
 
+    // Progress notifications require a protocol-aware receiver, so omit handleWebhookOption.
+    // Forward webhookUrl for a caller-owned receiver that filters progress notifications.
+    if (options.webhookUrl != null) {
+      body.callback_url = options.webhookUrl;
+    }
+
     this.addUniversalWarnings(options, warnings);
 
     const endpointPath = modeEndpointMap[effectiveMode];

--- a/packages/minimax/src/minimax-video-model.test.ts
+++ b/packages/minimax/src/minimax-video-model.test.ts
@@ -1,6 +1,7 @@
 import type {
   JSONValue,
   SharedV4ProviderOptions,
+  Experimental_VideoModelV4 as VideoModelV4,
   Experimental_VideoModelV4File,
 } from '@ai-sdk/provider';
 import { DownloadError, type FetchFunction } from '@ai-sdk/provider-utils';
@@ -136,13 +137,18 @@ describe('MiniMaxVideoModel', () => {
     });
   });
 
+  it('should leave the generic webhook hook undefined', () => {
+    const model: VideoModelV4 = createModel();
+    expect(model.handleWebhookOption).toBeUndefined();
+  });
+
   describe('doStart / doStatus', () => {
     const operation = {
       taskId: TASK_ID,
       resolvedInputs: { imageCount: 0, referenceVideoIndices: [] },
     };
 
-    it('should submit once without polling or registering a webhook', async () => {
+    it('should submit once with callback_url without polling', async () => {
       const testDate = new Date('2026-01-01T00:00:00Z');
       server.urls[CREATE_URL].response = {
         type: 'json-value',
@@ -156,10 +162,10 @@ describe('MiniMaxVideoModel', () => {
         webhookUrl: 'https://example.com/callback',
       });
 
-      expect(model).not.toHaveProperty('handleWebhookOption');
       expect(server.calls).toHaveLength(1);
       expect(server.calls[0].requestMethod).toBe('POST');
       expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        callback_url: 'https://example.com/callback',
         model: 'MiniMax-H3',
         content: [{ type: 'text', text: prompt }],
         resolution: '2K',
@@ -173,6 +179,16 @@ describe('MiniMaxVideoModel', () => {
         modelId: 'MiniMax-H3',
         headers: { 'x-minimax-request-id': 'start-request' },
       });
+    });
+
+    it('should omit callback_url when webhookUrl is not provided', async () => {
+      const result = await createModel().doStart(defaultOptions);
+
+      expect(server.calls).toHaveLength(1);
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'callback_url',
+      );
+      expect(result.operation).toStrictEqual(operation);
     });
 
     it('should preserve normalized inputs and metadata across JSON and a fresh model', async () => {

--- a/packages/minimax/src/minimax-video-model.ts
+++ b/packages/minimax/src/minimax-video-model.ts
@@ -586,7 +586,14 @@ export class MiniMaxVideoModel implements VideoModelV4 {
         await resolve(this.config.headers),
         options.headers,
       ),
-      body,
+      body: {
+        ...body,
+        // The challenge handshake and progress notifications rule out handleWebhookOption.
+        // Forward webhookUrl for caller-owned receivers that echo the challenge within 3s.
+        ...(options.webhookUrl != null
+          ? { callback_url: options.webhookUrl }
+          : {}),
+      },
       failedResponseHandler: minimaxVideoFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
         minimaxCreateVideoResponseSchema,


### PR DESCRIPTION
## Background

KlingAI, ByteDance, and MiniMax video adapters accept the start-operation interface but previously ignored its callback URL. Applications with their own callback endpoints need that URL included in the task submission. These providers send progress notifications or require challenge verification, so callback registration does not imply compatibility with a generic first-notification receiver.

## Summary

- Forward `doStart({ webhookUrl })` as `callback_url` in all three adapters, including all four KlingAI endpoints. Preserve field omission and explicit-over-raw callback URL precedence.
- Leave `handleWebhookOption` undefined, with regression assertions and short protocol explanations. Document caller-managed `experimental_startVideo` / `experimental_getVideoStatus` usage and retain generic polling fallback.
- Treat ByteDance `expired` tasks as terminal errors.
- Observe video delivery-promise rejections before awaiting task submission, preserving start-error precedence and assimilating custom thenables once.
- Add Google batch callback-omission tests for inline and uploaded-file inputs alongside existing forwarding coverage.
- Update the KlingAI fallback example and add four patch changesets.

## Verification

Using Node 24.14.0:

| Suite | Node | Edge |
| --- | ---: | ---: |
| KlingAI package | 122 | 122 |
| ByteDance package | 90 | 90 |
| MiniMax package | 170 | 170 |
| Google package | 826 | 826 |
| Core generate-video | 69 | 69 |

`pnpm type-check:full`, `pnpm check`, and `git diff --check` passed. The six core rejection regressions were also checked against the original implementation and failed without the fix. Independent final review found no implementation blockers.

## End-to-End Verification

Live provider callback delivery and challenge exchange have not been exercised. Callback receiver behavior still needs live verification with application-owned endpoints.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

Generic progress-aware receivers with bounded waits, and polling fallback after an early notification, remain separate work. This PR does not change the Workflow package or video specification.