### PR TITLE
fix(react): abort chats when their `useChat` id changes during a stream

### DIFF
--- a/.changeset/fresh-chats-abort.md
+++ b/.changeset/fresh-chats-abort.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/react': patch
+---
+
+fix(react): abort chats when their `useChat` id changes during a stream

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -121,34 +121,35 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
       latestRef.current.sendAutomaticallyWhen?.(arg) ?? false,
   };
 
-  const chatRef = useRef<Chat<UI_MESSAGE>>(
-    'chat' in options ? options.chat : new Chat(chatOptions),
-  );
-  const isChatExternallyManagedRef = useRef('chat' in options);
+  const chatStateRef = useRef({
+    chat: 'chat' in options ? options.chat : new Chat(chatOptions),
+    isExternallyManaged: 'chat' in options,
+  });
 
   const shouldRecreateChat =
-    ('chat' in options && options.chat !== chatRef.current) ||
+    ('chat' in options && options.chat !== chatStateRef.current.chat) ||
     ('id' in options &&
       options.id != null &&
-      chatRef.current.id !== options.id);
+      chatStateRef.current.chat.id !== options.id);
 
   if (shouldRecreateChat) {
-    chatRef.current = 'chat' in options ? options.chat : new Chat(chatOptions);
-    isChatExternallyManagedRef.current = 'chat' in options;
+    chatStateRef.current = {
+      chat: 'chat' in options ? options.chat : new Chat(chatOptions),
+      isExternallyManaged: 'chat' in options,
+    };
   }
 
-  const chat = chatRef.current;
-  const isChatExternallyManaged = isChatExternallyManagedRef.current;
+  const { chat, isExternallyManaged } = chatStateRef.current;
 
   useEffect(() => {
-    if (isChatExternallyManaged) {
+    if (isExternallyManaged) {
       return;
     }
 
     return () => {
       void chat.stop();
     };
-  }, [chat, isChatExternallyManaged]);
+  }, [chat, isExternallyManaged]);
 
   const messagesSnapshotRef = useRef({
     chat,
@@ -227,9 +228,9 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
   );
 
   const error = useSyncExternalStore(
-    chatRef.current['~registerErrorCallback'],
-    () => chatRef.current.error,
-    () => chatRef.current.error,
+    chatStateRef.current.chat['~registerErrorCallback'],
+    () => chatStateRef.current.chat.error,
+    () => chatStateRef.current.chat.error,
   );
 
   const setMessages = useCallback(
@@ -237,35 +238,35 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
       messagesParam: UI_MESSAGE[] | ((messages: UI_MESSAGE[]) => UI_MESSAGE[]),
     ) => {
       if (typeof messagesParam === 'function') {
-        messagesParam = messagesParam(chatRef.current.messages);
+        messagesParam = messagesParam(chatStateRef.current.chat.messages);
       }
-      chatRef.current.messages = messagesParam;
+      chatStateRef.current.chat.messages = messagesParam;
     },
-    [chatRef],
+    [chatStateRef],
   );
 
   useEffect(() => {
     if (resume) {
-      chatRef.current.resumeStream();
+      chatStateRef.current.chat.resumeStream();
     }
-  }, [resume, chatRef]);
+  }, [resume, chatStateRef]);
 
   return {
-    id: chatRef.current.id,
+    id: chatStateRef.current.chat.id,
     messages,
     setMessages,
-    sendMessage: chatRef.current.sendMessage,
-    regenerate: chatRef.current.regenerate,
-    clearError: chatRef.current.clearError,
-    stop: chatRef.current.stop,
+    sendMessage: chatStateRef.current.chat.sendMessage,
+    regenerate: chatStateRef.current.chat.regenerate,
+    clearError: chatStateRef.current.chat.clearError,
+    stop: chatStateRef.current.chat.stop,
     error,
-    resumeStream: chatRef.current.resumeStream,
+    resumeStream: chatStateRef.current.chat.resumeStream,
     status,
     /**
      * @deprecated Use `addToolOutput` instead.
      */
-    addToolResult: chatRef.current.addToolOutput,
-    addToolOutput: chatRef.current.addToolOutput,
-    addToolApprovalResponse: chatRef.current.addToolApprovalResponse,
+    addToolResult: chatStateRef.current.chat.addToolOutput,
+    addToolOutput: chatStateRef.current.chat.addToolOutput,
+    addToolApprovalResponse: chatStateRef.current.chat.addToolApprovalResponse,
   };
 }

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -124,6 +124,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
   const chatRef = useRef<Chat<UI_MESSAGE>>(
     'chat' in options ? options.chat : new Chat(chatOptions),
   );
