### PR TITLE
feat(harness): support `instructions` on `HarnessAgent` to be a `SystemModelMessage` for parity with `ToolLoopAgent`

### DIFF
--- a/.changeset/brown-timers-matter.md
+++ b/.changeset/brown-timers-matter.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/harness": patch
+---
+
+feat(harness): support `instructions` on `HarnessAgent` to be a `SystemModelMessage` for parity with `ToolLoopAgent`

--- a/packages/harness/src/agent/harness-agent-settings.test-d.ts
+++ b/packages/harness/src/agent/harness-agent-settings.test-d.ts
@@ -1,7 +1,7 @@
 import type { HarnessV1, HarnessV1SandboxProvider } from '../v1';
 import type { HarnessAgentSettings } from './harness-agent-settings';
 import type { HarnessAllTools } from './harness-agent-tool-types';
-import { tool } from '@ai-sdk/provider-utils';
+import { tool, type SystemModelMessage } from '@ai-sdk/provider-utils';
 import { describe, expectTypeOf, test } from 'vitest';
 import { z } from 'zod/v4';
 
@@ -102,7 +102,10 @@ describe('HarnessAgentSettings tool filtering types', () => {
         expectTypeOf(options).toEqualTypeOf<CallOptions>();
         return {
           ...rest,
-          instructions: `Serve ${options.tenant}`,
+          instructions: {
+            role: 'system',
+            content: `Serve ${options.tenant}`,
+          },
         };
       },
     };
@@ -126,6 +129,21 @@ describe('HarnessAgentSettings tool filtering types', () => {
     };
 
     expectTypeOf(settings.model).toEqualTypeOf<string | undefined>();
+  });
+
+  test('instructions accept a SystemModelMessage', () => {
+    const settings: Settings = {
+      harness,
+      instructions: {
+        role: 'system',
+        content: 'Serve the user.',
+        providerOptions: { test: { cache: true } },
+      },
+    };
+
+    expectTypeOf(settings.instructions).toEqualTypeOf<
+      string | SystemModelMessage | undefined
+    >();
   });
 
   test('headers accept undefined values', () => {

--- a/packages/harness/src/agent/harness-agent-settings.ts
+++ b/packages/harness/src/agent/harness-agent-settings.ts
@@ -14,6 +14,7 @@ import type {
   Experimental_SandboxSession as SandboxSession,
   FlexibleSchema,
   MaybePromiseLike,
+  SystemModelMessage,
   ToolSet,
 } from '@ai-sdk/provider-utils';
 import type {
@@ -159,9 +160,10 @@ export type HarnessAgentSettings<
    * Instructions for the underlying agent runtime. Adapters append these to a
    * native system or developer prompt when supported. Otherwise, they prepend
    * them to the user message. `prepareCall` can replace them between completed
-   * turns.
+   * turns. When a `SystemModelMessage` is provided, only its `content` is
+   * forwarded to the harness adapter.
    */
-  readonly instructions?: string;
+  readonly instructions?: string | SystemModelMessage;
 
   /**
    * Additional HTTP headers to be sent with every model request.

--- a/packages/harness/src/agent/harness-agent.test.ts
+++ b/packages/harness/src/agent/harness-agent.test.ts
@@ -731,7 +731,11 @@ describe('HarnessAgent', () => {
               content: `${options.tenant} instructions`,
             },
           ],
-          instructions: `Serve ${options.tenant}`,
+          instructions: {
+            role: 'system',
+            content: `Serve ${options.tenant}`,
+            providerOptions: { test: { cache: true } },
+          },
           tools: options.tenant === 'alpha' ? { echo } : undefined,
         };
       },
@@ -1996,7 +2000,11 @@ describe('HarnessAgent', () => {
     const agent = new HarnessAgent({
       harness,
       sandbox: makeSandboxProvider(),
-      instructions: 'Be concise.',
+      instructions: {
+        role: 'system',
+        content: 'Be concise.',
+        providerOptions: { test: { cache: true } },
+      },
     });
     const session = await agent.createSession({
       continueFrom: {

--- a/packages/harness/src/agent/harness-agent.ts
+++ b/packages/harness/src/agent/harness-agent.ts
@@ -15,6 +15,7 @@ import {
   type Context,
   type Experimental_SandboxSession as SandboxSession,
   type ModelMessage,
+  type SystemModelMessage,
   type ToolApprovalResponse,
   type ToolResultPart,
   type ToolSet,
@@ -989,7 +990,7 @@ export class HarnessAgent<
   private _prepareTurnSettings(options: {
     model?: string;
     skills?: ReadonlyArray<HarnessAgentSkill>;
-    instructions?: string;
+    instructions?: string | SystemModelMessage;
     tools?: TUserTools;
   }): PreparedHarnessAgentTurnSettings<THarness, TUserTools> {
     const userTools = options.tools ?? ({} as TUserTools);
@@ -1011,7 +1012,10 @@ export class HarnessAgent<
     return {
       model: options.model,
       skills: options.skills ?? [],
-      instructions: options.instructions,
+      instructions:
+        typeof options.instructions === 'string'
+          ? options.instructions
+          : options.instructions?.content,
       tools,
       activeTools: toolFiltering.activeUserTools,
       toolSpecs: this._toToolSpecs(toolFiltering.activeUserTools),


### PR DESCRIPTION
## Background

`HarnessAgent` only accepted string instructions, while `ToolLoopAgent` also accepts a `SystemModelMessage`. This prevented shared agent configuration from using the same object shape.

## Summary

- Allow `HarnessAgentSettings.instructions` and `prepareCall` to accept a single `SystemModelMessage`.
- Extract the message content before passing instructions to string-only `HarnessV1` adapters.
- Add type and runtime coverage for fresh and continued turns.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
