### PR TITLE
fix(react): defer useChat cleanup until commit

### DIFF
--- a/packages/react/src/use-chat.ts
+++ b/packages/react/src/use-chat.ts
@@ -133,15 +133,23 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>({
       chatRef.current.id !== options.id);
 
   if (shouldRecreateChat) {
-    if (!isChatExternallyManagedRef.current) {
-      void chatRef.current.stop();
-    }
-
     chatRef.current = 'chat' in options ? options.chat : new Chat(chatOptions);
     isChatExternallyManagedRef.current = 'chat' in options;
   }
 
   const chat = chatRef.current;
+  const isChatExternallyManaged = isChatExternallyManagedRef.current;
+
+  useEffect(() => {
+    if (isChatExternallyManaged) {
+      return;
+    }
+
+    return () => {
+      void chat.stop();
+    };
+  }, [chat, isChatExternallyManaged]);
+
   const messagesSnapshotRef = useRef({
     chat,
     messages: chat.messages,

--- a/packages/react/src/use-chat.ui.test.tsx
+++ b/packages/react/src/use-chat.ui.test.tsx
@@ -2737,6 +2737,73 @@ describe('use-chat', () => {
     });
   });
 
+  describe('suspended id changes', () => {
+    let requestSignal: AbortSignal | undefined;
+    const pending = new Promise<never>(() => {});
+
+    setupTestComponent(
+      () => {
+        const [id, setId] = React.useState('initial-id');
+        const [shouldSuspend, setShouldSuspend] = React.useState(false);
+        const { sendMessage, id: chatId } = useChat({
+          id,
+          generateId: mockId(),
+          transport: {
+            sendMessages: async ({ abortSignal }) => {
+              requestSignal = abortSignal;
+              return new ReadableStream();
+            },
+            reconnectToStream: async () => null,
+          },
+        });
+
+        if (shouldSuspend) {
+          throw pending;
+        }
+
+        return (
+          <div>
+            <div data-testid="suspended-chat-id">{chatId}</div>
+            <button
+              data-testid="suspended-chat-send"
+              onClick={() => {
+                void sendMessage({ parts: [{ text: 'hi', type: 'text' }] });
+              }}
+            />
+            <button
+              data-testid="suspended-chat-change-id"
+              onClick={() => {
+                React.startTransition(() => {
+                  setId('second-id');
+                  setShouldSuspend(true);
+                });
+              }}
+            />
+          </div>
+        );
+      },
+      {
+        init: TestComponent => (
+          <React.Suspense fallback={<div>Loading</div>}>
+            <TestComponent />
+          </React.Suspense>
+        ),
+      },
+    );
+
+    it('should not abort the active stream before an id change commits', async () => {
+      await userEvent.click(screen.getByTestId('suspended-chat-send'));
+      await waitFor(() => expect(requestSignal).toBeDefined());
+
+      await userEvent.click(screen.getByTestId('suspended-chat-change-id'));
+
+      expect(screen.getByTestId('suspended-chat-id')).toHaveTextContent(
+        'initial-id',
+      );
+      expect(requestSignal?.aborted).toBe(false);
+    });
+  });
+
   describe('undefined id', () => {
     setupTestComponent(
       () => {


### PR DESCRIPTION
## Summary

- move cleanup of internally managed Chat instances into the React effect lifecycle
- avoid aborting the committed chat when an ID-changing concurrent render suspends
- preserve caller-managed Chat instances
- add a Suspense regression test for an uncommitted ID change

## Verification

- pnpm --dir packages/react exec vitest --config vitest.config.js --run src/use-chat.ui.test.tsx
- pnpm --filter @ai-sdk/react type-check
- pnpm type-check:full
- pnpm exec ultracite check packages/react/src/use-chat.ts packages/react/src/use-chat.ui.test.tsx

Stacked on #20654.