### PR TITLE
feat(harness-jcode): add Jcode Harness V1 adapter

### DIFF
--- a/.changeset/bright-pandas-juggle.md
+++ b/.changeset/bright-pandas-juggle.md
@@ -3,4 +3,5 @@
 ---
 
 Add the initial Jcode Harness V1 adapter with typed text, reasoning, tool,
-usage, compaction, lifecycle, and cancellation event handling.
+usage, compaction, lifecycle, and cancellation event handling. Include the
+in-sandbox bridge runtime and deterministic bootstrap assets.

--- a/.changeset/bright-pandas-juggle.md
+++ b/.changeset/bright-pandas-juggle.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/harness-jcode': minor
+---
+
+Add the initial Jcode Harness V1 adapter with typed text, reasoning, tool,
+usage, compaction, lifecycle, and cancellation event handling.

--- a/packages/harness-jcode/README.md
+++ b/packages/harness-jcode/README.md
@@ -6,22 +6,38 @@ Experimental Harness V1 adapter for [Jcode](https://github.com/1jehuang/jcode).
 import { createJcode } from '@ai-sdk/harness-jcode';
 
 const harness = createJcode({
-  // Temporary opt-in until the in-sandbox Jcode bridge is implemented.
-  experimentalHostExecution: true,
   model: 'openai-oauth:gpt-5.6-sol',
   reasoningEffort: 'high',
+  env: {
+    AI_GATEWAY_API_KEY: process.env.AI_GATEWAY_API_KEY!,
+  },
+});
+```
+
+By default, Jcode runs inside the supplied network sandbox. Install the recipe
+returned by `harness.getBootstrap()` in the sandbox before starting a session,
+and expose at least one TCP port. The adapter starts `dist`'s bootstrap bridge
+with a per-session work directory, bridge state directory, Jcode home, random
+authentication token, and exposed port. `env` is forwarded to that sandbox
+process for API-key or gateway authentication.
+
+For basic sandbox sessions without port discovery, configure both `port` and
+`portEndpoint`. `jcodeHome` can override the default durable per-session Jcode
+home.
+
+The adapter supports typed prompt, manual compaction, stop/resume, and destroy
+lifecycle operations. Host-defined tools, turn suspension, lossless turn
+continuation, live detach, JSON response formats, and mid-turn user messages are
+not supported yet and reject with `HarnessCapabilityUnsupportedError`.
+
+Host execution remains an explicit fallback for trusted local workspaces only:
+
+```ts
+const hostHarness = createJcode({
+  experimentalHostExecution: true,
   jcodeHome: '/durable/jcode-home',
 });
 ```
 
-The initial implementation launches Jcode through `@1jehuang/jcode-sdk` and
-streams text, reasoning, built-in tool lifecycle, usage, compaction, and raw
-events as typed Harness V1 stream parts. Host-defined tools and lossless
-cross-process turn continuation require future Jcode protocol additions.
-
-Host execution is deliberately opt-in because it does not enforce the supplied
-Harness sandbox boundary. Do not enable it for remote or untrusted workspaces.
-The production path is an in-sandbox bootstrap/bridge, which remains the next
-host-integration phase. The bridge runtime and deterministic bootstrap recipe
-are included in this package; wiring the host `SandboxChannel` startup path is
-still in progress.
+Host execution bypasses the supplied sandbox boundary. Do not enable it for
+remote or untrusted workspaces.

--- a/packages/harness-jcode/README.md
+++ b/packages/harness-jcode/README.md
@@ -1,0 +1,25 @@
+# `@ai-sdk/harness-jcode`
+
+Experimental Harness V1 adapter for [Jcode](https://github.com/1jehuang/jcode).
+
+```ts
+import { createJcode } from '@ai-sdk/harness-jcode';
+
+const harness = createJcode({
+  // Temporary opt-in until the in-sandbox Jcode bridge is implemented.
+  experimentalHostExecution: true,
+  model: 'openai-oauth:gpt-5.6-sol',
+  reasoningEffort: 'high',
+  jcodeHome: '/durable/jcode-home',
+});
+```
+
+The initial implementation launches Jcode through `@1jehuang/jcode-sdk` and
+streams text, reasoning, built-in tool lifecycle, usage, compaction, and raw
+events as typed Harness V1 stream parts. Host-defined tools and lossless
+cross-process turn continuation require future Jcode protocol additions.
+
+Host execution is deliberately opt-in because it does not enforce the supplied
+Harness sandbox boundary. Do not enable it for remote or untrusted workspaces.
+The production path is an in-sandbox bootstrap/bridge, which remains the next
+implementation phase.

--- a/packages/harness-jcode/README.md
+++ b/packages/harness-jcode/README.md
@@ -25,10 +25,19 @@ For basic sandbox sessions without port discovery, configure both `port` and
 `portEndpoint`. `jcodeHome` can override the default durable per-session Jcode
 home.
 
-The adapter supports typed prompt, manual compaction, stop/resume, and destroy
-lifecycle operations. Host-defined tools, turn suspension, lossless turn
-continuation, live detach, JSON response formats, and mid-turn user messages are
-not supported yet and reject with `HarnessCapabilityUnsupportedError`.
+The adapter supports typed prompt, host-defined tools, manual compaction,
+stop/resume, and destroy lifecycle operations. Host tools execute outside Jcode
+through Harness V1's `submitToolResult` flow and require Jcode runtime and SDK
+1.3.0 or newer. Turn suspension, lossless turn continuation, live detach, JSON
+response formats, and mid-turn user messages are not supported yet and reject
+with `HarnessCapabilityUnsupportedError`.
+
+For release validation, run `scripts/release-validation.sh`. It builds release
+binaries, packs the local SDK and runtime, installs all artifacts into a clean
+consumer, launches the bundled runtime, and verifies `external_tools_v1`. Setting
+`RUN_VERCEL_SANDBOX=1` additionally requires `VERCEL_OIDC_TOKEN` and a bridge
+lockfile regenerated against the published SDK version. This prevents a sandbox
+release from silently installing an older SDK.
 
 Host execution remains an explicit fallback for trusted local workspaces only:
 

--- a/packages/harness-jcode/README.md
+++ b/packages/harness-jcode/README.md
@@ -22,4 +22,6 @@ cross-process turn continuation require future Jcode protocol additions.
 Host execution is deliberately opt-in because it does not enforce the supplied
 Harness sandbox boundary. Do not enable it for remote or untrusted workspaces.
 The production path is an in-sandbox bootstrap/bridge, which remains the next
-implementation phase.
+host-integration phase. The bridge runtime and deterministic bootstrap recipe
+are included in this package; wiring the host `SandboxChannel` startup path is
+still in progress.

--- a/packages/harness-jcode/docs/HARNESS_FEATURE_MATRIX.md
+++ b/packages/harness-jcode/docs/HARNESS_FEATURE_MATRIX.md
@@ -1,0 +1,239 @@
+# Harness Adapter Feature Matrix
+
+Source audit of every `packages/harness-*` adapter in this monorepo. Findings come from package source, tests, READMEs, and package metadata rather than assumptions about the upstream CLIs.
+
+**Legend:** ✅ supported, ◐ partial or runtime-dependent, ❌ unsupported.
+
+## Summary matrix
+
+| Harness         | Runtime and sandbox                                         | Auth                                                             | Host tools                                    | Built-in approvals / filtering | Skills and instructions                                        | Model and reasoning                                          | Streaming                                                          | Compaction                   | Lifecycle                                                          | Observability                      | MCP                       | Subagents                                          |
+| --------------- | ----------------------------------------------------------- | ---------------------------------------------------------------- | --------------------------------------------- | ------------------------------ | -------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------ | ---------------------------- | ------------------------------------------------------------------ | ---------------------------------- | ------------------------- | -------------------------------------------------- |
+| **Claude Code** | In-sandbox Agent SDK/CLI bridge; WebSocket port required    | Anthropic/direct and gateway-aware credential brokering          | ✅ reserved host-tool MCP                     | ✅ / ✅                        | Native `.claude/skills`; instructions remain separate          | Model; adaptive, budgeted, or disabled thinking; effort      | Text, reasoning, tools, approvals, steps, finish                   | ✅ manual and native events  | Resume, suspend/continue, live detach, stop, destroy               | Diagnostics and debug forwarding   | ✅ native plus host relay | ✅ native `Agent` and task tools                   |
+| **Codex**       | In-sandbox Codex SDK/CLI bridge; port required              | OpenAI direct/gateway with credential brokering                  | ✅ CLI/tool relay                             | ❌ / ❌; requires `allow-all`  | Native `.agents/skills`; developer instructions                | Default `gpt-5.5`; override, reasoning effort, native config | Text, reasoning, tools, file changes, steps, finish                | ❌ manual                    | Resume, suspend/continue, detach, stop, destroy                    | Diagnostics and debug forwarding   | ✅ native plus host relay | No explicit adapter API                            |
+| **Pi**          | Host-process SDK using remote sandbox FS/shell; no port     | Provider/gateway resolution; reusable Pi agent dir               | ✅ in-process                                 | ✅ / ✅                        | Native `.agents/skills`, project skills, separate instructions | Model resolver and thinking level                            | Text, reasoning, tools, approvals, file changes, compaction, steps | ✅                           | Resume, suspend/continue, persisted detach/stop, destroy           | In-process errors/events           | ✅ `pi-mcp-adapter`       | No explicit adapter API                            |
+| **ACP**         | Generic in-sandbox ACP implementation and bridge            | Configurable implementation/provider auth, forwarding, brokering | ✅ host-tool MCP                              | ✅ / ❌                        | Configurable skills dir and instruction mapping                | ACP model selection; reasoning implementation-dependent      | ACP text, thoughts, tools, plans, commands, finish                 | ❌ manual                    | Resume/load, replay/rerun, suspend/continue, detach, stop, destroy | Bridge diagnostics/debug           | ✅ native plus relay      | Implementation-dependent                           |
+| **Cline**       | Host-process `@cline/agents`; remote sandbox ops; no port   | Auto, direct/provider, or AI Gateway                             | ✅ in-process                                 | ✅ / ✅                        | Materialized skills plus prompt section                        | Provider/model, endpoint/headers, reasoning effort           | Text, reasoning, tools, approvals, file changes, steps             | ❌                           | Resume, suspend/continue, persisted detach/stop, destroy           | Host-process errors                | ✅                        | No explicit adapter API                            |
+| **Cursor**      | ACP wrapper; Cursor CLI installed in sandbox; port required | `CURSOR_API_KEY`; provider route remains account configuration   | ACP host tools                                | ACP approvals / no filtering   | ACP behavior                                                   | ACP model selection; no reasoning setting                    | ACP translation                                                    | ❌                           | Inherits ACP                                                       | Inherits ACP                       | ✅                        | Cursor-dependent                                   |
+| **DeepAgents**  | In-sandbox LangGraph/Deep Agents bridge; port required      | Anthropic, OpenAI, or AI Gateway                                 | ✅                                            | ✅ / bridge-supported          | Host and project `.agents/skills`; per-turn instructions       | Model, Anthropic thinking/effort, recursion limit            | Text, reasoning, tools, approvals, steps                           | ❌                           | Suspend/continue, detach/replay, stop, destroy                     | Diagnostics/debug                  | ✅                        | Runtime-native, not separately surfaced            |
+| **fx**          | ACP wrapper; canonical installer; port required             | AI Gateway key or OIDC                                           | ACP host tools and rich native terminal tools | ACP approvals / no filtering   | ACP behavior                                                   | ACP model selection                                          | ACP translation                                                    | ❌                           | Inherits ACP                                                       | Inherits ACP                       | ✅ with name mapping      | fx-dependent                                       |
+| **Grok Build**  | ACP wrapper; pinned implementation; port required           | xAI direct or AI Gateway                                         | ACP host tools                                | ACP approvals / no filtering   | ACP behavior                                                   | ACP Grok model selection                                     | ACP translation                                                    | ❌                           | Inherits ACP                                                       | Inherits ACP                       | ✅                        | Runtime-dependent                                  |
+| **Jcode**       | In-sandbox bridge by default; unsafe host-execution opt-in  | Forwarded env; optional inherited logins                         | ❌                                            | ❌ / ❌                        | No Harness skills; instructions transported by session         | Model and arbitrary reasoning-effort string                  | Text/reasoning/tool observations translated from SDK               | ✅ manual                    | Stop/resume and destroy only                                       | Limited bridge/process diagnostics | ❌                        | Not exposed by adapter                             |
+| **OpenCode**    | In-sandbox OpenCode server bridge; port required            | Direct/gateway credentials with brokering                        | ✅ host-tool MCP                              | ✅ / ✅                        | `.agents/skills`; instructions forwarded                       | Provider/model split and reasoning variant                   | Text, reasoning, tools, usage, steps, finish                       | ✅ when runtime state allows | Full resume, suspend/continue, detach, stop, destroy               | Diagnostics/debug and usage        | ✅ native plus relay      | Native agents may appear as tools; no separate API |
+
+## Deep comparison: Claude Code, Codex, and Pi
+
+### Bootstrap and isolation
+
+- **Claude Code** and **Codex** install their SDK/CLI and a package-owned bridge inside the sandbox. Both require an exposed TCP port and use per-session work and bridge-state directories. Both can replace real credentials with sandbox placeholders and inject the real values through outbound request transformations.
+- **Pi** runs in the adapter host process. Its filesystem and shell tools target the supplied sandbox through remote operations and a virtual filesystem, so no port or bridge bootstrap is required. Pi extension factories consequently execute on the host and must be trusted.
+
+Evidence:
+
+- `packages/harness-claude-code/src/claude-code-bootstrap.ts`
+- `packages/harness-claude-code/src/claude-code-harness.ts:831-1182`
+- `packages/harness-codex/src/codex-bootstrap.ts`
+- `packages/harness-codex/src/codex-harness.ts:208-554`
+- `packages/harness-pi/src/pi-harness.ts:20-54`
+- `packages/harness-pi/src/pi-remote-ops.ts`
+- `packages/harness-pi/src/pi-workspace-vfs.ts`
+
+### Authentication
+
+- **Claude Code:** resolves Anthropic/gateway-oriented credential environments, supports request transformation brokering, and persists sandbox credential placeholders for resume.
+- **Codex:** resolves OpenAI direct/gateway modes with the same request-transformation/fallback-forwarding architecture.
+- **Pi:** resolves credentials in-process. `agentDir` can reuse Pi CLI `auth.json`, `models.json`, and settings; otherwise it uses per-session configuration.
+
+Evidence:
+
+- `packages/harness-claude-code/src/claude-code-auth.ts`
+- `packages/harness-claude-code/src/claude-code-auth.test.ts`
+- `packages/harness-codex/src/codex-auth.ts`
+- `packages/harness-codex/src/codex-auth.test.ts`
+- `packages/harness-pi/src/pi-auth.ts`
+- `packages/harness-pi/src/pi-model-resolver.ts`
+
+### Tools, approvals, and filtering
+
+- **Claude Code:** exposes a large typed native catalog, including file, shell, web, notebook, planning, worktree, task, skill, MCP-resource, and subagent tools. It supports both built-in approvals and filtering. Host tools use the reserved `harness-tools` MCP server, and duplicate host-tool events are filtered from the native stream.
+- **Codex:** supports host tools through CLI/tool relay but explicitly rejects native filtering and non-`allow-all` permission modes. The bridge configures `approvalPolicy: 'never'`, so native Codex approvals are not mediated by Harness.
+- **Pi:** provides typed `read`, `write`, `edit`, `bash`, `grep`, `glob`, and `ls` tools. Both filtering and approvals are supported in-process. Permission checks use each tool's readonly/edit/bash kind.
+
+Evidence:
+
+- `packages/harness-claude-code/src/claude-code-harness.ts:137-775`
+- `packages/harness-claude-code/src/bridge/tool-filtering.ts`
+- `packages/harness-claude-code/src/bridge/index.ts`
+- `packages/harness-codex/src/codex-harness.ts:205-222`
+- `packages/harness-codex/src/bridge/index.ts:198`
+- `packages/harness-codex/src/bridge/cli-relay.ts`
+- `packages/harness-pi/src/pi-harness.ts:57-140`
+- `packages/harness-pi/src/pi-session.ts:918-947,1603-1607`
+
+### Skills and instructions
+
+- **Claude Code:** writes `$HOME/.claude/skills/<name>/SKILL.md`, validates names and attached-file paths, and supplies skill names through the Claude SDK. Instructions remain separate from user text on fresh, resumed, and continued turns.
+- **Codex:** current source writes `$HOME/.agents/skills/<name>/SKILL.md` and intentionally sends no skill metadata in the bridge start message. Instructions become Codex `developer_instructions`. This contradicts `packages/harness-codex/README.md`, which still says skills are injected inline on every turn.
+- **Pi:** writes host-provided skills below sandbox `$HOME/.agents/skills`, retains project skills, and filters unrelated global discovery. Trusted inline extensions are supported, while filesystem-discovered extensions, themes, and prompt templates remain disabled.
+
+Evidence:
+
+- `packages/harness-claude-code/src/claude-code-harness.ts:1254-1279`
+- `packages/harness-claude-code/src/claude-code-instructions.test.ts`
+- `packages/harness-codex/src/codex-harness.ts:627-645`
+- `packages/harness-codex/src/codex-instructions.test.ts:361-424`
+- `packages/harness-codex/src/bridge/index.ts:125-126`
+- `packages/harness-pi/src/pi-session.ts:337-347,495-503`
+- `packages/harness-pi/src/pi-skills.ts`
+
+### Model and reasoning
+
+- **Claude Code:** explicit Anthropic model, adaptive thinking, fixed token-budget thinking, disabled thinking, summarized/omitted display, and effort control.
+- **Codex:** deliberately defaults to `gpt-5.5` because the source documents an upstream Responses Lite/tool exposure issue for newer models. It accepts model override, `low | medium | high` reasoning effort, web-search toggle, and native snake_case `codexConfig`.
+- **Pi:** resolves explicit or configured models and maps `thinkingLevel` directly into Pi session creation.
+
+Evidence:
+
+- `packages/harness-claude-code/src/claude-code-thinking.ts`
+- `packages/harness-claude-code/src/claude-code-harness.ts:89-116`
+- `packages/harness-codex/src/codex-harness.ts:74-123`
+- `packages/harness-codex/src/bridge/index.ts:149-202`
+- `packages/harness-pi/src/pi-model-resolver.ts`
+- `packages/harness-pi/src/pi-harness.ts:27-43`
+
+### Streaming parts
+
+All three emit text, reasoning, tool-call/result, step, and final-finish information.
+
+- **Claude Code:** additionally emits approval requests and coordinates native compaction. It supports schema-backed JSON output through bridge-side JSON-Schema-to-Zod conversion.
+- **Codex:** includes `file-change` and bridge-thread tracking. A step tracker derives step boundaries from Codex events. Schema-backed JSON is supported, while schema-less JSON is rejected.
+- **Pi:** includes approvals, file changes, and explicit `compaction` events. Translation happens directly from Pi in-process events rather than a wire protocol.
+
+Evidence:
+
+- `packages/harness-claude-code/src/bridge/create-emit-stream-event.ts`
+- `packages/harness-claude-code/src/bridge/json-schema-to-zod.ts`
+- `packages/harness-codex/src/bridge/create-emit-stream-event.ts`
+- `packages/harness-codex/src/bridge/codex-step-tracker.ts`
+- `packages/harness-pi/src/pi-translate.ts`
+- `packages/harness-pi/src/pi-events.ts`
+
+### Compaction and lifecycle
+
+- **Claude Code:** implements manual compaction with optional instructions through a compaction latch. It can suspend a live bridge-side turn, continue by attaching/replaying/rerunning, live-detach, persistently stop, resume, and destroy.
+- **Codex:** manual compaction is unsupported. Resume, suspend/continue, live detach, stop, and destroy are implemented with replay/rerun recovery.
+- **Pi:** supports manual compaction. Suspension intentionally aborts the host-side SDK operation at a safe slice and returns continuation state. Since the runtime is host-process, detach may persist/stop rather than leave a sandbox bridge alive.
+
+Evidence:
+
+- `packages/harness-claude-code/src/bridge/compaction-latch.ts`
+- `packages/harness-claude-code/src/claude-code-harness.ts:1746-1972`
+- `packages/harness-codex/src/codex-harness.ts:920-1205`
+- `packages/harness-pi/src/pi-session.ts:1262-1450`
+- `packages/harness-pi/src/pi-resume-state.ts`
+
+### Observability, MCP, and subagents
+
+- **Claude Code:** translates bridge diagnostics, forwards debug configuration, accepts native MCP servers, reserves a host-tool MCP server, and explicitly exposes the native `Agent` subagent tool plus task management. A subagent stream fixture covers nested step translation.
+- **Codex:** translates bridge diagnostics and accepts native MCP servers plus its host relay. No explicit subagent API or typed subagent tool was found.
+- **Pi:** uses native in-process error/event handling and `pi-mcp-adapter`. No explicit subagent API was found.
+
+Evidence:
+
+- `packages/harness-claude-code/src/claude-code-harness.ts:293-425,928-930`
+- `packages/harness-claude-code/src/bridge/__fixtures__/subagent-step-stream.json`
+- `packages/harness-codex/src/codex-harness.ts:327`
+- `packages/harness-codex/src/bridge/tool-relay.ts`
+- `packages/harness-pi/package.json`
+- `packages/harness-pi/src/pi-session.ts:429-452`
+
+## Other adapters
+
+### ACP
+
+Generic bridge foundation used directly and by Cursor, fx, and Grok Build. It supports configurable implementation installation, executable arguments, implementation and provider authentication, credential brokering, host-tool MCP, permission-mode mappings, configurable native skill directories, several instruction mappings, output schema mappings, model selection, ACP resume/load, disk replay, lossy rerun, suspend/continue, detach, stop, and destroy. Built-in filtering and manual compaction are unsupported.
+
+Evidence: `packages/harness-acp/src/acp-harness.ts`, `packages/harness-acp/src/v1/acp-v1-harness.ts`, `packages/harness-acp/src/v1/acp-v1-lifecycle.ts`, `packages/harness-acp/src/v1/bridge/permission-controller.ts`, `packages/harness-acp/src/v1/bridge/host-tool-mcp-server.ts`.
+
+### Cline
+
+Host-process `@cline/agents` adapter with remote sandbox tools. Supports direct/provider or AI Gateway auth, provider/model, custom endpoint and headers, reasoning effort, max iterations, host tools, approvals, filtering, materialized skills, MCP, resume, suspend/continue, persisted detach/stop, and destroy. Manual compaction is unsupported.
+
+Evidence: `packages/harness-cline/src/cline-harness.ts`, `packages/harness-cline/src/cline-session.ts`, `packages/harness-cline/src/cline-tools.ts`, `packages/harness-cline/src/cline-skills.ts`, `packages/harness-cline/src/cline-mcp.ts`.
+
+### Cursor
+
+Thin ACP specialization using Cursor's installer. Requires `CURSOR_API_KEY`. The `auth` setting documents provider routing but cannot change Cursor account configuration. Provides typed mappings for Cursor shell, file, search, TODO, and related tool calls. Lifecycle and protocol features inherit ACP.
+
+Evidence: `packages/harness-cursor/src/cursor-harness.ts`, `packages/harness-cursor/src/cursor-harness.test.ts`, `packages/harness-cursor/README.md`.
+
+### DeepAgents
+
+In-sandbox LangGraph bridge with Anthropic/OpenAI/AI Gateway auth, request brokering, host tools, approvals, filtering input, repository and host skills, model, Anthropic thinking/effort, recursion limit, and MCP. Current source implements suspend/continue and detach/replay even though the README status paragraph still says those are follow-ups. Manual compaction remains unsupported.
+
+Evidence: `packages/harness-deepagents/src/deepagents-harness.ts:71-131,790-926`, `packages/harness-deepagents/src/bridge/approvals.ts`, `packages/harness-deepagents/README.md`.
+
+### fx
+
+ACP specialization installed through the canonical fx installer. Auth ultimately uses Vercel AI Gateway. Supports model selection, MCP, host tools, and a rich native terminal/monitoring catalog. Lifecycle and protocol behavior inherit ACP.
+
+Evidence: `packages/harness-fx/src/fx-harness.ts`, `packages/harness-fx/src/fx-harness.test.ts`, `packages/harness-fx/README.md`.
+
+### Grok Build
+
+ACP specialization backed by a pinned Grok Build implementation. Supports direct xAI or AI Gateway auth, model selection, MCP, host tools, and typed terminal/edit/search/web tools. Lifecycle and protocol behavior inherit ACP.
+
+Evidence: `packages/harness-grok-build/src/grok-build-harness.ts`, `packages/harness-grok-build/src/grok-build-harness.test.ts`, `packages/harness-grok-build/README.md`.
+
+### OpenCode
+
+In-sandbox OpenCode server bridge with direct/gateway auth and brokering, host-tool MCP, native MCP, approvals, filtering, `.agents/skills`, provider/model selection, reasoning variant, diagnostics, usage tracking, compaction, and full resume/suspend/continue/detach/stop/destroy lifecycle with replay/rerun recovery.
+
+Evidence: `packages/harness-opencode/src/opencode-harness.ts`, `packages/harness-opencode/src/bridge/opencode-events.ts`, `packages/harness-opencode/src/bridge/opencode-usage.ts`, `packages/harness-opencode/src/bridge/opencode-finish-step.ts`, `packages/harness-opencode/src/bridge/host-tool-mcp.ts`.
+
+## Jcode gaps and priorities
+
+Jcode currently has the narrowest Harness surface among the standalone adapters. Its sandbox-first bridge and typed session translation are useful foundations, but the following features explicitly reject with `HarnessCapabilityUnsupportedError` or are absent:
+
+1. **Host-defined tools:** no host tool relay or MCP transport.
+2. **Built-in tool approvals:** `supportsBuiltinToolApprovals` is false.
+3. **Built-in filtering:** `supportsBuiltinToolFiltering` is false and filtering input is rejected.
+4. **Turn suspension:** no `doSuspendTurn` handoff.
+5. **Lossless continuation:** `continueFrom` is rejected; no live/replayed turn continuation.
+6. **Live detach:** detach does not preserve an active bridge turn for reattachment.
+7. **Structured output:** JSON response formats are unsupported.
+8. **Mid-turn user messages:** no negotiated user-message response path.
+9. **Harness skills:** no materialization, discovery policy, or lifecycle fingerprinting.
+10. **MCP:** no native MCP server configuration or reserved host-tool server.
+11. **Observability:** no equivalent of the richer bridge diagnostic translation/reporting found in Claude Code, Codex, ACP, OpenCode, and DeepAgents.
+12. **Subagents:** Jcode may support swarms internally, but the adapter does not expose a typed Harness-level subagent capability or stream correlation.
+13. **Auth brokering:** credentials are forwarded through `env`; there is no request-transformation placeholder brokering equivalent to Claude Code, Codex, OpenCode, ACP, or DeepAgents.
+
+Existing strengths are sandbox-first execution, an explicit warning and opt-in for unsafe host execution, custom model/reasoning options, manual compaction, stop/resume, destroy, bridge token authentication, configurable Jcode home, and focused session/translation tests.
+
+Evidence:
+
+- `packages/harness-jcode/src/jcode-harness.ts:42-110`
+- `packages/harness-jcode/src/jcode-session.ts`
+- `packages/harness-jcode/src/jcode-resume-state.ts`
+- `packages/harness-jcode/src/jcode-bridge-session.ts`
+- `packages/harness-jcode/README.md`
+
+## Test breadth
+
+Test files under each package's `src`:
+
+| Package     | Test files |
+| ----------- | ---------: |
+| ACP         |         25 |
+| Pi          |         14 |
+| OpenCode    |         13 |
+| Claude Code |         12 |
+| Codex       |         10 |
+| Cline       |          9 |
+| DeepAgents  |          9 |
+| Jcode       |          7 |
+| Cursor      |          2 |
+| fx          |          2 |
+| Grok Build  |          2 |
+
+ACP has the broadest direct protocol, lifecycle, recovery, permissions, authentication, host-tool, and stream-translation coverage. Cursor, fx, and Grok Build deliberately rely heavily on ACP tests. Claude Code, Codex, Pi, OpenCode, Cline, and DeepAgents each have focused runtime and lifecycle suites. Jcode tests cover bootstrap, bridge protocol/session, harness typing and behavior, session lifecycle, and stream translation, but do not yet cover the unsupported features listed above.

--- a/packages/harness-jcode/docs/IMPLEMENTATION_PLAYBOOK.md
+++ b/packages/harness-jcode/docs/IMPLEMENTATION_PLAYBOOK.md
@@ -1,0 +1,689 @@
+# Host-Defined Tools and Subagents Implementation Playbook
+
+## 0. Purpose and status
+
+This is the execution playbook for implementing host-defined tools and restricted Jcode subagents across two repositories:
+
+- Jcode: `/Users/joan/wrk/jcode`
+- AI SDK: `/Users/joan/wrk/ai`
+
+It refines `packages/harness-jcode/docs/TOOLS_AND_SUBAGENTS_PLAN.md` into ordered, agent-executable work. It is not an implementation and does not authorize API invention beyond the decisions below.
+
+**Release gate:** Jcode runtime and `@1jehuang/jcode-sdk` support must be released before `@ai-sdk/harness-jcode` enables host tools. Do not merge or publish the AI SDK production change against an unreleased SDK API.
+
+## 1. Outcome
+
+A HarnessV1 host supplies tool metadata to a Jcode session, receives correlated calls from the root agent or an authorized descendant, executes each tool in the host process, and submits the result. Jcode waits for the result and resumes the model turn. Native Jcode tools remain Jcode-executed.
+
+The first shippable outcome is root-session host tools. Descendant policies and Jcode-specific subagent profiles follow only after the root path is secure and released.
+
+## 2. Principles
+
+1. **Authority stays with the host.** Send names, descriptions, schemas, calls, and results. Never send executable closures, credentials, bearer material, or host application state to Jcode.
+2. **Session-scoped, connection-owned capabilities.** An external-tool catalog belongs to one attached root session and one live SDK connection. It is neither process-global nor a persisted executable capability.
+3. **Fail closed.** Unknown sessions, unobserved descendants, stale revisions, wrong owners, duplicate results, name collisions, and oversized payloads are errors.
+4. **Separate namespaces and lifecycles.** Native/MCP tools and external host tools use separate policy, pending-call storage, events, and Harness translation flags.
+5. **Revalidate at execution.** Definition filtering alone is insufficient because Jcode locks tool snapshots. Recheck ownership, revision, membership, and descendant policy immediately before creating a call.
+6. **Capabilities only decrease down the tree.** A child gets at most the intersection of its parent's effective external tools and the requested child allowlist.
+7. **Ephemeral on resume.** Restoring or attaching a session never revives an old executor. The current connection must register the catalog again.
+8. **Smallest useful API.** Implement register/replace/clear, call event, result submission, revocation, and child allowlists. Defer active-turn replacement, binary results, aliases, universal subagent APIs, and policy DSLs.
+9. **One broker, one transport.** Use Jcode core plus the existing Harness API/SDK connection. Do not add MCP, HTTP, WebSocket, shell, or prompt-based relays.
+10. **Compatibility is additive.** Clients that do not use external tools must behave exactly as before.
+
+## 3. Non-goals
+
+- A universal HarnessV1 subagent/profile API.
+- Built-in Jcode tool filtering or approval changes.
+- Executing host tools inside Jcode.
+- Persisting host-tool authority in transcripts or session state.
+- Catalog changes during an active turn in v1.
+- Binary, image, file, or streaming tool results in v1. Accept bounded JSON values only.
+- Tool aliases or collision-resolution namespaces.
+- Per-call host-configurable deadlines in v1.
+- Host-tool calls from detached, ambient, or background subagents after the owning Harness prompt turn has settled. HarnessV1 `submitToolResult` is turn-scoped, so v1 descendant calls are permitted only while the root Harness turn that registered the catalog is active.
+- General remote multi-tenant authorization. Preserve the current authenticated/local connection boundary and bind ownership to it.
+- Stopping or restructuring existing swarm behavior beyond adding a reducing external-tool allowlist.
+
+## 4. Locked decisions
+
+Do not reopen these during implementation unless a stop condition in section 18 is met.
+
+| Topic                   | Decision                                                                                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Architecture            | First-class external-tool broker in `jcode-app-core`                                                                                                                           |
+| Catalog scope           | One live connection + one attached root session                                                                                                                                |
+| Catalog update          | Atomic replace. Empty list clears. Idle session and zero pending calls only                                                                                                    |
+| Revision                | Monotonic `u64` per root broker catalog                                                                                                                                        |
+| Tool names              | Reject invalid, duplicate, reserved, native, and MCP collisions                                                                                                                |
+| Call identity           | Broker-generated globally unique opaque `call_id`                                                                                                                              |
+| Result ownership        | Look up pending entry by `call_id`; never trust echoed session/revision fields                                                                                                 |
+| Result shape            | JSON `output`, `is_error`, optional `error_message`; deterministic conversion to `ToolOutput`                                                                                  |
+| Timeouts                | One finite Jcode-owned default timeout and bounded pending-call count; no public timeout option in v1                                                                          |
+| Disconnect              | Revoke catalog and descendants, fail pending calls immediately                                                                                                                 |
+| Descendant after revoke | Remove external capability. Continue native work only if the locked tool snapshot can be invalidated safely; otherwise stop with an explicit error                             |
+| Child allowlist omitted | Inherit parent effective external catalog                                                                                                                                      |
+| Child allowlist empty   | No external tools                                                                                                                                                              |
+| Child allowlist present | Exact intersection with parent; reject unknown or unavailable names                                                                                                            |
+| Unknown event/result    | Error and no state mutation                                                                                                                                                    |
+| Harness native events   | `providerExecuted: true`, `dynamic: true`                                                                                                                                      |
+| Harness external calls  | `providerExecuted: false`, `dynamic: false`                                                                                                                                    |
+| Resume                  | Always re-register before the next prompt                                                                                                                                      |
+| Turn scope              | Phase 1 is root-agent-only. Phase 3 descendants may call host tools only during the active owning root Harness turn; root turn completion revokes its pending descendant calls |
+| Capability              | Advertise exact string `external_tools_v1` in `hello_ok.capabilities`                                                                                                          |
+| Universal subagents     | Deferred                                                                                                                                                                       |
+
+Before coding, choose and document concrete protocol limits as named constants in `jcode-harness-api`. Start conservatively and keep them internal unless callers need them. Required limits: tool count, name bytes, description bytes, serialized schema bytes, input bytes, result bytes, pending calls per root, and wait duration.
+
+## 5. Smallest elegant architecture
+
+```text
+HarnessV1 host
+  │ tools on prompt                ▲ tool-call event
+  │ submitToolResult               │
+  ▼                                │
+@ai-sdk/harness-jcode
+  │ setExternalTools               │ external_tool_call
+  │ submitExternalToolResult       │
+  ▼                                │
+@1jehuang/jcode-sdk connection (owner identity)
+  │ Harness API requests/events
+  ▼
+jcode-harness-api-server BridgeState
+  │ verifies attached root and connection ownership
+  ▼
+jcode-app-core ExternalToolBroker
+  ├─ root catalog + revision + owner connection
+  ├─ server-observed root/parent/child policies
+  ├─ pending call map
+  └─ ExternalTool adapter implementing normal Jcode tool execution
+       │ wait for correlated result
+       ▼
+     model turn resumes
+```
+
+### Core state
+
+Create `crates/jcode-app-core/src/tool/external.rs` and expose it through `tool/mod.rs`. Keep the implementation local to core rather than placing anonymous definitions into the process-global `Registry`.
+
+Use conceptually these types. Follow repository naming conventions if an existing ID or connection token type is available. Do not replace typed IDs with new strings unnecessarily.
+
+```rust
+pub struct ExternalToolDefinition {
+    pub name: String,
+    pub description: Option<String>,
+    pub input_schema: serde_json::Value,
+}
+
+pub struct ExternalToolResult {
+    pub call_id: String,
+    pub output: serde_json::Value,
+    pub is_error: bool,
+    pub error_message: Option<String>,
+}
+
+struct RootCatalog {
+    owner_connection_id: ConnectionId,
+    root_session_id: SessionId,
+    revision: u64,
+    definitions: BTreeMap<String, ExternalToolDefinition>,
+}
+
+struct SessionExternalToolPolicy {
+    owner_root_session_id: SessionId,
+    catalog_revision: u64,
+    allowed_external_tools: Option<HashSet<String>>,
+}
+
+struct PendingExternalToolCall {
+    owner_connection_id: ConnectionId,
+    root_session_id: SessionId,
+    calling_session_id: SessionId,
+    catalog_revision: u64,
+    tool_name: String,
+    completion: oneshot::Sender<Result<ExternalToolResult, ExternalToolError>>,
+}
+```
+
+The broker needs methods equivalent to:
+
+```rust
+set_catalog(owner, root_session, definitions) -> Result<revision>
+clear_catalog(owner, root_session) -> Result<revision>
+effective_definitions(session_id) -> Result<Vec<ToolDefinition>>
+install_child_policy(owner, root, parent, child, requested) -> Result<()>
+begin_call(owner context, calling_session, name, input) -> Result<(ExternalToolCall, receiver)>
+submit_result(owner, root_session, result) -> Result<()>
+revoke_session(session_id, reason)
+revoke_owner(owner_connection_id, reason)
+```
+
+Names may adapt to established core patterns. Semantics and ownership checks may not.
+
+### Turn ownership boundary
+
+HarnessV1 exposes `submitToolResult` on `HarnessV1PromptControl`, not on the long-lived session. Therefore the catalog may be registered before each root prompt, but every accepted call must also belong to that active root Harness turn. Phase 1 exposes host tools only to the root agent. Phase 3 may route calls from server-proven descendants only while that same root turn remains active. When the root turn finishes, aborts, stops, detaches, or loses its bridge, Jcode and `harness-jcode` must reject all still-pending root and descendant calls.
+
+Do not keep a hidden session-level result callback for background descendants, carry pending calls into the next root turn, or make `submitToolResult` available outside prompt control. Supporting ambient or long-lived subagent host calls requires a future Harness contract with explicit executor lifetime and is out of scope.
+
+## 6. Dependency DAG and cross-repository ordering
+
+```mermaid
+graph TD
+  A[Jcode wire types and validation] --> B[Jcode core broker]
+  A --> C[Harness API server translation]
+  B --> C
+  A --> D[Rust SDK]
+  C --> D
+  A --> E[TypeScript SDK]
+  C --> E
+  D --> F[Jcode root-path integration tests]
+  E --> F
+  F --> G[Publish Jcode runtime and @1jehuang/jcode-sdk]
+  G --> H[Bump SDK in harness-jcode]
+  H --> I[harness-jcode direct host path]
+  H --> J[harness-jcode bridge path]
+  I --> K[Harness root-tool acceptance]
+  J --> K
+  K --> L[Jcode descendant ownership and CommSpawn allowlists]
+  L --> M[harness-jcode Jcode-specific subagent profiles]
+```
+
+**Hard ordering rules:**
+
+1. Land Jcode protocol, broker, API server, both SDKs, and root integration tests together or as a merge-safe stack whose intermediate commits compile.
+2. Publish a Jcode runtime release and `@1jehuang/jcode-sdk` release containing `external_tools_v1`.
+3. Only then update `/Users/joan/wrk/ai/packages/harness-jcode/package.json` and bridge lockfile.
+4. Land AI SDK root host tools behind capability detection.
+5. Add descendant policy in a later Jcode release.
+6. Add Jcode-specific subagent profiles only after the descendant release is available to the AI SDK package.
+
+Never point the published AI SDK package at a local path, git dependency, unpublished SDK version, or API it assumes without capability detection.
+
+## 7. Phase and commit plan
+
+Each bullet is one reviewable commit unless existing repository policy requires squashing. These are future implementation commits. This documentation task must not create them.
+
+### Phase 1: Jcode external-tool root path
+
+1. **`protocol: add external tool API types and limits`**
+   - Add stable wire structs, API requests/events, internal wire messages, capability, validation, serialization tests, and schema snapshots.
+2. **`core: add session-scoped external tool broker`**
+   - Add catalog ownership, revisioning, pending correlation, wait/cancel paths, deterministic result conversion, limits, and focused broker tests.
+3. **`core: expose external tools in agent turns`**
+   - Merge effective definitions before `locked_tools`; execute through the broker; invalidate snapshots on idle replacement; revoke on session/connection lifecycle.
+4. **`api: route external tools through attached connections`**
+   - Translate requests/events through `BridgeState`; enforce attached-root and owner checks; add wrong-owner/disconnect tests.
+5. **`sdk: expose external tools in Rust and TypeScript clients`**
+   - Add matching methods/types/events, parity tests, mock support, and multi-client isolation tests.
+6. **`test: add root external tool end-to-end coverage`**
+   - One real daemon/API/SDK scenario with success, error, abort, and second-client rejection.
+7. **`docs: document Jcode SDK external tools and release notes`**
+8. **Release Jcode runtime and SDK.** Do not proceed to AI SDK dependency work until the release artifacts are installable.
+
+### Phase 2: AI SDK root host tools
+
+1. **`deps(harness-jcode): update Jcode SDK for external tools`**
+   - Update `package.json`, `src/bridge/package.json`, and `src/bridge/pnpm-lock.yaml` consistently.
+2. **`feat(harness-jcode): support host tools in direct sessions`**
+   - Extend client interface, capability check, catalog registration, external call translation, pending IDs, result submission, and cleanup.
+3. **`feat(harness-jcode): support host tools through the sandbox bridge`**
+   - Pass `start.tools`, await shared bridge results, and submit them through the SDK. Keep the bridge thin.
+4. **`test(harness-jcode): cover host tool lifecycle and bridge parity`**
+5. **`docs(harness-jcode): document host tools and runtime requirement`**
+6. **`changeset: add Jcode host tool support`**
+   - Patch changeset for `@ai-sdk/harness-jcode` and any other published package actually changed.
+
+### Phase 3: Jcode descendant restrictions
+
+1. **`protocol: add allowed_host_tools to CommSpawn`**
+2. **`core: propagate server-observed external tool ownership`**
+3. **`core: enforce recursive child tool intersections`**
+4. **`test: cover visible headless inline and nested spawn policies`**
+5. **Release Jcode runtime and SDK capability update.** If a new capability is needed, prefer `external_tool_descendants_v1` rather than changing the meaning of `external_tools_v1` silently.
+
+Phase 3 does not authorize background calls after the root Harness turn completes. If Jcode swarm agents can outlive that turn, revoke their external-tool policy at turn completion while leaving native-only execution subject to the safe snapshot rules above.
+
+### Phase 4: Jcode-specific subagent profiles in AI SDK
+
+1. **`feat(harness-jcode): add subagent profile settings`**
+2. **`test(harness-jcode): cover profile mapping and intersections`**
+3. **`docs(harness-jcode): document subagent profiles`**
+4. **Patch changeset.**
+
+Do not start Phase 4 merely because profile types are easy to add. Start only after Jcode can enforce the policy before the child's first model request.
+
+## 8. Exact Jcode files and changes
+
+### Harness API and protocol
+
+- `crates/jcode-harness-api/src/lib.rs`
+  - Export `ExternalToolDefinition`, `ExternalToolCall`, and `ExternalToolResult`, preferably from a new `external_tools.rs` module.
+  - Export validation errors/helpers and internal limit constants where required by server validation.
+- `crates/jcode-harness-api/src/requests.rs`
+  - Add `ApiRequest::SetExternalTools { session_id, tools }`.
+  - Add `ApiRequest::SubmitExternalToolResult { session_id, call_id, output, is_error, error_message }`.
+  - Empty `tools` means atomic clear.
+- `crates/jcode-harness-api/src/events.rs`
+  - Add `ApiEvent::ExternalToolCall { session_id, root_session_id, call_id, catalog_revision, name, input }`.
+  - Add capability string `external_tools_v1` to the server's `HelloOk` capability source. Do not add a cancellation event in v1 unless an existing consumer demonstrably needs it.
+- `crates/jcode-harness-api/src/harness_api_tests/schema_snapshot.rs`
+  - Add exact JSON snapshots for both requests and the event.
+- `crates/jcode-harness-api/src/harness_api_tests/capability_coverage.rs`
+  - Classify the new requests and capability so coverage remains exhaustive.
+- `crates/jcode-protocol/src/wire.rs`
+  - Add internal request/event variants for set catalog, submit result, emit invocation, and revoke owner/catalog.
+  - Add `allowed_host_tools: Option<Vec<String>>` to `Request::CommSpawn` in Phase 3 with `#[serde(default)]` or the repository's equivalent backward-compatible pattern.
+- `crates/jcode-protocol/src/lib.rs`
+  - Update request ID extraction and request classification matches for all new variants.
+- `crates/jcode-protocol/src/protocol_tests/comm_requests.rs`
+- `crates/jcode-app-core/src/protocol_tests/comm_requests.rs`
+  - Update constructors, legacy decoding, and round trips. Assert omitted `allowed_host_tools` remains `None`.
+
+### API server connection boundary
+
+- `crates/jcode-harness-api-server/src/translate.rs`
+  - Extend `BridgeState` with or connect it to a stable owner connection identity.
+  - On set/clear: require this connection to be attached to the named root, serialize against detach/cancel/turn operations, validate limits, then send the core request.
+  - On result: resolve authorization from pending broker state. Require the same owner connection and root session. Do not authorize using event fields supplied by the SDK.
+  - On detach/socket close: issue owner/root revocation before discarding attachment state.
+  - Forward external calls only to the owner connection.
+- `crates/jcode-harness-api-server/src/translate_tests.rs`
+  - Reuse a two-connection fixture. Cover valid register/clear/result, before-attach, wrong root, wrong owner, duplicate, stale, disconnect, and legacy no-tool clients.
+
+### Core broker and turn integration
+
+- `crates/jcode-app-core/src/tool/external.rs` (new)
+  - Implement catalog, policy, pending calls, revocation, timeout, limits, and result conversion.
+  - Prefer `BTreeMap` for deterministic definition order and `HashMap` for pending lookup.
+  - Remove pending entries exactly once on result, timeout, abort, session end, owner revoke, or send failure.
+- `crates/jcode-app-core/src/tool/mod.rs`
+  - Export/integrate the broker.
+  - Keep `SessionToolPolicy`, `allowed_tools`, native registry filtering, and MCP dispatch semantics unchanged.
+  - If an adapter must implement the existing tool trait, place only the adapter hook here and broker logic in `external.rs`.
+- `crates/jcode-app-core/src/agent.rs`
+  - Store a session external-tool policy or broker handle separately from `allowed_tools`/`disabled_tools`.
+  - Restore must initialize with no live external authority until registration.
+- `crates/jcode-app-core/src/agent/turn_execution.rs`
+  - In `build_filtered_tool_definitions`, append effective external definitions before `locked_tools` is finalized.
+  - Preserve deterministic ordering and reject collisions before the model sees definitions.
+  - In execution dispatch, route an external name to the broker and await the result.
+  - Revalidate policy at dispatch time.
+  - On idle catalog replacement, invalidate `locked_tools` and any prompt-cache tracker affected by tool definitions.
+- `crates/jcode-app-core/src/server/client_lifecycle.rs`
+- `crates/jcode-app-core/src/server/client_lightweight_control.rs`
+  - Add internal request handling and lifecycle revocation in the actual request paths. Keep lightweight/full behavior equivalent.
+- `crates/jcode-app-core/src/server/comm_session.rs`
+  - Phase 3: update `spawn_swarm_agent` and all visible/headless/inline paths to install the child policy before creation/start.
+- `crates/jcode-app-core/src/tool/communicate.rs`
+  - Phase 3: add `allowed_host_tools` to spawn arguments and generated documentation.
+  - Validate friendly errors before sending, then enforce again server-side.
+  - Update both `Request::CommSpawn` construction sites, including `spawn_assignment_session` and the main `execute` spawn branch.
+- `crates/jcode-app-core/src/server/swarm_mutation_state.rs`
+  - Update persisted/replayed request handling only if spawn request fields are captured there. Do not persist live owner authority.
+
+### Rust SDK
+
+- `crates/jcode-sdk/src/client.rs`
+  - Add `set_external_tools(session_id, tools)` and `submit_external_tool_result(session_id, result)` matching existing request/response conventions.
+  - Yield `ApiEvent::ExternalToolCall` unchanged.
+- `crates/jcode-sdk/src/lib.rs`
+  - Re-export the external wire types if SDK users otherwise cannot name them.
+- `crates/jcode-sdk/src/sdk_tests/parity.rs`
+  - Keep Rust SDK request/event/capability parity complete.
+
+### TypeScript SDK
+
+- `sdk/typescript/src/protocol.ts`
+  - Add `ExternalToolDefinition`, `ExternalToolCall`, and `ExternalToolResult` interfaces.
+  - Add `set_external_tools` and `submit_external_tool_result` to `ApiRequest`.
+  - Add `external_tool_call` to `ApiEvent`.
+- `sdk/typescript/src/client.ts`
+  - Add:
+
+```ts
+setExternalTools(
+  sessionId: string,
+  tools: readonly ExternalToolDefinition[],
+): Promise<void>;
+
+submitExternalToolResult(
+  sessionId: string,
+  result: ExternalToolResult,
+): Promise<void>;
+```
+
+- Expose handshake capabilities through the existing client state/API. Do not infer support from package version.
+- `sdk/typescript/src/index.ts`
+  - Export the new public types.
+- `sdk/typescript/test/mock-harness.ts`
+  - Add reusable scripted request/event helpers, pending-call IDs, and two-client ownership support.
+- `sdk/typescript/test/client.test.ts`
+  - Cover request shapes, event yield, error propagation, and capabilities.
+- `sdk/typescript/test/schema-parity.test.ts`
+  - Require exact Rust/TypeScript request and event tag parity.
+- `sdk/typescript/test/live-capabilities.mjs`
+- `sdk/typescript/test/live-isolation.mjs`
+- Add one focused live external-tools script if fitting these files would obscure their purpose.
+- `sdk/typescript/README.md` and `sdk/typescript/RELEASING.md`
+  - Document lifecycle, JSON-only v1, re-registration, ownership, capability detection, and release ordering.
+
+## 9. Exact AI SDK files and changes
+
+- `packages/harness-jcode/package.json`
+  - Bump `@1jehuang/jcode-sdk` from the currently declared version only after publication. At writing, this package declares `1.1.0`, while the Jcode repository SDK package declares `1.2.0`; resolve that existing skew before selecting the feature version.
+- `packages/harness-jcode/src/bridge/package.json`
+- `packages/harness-jcode/src/bridge/pnpm-lock.yaml`
+  - Keep the in-sandbox bridge SDK version identical to the outer package dependency.
+- `packages/harness-jcode/src/jcode-client.ts`
+  - Import/re-export the SDK external types as needed.
+  - Add `setExternalTools`, `submitExternalToolResult`, and capability access to `JcodeSdkClient`.
+  - Keep the interface mockable for unit tests.
+- `packages/harness-jcode/src/jcode-session.ts`
+  - Remove the non-empty `options.tools` rejection.
+  - Normalize `HarnessV1ToolSpec` into SDK definitions. Reject duplicate names before sending.
+  - Check `external_tools_v1` before registering a non-empty catalog. Return `HarnessCapabilityUnsupportedError`, never a hang or generic transport error.
+  - Subscribe to events before `sendMessage`.
+  - Register `options.tools ?? []` before every prompt, including an empty list to clear the previous turn.
+  - Maintain a turn-local `Set<string>` of pending external call IDs plus the expected name.
+  - On `external_tool_call`, verify root ID, actual session routing, tool membership, and uniqueness; emit one host `tool-call`.
+  - `submitToolResult` accepts only a pending ID, calls the SDK, and removes it only after successful submission. Guard concurrent duplicate submissions with an in-flight state.
+  - On `done`, abort, cancel, stop, destroy, detach, iterator close, or error, settle and clear all pending state.
+- `packages/harness-jcode/src/jcode-translate.ts`
+  - Add external event translation or a narrowly scoped helper.
+  - Keep separate native and external maps.
+  - External event output:
+
+```ts
+{
+  type: 'tool-call',
+  toolCallId: event.call_id,
+  toolName: event.name,
+  input: JSON.stringify(event.input),
+  providerExecuted: false,
+  dynamic: false,
+}
+```
+
+- Do not emit a synthetic host `tool-result`; Harness execution already echoes submitted results.
+- `packages/harness-jcode/src/jcode-bridge-protocol.ts`
+  - The start schema already inherits shared `tools`. Do not add a Jcode-specific catalog field.
+  - Ensure the inbound control union includes the shared tool-result command rather than inventing a new command.
+- `packages/harness-jcode/src/jcode-bridge-session.ts`
+  - Include `tools` in the `start` message.
+  - Track external IDs observed from bridge `tool-call` events.
+  - Forward `submitToolResult` using the shared bridge control message; reject unknown, native, duplicate, and settled IDs locally.
+  - Clear state on channel close and teardown.
+- `packages/harness-jcode/src/bridge/index.ts`
+  - Before sending a prompt, require capability for non-empty tools and call `setExternalTools(sessionId, start.tools ?? [])`.
+  - Subscribe before registration/send so an early call cannot be lost.
+  - For each external event, emit the bridge `tool-call`, await `turn.requestToolResult(callId)`, then call `submitExternalToolResult`.
+  - Handle multiple pending calls without serializing unrelated calls if Jcode emits them concurrently.
+  - Abort all waits on turn abort/stop/destroy/disconnect/completion.
+- `packages/harness-jcode/src/jcode-harness.ts`
+  - Remove only the host-tool unsupported guard. Keep `supportsBuiltinToolFiltering: false`.
+  - Phase 4: add a Jcode-specific `subagents` setting only after the descendant capability release.
+- `packages/harness-jcode/src/index.ts`
+  - Export new public Jcode-specific settings/types only if they are part of the supported package API.
+- Tests:
+  - `jcode-session.test.ts`
+  - `jcode-translate.test.ts`
+  - `jcode-bridge-session.test.ts`
+  - `jcode-bridge-protocol.test.ts`
+  - `jcode-harness.test.ts`
+  - `jcode-harness.test-d.ts`
+  - bridge tests colocated with the existing bridge test strategy
+- Docs:
+  - `packages/harness-jcode/README.md`
+  - `packages/harness-jcode/docs/HARNESS_FEATURE_MATRIX.md`
+  - Keep `TOOLS_AND_SUBAGENTS_PLAN.md` as design history and link to this playbook.
+- Add a patch changeset under `/Users/joan/wrk/ai/.changeset/` for production changes.
+
+## 10. Invariants
+
+Every implementation and test must preserve these:
+
+1. At most one live owner connection controls a root catalog.
+2. A catalog cannot be installed until that connection is attached to the root session.
+3. A connection cannot set, clear, answer, or revoke another connection's catalog/call.
+4. A pending call records immutable owner, root, caller, revision, and name.
+5. A pending call is removed exactly once.
+6. A result cannot be accepted after result, timeout, abort, detach, disconnect, session end, or revocation.
+7. A root or descendant call cannot be accepted after the owning Harness prompt turn settles.
+8. Catalog replacement is rejected while a turn is active or any call is pending.
+9. Clearing the catalog removes definitions from the next locked snapshot.
+10. No restored session has executable external tools before current registration.
+11. External definitions never enter the process-global native/MCP registry without ownership metadata and atomic removal.
+12. Native/MCP/external collisions fail before the model sees an ambiguous definition.
+13. Native tool translation flags never change.
+14. Child policy installation happens before the child's first definition snapshot.
+15. A child or grandchild can never increase its parent's effective catalog.
+16. Child authority derives only from server-observed spawn edges.
+17. Host-tool payloads are bounded and validated at the API boundary and before execution/result conversion.
+18. Unknown protocol tags remain compatible according to the existing v1 protocol behavior.
+19. A client that never sends the new requests sees no behavioral change.
+
+## 11. Failure handling
+
+| Failure                                | Required behavior                                                                                                                                               |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Runtime lacks capability               | Harness throws `HarnessCapabilityUnsupportedError` before prompt submission                                                                                     |
+| Invalid/duplicate/colliding definition | Reject whole catalog atomically; retain previous catalog                                                                                                        |
+| Set during active turn/pending call    | Return `invalid_request`; no revision or snapshot change                                                                                                        |
+| Event delivery fails                   | Remove pending entry and fail tool execution                                                                                                                    |
+| Host returns error result              | Convert deterministically into Jcode tool failure visible to the model                                                                                          |
+| Host submission transport fails        | Keep local ID retryable only if server acceptance is unknown and protocol provides idempotence; otherwise settle turn with explicit error. Do not silently drop |
+| Duplicate/unknown/late result          | Reject; no mutation of other calls                                                                                                                              |
+| Wrong connection/root                  | Reject and log safe identifiers only                                                                                                                            |
+| Tool timeout                           | Remove pending entry, return explicit tool error, keep session consistent                                                                                       |
+| Abort/cancel                           | Fail all calls for that turn, then cancel native turn                                                                                                           |
+| Detach/disconnect                      | Revoke root and descendant authority immediately                                                                                                                |
+| Child termination                      | Fail only that child's pending calls                                                                                                                            |
+| Root Harness turn completes            | Revoke the turn's root and descendant external calls; do not carry them into the next turn                                                                      |
+| Catalog clear                          | Invalidate next snapshot; no old definition callable                                                                                                            |
+| Malformed/oversized input or result    | Reject at boundary with stable error; never panic or allocate unbounded memory                                                                                  |
+| Broker invariant violation             | Stop affected turn/session and surface an internal error. Do not guess ownership                                                                                |
+
+Use structured errors internally. Avoid exposing connection tokens, credentials, full schemas, or large tool payloads in logs.
+
+## 12. Migration and compatibility
+
+- All new API request/event variants are additive under protocol v1.
+- Preserve unknown-event skipping and unknown-field tolerance already tested by the Harness API.
+- Add `#[serde(default)]` to `CommSpawn.allowed_host_tools` so old serialized requests decode as inheritance (`None`).
+- Do not change existing `allowed_tools` semantics. It remains native/MCP policy.
+- Old SDKs continue to work and simply never register catalogs.
+- New SDKs must feature-detect `external_tools_v1` from the handshake rather than compare semantic versions.
+- `harness-jcode` must clear tools with `[]` on a later turn. It must not rely on daemon state matching the previous Harness turn.
+- Resume tokens/session data do not contain catalog definitions, owner identity, pending IDs, or executable authority.
+- If descendant support ships separately, advertise a distinct capability if older `external_tools_v1` runtimes cannot safely honor child policy.
+- The AI SDK package must declare the minimum released SDK dependency containing the API and lock the bridge to the same version.
+
+## 13. Concise test strategy and reusable fixtures
+
+### Reusable fixtures
+
+Create only these shared fixtures, then compose tests around them:
+
+1. **Catalog fixture:** `weather` and `lookup` definitions with tiny JSON schemas, plus invalid duplicate/collision/oversized variants.
+2. **Broker fixture:** fake owner IDs, root/child/grandchild sessions, controllable clock, deterministic call-ID generator, and captured event sink.
+3. **Two-client API fixture:** two `BridgeState`/SDK connections attached to different roots, with helpers to register, invoke, submit, detach, and disconnect.
+4. **Scripted SDK mock:** records method order and yields native plus external events. Use it in both direct and bridge tests where possible.
+5. **Harness turn fixture:** captures emitted stream parts and exposes `submitToolResult`, abort, stop, and destroy controls.
+6. **Spawn-tree fixture:** root → child → grandchild with visible/headless/inline parameterization.
+
+Do not duplicate large hand-built events in every test. Use builders with defaults and override only the field under test.
+
+### Test budgets
+
+Keep the suite focused:
+
+| Layer                             |                   Budget | Purpose                                                       |
+| --------------------------------- | -----------------------: | ------------------------------------------------------------- |
+| Pure validation/broker unit tests |               ≤ 25 cases | Limits, revisions, correlation, policy intersections, cleanup |
+| Protocol/schema/parity tests      |               ≤ 12 cases | Exact tags/shapes, legacy decode, capability parity           |
+| API server translation tests      |               ≤ 15 cases | Attachment, ownership, lifecycle, two-client isolation        |
+| SDK unit tests per language       |               ≤ 10 cases | Methods, events, capability, errors                           |
+| Jcode live integration tests      |              4 scenarios | success, error, abort/disconnect, wrong owner                 |
+| harness-jcode direct tests        |               ≤ 12 cases | flags, order, submit lifecycle, resume, capability            |
+| harness-jcode bridge tests        |               ≤ 10 cases | shared control, parity, abort/close, multiple calls           |
+| Descendant policy tests           | ≤ 12 parameterized cases | modes, omitted/empty/explicit, nested, revoke                 |
+
+A scenario may assert multiple tightly related invariants. Do not add combinatorial matrices when a table-driven test covers the same state transition.
+
+### Required acceptance scenarios
+
+1. Register `weather`, prompt, receive one external call, submit JSON, and observe the turn continue.
+2. A second connection cannot submit the result.
+3. Clearing between turns means the model no longer receives the definition.
+4. Abort/disconnect while waiting settles the waiter and leaves zero pending calls.
+5. Native `read` still emits provider-executed native events.
+6. Direct and bridge Harness paths emit identical external `tool-call` parts.
+7. Child with `['weather']` sees `weather` but not `lookup`; grandchild cannot regain `lookup`.
+
+## 14. Commands
+
+Run commands from the indicated repository. Prefer targeted commands while iterating, then the required final gates.
+
+### Jcode targeted
+
+```bash
+cd /Users/joan/wrk/jcode
+cargo test -p jcode-harness-api
+cargo test -p jcode-harness-api-server
+cargo test -p jcode-protocol
+cargo test -p jcode-app-core external
+cargo test -p jcode-sdk
+cd sdk/typescript && npm test
+```
+
+If a package name differs from its directory, read that crate's `Cargo.toml` and use its exact `[package].name`. Do not guess around a failing command.
+
+### Jcode final
+
+Use the repository's documented full formatting, lint, and test commands after inspecting its root contributor/agent instructions. At minimum:
+
+```bash
+cd /Users/joan/wrk/jcode
+cargo fmt --all -- --check
+cargo test --workspace
+cd sdk/typescript && npm run check
+```
+
+Also run the new live SDK scenarios against the built daemon using the same environment/launcher pattern as existing `sdk/typescript/test/live-*.mjs` tests.
+
+### AI SDK targeted
+
+```bash
+cd /Users/joan/wrk/ai/packages/harness-jcode
+pnpm test:node
+pnpm type-check
+pnpm build
+```
+
+### AI SDK final
+
+```bash
+cd /Users/joan/wrk/ai
+pnpm check
+pnpm type-check:full
+pnpm test
+```
+
+If the full monorepo suite is impractical, record the exact command, failure, and why it is unrelated. Do not substitute package unit tests for `pnpm type-check:full` without reporting the gap.
+
+## 15. Acceptance criteria
+
+### Jcode release acceptance
+
+- `hello_ok.capabilities` advertises `external_tools_v1` only when the full request/event/broker path is available.
+- Rust and TypeScript API tags and SDK capabilities are in parity.
+- A real TypeScript SDK client completes a root external tool call end to end.
+- A second client cannot answer it.
+- Invalid catalog updates are atomic.
+- Pending calls reach zero after success, error, timeout, abort, detach, disconnect, and shutdown.
+- Session restore requires re-registration.
+- Existing no-tool SDK/live tests pass unchanged.
+- Runtime binaries and `@1jehuang/jcode-sdk` are published at compatible versions.
+
+### AI SDK root acceptance
+
+- Non-empty `options.tools` works in direct and sandbox bridge paths against the released Jcode runtime.
+- External calls use `providerExecuted: false` and `dynamic: false`.
+- Native calls remain `providerExecuted: true` and `dynamic: true`.
+- Tool description and JSON schema reach Jcode unchanged except documented normalization.
+- Result success/error, multiple calls, out-of-order results, unknown/duplicate IDs, abort, stop, destroy, bridge close, empty catalog, and resume are tested.
+- Missing capability produces `HarnessCapabilityUnsupportedError` before the prompt.
+- No MCP server, HTTP relay, shell shim, or executable host payload is introduced.
+- README, feature matrix, and patch changeset are complete.
+
+### Descendant acceptance
+
+- All spawn modes install policy before first model request.
+- Omitted inherits, empty denies all, explicit restricts, and unknown rejects.
+- Recursive intersection is enforced for grandchildren.
+- Calls carry actual child `session_id` for observability but route only to the root owner.
+- Forged/unrelated sessions cannot call or answer.
+- Root disconnect revokes every descendant pending call.
+
+## 16. Rollout
+
+1. Merge Jcode implementation with capability disabled unless the full broker path is compiled and wired.
+2. Run release-candidate live tests using two SDK clients and root success/error/abort flows.
+3. Publish Jcode runtime binaries and `@1jehuang/jcode-sdk` together. Verify install on macOS arm64 plus at least one Linux target used in CI.
+4. Update AI SDK dependency and bridge lockfile to the released version.
+5. Enable root host tools only after capability detection succeeds.
+6. Publish `@ai-sdk/harness-jcode` as a patch release and document the minimum Jcode SDK/runtime requirement.
+7. Monitor unsupported-capability errors, pending-call timeout rate, disconnect cleanup, wrong-owner attempts, and broker pending-count leaks. Metrics/logs must not include payloads or credentials.
+8. Ship descendants in a separate Jcode release and profiles in a later AI SDK patch.
+
+## 17. Rollback
+
+- **Before publication:** revert the failing phase/commit. Additive protocol variants may remain only if unreachable and fully compatible, but prefer reverting the complete phase.
+- **After Jcode publication, before AI SDK publication:** do not enable the AI SDK feature. Publish a Jcode patch if the broker is faulty.
+- **After AI SDK publication:** publish a patch that treats the capability as unsupported or disables host tools while preserving existing non-tool sessions. Do not silently fall back to an insecure relay.
+- **Descendant fault:** disable descendant capability/profile exposure while leaving root external tools intact, provided root isolation remains sound.
+- **Security/ownership fault:** immediately disable `external_tools_v1`, cancel pending calls, and issue patched Jcode runtime/SDK and AI SDK releases. Compatibility is secondary to preventing cross-session execution.
+- Never roll back by persisting executors, accepting results without owner checks, reusing native tool events, or weakening child intersections.
+
+## 18. Stop and escalation conditions
+
+Stop implementation and obtain maintainer/user direction if any of these occurs:
+
+1. Jcode cannot expose a stable per-connection identity through `BridgeState` and core without architectural changes outside the listed crates.
+2. Tool execution dispatch cannot distinguish external definitions from native/MCP definitions without overloading global registry state.
+3. `locked_tools` or prompt-cache state cannot be safely invalidated between idle turns.
+4. Disconnect/revocation cannot guarantee pending waiter cleanup.
+5. The existing `ToolOutput` cannot represent bounded JSON/text results deterministically. Escalate with two concrete conversion options and compatibility impact.
+6. Jcode executes tools concurrently in a way that makes current turn/session ownership ambiguous.
+7. A protocol major-version change appears necessary. Do not make one inside this feature without explicit approval.
+8. Omitted child allowlist inheritance conflicts with an accepted Jcode security policy or ADR.
+9. Existing swarm creation has a path that bypasses `CommSpawn`/server-observed parentage.
+10. The required Jcode SDK/runtime release cannot be published or installed. Do not merge AI SDK production code against an unpublished API.
+11. The AI SDK shared bridge control cannot carry tool results as assumed. Escalate before adding a Jcode-specific control protocol.
+12. Supporting subagent profiles would require changing HarnessV1 public interfaces. Defer and propose a separate cross-adapter design.
+13. Tests reveal cross-connection completion, stale-call acceptance, capability persistence after restore, or descendant privilege expansion. Treat these as release blockers, not follow-up bugs.
+14. Required payload limits or timeout values cannot be chosen from existing Jcode operational constraints. Ask for a maintainer decision rather than shipping unbounded behavior.
+
+When escalating, provide: the violated invariant, exact code path, smallest reproducer, two viable options, security/compatibility consequences, and the recommended option.
+
+## 19. Documentation checklist
+
+### Jcode
+
+- TypeScript SDK README: registration, event loop, result submission, capability check, error result, clear, resume, JSON-only limit.
+- Rust SDK docs: equivalent lifecycle and parity.
+- Harness API docs or schema comments: ownership, revision, idle-only replacement, size limits, disconnect behavior.
+- Communicate tool docs: `allowed_host_tools` omitted/empty/explicit semantics.
+- Release notes: exact runtime and SDK versions and capability strings.
+
+### AI SDK
+
+- `packages/harness-jcode/README.md`: minimal host-tool example, direct/bridge equivalence, minimum runtime, capability error, resume re-registration.
+- `docs/HARNESS_FEATURE_MATRIX.md`: change host tools from unsupported only after release and tests pass.
+- Jcode-specific subagent profiles: explicit inheritance and intersection examples, plus warning that profiles cannot grant absent root tools.
+- Changeset: user-visible behavior and minimum SDK/runtime requirement.
+- Keep universal subagent standardization explicitly deferred.
+
+## 20. Definition of done
+
+The work is done only when the dependency DAG has reached the requested outcome, all applicable acceptance criteria pass against released dependencies, documentation and changesets exist, and no stop condition remains unresolved. A compiling broker without live SDK isolation is not done. An AI SDK adapter using an unpublished Jcode API is not done. Root tools do not imply descendant support, and descendant support does not imply a universal HarnessV1 subagent contract.

--- a/packages/harness-jcode/docs/TOOLS_AND_SUBAGENTS_PLAN.md
+++ b/packages/harness-jcode/docs/TOOLS_AND_SUBAGENTS_PLAN.md
@@ -1,0 +1,857 @@
+# Host-Defined Tools and Subagents Plan
+
+## Status
+
+Implementation plan only. This document does not modify public APIs or runtime behavior.
+
+## Goals
+
+Add secure host-defined tool execution to `@ai-sdk/harness-jcode`, including calls made by Jcode subagents, while preserving the HarnessV1 contract:
+
+- The host owns and executes host-defined tools.
+- Jcode receives only tool metadata and returns correlated calls.
+- A Jcode agent waits for the host to submit each result.
+- Native Jcode tools remain provider-executed and distinct from host tools.
+- Subagents receive only an explicitly authorized subset of the root tool catalog.
+- Disconnects, aborts, lifecycle operations, stale calls, and forged descendant identities fail closed.
+
+## Current State
+
+### HarnessV1
+
+The universal contract already supports root-session host tools:
+
+- `packages/harness/src/v1/harness-v1-session.ts` supplies `tools` on each prompt or continuation turn.
+- `packages/harness/src/v1/harness-v1-tool-spec.ts` defines the name, description, and JSON Schema sent to a runtime.
+- `packages/harness/src/v1/harness-v1-prompt-control.ts` defines `submitToolResult`.
+- `packages/harness/src/v1/harness-v1-bridge-protocol.ts` serializes tool definitions in the bridge `start` frame.
+- The shared bridge runtime correlates host tool calls with results through its turn control surface.
+
+HarnessV1 does not define a universal host-configured subagent/profile API.
+
+### harness-jcode
+
+`packages/harness-jcode/src/jcode-session.ts` currently rejects non-empty `options.tools`, and its `submitToolResult` implementation throws. `packages/harness-jcode/src/jcode-bridge-session.ts` does the same.
+
+Jcode tool events translated by `packages/harness-jcode/src/jcode-translate.ts` are native/provider-executed events:
+
+```ts
+providerExecuted: true;
+dynamic: true;
+```
+
+They cannot represent Harness host tools because host tools must be emitted with `providerExecuted: false` and must wait for `submitToolResult`.
+
+### Jcode core and SDK
+
+Jcode has useful pieces but no SDK-visible external-tool broker:
+
+- `crates/jcode-app-core/src/tool/mod.rs` has a tool registry and session policies.
+- `crates/jcode-app-core/src/agent/turn_execution.rs` filters definitions and locks the tool snapshot.
+- `crates/jcode-app-core/src/agent.rs` carries `allowed_tools` and `disabled_tools`.
+- `crates/jcode-app-core/src/server/comm_session.rs` implements swarm spawning.
+- `crates/jcode-protocol/src/wire.rs` defines `CommSpawn`, but it has no child tool policy.
+- `crates/jcode-harness-api`, `crates/jcode-harness-api-server`, and the TypeScript/Rust SDKs expose native tool lifecycle events but no host tool registration or result request.
+
+## Comparison With Other Harnesses
+
+### Claude Code
+
+`packages/harness-claude-code/src/bridge/index.ts` creates an in-process MCP server named `harness-tools`. Each handler:
+
+1. Emits a Harness `tool-call`.
+2. Waits on `turn.requestToolResult(toolCallId)`.
+3. Emits/returns the result to Claude.
+
+Strengths:
+
+- Uses the shared bridge's correlation and cancellation lifecycle.
+- Keeps `execute` on the host.
+- Cleanly distinguishes host MCP tools from native tools.
+
+Limitations:
+
+- Task subagents generally see the same MCP server surface.
+- It does not establish a reusable per-descendant allowlist architecture.
+- An MCP server created inside the runtime is less natural for Jcode because Jcode already has an SDK/API boundary and its own registry.
+
+### Codex
+
+`packages/harness-codex/src/bridge/index.ts` and `src/bridge/tool-relay.ts` implement an authorized localhost HTTP relay and CLI shim because the Codex SDK path does not reliably expose MCP tools.
+
+Strengths:
+
+- Binds only to `127.0.0.1`.
+- Checks names against the registered catalog.
+- Requires an observed Codex command event to authorize a matching relay request.
+- Avoids embedding bearer material in the generated script.
+
+Limitations:
+
+- Tool discovery depends on prompt guidance and shell invocation.
+- Parsing/authorizing commands is complex and runtime-specific.
+- This is explicitly an upstream workaround and should not become Jcode's primary design.
+
+### Pi
+
+`packages/harness-pi/src/pi-session.ts` uses in-process `defineTool` handlers. A handler emits the call, blocks on a pending promise, and is resolved by `submitToolResult`.
+
+Strengths:
+
+- The cleanest host-tool lifecycle.
+- No secondary transport or shell relay.
+- Exact tool definitions and results remain typed and correlated.
+
+Limitations:
+
+- Pi runs in the same Node process. Jcode runs behind a daemon/API boundary, so the pending-call broker must live in Jcode core and the SDK protocol.
+
+### OpenCode descendant precedent
+
+Although not one of the primary comparison targets, `packages/harness-opencode/src/bridge/index.ts` provides an important security pattern. It observes parent-to-child task relationships, adds only proven descendants to an authorized set, and ignores events from unknown sessions. Jcode should use the same fail-closed principle rather than trusting a child-supplied swarm ID, working directory, or parent identifier.
+
+## Recommended Architecture
+
+Implement a first-class, session-scoped **external-tool broker** in Jcode.
+
+```text
+Harness host
+  |
+  | register catalog / submit result
+  v
+Jcode SDK connection
+  |
+  +-- root session external-tool catalog
+        |
+        +-- root agent effective catalog
+        |
+        +-- authorized descendant session
+              |
+              +-- parent catalog intersect child allowlist
+```
+
+### Catalog ownership
+
+A catalog is owned by:
+
+- An authenticated/local SDK connection.
+- One attached root Jcode session.
+- A monotonically increasing catalog revision.
+
+It is not process-global configuration and is not persisted as an executable capability in the session transcript.
+
+When the SDK connection detaches or closes, Jcode revokes the catalog and rejects all pending calls. A later client must explicitly register a new catalog.
+
+### Tool definition
+
+Each definition contains:
+
+```ts
+interface ExternalToolDefinition {
+  name: string;
+  description?: string;
+  input_schema?: unknown;
+}
+```
+
+Jcode must validate:
+
+- Tool name format and maximum length.
+- Maximum number of definitions.
+- Description and schema size.
+- Duplicate names.
+- Collisions with native, MCP, or reserved tool names.
+
+The safest initial collision policy is rejection. A later implementation may use a reserved internal name while preserving the Harness-visible name, but aliases add translation and cache complexity.
+
+### Invocation
+
+An invocation includes:
+
+```ts
+interface ExternalToolCall {
+  call_id: string;
+  session_id: string;
+  root_session_id: string;
+  catalog_revision: number;
+  name: string;
+  input: unknown;
+}
+```
+
+`call_id` must be globally unique for the broker lifetime. The pending-call entry also records the owner connection, actual calling session, catalog revision, cancellation token, and optional deadline.
+
+### Result
+
+The SDK submits:
+
+```ts
+interface ExternalToolResult {
+  call_id: string;
+  output: unknown;
+  is_error?: boolean;
+  error_message?: string;
+}
+```
+
+Jcode rejects:
+
+- Unknown or expired IDs.
+- Duplicate results.
+- Results sent by a different connection.
+- Results for a superseded catalog revision when the call was not retained as in-flight.
+- Results after the calling session or root catalog was revoked.
+- Oversized result payloads.
+
+### Execution lifecycle
+
+An external tool adapter in Jcode core:
+
+1. Revalidates catalog membership and the calling session's effective policy.
+2. Allocates a call ID.
+3. Emits `ExternalToolCall` to the owner SDK connection.
+4. Waits for result, abort, deadline, session shutdown, catalog revocation, or connection loss.
+5. Converts the response into Jcode `ToolOutput`.
+6. Removes the pending entry exactly once.
+
+Definition-time filtering is not sufficient. Execution-time revalidation is required because Jcode caches/locks tool definitions and catalog policy may change after a snapshot is created.
+
+## Per-Subagent Allowed Tools
+
+### Internal policy shape
+
+Keep native and host-tool policies distinct:
+
+```rust
+struct SessionExternalToolPolicy {
+    owner_root_session_id: String,
+    catalog_revision: u64,
+    allowed_external_tools: Option<HashSet<String>>,
+}
+```
+
+Do not overload Jcode's existing `allowed_tools` internally. It already covers native and MCP naming semantics, including special `mcp` handling.
+
+### Spawn request
+
+Extend `CommSpawn` with either:
+
+```rust
+allowed_host_tools: Option<Vec<String>>
+```
+
+or a structured policy object if more policy dimensions are immediately required. `allowed_host_tools` is preferable to `allowed_tools` because it avoids ambiguity with Jcode-native tools.
+
+Recommended semantics:
+
+- Omitted: inherit the parent's effective external-tool catalog.
+- Empty: expose no external tools.
+- Present: expose the intersection of the parent effective catalog and requested names.
+- Unknown or unauthorized names: reject the spawn request.
+- No child can grant itself a tool not available to its parent.
+- The policy is installed before the child's first model request and first locked tool snapshot.
+
+A stricter deployment may choose omitted = none, but inheritance matches common delegation behavior. If inheritance is used, document it prominently and provide a root default policy setting.
+
+### Descendant ownership
+
+A child receives access only through a server-observed spawn edge. The server records:
+
+```text
+owner connection -> root session -> parent session -> child session
+```
+
+Do not infer access from:
+
+- A claimed swarm ID.
+- A claimed parent session ID supplied by the child.
+- A shared working directory.
+- Transcript metadata.
+
+Nested children repeat the same intersection with their immediate parent's effective catalog.
+
+### Routing child calls
+
+An external call carries both actual `session_id` and `root_session_id`, but is delivered only to the owner connection. The host can use `session_id` for observability and policy decisions, while correlation and authorization rely on the pending-call entry rather than trusting fields sent back by the client.
+
+## Required Jcode Changes
+
+### `crates/jcode-harness-api/src/requests.rs`
+
+Add requests:
+
+```rust
+SetExternalTools {
+    session_id: String,
+    tools: Vec<ExternalToolDefinition>,
+}
+
+SubmitExternalToolResult {
+    session_id: String,
+    call_id: String,
+    output: serde_json::Value,
+    is_error: bool,
+    error_message: Option<String>,
+}
+```
+
+A separate `SetExternalTools` request is preferable to adding tools only to `CreateSession`. HarnessV1 supplies tools per turn, and the catalog can change between turns without recreating the native session.
+
+Define replacement semantics. In phase one, allow replacement only while the session is idle and has no pending external calls.
+
+An explicit `ClearExternalTools` is optional if an empty `SetExternalTools` atomically clears the catalog.
+
+### `crates/jcode-harness-api/src/events.rs`
+
+Add:
+
+```rust
+ExternalToolCall {
+    session_id: String,
+    root_session_id: String,
+    call_id: String,
+    catalog_revision: u64,
+    name: String,
+    input: serde_json::Value,
+}
+```
+
+Optionally add `ExternalToolCancelled` for UIs and diagnostics. Cancellation can otherwise be represented by rejecting result submission and terminating the pending SDK-side call.
+
+Do not reuse `ToolStart`, `ToolExec`, or `ToolDone`. Those events represent tools Jcode executes and are translated as `providerExecuted: true`.
+
+### `crates/jcode-harness-api/src/lib.rs` or a new external-tool module
+
+Define and export stable external-tool wire types. Include limits and validation helpers near the protocol boundary.
+
+### `crates/jcode-harness-api-server/src/translate.rs`
+
+Translate the new API requests/events to core protocol messages while preserving `BridgeState` connection ownership.
+
+Required checks:
+
+- The connection is attached to the named root session.
+- A catalog cannot be installed on an unrelated session.
+- A result belongs to a call owned by this connection.
+- Detach/disconnect emits a broker revocation command.
+- Catalog updates are serialized with session lifecycle operations.
+
+### `crates/jcode-harness-api-server/src/translate_tests.rs`
+
+Add tests for:
+
+- Registering a valid catalog.
+- Rejecting registration before attach.
+- Rejecting a wrong session ID.
+- Empty catalog clearing.
+- Result translation.
+- Forged, duplicate, and wrong-connection results.
+- Disconnect revocation.
+- Backward compatibility for clients that never use external tools.
+
+### `crates/jcode-protocol/src/wire.rs`
+
+Add internal requests/events for:
+
+- Set or replace external tool catalog.
+- Submit external tool result.
+- External tool invocation.
+- Catalog/connection revocation.
+
+Extend `CommSpawn` with `allowed_host_tools`.
+
+Update protocol randomized/round-trip tests and tag parity expectations.
+
+### `crates/jcode-app-core/src/tool/mod.rs`
+
+Add a session-scoped external-tool broker, potentially in a new `tool/external.rs` module.
+
+Responsibilities:
+
+- Catalog ownership and revisioning.
+- Effective per-session catalog calculation.
+- Pending-call storage and correlation.
+- Connection and session revocation.
+- Tool definition creation.
+- Execution-time authorization.
+- Payload and timeout limits.
+
+Do not add anonymous external tool definitions to a process-global registry. If the existing `Registry` is used, registrations must carry catalog/session ownership and must be removed atomically on revocation.
+
+### `crates/jcode-app-core/src/agent/turn_execution.rs`
+
+Merge effective external definitions into the tool list before `locked_tools` is populated.
+
+On an idle catalog update:
+
+- Clear or invalidate the relevant locked tool snapshot.
+- Reset the prompt cache tracker as needed.
+- Rebuild the definitions on the next turn.
+
+Phase one should reject catalog changes during an active turn. A later phase may support revisioned in-flight catalogs.
+
+### `crates/jcode-app-core/src/agent.rs`
+
+Associate the agent/session with its external-tool policy and broker ownership. Restore and attach must not make old external definitions callable unless an active owner connection re-registers them.
+
+Session persistence may retain descriptive history, but it must not persist a live executable host capability.
+
+### `crates/jcode-app-core/src/server/comm_session.rs`
+
+Extend `spawn_swarm_agent` to accept `allowed_host_tools` and calculate:
+
+```text
+child effective external tools =
+  parent effective external tools
+  intersection requested child allowed tools
+```
+
+Install this policy before creating or starting the child agent. Ensure both visible and headless/inline spawn paths apply the same policy.
+
+Revoke descendants when the owning root connection closes. Decide whether children should stop or continue without external tools. The safest initial behavior is to cancel pending calls, remove external tools, and let otherwise valid native work continue only if Jcode can refresh the locked tool snapshot safely. Otherwise stop the child with an explicit error.
+
+### `crates/jcode-app-core/src/tool/communicate.rs`
+
+Add `allowed_host_tools` to the `spawn` action's arguments and documentation.
+
+Validate requested names before sending the server request, then validate again server-side. Client/tool-side validation improves errors but is not a security boundary.
+
+Update communicate tests for direct, nested, headless, visible, and denied spawns.
+
+### TypeScript SDK: `sdk/typescript/src/protocol.ts`
+
+Mirror the Rust API request/event definitions and external-tool types. Add an additive capability such as:
+
+```text
+external_tools_v1
+```
+
+The existing schema parity test must fail if Rust and TypeScript tags drift.
+
+### TypeScript SDK: `sdk/typescript/src/client.ts`
+
+Add:
+
+```ts
+setExternalTools(sessionId, tools): Promise<void>
+submitExternalToolResult(sessionId, result): Promise<void>
+```
+
+`events()` should yield `external_tool_call` without automatically executing it. Execution remains an application/harness responsibility.
+
+### TypeScript SDK tests
+
+Update:
+
+- `sdk/typescript/test/schema-parity.test.ts`
+- `sdk/typescript/test/client.test.ts`
+- `sdk/typescript/test/mock-harness.ts`
+- live capability and isolation tests
+
+Test multiple clients to prove one connection cannot answer another connection's calls.
+
+### Rust SDK: `crates/jcode-sdk/src/client.rs`
+
+Add equivalent methods and event types.
+
+### Rust SDK parity
+
+Update `crates/jcode-sdk/src/sdk_tests/parity.rs` and client behavior tests so the Rust and TypeScript SDKs remain capability-equivalent.
+
+## Required harness-jcode Changes
+
+### `packages/harness-jcode/src/jcode-client.ts`
+
+Extend `JcodeSdkClient`:
+
+```ts
+setExternalTools(
+  sessionId: string,
+  tools: ReadonlyArray<ExternalToolDefinition>,
+): Promise<void>;
+
+submitExternalToolResult(
+  sessionId: string,
+  result: ExternalToolResult,
+): Promise<void>;
+```
+
+Expose runtime capabilities through the factory/client if capability negotiation is not already available at adapter startup.
+
+### `packages/harness-jcode/src/jcode-session.ts`
+
+Replace the current `options.tools` rejection and throwing `submitToolResult`.
+
+Per turn:
+
+1. Normalize tool definitions and reject duplicate names.
+2. Ensure the runtime advertises `external_tools_v1`.
+3. Register/replace the catalog before sending the prompt.
+4. Track the allowed names, catalog revision if returned, and pending call IDs.
+5. On `external_tool_call`, verify catalog membership and emit:
+
+```ts
+{
+  type: 'tool-call',
+  toolCallId: event.call_id,
+  toolName: event.name,
+  input: JSON.stringify(event.input),
+  providerExecuted: false,
+  dynamic: false,
+}
+```
+
+6. `submitToolResult` validates that the ID is pending for this turn, calls the SDK, and removes it once accepted.
+7. Reject duplicate, unknown, native-tool, or post-turn submissions.
+8. Abort/stop/destroy cancels the native turn and ensures all pending external calls are rejected or revoked.
+
+Use Pi's promise/result lifecycle as the behavioral reference.
+
+Do not emit a second synthetic consumer `tool-result` from native Jcode events. The Harness agent execution layer already echoes host-submitted results into its consumer stream.
+
+### `packages/harness-jcode/src/jcode-translate.ts`
+
+Add explicit translation for the new external call event. Keep native tool translation unchanged:
+
+```ts
+// Native Jcode tool
+providerExecuted: true;
+dynamic: true;
+
+// Host-defined tool
+providerExecuted: false;
+dynamic: false;
+```
+
+The translator state should maintain separate native and external pending maps to prevent ID or lifecycle confusion.
+
+### `packages/harness-jcode/src/jcode-bridge-protocol.ts`
+
+The shared start schema already includes `tools`. No new start field is required.
+
+Capability negotiation should surface an actionable unsupported error if the installed in-sandbox Jcode runtime or SDK lacks `external_tools_v1`.
+
+Prefer shared bridge control messages over Jcode-specific tool result messages.
+
+### `packages/harness-jcode/src/jcode-bridge-session.ts`
+
+Implement `submitToolResult` by forwarding the shared bridge tool-result command over `SandboxChannel`.
+
+Expand `JcodeBridgeChannel`'s inbound type if necessary to include the existing shared tool result command. Maintain a pending-call set and reject unknown/duplicate submissions before sending.
+
+On bridge closure, reject the turn and clear pending calls.
+
+### `packages/harness-jcode/src/bridge/index.ts`
+
+For every turn:
+
+1. Call SDK `setExternalTools` with `start.tools ?? []`.
+2. Subscribe to SDK events before sending the prompt.
+3. Translate `external_tool_call` to bridge `tool-call`.
+4. Await `turn.requestToolResult(callId)`.
+5. Call SDK `submitExternalToolResult`.
+6. Clean up pending handlers on abort, stop, destroy, disconnect, or turn completion.
+
+This bridge should remain a thin SDK driver. Do not add a second HTTP server or shell relay.
+
+### `packages/harness-jcode/src/jcode-harness.ts`
+
+Remove the host-tool unsupported path once SDK capability checks are available.
+
+Host-defined tool support is implicit in the HarnessV1 session contract rather than a `supportsHostTools` flag. Continue declaring `supportsBuiltinToolFiltering: false` until native common-name mapping, filtering, and approval behavior are implemented separately.
+
+### harness-jcode tests
+
+Expand:
+
+- `jcode-session.test.ts`
+- `jcode-translate.test.ts`
+- `jcode-harness.test.ts`
+- bridge tests
+- protocol schema tests
+
+Test both experimental host execution and the normal in-sandbox bridge path.
+
+## HarnessV1 Subagent Behavior
+
+### Recommended first implementation
+
+Do not add a universal HarnessV1 subagent API in the first tools change. Jcode swarms, Claude Task agents, OpenCode task sessions, and DeepAgents differ in lifecycle, visibility, nesting, resume semantics, and event shape.
+
+Keep subagent configuration Jcode-specific, for example:
+
+```ts
+export interface JcodeHarnessSettings {
+  // existing settings...
+  readonly subagents?: {
+    readonly defaultAllowedHostTools?: readonly string[];
+    readonly profiles?: Readonly<
+      Record<
+        string,
+        {
+          readonly instructions?: string;
+          readonly model?: string;
+          readonly reasoningEffort?: string;
+          readonly allowedHostTools?: readonly string[];
+        }
+      >
+    >;
+  };
+}
+```
+
+The adapter/runtime maps these profiles to Jcode's native swarm configuration and spawn policy. Profile policies still intersect with the root turn's current catalog.
+
+A profile must not be able to name or grant a tool absent from the active root catalog.
+
+### Future universal alternative
+
+After cross-adapter design work, introduce a `HarnessV1SubagentSpec` containing at least:
+
+- Name and description.
+- Instructions.
+- Model and reasoning settings.
+- Allowed host tools.
+- Builtin filtering.
+- Recursion/nesting policy.
+- Maximum concurrency.
+- Lifecycle and event visibility.
+- Resume behavior.
+
+Do not overload `HarnessV1ToolSpec` to describe a subagent. A subagent is a lifecycle-bearing runtime entity, not merely a function tool.
+
+## Permission and Filtering Rules
+
+1. Host-defined tools are not governed by Jcode's read/edit/bash permission mode. The Harness framework controls and executes them.
+2. Native built-in filtering and host-tool catalog filtering remain separate.
+3. Jcode validates host-tool membership when advertising definitions and again when executing a call.
+4. Descendant access is deny-by-default when the spawn relationship or owner connection cannot be proven.
+5. Per-child policy can only reduce the parent's effective catalog.
+6. Unknown allowlist names reject the request instead of silently disappearing.
+7. Tool and result payloads are size-limited and treated as untrusted input.
+8. Disconnect, abort, stop, destroy, child termination, and catalog replacement settle all pending calls.
+9. A restored session has no executable host tools until a current SDK connection registers them.
+10. Active tool calls retain a fixed owner and revision. Catalog changes cannot hijack them.
+11. Native, MCP, and external tool name collisions are rejected initially.
+12. The model must never see broker credentials, socket authorization material, or owner tokens.
+
+## Phased Implementation and Tests
+
+### Phase 1: Jcode external-tool protocol and broker
+
+Scope:
+
+- Root sessions only.
+- Catalog changes only while idle.
+- No child inheritance yet.
+- TypeScript and Rust SDK parity.
+
+Tests:
+
+- Protocol serialization and schema parity.
+- Register, replace, and clear catalog.
+- Tool definition validation and collisions.
+- Call/result success and error results.
+- Unknown, duplicate, late, and wrong-owner result rejection.
+- Abort, disconnect, detach, and shutdown cancellation.
+- Payload limits and malformed JSON/schema handling.
+- Tool snapshot invalidation between turns.
+- Native tools remain unaffected.
+
+Exit criteria:
+
+- A standalone SDK client can register a tool, receive a call, submit a result, and let the agent continue.
+- No call can be completed from a second client connection.
+
+### Phase 2: harness-jcode root host tools
+
+Scope:
+
+- `jcode-session.ts` host execution path.
+- In-sandbox bridge path.
+- HarnessV1 tool correlation.
+
+Tests:
+
+- Correct `providerExecuted: false` and `dynamic: false` flags.
+- Description/schema forwarding.
+- Host result and error forwarding.
+- Multiple calls, parallel calls if Jcode permits them, and out-of-order results.
+- Unknown and duplicate `submitToolResult` calls.
+- Abort while waiting for a result.
+- Stop/destroy while waiting.
+- Runtime without `external_tools_v1` returns `HarnessCapabilityUnsupportedError`.
+- Empty tools remove a previous turn's catalog.
+- Resume requires re-registration and does not inherit a dead executor.
+- Host and bridge behavior are equivalent.
+
+Exit criteria:
+
+- Existing Harness agent host-tool conformance behavior passes for Jcode.
+- No HTTP relay or MCP configuration is required.
+
+### Phase 3: Descendant ownership and allowlists
+
+Scope:
+
+- Extend `CommSpawn`.
+- Record root/parent/child ownership.
+- Route child calls to the root SDK connection.
+- Apply recursive intersections.
+
+Tests:
+
+- Omitted, empty, and explicit child allowlists.
+- Unknown/disallowed names reject spawn.
+- Child cannot expand parent permissions.
+- Grandchild receives the recursive intersection.
+- Headless, inline, visible, and fallback spawn paths apply identical policy.
+- Forged or unrelated session events are ignored/rejected.
+- Child call includes actual child session metadata but is answered only by root owner.
+- Root disconnect revokes descendants and pending calls.
+- Child stop affects only its own pending calls.
+- Policy is installed before the child's first tool snapshot.
+
+Exit criteria:
+
+- A child can call one explicitly permitted host tool and cannot see or execute another root tool.
+
+### Phase 4: Jcode-specific subagent profiles
+
+Scope:
+
+- `JcodeHarnessSettings.subagents`.
+- Profile mapping to model/instructions/effort/tool policy.
+- Documentation and examples.
+
+Tests:
+
+- Valid and invalid profile names.
+- Profile catalog intersection.
+- Profile cannot grant unavailable tools.
+- Default policy behavior.
+- Nested profile behavior.
+- Resume and runtime restart behavior.
+
+### Phase 5: Optional HarnessV1 standardization
+
+Scope:
+
+- Compare Claude Code, OpenCode, DeepAgents, Pi-style agents, and Jcode.
+- Add a universal contract only if common lifecycle semantics emerge.
+
+Tests would be adapter conformance tests rather than Jcode-only tests.
+
+## Alternatives
+
+### Alternative A: Session-scoped MCP server
+
+Run or configure a Jcode MCP server that relays calls to the host.
+
+Advantages:
+
+- Reuses Jcode's existing MCP registration.
+- Similar to Claude Code.
+
+Disadvantages:
+
+- Requires transport/authentication between sandbox and host.
+- Jcode MCP registration is asynchronous and tool snapshots have late-registration behavior.
+- Per-session and per-descendant ownership must still be added.
+- MCP naming/filter semantics can blur native and host tools.
+- Reconnect and resume still require a broker.
+
+Use only if Jcode intentionally standardizes all external tools on authenticated, dynamically managed MCP sessions. It does not eliminate most core work.
+
+### Alternative B: Local HTTP relay or CLI shim
+
+Copy the Codex workaround.
+
+Advantages:
+
+- Could be implemented mostly in `harness-jcode`.
+- Avoids immediate SDK protocol additions.
+
+Disadvantages:
+
+- Expands attack surface with a local server.
+- Requires bearer/authorization design and command correlation.
+- Shell/prompt guidance is brittle.
+- Hard to secure across Jcode subagents.
+- Duplicates capabilities Jcode core can expose directly.
+
+Reject as the primary design.
+
+### Alternative C: Execute host tools inside Jcode
+
+Send executable code or commands to Jcode.
+
+Advantages:
+
+- No asynchronous result protocol.
+
+Disadvantages:
+
+- Violates HarnessV1's host-owned `execute` model.
+- Cannot safely serialize closures or application state.
+- Moves credentials and authority into the sandbox/runtime.
+- Breaks framework approval and observability expectations.
+
+Reject.
+
+### Alternative D: Process-global external tool registry
+
+Register host tools globally in the Jcode daemon.
+
+Advantages:
+
+- Smallest core registry change.
+
+Disadvantages:
+
+- Cross-session data/capability leakage.
+- Ambiguous result routing with multiple clients.
+- Unsafe persistence and reconnect behavior.
+- No defensible subagent ownership model.
+
+Reject.
+
+### Alternative E: New universal HarnessV1 subagent API immediately
+
+Advantages:
+
+- One consumer configuration surface.
+
+Disadvantages:
+
+- Current runtimes expose materially different lifecycle models.
+- Delays root host-tool support.
+- Risks freezing Jcode-specific swarm concepts into a weak abstraction.
+
+Defer until after the Jcode-specific implementation and broader adapter comparison.
+
+## Blockers and Open Decisions
+
+1. **Cross-repository sequencing:** Jcode core, API, and SDK support must ship before `harness-jcode` can enable the feature safely.
+2. **Catalog updates during active turns:** phase one should reject them. Supporting them later requires revisioned pending calls and explicit stale-call semantics.
+3. **Omitted child allowlist:** inheritance is recommended for usability, but none-by-default is stricter. This must be documented and tested.
+4. **Name collision policy:** initial rejection is safest. Internal namespacing is a possible later enhancement.
+5. **Root disconnect behavior:** decide whether descendants stop or continue with external tools removed. Pending calls must always fail immediately.
+6. **Result representation:** structured JSON preserves values, while Jcode `ToolOutput` may be text/image oriented. Define deterministic conversion and size limits.
+7. **Image/file results:** phase one may support JSON/text only. Binary or image results need an explicit SDK wire representation rather than unbounded base64 inside generic JSON.
+8. **Concurrency:** confirm whether Jcode may execute multiple tools concurrently and size the pending broker accordingly.
+9. **Timeout ownership:** define whether the host, Jcode, or both can set deadlines. Jcode must always have a finite cleanup path.
+10. **Capabilities:** older runtimes must fail with a clear unsupported error, not hang after receiving a tool definition they cannot execute.
+11. **Resume:** external tools are ephemeral authority. Every restored session must re-register the active catalog.
+12. **Universal subagents:** HarnessV1 has no first-class subagent definition contract. Keep profiles Jcode-specific until cross-adapter semantics are established.
+
+## Recommended Delivery Order
+
+1. Land Jcode protocol types and broker with SDK tests.
+2. Publish a Jcode SDK/runtime version advertising `external_tools_v1`.
+3. Add root host tools to `harness-jcode` behind capability detection.
+4. Add descendant ownership and `allowed_host_tools` in Jcode.
+5. Add Jcode-specific subagent profiles and documentation.
+6. Evaluate a future HarnessV1 subagent contract using the working implementations as evidence.
+
+This ordering produces a secure, testable root tool path early without committing HarnessV1 to premature subagent abstractions.

--- a/packages/harness-jcode/package.json
+++ b/packages/harness-jcode/package.json
@@ -15,9 +15,10 @@
     "README.md"
   ],
   "scripts": {
-    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json && pnpm copy-bridge-assets",
     "build:watch": "pnpm clean && tsup --watch",
     "clean": "del-cli dist *.tsbuildinfo",
+    "copy-bridge-assets": "node -e \"import('node:fs/promises').then(async fs => { await fs.copyFile('src/bridge/package.json', 'dist/bridge/package.json'); await fs.copyFile('src/bridge/pnpm-lock.yaml', 'dist/bridge/pnpm-lock.yaml'); await fs.copyFile('src/bridge/pnpm-workspace.yaml', 'dist/bridge/pnpm-workspace.yaml'); })\"",
     "type-check": "tsc --build",
     "test": "pnpm test:node",
     "test:watch": "vitest --config vitest.node.config.js",
@@ -41,9 +42,11 @@
   },
   "devDependencies": {
     "@types/node": "22.19.19",
+    "@types/ws": "^8.5.13",
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "5.8.3",
+    "ws": "8.21.0",
     "zod": "3.25.76"
   },
   "engines": {

--- a/packages/harness-jcode/package.json
+++ b/packages/harness-jcode/package.json
@@ -33,7 +33,7 @@
     }
   },
   "dependencies": {
-    "@1jehuang/jcode-sdk": "1.1.0",
+    "@1jehuang/jcode-sdk": "1.3.0",
     "@ai-sdk/harness": "workspace:*",
     "@ai-sdk/provider-utils": "workspace:*",
     "ws": "8.21.0"

--- a/packages/harness-jcode/package.json
+++ b/packages/harness-jcode/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@ai-sdk/harness-jcode",
+  "version": "0.0.1",
+  "type": "module",
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "source": "./src/index.ts",
+  "files": [
+    "dist/**/*",
+    "src",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "pnpm clean && tsup --tsconfig tsconfig.build.json",
+    "build:watch": "pnpm clean && tsup --watch",
+    "clean": "del-cli dist *.tsbuildinfo",
+    "type-check": "tsc --build",
+    "test": "pnpm test:node",
+    "test:watch": "vitest --config vitest.node.config.js",
+    "test:node": "vitest --config vitest.node.config.js --run"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@1jehuang/jcode-sdk": "1.1.0",
+    "@ai-sdk/harness": "workspace:*",
+    "@ai-sdk/provider-utils": "workspace:*"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.76 || ^4.1.8"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.19",
+    "@vercel/ai-tsconfig": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "5.8.3",
+    "zod": "3.25.76"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "homepage": "https://ai-sdk.dev/docs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/ai",
+    "directory": "packages/harness-jcode"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/ai/issues"
+  },
+  "keywords": [
+    "ai",
+    "harness",
+    "jcode"
+  ]
+}

