### PR TITLE
docs: add New Relic to observability providers

### DIFF
--- a/content/providers/03-observability/index.mdx
+++ b/content/providers/03-observability/index.mdx
@@ -19,6 +19,7 @@ Several LLM observability providers offer integrations with the AI SDK telemetry
 - [Latitude](/providers/observability/latitude)
 - [Maxim](/providers/observability/maxim)
 - [MLflow](/providers/observability/mlflow)
+- [New Relic](/providers/observability/newrelic)
 - [PostHog](/providers/observability/posthog)
 - [Raindrop](/providers/observability/raindrop)
 - [Respan](/providers/observability/respan)

--- a/content/providers/03-observability/newrelic.mdx
+++ b/content/providers/03-observability/newrelic.mdx
@@ -1,0 +1,91 @@
+---
+title: New Relic
+description: Monitor and trace your AI SDK application with New Relic
+---
+
+# New Relic
+
+[New Relic](https://newrelic.com/) is an observability platform for application performance monitoring, distributed tracing, logs, and metrics. New Relic [ingests OpenTelemetry (OTLP) data natively](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/), so you can send AI SDK telemetry data to it with a standard OTLP exporter and no additional SDK.
+
+## Setup
+
+You'll need a [New Relic account](https://newrelic.com/signup) and your account's license key. OTLP requests authenticate with an `api-key` header set to the license key.
+
+New Relic's OTLP endpoint is `https://otlp.nr-data.net` for US accounts and `https://otlp.eu01.nr-data.net` for EU accounts. Both accept OTLP over HTTP on ports 443 and 4318, and over gRPC on port 4317.
+
+### Node.js
+
+Install the AI SDK OpenTelemetry adapter and the OpenTelemetry packages:
+
+<InstallPackages packages="@ai-sdk/otel @opentelemetry/sdk-node @opentelemetry/exporter-trace-otlp-http @opentelemetry/resources @opentelemetry/semantic-conventions" />
+
+Create an instrumentation file and load it before the rest of your app:
+
+```typescript filename="instrumentation.ts"
+import { registerTelemetry } from 'ai';
+import { LegacyOpenTelemetry } from '@ai-sdk/otel';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+
+const sdk = new NodeSDK({
+  resource: resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: 'my-ai-app',
+  }),
+  traceExporter: new OTLPTraceExporter({
+    url: 'https://otlp.nr-data.net:4318/v1/traces',
+    headers: {
+      'api-key': process.env.NEW_RELIC_LICENSE_KEY,
+    },
+  }),
+});
+
+sdk.start();
+
+registerTelemetry(new LegacyOpenTelemetry());
+```
+
+EU accounts use `https://otlp.eu01.nr-data.net:4318/v1/traces` as the exporter URL.
+
+### Next.js
+
+OpenTelemetry exporters also read the standard environment variables, so you can configure the endpoint and header in your `.env` file:
+
+```bash filename=".env"
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net
+OTEL_EXPORTER_OTLP_HEADERS="api-key=<your-license-key>"
+```
+
+Install `@ai-sdk/otel` and register the `LegacyOpenTelemetry` in your `instrumentation.ts` file:
+
+```typescript filename="instrumentation.ts"
+import { registerTelemetry } from 'ai';
+import { LegacyOpenTelemetry } from '@ai-sdk/otel';
+
+registerTelemetry(new LegacyOpenTelemetry());
+```
+
+## Enabling Telemetry
+
+With `registerTelemetry` in place, [AI SDK telemetry data](/docs/ai-sdk-core/telemetry) is captured automatically on every AI SDK call:
+
+```typescript
+import { generateText } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+const result = await generateText({
+  model: openai('gpt-4o-mini'),
+  prompt: 'What is 2 + 2?',
+  telemetry: {
+    functionId: 'my-function',
+  },
+});
+```
+
+The generated spans appear in New Relic's distributed tracing views for your service.
+
+## Resources
+
+- [New Relic OTLP endpoint reference](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/)
+- [Introduction to New Relic AI monitoring](https://docs.newrelic.com/docs/ai-monitoring/intro-to-ai-monitoring/)


### PR DESCRIPTION
## Background

The observability providers directory (https://ai-sdk.dev/providers/observability) lists 20+ integrations but not New Relic, even though New Relic ingests OTLP natively and needs no vendor SDK to receive AI SDK telemetry. Users searching the docs for a New Relic guide come up empty.

## Summary

Docs-only change.

- Added `content/providers/03-observability/newrelic.mdx`. It follows the structure of the other OTel-native pages (Traceloop, Axiom): a Node.js section with the standard `NodeSDK` + `OTLPTraceExporter` setup pointed at `https://otlp.nr-data.net:4318/v1/traces` with the `api-key` header, a Next.js section using the standard OTLP environment variables, and the `registerTelemetry(new LegacyOpenTelemetry())` registration the current telemetry docs prescribe.
- Added New Relic to the alphabetical list in `index.mdx`.

Every endpoint, port, and header claim is taken from New Relic's OTLP documentation (linked from the page). No New Relic package is referenced; the page only uses `@ai-sdk/otel` and standard OpenTelemetry packages. All five external links on the page return 200.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [ ] Tests have been added / updated (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [ ] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KybsFC28cLtu6pCdwdwBBw