+  const isChatExternallyManagedRef = useRef('chat' in options);
 
   const shouldRecreateChat =
     ('chat' in options && options.chat !== chatRef.current) ||
@@ -132,7 +133,12 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
       chatRef.current.id !== options.id);
 
   if (shouldRecreateChat) {
+    if (!isChatExternallyManagedRef.current) {
+      void chatRef.current.stop();
+    }
+
     chatRef.current = 'chat' in options ? options.chat : new Chat(chatOptions);
+    isChatExternallyManagedRef.current = 'chat' in options;
   }
 
   const chat = chatRef.current;

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -6,7 +6,13 @@ import {
   type UIMessage,
   DefaultChatTransport,
 } from 'ai';
-import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
 import { Chat } from './chat.react';
 
 export type { CreateUIMessage, UIMessage };
@@ -121,25 +127,14 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
       latestRef.current.sendAutomaticallyWhen?.(arg) ?? false,
   };
 
-  const chatStateRef = useRef({
-    chat: 'chat' in options ? options.chat : new Chat(chatOptions),
-    isExternallyManaged: 'chat' in options,
-  });
-
-  const shouldRecreateChat =
-    ('chat' in options && options.chat !== chatStateRef.current.chat) ||
-    ('id' in options &&
-      options.id != null &&
-      chatStateRef.current.chat.id !== options.id);
-
-  if (shouldRecreateChat) {
-    chatStateRef.current = {
+  const chatKey = 'chat' in options ? options.chat : options.id;
+  const { chat, isExternallyManaged } = useMemo(
+    () => ({
       chat: 'chat' in options ? options.chat : new Chat(chatOptions),
       isExternallyManaged: 'chat' in options,
-    };
-  }
-
-  const { chat, isExternallyManaged } = chatStateRef.current;
+    }),
+    [chatKey],
+  );
 
   useEffect(() => {
     if (isExternallyManaged) {
@@ -151,25 +146,18 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
     };
   }, [chat, isExternallyManaged]);
 
