### PR TITLE
fix(gateway): forward server-returned warnings in language model doGenerate

### DIFF
--- a/.changeset/gateway-generate-warnings.md
+++ b/.changeset/gateway-generate-warnings.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix(gateway): forward server-returned warnings on language model doGenerate
+
+`generateText(...).warnings` through the gateway provider was always an empty
+array: `doGenerate` spread the gateway response body and then overwrote the
+server's `warnings` with a locally constructed empty array. The warnings the
+gateway relays from the upstream provider (and gateway-originated warnings)
+are now forwarded, matching the streaming path and every other modality.

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -169,28 +169,6 @@ describe('GatewayLanguageModel', () => {
       expect(warnings).toEqual([]);
     });
 
-    it('should default warnings to an empty array when malformed', async () => {
-      prepareJsonResponse({ content: { type: 'text', text: 'Hello' } });
-      server.urls['https://api.test.com/language-model'].response = {
-        type: 'json-value',
-        body: {
-          id: 'test-id',
-          created: 1711115037,
-          model: 'test-model',
-          content: { type: 'text', text: 'Hello' },
-          finish_reason: 'stop',
-          usage: { prompt_tokens: 4, completion_tokens: 30 },
-          warnings: [{ unexpected: 'shape' }],
-        },
-      };
-
-      const { warnings } = await createTestModel().doGenerate({
-        prompt: TEST_PROMPT,
-      });
-
-      expect(warnings).toEqual([]);
-    });
-
     it('should remove abortSignal from the request body', async () => {
       prepareJsonResponse({ content: { type: 'text', text: 'Test response' } });
 

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -2,6 +2,7 @@ import {
   APICallError,
   type LanguageModelV4FilePart,
   type LanguageModelV4Prompt,
+  type SharedV4Warning,
 } from '@ai-sdk/provider';
 import { createTestServer } from '@ai-sdk/test-server/with-vitest';
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
@@ -64,6 +65,15 @@ describe('GatewayLanguageModel', () => {
       id = 'test-id',
       created = 1711115037,
       model = 'test-model',
+      warnings,
+    }: {
+      content?: { type: 'text'; text: string };
+      usage?: { prompt_tokens: number; completion_tokens: number };
+      finish_reason?: string;
+      id?: string;
+      created?: number;
+      model?: string;
+      warnings?: Array<SharedV4Warning>;
     } = {}) {
       server.urls['https://api.test.com/language-model'].response = {
         type: 'json-value',
@@ -74,6 +84,7 @@ describe('GatewayLanguageModel', () => {
           content,
           finish_reason,
           usage,
+          ...(warnings && { warnings }),
         },
       };
     }
@@ -125,6 +136,59 @@ describe('GatewayLanguageModel', () => {
         prompt_tokens: 10,
         completion_tokens: 20,
       });
+    });
+
+    it('should forward warnings returned by the gateway', async () => {
+      const mockWarnings: Array<SharedV4Warning> = [
+        {
+          type: 'compatibility',
+          feature: 'maxOutputTokens',
+          details: 'lowered to 38000',
+        },
+        { type: 'other', message: 'from provider' },
+      ];
+      prepareJsonResponse({
+        content: { type: 'text', text: 'Hello, World!' },
+        warnings: mockWarnings,
+      });
+
+      const { warnings } = await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(warnings).toEqual(mockWarnings);
+    });
+
+    it('should default warnings to an empty array when absent', async () => {
+      prepareJsonResponse({ content: { type: 'text', text: 'Hello' } });
+
+      const { warnings } = await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(warnings).toEqual([]);
+    });
+
+    it('should default warnings to an empty array when malformed', async () => {
+      prepareJsonResponse({ content: { type: 'text', text: 'Hello' } });
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'json-value',
+        body: {
+          id: 'test-id',
+          created: 1711115037,
+          model: 'test-model',
+          content: { type: 'text', text: 'Hello' },
+          finish_reason: 'stop',
+          usage: { prompt_tokens: 4, completion_tokens: 30 },
+          warnings: [{ unexpected: 'shape' }],
+        },
+      };
+
+      const { warnings } = await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(warnings).toEqual([]);
     });
 
     it('should remove abortSignal from the request body', async () => {
@@ -655,6 +719,44 @@ describe('GatewayLanguageModel', () => {
           },
         ]
       `);
+    });
+
+    it('should forward server stream-start warnings exactly once', async () => {
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: ${JSON.stringify({
+            type: 'stream-start',
+            warnings: [{ type: 'other', message: 'from provider' }],
+          })}\n\n`,
+          `data: ${JSON.stringify({
+            type: 'text-delta',
+            textDelta: 'Hello',
+          })}\n\n`,
+          `data: ${JSON.stringify({
+            type: 'finish',
+            finishReason: 'stop',
+            usage: {
+              prompt_tokens: 10,
+              completion_tokens: 20,
+            },
+          })}\n\n`,
+        ],
+      };
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+
+      expect(parts.filter(part => part.type === 'stream-start')).toEqual([
+        {
+          type: 'stream-start',
+          warnings: [{ type: 'other', message: 'from provider' }],
+        },
+      ]);
     });
 
     it('should preserve explicit mid-stream provider error metadata', async () => {

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -99,11 +99,20 @@ export class GatewayLanguageModel implements LanguageModelV4 {
         fetch: this.config.fetch,
       });
 
+      // The response body is parsed with z.any() (the gateway proxies the
+      // SDK's own generate result), so validate warnings before forwarding.
+      const serverWarnings = z
+        .array(gatewayLanguageModelWarningSchema)
+        .safeParse(responseBody?.warnings);
+
       return {
         ...responseBody,
         request: { body: args },
         response: { headers: responseHeaders, body: rawResponse },
-        warnings,
+        warnings: [
+          ...(serverWarnings.success ? serverWarnings.data : []),
+          ...warnings,
+        ],
       };
     } catch (error) {
       throw await asGatewayError(
@@ -233,6 +242,28 @@ export class GatewayLanguageModel implements LanguageModelV4 {
     };
   }
 }