--- a/packages/harness-jcode/package.json
+++ b/packages/harness-jcode/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "@1jehuang/jcode-sdk": "1.1.0",
     "@ai-sdk/harness": "workspace:*",
-    "@ai-sdk/provider-utils": "workspace:*"
+    "@ai-sdk/provider-utils": "workspace:*",
+    "ws": "8.21.0"
   },
   "peerDependencies": {
     "zod": "^3.25.76 || ^4.1.8"
@@ -46,7 +47,6 @@
     "@vercel/ai-tsconfig": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "5.8.3",
-    "ws": "8.21.0",
     "zod": "3.25.76"
   },
   "engines": {

--- a/packages/harness-jcode/scripts/release-validation.sh
+++ b/packages/harness-jcode/scripts/release-validation.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Production-equivalent release validation for Jcode + @ai-sdk/harness-jcode.
+#
+# This script only writes to a temporary directory. It builds release binaries,
+# packs publishable-equivalent npm artifacts, installs them into a clean consumer,
+# launches the bundled runtime, and verifies the external-tools capability.
+set -euo pipefail
+
+if [[ -x "${HOME:-}/.cargo/bin/cargo" ]]; then
+  export PATH="$HOME/.cargo/bin:$PATH"
+fi
+
+AI_REPO="${AI_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
+JCODE_REPO="${JCODE_REPO:-/Users/joan/wrk/jcode}"
+KEEP_WORK="${KEEP_WORK:-0}"
+RUN_VERCEL_SANDBOX="${RUN_VERCEL_SANDBOX:-auto}"
+
+package_dir="$AI_REPO/packages/harness-jcode"
+work="$(mktemp -d "${TMPDIR:-/tmp}/harness-jcode-release-XXXXXX")"
+cleanup() {
+  if [[ "$KEEP_WORK" == 1 ]]; then
+    echo "kept validation workspace: $work"
+  else
+    rm -rf "$work"
+  fi
+}
+trap cleanup EXIT
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "BLOCKED: required command not found: $1" >&2
+    exit 1
+  }
+}
+require cargo
+require node
+require npm
+require pnpm
+
+[[ -f "$JCODE_REPO/Cargo.toml" ]] || {
+  echo "BLOCKED: JCODE_REPO is not a Jcode checkout: $JCODE_REPO" >&2
+  exit 1
+}
+[[ -f "$package_dir/package.json" ]] || {
+  echo "BLOCKED: AI_REPO does not contain packages/harness-jcode: $AI_REPO" >&2
+  exit 1
+}
+
+sdk_version="$(node -p "require('$JCODE_REPO/sdk/typescript/package.json').version")"
+harness_sdk_version="$(node -p "require('$package_dir/package.json').dependencies['@1jehuang/jcode-sdk']")"
+bridge_sdk_version="$(node -p "require('$package_dir/src/bridge/package.json').dependencies['@1jehuang/jcode-sdk']")"
+if [[ "$harness_sdk_version" != "$sdk_version" || "$bridge_sdk_version" != "$sdk_version" ]]; then
+  echo "BLOCKED: SDK versions differ: sdk=$sdk_version harness=$harness_sdk_version bridge=$bridge_sdk_version" >&2
+  exit 1
+fi
+
+echo "== 1/5 build Jcode release binaries =="
+(
+  cd "$JCODE_REPO"
+  cargo build --release --locked --bin jcode --bin jcode-harness
+)
+"$JCODE_REPO/target/release/jcode" --version
+"$JCODE_REPO/target/release/jcode-harness" --help >/dev/null
+
+echo "== 2/5 pack the local Jcode SDK and current-platform runtime =="
+sdk_tarball="$(cd "$JCODE_REPO/sdk/typescript" && npm pack --pack-destination "$work" --silent | tail -n 1)"
+sdk_tarball="$work/$sdk_tarball"
+
+case "$(uname -s):$(uname -m)" in
+  Darwin:arm64) runtime_package=darwin-arm64 ;;
+  Darwin:x86_64) runtime_package=darwin-x64 ;;
+  Linux:aarch64) runtime_package=linux-arm64 ;;
+  Linux:x86_64) runtime_package=linux-x64 ;;
+  *)
+    echo "BLOCKED: no Jcode npm runtime package for $(uname -s)/$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+runtime_stage="$work/runtime-stage"
+mkdir -p "$runtime_stage/bin"
+cp "$JCODE_REPO/sdk/npm/$runtime_package/package.json" "$runtime_stage/"
+cp "$JCODE_REPO/sdk/npm/$runtime_package/README.md" "$runtime_stage/"
+cp "$JCODE_REPO/target/release/jcode" "$runtime_stage/bin/jcode"
+chmod +x "$runtime_stage/bin/jcode"
+runtime_tarball="$(cd "$runtime_stage" && npm pack --pack-destination "$work" --silent | tail -n 1)"
+runtime_tarball="$work/$runtime_tarball"
+
+echo "== 3/5 build and pack @ai-sdk/harness-jcode =="
+(
+  cd "$package_dir"
+  ./node_modules/.bin/tsup --tsconfig tsconfig.build.json
+  cp src/bridge/package.json src/bridge/pnpm-lock.yaml src/bridge/pnpm-workspace.yaml dist/bridge/
+)
+harness_stage="$work/harness-stage"
+mkdir -p "$harness_stage"
+cp -R "$package_dir/dist" "$package_dir/src" "$package_dir/README.md" "$package_dir/package.json" "$harness_stage/"
+node - "$harness_stage/package.json" "$AI_REPO" <<'JS'
+const [manifestPath, repo] = process.argv.slice(2);
+const fs = require('node:fs');
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+manifest.dependencies['@ai-sdk/harness'] = require(`${repo}/packages/harness/package.json`).version;
+manifest.dependencies['@ai-sdk/provider-utils'] = require(`${repo}/packages/provider-utils/package.json`).version;
+delete manifest.scripts;
+delete manifest.devDependencies;
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+JS
+harness_tarball_name="$(cd "$harness_stage" && npm pack --pack-destination "$work" --silent | tail -n 1)"
+harness_tarball="$work/$harness_tarball_name"
+[[ -n "$harness_tarball" ]] || {
+  echo "BLOCKED: pnpm pack did not produce an @ai-sdk/harness-jcode tarball" >&2
+  exit 1
+}
+
+echo "== 4/5 install tarballs into a clean consumer =="
+consumer="$work/consumer"
+mkdir -p "$consumer"
+cd "$consumer"
+printf '{"name":"harness-jcode-release-consumer","private":true,"type":"module"}\n' > package.json
+npm install --silent "$runtime_tarball" "$sdk_tarball" "$harness_tarball" zod@3.25.76
+node --input-type=module <<'JS'
+import { createJcode } from '@ai-sdk/harness-jcode';
+import { JcodeClient, bundledJcodeBinary } from '@1jehuang/jcode-sdk';
+import { access } from 'node:fs/promises';
+
+const binary = bundledJcodeBinary();
+if (!binary) throw new Error('the packed Jcode SDK did not resolve a runtime');
+await access(binary);
+const harness = createJcode({ experimentalHostExecution: true, binary });
+if (harness.specificationVersion !== 'harness-v1') {
+  throw new Error(`unexpected specification version: ${harness.specificationVersion}`);
+}
+const bootstrap = await harness.getBootstrap?.();
+if (!bootstrap) throw new Error('Jcode bootstrap is missing');
+for (const required of ['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', 'bridge.mjs']) {
+  if (!bootstrap.files.some(file => file.path.endsWith(`/${required}`))) {
+    throw new Error(`bootstrap is missing ${required}`);
+  }
+}
+const client = await JcodeClient.launch({ binary, inheritLogins: false });
+try {
+  if (!client.capabilities.includes('external_tools_v1')) {
+    throw new Error('packed runtime did not advertise external_tools_v1');
+  }
+  const session = await client.createSession(process.cwd());
+  await client.setExternalTools(session.session_id, [{
+    name: 'release_probe',
+    description: 'release validation probe',
+    input_schema: { type: 'object' },
+  }]);
+  await client.setExternalTools(session.session_id, []);
+  console.log(`consumer runtime ok; runtime=${binary}; capability=external_tools_v1; bootstrapFiles=${bootstrap.files.length}`);
+} finally {
+  await client.close();
+}
+JS
+
+echo "== 5/5 optional real Vercel Sandbox probe =="
+if [[ "$RUN_VERCEL_SANDBOX" == 0 ]]; then
+  echo "skipped: RUN_VERCEL_SANDBOX=0"
+elif [[ -z "${VERCEL_OIDC_TOKEN:-}" ]]; then
+  if [[ "$RUN_VERCEL_SANDBOX" == 1 ]]; then
+    echo "BLOCKED: RUN_VERCEL_SANDBOX=1 but VERCEL_OIDC_TOKEN is unset" >&2
+    exit 1
+  fi
+  echo "skipped: VERCEL_OIDC_TOKEN is unset"
+else
+  if ! grep -q "@1jehuang/jcode-sdk@$sdk_version" "$package_dir/src/bridge/pnpm-lock.yaml"; then
+    echo "BLOCKED: bridge lockfile does not resolve @1jehuang/jcode-sdk@$sdk_version; publish the SDK and regenerate the lockfile first" >&2
+    exit 1
+  fi
+  npm install --silent @vercel/sandbox@^3.0.0
+  node --input-type=module <<'JS'
+import { createJcode } from '@ai-sdk/harness-jcode';
+import { Sandbox } from '@vercel/sandbox';
+
+const sandbox = await Sandbox.create({ runtime: 'node24', timeout: 10 * 60 * 1000 });
+try {
+  const bootstrap = await createJcode().getBootstrap?.();
+  if (!bootstrap) throw new Error('Jcode bootstrap is missing');
+  const root = '/vercel/sandbox';
+  await sandbox.writeFiles(
+    bootstrap.files.map(file => ({
+      path: `${root}/${file.path}`,
+      content: Buffer.from(file.content),
+    })),
+  );
+  for (const step of bootstrap.commands) {
+    const command = await sandbox.runCommand({
+      cmd: 'bash',
+      args: ['-lc', step.command],
+      cwd: `${root}/${bootstrap.bootstrapDir}`,
+    });
+    const result = await command.wait();
+    if (result.exitCode !== 0) {
+      throw new Error(`sandbox bootstrap failed (${result.exitCode}): ${step.command}`);
+    }
+  }
+  console.log('real Vercel Sandbox bootstrap ok');
+} finally {
+  await sandbox.stop().catch(() => {});
+}
+JS
+fi
+
+echo "release validation passed"
+echo "artifacts: $sdk_tarball $runtime_tarball $harness_tarball"

