### PR TITLE
fix(xai): ignore Responses keepalive events

### DIFF
--- a/.changeset/quiet-foundry-heartbeats.md
+++ b/.changeset/quiet-foundry-heartbeats.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/xai': patch
+---
+
+Ignore keepalive heartbeat events in streamed Responses requests

--- a/packages/xai/src/responses/xai-responses-api.ts
+++ b/packages/xai/src/responses/xai-responses-api.ts
@@ -329,6 +329,10 @@ export const xaiResponsesChunkSchema = z.union([
     response: xaiResponsesResponseSchema.partial({ usage: true, status: true }),
   }),
   z.object({
+    type: z.literal('keepalive'),
+    sequence_number: z.number().optional(),
+  }),
+  z.object({
     type: z.literal('response.output_item.added'),
     item: outputItemSchema,
     output_index: z.number(),

--- a/packages/xai/src/responses/xai-responses-language-model.test.ts
+++ b/packages/xai/src/responses/xai-responses-language-model.test.ts
@@ -2545,6 +2545,60 @@ describe('XaiResponsesLanguageModel', () => {
   });
 
   describe('doStream', () => {
+    it('should ignore keepalive events', async () => {
+      prepareStreamChunks([
+        JSON.stringify({
+          type: 'response.created',
+          response: {
+            id: 'resp_123',
+            object: 'response',
+            model: 'grok-4-fast-non-reasoning',
+            output: [],
+          },
+        }),
+        JSON.stringify({
+          type: 'keepalive',
+          sequence_number: 5,
+        }),
+        JSON.stringify({
+          type: 'response.output_text.delta',
+          item_id: 'msg_123',
+          output_index: 0,
+          content_index: 0,
+          delta: 'OK',
+        }),
+        JSON.stringify({
+          type: 'response.completed',
+          response: {
+            id: 'resp_123',
+            object: 'response',
+            model: 'grok-4-fast-non-reasoning',
+            status: 'completed',
+            output: [],
+            usage: {
+              input_tokens: 1,
+              output_tokens: 1,
+            },
+          },
+        }),
+      ]);
+
+      const { stream } = await createModel().doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+
+      expect(parts).toContainEqual({
+        type: 'text-delta',
+        id: 'text-msg_123',
+        delta: 'OK',
+      });
+      expect(parts).not.toContainEqual(
+        expect.objectContaining({ type: 'error' }),
+      );
+    });
+
     it('should warn about unsupported sampling settings', async () => {
       prepareChunksFixtureResponse('xai-text-streaming.1');
 


### PR DESCRIPTION
## Summary

- Accept `keepalive` heartbeat events in the xAI Responses chunk schema.
- Treat the transport heartbeat as a no-op so the streamed response continues to subsequent events.
- Add a regression test and a patch changeset.

Fixes #20574

## Verification

- `pnpm --filter @ai-sdk/xai test:node`
- `pnpm --filter @ai-sdk/xai test:edge`
- `pnpm --filter @ai-sdk/xai type-check`
- `pnpm --filter @ai-sdk/xai build`
- `pnpm exec oxfmt --check packages/xai/src/responses/xai-responses-api.ts packages/xai/src/responses/xai-responses-language-model.test.ts`
- `pnpm exec oxlint packages/xai/src/responses/xai-responses-api.ts packages/xai/src/responses/xai-responses-language-model.test.ts`

All package tests, type checking, build, formatting, and linting checks passed locally.