### PR TITLE
fix(langchain): use secureJsonParse for OpenAI-format tool call arguments

### DIFF
--- a/.changeset/vuln-scanner-langchain-secure-json-parse.md
+++ b/.changeset/vuln-scanner-langchain-secure-json-parse.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/langchain': patch
+---
+
+fix: use secureJsonParse for OpenAI-format tool call arguments to guard against prototype pollution

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -36,10 +36,10 @@
     }
   },
   "dependencies": {
+    "@ai-sdk/provider-utils": "workspace:*",
     "ai": "workspace:*"
   },
   "devDependencies": {
-    "@ai-sdk/provider-utils": "workspace:*",
     "@langchain/core": "^1.1.46",
     "@langchain/langgraph": "^1.3.0",
     "@types/node": "22.19.19",

--- a/packages/langchain/src/utils.ts
+++ b/packages/langchain/src/utils.ts
@@ -17,6 +17,7 @@ import type {
   ProviderMetadata,
   JSONValue,
 } from 'ai';
+import { secureJsonParse } from '@ai-sdk/provider-utils';
 
 import type {
   LangGraphEventState,
@@ -2044,7 +2045,7 @@ export function processLangGraphEvent(
                       let args: unknown;
                       try {
                         args = functionData?.arguments
-                          ? JSON.parse(functionData.arguments)
+                          ? secureJsonParse(functionData.arguments)
                           : {};
                       } catch {
                         args = {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3346,13 +3346,13 @@ importers:
 
   packages/langchain:
     dependencies:
+      '@ai-sdk/provider-utils':
+        specifier: workspace:*
+        version: link:../provider-utils
       ai:
         specifier: workspace:*
         version: link:../ai
     devDependencies:
-      '@ai-sdk/provider-utils':
-        specifier: workspace:*
-        version: link:../provider-utils
       '@langchain/core':
         specifier: ^1.1.46
         version: 1.1.46(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.40.0(ws@8.21.3)(zod@4.4.3))(ws@8.21.3)


### PR DESCRIPTION
The `additional_kwargs.tool_calls` compatibility path in the LangChain adapter (OpenAI-format tool calls surfaced through LangChain message objects) parses `functionData.arguments` with raw `JSON.parse`, bypassing the SDK's own prototype-pollution guard.

`secureJsonParse` (exported from `@ai-sdk/provider-utils`) already replaced raw `JSON.parse` for provider-originated tool-call/error JSON in `packages/google`, `packages/anthropic`, and `packages/gateway` (#16773, backported as #16579; MCP got the same treatment in #14763/#14826). `functionData.arguments` here is the same category of input — a JSON string forwarded from the model's own tool-call output — so it should go through the same guard as every other untrusted tool-call payload in the codebase.

This is a hardening fix, not a demonstrated end-to-end exploit: I traced `ToolCall.args` forward from this call site and didn't find a consumer in this package that does an unsafe merge/assign keyed on `__proto__`/`constructor`. But per the project's own documented policy in `AGENTS.md` ("Never use `JSON.parse` directly in production code to prevent security risks... use `parseJSON` or `safeParseJSON`") and the precedent set by #16773/#14763, this is exactly the class of call site those fixes intended to close, and a future refactor that merges `args` unsafely would silently become exploitable.

### Change
- `packages/langchain/src/utils.ts`: swap the single `JSON.parse(functionData.arguments)` call for `secureJsonParse`, keeping the existing `try/catch` fallback unchanged.
- `packages/langchain/package.json`: move `@ai-sdk/provider-utils` from `devDependencies` to `dependencies` (it's now imported at runtime, not just for types/tests).
- `pnpm-lock.yaml`: corresponding importer update (workspace-linked package, no new external resolution).
- Added a patch changeset.

### Verification
- Reproduced locally: no — I do not have `pnpm` available in this environment to install workspace dependencies or run `pnpm test:node` / `pnpm type-check:full` for `packages/langchain`. The change mirrors the exact pattern (drop-in replacement inside an existing try/catch, identical `(text: string) => unknown` call shape) already merged in #16773 for three other provider packages.
- Command: `pnpm --filter @ai-sdk/langchain test:node` / `pnpm type-check:full` (not run — see above)
- Before: `JSON.parse(functionData.arguments)`
- After: `secureJsonParse(functionData.arguments)` (same signature, same try/catch fallback to `{}`)
- Environment: n/a (source-level change only)

Happy to adjust if maintainers would rather fold this into a broader sweep (I noticed #18187 tracks a related but distinct set of prototype-pollution-adjacent findings in `packages/ai`/`packages/mcp` — this one wasn't in that list).