--- a/packages/harness-jcode/src/bridge/index.test.ts
+++ b/packages/harness-jcode/src/bridge/index.test.ts
@@ -1,0 +1,124 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+const runtime = {
+  events: vi.fn(() =>
+    (async function* () {
+      yield {
+        ev: 'tool_start',
+        session_id: 'native-session',
+        call_id: 'call-1',
+        name: 'weather',
+      };
+      yield {
+        ev: 'tool_input_delta',
+        session_id: 'native-session',
+        call_id: 'call-1',
+        delta: '{"city":"Paris"}',
+      };
+      yield {
+        ev: 'tool_exec',
+        session_id: 'native-session',
+        call_id: 'call-1',
+        name: 'weather',
+      };
+      yield {
+        ev: 'external_tool_call',
+        session_id: 'native-session',
+        root_session_id: 'native-session',
+        call_id: 'call-1',
+        catalog_revision: 1,
+        name: 'weather',
+        input: { city: 'Paris' },
+      };
+      yield {
+        ev: 'tool_done',
+        session_id: 'native-session',
+        call_id: 'call-1',
+        name: 'weather',
+        output: '{"temperature":21}',
+      };
+      yield { ev: 'turn_done', session_id: 'native-session' };
+    })(),
+  ),
+  createSession: vi.fn(async () => ({ session_id: 'native-session' })),
+  setExternalTools: vi.fn(async () => {}),
+  sendMessage: vi.fn(async () => {}),
+  submitExternalToolResult: vi.fn(async () => {}),
+};
+let onStart: (start: any, turn: any) => Promise<void>;
+
+vi.mock('@1jehuang/jcode-sdk', () => ({
+  JcodeClient: { launch: vi.fn(async () => runtime) },
+}));
+vi.mock('@ai-sdk/harness/bridge', () => ({
+  runBridge: vi.fn(async (options: { onStart: typeof onStart }) => {
+    onStart = options.onStart;
+  }),
+}));
+vi.mock('node:process', () => ({
+  argv: [
+    'node',
+    'bridge',
+    '--workdir',
+    '/work',
+    '--bridgeStateDir',
+    '/state',
+    '--jcodeHome',
+    '/home',
+  ],
+}));
+
+beforeAll(async () => {
+  await import('./index');
+});
+
+describe('Jcode bridge runtime', () => {
+  it('forwards external tool calls and results', async () => {
+    const emit = vi.fn();
+    await onStart(
+      {
+        type: 'start',
+        prompt: 'hello',
+        tools: [{ name: 'weather', inputSchema: { type: 'object' } }],
+      },
+      {
+        emit,
+        requestToolResult: vi.fn(async () => ({
+          output: { temperature: 21 },
+          isError: false,
+        })),
+        abortSignal: new AbortController().signal,
+      },
+    );
+
+    expect(runtime.setExternalTools).toHaveBeenCalledWith('native-session', [
+      {
+        name: 'weather',
+        description: '',
+        input_schema: { type: 'object' },
+      },
+    ]);
+    expect(emit).toHaveBeenCalledWith({
+      type: 'tool-call',
+      toolCallId: 'call-1',
+      toolName: 'weather',
+      input: '{"city":"Paris"}',
+      providerExecuted: false,
+      dynamic: false,
+    });
+    expect(runtime.submitExternalToolResult).toHaveBeenCalledWith(
+      'native-session',
+      {
+        call_id: 'call-1',
+        output: { temperature: 21 },
+        is_error: false,
+      },
+    );
+    expect(emit).toHaveBeenCalledWith({
+      type: 'tool-result',
+      toolCallId: 'call-1',
+      toolName: 'weather',
+      result: { temperature: 21 },
+    });
+  });
+});

