### PR TITLE
Backport: fix(gateway): forward server-returned warnings in language model doGenerate

### DIFF
--- a/.changeset/gateway-generate-warnings.md
+++ b/.changeset/gateway-generate-warnings.md
@@ -1,0 +1,11 @@
+---
+'@ai-sdk/gateway': patch
+---
+
+fix(gateway): forward server-returned warnings on language model doGenerate
+
+`generateText(...).warnings` through the gateway provider was always an empty
+array: `doGenerate` spread the gateway response body and then overwrote the
+server's `warnings` with a locally constructed empty array. The warnings the
+gateway relays from the upstream provider (and gateway-originated warnings)
+are now forwarded, matching the streaming path and every other modality.

--- a/packages/gateway/src/gateway-language-model.test.ts
+++ b/packages/gateway/src/gateway-language-model.test.ts
@@ -1,5 +1,6 @@
 import {
   APICallError,
+  type LanguageModelV2CallWarning,
   type LanguageModelV2FilePart,
   type LanguageModelV2Prompt,
 } from '@ai-sdk/provider';
@@ -64,6 +65,15 @@ describe('GatewayLanguageModel', () => {
       id = 'test-id',
       created = 1711115037,
       model = 'test-model',
+      warnings,
+    }: {
+      content?: { type: 'text'; text: string };
+      usage?: { prompt_tokens: number; completion_tokens: number };
+      finish_reason?: string;
+      id?: string;
+      created?: number;
+      model?: string;
+      warnings?: Array<LanguageModelV2CallWarning>;
     } = {}) {
       server.urls['https://api.test.com/language-model'].response = {
         type: 'json-value',
@@ -74,6 +84,7 @@ describe('GatewayLanguageModel', () => {
           content,
           finish_reason,
           usage,
+          ...(warnings && { warnings }),
         },
       };
     }
@@ -125,6 +136,37 @@ describe('GatewayLanguageModel', () => {
         prompt_tokens: 10,
         completion_tokens: 20,
       });
+    });
+
+    it('should forward warnings returned by the gateway', async () => {
+      const mockWarnings: Array<LanguageModelV2CallWarning> = [
+        {
+          type: 'unsupported-setting',
+          setting: 'maxOutputTokens',
+          details: 'lowered to 38000',
+        },
+        { type: 'other', message: 'from provider' },
+      ];
+      prepareJsonResponse({
+        content: { type: 'text', text: 'Hello, World!' },
+        warnings: mockWarnings,
+      });
+
+      const { warnings } = await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(warnings).toEqual(mockWarnings);
+    });
+
+    it('should default warnings to an empty array when absent', async () => {
+      prepareJsonResponse({ content: { type: 'text', text: 'Hello' } });
+
+      const { warnings } = await createTestModel().doGenerate({
+        prompt: TEST_PROMPT,
+      });
+
+      expect(warnings).toEqual([]);
     });
 
     it('should remove abortSignal from the request body', async () => {
@@ -613,6 +655,44 @@ describe('GatewayLanguageModel', () => {
             prompt_tokens: 10,
             completion_tokens: 20,
           },
+        },
+      ]);
+    });
+
+    it('should forward server stream-start warnings exactly once', async () => {
+      server.urls['https://api.test.com/language-model'].response = {
+        type: 'stream-chunks',
+        chunks: [
+          `data: ${JSON.stringify({
+            type: 'stream-start',
+            warnings: [{ type: 'other', message: 'from provider' }],
+          })}\n\n`,
+          `data: ${JSON.stringify({
+            type: 'text-delta',
+            textDelta: 'Hello',
+          })}\n\n`,
+          `data: ${JSON.stringify({
+            type: 'finish',
+            finishReason: 'stop',
+            usage: {
+              prompt_tokens: 10,
+              completion_tokens: 20,
+            },
+          })}\n\n`,
+        ],
+      };
+
+      const { stream } = await createTestModel().doStream({
+        prompt: TEST_PROMPT,
+        includeRawChunks: false,
+      });
+
+      const parts = await convertReadableStreamToArray(stream);
+
+      expect(parts.filter(part => part.type === 'stream-start')).toEqual([
+        {
+          type: 'stream-start',
+          warnings: [{ type: 'other', message: 'from provider' }],
         },
       ]);
     });

--- a/packages/gateway/src/gateway-language-model.ts
+++ b/packages/gateway/src/gateway-language-model.ts
@@ -84,7 +84,7 @@ export class GatewayLanguageModel implements LanguageModelV2 {
         ...responseBody,
         request: { body: args },
         response: { headers: responseHeaders, body: rawResponse },
-        warnings,
+        warnings: [...(responseBody.warnings ?? []), ...warnings],
       };
     } catch (error) {
       throw await asGatewayError(error, await parseAuthMethod(resolvedHeaders));


### PR DESCRIPTION
Manual backport of #20675 to `release-v5.0` (no automated backport PR was opened for v5; #20676 covered v6).

`doGenerate` spread the gateway response body and then overwrote the server's `warnings` with a locally constructed empty array, so `generateText(...).warnings` was always `[]` through the gateway provider. Forward the server warnings instead, matching the streaming path and every other gateway modality. The source change is the same one-line merge as on `main` and `release-v6.0`.

### Conflict resolution (test file only)

- Imports: kept the `LanguageModelV2*` types and used `LanguageModelV2CallWarning` for the new assertions (v2 has no `SharedV2Warning`).
- The generate fixture uses `{ type: 'unsupported-setting', setting: 'maxOutputTokens' }` — the v2 variant the gateway emits on spec v2 — instead of `compatibility`, which does not exist on v2.
- The cherry-pick conflict region also pulled in the main-only `should preserve explicit mid-stream provider error metadata` test and main's inline-snapshot form of `should stream text deltas`; both are unrelated to this fix and were left out, keeping v5's existing `toEqual` assertion.

### Verification

`@ai-sdk/gateway` on this branch: `test:node` 324/324, `test:edge` 324/324, type-check clean. The three new tests (forward warnings on generate, default to `[]` when absent, server `stream-start` forwarded exactly once) pass.