### PR TITLE
fix: support Bedrock endpoints for non-standard AWS regions and service-specific overrides

### DIFF
--- a/.changeset/calm-beds-route.md
+++ b/.changeset/calm-beds-route.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+---
+
+fix: support Bedrock endpoints for non-standard AWS regions and service-specific overrides

--- a/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
+++ b/content/providers/01-ai-sdk-providers/08-amazon-bedrock.mdx
@@ -175,6 +175,10 @@ You can use the following optional settings to customize the Amazon Bedrock prov
 
   Optional. Base URL for the Bedrock API calls.
   Useful for custom endpoints or proxy configurations.
+  When omitted, the provider also supports the service-specific
+  `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` and
+  `AWS_ENDPOINT_URL_BEDROCK_AGENT_RUNTIME` environment variables, which take
+  precedence over the global `AWS_ENDPOINT_URL` environment variable.
 
 - **headers** _Record&lt;string, string&gt;_
 
@@ -1526,6 +1530,9 @@ You can use the following optional settings to customize the Bedrock Anthropic p
 
   Base URL for the Bedrock API calls.
   Useful for custom endpoints or proxy configurations.
+  When omitted, the provider also supports the service-specific
+  `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` environment variable, which takes
+  precedence over the global `AWS_ENDPOINT_URL` environment variable.
 
 - **headers** _Resolvable&lt;Record&lt;string, string | undefined&gt;&gt;_
 

