### PR TITLE
fix(test-server): serialize dts build

### DIFF
--- a/.changeset/quiet-builds-serialize.md
+++ b/.changeset/quiet-builds-serialize.md
@@ -1,0 +1,5 @@
+---
+'@ai-sdk/test-server': patch
+---
+
+serialize declaration generation for the test-server package's multiple exports

--- a/packages/test-server/src/build.test.ts
+++ b/packages/test-server/src/build.test.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const buildOutputDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of buildOutputDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('@ai-sdk/test-server build', () => {
+  it('maps both declaration entries to their matching source files', () => {
+    const config = readFileSync(resolve(packageRoot, 'tsup.config.ts'), 'utf8');
+
+    expect(config).not.toMatch(/dts: true/);
+    expect(config).toMatch(
+      /entry:\s*\{\s*index:\s*'src\/index\.ts',\s*'with-vitest':\s*'src\/with-vitest\.ts',\s*\}/,
+    );
+    expect(config).toMatch(/dts:\s*\{\s*only:\s*true\s*\}/);
+  });
+
+  it('emits substantive exports for both package entry points in isolation', () => {
+    const outputDirectory = mkdtempSync(
+      resolve(tmpdir(), 'ai-sdk-test-server-build-'),
+    );
+    buildOutputDirectories.push(outputDirectory);
+
+    execFileSync(
+      process.execPath,
+      [
+        resolve(packageRoot, 'node_modules/tsup/dist/cli-default.js'),
+        '--config',
+        resolve(packageRoot, 'tsup.config.ts'),
+        '--tsconfig',
+        resolve(packageRoot, 'tsconfig.build.json'),
+        '--out-dir',
+        outputDirectory,
+      ],
+      { cwd: packageRoot, stdio: 'inherit' },
+    );
+
+    const expectedExports = [
+      ['index.js', 'createTestServer', 'TestResponseController'],
+      ['with-vitest.js', 'createTestServer', 'TestResponseController'],
+    ] as const;
+
+    for (const [file, ...exports] of expectedExports) {
+      const output = resolve(outputDirectory, file);
+      expect(existsSync(output), file).toBe(true);
+      const contents = readFileSync(output, 'utf8');
+      for (const exportedName of exports) {
+        expect(contents, `${file} should export ${exportedName}`).toContain(
+          exportedName,
+        );
+      }
+    }
+
+    const indexDeclarations = readFileSync(
+      resolve(outputDirectory, 'index.d.ts'),
+      'utf8',
+    );
+    const withVitestDeclarations = readFileSync(
+      resolve(outputDirectory, 'with-vitest.d.ts'),
+      'utf8',
+    );
+
+    expect(indexDeclarations).toContain('server: {');
+    expect(indexDeclarations).not.toContain('readonly requestBodyJson');
+    expect(withVitestDeclarations).toContain('readonly requestBodyJson');
+    expect(withVitestDeclarations).not.toContain('server: {');
+  });
+});

--- a/packages/test-server/tsup.config.ts
+++ b/packages/test-server/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig([
   {
     entry: ['src/index.ts'],
     format: ['esm'],
-    dts: true,
+    dts: false,
     sourcemap: true,
     target: 'es2018',
     platform: 'node',
@@ -12,7 +12,7 @@ export default defineConfig([
   {
     entry: ['src/with-vitest.ts'],
     format: ['esm'],
-    dts: true,
+    dts: false,
     sourcemap: true,
     target: 'es2020',
     platform: 'node',
@@ -28,5 +28,13 @@ export default defineConfig([
       'vitest/dist/node/*',
       'vitest/dist/node/chunks/*',
     ],
+  },
+  {
+    entry: {
+      index: 'src/index.ts',
+      'with-vitest': 'src/with-vitest.ts',
+    },
+    dts: { only: true },
+    format: ['esm'],
   },
 ]);


### PR DESCRIPTION
## Background

The test-server package builds two public entry points with separate concurrent declaration-generation tasks. This can race in tsup and produce an ELIFECYCLE failure or declarations associated with the wrong entry point.

## Summary

Disable declaration generation in the two JavaScript builds and add one named multi-entry declaration-only build so each entry point is generated deterministically. Add regression coverage for the generated exports and a patch changeset.

## Contributor Credit

The issue reporter provided the reproduction context.

## End-to-End Verification

The package build completes successfully and emits both JavaScript entry points and their corresponding declaration files.

## Checklist

- [x] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

None.

## Related Issues

Fixes #10662