### PR TITLE
fix(openai): remove propertyNames from JSON Schema

### DIFF
--- a/.changeset/strip-openai-property-names.md
+++ b/.changeset/strip-openai-property-names.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/openai': patch
+---
+
+fix(openai): remove propertyNames from JSON Schema

--- a/examples/ai-functions/src/generate-text/openai/property-names.ts
+++ b/examples/ai-functions/src/generate-text/openai/property-names.ts
@@ -1,0 +1,26 @@
+import { openai } from '@ai-sdk/openai';
+import { generateText, Output } from 'ai';
+import { z as z4 } from 'zod/v4';
+import { print } from '../../lib/print';
+import { run } from '../../lib/run';
+
+run(async () => {
+  const result = await generateText({
+    model: openai.chat('gpt-4.1-mini'),
+    // This disables the separate strict-schema limitation for typed
+    // dictionaries, isolating `propertyNames`. Before the OpenAI schema
+    // normalization, this request failed with a 400 because Zod emits
+    // `propertyNames: { type: 'string' }` for z.record().
+
+    providerOptions: { openai: { strictJsonSchema: false } },
+    output: Output.object({
+      schema: z4.object({
+        variables: z4.record(z4.string(), z4.string()),
+      }),
+    }),
+    prompt: 'Return an object with a variables object containing two strings.',
+  });
+
+  print('Output:', result.output);
+  print('Warnings:', result.warnings);
+});

--- a/packages/openai/src/chat/openai-chat-language-model.test.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.test.ts
@@ -1070,6 +1070,66 @@ describe('doGenerate', () => {
       expect(warnings).toEqual([]);
     });
 