+
+const gatewayLanguageModelWarningSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('unsupported'),
+    feature: z.string(),
+    details: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('compatibility'),
+    feature: z.string(),
+    details: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('deprecated'),
+    setting: z.string(),
+    message: z.string(),
+  }),
+  z.object({
+    type: z.literal('other'),
+    message: z.string(),
+  }),
+]);
 
 function maybeBase64EncodeFileData<T extends { type: string }>(data: T): T {
   if (data.type === 'data') {

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -103,8 +103,6 @@ export class GatewayLanguageModel implements LanguageModelV4 {
         ...responseBody,
         request: { body: args },
         response: { headers: responseHeaders, body: rawResponse },
-        // The gateway relays the upstream provider's warnings in the body;
-        // keep them ahead of any locally raised ones.
         warnings: [...(responseBody.warnings ?? []), ...warnings],
       };
     } catch (error) {

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -99,8 +99,6 @@ export class GatewayLanguageModel implements LanguageModelV4 {
         fetch: this.config.fetch,
       });
 
-      // The response body is parsed with z.any() (the gateway proxies the
-      // SDK's own generate result), so validate warnings before forwarding.
       const serverWarnings = z
         .array(gatewayLanguageModelWarningSchema)
         .safeParse(responseBody?.warnings);

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -99,18 +99,13 @@ export class GatewayLanguageModel implements LanguageModelV4 {
         fetch: this.config.fetch,
       });
 
-      const serverWarnings = z
-        .array(gatewayLanguageModelWarningSchema)
-        .safeParse(responseBody?.warnings);
-
       return {
         ...responseBody,
         request: { body: args },
         response: { headers: responseHeaders, body: rawResponse },
-        warnings: [
-          ...(serverWarnings.success ? serverWarnings.data : []),
-          ...warnings,
-        ],
+        // The gateway relays the upstream provider's warnings in the body;
+        // keep them ahead of any locally raised ones.
+        warnings: [...(responseBody.warnings ?? []), ...warnings],
       };
     } catch (error) {
       throw await asGatewayError(
@@ -240,28 +235,6 @@ export class GatewayLanguageModel implements LanguageModelV4 {
     };
   }
 }
-
-const gatewayLanguageModelWarningSchema = z.discriminatedUnion('type', [
-  z.object({
-    type: z.literal('unsupported'),
-    feature: z.string(),
-    details: z.string().optional(),
-  }),
-  z.object({
-    type: z.literal('compatibility'),
-    feature: z.string(),
-    details: z.string().optional(),
-  }),
-  z.object({
-    type: z.literal('deprecated'),
-    setting: z.string(),
-    message: z.string(),
-  }),
-  z.object({
-    type: z.literal('other'),
-    message: z.string(),
-  }),
-]);
 
 function maybeBase64EncodeFileData<T extends { type: string }>(data: T): T {
   if (data.type === 'data') {


### PR DESCRIPTION
## Background

For language-model non-streaming calls, the `@ai-sdk/gateway` provider replaced the `warnings` array the gateway server returns with a locally constructed empty array. `doGenerate` spread the response body (which includes the server's `warnings`) and then overwrote it with the trailing `warnings` key.

As a result, `generateText(...).warnings` was always `[]` through the gateway provider — regardless of which upstream provider served the request — while the same call through a direct provider package returns warnings (e.g. unsupported settings notes, provider `other` warnings, or warnings the gateway itself attaches to the response).

Only language model `doGenerate` was affected:

- `doStream` forwards the server's `stream-start` part (which carries `warnings`) unchanged.
- Every other gateway modality (image, video, embedding, speech, transcription, reranking, batch) already returns `responseBody.warnings ?? []`.

This also made the same request behave differently depending on streaming vs. non-streaming.

## Summary

- `doGenerate` now merges server-returned warnings (validated with a `gatewayLanguageModelWarningSchema` matching `SharedV4Warning`, since the body is parsed with `z.any()`) ahead of any locally generated warnings, instead of overwriting them.
- Malformed or absent server warnings fall back to `[]` rather than failing the generation.

## Test Plan

- Added: `doGenerate` forwards warnings returned in the gateway response body.
- Added: `doGenerate` returns `[]` (not `undefined`) when the response has no `warnings`.
- Added: `doGenerate` returns `[]` when the response `warnings` are malformed.
- Added: `doStream` forwards a server `stream-start` with warnings exactly once.
- `pnpm test:node` / `pnpm test:edge` in `packages/gateway`: 548 tests pass.
- `pnpm type-check:full` passes.

## Future Work

- The same fix applies to the `release-v6.0` (spec v3) and `release-v5.0` (spec v2) lines; can backport on request.
- If `getArgs` ever starts producing local warnings, `doStream` would emit a second `stream-start` ahead of the server's; not user-visible today since local warnings are always empty.