### PR TITLE
fix(workflow): align provider result replay with ToolLoopAgent

### DIFF
--- a/.changeset/calm-lions-smile.md
+++ b/.changeset/calm-lions-smile.md
@@ -2,4 +2,4 @@
 '@ai-sdk/workflow': patch
 ---
 
-fix(workflow): replay provider-executed tool results in assistant messages
+fix(workflow): preserve provider-executed tool results across terminal, deferred, and paused responses

--- a/packages/workflow/src/add-tool-results-to-conversation.ts
+++ b/packages/workflow/src/add-tool-results-to-conversation.ts
@@ -3,20 +3,31 @@ import type {
   LanguageModelV4ToolResultPart,
 } from '@ai-sdk/provider';
 
+export interface ProviderExecutedToolResultPosition {
+  toolCallId: string;
+  contentIndex: number;
+}
+
 export function addToolResultsToConversation({
   messages,
   toolResults,
   providerExecutedToolCallIds,
+  providerExecutedToolResultPositions = [],
 }: {
   messages: LanguageModelV4Prompt;
   toolResults: LanguageModelV4ToolResultPart[];
   providerExecutedToolCallIds: Set<string>;
+  providerExecutedToolResultPositions?: ProviderExecutedToolResultPosition[];
 }) {
+  const providerResultIds = new Set([
+    ...providerExecutedToolCallIds,
+    ...providerExecutedToolResultPositions.map(position => position.toolCallId),
+  ]);
   const providerResults = new Map<string, LanguageModelV4ToolResultPart[]>();
   const clientResults: LanguageModelV4ToolResultPart[] = [];
 
   for (const toolResult of toolResults) {
-    if (providerExecutedToolCallIds.has(toolResult.toolCallId)) {
+    if (providerResultIds.has(toolResult.toolCallId)) {
       const results = providerResults.get(toolResult.toolCallId) ?? [];
       results.push(toolResult);
       providerResults.set(toolResult.toolCallId, results);
@@ -39,10 +50,30 @@ export function addToolResultsToConversation({
     }
 
     if (assistantMessage != null) {
-      const content: typeof assistantMessage.content = [];
+      let content = [...assistantMessage.content];
 
-      for (const part of assistantMessage.content) {
-        content.push(part);
+      for (const position of [...providerExecutedToolResultPositions].sort(
+        (a, b) => a.contentIndex - b.contentIndex,
+      )) {
+        const results = providerResults.get(position.toolCallId);
+        if (results == null || results.length === 0) {
+          continue;
+        }
+
+        const [result, ...remainingResults] = results;
+        content.splice(position.contentIndex, 0, result);
+
+        if (remainingResults.length === 0) {
+          providerResults.delete(position.toolCallId);
+        } else {
+          providerResults.set(position.toolCallId, remainingResults);
+        }
+      }
+
+      const contentWithFallbackResults: typeof assistantMessage.content = [];
+
+      for (const part of content) {
+        contentWithFallbackResults.push(part);
 
         if (part.type !== 'tool-call') {
           continue;
@@ -54,14 +85,14 @@ export function addToolResultsToConversation({
         }
 
         providerResults.delete(part.toolCallId);
-        content.push(...results);
+        contentWithFallbackResults.push(...results);
       }
 
       for (const results of providerResults.values()) {
-        content.push(...results);
+        contentWithFallbackResults.push(...results);
       }
 
-      assistantMessage.content = content;
+      assistantMessage.content = contentWithFallbackResults;
     }
   }
 

--- a/packages/workflow/src/add-tool-results-to-conversation.ts
+++ b/packages/workflow/src/add-tool-results-to-conversation.ts
@@ -25,6 +25,19 @@ export function addToolResultsToConversation({
   ]);
   const providerResults = new Map<string, LanguageModelV4ToolResultPart[]>();
   const clientResults: LanguageModelV4ToolResultPart[] = [];
+  let assistantMessageIndex = -1;
+  let assistantMessage:
+    | Extract<LanguageModelV4Prompt[number], { role: 'assistant' }>
+    | undefined;
+
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message.role === 'assistant') {
+      assistantMessageIndex = index;
+      assistantMessage = message;
+      break;
+    }
+  }
 
   for (const toolResult of toolResults) {
     if (providerResultIds.has(toolResult.toolCallId)) {
@@ -37,18 +50,6 @@ export function addToolResultsToConversation({
   }
 
   if (providerResults.size > 0) {
-    let assistantMessage:
-      | Extract<LanguageModelV4Prompt[number], { role: 'assistant' }>
-      | undefined;
-
-    for (let index = messages.length - 1; index >= 0; index--) {
-      const message = messages[index];
-      if (message.role === 'assistant') {
-        assistantMessage = message;
-        break;
-      }
-    }
-
     if (assistantMessage != null) {
       let content = [...assistantMessage.content];
 
@@ -102,4 +103,6 @@ export function addToolResultsToConversation({
       content: clientResults,
     });
   }
+
+  return assistantMessageIndex < 0 ? [] : messages.slice(assistantMessageIndex);
 }

--- a/packages/workflow/src/do-stream-step.test.ts
+++ b/packages/workflow/src/do-stream-step.test.ts
@@ -106,6 +106,72 @@ describe('doStreamStep', () => {
     });
   });
 
+  it('preserves provider metadata on provider-executed tool results', async () => {
+    const model = new MockLanguageModelV4({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start' as const, warnings: [] },
+          {
+            type: 'tool-call' as const,
+            toolCallId: 'provider-call',
+            toolName: 'providerTool',
+            input: '{}',
+            providerExecuted: true,
+            dynamic: true,
+          },
+          {
+            type: 'tool-result' as const,
+            toolCallId: 'provider-call',
+            toolName: 'providerTool',
+            result: { value: 'result' },
+            providerExecuted: true,
+            dynamic: true,
+            providerMetadata: {
+              openai: { itemId: 'provider-result-item' },
+            },
+          },
+          {
+            type: 'finish' as const,
+            finishReason: { unified: 'tool-calls' as const, raw: undefined },
+            usage: {
+              inputTokens: {
+                total: 1,
+                noCache: 1,
+                cacheRead: undefined,
+                cacheWrite: undefined,
+              },
+              outputTokens: {
+                total: 1,
+                text: 1,
+                reasoning: undefined,
+              },
+            },
+          },
+        ]),
+      }),
+    });
+
+    const result = await doStreamStep(prompt, model);
+
+    expect(result).toMatchObject({
+      providerExecutedToolResults: new Map([
+        [
+          'provider-call',
+          {
+            toolCallId: 'provider-call',
+            toolName: 'providerTool',
+            result: { value: 'result' },
+            isError: false,
+            dynamic: true,
+            providerMetadata: {
+              openai: { itemId: 'provider-result-item' },
+            },
+          },
+        ],
+      ]),
+    });
+  });
+
   it.each([
     { setting: 'zero retries', maxRetries: 0, expectedAttempts: 1 },
     { setting: 'two retries', maxRetries: 2, expectedAttempts: 3 },

--- a/packages/workflow/src/do-stream-step.ts
+++ b/packages/workflow/src/do-stream-step.ts
@@ -46,6 +46,8 @@ export interface ProviderExecutedToolResult {
   toolName: string;
   result: unknown;
   isError?: boolean;
+  dynamic?: boolean;
+  providerMetadata?: SharedV4ProviderMetadata;
 }
 
 /**
@@ -407,6 +409,8 @@ export async function doStreamStep(
               toolName: part.toolName,
               result: part.output,
               isError: false,
+              dynamic: part.dynamic,
+              providerMetadata: part.providerMetadata,
             });
           }
           break;
@@ -420,6 +424,8 @@ export async function doStreamStep(
               toolName: errorPart.toolName,
               result: errorPart.error,
               isError: true,
+              dynamic: errorPart.dynamic,
+              providerMetadata: errorPart.providerMetadata,
             });
           }
           break;

--- a/packages/workflow/src/do-stream-step.ts
+++ b/packages/workflow/src/do-stream-step.ts
@@ -117,6 +117,10 @@ export type DoStreamStepRawContentPart =
   | {
       type: 'tool-call';
       toolCallIndex: number;
+    }
+  | {
+      type: 'provider-tool-result';
+      toolCallId: string;
     };
 
 /**
@@ -412,6 +416,10 @@ export async function doStreamStep(
               dynamic: part.dynamic,
               providerMetadata: part.providerMetadata,
             });
+            content.push({
+              type: 'provider-tool-result',
+              toolCallId: part.toolCallId,
+            });
           }
           break;
         case 'tool-error': {
@@ -426,6 +434,10 @@ export async function doStreamStep(
               isError: true,
               dynamic: errorPart.dynamic,
               providerMetadata: errorPart.providerMetadata,
+            });
+            content.push({
+              type: 'provider-tool-result',
+              toolCallId: errorPart.toolCallId,
             });
           }
           break;

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -96,6 +96,8 @@ export interface StreamTextIteratorYieldValue {
   toolsContext?: Record<string, Context | undefined>;
   /** Provider-executed tool results (keyed by tool call ID) */
   providerExecutedToolResults?: Map<string, ProviderExecutedToolResult>;
+  /** Original positions of provider-executed results in assistant content. */
+  providerExecutedToolResultPositions?: ProviderExecutedToolResultPosition[];
   /** The sandbox selected for the current step. */
   experimental_sandbox?: SandboxSession;
 }
@@ -488,9 +490,10 @@ export async function* streamTextIterator({
           toolsContext: currentToolsContext,
           experimental_sandbox: stepSandbox,
           providerExecutedToolResults,
+          providerExecutedToolResultPositions,
         };
 
-        addToolResultsToConversation({
+        const responseMessages = addToolResultsToConversation({
           messages: conversationPrompt,
           toolResults,
           providerExecutedToolCallIds: new Set([
@@ -501,6 +504,9 @@ export async function* streamTextIterator({
           ]),
           providerExecutedToolResultPositions,
         });
+        step.response.messages.push(
+          ...(responseMessages as unknown as typeof step.response.messages),
+        );
 
         const stopConditionList =
           stopConditions == null
@@ -523,10 +529,14 @@ export async function* streamTextIterator({
         const { content: assistantContent } = getAssistantMessageContent(step);
 
         if (assistantContent.length > 0) {
-          conversationPrompt.push({
+          const assistantMessage = {
             role: 'assistant',
             content: assistantContent,
-          });
+          } as const;
+          conversationPrompt.push(assistantMessage);
+          step.response.messages.push(
+            assistantMessage as unknown as (typeof step.response.messages)[number],
+          );
         }
 
         done = true;

--- a/packages/workflow/src/stream-text-iterator.ts
+++ b/packages/workflow/src/stream-text-iterator.ts
@@ -30,7 +30,10 @@ import {
   type StreamFinish,
   type ToolInputLifecycleEvent,
 } from './do-stream-step.js';
-import { addToolResultsToConversation } from './add-tool-results-to-conversation.js';
+import {
+  addToolResultsToConversation,
+  type ProviderExecutedToolResultPosition,
+} from './add-tool-results-to-conversation.js';
 import { resolveToolContext } from './resolve-tool-context.js';
 import { serializeToolSet } from './serializable-schema.js';
 import type {
@@ -176,7 +179,8 @@ export async function* streamTextIterator({
   let _isFirstIteration = true;
   let stepNumber = 0;
   let lastStep: StepResult<any, any> | undefined;
-  let lastStepWasToolCalls = false;
+  let lastStepWasYielded = false;
+  const pendingDeferredToolCallIds = new Set<string>();
   let wasAborted = false;
   let terminalError: unknown;
   let hasTerminalError = false;
@@ -386,11 +390,17 @@ export async function* streamTextIterator({
       // Reconstruct the full StepResult outside the step boundary so the
       // durable event log doesn't carry StepResult's redundant copies (or the
       // per-chunk snapshot the step used to return).
-      const step = buildStepResult(raw, toolCalls, finish, {
-        stepNumber,
-        runtimeContext: currentRuntimeContext,
-        toolsContext: currentToolsContext,
-      });
+      const step = buildStepResult(
+        raw,
+        toolCalls,
+        finish,
+        providerExecutedToolResults,
+        {
+          stepNumber,
+          runtimeContext: currentRuntimeContext,
+          toolsContext: currentToolsContext,
+        },
+      );
 
       await telemetryDispatcher.onLanguageModelCallEnd?.({
         callId: step.callId,
@@ -409,19 +419,41 @@ export async function* streamTextIterator({
       stepNumber++;
       steps.push(step);
       lastStep = step;
-      lastStepWasToolCalls = false;
+      lastStepWasYielded = false;
 
       const finishReason = finish?.finishReason;
+      const isToolExecutionAllowed =
+        finishReason === 'tool-calls' || finishReason === 'stop';
+
+      for (const toolCall of toolCalls) {
+        if (
+          toolCall.providerExecuted &&
+          serializedTools[toolCall.toolName]?.supportsDeferredResults &&
+          !providerExecutedToolResults.has(toolCall.toolCallId)
+        ) {
+          pendingDeferredToolCallIds.add(toolCall.toolCallId);
+        }
+      }
+      for (const toolCallId of providerExecutedToolResults.keys()) {
+        pendingDeferredToolCallIds.delete(toolCallId);
+      }
+
+      const shouldProcessTools =
+        isToolExecutionAllowed &&
+        (toolCalls.length > 0 || providerExecutedToolResults.size > 0);
 
       if (hasTerminalError) {
         // The error crossed the durable step boundary as data. End the loop
         // without throwing so WorkflowAgent can preserve the existing
         // resolved-result contract and expose the original value.
         done = true;
-      } else if (finishReason === 'tool-calls') {
-        lastStepWasToolCalls = true;
+      } else if (shouldProcessTools) {
+        lastStepWasYielded = true;
 
-        const assistantContent = getAssistantMessageContent(step);
+        const {
+          content: assistantContent,
+          providerExecutedToolResultPositions,
+        } = getAssistantMessageContent(step);
         const includedToolCallIds = new Set(
           assistantContent.flatMap(part =>
             part.type === 'tool-call' ? [part.toolCallId] : [],
@@ -461,24 +493,34 @@ export async function* streamTextIterator({
         addToolResultsToConversation({
           messages: conversationPrompt,
           toolResults,
-          providerExecutedToolCallIds: new Set(
-            toolCalls.flatMap(toolCall =>
+          providerExecutedToolCallIds: new Set([
+            ...toolCalls.flatMap(toolCall =>
               toolCall.providerExecuted ? [toolCall.toolCallId] : [],
             ),
-          ),
+            ...providerExecutedToolResults.keys(),
+          ]),
+          providerExecutedToolResultPositions,
         });
 
-        if (stopConditions) {
-          const stopConditionList = Array.isArray(stopConditions)
-            ? stopConditions
-            : [stopConditions];
-          if (stopConditionList.some(test => test({ steps }))) {
-            done = true;
-          }
-        }
-      } else if (finishReason === 'stop') {
+        const stopConditionList =
+          stopConditions == null
+            ? []
+            : Array.isArray(stopConditions)
+              ? stopConditions
+              : [stopConditions];
+        const stopConditionMet = stopConditionList.some(test =>
+          test({ steps }),
+        );
+        const hasClientToolCalls = toolCalls.some(
+          toolCall => !toolCall.providerExecuted,
+        );
+
+        done =
+          stopConditionMet ||
+          (!hasClientToolCalls && pendingDeferredToolCallIds.size === 0);
+      } else if (finishReason === 'stop' || finishReason === 'tool-calls') {
         // Add assistant response content to the conversation
-        const assistantContent = getAssistantMessageContent(step);
+        const { content: assistantContent } = getAssistantMessageContent(step);
 
         if (assistantContent.length > 0) {
           conversationPrompt.push({
@@ -525,8 +567,8 @@ export async function* streamTextIterator({
     }
   }
 
-  // Yield the final step if it wasn't already yielded (tool-calls steps are yielded inside the loop)
-  if (lastStep && !lastStepWasToolCalls) {
+  // Yield the final step if it wasn't already yielded inside the loop.
+  if (lastStep && !lastStepWasYielded) {
     yield {
       toolCalls: [],
       messages: conversationPrompt,
@@ -659,6 +701,7 @@ function buildStepResult(
   raw: DoStreamStepRawResult,
   toolCalls: ParsedToolCall[],
   finish: StreamFinish | undefined,
+  providerExecutedToolResults: Map<string, ProviderExecutedToolResult>,
   opts: {
     stepNumber: number;
     runtimeContext: Context;
@@ -746,8 +789,52 @@ function buildStepResult(
         }
         break;
       }
+      case 'provider-tool-result': {
+        const result = providerExecutedToolResults.get(part.toolCallId);
+        if (result == null) {
+          break;
+        }
+
+        const toolCall = toolCalls.find(
+          toolCall => toolCall.toolCallId === result.toolCallId,
+        );
+        const common = {
+          toolCallId: result.toolCallId,
+          toolName: result.toolName,
+          input: toolCall?.input,
+          providerExecuted: true as const,
+          ...(result.dynamic === true || toolCall?.dynamic === true
+            ? { dynamic: true as const }
+            : {}),
+          ...(result.providerMetadata != null
+            ? { providerMetadata: result.providerMetadata }
+            : {}),
+          ...(toolCall?.toolMetadata != null
+            ? { toolMetadata: toolCall.toolMetadata }
+            : {}),
+        };
+
+        content.push(
+          result.isError
+            ? {
+                type: 'tool-error',
+                ...common,
+                error: result.result,
+              }
+            : {
+                type: 'tool-result',
+                ...common,
+                output: result.result,
+              },
+        );
+        break;
+      }
     }
   }
+
+  const toolResults = content.filter(
+    part => part.type === 'tool-result',
+  ) as StepResult<ToolSet, any>['toolResults'];
 
   return {
     callId: 'workflow-agent',
@@ -772,9 +859,9 @@ function buildStepResult(
     toolCalls: validToolCalls,
     staticToolCalls: validToolCalls.filter(tc => tc.dynamic !== true),
     dynamicToolCalls: validToolCalls.filter(tc => tc.dynamic),
-    toolResults: [],
-    staticToolResults: [],
-    dynamicToolResults: [],
+    toolResults,
+    staticToolResults: toolResults.filter(result => result.dynamic !== true),
+    dynamicToolResults: toolResults.filter(result => result.dynamic === true),
     finishReason: finish?.finishReason ?? 'other',
     rawFinishReason: finish?.rawFinishReason,
     usage:
@@ -818,19 +905,27 @@ function buildStepResult(
   } as StepResult<ToolSet, any>;
 }
 
-function getAssistantMessageContent(
-  step: StepResult<any, any>,
-): Extract<LanguageModelV4Prompt[number], { role: 'assistant' }>['content'] {
+function getAssistantMessageContent(step: StepResult<any, any>): {
+  content: Extract<
+    LanguageModelV4Prompt[number],
+    { role: 'assistant' }
+  >['content'];
+  providerExecutedToolResultPositions: ProviderExecutedToolResultPosition[];
+} {
   const content: Extract<
     LanguageModelV4Prompt[number],
     { role: 'assistant' }
   >['content'] = [];
+  const providerExecutedToolResultPositions: ProviderExecutedToolResultPosition[] =
+    [];
+  let contentIndex = 0;
 
   for (const part of step.content) {
     switch (part.type) {
       case 'text':
         if (part.text.length > 0) {
           content.push({ type: 'text', text: part.text });
+          contentIndex++;
         }
         break;
       case 'file':
@@ -845,14 +940,26 @@ function getAssistantMessageContent(
               }
             : {}),
         });
+        contentIndex++;
         break;
       case 'tool-call':
         content.push(toAssistantToolCallContent(part));
+        contentIndex++;
+        break;
+      case 'tool-result':
+      case 'tool-error':
+        if (part.providerExecuted) {
+          providerExecutedToolResultPositions.push({
+            toolCallId: part.toolCallId,
+            contentIndex,
+          });
+          contentIndex++;
+        }
         break;
     }
   }
 
-  return content;
+  return { content, providerExecutedToolResultPositions };
 }
 
 function toAssistantToolCallContent(toolCall: {

--- a/packages/workflow/src/workflow-agent-compat.test.ts
+++ b/packages/workflow/src/workflow-agent-compat.test.ts
@@ -1224,6 +1224,241 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
       expect(result.steps[0]?.staticToolResults).toEqual([]);
       expect(result.steps[0]?.dynamicToolResults).toEqual([]);
     });
+
+    it('preserves terminal provider tool results in stream order', async () => {
+      const model = new MockLanguageModelV4({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start' as const, warnings: [] },
+            {
+              type: 'tool-call' as const,
+              toolCallId: 'call-a',
+              toolName: 'providerA',
+              input: '{}',
+              providerExecuted: true,
+            },
+            {
+              type: 'tool-call' as const,
+              toolCallId: 'call-b',
+              toolName: 'providerB',
+              input: '{}',
+              providerExecuted: true,
+            },
+            {
+              type: 'tool-result' as const,
+              toolCallId: 'call-a',
+              toolName: 'providerA',
+              result: { value: 'a' },
+              providerExecuted: true,
+              providerMetadata: {
+                testProvider: { resultId: 'result-a' },
+              },
+            },
+            {
+              type: 'tool-result' as const,
+              toolCallId: 'call-b',
+              toolName: 'providerB',
+              result: { value: 'b' },
+              providerExecuted: true,
+            },
+            dummyStreamFinish,
+          ]),
+        }),
+      });
+      const agent = new WorkflowAgent({
+        model,
+        tools: {
+          providerA: tool({
+            type: 'provider',
+            id: 'test.provider_a',
+            isProviderExecuted: true,
+            args: {},
+            inputSchema: z.object({}),
+          }),
+          providerB: tool({
+            type: 'provider',
+            id: 'test.provider_b',
+            isProviderExecuted: true,
+            args: {},
+            inputSchema: z.object({}),
+          }),
+        },
+      });
+
+      const { writable } = createMockWritable();
+      const result = await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable,
+      });
+
+      expect(model.doStreamCalls).toHaveLength(1);
+      expect(
+        result.steps[0]?.content.map(part => ({
+          type: part.type,
+          toolCallId:
+            part.type === 'tool-call' ||
+            part.type === 'tool-result' ||
+            part.type === 'tool-error'
+              ? part.toolCallId
+              : undefined,
+        })),
+      ).toEqual([
+        { type: 'tool-call', toolCallId: 'call-a' },
+        { type: 'tool-call', toolCallId: 'call-b' },
+        { type: 'tool-result', toolCallId: 'call-a' },
+        { type: 'tool-result', toolCallId: 'call-b' },
+      ]);
+      expect(result.steps[0]?.toolResults).toContainEqual({
+        type: 'tool-result',
+        toolCallId: 'call-a',
+        toolName: 'providerA',
+        input: {},
+        output: { value: 'a' },
+        providerExecuted: true,
+        providerMetadata: {
+          testProvider: { resultId: 'result-a' },
+        },
+      });
+
+      const assistantMessage = result.messages.find(
+        message => message.role === 'assistant',
+      );
+      expect(Array.isArray(assistantMessage?.content)).toBe(true);
+      expect(
+        Array.isArray(assistantMessage?.content)
+          ? assistantMessage.content.map(part => ({
+              type: part.type,
+              toolCallId:
+                part.type === 'tool-call' || part.type === 'tool-result'
+                  ? part.toolCallId
+                  : undefined,
+            }))
+          : [],
+      ).toEqual([
+        { type: 'tool-call', toolCallId: 'call-a' },
+        { type: 'tool-call', toolCallId: 'call-b' },
+        { type: 'tool-result', toolCallId: 'call-a' },
+        { type: 'tool-result', toolCallId: 'call-b' },
+      ]);
+    });
+
+    it('replays deferred provider results emitted in a later response', async () => {
+      let responseNumber = 0;
+      const model = new MockLanguageModelV4({
+        doStream: async () => {
+          responseNumber++;
+
+          if (responseNumber === 1) {
+            return {
+              stream: convertArrayToReadableStream([
+                { type: 'stream-start' as const, warnings: [] },
+                {
+                  type: 'tool-call' as const,
+                  toolCallId: 'program-call',
+                  toolName: 'program',
+                  input: '{"code":"run()"}',
+                  providerExecuted: true,
+                },
+                {
+                  type: 'tool-call' as const,
+                  toolCallId: 'client-call',
+                  toolName: 'clientTool',
+                  input: '{}',
+                },
+                {
+                  ...dummyStreamFinish,
+                  finishReason: {
+                    unified: 'tool-calls' as const,
+                    raw: 'tool-calls',
+                  },
+                },
+              ]),
+            };
+          }
+
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start' as const, warnings: [] },
+              {
+                type: 'tool-result' as const,
+                toolCallId: 'program-call',
+                toolName: 'program',
+                result: { status: 'done' },
+                providerExecuted: true,
+                providerMetadata: {
+                  testProvider: { resultId: 'deferred-result' },
+                },
+              },
+              { type: 'text-start' as const, id: 'text-1' },
+              {
+                type: 'text-delta' as const,
+                id: 'text-1',
+                delta: 'Done.',
+              },
+              { type: 'text-end' as const, id: 'text-1' },
+              dummyStreamFinish,
+            ]),
+          };
+        },
+      });
+      const agent = new WorkflowAgent({
+        model,
+        tools: {
+          program: tool({
+            type: 'provider',
+            id: 'test.program',
+            isProviderExecuted: true,
+            supportsDeferredResults: true,
+            args: {},
+            inputSchema: z.object({ code: z.string() }),
+          }),
+          clientTool: tool({
+            inputSchema: z.object({}),
+            execute: async () => 'client result',
+          }),
+        },
+      });
+
+      const { writable } = createMockWritable();
+      const result = await agent.stream({
+        messages: [{ role: 'user', content: 'run the program' }],
+        writable,
+      });
+
+      expect(model.doStreamCalls).toHaveLength(2);
+      expect(result.steps).toHaveLength(2);
+      expect(result.steps[1]?.content).toContainEqual({
+        type: 'tool-result',
+        toolCallId: 'program-call',
+        toolName: 'program',
+        input: undefined,
+        output: { status: 'done' },
+        providerExecuted: true,
+        providerMetadata: {
+          testProvider: { resultId: 'deferred-result' },
+        },
+      });
+      expect(result.steps[1]?.toolResults).toContainEqual({
+        type: 'tool-result',
+        toolCallId: 'program-call',
+        toolName: 'program',
+        input: undefined,
+        output: { status: 'done' },
+        providerExecuted: true,
+        providerMetadata: {
+          testProvider: { resultId: 'deferred-result' },
+        },
+      });
+
+      const finalAssistantMessage = result.messages.at(-1);
+      expect(finalAssistantMessage?.role).toBe('assistant');
+      expect(
+        finalAssistantMessage?.role === 'assistant' &&
+          Array.isArray(finalAssistantMessage.content)
+          ? finalAssistantMessage.content.map(part => part.type)
+          : [],
+      ).toEqual(['tool-result', 'text']);
+    });
   });
 
   describe('onStepFinish', () => {

--- a/packages/workflow/src/workflow-agent-compat.test.ts
+++ b/packages/workflow/src/workflow-agent-compat.test.ts
@@ -1340,6 +1340,9 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
         { type: 'tool-result', toolCallId: 'call-a' },
         { type: 'tool-result', toolCallId: 'call-b' },
       ]);
+      expect(result.steps[0]?.response.messages).toEqual(
+        result.messages.slice(1),
+      );
     });
 
     it('replays deferred provider results emitted in a later response', async () => {
@@ -1458,6 +1461,96 @@ describe('WorkflowAgent (ToolLoopAgent compat)', () => {
           ? finalAssistantMessage.content.map(part => part.type)
           : [],
       ).toEqual(['tool-result', 'text']);
+      expect(result.messages.slice(1)).toEqual(
+        result.steps.flatMap(step => step.response.messages),
+      );
+    });
+
+    it('preserves provider result order and response messages when a client tool pauses the loop', async () => {
+      const model = new MockLanguageModelV4({
+        doStream: async () => ({
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start' as const, warnings: [] },
+            {
+              type: 'tool-call' as const,
+              toolCallId: 'provider-call',
+              toolName: 'providerTool',
+              input: '{}',
+              providerExecuted: true,
+            },
+            {
+              type: 'tool-call' as const,
+              toolCallId: 'client-call',
+              toolName: 'clientTool',
+              input: '{}',
+            },
+            {
+              type: 'tool-result' as const,
+              toolCallId: 'provider-call',
+              toolName: 'providerTool',
+              result: { value: 'provider result' },
+              providerExecuted: true,
+            },
+            {
+              ...dummyStreamFinish,
+              finishReason: {
+                unified: 'tool-calls' as const,
+                raw: 'tool-calls',
+              },
+            },
+          ]),
+        }),
+      });
+      const agent = new WorkflowAgent({
+        model,
+        tools: {
+          providerTool: tool({
+            type: 'provider',
+            id: 'test.provider_tool',
+            isProviderExecuted: true,
+            args: {},
+            inputSchema: z.object({}),
+          }),
+          clientTool: tool({
+            inputSchema: z.object({}),
+          }),
+        },
+      });
+
+      const { writable } = createMockWritable();
+      const result = await agent.stream({
+        messages: [{ role: 'user', content: 'test' }],
+        writable,
+      });
+
+      expect(model.doStreamCalls).toHaveLength(1);
+      expect(result.toolCalls.map(toolCall => toolCall.toolCallId)).toEqual([
+        'provider-call',
+        'client-call',
+      ]);
+      expect(
+        result.toolResults.map(toolResult => toolResult.toolCallId),
+      ).toEqual(['provider-call']);
+
+      const responseMessages = result.steps[0]?.response.messages ?? [];
+      expect(responseMessages).toEqual(result.messages.slice(1));
+      expect(
+        responseMessages.flatMap(message =>
+          message.role === 'assistant' && Array.isArray(message.content)
+            ? message.content.map(part => ({
+                type: part.type,
+                toolCallId:
+                  part.type === 'tool-call' || part.type === 'tool-result'
+                    ? part.toolCallId
+                    : undefined,
+              }))
+            : [],
+        ),
+      ).toEqual([
+        { type: 'tool-call', toolCallId: 'provider-call' },
+        { type: 'tool-call', toolCallId: 'client-call' },
+        { type: 'tool-result', toolCallId: 'provider-call' },
+      ]);
     });
   });
 

--- a/packages/workflow/src/workflow-agent.test.ts
+++ b/packages/workflow/src/workflow-agent.test.ts
@@ -828,6 +828,9 @@ describe('WorkflowAgent', () => {
         toolName: 'WebSearch',
         result: rawProviderResult,
         isError: false,
+        providerMetadata: {
+          openai: { itemId: 'provider-result-item' },
+        },
       });
 
       const mockIterator = {
@@ -874,6 +877,9 @@ describe('WorkflowAgent', () => {
         output: {
           type: 'text',
           value: 'model sees: provider result',
+        },
+        providerOptions: {
+          openai: { itemId: 'provider-result-item' },
         },
       });
       expect(result.toolResults[0]).toMatchObject({
@@ -1048,7 +1054,8 @@ describe('WorkflowAgent', () => {
         writable: mockWritable,
       });
 
-      // Verify that the iterator was called with error-text output type
+      // Provider-executed errors use the same JSON representation as
+      // ToolLoopAgent's response-message conversion.
       expect(mockIterator.next).toHaveBeenCalledTimes(2);
       const toolResultsCall = mockIterator.next.mock.calls[1][0];
       expect(toolResultsCall).toBeDefined();
@@ -1058,8 +1065,7 @@ describe('WorkflowAgent', () => {
         toolCallId: 'provider-call-id',
         toolName: 'WebSearch',
         output: {
-          // String error results use 'error-text' type with raw value
-          type: 'error-text',
+          type: 'error-json',
           value: 'Search failed: Rate limit exceeded',
         },
       });

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -1283,10 +1283,23 @@ function addToolResultsToStep(
     return;
   }
 
-  const toolOutputs = executedResults.map(result => {
+  const existingProviderResultIds = new Set(
+    step.content.flatMap(part =>
+      (part.type === 'tool-result' || part.type === 'tool-error') &&
+      part.providerExecuted
+        ? [part.toolCallId]
+        : [],
+    ),
+  );
+
+  const toolOutputs = executedResults.flatMap(result => {
     const toolCall = step.toolCalls.find(
       toolCall => toolCall.toolCallId === result.modelResult.toolCallId,
     );
+
+    if (existingProviderResultIds.has(result.modelResult.toolCallId)) {
+      return [];
+    }
 
     const common = {
       toolCallId: result.modelResult.toolCallId,
@@ -1298,17 +1311,19 @@ function addToolResultsToStep(
         : {}),
     };
 
-    return result.isError
-      ? {
-          type: 'tool-error' as const,
-          ...common,
-          error: result.rawOutput,
-        }
-      : {
-          type: 'tool-result' as const,
-          ...common,
-          output: result.rawOutput,
-        };
+    return [
+      result.isError
+        ? {
+            type: 'tool-error' as const,
+            ...common,
+            error: result.rawOutput,
+          }
+        : {
+            type: 'tool-result' as const,
+            ...common,
+            output: result.rawOutput,
+          },
+    ];
   });
 
   step.content.push(...(toolOutputs as StepResult<ToolSet, any>['content']));
@@ -2338,6 +2353,9 @@ export class WorkflowAgent<
           experimental_sandbox: stepSandbox,
           providerExecutedToolResults,
         } = result.value;
+        const capturedProviderToolResults =
+          providerExecutedToolResults ??
+          new Map<string, ProviderExecutedToolResult>();
         const toolExecutionSandbox = stepSandbox ?? sandbox;
         // Capture current step number before pushing (0-based)
         const currentStepNumber = steps.length;
@@ -2351,8 +2369,10 @@ export class WorkflowAgent<
           toolsContext = yieldedToolsContext;
         }
 
-        // Only execute tools if there are tool calls
-        if (toolCalls.length > 0) {
+        // Process client tool calls and any provider results captured in this
+        // response. Deferred provider results may arrive without a matching
+        // tool call in the current step.
+        if (toolCalls.length > 0 || capturedProviderToolResults.size > 0) {
           const invalidToolCalls = toolCalls.filter(tc => tc.invalid === true);
           const validToolCalls = toolCalls.filter(tc => tc.invalid !== true);
 
@@ -2363,6 +2383,29 @@ export class WorkflowAgent<
           const providerToolCalls = validToolCalls.filter(
             tc => tc.providerExecuted,
           );
+          const providerToolCallsForResults = [
+            ...providerToolCalls,
+            ...[...capturedProviderToolResults.values()].flatMap(
+              providerResult =>
+                providerToolCalls.some(
+                  toolCall => toolCall.toolCallId === providerResult.toolCallId,
+                )
+                  ? []
+                  : [
+                      {
+                        type: 'tool-call' as const,
+                        toolCallId: providerResult.toolCallId,
+                        toolName: providerResult.toolName,
+                        input: toolCalls.find(
+                          toolCall =>
+                            toolCall.toolCallId === providerResult.toolCallId,
+                        )?.input,
+                        providerExecuted: true,
+                        dynamic: providerResult.dynamic,
+                      },
+                    ],
+            ),
+          ];
 
           // Check which tools need approval (can be async)
           const approvalNeeded = await Promise.all(
@@ -2426,11 +2469,11 @@ export class WorkflowAgent<
 
             // Collect provider tool results
             const providerResultEntries = await Promise.all(
-              providerToolCalls.map(async toolCall => ({
+              providerToolCallsForResults.map(async toolCall => ({
                 toolCall,
                 result: await resolveProviderToolResult(
                   toolCall,
-                  providerExecutedToolResults,
+                  capturedProviderToolResults,
                   effectiveTools as ToolSet,
                   download,
                 ),
@@ -2454,9 +2497,9 @@ export class WorkflowAgent<
               ({ result }) => (result == null ? [] : [result]),
             );
 
-            const continuationInvalidResults = invalidToolCalls.map(
-              createInvalidToolResult,
-            );
+            const continuationInvalidResults = invalidToolCalls
+              .filter(toolCall => !toolCall.providerExecuted)
+              .map(createInvalidToolResult);
             const resolvedResults: LanguageModelV4ToolResultPart[] = [
               ...executableResults.map(result => result.modelResult),
               ...providerResults.map(result => result.modelResult),
@@ -2487,7 +2530,9 @@ export class WorkflowAgent<
               messages: iterMessages,
               toolResults: resolvedResults,
               providerExecutedToolCallIds: new Set(
-                providerToolCalls.map(toolCall => toolCall.toolCallId),
+                providerToolCallsForResults.map(
+                  toolCall => toolCall.toolCallId,
+                ),
               ),
             });
 
@@ -2612,11 +2657,11 @@ export class WorkflowAgent<
 
           // For provider-executed tools, use the results from the stream
           const providerToolResultEntries = await Promise.all(
-            providerToolCalls.map(async toolCall => ({
+            providerToolCallsForResults.map(async toolCall => ({
               toolCall,
               result: await resolveProviderToolResult(
                 toolCall,
-                providerExecutedToolResults,
+                capturedProviderToolResults,
                 effectiveTools as ToolSet,
                 download,
               ),
@@ -2639,9 +2684,9 @@ export class WorkflowAgent<
           const providerToolResults = providerToolResultEntries.flatMap(
             ({ result }) => (result == null ? [] : [result]),
           );
-          const continuationInvalidToolResults = invalidToolCalls.map(
-            createInvalidToolResult,
-          );
+          const continuationInvalidToolResults = invalidToolCalls
+            .filter(toolCall => !toolCall.providerExecuted)
+            .map(createInvalidToolResult);
 
           // Combine executable/provider results in the original order,
           // while preserving invalid tool calls as error results for the
@@ -2657,6 +2702,14 @@ export class WorkflowAgent<
             if (providerResult) return [providerResult];
             return [];
           });
+          const currentToolCallIds = new Set(
+            toolCalls.map(toolCall => toolCall.toolCallId),
+          );
+          executedToolResults.push(
+            ...providerToolResults.filter(
+              result => !currentToolCallIds.has(result.modelResult.toolCallId),
+            ),
+          );
           const continuationToolResults = toolCalls.flatMap(tc => {
             const invalidResult = continuationInvalidToolResults.find(
               r => r.toolCallId === tc.toolCallId,
@@ -2668,6 +2721,13 @@ export class WorkflowAgent<
             if (executedResult) return [executedResult.modelResult];
             return [];
           });
+          continuationToolResults.push(
+            ...providerToolResults.flatMap(result =>
+              currentToolCallIds.has(result.modelResult.toolCallId)
+                ? []
+                : [result.modelResult],
+            ),
+          );
 
           // Write tool results and step boundaries to the stream so the UI can
           // transition tool parts to the appropriate output state and properly

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -2352,6 +2352,7 @@ export class WorkflowAgent<
           toolsContext: yieldedToolsContext,
           experimental_sandbox: stepSandbox,
           providerExecutedToolResults,
+          providerExecutedToolResultPositions,
         } = result.value;
         const capturedProviderToolResults =
           providerExecutedToolResults ??
@@ -2526,7 +2527,7 @@ export class WorkflowAgent<
 
             addToolResultsToStep(step, executedResults);
 
-            addToolResultsToConversation({
+            const responseMessages = addToolResultsToConversation({
               messages: iterMessages,
               toolResults: resolvedResults,
               providerExecutedToolCallIds: new Set(
@@ -2534,7 +2535,13 @@ export class WorkflowAgent<
                   toolCall => toolCall.toolCallId,
                 ),
               ),
+              providerExecutedToolResultPositions,
             });
+            step?.response.messages.push(
+              ...(responseMessages as unknown as NonNullable<
+                typeof step
+              >['response']['messages']),
+            );
 
             const messages = iterMessages as unknown as ModelMessage[];
             const lastStep = steps[steps.length - 1];

--- a/packages/workflow/src/workflow-agent.ts
+++ b/packages/workflow/src/workflow-agent.ts
@@ -55,6 +55,7 @@ import { createLanguageModelToolResultOutput } from './create-language-model-too
 import type {
   ModelCallStreamPart,
   ModelStopCondition,
+  ProviderExecutedToolResult,
 } from './do-stream-step.js';
 import { resolveToolContext } from './resolve-tool-context.js';
 import { streamTextIterator } from './stream-text-iterator.js';
@@ -3138,10 +3139,7 @@ function aggregateUsage(steps: StepResult<any, any>[]): LanguageModelUsage {
 
 async function resolveProviderToolResult(
   toolCall: { toolCallId: string; toolName: string; input: unknown },
-  providerExecutedToolResults?: Map<
-    string,
-    { toolCallId: string; toolName: string; result: unknown; isError?: boolean }
-  >,
+  providerExecutedToolResults?: Map<string, ProviderExecutedToolResult>,
   tools?: ToolSet,
   download?: DownloadFunction,
 ): Promise<WorkflowToolExecutionResult | undefined> {
@@ -3176,11 +3174,7 @@ async function resolveProviderToolResult(
   }
 
   const result = streamResult.result;
-  const errorMode = streamResult.isError
-    ? typeof result === 'string'
-      ? 'text'
-      : 'json'
-    : 'none';
+  const errorMode = streamResult.isError ? 'json' : 'none';
 
   return {
     modelResult: {
@@ -3197,6 +3191,9 @@ async function resolveProviderToolResult(
         supportedUrls: {},
         download,
       }),
+      ...(streamResult.providerMetadata != null
+        ? { providerOptions: streamResult.providerMetadata }
+        : {}),
     },
     rawOutput: result,
     isError: streamResult.isError === true,


### PR DESCRIPTION
## Summary

This is a follow-up stacked on #20443.

- preserve provider result metadata and use the same JSON error encoding as ToolLoopAgent
- replay terminal and deferred provider results without introducing an extra model turn
- preserve provider emission order in assistant messages, including paused client-tool responses
- expose the replayed messages through step.response.messages

## Commits

- [58bef5487c](https://github.com/vercel/ai/commit/58bef5487c0cd6d9eac50fc423b9c9f02c1e3c41) preserves provider result metadata and error encoding
- [cd9fd60173](https://github.com/vercel/ai/commit/cd9fd601730bea3585b6c9fbbb025d16376ac583) preserves response order and handles terminal and deferred results
- [d93a452d11](https://github.com/vercel/ai/commit/d93a452d11ccfd86b8905e68894071b2af03c92d) exposes replayed response messages and covers paused loops

## Verification

- pnpm --filter @ai-sdk/workflow test:node (252 tests)
- pnpm --filter @ai-sdk/workflow test:edge (252 tests)
- pnpm check
- pnpm type-check:full