### PR TITLE
feat(anthropic): expand preserved thinking support to cover `prefix_mismatch_behavior: 'error'`

### DIFF
--- a/.changeset/rare-lobsters-watch.md
+++ b/.changeset/rare-lobsters-watch.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/anthropic": patch
+---
+
+feat(anthropic): expand preserved thinking support to cover `prefix_mismatch_behavior: 'error'`

--- a/content/providers/01-ai-sdk-providers/05-anthropic.mdx
+++ b/content/providers/01-ai-sdk-providers/05-anthropic.mdx
@@ -483,12 +483,13 @@ const result = streamText({
 ##### Thinking Binding Controls
 
 Fable 5.1 can recover from a thinking-block prefix mismatch by dropping the
-mismatched block. Set `blockBinding.prefixMismatchBehavior` to `drop_block`.
-You can provide block binding by itself to preserve the model's default
-thinking mode, or combine it with adaptive thinking.
+mismatched block. Set `blockBinding.prefixMismatchBehavior` to `drop_block`, or
+set it to `error` to reject the request. You can provide block binding by itself
+to preserve the model's default thinking mode, or combine it with adaptive
+thinking.
 
 ```ts highlight="7-11"
-const { text } = await generateText({
+const result = await generateText({
   model: anthropic('claude-fable-5-1'),
   prompt: 'Continue from this conversation.',
   providerOptions: {
@@ -501,7 +502,13 @@ const { text } = await generateText({
     } satisfies AnthropicLanguageModelOptions,
   },
 });
+
+console.log(result.providerMetadata?.anthropic?.inputTransformations);
 ```
+
+Dropped blocks are reported in
+`providerMetadata.anthropic.inputTransformations` with their `type`, `path`, and
+`reason`.
 
 #### Budget-Based Thinking
 

--- a/examples/ai-functions/src/stream-text/anthropic/claude-fable-5-1-thinking-binding.ts
+++ b/examples/ai-functions/src/stream-text/anthropic/claude-fable-5-1-thinking-binding.ts
@@ -1,5 +1,5 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import { generateText, type ModelMessage } from 'ai';
+import { generateText, streamText, type ModelMessage } from 'ai';
 import { print } from '../../lib/print';
 import { run } from '../../lib/run';
 
@@ -38,7 +38,7 @@ run(async () => {
     },
   ];
 
-  const secondTurn = await generateText({
+  const secondTurn = streamText({
     model: anthropic('claude-fable-5-1'),
     messages: changedHistory,
     providerOptions: {
@@ -53,9 +53,14 @@ run(async () => {
     },
   });
 
-  print('Text:', secondTurn.text);
+  for await (const textPart of secondTurn.textStream) {
+    process.stdout.write(textPart);
+  }
+  console.log();
+
   print(
     'Input transformations:',
-    secondTurn.providerMetadata?.anthropic?.inputTransformations,
+    (await secondTurn.finalStep).providerMetadata?.anthropic
+      ?.inputTransformations,
   );
 });

--- a/packages/anthropic/src/anthropic-api.ts
+++ b/packages/anthropic/src/anthropic-api.ts
@@ -727,6 +727,12 @@ const anthropicMcpToolResultContentSchema = z.union([
   ),
 ]);
 
+const anthropicInputTransformationSchema = z.object({
+  type: z.string(),
+  path: z.string(),
+  reason: z.string(),
+});
+
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
 export const anthropicResponseSchema = lazySchema(() =>
@@ -989,6 +995,9 @@ export const anthropicResponseSchema = lazySchema(() =>
       stop_reason: z.string().nullish(),
       stop_sequence: z.string().nullish(),
       stop_details: anthropicStopDetailsSchema.nullish(),
+      input_transformations: z
+        .array(anthropicInputTransformationSchema)
+        .nullish(),
       usage: z.looseObject({
         input_tokens: z.number(),
         output_tokens: z.number(),
@@ -1088,6 +1097,9 @@ export const anthropicChunkSchema = lazySchema(() =>
             )
             .nullish(),
           stop_reason: z.string().nullish(),
+          input_transformations: z
+            .array(anthropicInputTransformationSchema)
+            .nullish(),
           container: z
             .object({
               expires_at: z.string(),
@@ -1441,6 +1453,9 @@ export const anthropicChunkSchema = lazySchema(() =>
             )
             .nullish(),
         }),
+        input_transformations: z
+          .array(anthropicInputTransformationSchema)
+          .nullish(),
         context_management: z
           .object({
             applied_edits: z.array(

--- a/packages/anthropic/src/anthropic-batch.test.ts
+++ b/packages/anthropic/src/anthropic-batch.test.ts
@@ -1,7 +1,6 @@
 import type { Experimental_TextBatchV4Request as TextBatchV4Request } from '@ai-sdk/provider';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
-import fs from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 import { AnthropicLanguageModel } from './anthropic-language-model';
 import type { AnthropicLanguageModelOptions } from './anthropic-language-model-options';
@@ -93,12 +92,6 @@ function messageResultBody(text: string) {
       cache_read_input_tokens: 2,
     },
   };
-}
-
-function readJsonFixture(filename: string) {
-  return JSON.parse(
-    fs.readFileSync(`src/__fixtures__/${filename}.json`, 'utf8'),
-  );
 }
 
 describe('Anthropic batch', () => {
@@ -336,7 +329,7 @@ describe('Anthropic batch', () => {
           {
             "custom_id": "preserved-thinking",
             "params": {
-              "max_tokens": 5120,
+              "max_tokens": 4096,
               "messages": [
                 {
                   "content": [
@@ -942,48 +935,6 @@ describe('Anthropic batch', () => {
       urls.batch,
       urls.results,
     ]);
-  });
-
-  it('preserves input transformations in batch result metadata', async () => {
-    server.urls[urls.batch].response = {
-      type: 'json-value',
-      body: batchResponse(),
-    };
-    server.urls[urls.results].response = {
-      type: 'stream-chunks',
-      chunks: [
-        JSON.stringify({
-          custom_id: 'preserved-thinking',
-          result: {
-            type: 'succeeded',
-            message: readJsonFixture('anthropic-preserved-thinking-dropped.1'),
-          },
-        }),
-      ],
-    };
-    const model = createAnthropic({
-      apiKey: 'test-api-key',
-    }).experimental_batch();
-
-    const stream = await model.doGetBatchResults({
-      batchId: 'msgbatch_123',
-    });
-    const results = await convertReadableStreamToArray(stream);
-    const result = results[0];
-
-    expect(
-      result?.type === 'text' && result.status === 'succeeded'
-        ? result.result.providerMetadata?.anthropic?.inputTransformations
-        : undefined,
-    ).toMatchInlineSnapshot(`
-      [
-        {
-          "path": "messages.1.content.0",
-          "reason": "prefix_binding_mismatch",
-          "type": "drop",
-        },
-      ]
-    `);
   });
 
   it('preserves client and provider-executed tool content', async () => {

--- a/packages/anthropic/src/anthropic-batch.test.ts
+++ b/packages/anthropic/src/anthropic-batch.test.ts
@@ -1,6 +1,7 @@
 import type { Experimental_TextBatchV4Request as TextBatchV4Request } from '@ai-sdk/provider';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
+import fs from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 import { AnthropicLanguageModel } from './anthropic-language-model';
 import type { AnthropicLanguageModelOptions } from './anthropic-language-model-options';
@@ -92,6 +93,12 @@ function messageResultBody(text: string) {
       cache_read_input_tokens: 2,
     },
   };
+}
+
+function readJsonFixture(filename: string) {
+  return JSON.parse(
+    fs.readFileSync(`src/__fixtures__/${filename}.json`, 'utf8'),
+  );
 }
 
 describe('Anthropic batch', () => {
@@ -290,6 +297,72 @@ describe('Anthropic batch', () => {
         'Anthropic Message Batches do not support per-request betas (request "request-1"). Set providerOptions.anthropic.anthropicBeta on startBatch instead.',
     });
     expect(server.calls).toHaveLength(0);
+  });
+
+  it('starts a batch with thinking binding controls', async () => {
+    server.urls[urls.batches].response = {
+      type: 'json-value',
+      body: batchResponse({ processing_status: 'in_progress' }),
+    };
+    const model = createAnthropic({
+      apiKey: 'test-api-key',
+    }).experimental_batch();
+
+    await model.doStartBatch({
+      requests: [
+        {
+          id: 'preserved-thinking',
+          ...request('Continue the conversation.', {
+            maxOutputTokens: 4096,
+            providerOptions: {
+              anthropic: {
+                thinking: {
+                  type: 'adaptive',
+                  blockBinding: {
+                    prefixMismatchBehavior: 'error',
+                  },
+                },
+              } satisfies AnthropicLanguageModelOptions,
+            },
+          }),
+          modelId: 'claude-fable-5-1',
+        },
+      ],
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "requests": [
+          {
+            "custom_id": "preserved-thinking",
+            "params": {
+              "max_tokens": 5120,
+              "messages": [
+                {
+                  "content": [
+                    {
+                      "text": "Continue the conversation.",
+                      "type": "text",
+                    },
+                  ],
+                  "role": "user",
+                },
+              ],
+              "model": "claude-fable-5-1",
+              "thinking": {
+                "block_binding": {
+                  "prefix_mismatch_behavior": "error",
+                },
+                "type": "adaptive",
+              },
+            },
+          },
+        ],
+      }
+    `);
+    expect(
+      server.calls[0].requestHeaders['anthropic-beta'],
+    ).toMatchInlineSnapshot(`"thinking-binding-controls-2026-08-01"`);
   });
 
   it('rejects structured-output modes that require start-call context', async () => {
@@ -869,6 +942,48 @@ describe('Anthropic batch', () => {
       urls.batch,
       urls.results,
     ]);
+  });
+
+  it('preserves input transformations in batch result metadata', async () => {
+    server.urls[urls.batch].response = {
+      type: 'json-value',
+      body: batchResponse(),
+    };
+    server.urls[urls.results].response = {
+      type: 'stream-chunks',
+      chunks: [
+        JSON.stringify({
+          custom_id: 'preserved-thinking',
+          result: {
+            type: 'succeeded',
+            message: readJsonFixture('anthropic-preserved-thinking-dropped.1'),
+          },
+        }),
+      ],
+    };
+    const model = createAnthropic({
+      apiKey: 'test-api-key',
+    }).experimental_batch();
+
+    const stream = await model.doGetBatchResults({
+      batchId: 'msgbatch_123',
+    });
+    const results = await convertReadableStreamToArray(stream);
+    const result = results[0];
+
+    expect(
+      result?.type === 'text' && result.status === 'succeeded'
+        ? result.result.providerMetadata?.anthropic?.inputTransformations
+        : undefined,
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "path": "messages.1.content.0",
+          "reason": "prefix_binding_mismatch",
+          "type": "drop",
+        },
+      ]
+    `);
   });
 
   it('preserves client and provider-executed tool content', async () => {

--- a/packages/anthropic/src/anthropic-batch.ts
+++ b/packages/anthropic/src/anthropic-batch.ts
@@ -1095,6 +1095,9 @@ function convertAnthropicMessageMetadata(response: AnthropicResponse) {
     usage: response.usage as JSONObject,
     stopSequence: response.stop_sequence ?? null,
     ...(stopDetails != null ? { stopDetails } : {}),
+    ...(response.input_transformations != null
+      ? { inputTransformations: response.input_transformations }
+      : {}),
     iterations: response.usage.iterations
       ? response.usage.iterations.map(
           iteration =>

--- a/packages/anthropic/src/anthropic-language-model-options.ts
+++ b/packages/anthropic/src/anthropic-language-model-options.ts
@@ -163,7 +163,7 @@ export const anthropicLanguageModelOptions = z.object({
            */
           blockBinding: z
             .object({
-              prefixMismatchBehavior: z.literal('drop_block'),
+              prefixMismatchBehavior: z.enum(['error', 'drop_block']),
             })
             .optional(),
         }),
@@ -179,7 +179,7 @@ export const anthropicLanguageModelOptions = z.object({
       z.object({
         type: z.never().optional(),
         blockBinding: z.object({
-          prefixMismatchBehavior: z.literal('drop_block'),
+          prefixMismatchBehavior: z.enum(['error', 'drop_block']),
         }),
       }),
     ])

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -1798,37 +1798,6 @@ describe('AnthropicLanguageModel', () => {
       `);
     });
 
-    it('should expose empty preserved thinking input transformations', async () => {
-      prepareJsonFixtureResponse('anthropic-preserved-thinking-empty.1');
-
-      const result = await provider('claude-fable-5-1').doGenerate({
-        prompt: TEST_PROMPT,
-      });
-
-      expect(
-        result.providerMetadata?.anthropic?.inputTransformations,
-      ).toMatchInlineSnapshot(`[]`);
-    });
-
-    it('should expose dropped preserved thinking input transformations', async () => {
-      prepareJsonFixtureResponse('anthropic-preserved-thinking-dropped.1');
-
-      const result = await provider('claude-fable-5-1').doGenerate({
-        prompt: TEST_PROMPT,
-      });
-
-      expect(result.providerMetadata?.anthropic?.inputTransformations)
-        .toMatchInlineSnapshot(`
-        [
-          {
-            "path": "messages.1.content.0",
-            "reason": "prefix_binding_mismatch",
-            "type": "drop",
-          },
-        ]
-      `);
-    });
-
     it('should omit preserved thinking input transformations when absent', async () => {
       prepareJsonFixtureResponse('anthropic-text');
 
@@ -7369,31 +7338,6 @@ describe('AnthropicLanguageModel', () => {
           },
         },
       });
-    });
-
-    it('should expose streamed preserved thinking input transformations', async () => {
-      prepareChunksFixtureResponse('anthropic-preserved-thinking-dropped.1');
-
-      const { stream } = await provider('claude-fable-5-1').doStream({
-        prompt: TEST_PROMPT,
-      });
-
-      const result = await convertReadableStreamToArray(stream);
-      const finishPart = result.find(part => part.type === 'finish');
-
-      expect(
-        finishPart?.type === 'finish'
-          ? finishPart.providerMetadata?.anthropic?.inputTransformations
-          : undefined,
-      ).toMatchInlineSnapshot(`
-        [
-          {
-            "path": "messages.1.content.0",
-            "reason": "prefix_binding_mismatch",
-            "type": "drop",
-          },
-        ]
-      `);
     });
 
     it('should map a streamed classifier refusal to content-filter and expose stop details', async () => {

--- a/packages/anthropic/src/anthropic-language-model.test.ts
+++ b/packages/anthropic/src/anthropic-language-model.test.ts
@@ -1798,6 +1798,49 @@ describe('AnthropicLanguageModel', () => {
       `);
     });
 
+    it('should expose empty preserved thinking input transformations', async () => {
+      prepareJsonFixtureResponse('anthropic-preserved-thinking-empty.1');
+
+      const result = await provider('claude-fable-5-1').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(
+        result.providerMetadata?.anthropic?.inputTransformations,
+      ).toMatchInlineSnapshot(`[]`);
+    });
+
+    it('should expose dropped preserved thinking input transformations', async () => {
+      prepareJsonFixtureResponse('anthropic-preserved-thinking-dropped.1');
+
+      const result = await provider('claude-fable-5-1').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(result.providerMetadata?.anthropic?.inputTransformations)
+        .toMatchInlineSnapshot(`
+        [
+          {
+            "path": "messages.1.content.0",
+            "reason": "prefix_binding_mismatch",
+            "type": "drop",
+          },
+        ]
+      `);
+    });
+
+    it('should omit preserved thinking input transformations when absent', async () => {
+      prepareJsonFixtureResponse('anthropic-text');
+
+      const result = await provider('claude-fable-5-1').doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(
+        result.providerMetadata?.anthropic?.inputTransformations,
+      ).toBeUndefined();
+    });
+
     describe('refusal stop reason', () => {
       it('should map a classifier refusal to content-filter and expose stop details', async () => {
         prepareJsonFixtureResponse('anthropic-refusal');
@@ -7328,6 +7371,31 @@ describe('AnthropicLanguageModel', () => {
       });
     });
 
+    it('should expose streamed preserved thinking input transformations', async () => {
+      prepareChunksFixtureResponse('anthropic-preserved-thinking-dropped.1');
+
+      const { stream } = await provider('claude-fable-5-1').doStream({
+        prompt: TEST_PROMPT,
+      });
+
+      const result = await convertReadableStreamToArray(stream);
+      const finishPart = result.find(part => part.type === 'finish');
+
+      expect(
+        finishPart?.type === 'finish'
+          ? finishPart.providerMetadata?.anthropic?.inputTransformations
+          : undefined,
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "path": "messages.1.content.0",
+            "reason": "prefix_binding_mismatch",
+            "type": "drop",
+          },
+        ]
+      `);
+    });
+
     it('should map a streamed classifier refusal to content-filter and expose stop details', async () => {
       prepareChunksFixtureResponse('anthropic-refusal');
 
@@ -11888,6 +11956,52 @@ describe('claude-opus-4-7 specific behavior', () => {
         prefix_mismatch_behavior: 'drop_block',
       },
     });
+    expect(server.calls[0].requestHeaders['anthropic-beta']).toContain(
+      'thinking-binding-controls-2026-08-01',
+    );
+  });
+
+  it('should serialize strict thinking binding controls with adaptive thinking', async () => {
+    prepareJsonFixtureResponse('anthropic-text');
+
+    await provider('claude-fable-5-1').doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      maxOutputTokens: 4096,
+      providerOptions: {
+        anthropic: {
+          thinking: {
+            type: 'adaptive',
+            blockBinding: {
+              prefixMismatchBehavior: 'error',
+            },
+          },
+        } satisfies AnthropicLanguageModelOptions,
+      },
+    });
+
+    expect(await server.calls[0].requestBodyJson).toMatchInlineSnapshot(`
+      {
+        "max_tokens": 4096,
+        "messages": [
+          {
+            "content": [
+              {
+                "text": "Hello",
+                "type": "text",
+              },
+            ],
+            "role": "user",
+          },
+        ],
+        "model": "claude-fable-5-1",
+        "thinking": {
+          "block_binding": {
+            "prefix_mismatch_behavior": "error",
+          },
+          "type": "adaptive",
+        },
+      }
+    `);
     expect(server.calls[0].requestHeaders['anthropic-beta']).toContain(
       'thinking-binding-controls-2026-08-01',
     );

--- a/packages/anthropic/src/anthropic-language-model.ts
+++ b/packages/anthropic/src/anthropic-language-model.ts
@@ -1556,6 +1556,9 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
           usage: response.usage as JSONObject,
           stopSequence: response.stop_sequence ?? null,
           ...(stopDetails != null ? { stopDetails } : {}),
+          ...(response.input_transformations != null
+            ? { inputTransformations: response.input_transformations }
+            : {}),
 
           iterations: response.usage.iterations
             ? response.usage.iterations.map(
@@ -1693,6 +1696,7 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
     let rawUsage: JSONObject | undefined = undefined;
     let stopSequence: string | null = null;
     let stopDetails: AnthropicMessageMetadata['stopDetails'] = undefined;
+    let inputTransformations: AnthropicMessageMetadata['inputTransformations'];
     let container: AnthropicMessageMetadata['container'] | null = null;
     let isJsonResponseFromTool = false;
     let isMessageOpen = false;
@@ -2561,6 +2565,10 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                 ...(value.message.usage as JSONObject),
               };
 
+              if (value.message.input_transformations != null) {
+                inputTransformations = value.message.input_transformations;
+              }
+
               if (value.message.container != null) {
                 container = {
                   expiresAt: value.message.container.expires_at,
@@ -2689,6 +2697,10 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                 );
               }
 
+              if (value.input_transformations != null) {
+                inputTransformations = value.input_transformations;
+              }
+
               rawUsage = {
                 ...rawUsage,
                 ...(value.usage as JSONObject),
@@ -2705,6 +2717,9 @@ export class AnthropicLanguageModel implements LanguageModelV4 {
                 usage: (rawUsage as JSONObject) ?? null,
                 stopSequence,
                 ...(stopDetails != null ? { stopDetails } : {}),
+                ...(inputTransformations != null
+                  ? { inputTransformations }
+                  : {}),
                 iterations: usage.iterations
                   ? usage.iterations.map(
                       iter =>

--- a/packages/anthropic/src/anthropic-message-metadata.ts
+++ b/packages/anthropic/src/anthropic-message-metadata.ts
@@ -51,6 +51,18 @@ export interface AnthropicMessageMetadata {
   stopSequence: string | null;
 
   /**
+   * Input blocks that Anthropic transformed before inference. This is
+   * populated when thinking binding controls drop a mismatched thinking block.
+   * Values are intentionally open-ended so new transformation types and
+   * reasons remain forward compatible.
+   */
+  inputTransformations?: Array<{
+    type: string;
+    path: string;
+    reason: string;
+  }>;
+
+  /**
    * Details about why the request stopped. Present only when the API returns
    * a `refusal` stop reason together with a `stop_details` object (a
    * classifier block or a model refusal).


### PR DESCRIPTION
## Background

Anthropic supports strict preserved-thinking prefix mismatch handling and reports dropped blocks through input transformations, but the provider only accepted `drop_block` and did not expose those diagnostics; the `error` behavior wasn't supported.

## Summary

- Accept `prefixMismatchBehavior: 'error'` for Fable 5.1 thinking binding controls.
- Expose input transformations in Anthropic metadata for generated, streamed, and batch responses.
- Add two-turn generate and stream examples, documentation, and provider tests.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)