-  const messagesSnapshotRef = useRef({
-    chat,
-    messages: chat.messages,
-  });
-
-  if (messagesSnapshotRef.current.chat !== chat) {
-    messagesSnapshotRef.current = { chat, messages: chat.messages };
-  }
+  const messagesSnapshot = useMemo(() => ({ messages: chat.messages }), [chat]);
 
   const subscribeToMessages = useCallback(
     (update: () => void) => {
       let isSubscribed = true;
 
       const updateMessages = () => {
-        if (!isSubscribed || messagesSnapshotRef.current.chat !== chat) {
+        if (!isSubscribed) {
           return;
         }
 
-        messagesSnapshotRef.current = { chat, messages: chat.messages };
+        messagesSnapshot.messages = chat.messages;
         update();
       };
 
@@ -181,19 +169,19 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
       // Synchronize changes that may have happened between render and
       // subscription. useSyncExternalStore checks the snapshot after
       // subscribing and schedules a render when it changed.
-      messagesSnapshotRef.current = { chat, messages: chat.messages };
+      messagesSnapshot.messages = chat.messages;
 
       return () => {
         isSubscribed = false;
         unsubscribe();
       };
     },
-    [chat, throttleWaitMs],
+    [chat, messagesSnapshot, throttleWaitMs],
   );
 
   const getMessagesSnapshot = useCallback(
-    () => messagesSnapshotRef.current.messages,
-    [],
+    () => messagesSnapshot.messages,
+    [messagesSnapshot],
   );
 
   const messages = useSyncExternalStore(
@@ -205,18 +193,14 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
   const subscribeToStatus = useCallback(
     (update: () => void) =>
       chat['~registerStatusCallback'](() => {
-        if (messagesSnapshotRef.current.chat !== chat) {
-          return;
-        }
-
         if (chat.status === 'ready' || chat.status === 'error') {
           // Publish the latest messages before the terminal status can render.
-          messagesSnapshotRef.current = { chat, messages: chat.messages };
+          messagesSnapshot.messages = chat.messages;
         }
 
         update();
       }),
-    [chat],
+    [chat, messagesSnapshot],
   );
 
   const getStatusSnapshot = useCallback(() => chat.status, [chat]);
@@ -228,9 +212,9 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
   );
 
   const error = useSyncExternalStore(
-    chatStateRef.current.chat['~registerErrorCallback'],
-    () => chatStateRef.current.chat.error,
-    () => chatStateRef.current.chat.error,
+    chat['~registerErrorCallback'],
+    () => chat.error,
+    () => chat.error,
   );
 
   const setMessages = useCallback(
@@ -238,35 +222,35 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
       messagesParam: UI_MESSAGE[] | ((messages: UI_MESSAGE[]) => UI_MESSAGE[]),
     ) => {
       if (typeof messagesParam === 'function') {
-        messagesParam = messagesParam(chatStateRef.current.chat.messages);
+        messagesParam = messagesParam(chat.messages);
       }
-      chatStateRef.current.chat.messages = messagesParam;
+      chat.messages = messagesParam;
     },
-    [chatStateRef],
+    [chat],
   );
 
   useEffect(() => {
     if (resume) {
-      chatStateRef.current.chat.resumeStream();
+      chat.resumeStream();
     }
-  }, [resume, chatStateRef]);
+  }, [resume, chat]);
 
   return {
-    id: chatStateRef.current.chat.id,
+    id: chat.id,
     messages,
     setMessages,
-    sendMessage: chatStateRef.current.chat.sendMessage,
-    regenerate: chatStateRef.current.chat.regenerate,
-    clearError: chatStateRef.current.chat.clearError,
-    stop: chatStateRef.current.chat.stop,
+    sendMessage: chat.sendMessage,
+    regenerate: chat.regenerate,
+    clearError: chat.clearError,
+    stop: chat.stop,
     error,
-    resumeStream: chatStateRef.current.chat.resumeStream,
+    resumeStream: chat.resumeStream,
     status,
     /**
      * @deprecated Use `addToolOutput` instead.
      */
-    addToolResult: chatStateRef.current.chat.addToolOutput,
-    addToolOutput: chatStateRef.current.chat.addToolOutput,
-    addToolApprovalResponse: chatStateRef.current.chat.addToolApprovalResponse,
+    addToolResult: chat.addToolOutput,
+    addToolOutput: chat.addToolOutput,
+    addToolApprovalResponse: chat.addToolApprovalResponse,
   };
 }

--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -133,15 +133,23 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
       chatRef.current.id !== options.id);
 
   if (shouldRecreateChat) {
-    if (!isChatExternallyManagedRef.current) {
-      void chatRef.current.stop();
-    }
-
     chatRef.current = 'chat' in options ? options.chat : new Chat(chatOptions);
     isChatExternallyManagedRef.current = 'chat' in options;
   }
 
   const chat = chatRef.current;
+  const isChatExternallyManaged = isChatExternallyManagedRef.current;
+
+  useEffect(() => {
+    if (isChatExternallyManaged) {
+      return;
+    }
+
+    return () => {
+      void chat.stop();
+    };
+  }, [chat, isChatExternallyManaged]);
+
   const messagesSnapshotRef = useRef({
     chat,
     messages: chat.messages,

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -2737,6 +2737,73 @@ describe('use-chat', () => {
     });
   });
 
