### PR TITLE
fix(provider/google): strip JSON Schema references from tool response content

### DIFF
--- a/.changeset/google-function-response-schema-refs.md
+++ b/.changeset/google-function-response-schema-refs.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk/google": patch
+---
+
+fix(provider/google): strip JSON Schema references from tool response content

--- a/packages/google/src/convert-to-google-messages.test.ts
+++ b/packages/google/src/convert-to-google-messages.test.ts
@@ -658,6 +658,49 @@ describe('tool messages', () => {
     });
   });
 
+  it('should strip JSON Schema references from function response content', async () => {
+    const result = convertToGoogleMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolName: 'get_schema',
+            toolCallId: 'testCallId',
+            output: {
+              type: 'json',
+              value: {
+                inputSchema: {
+                  properties: {
+                    filter: { $ref: '#/$defs/Filter' },
+                  },
+                  $defs: {
+                    Filter: { type: 'object' },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(result.contents[0].parts[0]).toEqual({
+      functionResponse: {
+        id: 'testCallId',
+        name: 'get_schema',
+        response: {
+          name: 'get_schema',
+          content: {
+            inputSchema: {
+              properties: { filter: {} },
+            },
+          },
+        },
+      },
+    });
+  });
+
   it('should convert tool result content with image-data into functionResponse parts', async () => {
     const result = convertToGoogleMessages([
       {

--- a/packages/google/src/convert-to-google-messages.ts
+++ b/packages/google/src/convert-to-google-messages.ts
@@ -198,6 +198,35 @@ function appendLegacyToolResultParts(
   }
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) return false;
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function sanitizeFunctionResponseContent(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeFunctionResponseContent);
+  }
+
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, item] of Object.entries(value)) {
+    if (key === '$ref' || key === '$defs') {
+      continue;
+    }
+
+    sanitized[key] = sanitizeFunctionResponseContent(item);
+  }
+
+  return sanitized;
+}
+
 export function convertToGoogleMessages(
   prompt: LanguageModelV4Prompt,
   options?: {
@@ -622,7 +651,7 @@ export function convertToGoogleMessages(
                   content:
                     output.type === 'execution-denied'
                       ? (output.reason ?? 'Tool call execution denied.')
-                      : output.value,
+                      : sanitizeFunctionResponseContent(output.value),
                 },
               },
             });


### PR DESCRIPTION
## Background

Gemini rejects function response content containing JSON Schema `$ref` and `$defs` fields with a 400 INVALID_ARGUMENT error. This can occur when a tool returns a schema generated from a recursive or reusable definition. Fixes #14369.

## Summary

- Strip `$ref` and `$defs` keys recursively from plain objects and arrays in function response content.
- Preserve non-plain values such as Date instances.
- Add regression coverage and a patch changeset.

## Contributor Credit

Issue reporter: #14369.

Relevant maintainers for this provider area: Nick Oates, Gregor Martynus, and Aayush Kapoor.

## End-to-End Verification

A representative tool result containing nested schema references now produces a Gemini function response without `$ref` or `$defs` fields.

## Checklist

- [ ] All commits are signed (PRs with unsigned commits cannot be merged)
- [x] Tests have been added / updated (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] A _patch_ changeset for relevant packages has been added (for bug fixes / features - run `pnpm changeset` in the project root)
- [x] I have reviewed this pull request (self-review)

## Future Work

None.

## Related Issues

Fixes #14369