--- a/packages/harness-jcode/src/bridge/index.ts
+++ b/packages/harness-jcode/src/bridge/index.ts
@@ -1,0 +1,132 @@
+import { JcodeClient } from '@1jehuang/jcode-sdk';
+import {
+  runBridge,
+  type BridgeEvent,
+  type BridgeTurn,
+} from '@ai-sdk/harness/bridge';
+import { argv } from 'node:process';
+import type { JcodeBridgeStartMessage } from '../jcode-bridge-protocol';
+import {
+  createJcodeTranslatorState,
+  translateJcodeEvent,
+} from '../jcode-translate';
+
+const args = parseArgs(argv.slice(2));
+const workdir = required(args.workdir, '--workdir');
+const bridgeStateDir = required(args.bridgeStateDir, '--bridge-state-dir');
+const jcodeHome = required(args.jcodeHome, '--jcode-home');
+
+let client: JcodeClient | undefined;
+let sessionId: string | undefined;
+
+await runBridge<JcodeBridgeStartMessage>({
+  bridgeType: 'jcode',
+  bridgeStateDir,
+  onStart: runTurn,
+  onStop: () => ({ jcodeSessionId: sessionId }),
+  onDestroy: async () => {
+    await client?.close();
+    client = undefined;
+  },
+});
+
+async function runTurn(
+  start: JcodeBridgeStartMessage,
+  turn: BridgeTurn,
+): Promise<void> {
+  try {
+    const runtime = await ensureRuntime(start);
+    if (start.operation === 'compact') {
+      const summary = await runtime.compact(sessionId!);
+      turn.emit({
+        type: 'compaction',
+        trigger: 'manual',
+        summary,
+      } as BridgeEvent);
+      turn.emit(finishEvent());
+      return;
+    }
+
+    const stream = runtime.events(sessionId!);
+    const state = createJcodeTranslatorState();
+    const abort = () => {
+      void runtime.cancel(sessionId!).catch(() => {});
+    };
+    turn.abortSignal.addEventListener('abort', abort, { once: true });
+    turn.emit({
+      type: 'stream-start',
+      ...(start.model ? { modelId: start.model } : {}),
+    } as BridgeEvent);
+    try {
+      await runtime.sendMessage(sessionId!, start.prompt);
+      for await (const event of stream) {
+        if (event.ev === 'error') {
+          throw new Error(`${event.code}: ${event.message}`);
+        }
+        for (const part of translateJcodeEvent(event, state)) {
+          turn.emit(part as BridgeEvent);
+        }
+        if (event.ev === 'turn_done') return;
+      }
+      throw new Error('Jcode event stream closed before turn_done');
+    } finally {
+      turn.abortSignal.removeEventListener('abort', abort);
+      await stream.return?.();
+    }
+  } catch (error) {
+    turn.emitError({ error, message: 'Jcode turn failed' });
+  }
+}
+
+async function ensureRuntime(
+  start: JcodeBridgeStartMessage,
+): Promise<JcodeClient> {
+  client ??= await JcodeClient.launch({
+    jcodeHome,
+    workingDir: workdir,
+    inheritLogins: false,
+    clientName: 'ai-sdk/harness-jcode-bridge',
+  });
+  if (!sessionId) {
+    const session = start.resumeSessionId
+      ? await client.attachSession(start.resumeSessionId)
+      : await client.createSession(workdir);
+    sessionId = session.session_id;
+    if (start.model) await client.setModel(sessionId, start.model);
+    if (start.reasoningEffort) {
+      await client.setReasoningEffort(sessionId, start.reasoningEffort);
+    }
+  }
+  return client;
+}
+
+function finishEvent(): BridgeEvent {
+  return {
+    type: 'finish',
+    finishReason: { unified: 'stop', raw: 'compact' },
+    totalUsage: {
+      inputTokens: {
+        total: 0,
+        noCache: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+      outputTokens: { total: 0, text: 0, reasoning: 0 },
+    },
+  } as BridgeEvent;
+}
+
+function parseArgs(values: string[]): Record<string, string> {
+  const parsed: Record<string, string> = {};
+  for (let index = 0; index < values.length; index += 2) {
+    const key = values[index]?.replace(/^--/, '');
+    const value = values[index + 1];
+    if (key && value) parsed[key] = value;
+  }
+  return parsed;
+}
+
+function required(value: string | undefined, flag: string): string {
+  if (!value) throw new Error(`Missing ${flag} argument.`);
+  return value;
+}

--- a/packages/harness-jcode/src/bridge/index.ts
+++ b/packages/harness-jcode/src/bridge/index.ts
@@ -1,4 +1,8 @@
-import { JcodeClient } from '@1jehuang/jcode-sdk';
+import {
+  JcodeClient,
+  type ExternalToolCall,
+  type ExternalToolDefinition,
+} from '@1jehuang/jcode-sdk';
 import {
   runBridge,
   type BridgeEvent,
@@ -9,6 +13,8 @@ import type { JcodeBridgeStartMessage } from '../jcode-bridge-protocol';
 import {
   createJcodeTranslatorState,
   translateJcodeEvent,
+  translateJcodeExternalToolCall,
+  translateJcodeExternalToolResult,
 } from '../jcode-translate';
 
 const args = parseArgs(argv.slice(2));
@@ -49,6 +55,14 @@ async function runTurn(
 
     const stream = runtime.events(sessionId!);
     const state = createJcodeTranslatorState();
+    const externalToolNames = new Set(
+      (start.tools ?? []).map(tool => tool.name),
+    );
+    const externalCallIds = new Set<string>();
+    const externalResults = new Map<
+      string,
+      { readonly output: unknown; readonly isError: boolean }
+    >();
     const abort = () => {
       void runtime.cancel(sessionId!).catch(() => {});
     };
@@ -58,10 +72,69 @@ async function runTurn(
       ...(start.model ? { modelId: start.model } : {}),
     } as BridgeEvent);
     try {
+      await runtime.setExternalTools(
+        sessionId!,
+        (start.tools ?? []).map(toExternalToolDefinition),
+      );
       await runtime.sendMessage(sessionId!, start.prompt);
       for await (const event of stream) {
+        if (event.ev === 'tool_start' && externalToolNames.has(event.name)) {
+          externalCallIds.add(event.call_id);
+          for (const part of translateJcodeEvent(event, state)) {
+            turn.emit(part as BridgeEvent);
+          }
+          continue;
+        }
+        if (
+          event.ev === 'tool_input_delta' &&
+          externalCallIds.has(event.call_id)
+        ) {
+          translateJcodeEvent(event, state);
+          continue;
+        }
+        if (event.ev === 'tool_exec' && externalCallIds.has(event.call_id)) {
+          const tool = state.tools.get(event.call_id);
+          if (!tool)
+            throw new Error(`missing external tool state: ${event.call_id}`);
+          tool.emitted = true;
+          state.stepHadToolCall = true;
+          turn.emit({
+            type: 'tool-call',
+            toolCallId: event.call_id,
+            toolName: event.name,
+            input: tool.input || '{}',
+            providerExecuted: false,
+            dynamic: false,
+          } as BridgeEvent);
+          continue;
+        }
+        if (event.ev === 'tool_done' && externalCallIds.delete(event.call_id)) {
+          const submitted = externalResults.get(event.call_id);
+          externalResults.delete(event.call_id);
+          state.tools.delete(event.call_id);
+          turn.emit(
+            translateJcodeExternalToolResult({
+              toolCallId: event.call_id,
+              toolName: event.name,
+              output: submitted?.output ?? event.error ?? event.output,
+              isError: submitted?.isError ?? event.error != null,
+            }) as BridgeEvent,
+          );
+          continue;
+        }
         if (event.ev === 'error') {
           throw new Error(`${event.code}: ${event.message}`);
+        }
+        if (event.ev === 'external_tool_call') {
+          if (!externalCallIds.has(event.call_id)) {
+            state.stepHadToolCall = true;
+            turn.emit(translateJcodeExternalToolCall(event) as BridgeEvent);
+          }
+          externalResults.set(
+            event.call_id,
+            await forwardExternalToolCall(runtime, event, turn),
+          );
+          continue;
         }
         for (const part of translateJcodeEvent(event, state)) {
           turn.emit(part as BridgeEvent);
@@ -76,6 +149,35 @@ async function runTurn(
   } catch (error) {
     turn.emitError({ error, message: 'Jcode turn failed' });
   }
+}
+
+function toExternalToolDefinition(
+  tool: NonNullable<JcodeBridgeStartMessage['tools']>[number],
+): ExternalToolDefinition {
+  return {
+    name: tool.name,
+    description: tool.description ?? '',
+    input_schema:
+      tool.inputSchema != null &&
+      typeof tool.inputSchema === 'object' &&
+      !Array.isArray(tool.inputSchema)
+        ? (tool.inputSchema as Record<string, unknown>)
+        : {},
+  };
+}
+
+async function forwardExternalToolCall(
+  runtime: JcodeClient,
+  call: ExternalToolCall,
+  turn: BridgeTurn,
+): Promise<{ readonly output: unknown; readonly isError: boolean }> {
+  const result = await turn.requestToolResult(call.call_id);
+  await runtime.submitExternalToolResult(call.root_session_id, {
+    call_id: call.call_id,
+    output: result.output,
+    is_error: result.isError ?? false,
+  });
+  return { output: result.output, isError: result.isError ?? false };
 }
 
 async function ensureRuntime(

--- a/packages/harness-jcode/src/bridge/package.json
+++ b/packages/harness-jcode/src/bridge/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@1jehuang/jcode-sdk": "1.1.0",
+    "@1jehuang/jcode-sdk": "1.3.0",
     "ws": "8.21.0"
   }
 }

--- a/packages/harness-jcode/src/bridge/package.json
+++ b/packages/harness-jcode/src/bridge/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "harness-jcode-bridge",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@1jehuang/jcode-sdk": "1.1.0",
+    "ws": "8.21.0"
+  }
+}

--- a/packages/harness-jcode/src/bridge/pnpm-lock.yaml
+++ b/packages/harness-jcode/src/bridge/pnpm-lock.yaml
@@ -1,0 +1,128 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@1jehuang/jcode-sdk':
+        specifier: 1.1.0
+        version: 1.1.0
+      ws:
+        specifier: 8.21.0
+        version: 8.21.0
+
+packages:
+
+  '@1jehuang/jcode-darwin-arm64@1.1.0':
+    resolution: {integrity: sha512-OoVrOeZ79TkKAk3TXnR858WoeaBOn+dFQC3kvN7YMVaq4TjvuwcFfxTO7ud1ciVmpPvXaHzPi8L776aPDAx5Hw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@1jehuang/jcode-darwin-x64@1.1.0':
+    resolution: {integrity: sha512-wsiE7Qzt5UkJV/v2O+NzKQuipZNvuXzi5vyXCDbJDF0fvojQsjZY2njpXGjxwlzcOp4fTesE4inuH/xqL71rDw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@1jehuang/jcode-linux-arm64@1.1.0':
+    resolution: {integrity: sha512-5s9VUitbpx4PSgdtNdgsGy2FtSNlJtQpsfb6RWX5E8QXHpnwlfsbXoq1PuU5kwWitJY07OYnB1P4xozObpA68Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@1jehuang/jcode-linux-x64@1.1.0':
+    resolution: {integrity: sha512-9w+VpnSZQrpU+lYy/I7a4NsRbPAUSN9DHIX8uoJ1uhlocJ6WPB77AxDp2I5zWUn5H09knlAkw2LgzvhWANzpbQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@1jehuang/jcode-sdk@1.1.0':
+    resolution: {integrity: sha512-A9QcerzdNb9yXsRaip38doZd/Z8IGGlAsjmdLuRl9IvpitkHwizzjh4+e3U6YEwyLygvOlgkiNdgvf0UMosvPg==}
+    engines: {node: '>=20'}
+
+  '@1jehuang/jcode-win32-arm64@1.1.0':
+    resolution: {integrity: sha512-Gcqvjit05CQH+ELC9G8bBYTciP8o8MzbVLUz8PFWJYmSXzbVlJEbQzr4/D29egPUSUrgAsti8rtqAmGIjIBN6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@1jehuang/jcode-win32-x64@1.1.0':
+    resolution: {integrity: sha512-ePRfhzPk6HQ94WZFEmKxztuhhw4ZkzyiCdJKa3v4ERAHAz4APLO16K6H53kDc+x04YvW7nurgcALWWKVF+8JGA==}
+    cpu: [x64]
+    os: [win32]
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+snapshots:
+
+  '@1jehuang/jcode-darwin-arm64@1.1.0':
+    optional: true
+
+  '@1jehuang/jcode-darwin-x64@1.1.0':
+    optional: true
+
+  '@1jehuang/jcode-linux-arm64@1.1.0':
+    optional: true
+
+  '@1jehuang/jcode-linux-x64@1.1.0':
+    optional: true
+
+  '@1jehuang/jcode-sdk@1.1.0':
+    dependencies:
+      ajv: 8.20.0
+    optionalDependencies:
+      '@1jehuang/jcode-darwin-arm64': 1.1.0
+      '@1jehuang/jcode-darwin-x64': 1.1.0
+      '@1jehuang/jcode-linux-arm64': 1.1.0
+      '@1jehuang/jcode-linux-x64': 1.1.0
+      '@1jehuang/jcode-win32-arm64': 1.1.0
+      '@1jehuang/jcode-win32-x64': 1.1.0
+
+  '@1jehuang/jcode-win32-arm64@1.1.0':
+    optional: true
+
+  '@1jehuang/jcode-win32-x64@1.1.0':
+    optional: true
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.6: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  require-from-string@2.0.2: {}
+
+  ws@8.21.0: {}

--- a/packages/harness-jcode/src/bridge/pnpm-workspace.yaml
+++ b/packages/harness-jcode/src/bridge/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/packages/harness-jcode/src/index.ts
+++ b/packages/harness-jcode/src/index.ts
@@ -3,6 +3,7 @@ import { createJcode } from './jcode-harness';
 export const jcode = createJcode();
 
 export { createJcode } from './jcode-harness';
+export { getJcodeBootstrap, JCODE_BOOTSTRAP_DIR } from './jcode-bootstrap';
 export { VERSION } from './version';
 export type { JcodeHarnessSettings } from './jcode-harness';
 export type { JcodeClientFactory, JcodeSdkClient } from './jcode-client';

--- a/packages/harness-jcode/src/index.ts
+++ b/packages/harness-jcode/src/index.ts
@@ -1,0 +1,13 @@
+import { createJcode } from './jcode-harness';
+
+export const jcode = createJcode();
+
+export { createJcode } from './jcode-harness';
+export { VERSION } from './version';
+export type { JcodeHarnessSettings } from './jcode-harness';
+export type { JcodeClientFactory, JcodeSdkClient } from './jcode-client';
+export {
+  createJcodeTranslatorState,
+  translateJcodeEvent,
+} from './jcode-translate';
+export type { JcodeTranslatorState } from './jcode-translate';

--- a/packages/harness-jcode/src/jcode-bootstrap.test.ts
+++ b/packages/harness-jcode/src/jcode-bootstrap.test.ts
@@ -1,0 +1,37 @@
+import { readFile } from 'node:fs/promises';
+import type * as FsPromises from 'node:fs/promises';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs/promises', async importOriginal => {
+  const actual = await importOriginal<typeof FsPromises>();
+  return {
+    ...actual,
+    readFile: vi.fn(async (path: unknown) => `asset:${String(path)}`),
+  };
+});
+
+describe('getJcodeBootstrap', () => {
+  it('declares deterministic bridge assets and install verification', async () => {
+    const { getJcodeBootstrap, JCODE_BOOTSTRAP_DIR } =
+      await import('./jcode-bootstrap');
+    const first = await getJcodeBootstrap();
+    const second = await getJcodeBootstrap();
+
+    expect(second).toBe(first);
+    expect(first).toMatchObject({
+      harnessId: 'jcode',
+      bootstrapDir: JCODE_BOOTSTRAP_DIR,
+    });
+    expect(first.files.map(file => file.path)).toEqual([
+      `${JCODE_BOOTSTRAP_DIR}/package.json`,
+      `${JCODE_BOOTSTRAP_DIR}/pnpm-lock.yaml`,
+      `${JCODE_BOOTSTRAP_DIR}/pnpm-workspace.yaml`,
+      `${JCODE_BOOTSTRAP_DIR}/bridge.mjs`,
+    ]);
+    expect(first.commands[0]?.command).toContain(
+      'pnpm install --frozen-lockfile',
+    );
+    expect(first.commands[1]?.command).toContain('@1jehuang/jcode-sdk');
+    expect(readFile).toHaveBeenCalledTimes(4);
+  });
+});

--- a/packages/harness-jcode/src/jcode-bootstrap.ts
+++ b/packages/harness-jcode/src/jcode-bootstrap.ts
@@ -1,0 +1,55 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import type { HarnessV1Bootstrap } from '@ai-sdk/harness';
+
+export const JCODE_BOOTSTRAP_DIR = '.harness-bootstrap/jcode';
+
+let cachedBootstrap: HarnessV1Bootstrap | undefined;
+
+export async function getJcodeBootstrap(): Promise<HarnessV1Bootstrap> {
+  if (cachedBootstrap) return cachedBootstrap;
+  const [pkg, lock, workspace, bridge] = await Promise.all([
+    readBridgeAsset('package.json'),
+    readBridgeAsset('pnpm-lock.yaml'),
+    readBridgeAsset('pnpm-workspace.yaml'),
+    readBridgeAsset('index.mjs'),
+  ]);
+  cachedBootstrap = {
+    harnessId: 'jcode',
+    bootstrapDir: JCODE_BOOTSTRAP_DIR,
+    files: [
+      { path: `${JCODE_BOOTSTRAP_DIR}/package.json`, content: pkg },
+      { path: `${JCODE_BOOTSTRAP_DIR}/pnpm-lock.yaml`, content: lock },
+      {
+        path: `${JCODE_BOOTSTRAP_DIR}/pnpm-workspace.yaml`,
+        content: workspace,
+      },
+      { path: `${JCODE_BOOTSTRAP_DIR}/bridge.mjs`, content: bridge },
+    ],
+    commands: [
+      { command: 'pnpm install --frozen-lockfile --store-dir .pnpm-store' },
+      {
+        command:
+          'node -e "import(\'@1jehuang/jcode-sdk\').then(m => console.log(m.API_VERSION_MAJOR))"',
+      },
+    ],
+  };
+  return cachedBootstrap;
+}
+
+async function readBridgeAsset(name: string): Promise<string> {
+  const candidates = [
+    new URL(`./bridge/${name}`, import.meta.url),
+    new URL(`../bridge/${name}`, import.meta.url),
+  ];
+  let lastError: unknown;
+  for (const url of candidates) {
+    try {
+      return await readFile(fileURLToPath(url), 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      lastError = error;
+    }
+  }
+  throw lastError ?? new Error(`Jcode bridge asset not found: ${name}`);
+}

--- a/packages/harness-jcode/src/jcode-bridge-protocol.test.ts
+++ b/packages/harness-jcode/src/jcode-bridge-protocol.test.ts
@@ -25,5 +25,13 @@ describe('Jcode bridge protocol', () => {
     expect(jcodeBridgeInboundMessageSchema.parse({ type: 'abort' })).toEqual({
       type: 'abort',
     });
+    expect(
+      jcodeBridgeInboundMessageSchema.parse({
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        output: { temperature: 21 },
+        isError: false,
+      }),
+    ).toMatchObject({ type: 'tool-result', toolCallId: 'call-1' });
   });
 });

--- a/packages/harness-jcode/src/jcode-bridge-protocol.test.ts
+++ b/packages/harness-jcode/src/jcode-bridge-protocol.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  jcodeBridgeInboundMessageSchema,
+  jcodeBridgeStartMessageSchema,
+} from './jcode-bridge-protocol';
+
+describe('Jcode bridge protocol', () => {
+  it('accepts Jcode-specific start configuration', () => {
+    expect(
+      jcodeBridgeStartMessageSchema.parse({
+        type: 'start',
+        prompt: 'hello',
+        model: 'openai:test',
+        reasoningEffort: 'high',
+        resumeSessionId: 'session-1',
+      }),
+    ).toMatchObject({
+      type: 'start',
+      reasoningEffort: 'high',
+      resumeSessionId: 'session-1',
+    });
+  });
+
+  it('accepts shared bridge control commands', () => {
+    expect(jcodeBridgeInboundMessageSchema.parse({ type: 'abort' })).toEqual({
+      type: 'abort',
+    });
+  });
+});

--- a/packages/harness-jcode/src/jcode-bridge-protocol.ts
+++ b/packages/harness-jcode/src/jcode-bridge-protocol.ts
@@ -26,5 +26,8 @@ export const jcodeBridgeInboundMessageSchema = z.discriminatedUnion('type', [
   jcodeBridgeStartMessageSchema,
   ...harnessV1BridgeInboundCommandSchemas,
 ]);
+export type JcodeBridgeInboundMessage = z.infer<
+  typeof jcodeBridgeInboundMessageSchema
+>;
 
 export const jcodeBridgeReadySchema = harnessV1BridgeReadySchema;

--- a/packages/harness-jcode/src/jcode-bridge-protocol.ts
+++ b/packages/harness-jcode/src/jcode-bridge-protocol.ts
@@ -1,0 +1,30 @@
+import {
+  harnessV1BridgeInboundCommandSchemas,
+  harnessV1BridgeOutboundMessageSchema,
+  harnessV1BridgeReadySchema,
+  harnessV1BridgeStartBaseSchema,
+} from '@ai-sdk/harness';
+import { z } from 'zod/v4';
+
+export const jcodeBridgeOutboundMessageSchema =
+  harnessV1BridgeOutboundMessageSchema;
+export type JcodeBridgeOutboundMessage = z.infer<
+  typeof jcodeBridgeOutboundMessageSchema
+>;
+
+export const jcodeBridgeStartMessageSchema =
+  harnessV1BridgeStartBaseSchema.extend({
+    operation: z.enum(['prompt', 'compact']).optional(),
+    reasoningEffort: z.string().optional(),
+    resumeSessionId: z.string().optional(),
+  });
+export type JcodeBridgeStartMessage = z.infer<
+  typeof jcodeBridgeStartMessageSchema
+>;
+
+export const jcodeBridgeInboundMessageSchema = z.discriminatedUnion('type', [
+  jcodeBridgeStartMessageSchema,
+  ...harnessV1BridgeInboundCommandSchemas,
+]);
+
+export const jcodeBridgeReadySchema = harnessV1BridgeReadySchema;

--- a/packages/harness-jcode/src/jcode-bridge-session.test.ts
+++ b/packages/harness-jcode/src/jcode-bridge-session.test.ts
@@ -1,0 +1,158 @@
+import type { Experimental_SandboxProcess } from '@ai-sdk/provider-utils';
+import { describe, expect, it } from 'vitest';
+import type { JcodeBridgeOutboundMessage } from './jcode-bridge-protocol';
+import {
+  createJcodeBridgeSession,
+  type JcodeBridgeChannel,
+} from './jcode-bridge-session';
+
+class FakeChannel {
+  readonly sent: unknown[] = [];
+  private readonly listeners = new Map<
+    string,
+    Set<(message: JcodeBridgeOutboundMessage) => void>
+  >();
+  private closed = false;
+
+  on(type: string, listener: (message: JcodeBridgeOutboundMessage) => void) {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+    return () => listeners.delete(listener);
+  }
+
+  onClose() {}
+  beginClose() {}
+  isClosed() {
+    return this.closed;
+  }
+  send(message: unknown) {
+    this.sent.push(message);
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(message: JcodeBridgeOutboundMessage) {
+    for (const listener of this.listeners.get(message.type) ?? []) {
+      listener(message);
+    }
+  }
+}
+
+const fakeProcess = (): Experimental_SandboxProcess =>
+  ({
+    stdout: new ReadableStream(),
+    stderr: new ReadableStream(),
+    wait: async () => ({ exitCode: 0 }),
+    kill: async () => {},
+  }) as Experimental_SandboxProcess;
+
+describe('createJcodeBridgeSession', () => {
+  it('sends typed prompt and compaction turns and forwards stream events', async () => {
+    const channel = new FakeChannel();
+    const session = createJcodeBridgeSession({
+      sessionId: 'session-1',
+      channel: channel as unknown as JcodeBridgeChannel,
+      proc: fakeProcess(),
+      model: 'test-model',
+      reasoningEffort: 'high',
+      jcodeHome: '/sandbox/jcode-home',
+    });
+    const emitted: JcodeBridgeOutboundMessage[] = [];
+    const control = await session.doPromptTurn({
+      prompt: 'hello',
+      instructions: 'be concise',
+      emit: part => emitted.push(part as JcodeBridgeOutboundMessage),
+    });
+    expect(channel.sent[0]).toMatchObject({
+      type: 'start',
+      operation: 'prompt',
+      model: 'test-model',
+      reasoningEffort: 'high',
+    });
+    expect((channel.sent[0] as { prompt: string }).prompt).toContain(
+      'be concise',
+    );
+
+    channel.emit({ type: 'text-start', id: 'text-1' });
+    channel.emit({ type: 'text-delta', id: 'text-1', delta: 'hello' });
+    channel.emit({ type: 'text-end', id: 'text-1' });
+    channel.emit({
+      type: 'finish',
+      finishReason: { unified: 'stop', raw: 'stop' },
+      totalUsage: {
+        inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+        outputTokens: { total: 0, text: 0, reasoning: 0 },
+      },
+    });
+    await control.done;
+    expect(emitted.map(part => part.type)).toEqual([
+      'text-start',
+      'text-delta',
+      'text-end',
+      'finish',
+    ]);
+
+    const compact = session.doCompact();
+    expect(channel.sent.at(-1)).toMatchObject({
+      type: 'start',
+      operation: 'compact',
+    });
+    channel.emit({
+      type: 'finish',
+      finishReason: { unified: 'stop', raw: 'compact' },
+      totalUsage: {
+        inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+        outputTokens: { total: 0, text: 0, reasoning: 0 },
+      },
+    });
+    await compact;
+  });
+
+  it('rejects unsupported tools, suspend, continue, and detach', async () => {
+    const session = createJcodeBridgeSession({
+      sessionId: 'session-1',
+      channel: new FakeChannel() as unknown as JcodeBridgeChannel,
+      proc: fakeProcess(),
+      jcodeHome: '/sandbox/jcode-home',
+    });
+    await expect(
+      session.doPromptTurn({
+        prompt: 'hello',
+        tools: [{ name: 'tool', inputSchema: {} }],
+        emit: () => {},
+      }),
+    ).rejects.toThrow('host-defined tools are not supported yet');
+    await expect(session.doSuspendTurn()).rejects.toThrow(
+      'turn suspension is not supported yet',
+    );
+    await expect(session.doContinueTurn({ emit: () => {} })).rejects.toThrow(
+      'turn continuation is not supported yet',
+    );
+    await expect(session.doDetach()).rejects.toThrow(
+      'detaching a live sandbox bridge is not supported yet',
+    );
+  });
+
+  it('returns bridge stop data as resumable state', async () => {
+    const channel = new FakeChannel();
+    const session = createJcodeBridgeSession({
+      sessionId: 'session-1',
+      channel: channel as unknown as JcodeBridgeChannel,
+      proc: fakeProcess(),
+      jcodeHome: '/sandbox/jcode-home',
+    });
+    const stopping = session.doStop();
+    channel.emit({
+      type: 'bridge-stop',
+      data: { jcodeSessionId: 'native-session' },
+    });
+    await expect(stopping).resolves.toMatchObject({
+      type: 'resume-session',
+      data: {
+        jcodeSessionId: 'native-session',
+        jcodeHome: '/sandbox/jcode-home',
+      },
+    });
+  });
+});

--- a/packages/harness-jcode/src/jcode-bridge-session.test.ts
+++ b/packages/harness-jcode/src/jcode-bridge-session.test.ts
@@ -211,20 +211,52 @@ describe('createJcodeBridgeSession', () => {
     },
   );
 
-  it('rejects unsupported tools, suspend, continue, and detach', async () => {
+  it('forwards host tools and their results over the bridge', async () => {
+    const channel = new FakeChannel();
+    const session = createJcodeBridgeSession({
+      sessionId: 'session-1',
+      channel: channel as unknown as JcodeBridgeChannel,
+      proc: fakeProcess(),
+      jcodeHome: '/sandbox/jcode-home',
+    });
+    const control = await session.doPromptTurn({
+      prompt: 'hello',
+      tools: [{ name: 'weather', description: 'Get weather', inputSchema: {} }],
+      emit: () => {},
+    });
+    expect(channel.sent[0]).toMatchObject({
+      type: 'start',
+      tools: [{ name: 'weather', description: 'Get weather', inputSchema: {} }],
+    });
+    await control.submitToolResult({
+      toolCallId: 'call-1',
+      output: { temperature: 21 },
+      isError: false,
+    });
+    expect(channel.sent[1]).toEqual({
+      type: 'tool-result',
+      toolCallId: 'call-1',
+      output: { temperature: 21 },
+      isError: false,
+    });
+    channel.emit({
+      type: 'finish',
+      finishReason: { unified: 'stop', raw: 'stop' },
+      totalUsage: {
+        inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+        outputTokens: { total: 0, text: 0, reasoning: 0 },
+      },
+    });
+    await control.done;
+  });
+
+  it('rejects unsupported suspend, continue, and detach', async () => {
     const session = createJcodeBridgeSession({
       sessionId: 'session-1',
       channel: new FakeChannel() as unknown as JcodeBridgeChannel,
       proc: fakeProcess(),
       jcodeHome: '/sandbox/jcode-home',
     });
-    await expect(
-      session.doPromptTurn({
-        prompt: 'hello',
-        tools: [{ name: 'tool', inputSchema: {} }],
-        emit: () => {},
-      }),
-    ).rejects.toThrow('host-defined tools are not supported yet');
     await expect(session.doSuspendTurn()).rejects.toThrow(
       'turn suspension is not supported yet',
     );

--- a/packages/harness-jcode/src/jcode-bridge-session.test.ts
+++ b/packages/harness-jcode/src/jcode-bridge-session.test.ts
@@ -1,5 +1,5 @@
 import type { Experimental_SandboxProcess } from '@ai-sdk/provider-utils';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { JcodeBridgeOutboundMessage } from './jcode-bridge-protocol';
 import {
   createJcodeBridgeSession,
@@ -13,6 +13,9 @@ class FakeChannel {
     Set<(message: JcodeBridgeOutboundMessage) => void>
   >();
   private closed = false;
+  private closeListener:
+    | ((code: number | undefined, reason: string | undefined) => void)
+    | undefined;
 
   on(type: string, listener: (message: JcodeBridgeOutboundMessage) => void) {
     const listeners = this.listeners.get(type) ?? new Set();
@@ -21,7 +24,11 @@ class FakeChannel {
     return () => listeners.delete(listener);
   }
 
-  onClose() {}
+  onClose(
+    listener: (code: number | undefined, reason: string | undefined) => void,
+  ) {
+    this.closeListener = listener;
+  }
   beginClose() {}
   isClosed() {
     return this.closed;
@@ -36,6 +43,9 @@ class FakeChannel {
     for (const listener of this.listeners.get(message.type) ?? []) {
       listener(message);
     }
+  }
+  emitClose(code?: number, reason?: string) {
+    this.closeListener?.(code, reason);
   }
 }
 
@@ -108,6 +118,98 @@ describe('createJcodeBridgeSession', () => {
     });
     await compact;
   });
+
+  it('sends resume identity without reframing instructions', async () => {
+    const channel = new FakeChannel();
+    const session = createJcodeBridgeSession({
+      sessionId: 'session-1',
+      channel: channel as unknown as JcodeBridgeChannel,
+      proc: fakeProcess(),
+      resumeJcodeSessionId: 'native-session',
+      jcodeHome: '/sandbox/jcode-home',
+    });
+
+    const control = await session.doPromptTurn({
+      prompt: 'continue',
+      instructions: 'must not be injected on resume',
+      emit: () => {},
+    });
+
+    expect(channel.sent).toEqual([
+      {
+        type: 'start',
+        operation: 'prompt',
+        prompt: 'continue',
+        resumeSessionId: 'native-session',
+      },
+    ]);
+    channel.emit({
+      type: 'finish',
+      finishReason: { unified: 'stop', raw: 'stop' },
+      totalUsage: {
+        inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+        outputTokens: { total: 0, text: 0, reasoning: 0 },
+      },
+    });
+    await control.done;
+  });
+
+  it('aborts an active turn and rejects when the bridge closes early', async () => {
+    const channel = new FakeChannel();
+    const session = createJcodeBridgeSession({
+      sessionId: 'session-1',
+      channel: channel as unknown as JcodeBridgeChannel,
+      proc: fakeProcess(),
+      jcodeHome: '/sandbox/jcode-home',
+    });
+    const abort = new AbortController();
+    const aborted = await session.doPromptTurn({
+      prompt: 'wait',
+      abortSignal: abort.signal,
+      emit: () => {},
+    });
+    abort.abort(new Error('cancelled'));
+
+    await expect(aborted.done).rejects.toThrow('cancelled');
+    expect(channel.sent).toContainEqual({ type: 'abort' });
+
+    const closing = await session.doPromptTurn({
+      prompt: 'again',
+      emit: () => {},
+    });
+    channel.emitClose(1006, 'socket lost');
+    await expect(closing.done).rejects.toThrow(
+      'jcode bridge closed before the turn finished: socket lost',
+    );
+  });
+
+  it.each(['doStop', 'doDestroy'] as const)(
+    '%s closes the channel and kills the bridge process',
+    async operation => {
+      const channel = new FakeChannel();
+      const proc = fakeProcess();
+      proc.wait = vi.fn(async () => ({ exitCode: 0 }));
+      proc.kill = vi.fn(async () => {});
+      const session = createJcodeBridgeSession({
+        sessionId: 'session-1',
+        channel: channel as unknown as JcodeBridgeChannel,
+        proc,
+        jcodeHome: '/sandbox/jcode-home',
+      });
+
+      const closing = session[operation]();
+      if (operation === 'doStop') {
+        channel.emit({ type: 'bridge-stop', data: {} });
+      }
+      await closing;
+
+      expect(channel.isClosed()).toBe(true);
+      expect(proc.kill).toHaveBeenCalledOnce();
+      await expect(
+        session.doPromptTurn({ prompt: 'closed', emit: () => {} }),
+      ).rejects.toThrow('jcode harness session is closed');
+    },
+  );
 
   it('rejects unsupported tools, suspend, continue, and detach', async () => {
     const session = createJcodeBridgeSession({

--- a/packages/harness-jcode/src/jcode-bridge-session.ts
+++ b/packages/harness-jcode/src/jcode-bridge-session.ts
@@ -1,0 +1,263 @@
+import {
+  HarnessCapabilityUnsupportedError,
+  type HarnessV1PromptControl,
+  type HarnessV1PromptTurnOptions,
+  type HarnessV1ResumeSessionState,
+  type HarnessV1Session,
+  type HarnessV1StreamPart,
+} from '@ai-sdk/harness';
+import type { SandboxChannel } from '@ai-sdk/harness/utils';
+import type { Experimental_SandboxProcess } from '@ai-sdk/provider-utils';
+import type {
+  JcodeBridgeOutboundMessage,
+  JcodeBridgeStartMessage,
+} from './jcode-bridge-protocol';
+import { extractJcodePrompt, frameJcodeInstructions } from './jcode-utils';
+
+export type JcodeBridgeChannel = SandboxChannel<
+  JcodeBridgeOutboundMessage,
+  | JcodeBridgeStartMessage
+  | { type: 'abort' }
+  | { type: 'stop' }
+  | { type: 'destroy' }
+>;
+
+export interface CreateJcodeBridgeSessionInput {
+  readonly sessionId: string;
+  readonly channel: JcodeBridgeChannel;
+  readonly proc: Experimental_SandboxProcess;
+  readonly model?: string;
+  readonly reasoningEffort?: string;
+  readonly resumeJcodeSessionId?: string;
+  readonly jcodeHome: string;
+}
+
+const unsupported = (message: string) =>
+  new HarnessCapabilityUnsupportedError({
+    harnessId: 'jcode',
+    message: `jcode: ${message}`,
+  });
+
+export function createJcodeBridgeSession({
+  sessionId,
+  channel,
+  proc,
+  model,
+  reasoningEffort,
+  resumeJcodeSessionId,
+  jcodeHome,
+}: CreateJcodeBridgeSessionInput): HarnessV1Session {
+  let closed = false;
+  let firstPrompt = resumeJcodeSessionId == null;
+  let activeDone: Promise<void> | undefined;
+
+  const assertOpen = () => {
+    if (closed) throw new Error('jcode harness session is closed');
+  };
+
+  const wireTurn = ({
+    emit,
+    abortSignal,
+  }: Pick<
+    HarnessV1PromptTurnOptions,
+    'emit' | 'abortSignal'
+  >): HarnessV1PromptControl => {
+    if (activeDone) throw new Error('a Jcode turn is already active');
+
+    let resolveDone!: () => void;
+    let rejectDone!: (error: unknown) => void;
+    const done = new Promise<void>((resolve, reject) => {
+      resolveDone = resolve;
+      rejectDone = reject;
+    });
+    activeDone = done;
+    let settled = false;
+    const unsubs: Array<() => void> = [];
+
+    const settle = (error?: unknown) => {
+      if (settled) return;
+      settled = true;
+      for (const unsubscribe of unsubs) unsubscribe();
+      abortSignal?.removeEventListener('abort', onAbort);
+      activeDone = undefined;
+      error === undefined ? resolveDone() : rejectDone(error);
+    };
+    const forward = (part: HarnessV1StreamPart) => {
+      try {
+        emit(part);
+      } catch {}
+    };
+    const eventTypes = [
+      'stream-start',
+      'text-start',
+      'text-delta',
+      'text-end',
+      'reasoning-start',
+      'reasoning-delta',
+      'reasoning-end',
+      'tool-call',
+      'tool-result',
+      'file-change',
+      'finish-step',
+      'compaction',
+      'raw',
+    ] as const;
+    for (const type of eventTypes) {
+      unsubs.push(channel.on(type, message => forward(message)));
+    }
+    unsubs.push(
+      channel.on('finish', message => {
+        forward(message);
+        settle();
+      }),
+      channel.on('error', message => {
+        forward(message);
+        settle(message.error);
+      }),
+    );
+    channel.onClose((_code, reason) => {
+      if (!settled) {
+        settle(
+          new Error(
+            `jcode bridge closed before the turn finished${reason ? `: ${reason}` : ''}`,
+          ),
+        );
+      }
+    });
+
+    function onAbort() {
+      if (settled) return;
+      try {
+        channel.send({ type: 'abort' });
+      } catch {}
+      settle(abortSignal?.reason ?? new DOMException('Aborted', 'AbortError'));
+    }
+    if (abortSignal?.aborted) onAbort();
+    else abortSignal?.addEventListener('abort', onAbort, { once: true });
+
+    return {
+      done,
+      async submitToolResult() {
+        throw unsupported('host-defined tools are not supported yet');
+      },
+      async submitUserMessage() {
+        throw unsupported('mid-turn user messages are not supported yet');
+      },
+    };
+  };
+
+  const startTurn = (
+    options: HarnessV1PromptTurnOptions,
+    operation: 'prompt' | 'compact',
+    prompt: string,
+  ) => {
+    const control = wireTurn(options);
+    channel.send({
+      type: 'start',
+      operation,
+      prompt,
+      ...(model ? { model } : {}),
+      ...(reasoningEffort ? { reasoningEffort } : {}),
+      ...(resumeJcodeSessionId
+        ? { resumeSessionId: resumeJcodeSessionId }
+        : {}),
+    });
+    return control;
+  };
+
+  const teardown = async (operation: 'stop' | 'destroy') => {
+    channel.beginClose();
+    try {
+      if (!channel.isClosed()) channel.send({ type: operation });
+    } catch {}
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        proc.wait(),
+        new Promise<void>(resolve => {
+          timer = setTimeout(resolve, 5000);
+          timer.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+      try {
+        await proc.kill();
+      } catch {}
+      channel.close();
+    }
+  };
+
+  return {
+    sessionId,
+    isResume: resumeJcodeSessionId != null,
+    ...(model ? { modelId: model } : {}),
+    async doPromptTurn(options) {
+      assertOpen();
+      if (options.responseFormat?.type === 'json') {
+        throw unsupported('JSON response format is not supported yet');
+      }
+      if (options.tools?.length) {
+        throw unsupported('host-defined tools are not supported yet');
+      }
+      let prompt = extractJcodePrompt(options.prompt);
+      if (firstPrompt && options.instructions) {
+        prompt = frameJcodeInstructions(options.instructions, prompt);
+      }
+      firstPrompt = false;
+      return startTurn(options, 'prompt', prompt);
+    },
+    async doCompact(customInstructions) {
+      assertOpen();
+      if (customInstructions) {
+        throw unsupported('custom compaction instructions are not supported');
+      }
+      const control = startTurn({ prompt: '', emit: () => {} }, 'compact', '');
+      await control.done;
+    },
+    async doContinueTurn() {
+      throw unsupported('turn continuation is not supported yet');
+    },
+    async doSuspendTurn() {
+      throw unsupported('turn suspension is not supported yet');
+    },
+    async doDetach() {
+      throw unsupported(
+        'detaching a live sandbox bridge is not supported yet; use stop',
+      );
+    },
+    async doStop() {
+      assertOpen();
+      let stopData: unknown;
+      const stopReceived = new Promise<void>(resolve => {
+        const unsubscribe = channel.on('bridge-stop', message => {
+          stopData = message.data;
+          unsubscribe();
+          resolve();
+        });
+      });
+      channel.send({ type: 'stop' });
+      await Promise.race([
+        stopReceived,
+        new Promise<void>(resolve => setTimeout(resolve, 5000)),
+      ]);
+      closed = true;
+      await teardown('stop');
+      const data =
+        typeof stopData === 'object' && stopData != null
+          ? { ...stopData, jcodeHome }
+          : { jcodeHome };
+      return {
+        type: 'resume-session',
+        harnessId: 'jcode',
+        specificationVersion: 'harness-v1',
+        data,
+      } satisfies HarnessV1ResumeSessionState;
+    },
+    async doDestroy() {
+      if (closed) return;
+      closed = true;
+      await teardown('destroy');
+    },
+  };
+}

--- a/packages/harness-jcode/src/jcode-bridge-session.ts
+++ b/packages/harness-jcode/src/jcode-bridge-session.ts
@@ -9,17 +9,14 @@ import {
 import type { SandboxChannel } from '@ai-sdk/harness/utils';
 import type { Experimental_SandboxProcess } from '@ai-sdk/provider-utils';
 import type {
+  JcodeBridgeInboundMessage,
   JcodeBridgeOutboundMessage,
-  JcodeBridgeStartMessage,
 } from './jcode-bridge-protocol';
 import { extractJcodePrompt, frameJcodeInstructions } from './jcode-utils';
 
 export type JcodeBridgeChannel = SandboxChannel<
   JcodeBridgeOutboundMessage,
-  | JcodeBridgeStartMessage
-  | { type: 'abort' }
-  | { type: 'stop' }
-  | { type: 'destroy' }
+  JcodeBridgeInboundMessage
 >;
 
 export interface CreateJcodeBridgeSessionInput {
@@ -137,8 +134,9 @@ export function createJcodeBridgeSession({
 
     return {
       done,
-      async submitToolResult() {
-        throw unsupported('host-defined tools are not supported yet');
+      async submitToolResult(result) {
+        assertOpen();
+        channel.send({ type: 'tool-result', ...result });
       },
       async submitUserMessage() {
         throw unsupported('mid-turn user messages are not supported yet');
@@ -156,6 +154,7 @@ export function createJcodeBridgeSession({
       type: 'start',
       operation,
       prompt,
+      ...(options.tools?.length ? { tools: [...options.tools] } : {}),
       ...(model ? { model } : {}),
       ...(reasoningEffort ? { reasoningEffort } : {}),
       ...(resumeJcodeSessionId
@@ -196,9 +195,6 @@ export function createJcodeBridgeSession({
       assertOpen();
       if (options.responseFormat?.type === 'json') {
         throw unsupported('JSON response format is not supported yet');
-      }
-      if (options.tools?.length) {
-        throw unsupported('host-defined tools are not supported yet');
       }
       let prompt = extractJcodePrompt(options.prompt);
       if (firstPrompt && options.instructions) {

--- a/packages/harness-jcode/src/jcode-client.ts
+++ b/packages/harness-jcode/src/jcode-client.ts
@@ -5,8 +5,34 @@ import {
   type LaunchOptions,
 } from '@1jehuang/jcode-sdk';
 
+export interface JcodeExternalToolDefinition {
+  readonly name: string;
+  readonly description?: string;
+  readonly input_schema?: unknown;
+}
+
+export interface JcodeExternalToolResult {
+  readonly call_id: string;
+  readonly output: unknown;
+  readonly is_error?: boolean;
+  readonly error_message?: string;
+}
+
+export type JcodeExternalToolCallEvent = {
+  readonly ev: 'external_tool_call';
+  readonly session_id: string;
+  readonly root_session_id: string;
+  readonly call_id: string;
+  readonly catalog_revision: number;
+  readonly name: string;
+  readonly input: unknown;
+};
+
+export type JcodeSdkEvent = ApiEvent | JcodeExternalToolCallEvent;
+
 export interface JcodeSdkClient {
   readonly instanceHome?: string;
+  supports(capability: string): boolean;
   createSession(workingDir?: string): Promise<{ session_id: string }>;
   attachSession(sessionId: string): Promise<{ session_id: string }>;
   detachSession(sessionId: string): Promise<void>;
@@ -20,7 +46,15 @@ export interface JcodeSdkClient {
   compact(sessionId: string): Promise<string>;
   setModel(sessionId: string, model: string): Promise<void>;
   setReasoningEffort(sessionId: string, effort: string): Promise<void>;
-  events(sessionId?: string): AsyncIterableIterator<ApiEvent>;
+  setExternalTools(
+    sessionId: string,
+    tools: readonly JcodeExternalToolDefinition[],
+  ): Promise<void>;
+  submitExternalToolResult(
+    sessionId: string,
+    result: JcodeExternalToolResult,
+  ): Promise<void>;
+  events(sessionId?: string): AsyncIterableIterator<JcodeSdkEvent>;
   close(): Promise<void>;
 }
 
@@ -28,8 +62,8 @@ export type JcodeClientFactory = (
   options: LaunchOptions & ConnectOptions,
 ) => Promise<JcodeSdkClient>;
 
-export const launchJcodeClient: JcodeClientFactory = options =>
-  JcodeClient.launch(options);
+export const launchJcodeClient: JcodeClientFactory = async options =>
+  (await JcodeClient.launch(options)) as unknown as JcodeSdkClient;
 
 // `JcodeClient.close()` shuts down instances it launched. A between-turn
 // HarnessV1 detach must leave that runtime alive, so retain the connection for

--- a/packages/harness-jcode/src/jcode-client.ts
+++ b/packages/harness-jcode/src/jcode-client.ts
@@ -1,0 +1,53 @@
+import {
+  JcodeClient,
+  type ApiEvent,
+  type ConnectOptions,
+  type LaunchOptions,
+} from '@1jehuang/jcode-sdk';
+
+export interface JcodeSdkClient {
+  readonly instanceHome?: string;
+  createSession(workingDir?: string): Promise<{ session_id: string }>;
+  attachSession(sessionId: string): Promise<{ session_id: string }>;
+  detachSession(sessionId: string): Promise<void>;
+  sendMessage(sessionId: string, content: string): Promise<void>;
+  cancel(sessionId: string): Promise<void>;
+  softInterrupt(
+    sessionId: string,
+    content: string,
+    urgent?: boolean,
+  ): Promise<void>;
+  compact(sessionId: string): Promise<string>;
+  setModel(sessionId: string, model: string): Promise<void>;
+  setReasoningEffort(sessionId: string, effort: string): Promise<void>;
+  events(sessionId?: string): AsyncIterableIterator<ApiEvent>;
+  close(): Promise<void>;
+}
+
+export type JcodeClientFactory = (
+  options: LaunchOptions & ConnectOptions,
+) => Promise<JcodeSdkClient>;
+
+export const launchJcodeClient: JcodeClientFactory = options =>
+  JcodeClient.launch(options);
+
+// `JcodeClient.close()` shuts down instances it launched. A between-turn
+// HarnessV1 detach must leave that runtime alive, so retain the connection for
+// lossless same-process resume. Cross-process resume uses the persisted
+// `jcodeHome` and launches a new daemon after `doStop`.
+const parkedClients = new Map<string, JcodeSdkClient>();
+
+export function parkJcodeClient(
+  jcodeSessionId: string,
+  client: JcodeSdkClient,
+): void {
+  parkedClients.set(jcodeSessionId, client);
+}
+
+export function takeParkedJcodeClient(
+  jcodeSessionId: string,
+): JcodeSdkClient | undefined {
+  const client = parkedClients.get(jcodeSessionId);
+  parkedClients.delete(jcodeSessionId);
+  return client;
+}

--- a/packages/harness-jcode/src/jcode-harness.test-d.ts
+++ b/packages/harness-jcode/src/jcode-harness.test-d.ts
@@ -1,0 +1,10 @@
+import type { HarnessV1 } from '@ai-sdk/harness';
+import { expectTypeOf } from 'vitest';
+import { createJcode, type JcodeHarnessSettings } from './index';
+
+expectTypeOf(createJcode()).toMatchTypeOf<HarnessV1>();
+expectTypeOf<JcodeHarnessSettings>().toMatchTypeOf<{
+  model?: string;
+  reasoningEffort?: string;
+  jcodeHome?: string;
+}>();

--- a/packages/harness-jcode/src/jcode-harness.test.ts
+++ b/packages/harness-jcode/src/jcode-harness.test.ts
@@ -1,31 +1,329 @@
-import { describe, expect, it } from 'vitest';
+import type { HarnessV1NetworkSandboxSession } from '@ai-sdk/harness';
+import type * as HarnessUtils from '@ai-sdk/harness/utils';
+import type { Experimental_SandboxProcess } from '@ai-sdk/provider-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createJcode } from './jcode-harness';
 
+const mocks = vi.hoisted(() => ({
+  socketUrls: [] as string[],
+}));
+
+vi.mock('@ai-sdk/harness/utils', async importOriginal => {
+  const actual = await importOriginal<typeof HarnessUtils>();
+  return {
+    ...actual,
+    SandboxChannel: class {
+      private socket: { close(): void } | undefined;
+      constructor(
+        private readonly options: {
+          connect: () => Promise<{ close(): void }>;
+        },
+      ) {}
+      async open() {
+        this.socket = await this.options.connect();
+      }
+      on() {
+        return () => {};
+      }
+      onClose() {}
+      beginClose() {}
+      isClosed() {
+        return false;
+      }
+      send() {}
+      close() {
+        this.socket?.close();
+      }
+    },
+  };
+});
+
+vi.mock('ws', () => ({
+  WebSocket: class {
+    private readonly listeners = new Map<
+      string,
+      (...args: unknown[]) => void
+    >();
+    constructor(url: string) {
+      mocks.socketUrls.push(url);
+      queueMicrotask(() => this.listeners.get('open')?.());
+    }
+    once(type: string, listener: (...args: unknown[]) => void) {
+      this.listeners.set(type, listener);
+    }
+    close() {}
+  },
+}));
+
+function textStream(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      if (text) controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+}
+
+function networkSandbox({
+  stdout = '{"type":"bridge-ready","port":4319}\n',
+  stderr = '',
+  exitCode = 0,
+  runs = [],
+  spawns = [],
+  spawnEnvs = [],
+  endpoint = { url: 'ws://sandbox.example/bridge?existing=1' },
+}: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  runs?: string[];
+  spawns?: string[];
+  spawnEnvs?: Array<Record<string, string | undefined>>;
+  endpoint?: { url: string; headers?: Readonly<Record<string, string>> };
+} = {}): HarnessV1NetworkSandboxSession {
+  const proc = {
+    stdout: textStream(stdout),
+    stderr: textStream(stderr),
+    wait: async () => ({ exitCode }),
+    kill: async () => {},
+  } as Experimental_SandboxProcess;
+  const restricted = {
+    run: async ({ command }: { command: string }) => {
+      runs.push(command);
+      return { exitCode: 0, stdout: '', stderr: '' };
+    },
+    readTextFile: async () => null,
+    writeTextFile: async () => {},
+    spawn: async ({
+      command,
+      env,
+    }: {
+      command: string;
+      env?: Record<string, string | undefined>;
+    }) => {
+      spawns.push(command);
+      if (env) spawnEnvs.push(env);
+      return proc;
+    },
+  };
+  return {
+    id: 'sandbox-1',
+    defaultWorkingDirectory: '/sandbox',
+    restricted: () => restricted,
+    ports: [4319],
+    getPortEndpoint: vi.fn(async () => endpoint),
+    getPortUrl: vi.fn(async () => endpoint.url),
+    stop: async () => {},
+    ...restricted,
+  } as unknown as HarnessV1NetworkSandboxSession;
+}
+
 describe('createJcode', () => {
+  beforeEach(() => {
+    mocks.socketUrls.length = 0;
+  });
+
   it('declares the foundational HarnessV1 capabilities honestly', () => {
-    const harness = createJcode();
-    expect(harness).toMatchObject({
+    expect(createJcode()).toMatchObject({
       specificationVersion: 'harness-v1',
       harnessId: 'jcode',
       builtinTools: {},
       supportsBuiltinToolApprovals: false,
       supportsBuiltinToolFiltering: false,
+      getBootstrap: expect.any(Function),
     });
   });
 
-  it('exposes the deterministic sandbox bootstrap recipe', () => {
-    const harness = createJcode();
-    expect(harness.getBootstrap).toBeDefined();
+  it('starts the bridge with quoted paths, transformed env, endpoint, and token', async () => {
+    const runs: string[] = [];
+    const spawns: string[] = [];
+    const spawnEnvs: Array<Record<string, string | undefined>> = [];
+    const sandbox = networkSandbox({ runs, spawns, spawnEnvs });
+    const harness = createJcode({
+      env: { API_KEY: 'secret' },
+      jcodeHome: "/custom/jcode home's",
+      mintBridgeToken: id => `token-${id}`,
+    });
+
+    const session = await harness.doStart({
+      sessionId: 's1; unsafe',
+      sandboxSession: sandbox,
+      sessionWorkDir: "/sandbox/work dir's",
+    });
+
+    expect(runs[0]).toBe(
+      "mkdir -p '/sandbox/work dir'\\''s' '/sandbox/.agent-runs/s1; unsafe/bridge' '/custom/jcode home'\\''s'",
+    );
+    expect(spawns).toEqual([
+      "node '/sandbox/.harness-bootstrap/jcode/bridge.mjs' --workdir '/sandbox/work dir'\\''s' --bridge-state-dir '/sandbox/.agent-runs/s1; unsafe/bridge' --jcode-home '/custom/jcode home'\\''s'",
+    ]);
+    expect(spawnEnvs).toEqual([
+      {
+        API_KEY: 'secret',
+        BRIDGE_CHANNEL_TOKEN: 'token-sandbox-1',
+        BRIDGE_WS_PORT: '4319',
+      },
+    ]);
+    expect(sandbox.getPortEndpoint).toHaveBeenCalledWith({
+      port: 4319,
+      protocol: 'ws',
+    });
+    expect(mocks.socketUrls).toEqual([
+      'ws://sandbox.example/bridge?existing=1&token=token-sandbox-1',
+    ]);
+    expect(session.sessionId).toBe('s1; unsafe');
   });
 
-  it('requires bridge port settings for a basic sandbox', async () => {
-    const harness = createJcode();
+  it('includes bridge output and exit status when startup fails', async () => {
+    const harness = createJcode({ startupTimeoutMs: 50 });
+    let error: Error | undefined;
+    try {
+      await harness.doStart({
+        sessionId: 'failed',
+        sandboxSession: networkSandbox({
+          stdout: 'bridge diagnostic\n',
+          stderr: 'fatal detail\n',
+          exitCode: 23,
+        }),
+        sessionWorkDir: '/sandbox/work',
+      });
+    } catch (cause) {
+      error = cause as Error;
+    }
+
+    expect(error?.message).toContain(
+      'jcode bridge exited before becoming ready.',
+    );
+    expect(error?.message).toContain('bridge diagnostic');
+    expect(error?.message).toContain('fatal detail');
+    expect(error?.message).toContain('23');
+  });
+
+  it.each([
+    {
+      name: 'basic sandbox without explicit networking',
+      harness: createJcode(),
+      sandboxSession: {} as never,
+      expected: 'explicit `port` and `portEndpoint`',
+    },
+    {
+      name: 'network sandbox without an exposed port',
+      harness: createJcode(),
+      sandboxSession: { ...networkSandbox(), ports: [] },
+      expected: 'a TCP port must be exposed',
+    },
+    {
+      name: 'token factory with an id-less basic sandbox',
+      harness: createJcode({
+        port: 4319,
+        portEndpoint: { url: 'ws://localhost:4319' },
+        mintBridgeToken: () => 'token',
+      }),
+      sandboxSession: {
+        restricted: () => ({}),
+      } as never,
+      expected:
+        '`mintBridgeToken` requires a sandbox session that exposes an id',
+    },
+  ])('rejects $name', async ({ harness, sandboxSession, expected }) => {
     await expect(
       harness.doStart({
         sessionId: 'test',
-        sandboxSession: {} as never,
+        sandboxSession,
         sessionWorkDir: '/workspace',
       }),
-    ).rejects.toThrow('explicit `port` and `portEndpoint`');
+    ).rejects.toThrow(expected);
+  });
+
+  it('rejects malformed resume state and unsupported continuation before launch', async () => {
+    const clientFactory = vi.fn();
+    const harness = createJcode({
+      experimentalHostExecution: true,
+      clientFactory,
+    });
+    const base = {
+      sessionId: 'test',
+      sandboxSession: {} as never,
+      sessionWorkDir: '/workspace',
+    };
+
+    await expect(
+      harness.doStart({
+        ...base,
+        resumeFrom: {
+          type: 'resume-session',
+          specificationVersion: 'harness-v1',
+          harnessId: 'jcode',
+          data: { jcodeSessionId: 42 },
+        },
+      }),
+    ).rejects.toThrow();
+    await expect(
+      harness.doStart({
+        ...base,
+        continueFrom: {
+          type: 'continue-turn',
+          specificationVersion: 'harness-v1',
+          harnessId: 'jcode',
+          data: {},
+        } as never,
+      }),
+    ).rejects.toThrow('turn continuation is not supported yet');
+    expect(clientFactory).not.toHaveBeenCalled();
+  });
+
+  it('transforms host launch options and resume state without mutating env', async () => {
+    const env = { API_KEY: 'secret' };
+    const client = {
+      instanceHome: '/resumed/home',
+      attachSession: vi.fn(async () => ({ session_id: 'native-1' })),
+      createSession: vi.fn(),
+      detachSession: vi.fn(),
+      sendMessage: vi.fn(),
+      cancel: vi.fn(),
+      softInterrupt: vi.fn(),
+      compact: vi.fn(),
+      setModel: vi.fn(),
+      setReasoningEffort: vi.fn(),
+      events: vi.fn(() => (async function* () {})()),
+      close: vi.fn(),
+    };
+    const clientFactory = vi.fn(async () => client);
+    const harness = createJcode({
+      experimentalHostExecution: true,
+      env,
+      jcodeHome: '/configured/home',
+      binary: '/bin/jcode',
+      inheritLogins: false,
+      inheritStderr: true,
+      startupTimeoutMs: 1234,
+      clientFactory,
+    });
+
+    const session = await harness.doStart({
+      sessionId: 'test',
+      sandboxSession: {} as never,
+      sessionWorkDir: '/workspace',
+      resumeFrom: {
+        type: 'resume-session',
+        specificationVersion: 'harness-v1',
+        harnessId: 'jcode',
+        data: { jcodeSessionId: 'native-1', jcodeHome: '/resumed/home' },
+      },
+    });
+
+    expect(clientFactory).toHaveBeenCalledWith({
+      workingDir: '/workspace',
+      jcodeHome: '/resumed/home',
+      inheritLogins: false,
+      binary: '/bin/jcode',
+      env: { API_KEY: 'secret' },
+      startupTimeoutMs: 1234,
+      inheritStderr: true,
+      clientName: expect.stringMatching(/^ai-sdk\/harness-jcode\//),
+    });
+    expect(env).toEqual({ API_KEY: 'secret' });
+    expect(client.attachSession).toHaveBeenCalledWith('native-1');
+    expect(session.isResume).toBe(true);
   });
 });

--- a/packages/harness-jcode/src/jcode-harness.test.ts
+++ b/packages/harness-jcode/src/jcode-harness.test.ts
@@ -13,7 +13,12 @@ describe('createJcode', () => {
     });
   });
 
-  it('refuses to bypass the sandbox without explicit host opt-in', async () => {
+  it('exposes the deterministic sandbox bootstrap recipe', () => {
+    const harness = createJcode();
+    expect(harness.getBootstrap).toBeDefined();
+  });
+
+  it('requires bridge port settings for a basic sandbox', async () => {
     const harness = createJcode();
     await expect(
       harness.doStart({
@@ -21,6 +26,6 @@ describe('createJcode', () => {
         sandboxSession: {} as never,
         sessionWorkDir: '/workspace',
       }),
-    ).rejects.toThrow('experimentalHostExecution: true');
+    ).rejects.toThrow('explicit `port` and `portEndpoint`');
   });
 });

--- a/packages/harness-jcode/src/jcode-harness.test.ts
+++ b/packages/harness-jcode/src/jcode-harness.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { createJcode } from './jcode-harness';
+
+describe('createJcode', () => {
+  it('declares the foundational HarnessV1 capabilities honestly', () => {
+    const harness = createJcode();
+    expect(harness).toMatchObject({
+      specificationVersion: 'harness-v1',
+      harnessId: 'jcode',
+      builtinTools: {},
+      supportsBuiltinToolApprovals: false,
+      supportsBuiltinToolFiltering: false,
+    });
+  });
+
+  it('refuses to bypass the sandbox without explicit host opt-in', async () => {
+    const harness = createJcode();
+    await expect(
+      harness.doStart({
+        sessionId: 'test',
+        sandboxSession: {} as never,
+        sessionWorkDir: '/workspace',
+      }),
+    ).rejects.toThrow('experimentalHostExecution: true');
+  });
+});

--- a/packages/harness-jcode/src/jcode-harness.test.ts
+++ b/packages/harness-jcode/src/jcode-harness.test.ts
@@ -276,6 +276,7 @@ describe('createJcode', () => {
     const env = { API_KEY: 'secret' };
     const client = {
       instanceHome: '/resumed/home',
+      supports: vi.fn(() => true),
       attachSession: vi.fn(async () => ({ session_id: 'native-1' })),
       createSession: vi.fn(),
       detachSession: vi.fn(),
@@ -285,6 +286,8 @@ describe('createJcode', () => {
       compact: vi.fn(),
       setModel: vi.fn(),
       setReasoningEffort: vi.fn(),
+      setExternalTools: vi.fn(),
+      submitExternalToolResult: vi.fn(),
       events: vi.fn(() => (async function* () {})()),
       close: vi.fn(),
     };

--- a/packages/harness-jcode/src/jcode-harness.ts
+++ b/packages/harness-jcode/src/jcode-harness.ts
@@ -1,8 +1,35 @@
+import { randomBytes } from 'node:crypto';
+import path from 'node:path';
 import {
   HarnessCapabilityUnsupportedError,
   type HarnessV1,
+  type HarnessV1NetworkSandboxSession,
+  type HarnessV1PortEndpoint,
 } from '@ai-sdk/harness';
+import {
+  createBridgeStartupError,
+  drainBridgeProcessStream,
+  forwardBridgeProcessStream,
+  getRestrictedSandboxSession,
+  markBridgeStarting,
+  resolveSandboxDefaultWorkingDirectory,
+  SandboxChannel,
+  shellQuote,
+  waitForBridgeReady,
+} from '@ai-sdk/harness/utils';
 import type { ConnectOptions, LaunchOptions } from '@1jehuang/jcode-sdk';
+import type { Experimental_SandboxSession } from '@ai-sdk/provider-utils';
+import { WebSocket } from 'ws';
+import { JCODE_BOOTSTRAP_DIR, getJcodeBootstrap } from './jcode-bootstrap';
+import {
+  jcodeBridgeOutboundMessageSchema,
+  type JcodeBridgeOutboundMessage,
+  type JcodeBridgeStartMessage,
+} from './jcode-bridge-protocol';
+import {
+  createJcodeBridgeSession,
+  type JcodeBridgeChannel,
+} from './jcode-bridge-session';
 import {
   launchJcodeClient,
   takeParkedJcodeClient,
@@ -23,10 +50,17 @@ export interface JcodeHarnessSettings {
   readonly jcodeHome?: string;
   readonly inheritLogins?: boolean;
   readonly binary?: string;
+  /** Environment forwarded to the in-sandbox bridge, including API keys or gateway auth. */
   readonly env?: Readonly<Record<string, string>>;
   readonly startupTimeoutMs?: number;
   readonly inheritStderr?: boolean;
-  /** Dependency-injection seam for conformance tests and custom runtimes. */
+  /** Override the bridge port. Defaults to the first port exposed by the sandbox. */
+  readonly port?: number;
+  /** Host endpoint for a basic sandbox session. Required together with `port`. */
+  readonly portEndpoint?: HarnessV1PortEndpoint;
+  /** Creates the bridge token. Defaults to a random 32-byte hexadecimal token. */
+  readonly mintBridgeToken?: (sandboxId: string) => string;
+  /** Dependency-injection seam for conformance tests and custom host runtimes. */
   readonly clientFactory?: JcodeClientFactory;
 }
 
@@ -40,50 +74,262 @@ export function createJcode(
     supportsBuiltinToolApprovals: false,
     supportsBuiltinToolFiltering: false,
     lifecycleStateSchema: jcodeResumeDataSchema,
+    getBootstrap: getJcodeBootstrap,
     async doStart(options) {
-      if (!settings.experimentalHostExecution) {
-        throw new HarnessCapabilityUnsupportedError({
-          harnessId: 'jcode',
-          message:
-            'jcode: sandbox execution requires the planned in-sandbox bridge. Set experimentalHostExecution: true only for trusted host-local workspaces.',
-        });
+      if (options.builtinToolFiltering != null) {
+        throw unsupported('built-in tool filtering is not supported');
       }
-      const lifecycle = options.continueFrom ?? options.resumeFrom;
-      const resumeData = lifecycle?.data
-        ? jcodeResumeDataSchema.parse(lifecycle.data)
+      if (settings.experimentalHostExecution) {
+        return startHostSession(settings, options);
+      }
+
+      const sandboxSession = options.sandboxSession;
+      validateBasicSandboxSettings({
+        sandboxSession,
+        port: settings.port,
+        portEndpoint: settings.portEndpoint,
+      });
+      const sandboxId = 'id' in sandboxSession ? sandboxSession.id : undefined;
+      if (settings.mintBridgeToken && !sandboxId) {
+        throw unsupported(
+          '`mintBridgeToken` requires a sandbox session that exposes an id',
+        );
+      }
+      const sandbox = getRestrictedSandboxSession(sandboxSession);
+      const defaultWorkingDirectory =
+        await resolveSandboxDefaultWorkingDirectory({
+          sandboxSession,
+          abortSignal: options.abortSignal,
+        });
+      const resumeData = (options.continueFrom ?? options.resumeFrom)?.data
+        ? jcodeResumeDataSchema.parse(
+            (options.continueFrom ?? options.resumeFrom)!.data,
+          )
         : undefined;
-      const launchOptions: LaunchOptions & ConnectOptions = {
-        workingDir: options.sessionWorkDir,
-        ...((resumeData?.jcodeHome ?? settings.jcodeHome)
-          ? { jcodeHome: resumeData?.jcodeHome ?? settings.jcodeHome }
-          : {}),
-        ...(settings.inheritLogins == null
-          ? {}
-          : { inheritLogins: settings.inheritLogins }),
-        ...(settings.binary ? { binary: settings.binary } : {}),
-        ...(settings.env ? { env: { ...settings.env } } : {}),
-        ...(settings.startupTimeoutMs == null
-          ? {}
-          : { startupTimeoutMs: settings.startupTimeoutMs }),
-        ...(settings.inheritStderr == null
-          ? {}
-          : { inheritStderr: settings.inheritStderr }),
-        clientName: `ai-sdk/harness-jcode/${VERSION}`,
-      };
-      const client =
-        (resumeData?.jcodeSessionId
-          ? takeParkedJcodeClient(resumeData.jcodeSessionId)
-          : undefined) ??
-        (await (settings.clientFactory ?? launchJcodeClient)(launchOptions));
-      return createJcodeSession({
-        client,
+      if (options.continueFrom) {
+        throw unsupported('turn continuation is not supported yet');
+      }
+
+      const bootstrapDir = path.posix.resolve(
+        defaultWorkingDirectory,
+        JCODE_BOOTSTRAP_DIR,
+      );
+      const sessionDataDir = `${defaultWorkingDirectory}/.agent-runs/${options.sessionId}`;
+      const bridgeStateDir = `${sessionDataDir}/bridge`;
+      const jcodeHome =
+        resumeData?.jcodeHome ??
+        settings.jcodeHome ??
+        `${sessionDataDir}/jcode-home`;
+      const port = resolveBridgePort({
+        sandboxSession,
+        override: settings.port,
+      });
+      const token = settings.mintBridgeToken
+        ? settings.mintBridgeToken(sandboxId!)
+        : randomBytes(32).toString('hex');
+
+      await sandbox.run({
+        command: `mkdir -p ${shellQuote(options.sessionWorkDir)} ${shellQuote(bridgeStateDir)} ${shellQuote(jcodeHome)}`,
+        abortSignal: options.abortSignal,
+      });
+      await markBridgeStarting({
+        sandbox,
+        bridgeStateDir,
+        bridgeType: 'jcode',
+        abortSignal: options.abortSignal,
+      });
+
+      const proc = await sandbox.spawn({
+        command: `node ${shellQuote(`${bootstrapDir}/bridge.mjs`)} --workdir ${shellQuote(options.sessionWorkDir)} --bridge-state-dir ${shellQuote(bridgeStateDir)} --jcode-home ${shellQuote(jcodeHome)}`,
+        env: {
+          ...settings.env,
+          BRIDGE_CHANNEL_TOKEN: token,
+          BRIDGE_WS_PORT: String(port),
+        },
+        abortSignal: options.abortSignal,
+      });
+      const stderrTail: string[] = [];
+      const stderrDone = forwardBridgeProcessStream({
+        stream: proc.stderr,
+        streamName: 'stderr',
+        source: 'jcode',
+        collectTail: stderrTail,
+      });
+      const { port: boundPort } = await waitForBridgeReady({
+        proc,
+        sandbox,
+        bridgeStateDir,
+        bridgeType: 'jcode',
+        timeoutMs: settings.startupTimeoutMs ?? 120_000,
+        abortSignal: options.abortSignal,
+        createTimeoutError: ({ proc, stdoutTail }) =>
+          createBridgeStartupError({
+            message: 'jcode bridge did not become ready in time.',
+            proc,
+            stdoutTail,
+            stderrTail,
+            stderrDone,
+          }),
+        createExitError: ({ proc, stdoutTail }) =>
+          createBridgeStartupError({
+            message: 'jcode bridge exited before becoming ready.',
+            proc,
+            stdoutTail,
+            stderrTail,
+            stderrDone,
+          }),
+      });
+      void drainBridgeProcessStream(proc.stdout);
+
+      const endpoint = await resolveBridgeEndpoint({
+        sandboxSession,
+        override: settings.portEndpoint,
+        port: boundPort,
+      });
+      const channel: JcodeBridgeChannel = new SandboxChannel<
+        JcodeBridgeOutboundMessage,
+        | JcodeBridgeStartMessage
+        | { type: 'abort' }
+        | { type: 'stop' }
+        | { type: 'destroy' }
+      >({
+        connect: () => openWebSocket(withBridgeToken({ endpoint, token })),
+        outboundSchema: jcodeBridgeOutboundMessageSchema,
+      });
+      await channel.open();
+
+      return createJcodeBridgeSession({
         sessionId: options.sessionId,
-        sessionWorkDir: options.sessionWorkDir,
-        resumeJcodeSessionId: resumeData?.jcodeSessionId,
+        channel,
+        proc,
         model: settings.model,
         reasoningEffort: settings.reasoningEffort,
-        abortSignal: options.abortSignal,
+        resumeJcodeSessionId: resumeData?.jcodeSessionId,
+        jcodeHome,
       });
     },
   };
+}
+
+async function startHostSession(
+  settings: JcodeHarnessSettings,
+  options: Parameters<ReturnType<typeof createJcode>['doStart']>[0],
+) {
+  const lifecycle = options.continueFrom ?? options.resumeFrom;
+  if (options.continueFrom) {
+    throw unsupported('turn continuation is not supported yet');
+  }
+  const resumeData = lifecycle?.data
+    ? jcodeResumeDataSchema.parse(lifecycle.data)
+    : undefined;
+  const launchOptions: LaunchOptions & ConnectOptions = {
+    workingDir: options.sessionWorkDir,
+    ...((resumeData?.jcodeHome ?? settings.jcodeHome)
+      ? { jcodeHome: resumeData?.jcodeHome ?? settings.jcodeHome }
+      : {}),
+    ...(settings.inheritLogins == null
+      ? {}
+      : { inheritLogins: settings.inheritLogins }),
+    ...(settings.binary ? { binary: settings.binary } : {}),
+    ...(settings.env ? { env: { ...settings.env } } : {}),
+    ...(settings.startupTimeoutMs == null
+      ? {}
+      : { startupTimeoutMs: settings.startupTimeoutMs }),
+    ...(settings.inheritStderr == null
+      ? {}
+      : { inheritStderr: settings.inheritStderr }),
+    clientName: `ai-sdk/harness-jcode/${VERSION}`,
+  };
+  const client =
+    (resumeData?.jcodeSessionId
+      ? takeParkedJcodeClient(resumeData.jcodeSessionId)
+      : undefined) ??
+    (await (settings.clientFactory ?? launchJcodeClient)(launchOptions));
+  return createJcodeSession({
+    client,
+    sessionId: options.sessionId,
+    sessionWorkDir: options.sessionWorkDir,
+    resumeJcodeSessionId: resumeData?.jcodeSessionId,
+    model: settings.model,
+    reasoningEffort: settings.reasoningEffort,
+    abortSignal: options.abortSignal,
+  });
+}
+
+function resolveBridgePort({
+  sandboxSession,
+  override,
+}: {
+  sandboxSession: HarnessV1NetworkSandboxSession | Experimental_SandboxSession;
+  override?: number;
+}): number {
+  if (override != null) return override;
+  if ('ports' in sandboxSession && sandboxSession.ports.length > 0) {
+    return sandboxSession.ports[0];
+  }
+  throw unsupported(
+    'a TCP port must be exposed by the sandbox or configured with `port`',
+  );
+}
+
+function validateBasicSandboxSettings({
+  sandboxSession,
+  port,
+  portEndpoint,
+}: {
+  sandboxSession: HarnessV1NetworkSandboxSession | Experimental_SandboxSession;
+  port?: number;
+  portEndpoint?: HarnessV1PortEndpoint;
+}) {
+  if ('getPortEndpoint' in sandboxSession) return;
+  if (port == null || portEndpoint == null) {
+    throw unsupported(
+      'basic sandbox sessions require explicit `port` and `portEndpoint` settings',
+    );
+  }
+}
+
+async function resolveBridgeEndpoint({
+  sandboxSession,
+  override,
+  port,
+}: {
+  sandboxSession: HarnessV1NetworkSandboxSession | Experimental_SandboxSession;
+  override?: HarnessV1PortEndpoint;
+  port: number;
+}): Promise<HarnessV1PortEndpoint> {
+  if (override) return override;
+  if ('getPortEndpoint' in sandboxSession) {
+    return sandboxSession.getPortEndpoint({ port, protocol: 'ws' });
+  }
+  throw unsupported(
+    'basic sandbox sessions require an explicit `portEndpoint`',
+  );
+}
+
+function withBridgeToken({
+  endpoint,
+  token,
+}: {
+  endpoint: HarnessV1PortEndpoint;
+  token: string;
+}): HarnessV1PortEndpoint {
+  const url = new URL(endpoint.url);
+  url.searchParams.set('token', token);
+  return { ...endpoint, url: url.toString() };
+}
+
+function openWebSocket(endpoint: HarnessV1PortEndpoint): Promise<WebSocket> {
+  const socket = new WebSocket(endpoint.url, { headers: endpoint.headers });
+  return new Promise((resolve, reject) => {
+    socket.once('open', () => resolve(socket));
+    socket.once('error', reject);
+  });
+}
+
+function unsupported(message: string): HarnessCapabilityUnsupportedError {
+  return new HarnessCapabilityUnsupportedError({
+    harnessId: 'jcode',
+    message: `jcode: ${message}`,
+  });
 }

--- a/packages/harness-jcode/src/jcode-harness.ts
+++ b/packages/harness-jcode/src/jcode-harness.ts
@@ -1,0 +1,89 @@
+import {
+  HarnessCapabilityUnsupportedError,
+  type HarnessV1,
+} from '@ai-sdk/harness';
+import type { ConnectOptions, LaunchOptions } from '@1jehuang/jcode-sdk';
+import {
+  launchJcodeClient,
+  takeParkedJcodeClient,
+  type JcodeClientFactory,
+} from './jcode-client';
+import { jcodeResumeDataSchema } from './jcode-resume-state';
+import { createJcodeSession } from './jcode-session';
+import { VERSION } from './version';
+
+export interface JcodeHarnessSettings {
+  /**
+   * Explicitly run Jcode on the adapter host instead of inside the supplied
+   * sandbox. Experimental and unsafe for remote or untrusted workspaces.
+   */
+  readonly experimentalHostExecution?: boolean;
+  readonly model?: string;
+  readonly reasoningEffort?: string;
+  readonly jcodeHome?: string;
+  readonly inheritLogins?: boolean;
+  readonly binary?: string;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly startupTimeoutMs?: number;
+  readonly inheritStderr?: boolean;
+  /** Dependency-injection seam for conformance tests and custom runtimes. */
+  readonly clientFactory?: JcodeClientFactory;
+}
+
+export function createJcode(
+  settings: JcodeHarnessSettings = {},
+): HarnessV1<Record<string, never>> {
+  return {
+    specificationVersion: 'harness-v1',
+    harnessId: 'jcode',
+    builtinTools: {},
+    supportsBuiltinToolApprovals: false,
+    supportsBuiltinToolFiltering: false,
+    lifecycleStateSchema: jcodeResumeDataSchema,
+    async doStart(options) {
+      if (!settings.experimentalHostExecution) {
+        throw new HarnessCapabilityUnsupportedError({
+          harnessId: 'jcode',
+          message:
+            'jcode: sandbox execution requires the planned in-sandbox bridge. Set experimentalHostExecution: true only for trusted host-local workspaces.',
+        });
+      }
+      const lifecycle = options.continueFrom ?? options.resumeFrom;
+      const resumeData = lifecycle?.data
+        ? jcodeResumeDataSchema.parse(lifecycle.data)
+        : undefined;
+      const launchOptions: LaunchOptions & ConnectOptions = {
+        workingDir: options.sessionWorkDir,
+        ...((resumeData?.jcodeHome ?? settings.jcodeHome)
+          ? { jcodeHome: resumeData?.jcodeHome ?? settings.jcodeHome }
+          : {}),
+        ...(settings.inheritLogins == null
+          ? {}
+          : { inheritLogins: settings.inheritLogins }),
+        ...(settings.binary ? { binary: settings.binary } : {}),
+        ...(settings.env ? { env: { ...settings.env } } : {}),
+        ...(settings.startupTimeoutMs == null
+          ? {}
+          : { startupTimeoutMs: settings.startupTimeoutMs }),
+        ...(settings.inheritStderr == null
+          ? {}
+          : { inheritStderr: settings.inheritStderr }),
+        clientName: `ai-sdk/harness-jcode/${VERSION}`,
+      };
+      const client =
+        (resumeData?.jcodeSessionId
+          ? takeParkedJcodeClient(resumeData.jcodeSessionId)
+          : undefined) ??
+        (await (settings.clientFactory ?? launchJcodeClient)(launchOptions));
+      return createJcodeSession({
+        client,
+        sessionId: options.sessionId,
+        sessionWorkDir: options.sessionWorkDir,
+        resumeJcodeSessionId: resumeData?.jcodeSessionId,
+        model: settings.model,
+        reasoningEffort: settings.reasoningEffort,
+        abortSignal: options.abortSignal,
+      });
+    },
+  };
+}

--- a/packages/harness-jcode/src/jcode-resume-state.ts
+++ b/packages/harness-jcode/src/jcode-resume-state.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod/v4';
 
 export const jcodeResumeDataSchema = z.object({
-  jcodeSessionId: z.string(),
+  jcodeSessionId: z.string().optional(),
   jcodeHome: z.string().optional(),
 });
 

--- a/packages/harness-jcode/src/jcode-resume-state.ts
+++ b/packages/harness-jcode/src/jcode-resume-state.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod/v4';
+
+export const jcodeResumeDataSchema = z.object({
+  jcodeSessionId: z.string(),
+  jcodeHome: z.string().optional(),
+});
+
+export type JcodeResumeData = z.infer<typeof jcodeResumeDataSchema>;

--- a/packages/harness-jcode/src/jcode-session.test.ts
+++ b/packages/harness-jcode/src/jcode-session.test.ts
@@ -1,0 +1,205 @@
+import type { ApiEvent } from '@1jehuang/jcode-sdk';
+import type { HarnessV1StreamPart } from '@ai-sdk/harness';
+import { describe, expect, it, vi } from 'vitest';
+import { takeParkedJcodeClient, type JcodeSdkClient } from './jcode-client';
+import { createJcodeSession } from './jcode-session';
+
+function iteratorFrom(events: ApiEvent[]): AsyncIterableIterator<ApiEvent> {
+  const iterator = (async function* () {
+    yield* events;
+  })();
+  return iterator;
+}
+
+function fakeClient(events: ApiEvent[] = []): JcodeSdkClient & {
+  sendMessage: ReturnType<typeof vi.fn>;
+  cancel: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  detachSession: ReturnType<typeof vi.fn>;
+} {
+  return {
+    instanceHome: '/durable/jcode',
+    createSession: vi.fn(async () => ({ session_id: 'native-1' })),
+    attachSession: vi.fn(async id => ({ session_id: id })),
+    detachSession: vi.fn(async () => {}),
+    sendMessage: vi.fn(async () => {}),
+    cancel: vi.fn(async () => {}),
+    softInterrupt: vi.fn(async () => {}),
+    compact: vi.fn(async () => 'compacted'),
+    setModel: vi.fn(async () => {}),
+    setReasoningEffort: vi.fn(async () => {}),
+    events: vi.fn(() => iteratorFrom(events)),
+    close: vi.fn(async () => {}),
+  };
+}
+
+describe('createJcodeSession', () => {
+  it('streams a model-backed turn as typed harness parts', async () => {
+    const client = fakeClient([
+      { ev: 'reasoning_delta', session_id: 'native-1', text: 'Think' },
+      { ev: 'reasoning_done', session_id: 'native-1' },
+      { ev: 'text_delta', session_id: 'native-1', text: 'Hello' },
+      {
+        ev: 'token_usage',
+        session_id: 'native-1',
+        input: 10,
+        output: 2,
+        cache_read_input: 3,
+      },
+      { ev: 'turn_done', session_id: 'native-1' },
+    ]);
+    const session = await createJcodeSession({
+      client,
+      sessionId: 'harness-1',
+      sessionWorkDir: '/workspace',
+      model: 'openai:test',
+      reasoningEffort: 'high',
+    });
+    const emitted: HarnessV1StreamPart[] = [];
+    const control = await session.doPromptTurn({
+      prompt: 'hello',
+      emit: part => emitted.push(part),
+    });
+    await control.done;
+
+    expect(client.sendMessage).toHaveBeenCalledWith('native-1', 'hello');
+    expect(emitted.map(part => part.type)).toEqual([
+      'stream-start',
+      'reasoning-start',
+      'reasoning-delta',
+      'reasoning-end',
+      'text-start',
+      'text-delta',
+      'text-end',
+      'finish-step',
+      'finish',
+    ]);
+    expect(emitted.at(-1)).toMatchObject({
+      type: 'finish',
+      totalUsage: {
+        inputTokens: { total: 10, cacheRead: 3 },
+        outputTokens: { total: 2 },
+      },
+    });
+  });
+
+  it('frames instructions only into the first fresh prompt', async () => {
+    const client = fakeClient([{ ev: 'turn_done', session_id: 'native-1' }]);
+    const session = await createJcodeSession({
+      client,
+      sessionId: 'harness-1',
+      sessionWorkDir: '/workspace',
+    });
+    const first = await session.doPromptTurn({
+      prompt: 'one',
+      instructions: 'be concise',
+      emit: () => {},
+    });
+    await first.done;
+
+    expect(client.sendMessage.mock.calls[0]?.[1]).toContain(
+      '<session-instructions>\nbe concise',
+    );
+  });
+
+  it('returns durable native identity and closes on stop', async () => {
+    const client = fakeClient();
+    const session = await createJcodeSession({
+      client,
+      sessionId: 'harness-1',
+      sessionWorkDir: '/workspace',
+    });
+    const state = await session.doStop();
+
+    expect(state).toEqual({
+      type: 'resume-session',
+      harnessId: 'jcode',
+      specificationVersion: 'harness-v1',
+      data: {
+        jcodeSessionId: 'native-1',
+        jcodeHome: '/durable/jcode',
+      },
+    });
+    expect(client.detachSession).toHaveBeenCalledWith('native-1');
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it('parks the live client for same-process resume on detach', async () => {
+    const client = fakeClient();
+    const session = await createJcodeSession({
+      client,
+      sessionId: 'harness-1',
+      sessionWorkDir: '/workspace',
+    });
+
+    await session.doDetach();
+
+    expect(client.close).not.toHaveBeenCalled();
+    expect(takeParkedJcodeClient('native-1')).toBe(client);
+  });
+
+  it('cancels an active turn when aborted', async () => {
+    let release: (() => void) | undefined;
+    const client = fakeClient();
+    client.events = vi.fn(() =>
+      (async function* () {
+        await new Promise<void>(resolve => {
+          release = resolve;
+        });
+        yield { ev: 'turn_done', session_id: 'native-1' } as ApiEvent;
+      })(),
+    );
+    const session = await createJcodeSession({
+      client,
+      sessionId: 'harness-1',
+      sessionWorkDir: '/workspace',
+    });
+    const abort = new AbortController();
+    const control = await session.doPromptTurn({
+      prompt: 'wait',
+      abortSignal: abort.signal,
+      emit: () => {},
+    });
+    abort.abort();
+    await vi.waitFor(() =>
+      expect(client.cancel).toHaveBeenCalledWith('native-1'),
+    );
+    release?.();
+    await control.done;
+  });
+
+  it('terminates immediately on a protocol error event', async () => {
+    const client = fakeClient([
+      {
+        ev: 'error',
+        code: 'internal',
+        message: 'model failed',
+      },
+    ]);
+    const session = await createJcodeSession({
+      client,
+      sessionId: 'harness-1',
+      sessionWorkDir: '/workspace',
+    });
+    const emitted: HarnessV1StreamPart[] = [];
+    const control = await session.doPromptTurn({
+      prompt: 'fail',
+      emit: part => emitted.push(part),
+    });
+
+    await expect(control.done).rejects.toThrow('internal: model failed');
+    expect(emitted.filter(part => part.type === 'error')).toHaveLength(1);
+  });
+
+  it('rejects suspension instead of exporting unusable continuation state', async () => {
+    const session = await createJcodeSession({
+      client: fakeClient(),
+      sessionId: 'harness-1',
+      sessionWorkDir: '/workspace',
+    });
+
+    await expect(session.doSuspendTurn()).rejects.toThrow(
+      'turn suspension requires event replay cursors',
+    );
+  });
+});

--- a/packages/harness-jcode/src/jcode-session.test.ts
+++ b/packages/harness-jcode/src/jcode-session.test.ts
@@ -1,17 +1,22 @@
-import type { ApiEvent } from '@1jehuang/jcode-sdk';
 import type { HarnessV1StreamPart } from '@ai-sdk/harness';
 import { describe, expect, it, vi } from 'vitest';
-import { takeParkedJcodeClient, type JcodeSdkClient } from './jcode-client';
+import {
+  takeParkedJcodeClient,
+  type JcodeSdkClient,
+  type JcodeSdkEvent,
+} from './jcode-client';
 import { createJcodeSession } from './jcode-session';
 
-function iteratorFrom(events: ApiEvent[]): AsyncIterableIterator<ApiEvent> {
+function iteratorFrom(
+  events: JcodeSdkEvent[],
+): AsyncIterableIterator<JcodeSdkEvent> {
   const iterator = (async function* () {
     yield* events;
   })();
   return iterator;
 }
 
-function fakeClient(events: ApiEvent[] = []): JcodeSdkClient & {
+function fakeClient(events: JcodeSdkEvent[] = []): JcodeSdkClient & {
   sendMessage: ReturnType<typeof vi.fn>;
   cancel: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
@@ -19,6 +24,7 @@ function fakeClient(events: ApiEvent[] = []): JcodeSdkClient & {
 } {
   return {
     instanceHome: '/durable/jcode',
+    supports: vi.fn(() => true),
     createSession: vi.fn(async () => ({ session_id: 'native-1' })),
     attachSession: vi.fn(async id => ({ session_id: id })),
     detachSession: vi.fn(async () => {}),
@@ -28,12 +34,129 @@ function fakeClient(events: ApiEvent[] = []): JcodeSdkClient & {
     compact: vi.fn(async () => 'compacted'),
     setModel: vi.fn(async () => {}),
     setReasoningEffort: vi.fn(async () => {}),
+    setExternalTools: vi.fn(async () => {}),
+    submitExternalToolResult: vi.fn(async () => {}),
     events: vi.fn(() => iteratorFrom(events)),
     close: vi.fn(async () => {}),
   };
 }
 
 describe('createJcodeSession', () => {
+  it('registers, emits, and submits host-executed external tools', async () => {
+    let releaseTurn: (() => void) | undefined;
+    const client = fakeClient();
+    client.events = vi.fn(() =>
+      (async function* () {
+        yield {
+          ev: 'tool_start',
+          session_id: 'native-1',
+          call_id: 'call-1',
+          name: 'weather',
+        } as const;
+        yield {
+          ev: 'tool_input_delta',
+          session_id: 'native-1',
+          call_id: 'call-1',
+          delta: '{"city":"Berlin"}',
+        } as const;
+        yield {
+          ev: 'tool_exec',
+          session_id: 'native-1',
+          call_id: 'call-1',
+          name: 'weather',
+        } as const;
+        yield {
+          ev: 'external_tool_call',
+          session_id: 'native-1',
+          root_session_id: 'native-1',
+          call_id: 'call-1',
+          catalog_revision: 1,
+          name: 'weather',
+          input: { city: 'Berlin' },
+        } as const;
+        await new Promise<void>(resolve => {
+          releaseTurn = resolve;
+        });
+        yield {
+          ev: 'tool_done',
+          session_id: 'native-1',
+          call_id: 'call-1',
+          name: 'weather',
+          output: '{"temperature":18}',
+        } as const;
+        yield { ev: 'turn_done', session_id: 'native-1' } as const;
+      })(),
+    );
+    const session = await createJcodeSession({
+      client,
+      sessionId: 'harness-1',
+      sessionWorkDir: '/workspace',
+    });
+    const emitted: HarnessV1StreamPart[] = [];
+    const control = await session.doPromptTurn({
+      prompt: 'weather?',
+      tools: [
+        {
+          name: 'weather',
+          description: 'Get weather',
+          inputSchema: { type: 'object' },
+        },
+      ],
+      emit: part => emitted.push(part),
+    });
+
+    await vi.waitFor(() =>
+      expect(emitted).toContainEqual({
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'weather',
+        input: '{"city":"Berlin"}',
+        providerExecuted: false,
+        dynamic: false,
+      }),
+    );
+    expect(client.setExternalTools).toHaveBeenCalledWith('native-1', [
+      {
+        name: 'weather',
+        description: 'Get weather',
+        input_schema: { type: 'object' },
+      },
+    ]);
+
+    await control.submitToolResult({
+      toolCallId: 'call-1',
+      output: { temperature: 18 },
+    });
+    expect(client.submitExternalToolResult).toHaveBeenCalledWith('native-1', {
+      call_id: 'call-1',
+      output: { temperature: 18 },
+      is_error: false,
+    });
+    releaseTurn?.();
+    await control.done;
+    expect(emitted.filter(part => part.type === 'tool-call')).toHaveLength(1);
+    expect(emitted).toContainEqual({
+      type: 'tool-result',
+      toolCallId: 'call-1',
+      toolName: 'weather',
+      result: { temperature: 18 },
+    });
+  });
+
+  it('clears the previous external tool catalog on a tool-free turn', async () => {
+    const client = fakeClient([{ ev: 'turn_done', session_id: 'native-1' }]);
+    const session = await createJcodeSession({
+      client,
+      sessionId: 'harness-1',
+      sessionWorkDir: '/workspace',
+    });
+    const control = await session.doPromptTurn({
+      prompt: 'hello',
+      emit: () => {},
+    });
+    await control.done;
+    expect(client.setExternalTools).toHaveBeenCalledWith('native-1', []);
+  });
   it('streams a model-backed turn as typed harness parts', async () => {
     const client = fakeClient([
       { ev: 'reasoning_delta', session_id: 'native-1', text: 'Think' },
@@ -146,7 +269,7 @@ describe('createJcodeSession', () => {
         await new Promise<void>(resolve => {
           release = resolve;
         });
-        yield { ev: 'turn_done', session_id: 'native-1' } as ApiEvent;
+        yield { ev: 'turn_done', session_id: 'native-1' } as JcodeSdkEvent;
       })(),
     );
     const session = await createJcodeSession({

--- a/packages/harness-jcode/src/jcode-session.ts
+++ b/packages/harness-jcode/src/jcode-session.ts
@@ -1,0 +1,233 @@
+import {
+  HarnessCapabilityUnsupportedError,
+  type HarnessV1PromptControl,
+  type HarnessV1PromptTurnOptions,
+  type HarnessV1ResumeSessionState,
+  type HarnessV1Session,
+} from '@ai-sdk/harness';
+import { parkJcodeClient, type JcodeSdkClient } from './jcode-client';
+import {
+  createJcodeTranslatorState,
+  translateJcodeEvent,
+} from './jcode-translate';
+import { extractJcodePrompt, frameJcodeInstructions } from './jcode-utils';
+
+const HARNESS_ID = 'jcode';
+
+export interface CreateJcodeSessionInput {
+  readonly client: JcodeSdkClient;
+  readonly sessionId: string;
+  readonly sessionWorkDir: string;
+  readonly resumeJcodeSessionId?: string;
+  readonly model?: string;
+  readonly reasoningEffort?: string;
+  readonly abortSignal?: AbortSignal;
+}
+
+function unsupported(message: string): HarnessCapabilityUnsupportedError {
+  return new HarnessCapabilityUnsupportedError({
+    harnessId: HARNESS_ID,
+    message: `jcode: ${message}`,
+  });
+}
+
+export async function createJcodeSession({
+  client,
+  sessionId,
+  sessionWorkDir,
+  resumeJcodeSessionId,
+  model,
+  reasoningEffort,
+  abortSignal,
+}: CreateJcodeSessionInput): Promise<HarnessV1Session> {
+  if (abortSignal?.aborted) {
+    await client.close();
+    throw abortSignal.reason;
+  }
+
+  let jcodeSessionId: string;
+  try {
+    const nativeSession = resumeJcodeSessionId
+      ? await client.attachSession(resumeJcodeSessionId)
+      : await client.createSession(sessionWorkDir);
+    jcodeSessionId = nativeSession.session_id;
+    if (model) await client.setModel(jcodeSessionId, model);
+    if (reasoningEffort) {
+      await client.setReasoningEffort(jcodeSessionId, reasoningEffort);
+    }
+  } catch (error) {
+    await client.close();
+    throw error;
+  }
+
+  let closed = false;
+  let activeCancel: (() => Promise<void>) | undefined;
+  let activeDone: PromiseLike<void> | undefined;
+  let isFirstPrompt = resumeJcodeSessionId == null;
+
+  const lifecycleData = () => ({
+    jcodeSessionId,
+    ...(client.instanceHome ? { jcodeHome: client.instanceHome } : {}),
+  });
+
+  const assertOpen = () => {
+    if (closed) throw new Error('jcode harness session is closed');
+  };
+
+  const runTurn = async (
+    options: HarnessV1PromptTurnOptions,
+  ): Promise<HarnessV1PromptControl> => {
+    assertOpen();
+    if (activeCancel) throw new Error('a Jcode turn is already active');
+    if (options.responseFormat?.type === 'json') {
+      throw unsupported('JSON response format is not supported yet');
+    }
+    if (options.tools && options.tools.length > 0) {
+      throw unsupported(
+        'host-defined tools require session-scoped MCP support in Jcode',
+      );
+    }
+
+    let prompt = extractJcodePrompt(options.prompt);
+    if (isFirstPrompt && options.instructions) {
+      prompt = frameJcodeInstructions(options.instructions, prompt);
+    }
+    isFirstPrompt = false;
+
+    const iterator = client.events(jcodeSessionId);
+    const state = createJcodeTranslatorState();
+    options.emit({
+      type: 'stream-start',
+      ...(model ? { modelId: model } : {}),
+    });
+
+    let settled = false;
+    let cancelPromise: Promise<void> | undefined;
+    let abortListener: (() => void) | undefined;
+    const cancel = async () => {
+      if (settled) return;
+      cancelPromise ??= client.cancel(jcodeSessionId);
+      await cancelPromise;
+    };
+    activeCancel = cancel;
+
+    const done = (async () => {
+      try {
+        if (options.abortSignal) {
+          abortListener = () => {
+            void cancel().catch(() => {
+              // The turn's event stream remains the source of truth. Avoid an
+              // unhandled rejection if transport cancellation itself fails.
+            });
+          };
+          options.abortSignal.addEventListener('abort', abortListener, {
+            once: true,
+          });
+          if (options.abortSignal.aborted) await cancel();
+        }
+
+        await client.sendMessage(jcodeSessionId, prompt);
+        for await (const event of iterator) {
+          if (event.ev === 'error') {
+            throw new Error(`${event.code}: ${event.message}`);
+          }
+          for (const part of translateJcodeEvent(event, state)) {
+            options.emit(part);
+          }
+          if (event.ev === 'turn_done') return;
+        }
+        throw new Error('Jcode event stream closed before turn_done');
+      } catch (error) {
+        options.emit({ type: 'error', error });
+        throw error;
+      } finally {
+        settled = true;
+        activeCancel = undefined;
+        activeDone = undefined;
+        if (abortListener && options.abortSignal) {
+          options.abortSignal.removeEventListener('abort', abortListener);
+        }
+        await iterator.return?.();
+      }
+    })();
+    activeDone = done;
+
+    return {
+      done,
+      async submitToolResult() {
+        throw unsupported(
+          'host tool results require session-scoped MCP support in Jcode',
+        );
+      },
+      async submitUserMessage(text) {
+        await client.softInterrupt(jcodeSessionId, text);
+      },
+    };
+  };
+
+  const resumeState = (): HarnessV1ResumeSessionState => ({
+    type: 'resume-session',
+    harnessId: HARNESS_ID,
+    specificationVersion: 'harness-v1',
+    data: lifecycleData(),
+  });
+
+  return {
+    sessionId,
+    isResume: resumeJcodeSessionId != null,
+    ...(model ? { modelId: model } : {}),
+    doPromptTurn: runTurn,
+    async doCompact(customInstructions) {
+      assertOpen();
+      if (customInstructions) {
+        throw unsupported('custom compaction instructions are not supported');
+      }
+      await client.compact(jcodeSessionId);
+    },
+    async doContinueTurn() {
+      throw unsupported(
+        'lossless turn continuation requires event replay cursors in the Jcode SDK',
+      );
+    },
+    async doSuspendTurn() {
+      throw unsupported(
+        'turn suspension requires event replay cursors in the Jcode SDK',
+      );
+    },
+    async doDetach() {
+      assertOpen();
+      if (activeCancel) {
+        throw unsupported(
+          'cannot detach while a turn is active; suspend it first',
+        );
+      }
+      await client.detachSession(jcodeSessionId);
+      parkJcodeClient(jcodeSessionId, client);
+      closed = true;
+      return resumeState();
+    },
+    async doStop() {
+      assertOpen();
+      if (activeCancel) await activeCancel();
+      if (activeDone) await activeDone;
+      await client.detachSession(jcodeSessionId);
+      const state = resumeState();
+      closed = true;
+      await client.close();
+      return state;
+    },
+    async doDestroy() {
+      if (closed) return;
+      if (activeCancel) await activeCancel();
+      if (activeDone) {
+        try {
+          await activeDone;
+        } catch {
+          // Destruction must still release the owned runtime after turn failure.
+        }
+      }
+      closed = true;
+      await client.close();
+    },
+  };
+}

--- a/packages/harness-jcode/src/jcode-session.ts
+++ b/packages/harness-jcode/src/jcode-session.ts
@@ -5,9 +5,15 @@ import {
   type HarnessV1ResumeSessionState,
   type HarnessV1Session,
 } from '@ai-sdk/harness';
-import { parkJcodeClient, type JcodeSdkClient } from './jcode-client';
+import {
+  parkJcodeClient,
+  type JcodeSdkClient,
+  type JcodeSdkEvent,
+} from './jcode-client';
 import {
   createJcodeTranslatorState,
+  translateJcodeExternalToolCall,
+  translateJcodeExternalToolResult,
   translateJcodeEvent,
 } from './jcode-translate';
 import { extractJcodePrompt, frameJcodeInstructions } from './jcode-utils';
@@ -82,11 +88,25 @@ export async function createJcodeSession({
     if (options.responseFormat?.type === 'json') {
       throw unsupported('JSON response format is not supported yet');
     }
-    if (options.tools && options.tools.length > 0) {
+
+    const tools = options.tools ?? [];
+    if (tools.length > 0 && !client.supports('external_tools_v1')) {
       throw unsupported(
-        'host-defined tools require session-scoped MCP support in Jcode',
+        'the Jcode runtime does not support host-defined tools (external_tools_v1)',
       );
     }
+    const toolNames = new Set<string>();
+    const externalTools = tools.map(tool => {
+      if (toolNames.has(tool.name)) {
+        throw new Error(`duplicate host tool name: ${tool.name}`);
+      }
+      toolNames.add(tool.name);
+      return {
+        name: tool.name,
+        description: tool.description ?? '',
+        input_schema: tool.inputSchema ?? {},
+      };
+    });
 
     let prompt = extractJcodePrompt(options.prompt);
     if (isFirstPrompt && options.instructions) {
@@ -96,6 +116,22 @@ export async function createJcodeSession({
 
     const iterator = client.events(jcodeSessionId);
     const state = createJcodeTranslatorState();
+    const pendingExternalCalls = new Map<
+      string,
+      {
+        readonly name: string;
+        readonly ready: Promise<JcodeSdkEvent>;
+        readonly resolveReady: (event: JcodeSdkEvent) => void;
+        readonly rejectReady: (error: Error) => void;
+        readyEvent?: JcodeSdkEvent;
+        submitting: boolean;
+      }
+    >();
+    const externalCallIds = new Set<string>();
+    const submittedExternalResults = new Map<
+      string,
+      { readonly output: unknown; readonly isError: boolean }
+    >();
     options.emit({
       type: 'stream-start',
       ...(model ? { modelId: model } : {}),
@@ -126,8 +162,125 @@ export async function createJcodeSession({
           if (options.abortSignal.aborted) await cancel();
         }
 
+        await client.setExternalTools(jcodeSessionId, externalTools);
         await client.sendMessage(jcodeSessionId, prompt);
         for await (const event of iterator) {
+          if (event.ev === 'tool_start' && toolNames.has(event.name)) {
+            externalCallIds.add(event.call_id);
+            for (const part of translateJcodeEvent(event, state)) {
+              options.emit(part);
+            }
+            continue;
+          }
+          if (
+            event.ev === 'tool_input_delta' &&
+            externalCallIds.has(event.call_id)
+          ) {
+            translateJcodeEvent(event, state);
+            continue;
+          }
+          if (event.ev === 'tool_exec' && externalCallIds.has(event.call_id)) {
+            const tool = state.tools.get(event.call_id);
+            if (!tool)
+              throw new Error(`missing external tool state: ${event.call_id}`);
+            tool.emitted = true;
+            state.stepHadToolCall = true;
+            let resolveReady!: (event: JcodeSdkEvent) => void;
+            let rejectReady!: (error: Error) => void;
+            const ready = new Promise<JcodeSdkEvent>((resolve, reject) => {
+              resolveReady = resolve;
+              rejectReady = reject;
+            });
+            void ready.catch(() => {});
+            pendingExternalCalls.set(event.call_id, {
+              name: event.name,
+              ready,
+              resolveReady,
+              rejectReady,
+              submitting: false,
+            });
+            let input: unknown = tool.input || {};
+            try {
+              input = tool.input ? JSON.parse(tool.input) : {};
+            } catch {}
+            options.emit(
+              translateJcodeExternalToolCall({
+                ev: 'external_tool_call',
+                session_id: jcodeSessionId,
+                root_session_id: jcodeSessionId,
+                call_id: event.call_id,
+                catalog_revision: 0,
+                name: event.name,
+                input,
+              }),
+            );
+            continue;
+          }
+          if (
+            event.ev === 'tool_done' &&
+            externalCallIds.delete(event.call_id)
+          ) {
+            const submitted = submittedExternalResults.get(event.call_id);
+            submittedExternalResults.delete(event.call_id);
+            state.tools.delete(event.call_id);
+            options.emit(
+              translateJcodeExternalToolResult({
+                toolCallId: event.call_id,
+                toolName: event.name,
+                output: submitted?.output ?? event.error ?? event.output,
+                isError: submitted?.isError ?? event.error != null,
+              }),
+            );
+            continue;
+          }
+          if (event.ev === 'external_tool_call') {
+            if (event.root_session_id !== jcodeSessionId) {
+              throw new Error(
+                `external tool call ${event.call_id} was routed to the wrong root session`,
+              );
+            }
+            if (!event.session_id) {
+              throw new Error(
+                `external tool call ${event.call_id} has no calling session`,
+              );
+            }
+            if (!toolNames.has(event.name)) {
+              throw new Error(
+                `external tool call ${event.call_id} references unknown tool ${event.name}`,
+              );
+            }
+            const pending = pendingExternalCalls.get(event.call_id);
+            if (pending?.readyEvent) {
+              throw new Error(
+                `duplicate external tool call id: ${event.call_id}`,
+              );
+            }
+            if (pending) {
+              pending.readyEvent = event;
+              pending.resolveReady(event);
+            } else {
+              let resolveReady!: (event: JcodeSdkEvent) => void;
+              let rejectReady!: (error: Error) => void;
+              const ready = new Promise<JcodeSdkEvent>((resolve, reject) => {
+                resolveReady = resolve;
+                rejectReady = reject;
+              });
+              void ready.catch(() => {});
+              const fallback = {
+                name: event.name,
+                ready,
+                resolveReady,
+                rejectReady,
+                readyEvent: event,
+                submitting: false,
+              };
+              pendingExternalCalls.set(event.call_id, fallback);
+              fallback.resolveReady(event);
+              state.stepHadToolCall = true;
+              options.emit(translateJcodeExternalToolCall(event));
+            }
+            continue;
+          }
           if (event.ev === 'error') {
             throw new Error(`${event.code}: ${event.message}`);
           }
@@ -141,6 +294,16 @@ export async function createJcodeSession({
         options.emit({ type: 'error', error });
         throw error;
       } finally {
+        for (const pending of pendingExternalCalls.values()) {
+          if (!pending.readyEvent) {
+            pending.rejectReady(
+              new Error(
+                'Jcode turn ended before the external tool call became ready',
+              ),
+            );
+          }
+        }
+        pendingExternalCalls.clear();
         settled = true;
         activeCancel = undefined;
         activeDone = undefined;
@@ -154,10 +317,41 @@ export async function createJcodeSession({
 
     return {
       done,
-      async submitToolResult() {
-        throw unsupported(
-          'host tool results require session-scoped MCP support in Jcode',
-        );
+      async submitToolResult({ toolCallId, output, isError }) {
+        const pending = pendingExternalCalls.get(toolCallId);
+        if (!pending) {
+          throw new Error(
+            `unknown or settled external tool call: ${toolCallId}`,
+          );
+        }
+        if (pending.submitting) {
+          throw new Error(
+            `external tool result submission is already in flight: ${toolCallId}`,
+          );
+        }
+        pending.submitting = true;
+        submittedExternalResults.set(toolCallId, {
+          output,
+          isError: isError ?? false,
+        });
+        try {
+          const readyEvent = pending.readyEvent ?? (await pending.ready);
+          if (readyEvent.ev !== 'external_tool_call') {
+            throw new Error(
+              `unexpected external tool readiness event: ${readyEvent.ev}`,
+            );
+          }
+          await client.submitExternalToolResult(jcodeSessionId, {
+            call_id: toolCallId,
+            output,
+            is_error: isError ?? false,
+          });
+          pendingExternalCalls.delete(toolCallId);
+        } catch (error) {
+          submittedExternalResults.delete(toolCallId);
+          pending.submitting = false;
+          throw error;
+        }
       },
       async submitUserMessage(text) {
         await client.softInterrupt(jcodeSessionId, text);

--- a/packages/harness-jcode/src/jcode-translate.test.ts
+++ b/packages/harness-jcode/src/jcode-translate.test.ts
@@ -1,0 +1,268 @@
+import type { ApiEvent } from '@1jehuang/jcode-sdk';
+import type { HarnessV1StreamPart } from '@ai-sdk/harness';
+import { describe, expect, it } from 'vitest';
+import {
+  createJcodeTranslatorState,
+  translateJcodeEvent,
+} from './jcode-translate';
+
+function translate(
+  events: readonly ApiEvent[],
+  turnId: string | number = 1,
+): HarnessV1StreamPart[] {
+  const state = createJcodeTranslatorState(turnId);
+  return events.flatMap(event => translateJcodeEvent(event, state));
+}
+
+describe('translateJcodeEvent', () => {
+  it('frames interleaved reasoning and text deltas with stable per-turn ids', () => {
+    const events: ApiEvent[] = [
+      { ev: 'reasoning_delta', session_id: 's', text: 'think ' },
+      { ev: 'reasoning_delta', session_id: 's', text: 'more' },
+      { ev: 'reasoning_done', session_id: 's', duration_secs: 1.5 },
+      { ev: 'text_delta', session_id: 's', text: 'Hello' },
+      { ev: 'text_delta', session_id: 's', text: ' world' },
+      { ev: 'reasoning_delta', session_id: 's', text: 'check' },
+      { ev: 'text_delta', session_id: 's', text: 'Done' },
+      { ev: 'turn_done', session_id: 's' },
+    ];
+
+    expect(translate(events, 'abc')).toEqual([
+      { type: 'reasoning-start', id: 'jcode-turn-abc-reasoning-1' },
+      {
+        type: 'reasoning-delta',
+        id: 'jcode-turn-abc-reasoning-1',
+        delta: 'think ',
+      },
+      {
+        type: 'reasoning-delta',
+        id: 'jcode-turn-abc-reasoning-1',
+        delta: 'more',
+      },
+      { type: 'reasoning-end', id: 'jcode-turn-abc-reasoning-1' },
+      { type: 'text-start', id: 'jcode-turn-abc-text-2' },
+      { type: 'text-delta', id: 'jcode-turn-abc-text-2', delta: 'Hello' },
+      {
+        type: 'text-delta',
+        id: 'jcode-turn-abc-text-2',
+        delta: ' world',
+      },
+      { type: 'text-end', id: 'jcode-turn-abc-text-2' },
+      { type: 'reasoning-start', id: 'jcode-turn-abc-reasoning-3' },
+      {
+        type: 'reasoning-delta',
+        id: 'jcode-turn-abc-reasoning-3',
+        delta: 'check',
+      },
+      { type: 'reasoning-end', id: 'jcode-turn-abc-reasoning-3' },
+      { type: 'text-start', id: 'jcode-turn-abc-text-4' },
+      { type: 'text-delta', id: 'jcode-turn-abc-text-4', delta: 'Done' },
+      { type: 'text-end', id: 'jcode-turn-abc-text-4' },
+      {
+        type: 'finish',
+        finishReason: { unified: 'stop', raw: 'turn_done' },
+        totalUsage: {
+          inputTokens: {
+            total: 0,
+            noCache: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+          outputTokens: { total: 0, text: 0, reasoning: 0 },
+        },
+      },
+    ] satisfies HarnessV1StreamPart[]);
+  });
+
+  it('accumulates incremental JSON input and emits a provider-executed tool call before its result', () => {
+    const events: ApiEvent[] = [
+      { ev: 'text_delta', session_id: 's', text: 'I will read it.' },
+      { ev: 'tool_start', session_id: 's', call_id: 'call-1', name: 'read' },
+      {
+        ev: 'tool_input_delta',
+        session_id: 's',
+        call_id: 'call-1',
+        delta: '{"file_',
+      },
+      {
+        ev: 'tool_input_delta',
+        session_id: 's',
+        call_id: 'call-1',
+        delta: 'path":"a.txt"}',
+      },
+      { ev: 'tool_exec', session_id: 's', call_id: 'call-1', name: 'read' },
+      {
+        ev: 'tool_done',
+        session_id: 's',
+        call_id: 'call-1',
+        name: 'read',
+        output: 'contents',
+      },
+    ];
+
+    expect(translate(events)).toEqual([
+      { type: 'text-start', id: 'jcode-turn-1-text-1' },
+      {
+        type: 'text-delta',
+        id: 'jcode-turn-1-text-1',
+        delta: 'I will read it.',
+      },
+      { type: 'text-end', id: 'jcode-turn-1-text-1' },
+      {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'read',
+        input: '{"file_path":"a.txt"}',
+        providerExecuted: true,
+        dynamic: true,
+      },
+      {
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'read',
+        result: 'contents',
+      },
+    ] satisfies HarnessV1StreamPart[]);
+  });
+
+  it('fills missing tool lifecycle events, defaults empty input, and marks failures', () => {
+    const events: ApiEvent[] = [
+      {
+        ev: 'tool_done',
+        session_id: 's',
+        call_id: 'call-2',
+        name: 'bash',
+        output: 'stderr',
+        error: 'exit 1',
+      },
+    ];
+
+    expect(translate(events)).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'call-2',
+        toolName: 'bash',
+        input: '{}',
+        providerExecuted: true,
+        dynamic: true,
+      },
+      {
+        type: 'tool-result',
+        toolCallId: 'call-2',
+        toolName: 'bash',
+        result: 'exit 1',
+        isError: true,
+      },
+    ] satisfies HarnessV1StreamPart[]);
+  });
+
+  it('emits step usage, infers finish reasons, and aggregates known turn usage', () => {
+    const events: ApiEvent[] = [
+      { ev: 'tool_start', session_id: 's', call_id: 'c', name: 'ls' },
+      { ev: 'tool_exec', session_id: 's', call_id: 'c', name: 'ls' },
+      {
+        ev: 'token_usage',
+        session_id: 's',
+        input: 100,
+        output: 20,
+        cache_read_input: 40,
+      },
+      { ev: 'text_delta', session_id: 's', text: 'finished' },
+      { ev: 'token_usage', session_id: 's', input: 12, output: 3 },
+      { ev: 'turn_done', session_id: 's' },
+    ];
+
+    expect(translate(events)).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'c',
+        toolName: 'ls',
+        input: '{}',
+        providerExecuted: true,
+        dynamic: true,
+      },
+      {
+        type: 'finish-step',
+        finishReason: { unified: 'tool-calls', raw: 'tool-calls' },
+        usage: {
+          inputTokens: {
+            total: 100,
+            noCache: 60,
+            cacheRead: 40,
+            cacheWrite: 0,
+          },
+          outputTokens: {
+            total: 20,
+            text: undefined,
+            reasoning: undefined,
+          },
+        },
+      },
+      { type: 'text-start', id: 'jcode-turn-1-text-1' },
+      { type: 'text-delta', id: 'jcode-turn-1-text-1', delta: 'finished' },
+      { type: 'text-end', id: 'jcode-turn-1-text-1' },
+      {
+        type: 'finish-step',
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage: {
+          inputTokens: {
+            total: 12,
+            noCache: 12,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+          outputTokens: {
+            total: 3,
+            text: undefined,
+            reasoning: undefined,
+          },
+        },
+      },
+      {
+        type: 'finish',
+        finishReason: { unified: 'stop', raw: 'turn_done' },
+        totalUsage: {
+          inputTokens: {
+            total: 112,
+            noCache: 72,
+            cacheRead: 40,
+            cacheWrite: 0,
+          },
+          outputTokens: {
+            total: 23,
+            text: undefined,
+            reasoning: undefined,
+          },
+        },
+      },
+    ] satisfies HarnessV1StreamPart[]);
+  });
+
+  it('maps compaction, protocol errors, and otherwise unhandled events', () => {
+    const events: ApiEvent[] = [
+      { ev: 'reasoning_delta', session_id: 's', text: 'old context' },
+      { ev: 'compacted', session_id: 's', message: 'summary' },
+      { ev: 'error', code: 'internal', message: 'broken' },
+      { ev: 'session_status', session_id: 's', status: 'idle' },
+    ];
+
+    expect(translate(events)).toEqual([
+      { type: 'reasoning-start', id: 'jcode-turn-1-reasoning-1' },
+      {
+        type: 'reasoning-delta',
+        id: 'jcode-turn-1-reasoning-1',
+        delta: 'old context',
+      },
+      { type: 'reasoning-end', id: 'jcode-turn-1-reasoning-1' },
+      { type: 'compaction', trigger: 'auto', summary: 'summary' },
+      {
+        type: 'error',
+        error: { ev: 'error', code: 'internal', message: 'broken' },
+      },
+      {
+        type: 'raw',
+        rawValue: { ev: 'session_status', session_id: 's', status: 'idle' },
+      },
+    ] satisfies HarnessV1StreamPart[]);
+  });
+});

--- a/packages/harness-jcode/src/jcode-translate.ts
+++ b/packages/harness-jcode/src/jcode-translate.ts
@@ -1,0 +1,277 @@
+import type { ApiEvent } from '@1jehuang/jcode-sdk';
+import type { HarnessV1StreamPart } from '@ai-sdk/harness';
+
+type Usage = Extract<
+  HarnessV1StreamPart,
+  { readonly type: 'finish' }
+>['totalUsage'];
+
+interface PendingToolCall {
+  input: string;
+  name: string;
+  emitted: boolean;
+}
+
+/** Mutable state for translating one Jcode turn. Create a fresh state per turn. */
+export interface JcodeTranslatorState {
+  readonly turnId: string;
+  blockCounter: number;
+  currentTextId?: string;
+  currentReasoningId?: string;
+  readonly tools: Map<string, PendingToolCall>;
+  stepHadToolCall: boolean;
+  totalUsage: Usage;
+}
+
+export function createJcodeTranslatorState(
+  turnId: string | number = 1,
+): JcodeTranslatorState {
+  return {
+    turnId: String(turnId),
+    blockCounter: 0,
+    tools: new Map(),
+    stepHadToolCall: false,
+    totalUsage: zeroUsage(),
+  };
+}
+
+function zeroUsage(): Usage {
+  return {
+    inputTokens: {
+      total: 0,
+      noCache: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    outputTokens: { total: 0, text: 0, reasoning: 0 },
+  };
+}
+
+function usageFromEvent(
+  event: Extract<ApiEvent, { readonly ev: 'token_usage' }>,
+): Usage {
+  const cacheRead = event.cache_read_input ?? 0;
+  return {
+    inputTokens: {
+      total: event.input,
+      noCache: Math.max(0, event.input - cacheRead),
+      cacheRead,
+      cacheWrite: 0,
+    },
+    outputTokens: {
+      total: event.output,
+      text: undefined,
+      reasoning: undefined,
+    },
+  };
+}
+
+function addUsage(total: Usage, step: Usage): Usage {
+  const addKnown = (
+    left: number | undefined,
+    right: number | undefined,
+  ): number | undefined =>
+    left == null || right == null ? undefined : left + right;
+  return {
+    inputTokens: {
+      total: (total.inputTokens.total ?? 0) + (step.inputTokens.total ?? 0),
+      noCache:
+        (total.inputTokens.noCache ?? 0) + (step.inputTokens.noCache ?? 0),
+      cacheRead:
+        (total.inputTokens.cacheRead ?? 0) + (step.inputTokens.cacheRead ?? 0),
+      cacheWrite:
+        (total.inputTokens.cacheWrite ?? 0) +
+        (step.inputTokens.cacheWrite ?? 0),
+    },
+    outputTokens: {
+      total: (total.outputTokens.total ?? 0) + (step.outputTokens.total ?? 0),
+      text: addKnown(total.outputTokens.text, step.outputTokens.text),
+      reasoning: addKnown(
+        total.outputTokens.reasoning,
+        step.outputTokens.reasoning,
+      ),
+    },
+  };
+}
+
+function closeText(state: JcodeTranslatorState): HarnessV1StreamPart[] {
+  if (!state.currentTextId) return [];
+  const id = state.currentTextId;
+  state.currentTextId = undefined;
+  return [{ type: 'text-end', id }];
+}
+
+function closeReasoning(state: JcodeTranslatorState): HarnessV1StreamPart[] {
+  if (!state.currentReasoningId) return [];
+  const id = state.currentReasoningId;
+  state.currentReasoningId = undefined;
+  return [{ type: 'reasoning-end', id }];
+}
+
+function closeBlocks(state: JcodeTranslatorState): HarnessV1StreamPart[] {
+  return [...closeReasoning(state), ...closeText(state)];
+}
+
+function nextBlockId(
+  state: JcodeTranslatorState,
+  kind: 'text' | 'reasoning',
+): string {
+  state.blockCounter += 1;
+  return `jcode-turn-${state.turnId}-${kind}-${state.blockCounter}`;
+}
+
+function emitToolCall(
+  state: JcodeTranslatorState,
+  callId: string,
+): HarnessV1StreamPart[] {
+  const tool = state.tools.get(callId);
+  if (!tool || tool.emitted) return [];
+  tool.emitted = true;
+  state.stepHadToolCall = true;
+  return [
+    {
+      type: 'tool-call',
+      toolCallId: callId,
+      toolName: tool.name,
+      input: tool.input || '{}',
+      providerExecuted: true,
+      dynamic: true,
+    },
+  ];
+}
+
+/** Translate one Jcode API event into ordered harness stream parts. */
+export function translateJcodeEvent(
+  event: ApiEvent,
+  state: JcodeTranslatorState,
+): HarnessV1StreamPart[] {
+  switch (event.ev) {
+    case 'text_delta': {
+      const parts = closeReasoning(state);
+      if (!state.currentTextId) {
+        state.currentTextId = nextBlockId(state, 'text');
+        parts.push({ type: 'text-start', id: state.currentTextId });
+      }
+      parts.push({
+        type: 'text-delta',
+        id: state.currentTextId,
+        delta: event.text,
+      });
+      return parts;
+    }
+
+    case 'reasoning_delta': {
+      const parts = closeText(state);
+      if (!state.currentReasoningId) {
+        state.currentReasoningId = nextBlockId(state, 'reasoning');
+        parts.push({ type: 'reasoning-start', id: state.currentReasoningId });
+      }
+      parts.push({
+        type: 'reasoning-delta',
+        id: state.currentReasoningId,
+        delta: event.text,
+      });
+      return parts;
+    }
+
+    case 'reasoning_done':
+      return closeReasoning(state);
+
+    case 'tool_start':
+      state.tools.set(event.call_id, {
+        input: '',
+        name: event.name,
+        emitted: false,
+      });
+      return closeBlocks(state);
+
+    case 'tool_input_delta': {
+      const tool = state.tools.get(event.call_id);
+      if (tool && !tool.emitted) tool.input += event.delta;
+      return [];
+    }
+
+    case 'tool_exec': {
+      const existing = state.tools.get(event.call_id);
+      if (!existing) {
+        state.tools.set(event.call_id, {
+          input: '',
+          name: event.name,
+          emitted: false,
+        });
+      } else {
+        existing.name = event.name;
+      }
+      return [...closeBlocks(state), ...emitToolCall(state, event.call_id)];
+    }
+
+    case 'tool_done': {
+      const existing = state.tools.get(event.call_id);
+      if (!existing) {
+        state.tools.set(event.call_id, {
+          input: '',
+          name: event.name,
+          emitted: false,
+        });
+      }
+      const parts = [
+        ...closeBlocks(state),
+        ...emitToolCall(state, event.call_id),
+      ];
+      parts.push({
+        type: 'tool-result',
+        toolCallId: event.call_id,
+        toolName: event.name,
+        result: event.error ?? event.output,
+        ...(event.error ? { isError: true } : {}),
+      });
+      state.tools.delete(event.call_id);
+      return parts;
+    }
+
+    case 'token_usage': {
+      const usage = usageFromEvent(event);
+      state.totalUsage = addUsage(state.totalUsage, usage);
+      const finishReason = state.stepHadToolCall ? 'tool-calls' : 'stop';
+      state.stepHadToolCall = false;
+      const pendingToolCalls = [...state.tools.keys()].flatMap(callId =>
+        emitToolCall(state, callId),
+      );
+      return [
+        ...closeBlocks(state),
+        ...pendingToolCalls,
+        {
+          type: 'finish-step',
+          finishReason: { unified: finishReason, raw: finishReason },
+          usage,
+        },
+      ];
+    }
+
+    case 'compacted':
+      return [
+        ...closeBlocks(state),
+        {
+          type: 'compaction',
+          trigger: 'auto',
+          summary: event.message,
+        },
+      ];
+
+    case 'turn_done':
+      return [
+        ...closeBlocks(state),
+        {
+          type: 'finish',
+          finishReason: { unified: 'stop', raw: 'turn_done' },
+          totalUsage: state.totalUsage,
+        },
+      ];
+
+    case 'error':
+      return [{ type: 'error', error: event }];
+
+    default:
+      return [{ type: 'raw', rawValue: event }];
+  }
+}

--- a/packages/harness-jcode/src/jcode-translate.ts
+++ b/packages/harness-jcode/src/jcode-translate.ts
@@ -1,5 +1,6 @@
 import type { ApiEvent } from '@1jehuang/jcode-sdk';
 import type { HarnessV1StreamPart } from '@ai-sdk/harness';
+import type { JcodeExternalToolCallEvent } from './jcode-client';
 
 type Usage = Extract<
   HarnessV1StreamPart,
@@ -32,6 +33,42 @@ export function createJcodeTranslatorState(
     tools: new Map(),
     stepHadToolCall: false,
     totalUsage: zeroUsage(),
+  };
+}
+
+export function translateJcodeExternalToolCall(
+  event: JcodeExternalToolCallEvent,
+): HarnessV1StreamPart {
+  return {
+    type: 'tool-call',
+    toolCallId: event.call_id,
+    toolName: event.name,
+    input: JSON.stringify(event.input) ?? 'null',
+    providerExecuted: false,
+    dynamic: false,
+  };
+}
+
+export function translateJcodeExternalToolResult({
+  toolCallId,
+  toolName,
+  output,
+  isError,
+}: {
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly output: unknown;
+  readonly isError: boolean;
+}): HarnessV1StreamPart {
+  return {
+    type: 'tool-result',
+    toolCallId,
+    toolName,
+    result: output as Extract<
+      HarnessV1StreamPart,
+      { readonly type: 'tool-result' }
+    >['result'],
+    ...(isError ? { isError: true } : {}),
   };
 }
 

--- a/packages/harness-jcode/src/jcode-utils.ts
+++ b/packages/harness-jcode/src/jcode-utils.ts
@@ -1,0 +1,30 @@
+import {
+  HarnessCapabilityUnsupportedError,
+  type HarnessV1Prompt,
+} from '@ai-sdk/harness';
+
+const HARNESS_ID = 'jcode';
+
+export function extractJcodePrompt(prompt: HarnessV1Prompt): string {
+  if (typeof prompt === 'string') return prompt;
+  if (typeof prompt.content === 'string') return prompt.content;
+
+  return prompt.content
+    .map(part => {
+      if (part.type !== 'text') {
+        throw new HarnessCapabilityUnsupportedError({
+          harnessId: HARNESS_ID,
+          message: `jcode: only text user-message parts are supported in the initial adapter; got '${part.type}'.`,
+        });
+      }
+      return part.text;
+    })
+    .join('\n\n');
+}
+
+export function frameJcodeInstructions(
+  instructions: string,
+  userText: string,
+): string {
+  return `<session-instructions>\n${instructions}\n</session-instructions>\n\n<user-message>\n${userText}\n</user-message>`;
+}

--- a/packages/harness-jcode/src/version.ts
+++ b/packages/harness-jcode/src/version.ts
@@ -1,0 +1,6 @@
+// Version string of this package injected at build time.
+declare const __PACKAGE_VERSION__: string | undefined;
+export const VERSION: string =
+  typeof __PACKAGE_VERSION__ !== 'undefined'
+    ? __PACKAGE_VERSION__
+    : '0.0.0-test';

--- a/packages/harness-jcode/tsconfig.build.json
+++ b/packages/harness-jcode/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "composite": false }
+}

--- a/packages/harness-jcode/tsconfig.json
+++ b/packages/harness-jcode/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./node_modules/@vercel/ai-tsconfig/ts-library.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": ["dist", "build", "node_modules", "tsup.config.ts"],
+  "references": [
+    { "path": "../harness" },
+    { "path": "../provider-utils" }
+  ]
+}

--- a/packages/harness-jcode/tsup.config.ts
+++ b/packages/harness-jcode/tsup.config.ts
@@ -4,11 +4,24 @@ const packageVersion = JSON.stringify(
   (await import('./package.json', { with: { type: 'json' } })).default.version,
 );
 
-export default defineConfig({
-  entry: { index: 'src/index.ts' },
-  format: ['esm'],
-  target: 'es2022',
-  dts: true,
-  sourcemap: true,
-  define: { __PACKAGE_VERSION__: packageVersion },
-});
+export default defineConfig([
+  {
+    entry: { index: 'src/index.ts' },
+    format: ['esm'],
+    target: 'es2022',
+    dts: true,
+    sourcemap: true,
+    define: { __PACKAGE_VERSION__: packageVersion },
+  },
+  {
+    entry: { 'bridge/index': 'src/bridge/index.ts' },
+    format: ['esm'],
+    target: 'es2022',
+    outExtension: () => ({ js: '.mjs' }),
+    dts: false,
+    sourcemap: true,
+    platform: 'node',
+    noExternal: ['@ai-sdk/harness'],
+    external: ['@1jehuang/jcode-sdk', 'ws'],
+  },
+]);

--- a/packages/harness-jcode/tsup.config.ts
+++ b/packages/harness-jcode/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+const packageVersion = JSON.stringify(
+  (await import('./package.json', { with: { type: 'json' } })).default.version,
+);
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  target: 'es2022',
+  dts: true,
+  sourcemap: true,
+  define: { __PACKAGE_VERSION__: packageVersion },
+});

--- a/packages/harness-jcode/turbo.json
+++ b/packages/harness-jcode/turbo.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["//"],
+  "tasks": { "build": { "outputs": ["**/dist/**"] } }
+}

--- a/packages/harness-jcode/vitest.node.config.js
+++ b/packages/harness-jcode/vitest.node.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3151,6 +3151,9 @@ importers:
       '@ai-sdk/provider-utils':
         specifier: workspace:*
         version: link:../provider-utils
+      ws:
+        specifier: 8.21.0
+        version: 8.21.0
     devDependencies:
       '@types/node':
         specifier: 22.19.19
@@ -3167,9 +3170,6 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
-      ws:
-        specifier: 8.21.0
-        version: 8.21.0
       zod:
         specifier: 3.25.76
         version: 3.25.76

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3140,6 +3140,34 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
 
+  packages/harness-jcode:
+    dependencies:
+      '@1jehuang/jcode-sdk':
+        specifier: 1.1.0
+        version: 1.1.0
+      '@ai-sdk/harness':
+        specifier: workspace:*
+        version: link:../harness
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
+    devDependencies:
+      '@types/node':
+        specifier: 22.19.19
+        version: 22.19.19
+      '@vercel/ai-tsconfig':
+        specifier: workspace:*
+        version: link:../../tools/tsconfig
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.12)(typescript@5.8.3)(yaml@2.9.0)
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
   packages/harness-opencode:
     dependencies:
       '@ai-sdk/harness':
@@ -4482,6 +4510,40 @@ importers:
   tools/tsconfig: {}
 
 packages:
+
+  '@1jehuang/jcode-darwin-arm64@1.1.0':
+    resolution: {integrity: sha512-OoVrOeZ79TkKAk3TXnR858WoeaBOn+dFQC3kvN7YMVaq4TjvuwcFfxTO7ud1ciVmpPvXaHzPi8L776aPDAx5Hw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@1jehuang/jcode-darwin-x64@1.1.0':
+    resolution: {integrity: sha512-wsiE7Qzt5UkJV/v2O+NzKQuipZNvuXzi5vyXCDbJDF0fvojQsjZY2njpXGjxwlzcOp4fTesE4inuH/xqL71rDw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@1jehuang/jcode-linux-arm64@1.1.0':
+    resolution: {integrity: sha512-5s9VUitbpx4PSgdtNdgsGy2FtSNlJtQpsfb6RWX5E8QXHpnwlfsbXoq1PuU5kwWitJY07OYnB1P4xozObpA68Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@1jehuang/jcode-linux-x64@1.1.0':
+    resolution: {integrity: sha512-9w+VpnSZQrpU+lYy/I7a4NsRbPAUSN9DHIX8uoJ1uhlocJ6WPB77AxDp2I5zWUn5H09knlAkw2LgzvhWANzpbQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@1jehuang/jcode-sdk@1.1.0':
+    resolution: {integrity: sha512-A9QcerzdNb9yXsRaip38doZd/Z8IGGlAsjmdLuRl9IvpitkHwizzjh4+e3U6YEwyLygvOlgkiNdgvf0UMosvPg==}
+    engines: {node: '>=20'}
+
+  '@1jehuang/jcode-win32-arm64@1.1.0':
+    resolution: {integrity: sha512-Gcqvjit05CQH+ELC9G8bBYTciP8o8MzbVLUz8PFWJYmSXzbVlJEbQzr4/D29egPUSUrgAsti8rtqAmGIjIBN6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@1jehuang/jcode-win32-x64@1.1.0':
+    resolution: {integrity: sha512-ePRfhzPk6HQ94WZFEmKxztuhhw4ZkzyiCdJKa3v4ERAHAz4APLO16K6H53kDc+x04YvW7nurgcALWWKVF+8JGA==}
+    cpu: [x64]
+    os: [win32]
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
@@ -24452,6 +24514,35 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@1jehuang/jcode-darwin-arm64@1.1.0':
+    optional: true
+
+  '@1jehuang/jcode-darwin-x64@1.1.0':
+    optional: true
+
+  '@1jehuang/jcode-linux-arm64@1.1.0':
+    optional: true
+
+  '@1jehuang/jcode-linux-x64@1.1.0':
+    optional: true
+
+  '@1jehuang/jcode-sdk@1.1.0':
+    dependencies:
+      ajv: 8.20.0
+    optionalDependencies:
+      '@1jehuang/jcode-darwin-arm64': 1.1.0
+      '@1jehuang/jcode-darwin-x64': 1.1.0
+      '@1jehuang/jcode-linux-arm64': 1.1.0
+      '@1jehuang/jcode-linux-x64': 1.1.0
+      '@1jehuang/jcode-win32-arm64': 1.1.0
+      '@1jehuang/jcode-win32-x64': 1.1.0
+
+  '@1jehuang/jcode-win32-arm64@1.1.0':
+    optional: true
+
+  '@1jehuang/jcode-win32-x64@1.1.0':
+    optional: true
 
   '@adobe/css-tools@4.4.4': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3155,6 +3155,9 @@ importers:
       '@types/node':
         specifier: 22.19.19
         version: 22.19.19
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
       '@vercel/ai-tsconfig':
         specifier: workspace:*
         version: link:../../tools/tsconfig
@@ -3164,6 +3167,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      ws:
+        specifier: 8.21.0
+        version: 8.21.0
       zod:
         specifier: 3.25.76
         version: 3.25.76

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -121,6 +121,9 @@
       "path": "packages/harness-pi"
     },
     {
+      "path": "packages/harness-jcode"
+    },
+    {
       "path": "packages/harness"
     },
     {


### PR DESCRIPTION
## Background

The AI SDK harness family (`@ai-sdk/harness-<name>`) adapts coding agents to the Harness V1 interface. This PR adds an adapter for [Jcode](https://github.com/1jehuang/jcode) so hosts can run Jcode sessions through the same typed harness API used by other adapters.

## Summary

Adds the new `@ai-sdk/harness-jcode` package:

- **Adapter core**: `createJcode` harness with typed text, reasoning, tool, usage, compaction, lifecycle, and cancellation event handling, plus stop/resume and destroy lifecycle operations.
- **Sandbox bridge**: an in-sandbox bridge runtime with a deterministic bootstrap recipe (`harness.getBootstrap()`), per-session work/state directories, random auth token, and exposed-port discovery (`port` + `portEndpoint` for basic sandboxes).
- **Host-defined tools**: executed outside Jcode via Harness V1's `submitToolResult` flow (requires Jcode runtime and SDK 1.3.0+).
- **Unsupported capabilities** (turn suspension, lossless turn continuation, live detach, JSON response formats, mid-turn user messages) reject with `HarnessCapabilityUnsupportedError`.
- **Tests**: bridge conformance, session, translate, bootstrap, and harness unit tests plus type tests.
- **Release validation**: `scripts/release-validation.sh` builds release binaries, packs local SDK/runtime, installs into a clean consumer, and verifies `external_tools_v1` (optional Vercel Sandbox path via `RUN_VERCEL_SANDBOX=1`).
- Docs: README, feature matrix, and implementation playbook.

## End-to-End Verification

Ran `scripts/release-validation.sh`, which installs the packed adapter and bundled runtime into a clean consumer, launches the runtime, and verifies the `external_tools_v1` handshake end to end.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

- Turn suspension, lossless turn continuation, live detach, JSON response formats, and mid-turn user messages.
