### PR TITLE
fix(mcp): prevent SSRF in OAuth metadata discovery

### DIFF
--- a/.changeset/tidy-tools-travel.md
+++ b/.changeset/tidy-tools-travel.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/mcp': patch
+'@ai-sdk/provider-utils': patch
+---
+
+fix(mcp): prevent SSRF in OAuth metadata discovery

--- a/packages/mcp/src/tool/oauth.test.ts
+++ b/packages/mcp/src/tool/oauth.test.ts
@@ -137,6 +137,25 @@ describe('discoverOAuthProtectedResourceMetadata', () => {
     );
   });
 
+  it('rejects redirects from protected resource discovery to private addresses', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: {
+          location: 'http://169.254.169.254/latest/meta-data',
+        },
+      }),
+    );
+
+    await expect(
+      discoverOAuthProtectedResourceMetadata(
+        'https://resource.example.com/mcp',
+      ),
+    ).rejects.toThrow(/169\.254\.169\.254/);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
   it('returns metadata when first fetch fails but second without MCP header succeeds', async () => {
     // Set up a counter to control behavior
     let callCount = 0;
@@ -574,6 +593,33 @@ describe('discoverAuthorizationServerMetadata', () => {
     response_types_supported: ['code'],
     code_challenge_methods_supported: ['S256'],
   };
+
+  it('rejects private authorization server discovery targets', async () => {
+    await expect(
+      discoverAuthorizationServerMetadata(
+        'http://169.254.169.254/latest/meta-data',
+      ),
+    ).rejects.toThrow(/169\.254\.169\.254/);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects authorization server discovery redirects to private addresses', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: {
+          location: 'http://127.0.0.1:4000/.well-known/openid-configuration',
+        },
+      }),
+    );
+
+    await expect(
+      discoverAuthorizationServerMetadata('https://auth.example.com'),
+    ).rejects.toThrow(/127\.0\.0\.1/);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
 
   it('returns OAuth metadata when issuer matches path-aware discovery issuer', async () => {
     const tenantMetadata = {
@@ -2466,6 +2512,27 @@ describe('auth function', () => {
     ).rejects.toThrow(/does not match/);
 
     expect(evilTokenRequests).toHaveLength(0);
+  });
+
+  it('rejects a remote MCP server that advertises a loopback authorization server', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        resource: 'https://api.example.com/mcp-server',
+        authorization_servers: ['http://localhost:4000'],
+      }),
+    });
+
+    await expect(
+      auth(mockProvider, {
+        serverUrl: 'https://api.example.com/mcp-server',
+      }),
+    ).rejects.toThrow(
+      'OAuth endpoint URL is not allowed: http://localhost:4000/',
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it('allows providers to reject discovered authorization server URLs before metadata discovery', async () => {

--- a/packages/mcp/src/tool/oauth.ts
+++ b/packages/mcp/src/tool/oauth.ts
@@ -28,6 +28,8 @@ import {
 } from '../util/oauth-util';
 import { LATEST_PROTOCOL_VERSION } from './types';
 import {
+  fetchWithValidatedEndpoint,
+  fetchWithValidatedRedirects,
   parseJSON,
   validateDownloadUrl,
   type FetchFunction,
@@ -140,16 +142,20 @@ function isOAuthLoopbackHost(hostname: string): boolean {
 }
 
 /**
- * Guards metadata-derived token/registration URLs before credentials are sent.
- * Loopback is allowed for local OAuth; every other target uses the shared
- * download URL guard (http(s) only, no private/link-local IPs).
+ * Guards metadata-derived OAuth URLs before they are requested. Loopback is
+ * allowed only when the caller has established that it belongs to a locally
+ * configured OAuth server; every other target uses the shared URL guard.
  *
- * Credential POSTs use `redirect: 'error'` instead of
- * `fetchWithValidatedRedirects`, which is GET-only and would follow hops with
- * the authorization code, PKCE verifier, and client secret still attached.
+ * Credential POSTs use `fetchWithValidatedEndpoint`, which enforces
+ * `redirect: 'error'` so the authorization code, PKCE verifier, and client
+ * secret are never replayed to a redirect target.
  */
-function assertSafeOAuthEndpoint(endpointUrl: URL): void {
+function assertSafeOAuthEndpoint(
+  endpointUrl: URL,
+  { allowLoopback = false }: { allowLoopback?: boolean } = {},
+): void {
   if (
+    allowLoopback &&
     (endpointUrl.protocol === 'http:' || endpointUrl.protocol === 'https:') &&
     isOAuthLoopbackHost(endpointUrl.hostname)
   ) {
@@ -164,6 +170,13 @@ function assertSafeOAuthEndpoint(endpointUrl: URL): void {
       cause: error,
     });
   }
+}
+
+function getTrustedLoopbackOrigin(
+  authorizationServerUrl: string | URL,
+): string | undefined {
+  const url = new URL(authorizationServerUrl);
+  return isOAuthLoopbackHost(url.hostname) ? url.origin : undefined;
 }
 
 function validateAuthorizationResponseIssuer({
@@ -423,13 +436,31 @@ async function fetchWithCorsRetry(
   url: URL,
   headers?: Record<string, string>,
   fetchFn: FetchFunction = fetch,
+  trustedOrigin?: string,
 ): Promise<Response | undefined> {
   try {
-    return await fetchFn(url, { headers });
+    return await fetchWithValidatedRedirects({
+      url: url.href,
+      fetch: async (input, init) =>
+        fetchWithValidatedEndpoint({
+          url: input as string | URL,
+          init: {
+            ...init,
+            headers: new Headers(init?.headers).has('MCP-Protocol-Version')
+              ? headers
+              : undefined,
+          },
+          fetch: fetchFn,
+          trustedOrigin,
+          redirect: 'manual',
+        }),
+      headers,
+      trustedOrigin,
+    });
   } catch (error) {
     if (error instanceof TypeError) {
       if (headers) {
-        return fetchWithCorsRetry(url, undefined, fetchFn);
+        return fetchWithCorsRetry(url, undefined, fetchFn, trustedOrigin);
       } else {
         return undefined;
       }
@@ -445,11 +476,12 @@ async function tryMetadataDiscovery(
   url: URL,
   protocolVersion: string,
   fetchFn: FetchFunction = fetch,
+  trustedOrigin?: string,
 ): Promise<Response | undefined> {
   const headers = {
     'MCP-Protocol-Version': protocolVersion,
   };
-  return await fetchWithCorsRetry(url, headers, fetchFn);
+  return await fetchWithCorsRetry(url, headers, fetchFn, trustedOrigin);
 }
 
 /**
@@ -476,6 +508,7 @@ async function discoverMetadataWithFallback(
     protocolVersion?: string;
     metadataUrl?: string | URL;
     metadataServerUrl?: string | URL;
+    trustedOrigin?: string;
   },
 ): Promise<Response | undefined> {
   const issuer = new URL(serverUrl);
@@ -490,11 +523,21 @@ async function discoverMetadataWithFallback(
     url.search = issuer.search;
   }
 
-  let response = await tryMetadataDiscovery(url, protocolVersion, fetchFn);
+  let response = await tryMetadataDiscovery(
+    url,
+    protocolVersion,
+    fetchFn,
+    opts?.trustedOrigin,
+  );
 
   if (!opts?.metadataUrl && shouldAttemptFallback(response, issuer.pathname)) {
     const rootUrl = new URL(`/.well-known/${wellKnownType}`, issuer);
-    response = await tryMetadataDiscovery(rootUrl, protocolVersion, fetchFn);
+    response = await tryMetadataDiscovery(
+      rootUrl,
+      protocolVersion,
+      fetchFn,
+      opts?.trustedOrigin,
+    );
   }
 
   return response;
@@ -512,6 +555,9 @@ export async function discoverOAuthProtectedResourceMetadata(
     {
       protocolVersion: opts?.protocolVersion,
       metadataUrl: opts?.resourceMetadataUrl,
+      // The configured MCP server is trusted as a request target. Redirects
+      // crossing its origin are still validated before they are followed.
+      trustedOrigin: new URL(serverUrl).origin,
     },
   );
 
@@ -624,9 +670,11 @@ export async function discoverAuthorizationServerMetadata(
   {
     fetchFn = fetch,
     protocolVersion = LATEST_PROTOCOL_VERSION,
+    trustedOrigin,
   }: {
     fetchFn?: FetchFunction;
     protocolVersion?: string;
+    trustedOrigin?: string;
   } = {},
 ): Promise<AuthorizationServerMetadata | undefined> {
   const headers = { 'MCP-Protocol-Version': protocolVersion };
@@ -634,7 +682,12 @@ export async function discoverAuthorizationServerMetadata(
   const urlsToTry = buildDiscoveryUrls(authorizationServerUrl);
 
   for (const { url: endpointUrl, type, expectedIssuer } of urlsToTry) {
-    const response = await fetchWithCorsRetry(endpointUrl, headers, fetchFn);
+    const response = await fetchWithCorsRetry(
+      endpointUrl,
+      headers,
+      fetchFn,
+      trustedOrigin,
+    );
 
     if (!response) {
       /**
@@ -944,7 +997,10 @@ export async function exchangeAuthorization(
   const tokenUrl = metadata?.token_endpoint
     ? new URL(metadata.token_endpoint)
     : new URL('/token', authorizationServerUrl);
-  assertSafeOAuthEndpoint(tokenUrl);
+  const trustedOrigin = getTrustedLoopbackOrigin(authorizationServerUrl);
+  assertSafeOAuthEndpoint(tokenUrl, {
+    allowLoopback: tokenUrl.origin === trustedOrigin,
+  });
 
   if (
     metadata?.grant_types_supported &&
@@ -988,11 +1044,15 @@ export async function exchangeAuthorization(
     params.set('resource', resourceUrlStripSlash(resource));
   }
 
-  const response = await (fetchFn ?? fetch)(tokenUrl, {
-    method: 'POST',
-    headers,
-    body: params,
-    redirect: 'error',
+  const response = await fetchWithValidatedEndpoint({
+    url: tokenUrl,
+    init: {
+      method: 'POST',
+      headers,
+      body: params,
+    },
+    fetch: fetchFn,
+    trustedOrigin,
   });
 
   if (!response.ok) {
@@ -1049,7 +1109,10 @@ export async function refreshAuthorization(
   } else {
     tokenUrl = new URL('/token', authorizationServerUrl);
   }
-  assertSafeOAuthEndpoint(tokenUrl);
+  const trustedOrigin = getTrustedLoopbackOrigin(authorizationServerUrl);
+  assertSafeOAuthEndpoint(tokenUrl, {
+    allowLoopback: tokenUrl.origin === trustedOrigin,
+  });
 
   const headers = new Headers({
     'Content-Type': 'application/x-www-form-urlencoded',
@@ -1082,11 +1145,15 @@ export async function refreshAuthorization(
     params.set('resource', resourceUrlStripSlash(resource));
   }
 
-  const response = await (fetchFn ?? fetch)(tokenUrl, {
-    method: 'POST',
-    headers,
-    body: params,
-    redirect: 'error',
+  const response = await fetchWithValidatedEndpoint({
+    url: tokenUrl,
+    init: {
+      method: 'POST',
+      headers,
+      body: params,
+    },
+    fetch: fetchFn,
+    trustedOrigin,
   });
   if (!response.ok) {
     throw await parseErrorResponse(response);
@@ -1126,21 +1193,28 @@ export async function registerClient(
   } else {
     registrationUrl = new URL('/register', authorizationServerUrl);
   }
-  assertSafeOAuthEndpoint(registrationUrl);
+  const trustedOrigin = getTrustedLoopbackOrigin(authorizationServerUrl);
+  assertSafeOAuthEndpoint(registrationUrl, {
+    allowLoopback: registrationUrl.origin === trustedOrigin,
+  });
 
   const applicationType =
     clientMetadata.application_type ??
     inferOAuthApplicationType(clientMetadata.redirect_uris);
-  const response = await (fetchFn ?? fetch)(registrationUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
+  const response = await fetchWithValidatedEndpoint({
+    url: registrationUrl,
+    init: {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        ...clientMetadata,
+        application_type: applicationType,
+      }),
     },
-    body: JSON.stringify({
-      ...clientMetadata,
-      application_type: applicationType,
-    }),
-    redirect: 'error',
+    fetch: fetchFn,
+    trustedOrigin,
   });
 
   if (!response.ok) {
@@ -1273,6 +1347,24 @@ async function authInternal(
     authorizationServerUrl = serverUrl;
   }
 
+  const parsedServerUrl = new URL(serverUrl);
+  const parsedAuthorizationServerUrl = new URL(authorizationServerUrl);
+  const serverOrigin = parsedServerUrl.origin;
+  const authorizationServerOrigin = parsedAuthorizationServerUrl.origin;
+  const trustedAuthorizationServerOrigin =
+    authorizationServerOrigin === serverOrigin ||
+    (isOAuthLoopbackHost(parsedServerUrl.hostname) &&
+      isOAuthLoopbackHost(parsedAuthorizationServerUrl.hostname))
+      ? authorizationServerOrigin
+      : undefined;
+
+  // An authorization server selected by response metadata is untrusted until
+  // its target has passed the SSRF guard. A same-origin server is already the
+  // developer-configured MCP request target.
+  if (!trustedAuthorizationServerOrigin) {
+    assertSafeOAuthEndpoint(new URL(authorizationServerUrl));
+  }
+
   /** Validate and select the resource value sent to the AS */
   const resource: URL | undefined = await selectResourceURL(
     serverUrl,
@@ -1291,6 +1383,7 @@ async function authInternal(
     authorizationServerUrl,
     {
       fetchFn,
+      trustedOrigin: trustedAuthorizationServerOrigin,
     },
   );
   const currentAuthorizationServerInformation =

--- a/packages/provider-utils/src/fetch-with-validated-redirects.test.ts
+++ b/packages/provider-utils/src/fetch-with-validated-redirects.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DownloadError } from './download-error';
-import { fetchWithValidatedRedirects } from './fetch-with-validated-redirects';
+import {
+  fetchWithValidatedEndpoint,
+  fetchWithValidatedRedirects,
+} from './fetch-with-validated-redirects';
 
 const originalFetch = globalThis.fetch;
 
@@ -26,6 +29,45 @@ function okResponse(): Response {
     body: null,
   } as unknown as Response;
 }
+
+describe('fetchWithValidatedEndpoint', () => {
+  it('validates the URL before issuing the request', async () => {
+    const fetchMock = vi.fn();
+
+    await expect(
+      fetchWithValidatedEndpoint({
+        url: 'http://169.254.169.254/token',
+        fetch: fetchMock,
+      }),
+    ).rejects.toThrow(DownloadError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('uses redirect: error for credential-bearing requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(okResponse());
+    const body = new URLSearchParams({ code: 'secret-code' });
+
+    await fetchWithValidatedEndpoint({
+      url: new URL('https://auth.example.com/token'),
+      init: {
+        method: 'POST',
+        headers: { authorization: 'Basic secret' },
+        body,
+      },
+      fetch: fetchMock,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL('https://auth.example.com/token'),
+      {
+        method: 'POST',
+        headers: { authorization: 'Basic secret' },
+        body,
+        redirect: 'error',
+      },
+    );
+  });
+});
 
 describe('fetchWithValidatedRedirects', () => {
   it('validates the initial URL before requesting it', async () => {

--- a/packages/provider-utils/src/fetch-with-validated-redirects.ts
+++ b/packages/provider-utils/src/fetch-with-validated-redirects.ts
@@ -14,6 +14,63 @@ const MAX_DOWNLOAD_REDIRECTS = 10;
 // even when a server attaches a Location header.
 const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
 
+async function getValidatedFetch(
+  customFetch: FetchFunction | undefined,
+): Promise<FetchFunction> {
+  // Callers commonly pass globalThis.fetch through several abstraction
+  // layers. Preserve the DNS-pinned Node.js default in that case rather than
+  // accidentally treating it as an intentionally custom fetch.
+  return customFetch == null || customFetch === globalThis.fetch
+    ? await getDefaultDownloadFetch()
+    : customFetch;
+}
+
+/**
+ * Fetches one validated URL without following redirects.
+ *
+ * On Node.js, the default fetch validates and pins DNS results at connect time.
+ * An injected fetch is responsible for equivalent connect-time validation.
+ * Redirects are rejected by default. Callers using `redirect: 'manual'` must
+ * validate the Location target before issuing another request.
+ */
+export async function fetchWithValidatedEndpoint({
+  url,
+  init,
+  fetch: customFetch,
+  trustedOrigin,
+  redirect = 'error',
+}: {
+  url: string | URL;
+  init?: RequestInit;
+  fetch?: FetchFunction;
+  /**
+   * A developer-configured origin that may legitimately resolve to a private
+   * address. This must never be derived from untrusted response data.
+   */
+  trustedOrigin?: string;
+  redirect?: 'error' | 'manual';
+}): Promise<Response> {
+  const urlText = url.toString();
+  const isTrusted =
+    trustedOrigin !== undefined && isSameOrigin(urlText, trustedOrigin);
+
+  if (!isTrusted) {
+    validateDownloadUrl(urlText);
+  }
+
+  const fetch =
+    isTrusted && customFetch != null
+      ? customFetch
+      : isTrusted
+        ? globalThis.fetch
+        : await getValidatedFetch(customFetch);
+
+  return await fetch(url, {
+    ...init,
+    redirect,
+  });
+}
+
 /**
  * Fetches a URL while enforcing the download guard on every hop.
  *
@@ -106,8 +163,11 @@ export async function fetchWithValidatedRedirects({
     }
 
     const fetch =
-      customFetch ??
-      (isTrustedHop ? globalThis.fetch : await getDefaultDownloadFetch());
+      isTrustedHop && customFetch != null
+        ? customFetch
+        : isTrustedHop
+          ? globalThis.fetch
+          : await getValidatedFetch(customFetch);
 
     const response = await fetch(currentUrl, perHopInit('manual'));
 
@@ -121,7 +181,7 @@ export async function fetchWithValidatedRedirects({
       return await fetch(currentUrl, perHopInit('follow'));
     }
 
-    const location = response.headers.get('location');
+    const location = response.headers?.get('location');
     if (REDIRECT_STATUS_CODES.has(response.status) && location) {
       // Release the redirect response's connection before moving to the next
       // hop. Whether that hop is followed or rejected by the guard, an

--- a/packages/provider-utils/src/index.ts
+++ b/packages/provider-utils/src/index.ts
@@ -31,7 +31,10 @@ export {
 export { downloadBlob } from './download-blob';
 export { DownloadError } from './download-error';
 export { EMBEDDING_MODEL_MAX_INPUT_BYTES_PER_CALL as EXPERIMENTAL_EMBEDDING_MODEL_MAX_INPUT_BYTES_PER_CALL } from './embedding-model-capabilities';
-export { fetchWithValidatedRedirects } from './fetch-with-validated-redirects';
+export {
+  fetchWithValidatedEndpoint,
+  fetchWithValidatedRedirects,
+} from './fetch-with-validated-redirects';
 export { extractLines } from './extract-lines';
 export * from './extract-response-headers';
 export * from './fetch-function';


### PR DESCRIPTION
## Background

before, a malicious MCP server could tell the SDK that their oauth server is at this internal/private address and the SDK would follow that URL, including redirects, and its hostname checks did not inspect DNS results.

this could make the victim’s server contact internal services and potentially leak OAuth tokens or credentials.

## Summary

now: 
- Private, link-local and remote-selected loopback OAuth servers are blocked
- DNS results are validated and pinned before connecting
- Every metadata redirect is validated
- Token, refresh and registration requests never follow redirects

## End-to-End Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)