### PR TITLE
fix(vertex): download tool result file URLs

### DIFF
--- a/.changeset/bright-vertex-tool-images.md
+++ b/.changeset/bright-vertex-tool-images.md
@@ -1,0 +1,6 @@
+---
+'@ai-sdk/google': patch
+'@ai-sdk/google-vertex': patch
+---
+
+fix(vertex): download tool result file URLs

--- a/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
+++ b/content/providers/01-ai-sdk-providers/16-google-vertex.mdx
@@ -135,6 +135,13 @@ You can use the following optional settings to customize the provider instance:
   Optional. Base URL for the Google Vertex API calls e.g. to use proxy servers. By default, it is constructed using the location and project:
   `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/publishers/google`
 
+- **toolResultDownloads** _object_
+
+  Settings for downloading remote files in tool results before sending them to Vertex as inline data.
+  - **maxBytes** _number_
+
+    Maximum size in bytes for each downloaded file. Defaults to 7 MiB.
+
 <a id="google-vertex-edge-runtime"></a>
 #### Edge Runtime
 

--- a/examples/ai-functions/src/generate-text/google/vertex-tool-result-image-url.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-tool-result-image-url.ts
@@ -1,0 +1,46 @@
+import { googleVertex } from '@ai-sdk/google-vertex';
+import { generateText, isStepCount, tool } from 'ai';
+import { z } from 'zod';
+import { run } from '../../lib/run';
+
+const imageUrl =
+  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRr_-62a40u3lSIyRP5EKOjJeQiZROwTeVCOQ&s';
+
+run(async () => {
+  const getCatImage = tool({
+    description: 'Return the requested preview image.',
+    inputSchema: z.object({}),
+    execute: async () => ({ imageUrl }),
+    toModelOutput: ({ output }) => ({
+      type: 'content',
+      value: [
+        {
+          type: 'text',
+          text: 'Here is the requested preview image.',
+        },
+        {
+          type: 'file',
+          mediaType: 'image',
+          data: { type: 'url', url: new URL(output.imageUrl) },
+        },
+      ],
+    }),
+  });
+
+  // Reproduction for https://github.com/vercel/ai/issues/15671:
+  // before the Vertex fix, the remote file is sent back as URL-shaped content
+  // rather than image bytes, so the model cannot inspect the tool result.
+  const result = await generateText({
+    model: googleVertex('gemini-2.5-flash'),
+    tools: { get_cat_image: getCatImage },
+    stopWhen: isStepCount(2),
+    prepareStep: ({ stepNumber }) => ({
+      toolChoice:
+        stepNumber === 0 ? { type: 'tool', toolName: 'get_cat_image' } : 'none',
+    }),
+    prompt:
+      'Use get_cat_image exactly once, then describe the image it returned in one sentence.',
+  });
+
+  console.log(result.text);
+});

--- a/examples/ai-functions/src/generate-text/google/vertex-tool-result-image-url.ts
+++ b/examples/ai-functions/src/generate-text/google/vertex-tool-result-image-url.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { run } from '../../lib/run';
 
 const imageUrl =