--- a/examples/ai-functions/src/generate-text/openai/programmatic-tool-calling-denied-approval.ts
+++ b/examples/ai-functions/src/generate-text/openai/programmatic-tool-calling-denied-approval.ts
@@ -1,0 +1,99 @@
+import { openai } from '@ai-sdk/openai';
+import { parseJSON } from '@ai-sdk/provider-utils';
+import { generateText, isStepCount, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+const denialReason = 'ACCESS_DENIED_SENTINEL';
+
+run(async () => {
+  let executeCalled = false;
+
+  const result = await generateText({
+    model: openai('gpt-5.6-terra'),
+    prompt: `Use programmatic_tool_calling and run this JavaScript logic exactly once:
+
+let rejected = false;
+let value;
+try {
+  value = await tools.get_secret({});
+} catch (error) {
+  rejected = true;
+  value = error instanceof Error ? error.message : String(error);
+}
+text(JSON.stringify({ rejected, value, valueType: typeof value }));
+
+Do not call get_secret directly. After the program finishes, briefly report its JSON output.`,
+    providerOptions: {
+      openai: {
+        parallelToolCalls: false,
+        store: false,
+      },
+    },
+    stopWhen: isStepCount(10),
+    toolApproval: {
+      get_secret: {
+        type: 'denied',
+        reason: denialReason,
+      },
+    },
+    tools: {
+      get_secret: tool({
+        description:
+          'Returns a secret. This tool is denied by the application access policy.',
+        execute: async () => {
+          executeCalled = true;
+          return { secret: 'execute should never run' };
+        },
+        inputSchema: z.object({}),
+        outputSchema: z.object({ secret: z.string() }),
+        providerOptions: {
+          openai: {
+            allowedCallers: ['programmatic'],
+          },
+        },
+      }),
+      programmatic_tool_calling: openai.tools.programmaticToolCalling(),
+    },
+  });
+
+  const programResult = result.steps
+    .flatMap(step => step.toolResults)
+    .find(toolResult => toolResult.toolName === 'programmatic_tool_calling');
+
+  if (
+    programResult == null ||
+    typeof programResult.output !== 'object' ||
+    programResult.output === null ||
+    !('result' in programResult.output) ||
+    typeof programResult.output.result !== 'string'
+  ) {
+    throw new Error('The model did not produce the expected program result.');
+  }
+
+  const observation = await parseJSON({ text: programResult.output.result });
+
+  console.log('Tool execute callback called:', executeCalled);
+  console.log('Program observed:', observation);
+  console.log('Final model response:', result.text);
+
+  if (
+    executeCalled === false &&
+    typeof observation === 'object' &&
+    observation !== null &&
+    'rejected' in observation &&
+    observation.rejected === false &&
+    'value' in observation &&
+    observation.value === denialReason &&
+    'valueType' in observation &&
+    observation.valueType === 'string'
+  ) {
+    console.log(
+      '\nBUG REPRODUCED: a denied program-owned tool call resolved as a string.',
+    );
+  } else {
+    console.log(
+      '\nBug not reproduced: the denied call did not resolve with the denial string.',
+    );
+  }
+});

--- a/packages/amazon-bedrock/src/amazon-bedrock-provider.test.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-provider.test.ts
@@ -1,6 +1,6 @@
 import type * as AnthropicModule from '@ai-sdk/anthropic';
 import { anthropicTools } from '@ai-sdk/anthropic/internal';
-import { loadOptionalSetting } from '@ai-sdk/provider-utils';
+import { loadOptionalSetting, loadSetting } from '@ai-sdk/provider-utils';
 import type * as ProviderUtilsModule from '@ai-sdk/provider-utils';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { AmazonBedrockChatLanguageModel } from './amazon-bedrock-chat-language-model';
@@ -11,6 +11,7 @@ import {
   createApiKeyFetchFunction,
   createSigV4FetchFunction,
 } from './amazon-bedrock-sigv4-fetch';
+import { AmazonBedrockRerankingModel } from './reranking/amazon-bedrock-reranking-model';
 
 // Add type assertions for the mocked classes
 const AmazonBedrockChatLanguageModelMock =
@@ -18,6 +19,8 @@ const AmazonBedrockChatLanguageModelMock =
 const AmazonBedrockEmbeddingModelMock =
   AmazonBedrockEmbeddingModel as unknown as Mock;
 const AmazonBedrockImageModelMock = AmazonBedrockImageModel as unknown as Mock;
+const AmazonBedrockRerankingModelMock =
+  AmazonBedrockRerankingModel as unknown as Mock;
 
 vi.mock('./amazon-bedrock-chat-language-model', () => ({
   AmazonBedrockChatLanguageModel: vi.fn(),
@@ -29,6 +32,10 @@ vi.mock('./amazon-bedrock-embedding-model', () => ({
 
 vi.mock('./amazon-bedrock-image-model', () => ({
   AmazonBedrockImageModel: vi.fn(),
+}));
+
+vi.mock('./reranking/amazon-bedrock-reranking-model', () => ({
+  AmazonBedrockRerankingModel: vi.fn(),
 }));
 
 vi.mock('./amazon-bedrock-sigv4-fetch', () => ({
@@ -55,7 +62,7 @@ vi.mock('@ai-sdk/provider-utils', async importOriginal => {
     loadOptionalSetting: vi
       .fn()
       .mockImplementation(({ settingValue }) => settingValue),
-    withoutTrailingSlash: vi.fn(url => url),
+    withoutTrailingSlash: vi.fn(url => url?.replace(/\/$/, '')),
     generateId: vi.fn().mockReturnValue('mock-id'),
     createJsonErrorResponseHandler: vi.fn(),
     createJsonResponseHandler: vi.fn(),
@@ -74,6 +81,7 @@ vi.mock('./version', () => ({
 const mockCreateSigV4FetchFunction = vi.mocked(createSigV4FetchFunction);
 const mockCreateApiKeyFetchFunction = vi.mocked(createApiKeyFetchFunction);
 const mockLoadOptionalSetting = vi.mocked(loadOptionalSetting);
+const mockLoadSetting = vi.mocked(loadSetting);
 
 describe('AmazonBedrockProvider', () => {
   beforeEach(() => {
@@ -119,6 +127,134 @@ describe('AmazonBedrockProvider', () => {
         'ai-sdk/amazon-bedrock/0.0.0-test',
       );
       expect(constructorCall[1].baseUrl()).toBe('https://custom.url');
+    });
+
+    it.each([
+      ['cn-north-1', 'amazonaws.com.cn'],
+      ['us-gov-west-1', 'amazonaws.com'],
+      ['us-iso-east-1', 'c2s.ic.gov'],
+      ['us-isob-east-1', 'sc2s.sgov.gov'],
+      ['eu-isoe-west-1', 'cloud.adc-e.uk'],
+      ['us-isof-south-1', 'csp.hci.ic.gov'],
+      ['eusc-de-east-1', 'amazonaws.eu'],
+    ])('resolves the Bedrock Runtime endpoint for %s', (region, dnsSuffix) => {
+      const provider = createAmazonBedrock({ region });
+
+      provider('anthropic.claude-v2');
+
+      const constructorCall = AmazonBedrockChatLanguageModelMock.mock.calls[0];
+      expect(constructorCall[1].baseUrl()).toBe(
+        `https://bedrock-runtime.${region}.${dnsSuffix}`,
+      );
+    });
+
+    it('uses an explicit base URL without loading a region', () => {
+      mockLoadOptionalSetting.mockImplementation(
+        ({ settingValue, environmentVariableName }) => {
+          if (settingValue != null) {
+            return settingValue;
+          }
+          if (environmentVariableName === 'AWS_ENDPOINT_URL_BEDROCK_RUNTIME') {
+            return 'https://runtime.example.com';
+          }
+          if (environmentVariableName === 'AWS_ENDPOINT_URL') {
+            return 'https://global.example.com';
+          }
+          return undefined;
+        },
+      );
+
+      const provider = createAmazonBedrock({
+        apiKey: 'test-api-key',
+        baseURL: 'https://explicit.example.com/',
+      });
+
+      provider('anthropic.claude-v2');
+
+      const constructorCall = AmazonBedrockChatLanguageModelMock.mock.calls[0];
+      expect(constructorCall[1].baseUrl()).toBe('https://explicit.example.com');
+      expect(mockLoadSetting).not.toHaveBeenCalled();
+    });
+
+    it('prefers the service-specific Bedrock Runtime endpoint over the global endpoint', () => {
+      mockLoadOptionalSetting.mockImplementation(
+        ({ settingValue, environmentVariableName }) => {
+          if (environmentVariableName === 'AWS_ENDPOINT_URL_BEDROCK_RUNTIME') {
+            return 'https://runtime.example.com/';
+          }
+          if (environmentVariableName === 'AWS_ENDPOINT_URL') {
+            return 'https://global.example.com';
+          }
+          return settingValue;
+        },
+      );
+
+      const provider = createAmazonBedrock({
+        apiKey: 'test-api-key',
+      });
+
+      provider('anthropic.claude-v2');
+
+      const constructorCall = AmazonBedrockChatLanguageModelMock.mock.calls[0];
+      expect(constructorCall[1].baseUrl()).toBe('https://runtime.example.com');
+      expect(mockLoadSetting).not.toHaveBeenCalled();
+    });
+
+    it('uses the global endpoint override when no service-specific endpoint is set', () => {
+      mockLoadOptionalSetting.mockImplementation(
+        ({ settingValue, environmentVariableName }) =>
+          environmentVariableName === 'AWS_ENDPOINT_URL'
+            ? 'https://global.example.com/'
+            : settingValue,
+      );
+
+      const provider = createAmazonBedrock({
+        apiKey: 'test-api-key',
+      });
+
+      provider('anthropic.claude-v2');
+
+      const constructorCall = AmazonBedrockChatLanguageModelMock.mock.calls[0];
+      expect(constructorCall[1].baseUrl()).toBe('https://global.example.com');
+      expect(mockLoadSetting).not.toHaveBeenCalled();
+    });
+
+    it('uses a separate service-specific endpoint for Bedrock Agent Runtime', () => {
+      mockLoadOptionalSetting.mockImplementation(
+        ({ settingValue, environmentVariableName }) => {
+          if (environmentVariableName === 'AWS_ENDPOINT_URL_BEDROCK_RUNTIME') {
+            return 'https://runtime.example.com';
+          }
+          if (
+            environmentVariableName === 'AWS_ENDPOINT_URL_BEDROCK_AGENT_RUNTIME'
+          ) {
+            return 'https://agent-runtime.example.com';
+          }
+          return settingValue;
+        },
+      );
+
+      const provider = createAmazonBedrock({ region: 'us-east-1' });
+
+      provider.reranking('amazon.rerank-v1:0');
+
+      const constructorCall = AmazonBedrockRerankingModelMock.mock.calls[0];
+      expect(constructorCall[1].baseUrl()).toBe(
+        'https://agent-runtime.example.com',
+      );
+    });
+
+    it('resolves the Bedrock Agent Runtime endpoint for a non-standard AWS partition', () => {
+      const provider = createAmazonBedrock({
+        region: 'eu-isoe-west-1',
+      });
+
+      provider.reranking('amazon.rerank-v1:0');
+
+      const constructorCall = AmazonBedrockRerankingModelMock.mock.calls[0];
+      expect(constructorCall[1].baseUrl()).toBe(
+        'https://bedrock-agent-runtime.eu-isoe-west-1.cloud.adc-e.uk',
+      );
     });
 
     it('should accept a credentialProvider in options', () => {

--- a/packages/amazon-bedrock/src/amazon-bedrock-provider.ts
+++ b/packages/amazon-bedrock/src/amazon-bedrock-provider.ts
@@ -10,7 +10,6 @@ import {
   generateId,
   loadOptionalSetting,
   loadSetting,
-  withoutTrailingSlash,
   withUserAgentSuffix,
   type FetchFunction,
 } from '@ai-sdk/provider-utils';
@@ -30,6 +29,7 @@ import {
 } from './amazon-bedrock-sigv4-fetch';
 import { AmazonBedrockRerankingModel } from './reranking/amazon-bedrock-reranking-model';
 import type { AmazonBedrockRerankingModelId } from './reranking/amazon-bedrock-reranking-model-options';
+import { resolveAmazonBedrockBaseURL } from './resolve-amazon-bedrock-base-url';
 import { VERSION } from './version';
 
 export interface AmazonBedrockProviderSettings {
@@ -286,26 +286,34 @@ export function createAmazonBedrock(
   };
 
   const getAmazonBedrockRuntimeBaseUrl = (): string =>
-    withoutTrailingSlash(
-      options.baseURL ??
-        `https://bedrock-runtime.${loadSetting({
+    resolveAmazonBedrockBaseURL({
+      baseURL: options.baseURL,
+      getRegion: () =>
+        loadSetting({
           settingValue: options.region,
           settingName: 'region',
           environmentVariableName: 'AWS_REGION',
           description: 'AWS region',
-        })}.amazonaws.com`,
-    ) ?? `https://bedrock-runtime.us-east-1.amazonaws.com`;
+        }),
+      service: 'bedrock-runtime',
+      serviceEndpointUrlEnvironmentVariableName:
+        'AWS_ENDPOINT_URL_BEDROCK_RUNTIME',
+    });
 
   const getAmazonBedrockAgentRuntimeBaseUrl = (): string =>
-    withoutTrailingSlash(
-      options.baseURL ??
-        `https://bedrock-agent-runtime.${loadSetting({
+    resolveAmazonBedrockBaseURL({
+      baseURL: options.baseURL,
+      getRegion: () =>
+        loadSetting({
           settingValue: options.region,
           settingName: 'region',
           environmentVariableName: 'AWS_REGION',
           description: 'AWS region',
-        })}.amazonaws.com`,
-    ) ?? `https://bedrock-agent-runtime.us-west-2.amazonaws.com`;
+        }),
+      service: 'bedrock-agent-runtime',
+      serviceEndpointUrlEnvironmentVariableName:
+        'AWS_ENDPOINT_URL_BEDROCK_AGENT_RUNTIME',
+    });
 
   const createChatModel = (modelId: AmazonBedrockChatModelId) =>
     new AmazonBedrockChatLanguageModel(modelId, {

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.test.ts
@@ -4,6 +4,7 @@ import {
   AnthropicLanguageModel,
   anthropicTools,
 } from '@ai-sdk/anthropic/internal';
+import { loadOptionalSetting, loadSetting } from '@ai-sdk/provider-utils';
 import { vi, describe, beforeEach, it, expect } from 'vitest';
 
 vi.mock('@ai-sdk/provider-utils', async () => {
@@ -25,7 +26,9 @@ vi.mock('@ai-sdk/provider-utils', async () => {
       if (settingName === 'secretAccessKey') return 'mock-secret-key';
       return settingValue;
     }),
-    withoutTrailingSlash: vi.fn().mockImplementation(url => url),
+    withoutTrailingSlash: vi
+      .fn()
+      .mockImplementation(url => url?.replace(/\/$/, '')),
     withUserAgentSuffix: vi.fn().mockImplementation((headers, suffix) => ({
       ...headers,
       'user-agent': suffix,
@@ -56,9 +59,23 @@ vi.mock('../amazon-bedrock-sigv4-fetch', () => ({
   createApiKeyFetchFunction: vi.fn().mockReturnValue(vi.fn()),
 }));
 
+const mockLoadOptionalSetting = vi.mocked(loadOptionalSetting);
+const mockLoadSetting = vi.mocked(loadSetting);
+
 describe('amazon-bedrock-anthropic-provider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLoadOptionalSetting.mockImplementation(({ settingValue }) => {
+      if (settingValue === undefined) return undefined;
+      return settingValue;
+    });
+    mockLoadSetting.mockImplementation(({ settingValue, settingName }) => {
+      if (settingValue) return settingValue;
+      if (settingName === 'region') return 'us-east-1';
+      if (settingName === 'accessKeyId') return 'mock-access-key';
+      if (settingName === 'secretAccessKey') return 'mock-secret-key';
+      return settingValue as string;
+    });
   });
 
   it('should create a language model with default settings', () => {
@@ -190,11 +207,56 @@ describe('amazon-bedrock-anthropic-provider', () => {
     );
   });
 
-  it('should pass custom baseURL to the model when created', () => {
+  it('should pass custom baseURL without loading a region', () => {
     const customBaseURL = 'https://custom-bedrock.amazonaws.com';
     const provider = createAmazonBedrockAnthropic({
-      region: 'us-east-1',
+      apiKey: 'test-api-key',
       baseURL: customBaseURL,
+    });
+    provider('test-model-id');
+
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        baseURL: customBaseURL,
+      }),
+    );
+    expect(mockLoadSetting).not.toHaveBeenCalled();
+  });
+
+  it('prefers the service-specific endpoint over the global endpoint without loading a region', () => {
+    mockLoadOptionalSetting.mockImplementation(
+      ({ settingValue, environmentVariableName }) => {
+        if (settingValue != null) {
+          return settingValue;
+        }
+        if (environmentVariableName === 'AWS_ENDPOINT_URL_BEDROCK_RUNTIME') {
+          return 'https://runtime.example.com/';
+        }
+        if (environmentVariableName === 'AWS_ENDPOINT_URL') {
+          return 'https://global.example.com';
+        }
+        return undefined;
+      },
+    );
+
+    const provider = createAmazonBedrockAnthropic({
+      apiKey: 'test-api-key',
+    });
+    provider('test-model-id');
+
+    expect(AnthropicLanguageModel).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        baseURL: 'https://runtime.example.com',
+      }),
+    );
+    expect(mockLoadSetting).not.toHaveBeenCalled();
+  });
+
+  it('resolves the Bedrock Runtime endpoint for an AWS ISO region', () => {
+    const provider = createAmazonBedrockAnthropic({
+      region: 'us-iso-east-1',
       accessKeyId: 'test-key',
       secretAccessKey: 'test-secret',
     });
@@ -203,7 +265,7 @@ describe('amazon-bedrock-anthropic-provider', () => {
     expect(AnthropicLanguageModel).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        baseURL: customBaseURL,
+        baseURL: 'https://bedrock-runtime.us-iso-east-1.c2s.ic.gov',
       }),
     );
   });

--- a/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
+++ b/packages/amazon-bedrock/src/anthropic/amazon-bedrock-anthropic-provider.ts
@@ -7,7 +7,6 @@ import {
   loadOptionalSetting,
   loadSetting,
   resolve,
-  withoutTrailingSlash,
   withUserAgentSuffix,
   type FetchFunction,
   type Resolvable,
@@ -25,6 +24,7 @@ import {
   supportsNativeStructuredOutput,
   supportsStrictTools,
 } from '../amazon-bedrock-anthropic-model-support';
+import { resolveAmazonBedrockBaseURL } from '../resolve-amazon-bedrock-base-url';
 import { createAmazonBedrockAnthropicFetch } from './amazon-bedrock-anthropic-fetch';
 import type { AmazonBedrockAnthropicModelId } from './amazon-bedrock-anthropic-options';
 import { VERSION } from '../version';
@@ -239,15 +239,19 @@ export function createAmazonBedrockAnthropic(
   const fetchFunction = createAmazonBedrockAnthropicFetch(baseFetchFunction);
 
   const getBaseURL = (): string =>
-    withoutTrailingSlash(
-      options.baseURL ??
-        `https://bedrock-runtime.${loadSetting({
+    resolveAmazonBedrockBaseURL({
+      baseURL: options.baseURL,
+      getRegion: () =>
+        loadSetting({
           settingValue: options.region,
           settingName: 'region',
           environmentVariableName: 'AWS_REGION',
           description: 'AWS region',
-        })}.amazonaws.com`,
-    ) ?? 'https://bedrock-runtime.us-east-1.amazonaws.com';
+        }),
+      service: 'bedrock-runtime',
+      serviceEndpointUrlEnvironmentVariableName:
+        'AWS_ENDPOINT_URL_BEDROCK_RUNTIME',
+    });
 
   const getHeaders = async () => {
     const baseHeaders = (await resolve(options.headers)) ?? {};

--- a/packages/amazon-bedrock/src/resolve-amazon-bedrock-base-url.ts
+++ b/packages/amazon-bedrock/src/resolve-amazon-bedrock-base-url.ts
@@ -1,0 +1,51 @@
+import {
+  loadOptionalSetting,
+  withoutTrailingSlash,
+} from '@ai-sdk/provider-utils';
+
+const AWS_PARTITION_DNS_SUFFIXES = [
+  { regionPrefix: 'cn-', dnsSuffix: 'amazonaws.com.cn' },
+  { regionPrefix: 'us-iso-', dnsSuffix: 'c2s.ic.gov' },
+  { regionPrefix: 'us-isob-', dnsSuffix: 'sc2s.sgov.gov' },
+  { regionPrefix: 'eu-isoe-', dnsSuffix: 'cloud.adc-e.uk' },
+  { regionPrefix: 'us-isof-', dnsSuffix: 'csp.hci.ic.gov' },
+  { regionPrefix: 'eusc-', dnsSuffix: 'amazonaws.eu' },
+] as const;
+
+export function resolveAmazonBedrockBaseURL({
+  baseURL,
+  getRegion,
+  service,
+  serviceEndpointUrlEnvironmentVariableName,
+}: {
+  baseURL: string | undefined;
+  getRegion: () => string;
+  service: 'bedrock-runtime' | 'bedrock-agent-runtime';
+  serviceEndpointUrlEnvironmentVariableName:
+    | 'AWS_ENDPOINT_URL_BEDROCK_RUNTIME'
+    | 'AWS_ENDPOINT_URL_BEDROCK_AGENT_RUNTIME';
+}): string {
+  const resolvedBaseURL =
+    baseURL ??
+    loadOptionalSetting({
+      settingValue: undefined,
+      environmentVariableName: serviceEndpointUrlEnvironmentVariableName,
+    }) ??
+    loadOptionalSetting({
+      settingValue: undefined,
+      environmentVariableName: 'AWS_ENDPOINT_URL',
+    });
+
+  if (resolvedBaseURL != null) {
+    return withoutTrailingSlash(resolvedBaseURL) ?? resolvedBaseURL;
+  }
+
+  const region = getRegion();
+  const dnsSuffix =
+    AWS_PARTITION_DNS_SUFFIXES.find(({ regionPrefix }) =>
+      region.startsWith(regionPrefix),
+    )?.dnsSuffix ?? 'amazonaws.com';
+  const generatedBaseURL = `https://${service}.${region}.${dnsSuffix}`;
+
+  return withoutTrailingSlash(generatedBaseURL) ?? generatedBaseURL;
+}


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/11197

The published Amazon Bedrock provider generated invalid URLs for non-standard AWS partitions, ignored AWS endpoint override variables, and could not independently route Runtime and Agent Runtime operations.

Up-port for https://github.com/vercel/ai/pull/20552

## Root Cause

Endpoint construction hard-coded the amazonaws.com DNS suffix and reused one baseURL without consulting service-specific or global AWS endpoint variables; captured request URLs confirmed the incorrect ISO host and ignored override.

## Summary

Added shared partition-aware endpoint resolution for standard and Anthropic Bedrock providers, with explicit baseURL, service-specific environment variable, global environment variable, then generated endpoint precedence.

## End-to-end Validation

- `replay_original_reproduction`: exited successfully and captured the correct ISO and AWS_ENDPOINT_URL_BEDROCK_RUNTIME request URLs without the original bug signal.

## Related Issues

Fixes #11197

Closes #17652
Closes #13179
Closes #17624