### PR TITLE
feat(tools-registry): add AntiBrow

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -586,4 +586,40 @@ console.log(result.text);`,
     websiteUrl: 'https://nitrosend.com',
     npmUrl: 'https://www.npmjs.com/package/@nitrosend/ai-sdk',
   },
+  {
+    slug: 'antibrow',
+    name: 'AntiBrow',
+    description:
+      'Browser tools that drive a persistent AntiBrow profile. Cookies, storage, an engine-level fingerprint and one proxy per profile survive between runs, so pages behind a login open already signed in instead of starting over in a fresh Chromium. Navigate, read page text, click and fill from a local browser, with the profile as the unit of identity.',
+    packageName: 'ai-sdk-tool-antibrow',
+    tags: ['browser', 'browser-automation', 'web', 'extraction'],
+    apiKeyEnvName: 'ANTI_DETECT_BROWSER_KEY',
+    installCommand: {
+      pnpm: 'pnpm add ai-sdk-tool-antibrow',
+      npm: 'npm install ai-sdk-tool-antibrow',
+      yarn: 'yarn add ai-sdk-tool-antibrow',
+      bun: 'bun add ai-sdk-tool-antibrow',
+    },
+    codeExample: `import { gateway, generateText, stepCountIs } from 'ai';
+import { antibrowTools } from 'ai-sdk-tool-antibrow';
+
+const browser = antibrowTools({ profile: 'research-01' });
+
+try {
+  const { text } = await generateText({
+    model: gateway('openai/gpt-5-mini'),
+    prompt: 'Open https://example.com and tell me the heading.',
+    tools: browser.tools,
+    stopWhen: stepCountIs(5),
+  });
+
+  console.log(text);
+} finally {
+  await browser.close();
+}`,
+    docsUrl: 'https://antibrow.com/docs/ai-sdk',
+    apiKeyUrl: 'https://antibrow.com/dashboard',
+    websiteUrl: 'https://antibrow.com',
+    npmUrl: 'https://www.npmjs.com/package/ai-sdk-tool-antibrow',
+  },
 ];


### PR DESCRIPTION
Adds AntiBrow to the tools registry.

AntiBrow is an antidetect browser driven through the standard Playwright API. `ai-sdk-tool-antibrow` exposes four tools - `browserGoto`, `browserRead`, `browserClick`, `browserFill` - that share one persistent profile, so cookies, storage, the engine-level fingerprint and the per-profile proxy survive between agent runs.

Against the prerequisites in `contributing/add-new-tool-to-registry.md`:

- **Published on npm**: [`ai-sdk-tool-antibrow`](https://www.npmjs.com/package/ai-sdk-tool-antibrow) (MIT, source at [antibrow/antibrow](https://github.com/antibrow/antibrow/tree/main/ai-sdk-tool)).
- **Tested with the current AI SDK** (`ai@5.0.255`): the package ships `src/test.ts`, which runs the tools against a live browser and then runs `generateText` with `MockLanguageModelV2`, so the input schema, the tool-call dispatch and the tool result round-trip are exercised rather than assumed:

  ```
  goto -> { status: 200, title: 'Example Domain', url: 'https://example.com/' }
  read -> { url: 'https://example.com/', truncated: false, text: 'Example Domain' }
  tool results -> [{ "toolName": "browserGoto", "output": { "status": 200, "title": "Example Domain", ... } }]
  ```

- **Docs on our own site**: `docsUrl` points at the AI SDK guide, https://antibrow.com/docs/ai-sdk, not the homepage.

The `codeExample` is the same shape as that test with a real model in place of the mock.