+  describe('suspended id changes', () => {
+    let requestSignal: AbortSignal | undefined;
+    const pending = new Promise<never>(() => {});
+
+    setupTestComponent(
+      () => {
+        const [id, setId] = React.useState('initial-id');
+        const [shouldSuspend, setShouldSuspend] = React.useState(false);
+        const { sendMessage, id: chatId } = useChat({
+          id,
+          generateId: mockId(),
+          transport: {
+            sendMessages: async ({ abortSignal }) => {
+              requestSignal = abortSignal;
+              return new ReadableStream();
+            },
+            reconnectToStream: async () => null,
+          },
+        });
+
+        if (shouldSuspend) {
+          throw pending;
+        }
+
+        return (
+          <div>
+            <div data-testid="suspended-chat-id">{chatId}</div>
+            <button
+              data-testid="suspended-chat-send"
+              onClick={() => {
+                void sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
+              }}
+            />
+            <button
+              data-testid="suspended-chat-change-id"
+              onClick={() => {
+                React.startTransition(() => {
+                  setId('second-id');
+                  setShouldSuspend(true);
+                });
+              }}
+            />
+          </div>
+        );
+      },
+      {
+        init: TestComponent => (
+          <React.Suspense fallback={<div>Loading</div>}>
+            <TestComponent />
+          </React.Suspense>
+        ),
+      },
+    );
+
+    it('should not abort the active stream before an id change commits', async () => {
+      await userEvent.click(screen.getByTestId('suspended-chat-send'));
+      await waitFor(() => expect(requestSignal).toBeDefined());
+
+      await userEvent.click(screen.getByTestId('suspended-chat-change-id'));
+
+      expect(screen.getByTestId('suspended-chat-id')).toHaveTextContent(
+        'initial-id',
+      );
+      expect(requestSignal?.aborted).toBe(false);
+    });
+  });
+
   describe('undefined id', () => {
     setupTestComponent(
       () => {

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -2539,7 +2539,7 @@ describe('use-chat', () => {
       });
 
       expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
-      controller.close();
+      await controller.close().catch(() => {});
     });
   });
 
@@ -2710,6 +2710,31 @@ describe('use-chat', () => {
 
       expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
     });
