### PR TITLE
fix(ai): keep an explicit non-image media type on file parts

### DIFF
--- a/.changeset/keep-explicit-non-image-media-type.md
+++ b/.changeset/keep-explicit-non-image-media-type.md
@@ -1,0 +1,5 @@
+---
+"ai": patch
+---
+
+fix(ai): keep an explicit non-image media type on file parts whose bytes start with an image signature

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.test.ts
@@ -1579,6 +1579,73 @@ describe('convertToLanguageModelMessage', () => {
         });
       });
 
+      it.each([
+        ['BM25 ranking notes', 'image/bmp'],
+        ['GIF support notes', 'image/gif'],
+      ])(
+        'should keep an explicit non-image mediaType when the data starts with an image signature (%s)',
+        async (text, _sniffedAs) => {
+          const result = await convertToLanguageModelPrompt({
+            prompt: {
+              instructions: undefined,
+              messages: [
+                {
+                  role: 'user',
+                  content: [
+                    {
+                      type: 'file',
+                      filename: 'notes.txt',
+                      mediaType: 'text/plain',
+                      data: new TextEncoder().encode(text),
+                    },
+                  ],
+                },
+              ],
+            },
+            supportedUrls: {},
+            download: undefined,
+          });
+
+          expect(result[0].content[0]).toMatchObject({
+            type: 'file',
+            filename: 'notes.txt',
+            mediaType: 'text/plain',
+          });
+        },
+      );
+
+      it('should still detect the image type for a generic mediaType', async () => {
+        const result = await convertToLanguageModelPrompt({
+          prompt: {
+            instructions: undefined,
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  {
+                    type: 'file',
+                    mediaType: 'image',
+                    data: new Uint8Array([0x42, 0x4d, 0x00, 0x00]),
+                  },
+                  {
+                    type: 'file',
+                    mediaType: 'application/octet-stream',
+                    data: new Uint8Array([0x47, 0x49, 0x46, 0x38]),
+                  },
+                ],
+              },
+            ],
+          },
+          supportedUrls: {},
+          download: undefined,
+        });
+
+        expect(result[0].content).toMatchObject([
+          { type: 'file', mediaType: 'image/bmp' },
+          { type: 'file', mediaType: 'image/gif' },
+        ]);
+      });
+
       it('should prefer detected mediaType', async () => {
         const result = convertToLanguageModelMessage({
           message: {

--- a/packages/ai/src/prompt/convert-to-language-model-prompt.ts
+++ b/packages/ai/src/prompt/convert-to-language-model-prompt.ts
@@ -581,7 +581,8 @@ function convertPartToLanguageModelPart(
 
   if (
     data.type === 'data' &&
-    (data.data instanceof Uint8Array || typeof data.data === 'string')
+    (data.data instanceof Uint8Array || typeof data.data === 'string') &&
+    shouldDetectImageMediaType(mediaType)
   ) {
     const imageMediaType = detectMediaType({
       data: data.data,
@@ -603,6 +604,24 @@ function convertPartToLanguageModelPart(
     data,
     providerOptions: part.providerOptions,
   };
+}
+
+/**
+ * Whether the image signature sniffing may replace the given media type.
+ *
+ * Sniffing exists to fill in a missing or generic type (`image`, `image/*`,
+ * `application/octet-stream`) and to correct a mislabeled image type
+ * (`image/png` for JPEG bytes). It must not override an explicit non-image
+ * type: a `text/plain` file whose bytes happen to start with `BM` or `GIF`
+ * is not a bitmap or a GIF.
+ */
+function shouldDetectImageMediaType(mediaType: string | undefined): boolean {
+  return (
+    mediaType == null ||
+    !isFullMediaType(mediaType) ||
+    mediaType === 'application/octet-stream' ||
+    mediaType.startsWith('image/')
+  );
 }
 
 export function mapToolResultOutput({


### PR DESCRIPTION
## Background

`convertPartToLanguageModelPart` sniffs every inline file payload for an image signature and lets the result replace whatever media type the caller set. A `text/plain` file whose bytes happen to start with `BM` or `GIF` is therefore sent to the provider as `image/bmp` / `image/gif` (#20585). The sniffing exists to fill in a missing or generic type and to correct a mislabeled image (`data:image/png;base64,/9j/…` → `image/jpeg`, which an existing test pins), so it cannot simply be removed.

## Summary

`packages/ai/src/prompt/convert-to-language-model-prompt.ts`: image sniffing now runs only when the media type is missing, not a full type (`image`, `image/*`), `application/octet-stream`, or already an image type. An explicit non-image type such as `text/plain` survives; a mislabeled image is still corrected; generic types are still refined.

Tests in `convert-to-language-model-prompt.test.ts`: `text/plain` parts starting with `BM25 …` / `GIF …` keep `text/plain` (fail on `main`), and generic `image` / `application/octet-stream` parts with BMP / GIF bytes are still detected. The existing detection tests are unchanged (71 passed in the file, 476 across `src/prompt` and `generate-text.test.ts`; `tsc --build` clean).

Changeset: `.changeset/keep-explicit-non-image-media-type.md` (`ai`: patch).

## Contributor Credit

@O4epegb for the report and the standalone reproduction with `MockLanguageModelV4`.

## End-to-End Verification

Ran the reproduction from the issue against the local build: with the change the prompt logged by `MockLanguageModelV4.doGenerate` carries `mediaType: "text/plain"` for `notes.txt` (`BM25 ranking notes`) and for the `GIF support notes` variant; on `main` it carries `image/bmp` / `image/gif`.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes #20585