+    it('should remove string propertyNames from response schemas and warn', async () => {
+      prepareJsonFixtureResponse('openai-text');
+
+      const model = provider.chat('gpt-4o-2024-08-06');
+
+      const { warnings } = await model.doGenerate({
+        responseFormat: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {
+              variables: {
+                type: 'object',
+                propertyNames: {
+                  type: 'string',
+                  format: 'uuid',
+                },
+                additionalProperties: { type: 'string' },
+              },
+            },
+            required: ['variables'],
+            additionalProperties: false,
+          },
+        },
+        prompt: TEST_PROMPT,
+      });
+
+      expect(await server.calls[0].requestBodyJson).toStrictEqual({
+        model: 'gpt-4o-2024-08-06',
+        messages: [{ role: 'user', content: 'Hello' }],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'response',
+            strict: true,
+            schema: {
+              type: 'object',
+              properties: {
+                variables: {
+                  type: 'object',
+                  additionalProperties: { type: 'string' },
+                },
+              },
+              required: ['variables'],
+              additionalProperties: false,
+            },
+          },
+        },
+      });
+
+      expect(warnings).toStrictEqual([
+        {
+          type: 'compatibility',
+          feature: 'JSON Schema propertyNames',
+          details:
+            'OpenAI does not support JSON Schema propertyNames. It was removed before sending the schema, so OpenAI will not enforce property-name constraints.',
+        },
+      ]);
+    });
+
     it('should use json_schema & strict with responseFormat json', async () => {
       prepareJsonFixtureResponse('openai-text');
 

--- a/packages/openai/src/chat/openai-chat-language-model.ts
+++ b/packages/openai/src/chat/openai-chat-language-model.ts
@@ -48,6 +48,7 @@ import {
   type OpenAIChatModelId,
 } from './openai-chat-language-model-options';
 import { prepareChatTools } from './openai-chat-prepare-tools';
+import { normalizeOpenAIJsonSchema } from '../normalize-openai-json-schema';
 
 type OpenAIChatConfig = {
   provider: string;
@@ -159,6 +160,14 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
     warnings.push(...messageWarnings);
 
     const strictJsonSchema = openaiOptions.strictJsonSchema ?? true;
+    const normalizedResponseFormatSchema =
+      responseFormat?.type === 'json' && responseFormat.schema != null
+        ? normalizeOpenAIJsonSchema(responseFormat.schema)
+        : undefined;
+
+    if (normalizedResponseFormatSchema != null) {
+      warnings.push(...normalizedResponseFormatSchema.warnings);
+    }
 
     const baseArgs = {
       // model id:
@@ -190,11 +199,11 @@ export class OpenAIChatLanguageModel implements LanguageModelV4 {
       presence_penalty: presencePenalty,
       response_format:
         responseFormat?.type === 'json'
-          ? responseFormat.schema != null
+          ? normalizedResponseFormatSchema != null
             ? {
                 type: 'json_schema',
                 json_schema: {
-                  schema: responseFormat.schema,
+                  schema: normalizedResponseFormatSchema.schema,
                   strict: strictJsonSchema,
                   name: responseFormat.name ?? 'response',
                   description: responseFormat.description,

--- a/packages/openai/src/chat/openai-chat-prepare-tools.test.ts
+++ b/packages/openai/src/chat/openai-chat-prepare-tools.test.ts
@@ -59,6 +59,55 @@ describe('prepareChatTools', () => {
   `);
   });
 
+  it('should remove string propertyNames from function tools and warn', () => {
+    const result = prepareChatTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'testFunction',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              values: {
+                type: 'object',
+                propertyNames: { type: 'string', pattern: '^[A-Z_]+$' },
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'testFunction',
+            description: undefined,
+            parameters: {
+              type: 'object',
+              properties: {
+                values: {
+                  type: 'object',
+                },
+              },
+            },
+          },
+        },
+      ],
+      toolChoice: undefined,
+      toolWarnings: [
+        {
+          type: 'compatibility',
+          feature: 'JSON Schema propertyNames',
+          details:
+            'OpenAI does not support JSON Schema propertyNames. It was removed before sending the schema, so OpenAI will not enforce property-name constraints.',
+        },
+      ],
+    });
+  });
+
   it('should add warnings for unsupported tools', () => {
     const result = prepareChatTools({
       tools: [

--- a/packages/openai/src/chat/openai-chat-prepare-tools.ts
+++ b/packages/openai/src/chat/openai-chat-prepare-tools.ts
@@ -7,6 +7,7 @@ import type {
   OpenAIChatToolChoice,
   OpenAIChatFunctionTool,
 } from './openai-chat-api';
+import { normalizeOpenAIJsonSchema } from '../normalize-openai-json-schema';
 
 export function prepareChatTools({
   tools,
@@ -32,17 +33,23 @@ export function prepareChatTools({
 
   for (const tool of tools) {
     switch (tool.type) {
-      case 'function':
+      case 'function': {
+        const normalizedInputSchema = normalizeOpenAIJsonSchema(
+          tool.inputSchema,
+        );
+        toolWarnings.push(...normalizedInputSchema.warnings);
+
         openaiTools.push({
           type: 'function',
           function: {
             name: tool.name,
             description: tool.description,
-            parameters: tool.inputSchema,
+            parameters: normalizedInputSchema.schema,
             ...(tool.strict != null ? { strict: tool.strict } : {}),
           },
         });
         break;
+      }
       default:
         toolWarnings.push({
           type: 'unsupported',

--- a/packages/openai/src/normalize-openai-json-schema.test.ts
+++ b/packages/openai/src/normalize-openai-json-schema.test.ts
@@ -1,0 +1,86 @@
+import {
+  UnsupportedFunctionalityError,
+  type JSONSchema7,
+} from '@ai-sdk/provider';
+import { describe, expect, it } from 'vitest';
+import { normalizeOpenAIJsonSchema } from './normalize-openai-json-schema';
+
+describe('normalizeOpenAIJsonSchema', () => {
+  it('removes string propertyNames recursively and warns', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        variables: {
+          type: 'object',
+          propertyNames: {
+            type: 'string',
+            format: 'uuid',
+          },
+          additionalProperties: {
+            type: 'object',
+            propertyNames: { type: 'string', pattern: '^[A-Z_]+$' },
+          },
+        },
+      },
+      definitions: {
+        variable: {
+          type: 'object',
+          propertyNames: { type: 'string' },
+        },
+      },
+      $defs: {
+        conditional: {
+          if: {
+            type: 'object',
+            propertyNames: { type: 'string' },
+          },
+        },
+      },
+    };
+
+    expect(normalizeOpenAIJsonSchema(schema)).toStrictEqual({
+      schema: {
+        type: 'object',
+        properties: {
+          variables: {
+            type: 'object',
+            additionalProperties: {
+              type: 'object',
+            },
+          },
+        },
+        definitions: {
+          variable: {
+            type: 'object',
+          },
+        },
+        $defs: {
+          conditional: {
+            if: {
+              type: 'object',
+            },
+          },
+        },
+      },
+      warnings: [
+        {
+          type: 'compatibility',
+          feature: 'JSON Schema propertyNames',
+          details:
+            'OpenAI does not support JSON Schema propertyNames. It was removed before sending the schema, so OpenAI will not enforce property-name constraints.',
+        },
+      ],
+    });
+
+    expect(schema.properties?.variables).toHaveProperty('propertyNames');
+  });
+
+  it('rejects non-string propertyNames schemas', () => {
+    expect(() =>
+      normalizeOpenAIJsonSchema({
+        type: 'object',
+        propertyNames: { type: 'number' },
+      }),
+    ).toThrow(UnsupportedFunctionalityError);
+  });
+});

--- a/packages/openai/src/normalize-openai-json-schema.ts
+++ b/packages/openai/src/normalize-openai-json-schema.ts
@@ -1,0 +1,161 @@
+import {
+  UnsupportedFunctionalityError,
+  type JSONSchema7,
+  type JSONSchema7Definition,
+  type SharedV4Warning,
+} from '@ai-sdk/provider';
+
+/**
+ * Normalizes JSON Schema for OpenAI structured outputs.
+ *
+ * OpenAI does not support the JSON Schema `propertyNames` keyword. Property
+ * names in JSON objects are always strings, so string-based constraints can be
+ * left to client-side validation after removing the keyword. This
+ * compatibility layer does not rewrite non-string property name schemas.
+ */
+export function normalizeOpenAIJsonSchema(schema: JSONSchema7): {
+  schema: JSONSchema7;
+  warnings: SharedV4Warning[];
+} {
+  let removedPropertyNames = false;
+
+  const normalizedSchema = normalizeSchema(schema);
+
+  return {
+    schema: normalizedSchema,
+    warnings: removedPropertyNames
+      ? [
+          {
+            type: 'compatibility',
+            feature: 'JSON Schema propertyNames',
+            details:
+              'OpenAI does not support JSON Schema propertyNames. It was removed before sending the schema, so OpenAI will not enforce property-name constraints.',
+          },
+        ]
+      : [],
+  };
+
+  function normalizeSchema(schema: JSONSchema7): JSONSchema7 {
+    const propertyNames = schema.propertyNames;
+
+    if (propertyNames != null) {
+      if (
+        typeof propertyNames === 'boolean' ||
+        propertyNames.type !== 'string'
+      ) {
+        throw new UnsupportedFunctionalityError({
+          functionality:
+            'JSON Schema propertyNames that does not use a string schema',
+        });
+      }
+
+      removedPropertyNames = true;
+    }
+
+    const normalizedSchema = { ...schema };
+    delete normalizedSchema.propertyNames;
+
+    if (normalizedSchema.properties != null) {
+      normalizedSchema.properties = normalizeSchemaRecord(
+        normalizedSchema.properties,
+      );
+    }
+
+    if (normalizedSchema.patternProperties != null) {
+      normalizedSchema.patternProperties = normalizeSchemaRecord(
+        normalizedSchema.patternProperties,
+      );
+    }
+
+    if (normalizedSchema.additionalProperties != null) {
+      normalizedSchema.additionalProperties = normalizeDefinition(
+        normalizedSchema.additionalProperties,
+      );
+    }
+
+    if (normalizedSchema.additionalItems != null) {
+      normalizedSchema.additionalItems = normalizeDefinition(
+        normalizedSchema.additionalItems,
+      );
+    }
+
+    if (normalizedSchema.items != null) {
+      normalizedSchema.items = Array.isArray(normalizedSchema.items)
+        ? normalizedSchema.items.map(normalizeDefinition)
+        : normalizeDefinition(normalizedSchema.items);
+    }
+
+    if (normalizedSchema.contains != null) {
+      normalizedSchema.contains = normalizeDefinition(
+        normalizedSchema.contains,
+      );
+    }
+
+    if (normalizedSchema.not != null) {
+      normalizedSchema.not = normalizeDefinition(normalizedSchema.not);
+    }
+
+    if (normalizedSchema.allOf != null) {
+      normalizedSchema.allOf = normalizedSchema.allOf.map(normalizeDefinition);
+    }
+
+    if (normalizedSchema.anyOf != null) {
+      normalizedSchema.anyOf = normalizedSchema.anyOf.map(normalizeDefinition);
+    }
+
+    if (normalizedSchema.oneOf != null) {
+      normalizedSchema.oneOf = normalizedSchema.oneOf.map(normalizeDefinition);
+    }
+
+    if (normalizedSchema.definitions != null) {
+      normalizedSchema.definitions = normalizeSchemaRecord(
+        normalizedSchema.definitions,
+      );
+    }
+
+    if (normalizedSchema.$defs != null) {
+      normalizedSchema.$defs = normalizeSchemaRecord(normalizedSchema.$defs);
+    }
+
+    if (normalizedSchema.dependencies != null) {
+      normalizedSchema.dependencies = Object.fromEntries(
+        Object.entries(normalizedSchema.dependencies).map(
+          ([key, dependency]) => [
+            key,
+            Array.isArray(dependency)
+              ? dependency
+              : normalizeDefinition(dependency),
+          ],
+        ),
+      );
+    }
+
+    for (const keyword of ['if', 'then', 'else'] as const) {
+      const conditionalSchema = normalizedSchema[keyword];
+      if (conditionalSchema != null) {
+        normalizedSchema[keyword] = normalizeDefinition(conditionalSchema);
+      }
+    }
+
+    return normalizedSchema;
+  }
+
+  function normalizeSchemaRecord(
+    schemas: Record<string, JSONSchema7Definition>,
+  ): Record<string, JSONSchema7Definition> {
+    return Object.fromEntries(
+      Object.entries(schemas).map(([key, schema]) => [
+        key,
+        normalizeDefinition(schema),
+      ]),
+    );
+  }
+
+  function normalizeDefinition(
+    definition: JSONSchema7Definition,
+  ): JSONSchema7Definition {
+    return typeof definition === 'boolean'
+      ? definition
+      : normalizeSchema(definition);
+  }
+}

--- a/packages/openai/src/responses/openai-responses-language-model.test.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.test.ts
@@ -2223,6 +2223,64 @@ describe('OpenAIResponsesLanguageModel', () => {
         expect(warnings).toStrictEqual([]);
       });
 
+      it('should remove string propertyNames from response schemas and warn', async () => {
+        const { warnings } = await createModel('gpt-4o').doGenerate({
+          responseFormat: {
+            type: 'json',
+            schema: {
+              type: 'object',
+              properties: {
+                variables: {
+                  type: 'object',
+                  propertyNames: { type: 'string', pattern: '^[A-Z_]+$' },
+                  additionalProperties: { type: 'string' },
+                },
+              },
+              required: ['variables'],
+              additionalProperties: false,
+            },
+          },
+          prompt: TEST_PROMPT,
+        });
+
+        expect(await server.calls[0].requestBodyJson).toStrictEqual({
+          model: 'gpt-4o',
+          text: {
+            format: {
+              type: 'json_schema',
+              strict: true,
+              name: 'response',
+              schema: {
+                type: 'object',
+                properties: {
+                  variables: {
+                    type: 'object',
+                    additionalProperties: { type: 'string' },
+                  },
+                },
+                required: ['variables'],
+                additionalProperties: false,
+              },
+            },
+          },
+          input: [
+            {
+              role: 'user',
+              content: [{ type: 'input_text', text: 'Hello' }],
+            },
+          ],
+        });
+
+        expect(warnings).toStrictEqual([
+          {
+            type: 'compatibility',
+            feature: 'JSON Schema propertyNames',
+            details:
+              'OpenAI does not support JSON Schema propertyNames. It was removed before sending the schema, so OpenAI will not enforce property-name constraints.',
+          },
+        ]);
+      });
+
       it('should send responseFormat json_schema format with strictJsonSchema false', async () => {
         const { warnings } = await createModel('gpt-4o').doGenerate({
           responseFormat: {

--- a/packages/openai/src/responses/openai-responses-language-model.ts
+++ b/packages/openai/src/responses/openai-responses-language-model.ts
@@ -70,6 +70,7 @@ import {
   isUndeclaredParallelToolCall,
 } from './expand-parallel-tool-call';
 import { mapOpenAIResponseFinishReason } from './map-openai-responses-finish-reason';
+import { normalizeOpenAIJsonSchema } from '../normalize-openai-json-schema';
 import {
   openaiResponsesChunkSchema,
   openaiResponsesResponseSchema,
@@ -444,6 +445,14 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
     }
 
     const strictJsonSchema = openaiOptions?.strictJsonSchema ?? true;
+    const normalizedResponseFormatSchema =
+      responseFormat?.type === 'json' && responseFormat.schema != null
+        ? normalizeOpenAIJsonSchema(responseFormat.schema)
+        : undefined;
+
+    if (normalizedResponseFormatSchema != null) {
+      warnings.push(...normalizedResponseFormatSchema.warnings);
+    }
 
     let include: OpenAIResponsesIncludeOptions = openaiOptions?.include;
 
@@ -517,13 +526,13 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV4 {
         text: {
           ...(responseFormat?.type === 'json' && {
             format:
-              responseFormat.schema != null
+              normalizedResponseFormatSchema != null
                 ? {
                     type: 'json_schema',
                     strict: strictJsonSchema,
                     name: responseFormat.name ?? 'response',
                     description: responseFormat.description,
-                    schema: responseFormat.schema,
+                    schema: normalizedResponseFormatSchema.schema,
                   }
                 : { type: 'json_object' },
           }),

--- a/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.test.ts
@@ -4,6 +4,54 @@ import { prepareResponsesTools } from './openai-responses-prepare-tools';
 import { describe, it, expect } from 'vitest';
 
 describe('prepareResponsesTools', () => {
+  it('should remove string propertyNames from function tools and warn', async () => {
+    const result = await prepareResponsesTools({
+      tools: [
+        {
+          type: 'function',
+          name: 'get_weather',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              values: {
+                type: 'object',
+                propertyNames: { type: 'string', format: 'uuid' },
+              },
+            },
+          },
+        },
+      ],
+      toolChoice: undefined,
+    });
+
+    expect(result).toEqual({
+      tools: [
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: undefined,
+          parameters: {
+            type: 'object',
+            properties: {
+              values: {
+                type: 'object',
+              },
+            },
+          },
+        },
+      ],
+      toolChoice: undefined,
+      toolWarnings: [
+        {
+          type: 'compatibility',
+          feature: 'JSON Schema propertyNames',
+          details:
+            'OpenAI does not support JSON Schema propertyNames. It was removed before sending the schema, so OpenAI will not enforce property-name constraints.',
+        },
+      ],
+    });
+  });
+
   describe('async tools', () => {
     it('should pass through async mode for function tools', async () => {
       const result = await prepareResponsesTools({

--- a/packages/openai/src/responses/openai-responses-prepare-tools.ts
+++ b/packages/openai/src/responses/openai-responses-prepare-tools.ts
@@ -21,6 +21,7 @@ import { shellArgsSchema } from '../tool/shell';
 import { toolSearchArgsSchema } from '../tool/tool-search';
 import { webSearchArgsSchema } from '../tool/web-search';
 import { webSearchPreviewArgsSchema } from '../tool/web-search-preview';
+import { normalizeOpenAIJsonSchema } from '../normalize-openai-json-schema';
 import type {
   OpenAIResponsesAllowedTool,
   OpenAIResponsesFunctionTool,
@@ -147,6 +148,7 @@ export async function prepareResponsesTools({
         const openaiFunctionTool = prepareFunctionTool({
           tool,
           options: openaiOptions,
+          toolWarnings,
           async: resolveAsyncToolOption({
             value: openaiOptions?.async,
             supportsAsyncToolCalling,
@@ -627,19 +629,31 @@ function toAllowedToolResolution(
 function prepareFunctionTool({
   tool,
   options,
+  toolWarnings,
   async,
 }: {
   tool: LanguageModelV4FunctionTool;
   options: OpenAIToolOptions | undefined;
+  toolWarnings: SharedV4Warning[];
   async: boolean | undefined;
 }): OpenAIResponsesFunctionTool {
   const deferLoading = options?.deferLoading;
+  const normalizedInputSchema = normalizeOpenAIJsonSchema(tool.inputSchema);
+  const normalizedOutputSchema =
+    options?.outputSchema != null
+      ? normalizeOpenAIJsonSchema(options.outputSchema as JSONSchema7)
+      : undefined;
+
+  toolWarnings.push(
+    ...normalizedInputSchema.warnings,
+    ...(normalizedOutputSchema?.warnings ?? []),
+  );
 
   return {
     type: 'function',
     name: tool.name,
     description: tool.description,
-    parameters: tool.inputSchema,
+    parameters: normalizedInputSchema.schema,
     ...(async != null ? { async } : {}),
     ...(tool.strict != null ? { strict: tool.strict } : {}),
     ...(deferLoading != null ? { defer_loading: deferLoading } : {}),
@@ -647,7 +661,7 @@ function prepareFunctionTool({
       ? { allowed_callers: options.allowedCallers }
       : {}),
     ...(options?.outputSchema != null
-      ? { output_schema: options.outputSchema as JSONSchema7 }
+      ? { output_schema: normalizedOutputSchema?.schema }
       : {}),
   };
 }


### PR DESCRIPTION
## Background

- Zod 4 emits `propertyNames` to describe Record keys
- OpenAI rejects JSON Schemas with `propertyNames`

This only reproduces when strict mode is disabled because OpenAI normally rejects Records entirely, regardless of if they are explicitly keyed.

## Summary

- Strip `propertyNames` when it's `{ type: 'string' }` before sending schema to OpenAI
  - JSON keys are always strings anyway, so this part of the schema isn't necessary anyway - there's no behavior difference
- Fail when `propertyNames` is any other `type`
  - OpenAI rejects this and it's impossible to represent a different type as a JSON key anyway

## End-to-End Verification

Added a `property-names.ts` example and ran it

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

- Fixes #9601