-  'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRr_-62a40u3lSIyRP5EKOjJeQiZROwTeVCOQ&s';
+  'https://raw.githubusercontent.com/vercel/ai/b3b56246cbbe191fdb73005daa68e8c54d282aa3/examples/ai-functions/data/comic-cat.png';
 
 run(async () => {
   const getCatImage = tool({

--- a/packages/google-vertex/src/google-vertex-provider-base.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.test.ts
@@ -101,6 +101,22 @@ describe('google-vertex-provider-base', () => {
     );
   });
 
+  it('should configure the tool result download size limit', () => {
+    const provider = createGoogleVertex({
+      project: 'test-project',
+      location: 'test-location',
+      toolResultDownloads: { maxBytes: 20 * 1024 * 1024 },
+    });
+    provider('test-model-id');
+
+    expect(GoogleLanguageModel).toHaveBeenCalledWith(
+      'test-model-id',
+      expect.objectContaining({
+        downloadToolResultFiles: { maxBytes: 20 * 1024 * 1024 },
+      }),
+    );
+  });
+
   it('should create an interactions model targeting the location-scoped interactions resource', () => {
     const provider = createGoogleVertex({
       project: 'test-project',
@@ -516,7 +532,9 @@ describe('google-vertex-provider-base', () => {
       .toMatchInlineSnapshot(`
         {
           "baseURL": "https://aiplatform.us.rep.googleapis.com/v1beta1/projects/test-project/locations/us/publishers/google",
-          "downloadToolResultFiles": true,
+          "downloadToolResultFiles": {
+            "maxBytes": 7340032,
+          },
           "fetch": undefined,
           "generateId": [MockFunction],
           "headers": [Function],
@@ -537,7 +555,9 @@ describe('google-vertex-provider-base', () => {
       .toMatchInlineSnapshot(`
         {
           "baseURL": "https://aiplatform.eu.rep.googleapis.com/v1beta1/projects/test-project/locations/eu/publishers/google",
-          "downloadToolResultFiles": true,
+          "downloadToolResultFiles": {
+            "maxBytes": 7340032,
+          },
           "fetch": undefined,
           "generateId": [MockFunction],
           "headers": [Function],

--- a/packages/google-vertex/src/google-vertex-provider-base.test.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.test.ts
@@ -516,6 +516,7 @@ describe('google-vertex-provider-base', () => {
       .toMatchInlineSnapshot(`
         {
           "baseURL": "https://aiplatform.us.rep.googleapis.com/v1beta1/projects/test-project/locations/us/publishers/google",
+          "downloadToolResultFiles": true,
           "fetch": undefined,
           "generateId": [MockFunction],
           "headers": [Function],
@@ -536,6 +537,7 @@ describe('google-vertex-provider-base', () => {
       .toMatchInlineSnapshot(`
         {
           "baseURL": "https://aiplatform.eu.rep.googleapis.com/v1beta1/projects/test-project/locations/eu/publishers/google",
+          "downloadToolResultFiles": true,
           "fetch": undefined,
           "generateId": [MockFunction],
           "headers": [Function],

--- a/packages/google-vertex/src/google-vertex-provider-base.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.ts
@@ -193,6 +193,17 @@ export interface GoogleVertexProviderSettings {
    * `ws` package in Node.js, which Vertex's OAuth Bearer header requires).
    */
   webSocket?: WebSocketConstructor;
+
+  /**
+   * Settings for downloading remote files in tool results before sending them
+   * to Vertex as inline data.
+   */
+  toolResultDownloads?: {
+    /**
+     * Maximum size in bytes for each downloaded file. Defaults to 7 MiB.
+     */
+    maxBytes?: number;
+  };
 }
 
 /**
@@ -294,7 +305,9 @@ export function createGoogleVertex(
           /^gs:\/\/.*$/,
         ],
       }),
-      downloadToolResultFiles: true,
+      downloadToolResultFiles: {
+        maxBytes: options.toolResultDownloads?.maxBytes ?? 7 * 1024 * 1024,
+      },
     });
   };
 

--- a/packages/google-vertex/src/google-vertex-provider-base.ts
+++ b/packages/google-vertex/src/google-vertex-provider-base.ts
@@ -294,6 +294,7 @@ export function createGoogleVertex(
           /^gs:\/\/.*$/,
         ],
       }),
+      downloadToolResultFiles: true,
     });
   };
 

--- a/packages/google/src/download-tool-result-files.test.ts
+++ b/packages/google/src/download-tool-result-files.test.ts
@@ -1,0 +1,92 @@
+import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { downloadToolResultFiles } from './download-tool-result-files';
+
+describe('downloadToolResultFiles', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('downloads remote files in tool results without changing user files', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(new Uint8Array([0xff, 0xd8, 0xff]), {
+        headers: { 'content-type': 'image/jpeg' },
+      }),
+    );
+    const prompt: LanguageModelV4Prompt = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            data: {
+              type: 'url',
+              url: new URL('https://example.com/user-image.png'),
+            },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'tool-call-id',
+            toolName: 'get-image',
+            output: {
+              type: 'content',
+              value: [
+                {
+                  type: 'file',
+                  mediaType: 'image',
+                  data: {
+                    type: 'url',
+                    url: new URL('https://example.com/tool-image.jpg'),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = await downloadToolResultFiles(prompt, undefined);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://example.com/tool-image.jpg',
+      expect.objectContaining({ redirect: 'manual' }),
+    );
+    expect(result).toMatchObject([
+      prompt[0],
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            output: {
+              type: 'content',
+              value: [
+                {
+                  type: 'file',
+                  mediaType: 'image/jpeg',
+                  data: {
+                    type: 'data',
+                    data: new Uint8Array([0xff, 0xd8, 0xff]),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/google/src/download-tool-result-files.test.ts
+++ b/packages/google/src/download-tool-result-files.test.ts
@@ -2,6 +2,29 @@ import type { LanguageModelV4Prompt } from '@ai-sdk/provider';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { downloadToolResultFiles } from './download-tool-result-files';
 
+function createToolResultPrompt(urls: string[]): LanguageModelV4Prompt {
+  return [
+    {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'tool-call-id',
+          toolName: 'get-image',
+          output: {
+            type: 'content',
+            value: urls.map(url => ({
+              type: 'file' as const,
+              mediaType: 'image',
+              data: { type: 'url' as const, url: new URL(url) },
+            })),
+          },
+        },
+      ],
+    },
+  ];
+}
+
 describe('downloadToolResultFiles', () => {
   const originalFetch = globalThis.fetch;
 
@@ -58,7 +81,10 @@ describe('downloadToolResultFiles', () => {
       },
     ];
 
-    const result = await downloadToolResultFiles(prompt, undefined);
+    const result = await downloadToolResultFiles(prompt, {
+      abortSignal: undefined,
+      maxBytes: 7 * 1024 * 1024,
+    });
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
       'https://example.com/tool-image.jpg',
@@ -88,5 +114,41 @@ describe('downloadToolResultFiles', () => {
         ],
       },
     ]);
+  });
+
+  it('limits the size of each download', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(new Uint8Array([0xff, 0xd8, 0xff])),
+    );
+
+    await expect(
+      downloadToolResultFiles(
+        createToolResultPrompt(['https://example.com/tool-image.jpg']),
+        { abortSignal: undefined, maxBytes: 2 },
+      ),
+    ).rejects.toThrow('exceeded maximum size of 2 bytes');
+  });
+
+  it('downloads files sequentially', async () => {
+    let activeDownloads = 0;
+    let maxActiveDownloads = 0;
+
+    vi.mocked(globalThis.fetch).mockImplementation(async () => {
+      activeDownloads++;
+      maxActiveDownloads = Math.max(maxActiveDownloads, activeDownloads);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      activeDownloads--;
+      return new Response(new Uint8Array([0xff, 0xd8, 0xff]));
+    });
+
+    await downloadToolResultFiles(
+      createToolResultPrompt([
+        'https://example.com/tool-image-1.jpg',
+        'https://example.com/tool-image-2.jpg',
+      ]),
+      { abortSignal: undefined, maxBytes: 7 * 1024 * 1024 },
+    );
+
+    expect(maxActiveDownloads).toBe(1);
   });
 });

--- a/packages/google/src/download-tool-result-files.ts
+++ b/packages/google/src/download-tool-result-files.ts
@@ -14,92 +14,111 @@ import {
  */
 export async function downloadToolResultFiles(
   prompt: LanguageModelV4Prompt,
-  abortSignal: AbortSignal | undefined,
+  {
+    abortSignal,
+    maxBytes,
+  }: {
+    abortSignal: AbortSignal | undefined;
+    maxBytes: number;
+  },
 ): Promise<LanguageModelV4Prompt> {
-  return await Promise.all(
-    prompt.map(async message => {
-      if (message.role === 'assistant') {
-        return {
-          ...message,
-          content: await Promise.all(
-            message.content.map(async part => {
-              if (part.type !== 'tool-result') {
-                return part;
-              }
+  const result: LanguageModelV4Prompt = [];
 
-              return {
+  for (const message of prompt) {
+    if (message.role === 'assistant') {
+      const content: typeof message.content = [];
+
+      for (const part of message.content) {
+        content.push(
+          part.type === 'tool-result'
+            ? {
                 ...part,
-                output: await downloadToolResultOutput(
-                  part.output,
+                output: await downloadToolResultOutput(part.output, {
                   abortSignal,
-                ),
-              };
-            }),
-          ),
-        };
+                  maxBytes,
+                }),
+              }
+            : part,
+        );
       }
 
-      if (message.role === 'tool') {
-        return {
-          ...message,
-          content: await Promise.all(
-            message.content.map(async part => {
-              if (part.type !== 'tool-result') {
-                return part;
-              }
+      result.push({ ...message, content });
+      continue;
+    }
 
-              return {
-                ...part,
-                output: await downloadToolResultOutput(
-                  part.output,
-                  abortSignal,
-                ),
-              };
-            }),
-          ),
-        };
+    if (message.role === 'tool') {
+      const content: typeof message.content = [];
+
+      for (const part of message.content) {
+        if (part.type !== 'tool-result') {
+          content.push(part);
+          continue;
+        }
+
+        content.push({
+          ...part,
+          output: await downloadToolResultOutput(part.output, {
+            abortSignal,
+            maxBytes,
+          }),
+        });
       }
 
-      return message;
-    }),
-  );
+      result.push({ ...message, content });
+      continue;
+    }
+
+    result.push(message);
+  }
+
+  return result;
 }
 
 async function downloadToolResultOutput(
   output: LanguageModelV4ToolResultOutput,
-  abortSignal: AbortSignal | undefined,
+  {
+    abortSignal,
+    maxBytes,
+  }: {
+    abortSignal: AbortSignal | undefined;
+    maxBytes: number;
+  },
 ): Promise<LanguageModelV4ToolResultOutput> {
   if (output.type !== 'content') {
     return output;
   }
 
+  const value: typeof output.value = [];
+
+  for (const part of output.value) {
+    if (part.type !== 'file' || part.data.type !== 'url') {
+      value.push(part);
+      continue;
+    }
+
+    const blob = await downloadBlob(part.data.url.toString(), {
+      abortSignal,
+      maxBytes,
+    });
+    const data = new Uint8Array(await blob.arrayBuffer());
+    const detectedMediaType = detectMediaType({
+      data,
+      topLevelType: 'image',
+    });
+
+    value.push({
+      ...part,
+      data: { type: 'data' as const, data },
+      mediaType:
+        detectedMediaType ??
+        (blob.type && !isFullMediaType(part.mediaType)
+          ? blob.type
+          : part.mediaType),
+    });
+  }
+
   return {
     ...output,
-    value: await Promise.all(
-      output.value.map(async part => {
-        if (part.type !== 'file' || part.data.type !== 'url') {
-          return part;
-        }
-
-        const blob = await downloadBlob(part.data.url.toString(), {
-          abortSignal,
-        });
-        const data = new Uint8Array(await blob.arrayBuffer());
-        const detectedMediaType = detectMediaType({
-          data,
-          topLevelType: 'image',
-        });
-
-        return {
-          ...part,
-          data: { type: 'data' as const, data },
-          mediaType:
-            detectedMediaType ??
-            (blob.type && !isFullMediaType(part.mediaType)
-              ? blob.type
-              : part.mediaType),
-        };
-      }),
-    ),
+    value,
   };
 }

--- a/packages/google/src/download-tool-result-files.ts
+++ b/packages/google/src/download-tool-result-files.ts
@@ -1,0 +1,105 @@
+import type {
+  LanguageModelV4Prompt,
+  LanguageModelV4ToolResultOutput,
+} from '@ai-sdk/provider';
+import {
+  detectMediaType,
+  downloadBlob,
+  isFullMediaType,
+} from '@ai-sdk/provider-utils';
+
+/**
+ * Vertex function responses only accept inline file data. Download remote tool
+ * result files before converting the prompt to the Google request format.
+ */
+export async function downloadToolResultFiles(
+  prompt: LanguageModelV4Prompt,
+  abortSignal: AbortSignal | undefined,
+): Promise<LanguageModelV4Prompt> {
+  return await Promise.all(
+    prompt.map(async message => {
+      if (message.role === 'assistant') {
+        return {
+          ...message,
+          content: await Promise.all(
+            message.content.map(async part => {
+              if (part.type !== 'tool-result') {
+                return part;
+              }
+
+              return {
+                ...part,
+                output: await downloadToolResultOutput(
+                  part.output,
+                  abortSignal,
+                ),
+              };
+            }),
+          ),
+        };
+      }
+
+      if (message.role === 'tool') {
+        return {
+          ...message,
+          content: await Promise.all(
+            message.content.map(async part => {
+              if (part.type !== 'tool-result') {
+                return part;
+              }
+
+              return {
+                ...part,
+                output: await downloadToolResultOutput(
+                  part.output,
+                  abortSignal,
+                ),
+              };
+            }),
+          ),
+        };
+      }
+
+      return message;
+    }),
+  );
+}
+
+async function downloadToolResultOutput(
+  output: LanguageModelV4ToolResultOutput,
+  abortSignal: AbortSignal | undefined,
+): Promise<LanguageModelV4ToolResultOutput> {
+  if (output.type !== 'content') {
+    return output;
+  }
+
+  return {
+    ...output,
+    value: await Promise.all(
+      output.value.map(async part => {
+        if (part.type !== 'file' || part.data.type !== 'url') {
+          return part;
+        }
+
+        const blob = await downloadBlob(part.data.url.toString(), {
+          abortSignal,
+        });
+        const data = new Uint8Array(await blob.arrayBuffer());
+        const detectedMediaType = detectMediaType({
+          data,
+          topLevelType: 'image',
+        });
+
+        return {
+          ...part,
+          data: { type: 'data' as const, data },
+          mediaType:
+            detectedMediaType ??
+            (blob.type && !isFullMediaType(part.mediaType)
+              ? blob.type
+              : part.mediaType),
+        };
+      }),
+    ),
+  };
+}

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -40,6 +40,7 @@ import {
 } from './convert-google-usage';
 import { convertJSONSchemaToOpenAPISchema } from './convert-json-schema-to-openapi-schema';
 import { convertToGoogleMessages } from './convert-to-google-messages';
+import { downloadToolResultFiles } from './download-tool-result-files';
 import { getModelPath } from './get-model-path';
 import { googleFailedResponseHandler } from './google-error';
 import {
@@ -76,6 +77,11 @@ export type GoogleLanguageModelConfig = {
    * The supported URLs for the model.
    */
   supportedUrls?: () => LanguageModelV4['supportedUrls'];
+
+  /**
+   * Whether remote files in tool results must be downloaded before conversion.
+   */
+  downloadToolResultFiles?: boolean;
 };
 
 export class GoogleLanguageModel implements LanguageModelV4 {
@@ -132,6 +138,7 @@ export class GoogleLanguageModel implements LanguageModelV4 {
       toolChoice,
       reasoning,
       providerOptions,
+      abortSignal,
     },
     isStreaming = false,
   }: {
@@ -287,14 +294,21 @@ export class GoogleLanguageModel implements LanguageModelV4 {
 
     const { usesGemini3Features } = getGoogleModelCapabilities(modelId);
 
-    const { contents, systemInstruction } = convertToGoogleMessages(prompt, {
-      isGemmaModel,
-      isGemini3Model: usesGemini3Features,
-      onWarning: warning => warnings.push(warning),
-      providerOptionsNames,
-      supportsFunctionResponseParts: usesGemini3Features,
-      includeFunctionCallIds: !isVertexProvider,
-    });
+    const promptWithDownloadedToolResultFiles = config.downloadToolResultFiles
+      ? await downloadToolResultFiles(prompt, abortSignal)
+      : prompt;
+
+    const { contents, systemInstruction } = convertToGoogleMessages(
+      promptWithDownloadedToolResultFiles,
+      {
+        isGemmaModel,
+        isGemini3Model: usesGemini3Features,
+        onWarning: warning => warnings.push(warning),
+        providerOptionsNames,
+        supportsFunctionResponseParts: usesGemini3Features,
+        includeFunctionCallIds: !isVertexProvider,
+      },
+    );
 
     const {
       tools: googleTools,

--- a/packages/google/src/google-language-model.ts
+++ b/packages/google/src/google-language-model.ts
@@ -79,9 +79,11 @@ export type GoogleLanguageModelConfig = {
   supportedUrls?: () => LanguageModelV4['supportedUrls'];
 
   /**
-   * Whether remote files in tool results must be downloaded before conversion.
+   * Settings for downloading remote files in tool results before conversion.
    */
-  downloadToolResultFiles?: boolean;
+  downloadToolResultFiles?: {
+    maxBytes: number;
+  };
 };
 
 export class GoogleLanguageModel implements LanguageModelV4 {
@@ -295,7 +297,10 @@ export class GoogleLanguageModel implements LanguageModelV4 {
     const { usesGemini3Features } = getGoogleModelCapabilities(modelId);
 
     const promptWithDownloadedToolResultFiles = config.downloadToolResultFiles
-      ? await downloadToolResultFiles(prompt, abortSignal)
+      ? await downloadToolResultFiles(prompt, {
+          abortSignal,
+          maxBytes: config.downloadToolResultFiles.maxBytes,
+        })
       : prompt;
 
     const { contents, systemInstruction } = convertToGoogleMessages(


### PR DESCRIPTION
## Background

- Vertex tool results with remote image URLs were sent as text instead of image bytes.
- Vertex supports image URLs in user messages, but not in tool results
  - AI SDK `supportedUrls` can't differentiate between this when downloading images for models that don't support URLs. 
  
## Summary

- Download remote files only for Vertex tool results, then send them as inline image data.
- Reuse the existing safe download utility from `@ai-sdk/provider-utils`.

## End-to-End Verification

Added a live example and ran it:

- Pre-fix: Vertex received URL text rather than image bytes, and the model hallucinated a nonexistent landscape.
- After fix: the model described the cat in the returned image.

## Checklist

- [X] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future work

Add some capability to `supportedUrls` to differentiate between tool results and user messages, so that the download logic lives in core

## Related Issues

Fixes #15671