### PR TITLE
fix(provider-utils): avoid detecting plain text prefixes as BMP or GIF images

### DIFF
--- a/.changeset/tidy-signatures-visit.md
+++ b/.changeset/tidy-signatures-visit.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/provider-utils': patch
+---
+
+fix(provider-utils): avoid detecting plain text prefixes as BMP or GIF images

--- a/packages/provider-utils/src/detect-media-type.test.ts
+++ b/packages/provider-utils/src/detect-media-type.test.ts
@@ -10,7 +10,14 @@ import { convertUint8ArrayToBase64 } from './uint8-utils';
 describe('detectMediaType signature matching', () => {
   describe('GIF', () => {
     it('should detect GIF from bytes', () => {
-      const gifBytes = new Uint8Array([0x47, 0x49, 0x46, 0xff, 0xff]);
+      const gifBytes = new Uint8Array([
+        0x47,
+        0x49,
+        0x46,
+        0x38,
+        0x39,
+        0x61, // GIF89a
+      ]);
       expect(
         detectMediaType({
           data: gifBytes,
@@ -20,13 +27,24 @@ describe('detectMediaType signature matching', () => {
     });
 
     it('should detect GIF from base64', () => {
-      const gifBase64 = 'R0lGabc123'; // Base64 string starting with GIF signature
+      const gifBase64 = convertUint8ArrayToBase64(
+        new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x37, 0x61]), // GIF87a
+      );
       expect(
         detectMediaType({
           data: gifBase64,
           topLevelType: 'image',
         }),
       ).toBe('image/gif');
+    });
+
+    it('should not detect text that only starts with GIF', () => {
+      expect(
+        detectMediaType({
+          data: new TextEncoder().encode('GIF support notes'),
+          topLevelType: 'image',
+        }),
+      ).toBeUndefined();
     });
   });
 
@@ -191,24 +209,44 @@ describe('detectMediaType signature matching', () => {
   });
 
   describe('BMP', () => {
+    const bmpHeader = new Uint8Array([
+      0x42,
+      0x4d, // BM
+      0x36,
+      0x00,
+      0x00,
+      0x00, // file size
+      0x00,
+      0x00,
+      0x00,
+      0x00, // reserved fields
+    ]);
+
     it('should detect BMP from bytes', () => {
-      const bmpBytes = new Uint8Array([0x42, 0x4d, 0xff, 0xff]);
       expect(
         detectMediaType({
-          data: bmpBytes,
+          data: bmpHeader,
           topLevelType: 'image',
         }),
       ).toBe('image/bmp');
     });
 
     it('should detect BMP from base64', () => {
-      const bmpBytes = new Uint8Array([0x42, 0x4d, 0xff, 0xff]);
       expect(
         detectMediaType({
-          data: convertUint8ArrayToBase64(bmpBytes),
+          data: convertUint8ArrayToBase64(bmpHeader),
           topLevelType: 'image',
         }),
       ).toBe('image/bmp');
+    });
+
+    it('should not detect text that only starts with BM', () => {
+      expect(
+        detectMediaType({
+          data: new TextEncoder().encode('BM25 ranking notes'),
+          topLevelType: 'image',
+        }),
+      ).toBeUndefined();
     });
   });
 

--- a/packages/provider-utils/src/detect-media-type.ts
+++ b/packages/provider-utils/src/detect-media-type.ts
@@ -3,7 +3,11 @@ import { convertBase64ToUint8Array } from './uint8-utils';
 const imageMediaTypeSignatures = [
   {
     mediaType: 'image/gif' as const,
-    bytesPrefix: [0x47, 0x49, 0x46], // GIF
+    bytesPrefix: [0x47, 0x49, 0x46, 0x38, 0x37, 0x61], // GIF87a
+  },
+  {
+    mediaType: 'image/gif' as const,
+    bytesPrefix: [0x47, 0x49, 0x46, 0x38, 0x39, 0x61], // GIF89a
   },
   {
     mediaType: 'image/png' as const,
@@ -32,7 +36,7 @@ const imageMediaTypeSignatures = [
   },
   {
     mediaType: 'image/bmp' as const,
-    bytesPrefix: [0x42, 0x4d],
+    bytesPrefix: [0x42, 0x4d, null, null, null, null, 0x00, 0x00, 0x00, 0x00],
   },
   {
     mediaType: 'image/tiff' as const,


### PR DESCRIPTION
## Background

- AI SDK sniffs inline file bytes to identify image inputs before sending them to providers.
- BMP detection checked only `BM`, and GIF detection checked only `GIF`.
- As a result, plain-text files beginning with `BM` or `GIF` were reclassified from `text/plain` to an image type.

## Summary

- Require `GIF87a` or `GIF89a` before classifying data as GIF.
- Require BMP's zeroed reserved header fields after `BM`.

## End-to-End Verification

Verified that `generateText` forwards both `BM25 ranking notes` and `GIF support notes` as `text/plain`.

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes https://github.com/vercel/ai/issues/20585