### PR TITLE
fix(ai): notify telemetry onError on mid-stream provider stream errors

### DIFF
--- a/.changeset/olive-spans-close.md
+++ b/.changeset/olive-spans-close.md
@@ -1,0 +1,5 @@
+---
+'ai': patch
+---
+
+Notify telemetry onError on mid-stream provider stream errors so OTEL spans close instead of leaking

--- a/packages/ai/src/generate-text/stream-text.test.ts
+++ b/packages/ai/src/generate-text/stream-text.test.ts
@@ -24892,6 +24892,89 @@ describe('streamText', () => {
     });
   });
 
+  describe('provider stream error', () => {
+    let result: StreamTextResult<ToolSet, any, never>;
+    let telemetryCalls: Array<{ name: string; event?: unknown }> = [];
+    const streamError = new Error('socket closed');
+
+    beforeEach(() => {
+      telemetryCalls = [];
+
+      let pullCalls = 0;
+      const telemetryIntegration: Telemetry = {
+        onAbort: event => {
+          telemetryCalls.push({ name: 'onAbort', event });
+        },
+        onEnd: event => {
+          telemetryCalls.push({ name: 'onEnd', event });
+        },
+        onError: event => {
+          telemetryCalls.push({ name: 'onError', event });
+        },
+      };
+
+      result = streamText({
+        telemetry: {
+          integrations: telemetryIntegration,
+        },
+        _internal: {
+          generateCallId: () => 'test-telemetry-call-id',
+        },
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: new ReadableStream({
+              pull(controller) {
+                switch (pullCalls++) {
+                  case 0:
+                    controller.enqueue({
+                      type: 'stream-start',
+                      warnings: [],
+                    });
+                    break;
+                  case 1:
+                    controller.enqueue({
+                      type: 'text-start',
+                      id: '1',
+                    });
+                    break;
+                  case 2:
+                    controller.enqueue({
+                      type: 'text-delta',
+                      id: '1',
+                      delta: 'Hello',
+                    });
+                    break;
+                  case 3:
+                    controller.error(streamError);
+                    break;
+                }
+              },
+            }),
+          }),
+        }),
+        prompt: 'test-input',
+      });
+    });
+
+    it('should call telemetry onError with callId and error when the provider stream errors', async () => {
+      await result.consumeStream();
+      expect(telemetryCalls.map(({ name }) => name)).toEqual(['onError']);
+      expect(telemetryCalls[0].event).toMatchObject({
+        callId: 'test-telemetry-call-id',
+        error: streamError,
+      });
+    });
+
+    it('should not call telemetry onAbort or onEnd when the provider stream errors', async () => {
+      await result.consumeStream();
+      expect(
+        telemetryCalls
+          .map(({ name }) => name)
+          .filter(name => name === 'onAbort' || name === 'onEnd'),
+      ).toEqual([]);
+    });
+  });
+
   describe('context', () => {
     it('should send context to tool execution', async () => {
       let recordedContext: unknown | undefined;

--- a/packages/ai/src/generate-text/stream-text.ts
+++ b/packages/ai/src/generate-text/stream-text.ts
@@ -1878,6 +1878,16 @@ class DefaultStreamTextResult<
           if (isAbortError(error) && abortSignal?.aborted) {
             await abort();
           } else {
+            // Mid-stream transport errors (e.g. a socket failure while reading
+            // the provider response body) never surface as stream parts, so
+            // neither the user `onError` handler nor the telemetry dispatcher
+            // would otherwise observe them. Notify telemetry so integrations
+            // (e.g. OpenTelemetry) can record the error and end open spans,
+            // mirroring the setup-error path below.
+            await notify({
+              event: { callId, error },
+              callbacks: telemetryDispatcher.onError,
+            });
             controller.error(error);
           }
         }

--- a/packages/otel/src/open-telemetry.test.ts
+++ b/packages/otel/src/open-telemetry.test.ts
@@ -2435,6 +2435,64 @@ describe('OpenTelemetry', () => {
     });
   });
 
+  describe('provider stream error', () => {
+    it('closes streamText spans when the provider stream errors', async () => {
+      let pullCalls = 0;
+
+      const result = streamText({
+        model: new MockLanguageModelV4({
+          doStream: async () => ({
+            stream: new ReadableStream({
+              pull(controller) {
+                switch (pullCalls++) {
+                  case 0:
+                    controller.enqueue({
+                      type: 'stream-start',
+                      warnings: [],
+                    });
+                    break;
+                  case 1:
+                    controller.enqueue({
+                      type: 'text-start',
+                      id: '1',
+                    });
+                    break;
+                  case 2:
+                    controller.enqueue({
+                      type: 'text-delta',
+                      id: '1',
+                      delta: 'Hello',
+                    });
+                    break;
+                  case 3:
+                    controller.error(new Error('socket closed'));
+                    break;
+                }
+              },
+            }),
+          }),
+        }),
+        prompt: 'test-input',
+        telemetry: {
+          integrations: integration,
+        },
+      });
+
+      await result.consumeStream();
+
+      expect(
+        tracer.spans.map(span => ({
+          name: span.name,
+          ended: span.ended,
+        })),
+      ).toEqual([
+        { name: 'invoke_agent mock-model-id', ended: true },
+        { name: 'step 1', ended: true },
+        { name: 'chat mock-model-id', ended: true },
+      ]);
+    });
+  });
+
   describe('full lifecycle', () => {
     it('creates correct span hierarchy for multi-step tool loop', () => {
       integration.onStart!(makeOnStartEvent());


### PR DESCRIPTION
Fixes #20586.

In streamText's resilient stream, a non-abort mid-stream provider error (a socket dying while reading the response body) hit a bare controller.error(). telemetryDispatcher.onError never fired, so the OTEL root, step, and chat spans stayed open. Exporters never receive un-ended spans, so earlier steps show as orphans. Setup errors and aborts already had telemetry cleanup. This path did not.

The fix notifies telemetryDispatcher.onError with { callId, error } before erroring the stream, mirroring the setup-error path. The abort path is untouched.

Verified: the new otel test fails before (spans un-ended) and passes after (all three ended). I also ran it in a real Chromium page driving streamText against a dying stream: un-ended without the fix, ended with it. stream-text.test.ts 453/453, open-telemetry.test.ts 51/51, type-check clean.