+
+    it('should abort the previous stream when the id changes', async () => {
+      const controller = new TestResponseController();
+      const abortStream = vi.spyOn(controller, 'error');
+      server.urls['/api/chat'].response = {
+        type: 'controlled-stream',
+        controller,
+      };
+
+      await userEvent.click(screen.getByTestId('do-send'));
+      await waitFor(() => {
+        expect(screen.getByTestId('status')).toHaveTextContent('submitted');
+      });
+
+      await userEvent.click(screen.getByTestId('do-change-id'));
+
+      try {
+        await vi.waitUntil(() => abortStream.mock.calls.length > 0, {
+          timeout: 1000,
+        });
+        expect(abortStream).toHaveBeenCalledOnce();
+      } finally {
+        await controller.close().catch(() => {});
+      }
+    });
   });
 
   describe('undefined id', () => {
@@ -2791,14 +2816,17 @@ describe('use-chat', () => {
   });
 
   describe('chat instance changes', () => {
+    let initialChat: Chat<UIMessage>;
+
     setupTestComponent(
       () => {
-        const [chat, setChat] = React.useState<Chat<UIMessage>>(
-          new Chat({
+        const [chat, setChat] = React.useState<Chat<UIMessage>>(() => {
+          initialChat = new Chat({
             id: 'initial-id',
             generateId: mockId(),
-          }),
-        );
+          });
+          return initialChat;
+        });
 
         const {
           messages,
@@ -2888,6 +2916,14 @@ describe('use-chat', () => {
       await userEvent.click(screen.getByTestId('do-change-chat'));
 
       expect(screen.queryByTestId('message-0')).not.toBeInTheDocument();
+    });
+
+    it('should not stop a caller-managed chat when it is replaced', async () => {
+      const stop = vi.spyOn(initialChat, 'stop');
+
+      await userEvent.click(screen.getByTestId('do-change-chat'));
+
+      expect(stop).not.toHaveBeenCalled();
     });
 
     it('should handle streaming correctly when the id changes', async () => {

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -2739,19 +2739,30 @@ describe('use-chat', () => {
 
   describe('suspended id changes', () => {
     let requestSignal: AbortSignal | undefined;
+    let responseController:
+      | ReadableStreamDefaultController<UIMessageChunk>
+      | undefined;
     const pending = new Promise<never>(() => {});
 
     setupTestComponent(
       () => {
         const [id, setId] = React.useState('initial-id');
         const [shouldSuspend, setShouldSuspend] = React.useState(false);
-        const { sendMessage, id: chatId } = useChat({
+        const {
+          sendMessage,
+          id: chatId,
+          messages,
+        } = useChat({
           id,
           generateId: mockId(),
           transport: {
             sendMessages: async ({ abortSignal }) => {
               requestSignal = abortSignal;
-              return new ReadableStream();
+              return new ReadableStream<UIMessageChunk>({
+                start(controller) {
+                  responseController = controller;
+                },
+              });
             },
             reconnectToStream: async () => null,
           },
@@ -2764,6 +2775,9 @@ describe('use-chat', () => {
         return (
           <div>
             <div data-testid="suspended-chat-id">{chatId}</div>
+            <div data-testid="suspended-chat-messages">
+              {JSON.stringify(messages)}
+            </div>
             <button
               data-testid="suspended-chat-send"
               onClick={() => {
@@ -2791,16 +2805,38 @@ describe('use-chat', () => {
       },
     );
 
-    it('should not abort the active stream before an id change commits', async () => {
+    it('should keep the active stream connected before an id change commits', async () => {
       await userEvent.click(screen.getByTestId('suspended-chat-send'));
-      await waitFor(() => expect(requestSignal).toBeDefined());
+      await waitFor(() => {
+        expect(requestSignal).toBeDefined();
+        expect(responseController).toBeDefined();
+      });
 
       await userEvent.click(screen.getByTestId('suspended-chat-change-id'));
 
-      expect(screen.getByTestId('suspended-chat-id')).toHaveTextContent(
-        'initial-id',
-      );
-      expect(requestSignal?.aborted).toBe(false);
+      try {
+        expect(screen.getByTestId('suspended-chat-id')).toHaveTextContent(
+          'initial-id',
+        );
+        expect(requestSignal?.aborted).toBe(false);
+
+        await act(async () => {
+          responseController!.enqueue({ type: 'text-start', id: '0' });
+          responseController!.enqueue({
+            type: 'text-delta',
+            id: '0',
+            delta: 'Hello',
+          });
+        });
+
+        await waitFor(() => {
+          expect(
+            screen.getByTestId('suspended-chat-messages'),
+          ).toHaveTextContent('Hello');
+        });
+      } finally {
+        responseController!.close();
+      }
     });
   });
 


### PR DESCRIPTION
## Background

- `useChat({ id })` creates and owns an internal `Chat` for that ID. When the ID changes, the old chat is no longer reachable through the hook, so any active request it owns must be cleaned up.
- Cleanup cannot happen during render. React may start rendering a new ID inside a transition, suspend that render, and continue showing the previous chat. Stopping or replacing shared state during that unfinished render can interrupt the chat that is still on screen.
- A caller-provided `Chat` has a different ownership model. The caller may intentionally keep it alive while switching between threads, so `useChat` must not stop it.

## Summary

- Tie each internally created `Chat` and its message snapshot to the requested ID, so an unfinished render cannot overwrite the state used by the committed UI.
- Stop internally owned chats through React effect cleanup. This runs only after a replacement commits or the hook unmounts, rather than during a speculative render.
- Keep caller-provided `Chat` instances untouched because their lifecycle belongs to the caller.

## End-to-End Verification

- Started a response for `thread-a`, then committed a switch to `thread-b` and verified the unreachable `thread-a` request was aborted.
- Started another response and attempted the ID change through a suspended transition. Verified `thread-a` remained visible, its request stayed active, and newly streamed text continued appearing in its UI because `thread-b` had not committed.
- Replaced a caller-managed `Chat` and verified it was not stopped.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A *patch* changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Related Issues

Fixes [https://github.com/vercel/ai/issues/13304](https://github.com/vercel/ai/issues/13304)
Closes [https://github.com/vercel/ai/pull/13305](https://github.com/vercel/ai/pull/13305)
