### PR TITLE
fix(harness-pi): support explicit custom provider models

### DIFF
--- a/.changeset/tiny-pis-route.md
+++ b/.changeset/tiny-pis-route.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/harness-pi': patch
+---
+
+fix(harness-pi): register explicit custom provider models and prefer authenticated providers during model resolution

--- a/content/providers/02-ai-sdk-harnesses/03-pi.mdx
+++ b/content/providers/02-ai-sdk-harnesses/03-pi.mdx
@@ -86,6 +86,7 @@ Settings:
 - `extensionFactories`: trusted inline Pi extension factories that run in the
   host Node.js process.
 - `mcpServers`: MCP server definitions keyed by server name.
+- `providers`: explicit Pi provider configurations for custom models.
 - `thinkingLevel`: Pi thinking level (`off`, `minimal`, `low`, `medium`,
   `high`, `xhigh`, or `max`).
 
@@ -152,6 +153,34 @@ With `custom`, standard providers use environment variables such as
 `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `ANTHROPIC_API_KEY`, and
 `ANTHROPIC_BASE_URL`. Other providers use a `<PREFIX>_API_KEY` and matching
 `<PREFIX>_BASE_URL` pair.
+
+Authentication variables do not identify a provider's API protocol or models.
+Register that metadata explicitly when using a custom model:
+
+```ts
+const harness = createPi({
+  auth: {
+    MYPROVIDER_API_KEY: await resolveMyProviderToken(),
+    MYPROVIDER_BASE_URL: 'https://api.example.com/v1',
+  },
+  providers: {
+    myprovider: {
+      api: 'openai-completions',
+      models: [
+        {
+          id: 'my-custom-model',
+          name: 'My Custom Model',
+          reasoning: false,
+          input: ['text'],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128_000,
+          maxTokens: 16_384,
+        },
+      ],
+    },
+  },
+});
+```
 
 ## Sandbox
 

--- a/packages/harness-pi/src/pi-harness.test-d.ts
+++ b/packages/harness-pi/src/pi-harness.test-d.ts
@@ -18,3 +18,24 @@ test('PiHarnessSettings accepts readonly extension factory arrays', () => {
 test('createPi accepts the max thinking level', () => {
   createPi({ thinkingLevel: 'max' });
 });
+
+test('createPi accepts explicit provider model configurations', () => {
+  createPi({
+    providers: {
+      myprovider: {
+        api: 'openai-completions',
+        models: [
+          {
+            id: 'my-custom-model',
+            name: 'My Custom Model',
+            reasoning: false,
+            input: ['text'],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128_000,
+            maxTokens: 16_384,
+          },
+        ],
+      },
+    },
+  });
+});

--- a/packages/harness-pi/src/pi-harness.ts
+++ b/packages/harness-pi/src/pi-harness.ts
@@ -4,7 +4,10 @@ import {
   type HarnessV1BuiltinTool,
 } from '@ai-sdk/harness';
 import { tool } from '@ai-sdk/provider-utils';
-import type { ExtensionFactory } from '@earendil-works/pi-coding-agent';
+import type {
+  ExtensionFactory,
+  ProviderConfig,
+} from '@earendil-works/pi-coding-agent';
 import { z } from 'zod/v4';
 import type { PiAuthenticationMode } from './pi-auth';
 import { piResumeStateSchema } from './pi-resume-state';
@@ -23,6 +26,12 @@ const PI_CLIENT_APP = `ai-sdk/harness-pi/${VERSION}`;
 export type PiHarnessSettings = {
   /** Where Pi sources API keys / gateway credentials from. */
   readonly auth?: PiAuthenticationMode;
+  /**
+   * Explicit Pi provider configurations keyed by provider id. Use this to
+   * register custom models and their API protocol without coupling model
+   * metadata to authentication environment variables.
+   */
+  readonly providers?: Readonly<Record<string, ProviderConfig>>;
   /**
    * Pi's extended-thinking budget level. Maps directly to the SDK's
    * `thinkingLevel` option on `createAgentSession`.
@@ -149,6 +158,7 @@ export function createPi(
             ? { thinkingLevel: settings.thinkingLevel }
             : {}),
           ...(settings.mcpServers ? { mcpServers: settings.mcpServers } : {}),
+          ...(settings.providers ? { providers: settings.providers } : {}),
           ...(settings.extensionFactories
             ? { extensionFactories: settings.extensionFactories }
             : {}),

--- a/packages/harness-pi/src/pi-model-resolver.test.ts
+++ b/packages/harness-pi/src/pi-model-resolver.test.ts
@@ -74,6 +74,12 @@ const openaiProxiedThroughOpenRouter: PiModel = {
   baseUrl: 'https://openrouter.ai/api/v1',
 };
 
+const azureOpenaiModel: PiModel = {
+  ...openaiModel,
+  provider: 'azure-openai-responses',
+  baseUrl: 'https://azure.example.test',
+};
+
 describe('createPiModelResolver', () => {
   it('returns matching model by id', async () => {
     const resolve = createPiModelResolver({
@@ -89,6 +95,16 @@ describe('createPiModelResolver', () => {
       env: {},
     });
     expect(resolve('My Model')).toEqual(sampleModel);
+  });
+
+  it('prefers the only authenticated provider for a flat catalog match', async () => {
+    const modelRegistry = await makeRegistry([azureOpenaiModel, openaiModel]);
+    vi.spyOn(modelRegistry, 'hasConfiguredAuth').mockImplementation(
+      model => model.provider === 'openai',
+    );
+    const resolve = createPiModelResolver({ modelRegistry, env: {} });
+
+    expect(resolve('gpt-4o')).toEqual(openaiModel);
   });
 
   it('looks up the gateway default when no id and AI_GATEWAY_API_KEY is set', async () => {

--- a/packages/harness-pi/src/pi-model-resolver.ts
+++ b/packages/harness-pi/src/pi-model-resolver.ts
@@ -77,13 +77,15 @@ export function createPiModelResolver({
     if (gatewayMatch) return gatewayMatch;
 
     const scopedMatch = findScopedMatch(effectiveId, models);
-    if (scopedMatch && !modelRegistry.hasConfiguredAuth(scopedMatch)) {
-      const authenticatedFlatMatches = models.filter(
-        m => m.id === effectiveId && modelRegistry.hasConfiguredAuth(m),
-      );
-      if (authenticatedFlatMatches.length === 1) {
-        return authenticatedFlatMatches[0];
-      }
+    if (scopedMatch && modelRegistry.hasConfiguredAuth(scopedMatch)) {
+      return scopedMatch;
+    }
+
+    const authenticatedFlatMatches = models.filter(
+      m => matches(m) && modelRegistry.hasConfiguredAuth(m),
+    );
+    if (authenticatedFlatMatches.length === 1) {
+      return authenticatedFlatMatches[0];
     }
 
     return scopedMatch ?? models.find(matches);

--- a/packages/harness-pi/src/pi-session.test.ts
+++ b/packages/harness-pi/src/pi-session.test.ts
@@ -3,6 +3,7 @@ import {
   type AgentSession,
   type ExtensionAPI,
   type ExtensionFactory,
+  type ProviderConfig,
   type ToolDefinition,
   ModelRuntime,
   SettingsManager,
@@ -69,6 +70,7 @@ const piMock = vi.hoisted(() => {
     extensionHandlers,
     resourceLoaderReloadCount: 0,
     resourceLoaderOptions: [] as ResourceLoaderOptions[],
+    registerProvider: vi.fn(),
     session: undefined as AgentSession | undefined,
     sessionManagerOpen: vi.fn(),
   };
@@ -123,8 +125,19 @@ vi.mock('@earendil-works/pi-coding-agent', () => {
     },
     defineTool: vi.fn(tool => tool),
     ModelRegistry: class {
+      private readonly providerConfigs = new Map<string, ProviderConfig>();
+
       getAll = vi.fn(() => []);
-      registerProvider = vi.fn();
+      getRegisteredProviderConfig = vi.fn((provider: string) =>
+        this.providerConfigs.get(provider),
+      );
+      registerProvider = vi.fn((provider: string, config: ProviderConfig) => {
+        this.providerConfigs.set(provider, {
+          ...this.providerConfigs.get(provider),
+          ...config,
+        });
+        piMock.registerProvider(provider, config);
+      });
     },
     ModelRuntime: {
       create: vi.fn(async () => ({
@@ -153,6 +166,7 @@ describe('createPiSession', () => {
     piMock.extensionHandlers.clear();
     piMock.resourceLoaderReloadCount = 0;
     piMock.resourceLoaderOptions = [];
+    piMock.registerProvider.mockClear();
     piMock.session = undefined;
     mcpAdapterMock.createMcpAdapter.mockClear();
     mcpAdapterMock.mcpExtensionFactory.mockClear();
@@ -1297,6 +1311,40 @@ describe('createPiSession', () => {
     });
     expect(SettingsManager.create).toHaveBeenCalledTimes(1);
     expect(SettingsManager.inMemory).not.toHaveBeenCalled();
+  });
+
+  it('registers explicit provider model configurations', async () => {
+    const provider: ProviderConfig = {
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.example.test/v1',
+      api: 'openai-completions',
+      authHeader: true,
+      models: [
+        {
+          id: 'my-custom-model',
+          name: 'My Custom Model',
+          reasoning: false,
+          input: ['text'],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128_000,
+          maxTokens: 16_384,
+        },
+      ],
+    };
+
+    await createPiSession({
+      sessionId: 'session-custom-provider',
+      sandboxSession: createSandboxSession(),
+      sessionWorkDir: '/sandbox/work',
+      settings: { providers: { myprovider: provider } },
+      clientApp: 'ai-sdk/harness-pi/0.0.0-test',
+      isResume: false,
+    });
+
+    expect(piMock.registerProvider).toHaveBeenLastCalledWith(
+      'myprovider',
+      provider,
+    );
   });
 
   it('falls back to temp dir and inMemory settings when agentDir is omitted', async () => {

--- a/packages/harness-pi/src/pi-session.ts
+++ b/packages/harness-pi/src/pi-session.ts
@@ -8,6 +8,7 @@ import {
   type AgentSession,
   type AgentToolResult,
   type ExtensionFactory,
+  type ProviderConfig,
   type Skill,
   type ToolDefinition,
 } from '@earendil-works/pi-coding-agent';
@@ -222,6 +223,7 @@ export interface PiSessionSettings {
   readonly headers?: Readonly<Record<string, string>>;
   readonly thinkingLevel?: PiThinkingLevel;
   readonly mcpServers?: Record<string, unknown>;
+  readonly providers?: Readonly<Record<string, ProviderConfig>>;
   readonly extensionFactories?: ReadonlyArray<ExtensionFactory>;
 }
 
@@ -454,6 +456,14 @@ export async function createPiSession(
     clientApp: input.clientApp,
     headers: input.settings.headers,
   });
+  for (const [provider, config] of Object.entries(
+    input.settings.providers ?? {},
+  )) {
+    modelRegistry.registerProvider(provider, {
+      ...modelRegistry.getRegisteredProviderConfig(provider),
+      ...config,
+    });
+  }
   const resolveModel = createPiModelResolver({
     modelRegistry,
     env: resolverEnv,


### PR DESCRIPTION
## Background

https://github.com/vercel/ai/issues/18147

Before:

- auth registered only credentials and base URL.
- Custom providers contributed no model catalog entries
- Custom model IDs could not resolve

## Summary

After:

- New optional providers setting explicitly defines each custom model and API protocol
- Provider metadata merges with credentials registered through auth
- Custom models become real Pi catalog entries and resolve normally

## End-to-End Verification

na

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

fixes #18147