### PR TITLE
ci: exclude pull requests from CI failure notifications

### DIFF
--- a/.github/workflows/slack-workflow-failure-notification.yml
+++ b/.github/workflows/slack-workflow-failure-notification.yml
@@ -17,14 +17,21 @@ permissions:
 jobs:
   notify-on-failure:
     runs-on: ubuntu-latest
-    # Only branch-filter CI; notify other workflows as before.
+    # Only notify for CI pushes to main or release branches; notify other
+    # workflows as before. For pull requests, head_branch is the source branch
+    # and can also be named main or release-v* in a fork.
     if: >-
       ${{
         github.event.workflow_run.conclusion == 'failure' &&
         (
           github.event.workflow_run.name != 'CI' ||
-          github.event.workflow_run.head_branch == 'main' ||
-          startsWith(github.event.workflow_run.head_branch, 'release-v')
+          (
+            github.event.workflow_run.event == 'push' &&
+            (
+              github.event.workflow_run.head_branch == 'main' ||
+              startsWith(github.event.workflow_run.head_branch, 'release-v')
+            )
+          )
         )
       }}
 


### PR DESCRIPTION
## Background

The Slack notification run https://github.com/vercel/ai/actions/runs/34558476143 was triggered by the expired CI run https://github.com/vercel/ai/actions/runs/31559875228.

The CI run was created for a pull request from `BlairCurrey/vercel-ai`, whose source branch was named `main`. After waiting for approval for 30 days, it completed as a failure with zero jobs.

#20279 correctly limits its expiration detector to Backport runs. However, the CI notification filter only checked `head_branch`, so the fork's `main` branch was mistaken for a push to `vercel/ai`'s protected `main` branch and sent a notification.

## Summary

- Require CI failure notifications to originate from a `push` event before checking for `main` or `release-v*`.
- Preserve notifications for genuine CI push failures on protected branches.
- Exclude all CI pull-request failures, including expired fork approvals whose source branches happen to use protected-branch names.

## End-to-End Verification

Compared the updated condition against live workflow-run metadata:

- Expired run 31559875228 has `event: pull_request` and `head_branch: main`, so it is now excluded.
- Genuine failed protected-branch run 34501235626 has `event: push` and `head_branch: main`, so it still notifies.

## Verification

- `pnpm check`
- `pnpm type-check:full`
- Parsed the updated workflow as YAML

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related

- Follow-up to #20279
- Notification run: https://github.com/vercel/ai/actions/runs/34558476143
- Expired CI run: https://github.com/vercel/ai/actions/runs/31559875228
