### PR TITLE
feat(tools-registry): add pushary

### DIFF
--- a/content/tools-registry/registry.ts
+++ b/content/tools-registry/registry.ts
@@ -586,4 +586,44 @@ console.log(result.text);`,
     websiteUrl: 'https://nitrosend.com',
     npmUrl: 'https://www.npmjs.com/package/@nitrosend/ai-sdk',
   },
+  {
+    slug: 'pushary',
+    name: 'Pushary',
+    description:
+      'Ask an enrolled customer for confirmation, a choice, or text in the Pushary mobile app and return their response to your agent. Questions collect input; protected actions require a separate enforced approval gate.',
+    packageName: '@pushary/ai-sdk',
+    tags: ['human-in-the-loop', 'customer-input'],
+    apiKeyEnvName: 'PUSHARY_API_KEY',
+    installCommand: {
+      pnpm: 'pnpm add @pushary/ai-sdk ai zod',
+      npm: 'npm install @pushary/ai-sdk ai zod',
+      yarn: 'yarn add @pushary/ai-sdk ai zod',
+      bun: 'bun add @pushary/ai-sdk ai zod',
+    },
+    codeExample: `import { generateText, isStepCount } from 'ai';
+import { createPusharyTools } from '@pushary/ai-sdk';
+
+const apiKey = process.env.PUSHARY_API_KEY;
+const externalId = process.env.PUSHARY_EXTERNAL_ID;
+if (!apiKey || !externalId) {
+  throw new Error('Set a Pushary Partner key and an enrolled customer ID.');
+}
+
+const result = await generateText({
+  model: 'openai/gpt-5-mini',
+  tools: createPusharyTools({ apiKey, externalId, timeoutMs: 55000 }),
+  toolChoice: { type: 'tool', toolName: 'askHuman' },
+  stopWhen: isStepCount(1),
+  prompt:
+    'Ask the customer to choose Standard or Express shipping using a select question. Do not place an order.',
+});
+
+console.log(result.toolResults);`,
+    docsUrl:
+      'https://pushary.com/human-in-the-loop-vercel-ai-sdk?utm_source=ai-sdk&utm_medium=integration-directory&utm_campaign=pushary-ai-sdk&utm_content=guide',
+    apiKeyUrl:
+      'https://pushary.com/sign-up?from=agent&plan=partner&utm_source=ai-sdk&utm_medium=integration-directory&utm_campaign=pushary-ai-sdk&utm_content=partner-start',
+    websiteUrl: 'https://pushary.com',
+    npmUrl: 'https://www.npmjs.com/package/@pushary/ai-sdk',
+  },
 ];


### PR DESCRIPTION
Adds Pushary's customer-input tool to the Tools Registry. It asks an enrolled customer for confirmation, a choice or text in the native Pushary app. The example collects a shipping choice; it does not execute a purchase or treat a question as an enforced approval gate.

The links lead to Partner signup and the AI SDK integration guide. Live usage needs a server-side Partner key, an enrolled test customer's ID, and AI Gateway credentials or supported Vercel authentication. Production applications bind the recipient to their authenticated user.

Validation:

- Refreshed 2026-09-14: clean installation of `@pushary/ai-sdk@0.3.0` with `ai@7.0.99`; the published adapter's askHuman execution smoke check passed with simulated HTTP. `@pushary/server@2.1.1` resolved once, with no dependency-tree problems or stale Pushary packages.
- Earlier example validation (2026-09-11): the exact registry example ran through the real AI SDK with a scripted model and simulated HTTP using AI SDK 7.0.97. Select, input, confirmation yes/no and expiry passed; typed `yes` remains data. Focused strict TypeScript and upstream oxfmt checks passed.
- No registry code changed in this refresh. Full upstream workspace typecheck was previously attempted but could not validate the clean clone without its workspace dependencies.

The Vercel preview currently requires maintainer deployment authorization; the contributor cannot clear that gate. No paid-model or physical-device result is claimed by these tests.

Disclosure: I maintain Pushary. AI-assisted contribution, reviewed and tested as described above.
