### PR TITLE
fix(harness-codex): preserve web search metadata

### DIFF
--- a/.changeset/bright-searches-remember.md
+++ b/.changeset/bright-searches-remember.md
@@ -2,4 +2,4 @@
 '@ai-sdk/harness-codex': patch
 ---
 
-Preserve web search query and action metadata in the Codex bridge
+fix(harness-codex): preserve web search query and action metadata in the Codex bridge

--- a/.changeset/bright-searches-remember.md
+++ b/.changeset/bright-searches-remember.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-codex': patch
+---
+
+Preserve web search query and action metadata in the Codex bridge

--- a/packages/harness-codex/src/bridge/create-emit-stream-event.test.ts
+++ b/packages/harness-codex/src/bridge/create-emit-stream-event.test.ts
@@ -245,4 +245,58 @@ describe('createEmitStreamEvent', () => {
       ]
     `);
   });
+
+  it('preserves web search action metadata', () => {
+    const emitted: Record<string, unknown>[] = [];
+    const stepTracker = {
+      observeEvent: () => {},
+      finishTurn: () => {},
+    } as CodexStepTracker;
+    const emitStreamEvent = createEmitStreamEvent({
+      send: event => emitted.push(event),
+      stepTracker,
+      setTurnUsage: () => {},
+      setThreadId: () => {},
+      emitWarning: () => {},
+      emitError: () => {},
+    });
+
+    const action = {
+      type: 'search',
+      query: 'top news stories',
+    };
+    emitStreamEvent({
+      type: 'item.started',
+      item: {
+        type: 'web_search',
+        id: 'search-1',
+        action,
+      },
+    });
+    emitStreamEvent({
+      type: 'item.completed',
+      item: {
+        type: 'web_search',
+        id: 'search-1',
+        action,
+      },
+    });
+
+    expect(emitted).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'search-1',
+        toolName: 'webSearch',
+        nativeName: 'web_search',
+        input: JSON.stringify({ query: 'top news stories' }),
+        providerExecuted: true,
+      },
+      {
+        type: 'tool-result',
+        toolCallId: 'search-1',
+        toolName: 'webSearch',
+        result: action,
+      },
+    ]);
+  });
 });

--- a/packages/harness-codex/src/bridge/create-emit-stream-event.ts
+++ b/packages/harness-codex/src/bridge/create-emit-stream-event.ts
@@ -19,6 +19,10 @@ export type CodexItem = {
   result?: { content?: unknown; structured_content?: unknown } | unknown;
   error?: { message?: string };
   query?: string;
+  action?: {
+    query?: string;
+    [key: string]: unknown;
+  };
   message?: string;
   changes?: ReadonlyArray<{
     path: string;
@@ -208,7 +212,9 @@ export function createEmitStreamEvent({
           toolCallId: id,
           toolName: toCommonName(nativeName),
           nativeName,
-          input: JSON.stringify({ query: item.query ?? '' }),
+          input: JSON.stringify({
+            query: item.query ?? item.action?.query ?? '',
+          }),
           providerExecuted: true,
         });
       } else if (event.type === 'item.completed') {
@@ -216,7 +222,7 @@ export function createEmitStreamEvent({
           type: 'tool-result',
           toolCallId: id,
           toolName: toCommonName(nativeName),
-          result: item.result ?? null,
+          result: item.result ?? item.action ?? null,
         });
       }
       observeStep();


### PR DESCRIPTION
## Summary

- Preserve the web-search query from the Codex item action when the top-level query is absent.
- Preserve the action payload as the tool result when the event does not provide a separate result.
- Add a regression test and a patch changeset.

Fixes #20568

## Verification

- `pnpm --filter @ai-sdk/harness-codex test`
- `pnpm --filter @ai-sdk/harness-codex type-check`
- `pnpm --filter @ai-sdk/harness-codex... build`
- `pnpm exec oxfmt --check packages/harness-codex/src/bridge/create-emit-stream-event.ts packages/harness-codex/src/bridge/create-emit-stream-event.test.ts`
- `pnpm exec oxlint packages/harness-codex/src/bridge/create-emit-stream-event.ts packages/harness-codex/src/bridge/create-emit-stream-event.test.ts`

The focused regression fails on the unmodified main branch with an empty query and null result, and passes on this branch. All package tests, type checking, dependency builds, formatting, and linting checks passed locally.