### PR TITLE
fix(provider/deepseek): preserve prior-turn reasoning_content for the deepseek-flash alias (v6 backport)

### DIFF
--- a/.changeset/deepseek-flash-v4-reasoning.md
+++ b/.changeset/deepseek-flash-v4-reasoning.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/deepseek": patch
+---
+
+fix(provider/deepseek): treat the `deepseek-flash` alias as a V4 model so prior-turn `reasoning_content` is preserved in multi-turn requests

--- a/content/providers/01-ai-sdk-providers/30-deepseek.mdx
+++ b/content/providers/01-ai-sdk-providers/30-deepseek.mdx
@@ -92,9 +92,9 @@ DeepSeek language models can be used in the `streamText` function
 (see [AI SDK Core](/docs/ai-sdk-core)).
 
 DeepSeek retired the `deepseek-chat` and `deepseek-reasoner` aliases on July 24,
-2026. Use `deepseek-v4-flash` or `deepseek-v4-pro` for the current API. Custom
-and legacy model IDs remain accepted as strings for compatibility with custom
-endpoints.
+2026. Use `deepseek-flash` (the alias for the current V4.x Flash release),
+`deepseek-v4-flash`, or `deepseek-v4-pro` for the current API. Custom and legacy
+model IDs remain accepted as strings for compatibility with custom endpoints.
 
 The following optional provider options are available for DeepSeek models:
 
@@ -452,6 +452,7 @@ at most 8,192 characters.
 
 | Model                          | Text Generation     | Object Generation   | Image Input         | Tool Usage          | Tool Streaming      |
 | ------------------------------ | ------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
+| `deepseek-flash`               | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `deepseek-v4-flash`            | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `deepseek-v4-pro`              | <Check size={18} /> | <Check size={18} /> | <Cross size={18} /> | <Check size={18} /> | <Check size={18} /> |
 | `deepseek-v4-flash-vision-exp` | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> | <Check size={18} /> |

