### PR TITLE
fix: reject unsupported batch request types

### DIFF
--- a/.changeset/batch-request-type-validation.md
+++ b/.changeset/batch-request-type-validation.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/anthropic': patch
+'@ai-sdk/gateway': patch
+'@ai-sdk/google': patch
+'@ai-sdk/openai': patch
+'@ai-sdk/provider': patch
+'@ai-sdk/xai': patch
+'ai': patch
+---
+
+fix: reject unsupported batch request types

--- a/packages/ai/scripts/check-bundle-size.ts
+++ b/packages/ai/scripts/check-bundle-size.ts
@@ -3,7 +3,7 @@ import { writeFileSync, statSync } from 'fs';
 import { join } from 'path';
 
 // Bundle size limits in bytes
-const LIMIT = 470 * 1024;
+const LIMIT = 480 * 1024;
 
 interface BundleResult {
   size: number;

--- a/packages/ai/src/batch/batch.test.ts
+++ b/packages/ai/src/batch/batch.test.ts
@@ -169,6 +169,28 @@ describe('listBatches', () => {
 });
 
 describe('startBatch', () => {
+  it('rejects unsupported request types before starting a batch', async () => {
+    const doStartBatch = vi.fn(createMockBatchApi().doStartBatch);
+    const batchApi = createMockBatchApi({ doStartBatch });
+
+    await expect(
+      startBatch({
+        provider: batchApi,
+        requests: [
+          {
+            id: 'request-1',
+            type: 'image',
+          } as never,
+        ],
+      }),
+    ).rejects.toMatchObject({
+      name: 'AI_InvalidArgumentError',
+      parameter: 'requests',
+    });
+
+    expect(doStartBatch).not.toHaveBeenCalled();
+  });
+
   it('uses the global default provider when provider is omitted', async () => {
     const calls: Array<Parameters<BatchV4['doStartBatch']>[0]> = [];
     const batchApi = createMockBatchApi({

--- a/packages/ai/src/batch/batch.ts
+++ b/packages/ai/src/batch/batch.ts
@@ -2,7 +2,6 @@ import {
   UnsupportedFunctionalityError,
   type Experimental_BatchV4 as BatchV4,
   type Experimental_BatchV4ItemResult as BatchV4ItemResult,
-  type Experimental_BatchV4StartOptions as BatchV4StartOptions,
   type LanguageModelV4GenerateResult,
   type LanguageModelV4ToolCall,
   type ProviderV4,
@@ -164,7 +163,7 @@ export async function startBatch<
   );
   const supportedUrls = await batchApi.supportedUrls;
   operationAbortSignal?.throwIfAborted();
-  const normalizedRequests: Array<BatchV4StartOptions['requests'][number]> = [];
+  const normalizedRequests = [];
   const toolsByName = new Map<string, unknown>();
 
   for (const request of requests) {

--- a/packages/ai/src/batch/batch.ts
+++ b/packages/ai/src/batch/batch.ts
@@ -29,7 +29,6 @@ import { VERSION } from '../version';
 import { asProviderV4 } from '../model/as-provider-v4';
 import type {
   BatchItemResult,
-  BatchRequest,
   BatchProvider,
   BatchReference,
   BatchStatus,
@@ -169,8 +168,6 @@ export async function startBatch<
   const toolsByName = new Map<string, unknown>();
 
   for (const request of requests) {
-    validateBatchRequestType(request);
-
     switch (request.type) {
       case 'text': {
         const standardizedPrompt = await standardizePrompt(request);
@@ -203,6 +200,14 @@ export async function startBatch<
           },
         });
         break;
+      }
+      default: {
+        const _exhaustiveCheck: never = request.type;
+        throw new InvalidArgumentError({
+          parameter: 'requests',
+          value: _exhaustiveCheck,
+          message: `Unsupported batch request type "${_exhaustiveCheck}".`,
+        });
       }
     }
     operationAbortSignal?.throwIfAborted();
@@ -242,21 +247,6 @@ export async function startBatch<
     };
   } catch (error) {
     throw wrapGatewayError(error);
-  }
-}
-
-function validateBatchRequestType(request: BatchRequest) {
-  switch (request.type) {
-    case 'text':
-      return;
-    default: {
-      const _exhaustiveCheck: never = request.type;
-      throw new InvalidArgumentError({
-        parameter: 'requests',
-        value: _exhaustiveCheck,
-        message: `Unsupported batch request type "${_exhaustiveCheck}".`,
-      });
-    }
   }
 }
 

--- a/packages/ai/src/batch/batch.ts
+++ b/packages/ai/src/batch/batch.ts
@@ -2,6 +2,7 @@ import {
   UnsupportedFunctionalityError,
   type Experimental_BatchV4 as BatchV4,
   type Experimental_BatchV4ItemResult as BatchV4ItemResult,
+  type Experimental_BatchV4StartOptions as BatchV4StartOptions,
   type LanguageModelV4GenerateResult,
   type LanguageModelV4ToolCall,
   type ProviderV4,
@@ -28,6 +29,7 @@ import { VERSION } from '../version';
 import { asProviderV4 } from '../model/as-provider-v4';
 import type {
   BatchItemResult,
+  BatchRequest,
   BatchProvider,
   BatchReference,
   BatchStatus,
@@ -163,10 +165,12 @@ export async function startBatch<
   );
   const supportedUrls = await batchApi.supportedUrls;
   operationAbortSignal?.throwIfAborted();
-  const normalizedRequests = [];
+  const normalizedRequests: Array<BatchV4StartOptions['requests'][number]> = [];
   const toolsByName = new Map<string, unknown>();
 
   for (const request of requests) {
+    validateBatchRequestType(request);
+
     switch (request.type) {
       case 'text': {
         const standardizedPrompt = await standardizePrompt(request);
@@ -238,6 +242,21 @@ export async function startBatch<
     };
   } catch (error) {
     throw wrapGatewayError(error);
+  }
+}
+
+function validateBatchRequestType(request: BatchRequest) {
+  switch (request.type) {
+    case 'text':
+      return;
+    default: {
+      const _exhaustiveCheck: never = request.type;
+      throw new InvalidArgumentError({
+        parameter: 'requests',
+        value: _exhaustiveCheck,
+        message: `Unsupported batch request type "${_exhaustiveCheck}".`,
+      });
+    }
   }
 }
 

--- a/packages/anthropic/src/anthropic-batch.test.ts
+++ b/packages/anthropic/src/anthropic-batch.test.ts
@@ -93,6 +93,23 @@ function messageResultBody(text: string) {
 }
 
 describe('Anthropic batch', () => {
+  it('rejects unsupported request types before making an API request', async () => {
+    const model = createAnthropic({
+      apiKey: 'test-api-key',
+    }).experimental_batch();
+
+    await expect(
+      model.doStartBatch({
+        requests: [{ id: 'image-1', type: 'image' } as never],
+      }),
+    ).rejects.toMatchObject({
+      name: 'AI_UnsupportedFunctionalityError',
+      functionality: 'batch request type: image',
+    });
+
+    expect(server.calls).toHaveLength(0);
+  });
+
   it('starts a batch from prepared requests and combines batch and inferred betas', async () => {
     server.urls[urls.batches].response = {
       type: 'json-value',

--- a/packages/anthropic/src/anthropic-batch.ts
+++ b/packages/anthropic/src/anthropic-batch.ts
@@ -206,7 +206,9 @@ export class AnthropicBatch implements BatchV4<{
     headers,
     abortSignal,
     webhookUrl,
-  }: BatchV4StartOptions): Promise<BatchV4StartResult> {
+  }: BatchV4StartOptions<{
+    text: AnthropicModelId;
+  }>): Promise<BatchV4StartResult> {
     assertTextBatchRequests(requests);
     validateRequestIds(requests);
 

--- a/packages/anthropic/src/anthropic-batch.ts
+++ b/packages/anthropic/src/anthropic-batch.ts
@@ -148,6 +148,24 @@ type AnthropicBatchResultLine = InferSchema<
 
 type AnthropicResponse = InferSchema<typeof anthropicResponseSchema>;
 
+function assertTextBatchRequests(
+  requests: BatchV4StartOptions['requests'],
+): asserts requests is ReadonlyArray<AnthropicBatchRequest> {
+  for (const request of requests) {
+    switch (request.type) {
+      case 'text':
+        break;
+      default: {
+        const _exhaustiveCheck: never = request.type;
+        throw new UnsupportedFunctionalityError({
+          functionality: `batch request type: ${_exhaustiveCheck}`,
+          message: `The Anthropic Message Batches API does not support batch requests with type "${_exhaustiveCheck}".`,
+        });
+      }
+    }
+  }
+}
+
 export class AnthropicBatch implements BatchV4<{
   readonly text: AnthropicModelId;
 }> {
@@ -174,9 +192,8 @@ export class AnthropicBatch implements BatchV4<{
     headers,
     abortSignal,
     webhookUrl,
-  }: BatchV4StartOptions<{
-    text: AnthropicModelId;
-  }>): Promise<BatchV4StartResult> {
+  }: BatchV4StartOptions): Promise<BatchV4StartResult> {
+    assertTextBatchRequests(requests);
     validateRequestIds(requests);
 
     const explicitBatchBetas = new Set(

--- a/packages/gateway/src/gateway-batch.test.ts
+++ b/packages/gateway/src/gateway-batch.test.ts
@@ -83,6 +83,19 @@ describe('GatewayBatch', () => {
   }
 
   describe('doStartBatch', () => {
+    it('should reject unsupported request types before sending a request', async () => {
+      await expect(
+        createTestBatch().doStartBatch({
+          requests: [{ id: 'image-1', type: 'image' } as never],
+        }),
+      ).rejects.toMatchObject({
+        name: 'AI_UnsupportedFunctionalityError',
+        functionality: 'batch request type: image',
+      });
+
+      expect(server.calls).toHaveLength(0);
+    });
+
     it('should fail before sending a request when models are mixed', async () => {
       await expect(
         createTestBatch().doStartBatch({

--- a/packages/gateway/src/gateway-batch.ts
+++ b/packages/gateway/src/gateway-batch.ts
@@ -51,7 +51,9 @@ export class GatewayBatch implements BatchV4<{ text: GatewayModelId }> {
     headers,
     abortSignal,
     webhookUrl,
-  }: BatchV4StartOptions): Promise<BatchV4StartResult> {
+  }: BatchV4StartOptions<{
+    text: GatewayModelId;
+  }>): Promise<BatchV4StartResult> {
     assertTextBatchRequests(requests);
     const modelId = validateSingleModel(requests);
 

--- a/packages/gateway/src/gateway-batch.ts
+++ b/packages/gateway/src/gateway-batch.ts
@@ -1,11 +1,13 @@
 import {
   InvalidArgumentError,
+  UnsupportedFunctionalityError,
   type Experimental_BatchV4 as BatchV4,
   type Experimental_BatchV4ItemResult as BatchV4ItemResult,
   type Experimental_BatchV4OperationOptions as BatchV4OperationOptions,
   type Experimental_BatchV4StartResult as BatchV4StartResult,
   type Experimental_BatchV4Status as BatchV4Status,
   type Experimental_BatchV4StartOptions as BatchV4StartOptions,
+  type Experimental_TextBatchV4Request as TextBatchV4Request,
   type LanguageModelV4CallOptions,
   type SharedV4ProviderMetadata,
   type SharedV4ProviderOptions,
@@ -49,9 +51,8 @@ export class GatewayBatch implements BatchV4<{ text: GatewayModelId }> {
     headers,
     abortSignal,
     webhookUrl,
-  }: BatchV4StartOptions<{
-    text: GatewayModelId;
-  }>): Promise<BatchV4StartResult> {
+  }: BatchV4StartOptions): Promise<BatchV4StartResult> {
+    assertTextBatchRequests(requests);
     const modelId = validateSingleModel(requests);
 
     const resolvedHeaders = this.config.headers
@@ -251,7 +252,7 @@ function maybeBase64EncodeFileData<T extends { type: string }>(data: T): T {
 }
 
 function validateSingleModel(
-  requests: BatchV4StartOptions<{ text: GatewayModelId }>['requests'],
+  requests: ReadonlyArray<TextBatchV4Request<GatewayModelId>>,
 ): GatewayModelId {
   const modelId = requests[0]?.modelId;
 
@@ -274,6 +275,24 @@ function validateSingleModel(
   }
 
   return modelId;
+}
+
+function assertTextBatchRequests(
+  requests: BatchV4StartOptions['requests'],
+): asserts requests is ReadonlyArray<TextBatchV4Request<GatewayModelId>> {
+  for (const request of requests) {
+    switch (request.type) {
+      case 'text':
+        break;
+      default: {
+        const _exhaustiveCheck: never = request.type;
+        throw new UnsupportedFunctionalityError({
+          functionality: `batch request type: ${_exhaustiveCheck}`,
+          message: `The AI Gateway Batch API does not support batch requests with type "${_exhaustiveCheck}".`,
+        });
+      }
+    }
+  }
 }
 
 /**

--- a/packages/google/src/google-batch.test.ts
+++ b/packages/google/src/google-batch.test.ts
@@ -155,6 +155,21 @@ function prepareOutput(lines: unknown[]) {
 }
 
 describe('GoogleBatch', () => {
+  it('rejects unsupported request types before creating a batch', async () => {
+    const batch = createGoogle({ apiKey: 'test-api-key' }).experimental_batch();
+
+    await expect(
+      batch.doStartBatch({
+        requests: [{ id: 'image-1', type: 'image' } as never],
+      }),
+    ).rejects.toMatchObject({
+      name: 'AI_UnsupportedFunctionalityError',
+      functionality: 'batch request type: image',
+    });
+
+    expect(server.calls).toHaveLength(0);
+  });
+
   it('rejects mixed models before creating a batch', async () => {
     const batch = createGoogle({ apiKey: 'test-api-key' }).experimental_batch();
 

--- a/packages/google/src/google-batch.ts
+++ b/packages/google/src/google-batch.ts
@@ -188,7 +188,7 @@ export class GoogleBatch implements BatchV4<{ readonly text: GoogleModelId }> {
   }
 
   async doStartBatch(
-    options: BatchV4StartOptions,
+    options: BatchV4StartOptions<{ text: GoogleModelId }>,
   ): Promise<BatchV4StartResult> {
     assertTextBatchRequests(options.requests);
     const modelId = getGoogleBatchModelId(options.requests);

--- a/packages/google/src/google-batch.ts
+++ b/packages/google/src/google-batch.ts
@@ -1,6 +1,7 @@
 import {
   InvalidArgumentError,
   InvalidResponseDataError,
+  UnsupportedFunctionalityError,
   type Experimental_BatchV4 as BatchV4,
   type Experimental_BatchV4Error as BatchV4Error,
   type Experimental_BatchV4ItemResult as BatchV4ItemResult,
@@ -45,6 +46,24 @@ const supportedGoogleBatchContentTypes = new Set<
 >(['text', 'reasoning', 'source', 'tool-call', 'tool-result']);
 
 type GoogleBatchRequest = TextBatchV4Request<GoogleModelId>;
+
+function assertTextBatchRequests(
+  requests: BatchV4StartOptions['requests'],
+): asserts requests is ReadonlyArray<GoogleBatchRequest> {
+  for (const request of requests) {
+    switch (request.type) {
+      case 'text':
+        break;
+      default: {
+        const _exhaustiveCheck: never = request.type;
+        throw new UnsupportedFunctionalityError({
+          functionality: `batch request type: ${_exhaustiveCheck}`,
+          message: `The Google Batch API does not support batch requests with type "${_exhaustiveCheck}".`,
+        });
+      }
+    }
+  }
+}
 
 const googleRpcStatusSchema = z.object({
   code: z.union([z.number(), z.string()]).nullish(),
@@ -152,8 +171,9 @@ export class GoogleBatch implements BatchV4<{ readonly text: GoogleModelId }> {
   }
 
   async doStartBatch(
-    options: BatchV4StartOptions<{ text: GoogleModelId }>,
+    options: BatchV4StartOptions,
   ): Promise<BatchV4StartResult> {
+    assertTextBatchRequests(options.requests);
     const modelId = getGoogleBatchModelId(options.requests);
     const warnings: BatchV4StartResult['warnings'] = [];
     const displayName = `ai-sdk-batch-${this.batchGenerateId()}`;

--- a/packages/openai/src/openai-batch.test.ts
+++ b/packages/openai/src/openai-batch.test.ts
@@ -125,6 +125,21 @@ function resultLine({ id, body }: { id: string; body: unknown }) {
 }
 
 describe('OpenAI batch service', () => {
+  it('rejects unsupported request types before uploading a batch input file', async () => {
+    const batch = createOpenAI({ apiKey: 'test-api-key' }).experimental_batch();
+
+    await expect(
+      batch.doStartBatch({
+        requests: [{ id: 'image-1', type: 'image' } as never],
+      }),
+    ).rejects.toMatchObject({
+      name: 'AI_UnsupportedFunctionalityError',
+      functionality: 'batch request type: image',
+    });
+
+    expect(server.calls).toHaveLength(0);
+  });
+
   it('creates a Responses batch from prepared JSONL requests', async () => {
     prepareCreateResponse({
       status: 'validating',

--- a/packages/openai/src/openai-batch.ts
+++ b/packages/openai/src/openai-batch.ts
@@ -1,6 +1,7 @@
 import {
   InvalidArgumentError,
   InvalidResponseDataError,
+  UnsupportedFunctionalityError,
   type Experimental_BatchV4 as BatchV4,
   type Experimental_BatchV4CancelResult as BatchV4CancelResult,
   type Experimental_BatchV4StartResult as BatchV4StartResult,
@@ -89,6 +90,24 @@ type OpenAIBatchResultConversion =
   | { success: true; result: LanguageModelV4GenerateResult }
   | { success: false; error: BatchV4Error };
 
+function assertTextBatchRequests(
+  requests: BatchV4StartOptions['requests'],
+): asserts requests is ReadonlyArray<OpenAIBatchRequest> {
+  for (const request of requests) {
+    switch (request.type) {
+      case 'text':
+        break;
+      default: {
+        const _exhaustiveCheck: never = request.type;
+        throw new UnsupportedFunctionalityError({
+          functionality: `batch request type: ${_exhaustiveCheck}`,
+          message: `The OpenAI Batch API does not support batch requests with type "${_exhaustiveCheck}".`,
+        });
+      }
+    }
+  }
+}
+
 const openaiBatchResponseZodSchema = () =>
   z.object({
     id: z.string(),
@@ -172,8 +191,9 @@ export class OpenAIBatch implements BatchV4<OpenAIBatchModelIds> {
   }
 
   async doStartBatch(
-    options: BatchV4StartOptions<OpenAIBatchModelIds>,
+    options: BatchV4StartOptions,
   ): Promise<BatchV4StartResult> {
+    assertTextBatchRequests(options.requests);
     validateSingleModel(options.requests);
 
     const fileParts: string[] = [];

--- a/packages/openai/src/openai-batch.ts
+++ b/packages/openai/src/openai-batch.ts
@@ -191,7 +191,7 @@ export class OpenAIBatch implements BatchV4<OpenAIBatchModelIds> {
   }
 
   async doStartBatch(
-    options: BatchV4StartOptions,
+    options: BatchV4StartOptions<OpenAIBatchModelIds>,
   ): Promise<BatchV4StartResult> {
     assertTextBatchRequests(options.requests);
     validateSingleModel(options.requests);

--- a/packages/xai/src/xai-batch.test.ts
+++ b/packages/xai/src/xai-batch.test.ts
@@ -115,6 +115,21 @@ function successfulResult(id: string, text: string) {
 }
 
 describe('xAI batch', () => {
+  it('rejects unsupported request types before uploading a batch input file', async () => {
+    const batch = createXai({ apiKey: 'test-api-key' }).experimental_batch();
+
+    await expect(
+      batch.doStartBatch({
+        requests: [{ id: 'image-1', type: 'image' } as never],
+      }),
+    ).rejects.toMatchObject({
+      name: 'AI_UnsupportedFunctionalityError',
+      functionality: 'batch request type: image',
+    });
+
+    expect(server.calls).toHaveLength(0);
+  });
+
   it('uploads prepared JSONL requests and creates a file-backed batch', async () => {
     server.urls[urls.files].response = {
       type: 'json-value',

--- a/packages/xai/src/xai-batch.ts
+++ b/packages/xai/src/xai-batch.ts
@@ -182,7 +182,7 @@ export class XaiBatch implements BatchV4<XaiBatchModelIds> {
   }
 
   async doStartBatch(
-    options: BatchV4StartOptions,
+    options: BatchV4StartOptions<XaiBatchModelIds>,
   ): Promise<BatchV4StartResult> {
     assertTextBatchRequests(options.requests);
     const fileParts: string[] = [];

--- a/packages/xai/src/xai-batch.ts
+++ b/packages/xai/src/xai-batch.ts
@@ -1,5 +1,6 @@
 import {
   InvalidArgumentError,
+  UnsupportedFunctionalityError,
   type Experimental_BatchV4 as BatchV4,
   type Experimental_BatchV4Error as BatchV4Error,
   type Experimental_BatchV4ItemResult as BatchV4ItemResult,
@@ -80,6 +81,24 @@ type XaiBatchResponseConversion =
   | { success: true; result: LanguageModelV4GenerateResult }
   | { success: false; error: BatchV4Error };
 
+function assertTextBatchRequests(
+  requests: BatchV4StartOptions['requests'],
+): asserts requests is ReadonlyArray<XaiBatchRequest> {
+  for (const request of requests) {
+    switch (request.type) {
+      case 'text':
+        break;
+      default: {
+        const _exhaustiveCheck: never = request.type;
+        throw new UnsupportedFunctionalityError({
+          functionality: `batch request type: ${_exhaustiveCheck}`,
+          message: `The xAI Batch API does not support batch requests with type "${_exhaustiveCheck}".`,
+        });
+      }
+    }
+  }
+}
+
 const xaiBatchResponseSchema = lazySchema(() =>
   zodSchema(
     z.object({
@@ -150,8 +169,9 @@ export class XaiBatch implements BatchV4<XaiBatchModelIds> {
   }
 
   async doStartBatch(
-    options: BatchV4StartOptions<XaiBatchModelIds>,
+    options: BatchV4StartOptions,
   ): Promise<BatchV4StartResult> {
+    assertTextBatchRequests(options.requests);
     const fileParts: string[] = [];
     const warnings: BatchV4StartResult['warnings'] =
       options.webhookUrl == null


### PR DESCRIPTION
## Background

Right now, the only Batch request type is `text`. Both AI SDK Core and provider packages follow that TypeScript type, and assume `type` is *always* `text`.

When we extend that `type` to a union and add other request types (e.g. image, embedding) it will break existing provider packages that treat all requests as text requests.

## Summary

Validate that `type` is a supported request type.
- In core, check that it's any valid request type
- In providers, check that it's a supported request type for that provider

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [X] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [X] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [X] I have reviewed this pull request (self-review)
