### PR TITLE
docs: correct runtime context filtering description in telemetry docs

### DIFF
--- a/content/docs/03-ai-sdk-core/60-telemetry.mdx
+++ b/content/docs/03-ai-sdk-core/60-telemetry.mdx
@@ -587,9 +587,10 @@ The callback runs when each span is created and receives:
 Custom attributes are merged with AI SDK attributes on the span. AI SDK-owned
 attributes take precedence when a custom attribute uses the same key.
 
-`sensitiveRuntimeContext` is applied before telemetry integrations receive
-`runtimeContext`, so custom span enrichment does not receive top-level runtime
-context properties marked as sensitive.
+`telemetry.includeRuntimeContext` is applied before telemetry integrations receive
+`runtimeContext`, so custom span enrichment only receives top-level runtime context
+properties explicitly set to `true`. If the option is omitted, no runtime context
+properties are included.
 
 ### Supplemental AI SDK attributes on OpenTelemetry spans
 


### PR DESCRIPTION
## Background

The old wording implied context was shared unless marked sensitive. The corrected wording explains that context is excluded by default

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)