--- a/examples/ai-functions/src/stream-text/deepseek/multi-turn-reasoning-history.ts
+++ b/examples/ai-functions/src/stream-text/deepseek/multi-turn-reasoning-history.ts
@@ -1,0 +1,74 @@
+import { deepseek } from '@ai-sdk/deepseek';
+import { stepCountIs, streamText, type ModelMessage } from 'ai';
+import { printFullStream } from '../../lib/print-full-stream';
+import { run } from '../../lib/run';
+import { weatherTool } from '../../tools/weather-tool';
+
+// Multi-turn tool use on the `deepseek-flash` alias (V4.1 Flash). DeepSeek V4
+// accepts `reasoning_content` on replayed assistant turns from earlier rounds
+// and counts it toward the prompt. Before the provider recognized
+// `deepseek-flash` as V4 it applied the R1 rule and silently stripped that
+// history, so the model lost its prior reasoning.
+//
+// The check replays the same history twice with a one-token budget, once with
+// the real reasoning and once with the reasoning blanked, and compares
+// inputTokens. Equal counts mean the reasoning never reached the model.
+run(async () => {
+  const model = deepseek('deepseek-flash');
+  const tools = { weather: weatherTool };
+  const opening = 'What is the weather in San Francisco?';
+
+  console.log('=== TURN 1 (tool call + answer) ===');
+  const turn1 = streamText({
+    model,
+    tools,
+    stopWhen: stepCountIs(2),
+    prompt: opening,
+  });
+  await printFullStream({ result: turn1 });
+
+  const history: ModelMessage[] = [
+    { role: 'user', content: opening },
+    ...(await turn1.response).messages,
+    { role: 'user', content: 'How about in New York?' },
+  ];
+
+  console.log('\n=== TURN 2 (replay history + new user turn) ===');
+  const withReasoning = await inputTokens(history);
+  const withBlankReasoning = await inputTokens(history.map(blankReasoning));
+  console.log(`inputTokens with prior reasoning:    ${withReasoning}`);
+  console.log(`inputTokens with reasoning blanked:  ${withBlankReasoning}`);
+
+  if (
+    withReasoning === undefined ||
+    withBlankReasoning === undefined ||
+    withReasoning <= withBlankReasoning
+  ) {
+    throw new Error(
+      'FAIL: prior-turn reasoning_content did not reach DeepSeek',
+    );
+  }
+  console.log(
+    `PASS: prior-turn reasoning_content reached DeepSeek (+${
+      withReasoning - withBlankReasoning
+    } tokens)`,
+  );
+
+  async function inputTokens(messages: ModelMessage[]) {
+    const result = streamText({ model, tools, messages, maxOutputTokens: 1 });
+    await result.consumeStream();
+    return (await result.usage).inputTokens;
+  }
+});
+
+function blankReasoning(message: ModelMessage): ModelMessage {
+  if (message.role !== 'assistant' || typeof message.content === 'string') {
+    return message;
+  }
+  return {
+    ...message,
+    content: message.content.map(part =>
+      part.type === 'reasoning' ? { ...part, text: '' } : part,
+    ),
+  };
+}

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.test.ts
@@ -827,6 +827,39 @@ describe('convertToDeepSeekChatMessages', () => {
       `);
     });
 
+    // `deepseek-flash` is DeepSeek's unversioned alias for V4.1 Flash; it has
+    // the same reasoning_content contract as the `deepseek-v4-*` ids.
+    it('should preserve reasoning_content from prior turns for the deepseek-flash alias', async () => {
+      const result = await convertToDeepSeekChatMessages({
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'reasoning', text: 'Prior-turn reasoning.' },
+              { type: 'text', text: 'Hi there' },
+            ],
+          },
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'Again' }],
+          },
+        ],
+        responseFormat: undefined,
+        modelId: 'deepseek-flash',
+      });
+
+      expect(result.messages[1]).toStrictEqual({
+        role: 'assistant',
+        content: 'Hi there',
+        reasoning_content: 'Prior-turn reasoning.',
+        tool_calls: undefined,
+      });
+    });
+
     it('should back-fill empty reasoning_content for deepseek-v4 assistant messages with no reasoning part', async () => {
       const result = await convertToDeepSeekChatMessages({
         prompt: [

--- a/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
+++ b/packages/deepseek/src/chat/convert-to-deepseek-chat-messages.ts
@@ -12,6 +12,7 @@ import type {
 } from './deepseek-chat-api-types';
 import { deepseekAssistantMessageProviderOptions } from './deepseek-chat-options';
 import { deepseekFilePartProviderOptions } from './deepseek-file-part-options';
+import { isDeepSeekV4Model } from './is-deepseek-v4-model';
 
 const supportedImageMediaTypes = new Set([
   'image/gif',
@@ -39,7 +40,7 @@ export async function convertToDeepSeekChatMessages({
   messages: DeepSeekChatPrompt;
   warnings: Array<SharedV3Warning>;
 }> {
-  const isDeepSeekV4 = modelId.includes('deepseek-v4');
+  const isDeepSeekV4 = isDeepSeekV4Model(modelId);
   const messages: DeepSeekChatPrompt = [];
   const warnings: Array<SharedV3Warning> = [];
 

--- a/packages/deepseek/src/chat/deepseek-chat-language-model.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-language-model.ts
@@ -38,6 +38,7 @@ import {
 } from './deepseek-chat-options';
 import { prepareTools } from './deepseek-prepare-tools';
 import { getResponseMetadata } from './get-response-metadata';
+import { isDeepSeekV4Model } from './is-deepseek-v4-model';
 import { mapDeepSeekFinishReason } from './map-deepseek-finish-reason';
 
 export type DeepSeekChatConfig = {
@@ -203,7 +204,7 @@ export class DeepSeekChatLanguageModel implements LanguageModelV3 {
       thinking?.type !== 'disabled' &&
       (thinking != null ||
         this.modelId === 'deepseek-reasoner' ||
-        this.modelId.includes('deepseek-v4'));
+        isDeepSeekV4Model(this.modelId));
 
     if (isThinkingEnabled && temperature != null) {
       allWarnings.push({

--- a/packages/deepseek/src/chat/deepseek-chat-options.ts
+++ b/packages/deepseek/src/chat/deepseek-chat-options.ts
@@ -2,6 +2,7 @@ import { z } from 'zod/v4';
 
 // https://api-docs.deepseek.com/quick_start/pricing
 export type DeepSeekChatModelId =
+  | 'deepseek-flash'
   | 'deepseek-v4-flash'
   | 'deepseek-v4-pro'
   | 'deepseek-v4-flash-vision-exp'

--- a/packages/deepseek/src/chat/is-deepseek-v4-model.test.ts
+++ b/packages/deepseek/src/chat/is-deepseek-v4-model.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { isDeepSeekV4Model } from './is-deepseek-v4-model';
+
+describe('isDeepSeekV4Model', () => {
+  it.each([
+    'deepseek-v4-pro',
+    'deepseek-v4-pro-0813',
+    'deepseek-v4-flash',
+    'deepseek-v4-flash-0731',
+    'deepseek-v4-flash-vision-exp',
+    'deepseek-flash',
+    'deepseek-pro',
+  ])('should treat %s as V4', modelId => {
+    expect(isDeepSeekV4Model(modelId)).toBe(true);
+  });
+
+  it.each(['deepseek-chat', 'deepseek-reasoner'])(
+    'should not treat legacy %s as V4',
+    modelId => {
+      expect(isDeepSeekV4Model(modelId)).toBe(false);
+    },
+  );
+});

--- a/packages/deepseek/src/chat/is-deepseek-v4-model.ts
+++ b/packages/deepseek/src/chat/is-deepseek-v4-model.ts
@@ -1,0 +1,16 @@
+/**
+ * Whether a model id is a DeepSeek V4-generation model (thinking mode on by
+ * default, `reasoning_content` required on every assistant turn).
+ *
+ * DeepSeek publishes V4 models under both versioned ids (`deepseek-v4-pro`,
+ * `deepseek-v4-flash-*`) and unversioned aliases (`deepseek-flash`, currently
+ * serving V4.1 Flash). Only the legacy `deepseek-chat` / `deepseek-reasoner`
+ * ids predate V4.
+ */
+export function isDeepSeekV4Model(modelId: string): boolean {
+  return (
+    modelId.includes('deepseek-v4') ||
+    modelId.startsWith('deepseek-flash') ||
+    modelId.startsWith('deepseek-pro')
+  );
+}

--- a/packages/deepseek/src/deepseek-provider.test-d.ts
+++ b/packages/deepseek/src/deepseek-provider.test-d.ts
@@ -10,9 +10,13 @@ type FirstClassModelId<T> = T extends string
   : never;
 
 expectTypeOf<FirstClassModelId<ModelId>>().toEqualTypeOf<
-  'deepseek-v4-flash' | 'deepseek-v4-pro' | 'deepseek-v4-flash-vision-exp'
+  | 'deepseek-flash'
+  | 'deepseek-v4-flash'
+  | 'deepseek-v4-pro'
+  | 'deepseek-v4-flash-vision-exp'
 >();
 
+deepseek('deepseek-flash');
 deepseek('deepseek-v4-flash');
 deepseek('deepseek-v4-pro');
 deepseek('deepseek-v4-flash-vision-exp');


### PR DESCRIPTION
Backport of #20662 to `release-v6.0`.

## Background

DeepSeek V4 models accept (and count toward the prompt) `reasoning_content` on replayed assistant messages from earlier rounds, and require it on the current round. The provider gates that behavior on `modelId.includes('deepseek-v4')`. DeepSeek also serves V4 under the unversioned alias `deepseek-flash` (currently V4.1 Flash; it is one of the two ids returned by `GET /models` today), which fails that check and falls into the R1 path: reasoning parts on assistant messages at or before the last user message are silently stripped, so the model loses its prior reasoning on every multi-turn request.

## Summary

- Add `isDeepSeekV4Model()` and use it at both existing call sites (`convertToDeepSeekChatMessages` and the thinking-enabled check in `DeepSeekChatLanguageModel`). It recognizes `deepseek-v4*` plus the `deepseek-flash` / `deepseek-pro` aliases; only the legacy `deepseek-chat` / `deepseek-reasoner` ids predate V4.
- Add `deepseek-flash` to the `DeepSeekChatModelId` union and the provider docs table.
- Tests: unit tests for the helper, a `deepseek-flash` prior-turn preservation case in the message-conversion suite, and the type test update.

## Verification

New example `examples/ai-functions/src/stream-text/deepseek/multi-turn-reasoning-history.ts` runs a tool-call turn on `deepseek-flash`, then replays the history plus a new user turn twice (real reasoning vs. blanked reasoning, `maxOutputTokens: 1`) and compares `inputTokens`. Equal counts mean the reasoning never reached the API.

Before (release-v6.0):
```
inputTokens with prior reasoning:    449
inputTokens with reasoning blanked:  449
Error: FAIL: prior-turn reasoning_content did not reach DeepSeek
```

After:
```
inputTokens with prior reasoning:    475
inputTokens with reasoning blanked:  457
PASS: prior-turn reasoning_content reached DeepSeek (+18 tokens)
```

The example compares against blanked (`''`) rather than omitted reasoning on purpose: DeepSeek reconstructs an omitted `reasoning_content` server-side for tool-call ids it minted, which would hide the difference.

`pnpm vitest run` in `packages/deepseek`: 102 passed. `tsc --noEmit` clean.