### PR TITLE
fix(openai): allow providers to disable web search source includes

### DIFF
--- a/.changeset/fuzzy-pandas-search.md
+++ b/.changeset/fuzzy-pandas-search.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/amazon-bedrock': patch
+'@ai-sdk/openai': patch
+---
+
+fix(openai): allow providers to disable web search source includes

--- a/packages/amazon-bedrock/src/mantle/bedrock-mantle-provider.test.ts
+++ b/packages/amazon-bedrock/src/mantle/bedrock-mantle-provider.test.ts
@@ -121,6 +121,7 @@ describe('bedrock-mantle-provider', () => {
       'test-model',
       expect.objectContaining({
         provider: 'bedrock-mantle.responses',
+        supportsWebSearchSourcesInclude: false,
       }),
     );
   });

--- a/packages/amazon-bedrock/src/mantle/bedrock-mantle-provider.ts
+++ b/packages/amazon-bedrock/src/mantle/bedrock-mantle-provider.ts
@@ -249,6 +249,7 @@ export function createBedrockMantle(
       url,
       headers: getHeaders,
       fetch: fetchFunction,
+      supportsWebSearchSourcesInclude: false,
     });
 
   const provider = function (modelId: BedrockMantleChatModelId) {

--- a/packages/openai/src/openai-config.ts
+++ b/packages/openai/src/openai-config.ts
@@ -25,6 +25,13 @@ export type OpenAIConfig = {
    */
   explicitMessageItemType?: boolean;
   /**
+   * Whether the provider supports the
+   * `web_search_call.action.sources` Responses API include value.
+   *
+   * Defaults to `true`.
+   */
+  supportsWebSearchSourcesInclude?: boolean;
+  /**
    * This is soft-deprecated. Use provider references (e.g. `{ openai: 'file-abc123' }`)
    * in file part data instead. File ID prefixes used to identify file IDs
    * in Responses API. When undefined, all string file data is treated as

--- a/packages/openai/src/responses/openai-responses-language-model-options.ts
+++ b/packages/openai/src/responses/openai-responses-language-model-options.ts
@@ -180,6 +180,15 @@ export const openaiLanguageModelResponsesOptionsSchema = lazySchema(() =>
         .nullish(),
 
       /**
+       * Whether to automatically include web search action sources in the
+       * response. Disable this for OpenAI-compatible providers that do not
+       * support the `web_search_call.action.sources` include value.
+       *
+       * Defaults to `true`.
+       */
+      includeWebSearchSources: z.boolean().optional(),
+
+      /**
        * Instructions for the model.
        * They can be used to change the system or developer message when continuing a conversation using the `previousResponseId` option.
        * Defaults to `undefined`.

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -223,12 +223,16 @@ const nonReasoningModelIds = openaiResponsesModelIds.filter(
     ),
 );
 
-function createModel(modelId: string) {
+function createModel(
+  modelId: string,
+  config: { supportsWebSearchSourcesInclude?: boolean } = {},
+) {
   return new OpenAIResponsesLanguageModel(modelId, {
     provider: 'openai',
     url: ({ path }) => `https://api.openai.com/v1${path}`,
     headers: () => ({ Authorization: `Bearer APIKEY` }),
     generateId: mockId(),
+    ...config,
   });
 }
 
@@ -4042,6 +4046,53 @@ describe('OpenAIResponsesLanguageModel', () => {
       it('should include web search tool call and result in content', async () => {
         expect(result.content).toMatchSnapshot();
       });
+    });
+
+    it('should not include web search sources when disabled by provider options', async () => {
+      prepareJsonFixtureResponse('openai-web-search-tool.1');
+
+      await createModel('gpt-5-nano').doGenerate({
+        tools: [
+          {
+            type: 'provider',
+            id: 'openai.web_search',
+            name: 'webSearch',
+            args: {},
+          },
+        ],
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          openai: {
+            includeWebSearchSources: false,
+          },
+        },
+      });
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'include',
+      );
+    });
+
+    it('should not include unsupported web search sources', async () => {
+      prepareJsonFixtureResponse('openai-web-search-tool.1');
+
+      await createModel('gpt-5-nano', {
+        supportsWebSearchSourcesInclude: false,
+      }).doGenerate({
+        tools: [
+          {
+            type: 'provider',
+            id: 'openai.web_search',
+            name: 'webSearch',
+            args: {},
+          },
+        ],
+        prompt: TEST_PROMPT,
+      });
+
+      expect(await server.calls[0].requestBodyJson).not.toHaveProperty(
+        'include',
+      );
     });
 
     describe('shell tool', () => {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -486,7 +486,11 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
       ) as LanguageModelV4ProviderTool | undefined
     )?.name;
 
-    if (webSearchToolName) {
+    if (
+      webSearchToolName &&
+      config.supportsWebSearchSourcesInclude !== false &&
+      openaiOptions?.includeWebSearchSources !== false
+    ) {
       addInclude('web_search_call.action.sources');
     }
 


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/18507

any OpenAI web-search tool automatically added `web_search_call.action.source`. Bedrock Mantle reused this logic but rejects that include value, breaking web search

## Summary

added an opt-out `includeWebSearchSources` which helps in setting an internal provider capability flag

## End-to-End Verification

verified by running the following repro: 
<details>

```ts
import { createBedrockMantle } from '@ai-sdk/amazon-bedrock/mantle';
import { openai } from '@ai-sdk/openai';
import { parseJSON } from '@ai-sdk/provider-utils';
import assert from 'node:assert/strict';
import { generateText } from 'ai';
import { run } from '../../lib/run';

const unsupportedInclude = 'web_search_call.action.sources';

type RequestBody = {
  include?: string[];
  tools?: Array<{
    type: string;
    external_web_access?: boolean;
  }>;
};

const bedrockMantle = createBedrockMantle({
  region: 'us-east-1',
  apiKey: 'not-used',
  fetch: async (_url, options) => {
    const body = (await parseJSON({
      text: options!.body! as string,
    })) as RequestBody;

    console.log(
      'Relevant request fields:',
      JSON.stringify({ include: body.include, tools: body.tools }, null, 2),
    );

    // The web search tool itself is compatible with Bedrock Mantle.
    assert.deepEqual(body.tools, [
      {
        type: 'web_search',
        external_web_access: false,
      },
    ]);

    if (body.include?.includes(unsupportedInclude)) {
      // Reproduce the response returned by Bedrock Mantle for this include value.
      return new Response(
        JSON.stringify({
          error: {
            message:
              `Unsupported value: '${unsupportedInclude}' is not supported with the ` +
              "'openai.gpt-5.6-terra' model. Supported values are: " +
              "'reasoning.encrypted_content' and 'message.output_text.logprobs'.",
            type: 'invalid_request_error',
            param: 'include',
            code: 'unsupported_value',
          },
        }),
        {
          status: 400,
          headers: { 'content-type': 'application/json' },
        },
      );
    }

    return new Response(
      JSON.stringify({
        id: 'resp_test',
        object: 'response',
        created_at: 0,
        model: 'openai.gpt-5.6-terra',
        status: 'completed',
        error: null,
        incomplete_details: null,
        output: [
          {
            type: 'message',
            id: 'msg_1',
            role: 'assistant',
            status: 'completed',
            content: [
              {
                type: 'output_text',
                text: 'ok',
                annotations: [],
              },
            ],
          },
        ],
        usage: {
          input_tokens: 1,
          output_tokens: 1,
          total_tokens: 2,
        },
      }),
      { headers: { 'content-type': 'application/json' } },
    );
  },
});

run(async () => {
  const result = await generateText({
    model: bedrockMantle.responses('openai.gpt-5.6-terra'),
    tools: {
      web_search: openai.tools.webSearch({
        externalWebAccess: false,
      }),
    },
    prompt: 'What is the latest news about Amazon Bedrock?',
  });

  assert.equal(result.text, 'ok');
  console.log(
    'Verified: the unsupported web search source include was omitted.',
  );
});
```
</details>

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #18507