### PR TITLE
docs: add aiworker-ai-sdk-tools to the ready-to-use tool packages

### DIFF
--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -281,6 +281,7 @@ These packages provide pre-built tools you can install and use immediately:
 - **[JigsawStack](http://www.jigsawstack.com/docs/integration/vercel)** - Over 30+ small custom fine-tuned models available for specific uses.
 - **[AI Tools Registry](https://ai-tools-registry.vercel.app)** - A Shadcn-compatible tool definitions and components registry for the AI SDK.
 - **[Toolhouse](https://docs.toolhouse.ai/toolhouse/toolhouse-sdk/using-vercel-ai)** - AI function-calling in 3 lines of code for over 25 different actions.
+- **[aiworker-ai-sdk-tools](https://www.npmjs.com/package/aiworker-ai-sdk-tools)** - Seventeen paid data tools (DeFi yields, page-to-Markdown, Base token and wallet checks, Polymarket odds, history and backtests, fact checks, news search) built from a live catalogue; each call pays itself in USDC over x402 from the agent's wallet, no API key.
 - **[bash-tool](https://www.npmjs.com/package/bash-tool)** - Provides `bash`, `readFile`, and `writeFile` tools for AI agents. Supports [@vercel/sandbox](https://vercel.com/docs/vercel-sandbox) for full VM isolation.
 
 ### MCP Tools


### PR DESCRIPTION
## docs: add aiworker-ai-sdk-tools to the ready-to-use tool packages

One bullet in `content/docs/02-foundations/04-tools.mdx`, "Ready-to-Use Tool Packages".

`aiworker-ai-sdk-tools` (https://www.npmjs.com/package/aiworker-ai-sdk-tools, MIT, source
https://github.com/ai-worker227/aiworker-examples/tree/main/vercel-ai) builds one AI SDK `tool()` per route of
[aiworker](https://aiworker.duckdns.org)'s live OpenAPI catalogue — seventeen paid data routes (DeFi yields,
page-to-Markdown, Base token and wallet checks, Polymarket odds, history and backtests, fact checks, news search).
Each call pays itself in USDC over the x402 protocol from the agent's wallet; no API key; a `maxPriceUsd` cap drops
routes above it. Tools are `tool({ description, inputSchema, execute })` from `ai` v6/v7 with zod schemas derived from
the catalogue.
